### PR TITLE
Optimistic Chain Clients

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -14,7 +14,7 @@ use linera_base::{
 };
 use linera_chain::data_types::Certificate;
 use linera_core::{
-    client::{ChainClient, Client, MessagePolicy},
+    client::{ChainClient, Client, ClientMode, MessagePolicy},
     data_types::ClientOutcome,
     join_set_ext::{JoinSet, JoinSetExt as _},
     node::CrossChainMessageDelivery,
@@ -215,6 +215,7 @@ where
             chain.next_block_height,
             chain.pending_block.clone(),
             chain.pending_blobs.clone(),
+            ClientMode::Optimistic,
         );
         chain_client.options_mut().message_policy = MessagePolicy::new(
             self.options.blanket_message_policy,

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -14,7 +14,7 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_core::{
-    client::{ChainClient, Client},
+    client::{ChainClient, Client, ClientMode},
     node::CrossChainMessageDelivery,
     test_utils::{MemoryStorageBuilder, NodeProvider, StorageBuilder as _, TestBuilder},
 };
@@ -75,6 +75,7 @@ impl chain_listener::ClientContext for ClientContext {
             chain.next_block_height,
             chain.pending_block.clone(),
             chain.pending_blobs.clone(),
+            ClientMode::Optimistic,
         )
     }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1030,7 +1030,8 @@ where
                     local_node: local_node.clone(),
                 };
                 let action = action.clone();
-                Box::pin(async move { updater.send_chain_update(action).await })
+                let is_optimistic = self.is_optimistic();
+                Box::pin(async move { updater.send_chain_update(action, is_optimistic).await })
             },
         )
         .await?;

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -51,7 +51,7 @@ use {
 };
 
 use crate::{
-    client::{ChainClient, Client},
+    client::{ChainClient, Client, ClientMode},
     data_types::*,
     node::{
         CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
@@ -799,6 +799,7 @@ where
             block_height,
             None,
             BTreeMap::new(),
+            ClientMode::Optimistic,
         ))
     }
 

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -377,6 +377,7 @@ where
     pub async fn send_chain_update(
         &mut self,
         action: CommunicateAction,
+        optimistic_client: bool,
     ) -> Result<LiteVote, NodeError> {
         let (target_block_height, chain_id) = match &action {
             CommunicateAction::SubmitBlock { proposal, .. } => {
@@ -391,10 +392,12 @@ where
                 height, chain_id, ..
             } => (*height, *chain_id),
         };
-        // Update the validator with missing information, if needed.
-        let delivery = CrossChainMessageDelivery::NonBlocking;
-        self.send_chain_information(chain_id, target_block_height, delivery)
-            .await?;
+        if !optimistic_client {
+            // Update the validator with missing information, if needed.
+            let delivery = CrossChainMessageDelivery::NonBlocking;
+            self.send_chain_information(chain_id, target_block_height, delivery)
+                .await?;
+        }
         // Send the block proposal, certificate or timeout request and return a vote.
         let vote = match action {
             CommunicateAction::SubmitBlock { proposal, blob_ids } => {


### PR DESCRIPTION
## Motivation

Chain clients are pessimistic in general. `ChainInfoQueries` are made to ensure that chain clients are up to date with the network's state

## Proposal

In certain situations, like single-owner chains or when running a node service, we can assume that the chain client is up to date and act 'optimistically'.

There is a tradeoff here, lower latency for a low probability of submitting an invalid block incurring additional fees, so the client is configurable.

This PR is still a draft as I suspect there will be some further discussion around design.

## Test Plan

Regressions will be caught by tests.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
