### PR TITLE
Include chain in client node name.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -154,14 +154,20 @@ where
         };
         let node_provider = NodeProvider::new(node_options);
         let delivery = CrossChainMessageDelivery::new(options.wait_for_outgoing_messages);
+        let chain_ids = wallet.chain_ids();
+        let name = match chain_ids.len() {
+            0 => "Client node".to_string(),
+            1 => format!("Client node for {:.8}", chain_ids[0]),
+            n => format!("Client node for {:.8} and {} others", chain_ids[0], n - 1),
+        };
         let client = Client::new(
             node_provider,
             storage,
             options.max_pending_message_bundles,
             delivery,
             options.long_lived_services,
-            wallet.chain_ids(),
-            "Client node",
+            chain_ids,
+            name,
         );
 
         ClientContext {

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -161,7 +161,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
             delivery,
             false,
             [chain_id0],
-            "Client node",
+            format!("Client node for {:.8}", chain_id0),
         )),
     };
     let key_pair = KeyPair::generate_from(&mut rng);


### PR DESCRIPTION
## Motivation

The `Client` is always called `"Client node"`. This makes debugging difficult in tests involving multiple clients.

## Proposal

Include the chain ID(s) in the name.

## Test Plan

No changed logic, but it should make debugging end-to-end tests easier.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- (Found while debugging https://github.com/linera-io/linera-protocol/pull/2538.)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
