### PR TITLE
Improve the performance of the RocksDb.

### DIFF
--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -195,9 +195,10 @@ impl ClientOptions {
             cfg_if::cfg_if! {
                 if #[cfg(all(feature = "rocksdb", feature = "fs"))] {
                     // The block_in_place is enabled since the client is run in multi-threaded
+                    let spawn_mode = linera_views::rocks_db::get_spawn_mode_from_runtime();
                     let storage_config = crate::storage::StorageConfig::RocksDb {
                         path: self.config_path()?.join("wallet.db"),
-                        block_in_place: true,
+                        spawn_mode,
                     };
                     let namespace = "default".to_string();
                     Ok(StorageConfigNamespace {

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -195,7 +195,7 @@ impl ClientOptions {
             cfg_if::cfg_if! {
                 if #[cfg(all(feature = "rocksdb", feature = "fs"))] {
                     // The block_in_place is enabled since the client is run in multi-threaded
-                    let spawn_mode = linera_views::rocks_db::get_spawn_mode_from_runtime();
+                    let spawn_mode = linera_views::rocks_db::RocksDbSpawnMode::get_spawn_mode_from_runtime();
                     let storage_config = crate::storage::StorageConfig::RocksDb {
                         path: self.config_path()?.join("wallet.db"),
                         spawn_mode,

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -194,8 +194,10 @@ impl ClientOptions {
         } else {
             cfg_if::cfg_if! {
                 if #[cfg(all(feature = "rocksdb", feature = "fs"))] {
+                    // The block_in_place is enabled since the client is run in multi-threaded
                     let storage_config = crate::storage::StorageConfig::RocksDb {
                         path: self.config_path()?.join("wallet.db"),
+                        block_in_place: true,
                     };
                     let namespace = "default".to_string();
                     Ok(StorageConfigNamespace {

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -214,6 +214,7 @@ example service:tcp:127.0.0.1:7878:table_do_my_test"
                 let spawn_mode = match parts[1] {
                     "spawn_blocking" => Ok(RocksDbSpawnMode::SpawnBlocking),
                     "block_in_place" => Ok(RocksDbSpawnMode::BlockInPlace),
+                    "runtime" => Ok(RocksDbSpawnMode::get_spawn_mode_from_runtime()),
                     _ => Err(Error::Format(format!(
                         "Failed to parse {} as a spawn_mode",
                         parts[1]

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -91,7 +91,7 @@ pub enum StorageConfig {
     RocksDb {
         /// The path used
         path: PathBuf,
-        /// Whether to use `block_in_place` or `span_blocking`.
+        /// Whether to use `block_in_place` or `spawn_blocking`.
         spawn_mode: RocksDbSpawnMode,
     },
     /// The DynamoDB description

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -45,8 +45,11 @@ impl RocksDbRunner {
         };
         let path_buf = config.client.storage.as_path().to_path_buf();
         let path_with_guard = PathWithGuard::new(path_buf);
+        // The tests are run in single threaded mode
+        let block_in_place = false;
         let store_config = RocksDbStoreConfig {
             path_with_guard,
+            block_in_place,
             common_config,
         };
         let namespace = config.client.namespace.clone();

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use clap::Parser as _;
 use linera_views::{
     common::{AdminKeyValueStore, CommonStoreConfig},
-    rocks_db::{PathWithGuard, RocksDbStore, RocksDbStoreConfig},
+    rocks_db::{PathWithGuard, RocksDbSpawnMode, RocksDbStore, RocksDbStoreConfig},
 };
 
 use crate::{
@@ -45,11 +45,12 @@ impl RocksDbRunner {
         };
         let path_buf = config.client.storage.as_path().to_path_buf();
         let path_with_guard = PathWithGuard::new(path_buf);
-        // The tests are run in single threaded mode
-        let block_in_place = false;
+        // The tests are run in single threaded mode, therefore we need
+        // to use the safe default value of SpawnBlocking.
+        let spawn_mode = RocksDbSpawnMode::SpawnBlocking;
         let store_config = RocksDbStoreConfig {
             path_with_guard,
-            block_in_place,
+            spawn_mode,
             common_config,
         };
         let namespace = config.client.namespace.clone();

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -15,7 +15,7 @@ use linera_views::{
 #[cfg(with_rocksdb)]
 use linera_views::{
     common::AdminKeyValueStore,
-    rocks_db::{PathWithGuard, RocksDbStore, RocksDbStoreConfig},
+    rocks_db::{get_spawn_mode_from_runtime, PathWithGuard, RocksDbStore, RocksDbStoreConfig},
 };
 use serde::Serialize;
 use tonic::{transport::Server, Request, Response, Status};
@@ -584,10 +584,10 @@ async fn main() {
             let path_buf = path.into();
             let path_with_guard = PathWithGuard::new(path_buf);
             // The server is run in multi-threaded mode so we can use the block_in_place.
-            let block_in_place = true;
+            let spawn_mode = get_spawn_mode_from_runtime();
             let config = RocksDbStoreConfig {
                 path_with_guard,
-                block_in_place,
+                spawn_mode,
                 common_config,
             };
             let store = RocksDbStore::maybe_create_and_connect(&config, namespace, root_key)

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -583,8 +583,11 @@ async fn main() {
         ServiceStoreServerOptions::RocksDb { path, endpoint } => {
             let path_buf = path.into();
             let path_with_guard = PathWithGuard::new(path_buf);
+            // The server is run in multi-threaded mode so we can use the block_in_place.
+            let block_in_place = true;
             let config = RocksDbStoreConfig {
                 path_with_guard,
+                block_in_place,
                 common_config,
             };
             let store = RocksDbStore::maybe_create_and_connect(&config, namespace, root_key)

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -15,7 +15,7 @@ use linera_views::{
 #[cfg(with_rocksdb)]
 use linera_views::{
     common::AdminKeyValueStore,
-    rocks_db::{get_spawn_mode_from_runtime, PathWithGuard, RocksDbStore, RocksDbStoreConfig},
+    rocks_db::{PathWithGuard, RocksDbStore, RocksDbSpawnMode, RocksDbStoreConfig},
 };
 use serde::Serialize;
 use tonic::{transport::Server, Request, Response, Status};
@@ -584,7 +584,7 @@ async fn main() {
             let path_buf = path.into();
             let path_with_guard = PathWithGuard::new(path_buf);
             // The server is run in multi-threaded mode so we can use the block_in_place.
-            let spawn_mode = get_spawn_mode_from_runtime();
+            let spawn_mode = RocksDbSpawnMode::get_spawn_mode_from_runtime();
             let config = RocksDbStoreConfig {
                 path_with_guard,
                 spawn_mode,

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -15,7 +15,7 @@ use linera_views::{
 #[cfg(with_rocksdb)]
 use linera_views::{
     common::AdminKeyValueStore,
-    rocks_db::{PathWithGuard, RocksDbStore, RocksDbSpawnMode, RocksDbStoreConfig},
+    rocks_db::{PathWithGuard, RocksDbSpawnMode, RocksDbStore, RocksDbStoreConfig},
 };
 use serde::Serialize;
 use tonic::{transport::Server, Request, Response, Status};

--- a/linera-views/benches/stores.rs
+++ b/linera-views/benches/stores.rs
@@ -10,7 +10,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 #[cfg(with_dynamodb)]
 use linera_views::dynamo_db::create_dynamo_db_test_store;
 #[cfg(with_rocksdb)]
-use linera_views::rocks_db::create_rocks_db_test_store;
+use linera_views::rocks_db::create_rocks_db_benchmark_store;
 #[cfg(with_scylladb)]
 use linera_views::scylla_db::create_scylla_db_test_store;
 use linera_views::{
@@ -77,7 +77,7 @@ where
 }
 
 fn bench_contains_key(criterion: &mut Criterion) {
-    criterion.bench_function("memory_contains_key", |bencher| {
+    criterion.bench_function("store_memory_contains_key", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -87,17 +87,17 @@ fn bench_contains_key(criterion: &mut Criterion) {
     });
 
     #[cfg(with_rocksdb)]
-    criterion.bench_function("rocksdb_contains_key", |bencher| {
+    criterion.bench_function("store_rocksdb_contains_key", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_test_store().await;
+                let store = create_rocks_db_benchmark_store().await;
                 performance_contains_key(store, iterations).await
             })
     });
 
     #[cfg(with_dynamodb)]
-    criterion.bench_function("dynamodb_contains_key", |bencher| {
+    criterion.bench_function("store_dynamodb_contains_key", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -107,7 +107,7 @@ fn bench_contains_key(criterion: &mut Criterion) {
     });
 
     #[cfg(with_scylladb)]
-    criterion.bench_function("scylladb_contains_key", |bencher| {
+    criterion.bench_function("store_scylladb_contains_key", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -148,7 +148,7 @@ where
 }
 
 fn bench_contains_keys(criterion: &mut Criterion) {
-    criterion.bench_function("memory_contains_keys", |bencher| {
+    criterion.bench_function("store_memory_contains_keys", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -158,17 +158,17 @@ fn bench_contains_keys(criterion: &mut Criterion) {
     });
 
     #[cfg(with_rocksdb)]
-    criterion.bench_function("rocksdb_contains_keys", |bencher| {
+    criterion.bench_function("store_rocksdb_contains_keys", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_test_store().await;
+                let store = create_rocks_db_benchmark_store().await;
                 performance_contains_keys(store, iterations).await
             })
     });
 
     #[cfg(with_dynamodb)]
-    criterion.bench_function("dynamodb_contains_keys", |bencher| {
+    criterion.bench_function("store_dynamodb_contains_keys", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -178,7 +178,7 @@ fn bench_contains_keys(criterion: &mut Criterion) {
     });
 
     #[cfg(with_scylladb)]
-    criterion.bench_function("scylladb_contains_keys", |bencher| {
+    criterion.bench_function("store_scylladb_contains_keys", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -218,7 +218,7 @@ where
 }
 
 fn bench_find_keys_by_prefix(criterion: &mut Criterion) {
-    criterion.bench_function("memory_find_keys_by_prefix", |bencher| {
+    criterion.bench_function("store_memory_find_keys_by_prefix", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -228,17 +228,17 @@ fn bench_find_keys_by_prefix(criterion: &mut Criterion) {
     });
 
     #[cfg(with_rocksdb)]
-    criterion.bench_function("rocksdb_find_keys_by_prefix", |bencher| {
+    criterion.bench_function("store_rocksdb_find_keys_by_prefix", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_test_store().await;
+                let store = create_rocks_db_benchmark_store().await;
                 performance_find_keys_by_prefix(store, iterations).await
             })
     });
 
     #[cfg(with_dynamodb)]
-    criterion.bench_function("dynamodb_find_keys_by_prefix", |bencher| {
+    criterion.bench_function("store_dynamodb_find_keys_by_prefix", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -248,7 +248,7 @@ fn bench_find_keys_by_prefix(criterion: &mut Criterion) {
     });
 
     #[cfg(with_scylladb)]
-    criterion.bench_function("scylladb_find_keys_by_prefix", |bencher| {
+    criterion.bench_function("store_scylladb_find_keys_by_prefix", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -293,7 +293,7 @@ where
 }
 
 fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
-    criterion.bench_function("memory_find_key_values_by_prefix", |bencher| {
+    criterion.bench_function("store_memory_find_key_values_by_prefix", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -303,17 +303,17 @@ fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
     });
 
     #[cfg(with_rocksdb)]
-    criterion.bench_function("rocksdb_find_key_values_by_prefix", |bencher| {
+    criterion.bench_function("store_rocksdb_find_key_values_by_prefix", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_test_store().await;
+                let store = create_rocks_db_benchmark_store().await;
                 performance_find_key_values_by_prefix(store, iterations).await
             })
     });
 
     #[cfg(with_dynamodb)]
-    criterion.bench_function("dynamodb_find_key_values_by_prefix", |bencher| {
+    criterion.bench_function("store_dynamodb_find_key_values_by_prefix", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -323,7 +323,7 @@ fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
     });
 
     #[cfg(with_scylladb)]
-    criterion.bench_function("scylladb_find_key_values_by_prefix", |bencher| {
+    criterion.bench_function("store_scylladb_find_key_values_by_prefix", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -365,7 +365,7 @@ where
 }
 
 fn bench_read_value_bytes(criterion: &mut Criterion) {
-    criterion.bench_function("memory_read_value_bytes", |bencher| {
+    criterion.bench_function("store_memory_read_value_bytes", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -375,17 +375,17 @@ fn bench_read_value_bytes(criterion: &mut Criterion) {
     });
 
     #[cfg(with_rocksdb)]
-    criterion.bench_function("rocksdb_read_value_bytes", |bencher| {
+    criterion.bench_function("store_rocksdb_read_value_bytes", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_test_store().await;
+                let store = create_rocks_db_benchmark_store().await;
                 performance_read_value_bytes(store, iterations).await
             })
     });
 
     #[cfg(with_dynamodb)]
-    criterion.bench_function("dynamodb_read_value_bytes", |bencher| {
+    criterion.bench_function("store_dynamodb_read_value_bytes", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -395,7 +395,7 @@ fn bench_read_value_bytes(criterion: &mut Criterion) {
     });
 
     #[cfg(with_scylladb)]
-    criterion.bench_function("scylladb_read_value_bytes", |bencher| {
+    criterion.bench_function("store_scylladb_read_value_bytes", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -439,7 +439,7 @@ where
 }
 
 fn bench_read_multi_values_bytes(criterion: &mut Criterion) {
-    criterion.bench_function("memory_read_multi_values_bytes", |bencher| {
+    criterion.bench_function("store_memory_read_multi_values_bytes", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -449,17 +449,17 @@ fn bench_read_multi_values_bytes(criterion: &mut Criterion) {
     });
 
     #[cfg(with_rocksdb)]
-    criterion.bench_function("rocksdb_read_multi_values_bytes", |bencher| {
+    criterion.bench_function("store_rocksdb_read_multi_values_bytes", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_test_store().await;
+                let store = create_rocks_db_benchmark_store().await;
                 performance_read_multi_values_bytes(store, iterations).await
             })
     });
 
     #[cfg(with_dynamodb)]
-    criterion.bench_function("dynamodb_read_multi_values_bytes", |bencher| {
+    criterion.bench_function("store_dynamodb_read_multi_values_bytes", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -469,7 +469,7 @@ fn bench_read_multi_values_bytes(criterion: &mut Criterion) {
     });
 
     #[cfg(with_scylladb)]
-    criterion.bench_function("scylladb_read_multi_values_bytes", |bencher| {
+    criterion.bench_function("store_scylladb_read_multi_values_bytes", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -505,7 +505,7 @@ where
 }
 
 fn bench_write_batch(criterion: &mut Criterion) {
-    criterion.bench_function("memory_write_batch", |bencher| {
+    criterion.bench_function("store_memory_write_batch", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -515,17 +515,17 @@ fn bench_write_batch(criterion: &mut Criterion) {
     });
 
     #[cfg(with_rocksdb)]
-    criterion.bench_function("rocksdb_write_batch", |bencher| {
+    criterion.bench_function("store_rocksdb_write_batch", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_test_store().await;
+                let store = create_rocks_db_benchmark_store().await;
                 performance_write_batch(store, iterations).await
             })
     });
 
     #[cfg(with_dynamodb)]
-    criterion.bench_function("dynamodb_write_batch", |bencher| {
+    criterion.bench_function("store_dynamodb_write_batch", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
@@ -535,7 +535,7 @@ fn bench_write_batch(criterion: &mut Criterion) {
     });
 
     #[cfg(with_scylladb)]
-    criterion.bench_function("scylladb_write_batch", |bencher| {
+    criterion.bench_function("store_scylladb_write_batch", |bencher| {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -15,7 +15,6 @@ use tempfile::TempDir;
 use thiserror::Error;
 use tokio::runtime::Handle;
 
-
 #[cfg(with_metrics)]
 use crate::metering::{
     MeteredStore, LRU_CACHING_METRICS, ROCKS_DB_METRICS, VALUE_SPLITTING_METRICS,
@@ -133,7 +132,10 @@ impl RocksDbStoreInternal {
         Ok(results)
     }
 
-    fn inner_read_multi_values_bytes(&self, keys: Vec<Vec<u8>>) -> Result<Vec<Option<Vec<u8>>>, RocksDbStoreError> {
+    fn inner_read_multi_values_bytes(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<Option<Vec<u8>>>, RocksDbStoreError> {
         for key in &keys {
             ensure!(key.len() <= MAX_KEY_SIZE, RocksDbStoreError::KeyTooLong);
         }
@@ -149,7 +151,10 @@ impl RocksDbStoreInternal {
         Ok(entries.into_iter().collect::<Result<_, _>>()?)
     }
 
-    fn inner_find_keys_by_prefix(&self, key_prefix: Vec<u8>) -> Result<Vec<Vec<u8>>, RocksDbStoreError> {
+    fn inner_find_keys_by_prefix(
+        &self,
+        key_prefix: Vec<u8>,
+    ) -> Result<Vec<Vec<u8>>, RocksDbStoreError> {
         ensure!(
             key_prefix.len() <= MAX_KEY_SIZE,
             RocksDbStoreError::KeyTooLong
@@ -172,7 +177,11 @@ impl RocksDbStoreInternal {
         Ok(keys)
     }
 
-    fn inner_find_key_values_by_prefix(&self, key_prefix: Vec<u8>) -> Result<Vec<(Vec<u8>,Vec<u8>)>, RocksDbStoreError> {
+    #[allow(clippy::type_complexity)]
+    fn inner_find_key_values_by_prefix(
+        &self,
+        key_prefix: Vec<u8>,
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, RocksDbStoreError> {
         ensure!(
             key_prefix.len() <= MAX_KEY_SIZE,
             RocksDbStoreError::KeyTooLong
@@ -253,7 +262,6 @@ impl RocksDbStoreInternal {
         self.db.write(inner_batch)?;
         Ok(())
     }
-
 }
 
 impl WithError for RocksDbStoreInternal {
@@ -275,9 +283,7 @@ impl ReadableKeyValueStore for RocksDbStoreInternal {
         let mut full_key = self.root_key.to_vec();
         full_key.extend(key);
         if self.spawn_blocking {
-            Ok(tokio::task::spawn_blocking(move || {
-                client.db.get(&full_key)
-            }).await??)
+            Ok(tokio::task::spawn_blocking(move || client.db.get(&full_key)).await??)
         } else {
             Ok(tokio::task::block_in_place(move || {
                 client.db.get(&full_key)
@@ -325,11 +331,11 @@ impl ReadableKeyValueStore for RocksDbStoreInternal {
         let client = self.clone();
         let key_prefix = key_prefix.to_vec();
         if self.spawn_blocking {
-            tokio::task::spawn_blocking(move || client.inner_find_keys_by_prefix(key_prefix)).await?
+            tokio::task::spawn_blocking(move || client.inner_find_keys_by_prefix(key_prefix))
+                .await?
         } else {
             tokio::task::block_in_place(move || client.inner_find_keys_by_prefix(key_prefix))
         }
-
     }
 
     async fn find_key_values_by_prefix(
@@ -339,7 +345,8 @@ impl ReadableKeyValueStore for RocksDbStoreInternal {
         let client = self.clone();
         let key_prefix = key_prefix.to_vec();
         if self.spawn_blocking {
-            tokio::task::spawn_blocking(move || client.inner_find_key_values_by_prefix(key_prefix)).await?
+            tokio::task::spawn_blocking(move || client.inner_find_key_values_by_prefix(key_prefix))
+                .await?
         } else {
             tokio::task::block_in_place(move || client.inner_find_key_values_by_prefix(key_prefix))
         }

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -62,7 +62,7 @@ pub struct RocksDbStoreConfig {
     pub path_with_guard: PathWithGuard,
     /// The use of the block_in_place function. One way to set it up is via:
     /// let block_in_place = (tokio::runtime::Handle::current().metrics().num_workers() > 1);
-    /// The block_in_place is documented in https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html
+    /// The block_in_place is documented in <https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html>
     pub block_in_place: bool,
     /// The common configuration of the key value store
     pub common_config: CommonStoreConfig,

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -52,7 +52,7 @@ pub type DB = rocksdb::DBWithThreadMode<rocksdb::MultiThreaded>;
 /// The BlockInPlace is documented in <https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html>
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RocksDbSpawnMode {
-    /// This uses the `span_blocking` function of tokio.
+    /// This uses the `spawn_blocking` function of tokio.
     SpawnBlocking,
     /// This uses the `block_in_place` function of tokio.
     BlockInPlace,


### PR DESCRIPTION
## Motivation

The RocksDb storage is a very important store for which every impact in performance is key.

## Proposal

The following was done:
* The effective computation was moved to `inner_*` functions which are not async.
* The constructor of the RocksDbStoreInternal is now building a boolean indicating whether to use `spawn_blocking` or `block_in_place`.
* Each method is choosen according to the context.

## Test Plan

(A) It has been verified that the `linera-views` tests are running with `spawn_blocking` and the benchmarks
with `block_in_place`.

(B) Correctness should be provided by the CI.

(C) Since this is a performance improvement PR, performance results are needed.
* This was done with: `cargo bench store_rocksdb_ --features rocksdb`.
* As the benchmarks numbers are quite unstable, it was repeated 10 times with the first 1 dropped.
* Computation was on a Macbook Pro16 x86 in a terminal with the benchmarks being the only active process.

Results are following:
* **read_value_bytes**: 138 mus (old) vs 132 mus (new) 
* **read_multi_values_bytes**: 252 mus vs 226 mus
* **contains_key**: 2239 mus vs 135 mus
* **contains_keys**: 2485 mus vs 134 mus
* **find_keys_by_prefix**: 118 mus vs 106 mus
* **find_key_values_by_prefix**: 359 mus vs 338 mus
* **write_batch**: 3666 mus vs 3554 mus

## Release Plan

- Nothing to do / These changes follow the usual release cycle. It provides some speed improvements.

## Links

None