### PR TITLE
RM UserData from Transfer command and node service.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -140,7 +140,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 
 Transfer funds
 
-**Usage:** `linera transfer [OPTIONS] --from <SENDER> --to <RECIPIENT> <AMOUNT>`
+**Usage:** `linera transfer --from <SENDER> --to <RECIPIENT> <AMOUNT>`
 
 ###### **Arguments:**
 
@@ -150,7 +150,6 @@ Transfer funds
 
 * `--from <SENDER>` — Sending chain ID (must be one of our chains)
 * `--to <RECIPIENT>` — Recipient account
-* `--data <USER_DATA>` — User Data (should be a string whose bytes are at most 32 in length)
 
 
 

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -89,7 +89,6 @@ impl BlockTestExt for Block {
             owner,
             recipient,
             amount,
-            user_data: Default::default(),
         })
     }
 

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -17,7 +17,7 @@ use linera_base::{
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName, ValidatorState},
-    system::{OpenChainConfig, Recipient, UserData},
+    system::{OpenChainConfig, Recipient},
     test_utils::{ExpectedCall, MockApplication},
     ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message, MessageKind,
     Operation, ResourceControlPolicy, SystemMessage, SystemOperation, TestExecutionRuntimeContext,
@@ -153,7 +153,6 @@ async fn test_block_size_limit() {
             owner: None,
             recipient: Recipient::root(0),
             amount: Amount::ONE,
-            user_data: UserData::default(),
         });
     let result = chain.execute_block(&invalid_block, time, None).await;
     assert_matches!(

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -35,7 +35,7 @@ use {
     linera_core::data_types::ChainInfoQuery,
     linera_execution::{
         committee::Epoch,
-        system::{OpenChainConfig, Recipient, SystemOperation, UserData, OPEN_CHAIN_MESSAGE_INDEX},
+        system::{OpenChainConfig, Recipient, SystemOperation, OPEN_CHAIN_MESSAGE_INDEX},
         Operation,
     },
     linera_rpc::{

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -694,7 +694,6 @@ where
                     owner: None,
                     recipient: Recipient::chain(next_recipient),
                     amount,
-                    user_data: UserData::default(),
                 }),
             };
             let operations = iter::repeat(operation)

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -301,10 +301,6 @@ pub enum ClientCommand {
 
         /// Amount to transfer
         amount: Amount,
-
-        /// User Data (should be a string whose bytes are at most 32 in length)
-        #[arg(long = "data")]
-        user_data: Option<String>,
     },
 
     /// Open (i.e. activate) a new chain deriving the UID from an existing one.

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -18,10 +18,7 @@ use linera_core::{
     node::CrossChainMessageDelivery,
     test_utils::{MemoryStorageBuilder, NodeProvider, StorageBuilder as _, TestBuilder},
 };
-use linera_execution::{
-    system::{Recipient, UserData},
-    ResourceControlPolicy,
-};
+use linera_execution::{system::Recipient, ResourceControlPolicy};
 use linera_rpc::{
     config::{NetworkProtocol, ValidatorPublicNetworkPreConfig},
     simple::TransportProtocol,
@@ -189,9 +186,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     // Transfer one token to chain 0. The listener should eventually become leader and receive
     // the message.
     let recipient0 = Recipient::chain(chain_id0);
-    client1
-        .transfer(None, Amount::ONE, recipient0, UserData::default())
-        .await?;
+    client1.transfer(None, Amount::ONE, recipient0).await?;
     for i in 0.. {
         client0.synchronize_from_validators().boxed().await?;
         let balance = client0.local_balance().await?;

--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -11,7 +11,7 @@ use linera_core::{
     client,
     test_utils::{MemoryStorageBuilder, NodeProvider, StorageBuilder, TestBuilder},
 };
-use linera_execution::system::{Recipient, UserData};
+use linera_execution::system::Recipient;
 use linera_storage::{
     READ_CERTIFICATE_COUNTER, READ_HASHED_CERTIFICATE_VALUE_COUNTER, WRITE_CERTIFICATE_COUNTER,
     WRITE_HASHED_CERTIFICATE_VALUE_COUNTER,
@@ -63,7 +63,7 @@ where
 
     let account = Account::owner(chain2.chain_id(), owner1);
     let cert = chain1
-        .transfer_to_account(None, amt, account, UserData(None))
+        .transfer_to_account(None, amt, account)
         .await
         .unwrap()
         .unwrap();
@@ -80,7 +80,7 @@ where
 
     let account = Recipient::chain(chain1.chain_id());
     let cert = chain1
-        .claim(owner1, chain2.chain_id(), account, amt, UserData(None))
+        .claim(owner1, chain2.chain_id(), account, amt)
         .await
         .unwrap()
         .unwrap();

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -48,7 +48,7 @@ use linera_chain::{
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
     system::{
-        AdminOperation, OpenChainConfig, Recipient, SystemChannel, SystemOperation, UserData,
+        AdminOperation, OpenChainConfig, Recipient, SystemChannel, SystemOperation,
         CREATE_APPLICATION_MESSAGE_INDEX, OPEN_CHAIN_MESSAGE_INDEX,
     },
     ExecutionError, Message, Operation, Query, Response, SystemExecutionError, SystemMessage,
@@ -1287,20 +1287,18 @@ where
     }
 
     /// Sends money.
-    #[tracing::instrument(level = "trace", skip(user_data))]
+    #[tracing::instrument(level = "trace")]
     pub async fn transfer(
         &self,
         owner: Option<Owner>,
         amount: Amount,
         recipient: Recipient,
-        user_data: UserData,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
         // TODO(#467): check the balance of `owner` before signing any block proposal.
         self.execute_operation(Operation::System(SystemOperation::Transfer {
             owner,
             recipient,
             amount,
-            user_data,
         }))
         .await
     }
@@ -1321,21 +1319,19 @@ where
     }
 
     /// Claims money in a remote chain.
-    #[tracing::instrument(level = "trace", skip(user_data))]
+    #[tracing::instrument(level = "trace")]
     pub async fn claim(
         &self,
         owner: Owner,
         target_id: ChainId,
         recipient: Recipient,
         amount: Amount,
-        user_data: UserData,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
         self.execute_operation(Operation::System(SystemOperation::Claim {
             owner,
             target_id,
             recipient,
             amount,
-            user_data,
         }))
         .await
     }
@@ -2140,28 +2136,25 @@ where
     }
 
     /// Sends tokens to a chain.
-    #[tracing::instrument(level = "trace", skip(user_data))]
+    #[tracing::instrument(level = "trace")]
     pub async fn transfer_to_account(
         &self,
         owner: Option<Owner>,
         amount: Amount,
         account: Account,
-        user_data: UserData,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
-        self.transfer(owner, amount, Recipient::Account(account), user_data)
+        self.transfer(owner, amount, Recipient::Account(account))
             .await
     }
 
     /// Burns tokens.
-    #[tracing::instrument(level = "trace", skip(user_data))]
+    #[tracing::instrument(level = "trace")]
     pub async fn burn(
         &self,
         owner: Option<Owner>,
         amount: Amount,
-        user_data: UserData,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
-        self.transfer(owner, amount, Recipient::Burn, user_data)
-            .await
+        self.transfer(owner, amount, Recipient::Burn).await
     }
 
     /// Attempts to synchronize chains that have sent us messages and populate our local
@@ -2722,19 +2715,17 @@ where
     /// Sends money to a chain.
     /// Do not check balance. (This may block the client)
     /// Do not confirm the transaction.
-    #[tracing::instrument(level = "trace", skip(user_data))]
+    #[tracing::instrument(level = "trace")]
     pub async fn transfer_to_account_unsafe_unconfirmed(
         &self,
         owner: Option<Owner>,
         amount: Amount,
         account: Account,
-        user_data: UserData,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
         self.execute_operation(Operation::System(SystemOperation::Transfer {
             owner,
             recipient: Recipient::Account(account),
             amount,
-            user_data,
         }))
         .await
     }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -22,7 +22,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Committee, Epoch},
-    system::{Recipient, SystemOperation, UserData},
+    system::{Recipient, SystemOperation},
     ExecutionError, Message, MessageKind, Operation, ResourceControlPolicy, SystemExecutionError,
     SystemMessage, SystemQuery, SystemResponse,
 };
@@ -104,7 +104,6 @@ where
                 None,
                 Amount::from_tokens(3),
                 Account::chain(ChainId::root(2)),
-                UserData(Some(*b"I paid 0.001 to pay you these 3!")),
             )
             .await
             .unwrap()
@@ -160,7 +159,6 @@ where
             None,
             Amount::from_tokens(3),
             Account::owner(ChainId::root(2), owner),
-            UserData(None),
         )
         .await
         .unwrap()
@@ -170,7 +168,6 @@ where
             None,
             Amount::from_millis(100),
             Account::owner(ChainId::root(2), friend),
-            UserData(None),
         )
         .await
         .unwrap()
@@ -221,7 +218,6 @@ where
             ChainId::root(2),
             Recipient::root(1),
             Amount::from_tokens(5),
-            UserData(None),
         )
         .await
         .unwrap();
@@ -232,7 +228,6 @@ where
             ChainId::root(2),
             Recipient::root(1),
             Amount::from_tokens(2),
-            UserData(None),
         )
         .await
         .unwrap()
@@ -307,7 +302,6 @@ where
             None,
             Amount::from_tokens(3),
             Account::chain(ChainId::root(2)),
-            UserData::default(),
         )
         .await
         .unwrap();
@@ -363,7 +357,6 @@ where
                 None,
                 Amount::from_tokens(3),
                 Account::chain(ChainId::root(2)),
-                UserData::default()
             )
             .await,
         Err(ChainClientError::CannotFindKeyForChain(_))
@@ -413,7 +406,6 @@ where
             None,
             Amount::from_tokens(2),
             Account::chain(ChainId::root(2)),
-            UserData::default(),
         )
         .await
         .unwrap();
@@ -442,12 +434,7 @@ where
     // We need at least three validators for making a transfer.
     builder.set_fault_type([0, 1], FaultType::Offline).await;
     let result = client
-        .transfer_to_account(
-            None,
-            Amount::ONE,
-            Account::chain(ChainId::root(3)),
-            UserData::default(),
-        )
+        .transfer_to_account(None, Amount::ONE, Account::chain(ChainId::root(3)))
         .await;
     assert_matches!(
         result,
@@ -459,12 +446,7 @@ where
     builder.set_fault_type([2, 3], FaultType::Offline).await;
     assert_matches!(
         sender
-            .transfer_to_account(
-                None,
-                Amount::ONE,
-                Account::chain(ChainId::root(3)),
-                UserData::default(),
-            )
+            .transfer_to_account(None, Amount::ONE, Account::chain(ChainId::root(3)),)
             .await,
         Err(ChainClientError::CommunicationError(
             CommunicationError::Trusted(ClientIoError { .. })
@@ -484,12 +466,7 @@ where
     );
     client.clear_pending_block();
     client
-        .transfer_to_account(
-            None,
-            Amount::ONE,
-            Account::chain(ChainId::root(3)),
-            UserData::default(),
-        )
+        .transfer_to_account(None, Amount::ONE, Account::chain(ChainId::root(3)))
         .await
         .unwrap()
         .unwrap();
@@ -500,12 +477,7 @@ where
     assert_eq!(sender.local_balance().await.unwrap(), Amount::ONE);
     sender.clear_pending_block();
     sender
-        .transfer_to_account(
-            None,
-            Amount::ONE,
-            Account::chain(ChainId::root(2)),
-            UserData::default(),
-        )
+        .transfer_to_account(None, Amount::ONE, Account::chain(ChainId::root(2)))
         .await
         .unwrap();
 
@@ -592,12 +564,7 @@ where
     });
     // Transfer before creating the chain. The validators will ignore the cross-chain messages.
     sender
-        .transfer_to_account(
-            None,
-            Amount::from_tokens(2),
-            Account::chain(new_id),
-            UserData::default(),
-        )
+        .transfer_to_account(None, Amount::from_tokens(2), Account::chain(new_id))
         .await
         .unwrap();
     // Open the new chain.
@@ -643,12 +610,7 @@ where
     // Make another block on top of the one that sent the two tokens, so that the validators
     // process the cross-chain messages.
     let certificate2 = sender
-        .transfer_to_account(
-            None,
-            Amount::from_tokens(1),
-            Account::chain(new_id),
-            UserData::default(),
-        )
+        .transfer_to_account(None, Amount::from_tokens(1), Account::chain(new_id))
         .await
         .unwrap()
         .unwrap();
@@ -665,7 +627,6 @@ where
             None,
             Amount::from_tokens(3),
             Account::chain(ChainId::root(3)),
-            UserData::default(),
         )
         .await
         .unwrap();
@@ -698,12 +659,7 @@ where
     });
     // Transfer before creating the chain.
     sender
-        .transfer_to_account(
-            None,
-            Amount::from_tokens(3),
-            Account::chain(new_id),
-            UserData::default(),
-        )
+        .transfer_to_account(None, Amount::from_tokens(3), Account::chain(new_id))
         .await
         .unwrap();
     // Open the new chain.
@@ -750,7 +706,6 @@ where
             None,
             Amount::from_tokens(3),
             Account::chain(ChainId::root(3)),
-            UserData::default(),
         )
         .await;
     assert_matches!(
@@ -796,12 +751,7 @@ where
     let new_id = ChainId::child(message_id);
     // Transfer after creating the chain.
     let transfer_certificate = sender
-        .transfer_to_account(
-            None,
-            Amount::from_tokens(3),
-            Account::chain(new_id),
-            UserData::default(),
-        )
+        .transfer_to_account(None, Amount::from_tokens(3), Account::chain(new_id))
         .await
         .unwrap()
         .unwrap();
@@ -831,7 +781,6 @@ where
             None,
             Amount::from_tokens(3),
             Account::chain(ChainId::root(3)),
-            UserData::default(),
         )
         .await
         .unwrap();
@@ -884,7 +833,6 @@ where
             None,
             Amount::from_tokens(3),
             Account::chain(ChainId::root(2)),
-            UserData::default(),
         )
         .await;
     assert!(
@@ -904,7 +852,6 @@ where
             None,
             Amount::from_tokens(3),
             Account::chain(ChainId::root(1)),
-            UserData::default(),
         )
         .await
         .unwrap()
@@ -961,7 +908,6 @@ where
             None,
             Amount::from_tokens(3),
             Account::chain(ChainId::root(2)),
-            UserData(Some(*b"hello...........hello...........")),
         )
         .await;
     assert_matches!(
@@ -1013,7 +959,6 @@ where
             None,
             Amount::from_tokens(3),
             Account::chain(client2.chain_id),
-            UserData::default(),
         )
         .await
         .unwrap()
@@ -1054,12 +999,7 @@ where
     // Process the inbox and send back some money.
     assert_eq!(client2.next_block_height(), BlockHeight::ZERO);
     client2
-        .transfer_to_account(
-            None,
-            Amount::ONE,
-            Account::chain(client1.chain_id),
-            UserData::default(),
-        )
+        .transfer_to_account(None, Amount::ONE, Account::chain(client1.chain_id))
         .await
         .unwrap();
     assert_eq!(client2.next_block_height(), BlockHeight::from(1));
@@ -1106,7 +1046,6 @@ where
             None,
             Amount::from_tokens(2),
             Account::chain(client2.chain_id),
-            UserData::default(),
         )
         .await
         .unwrap()
@@ -1159,21 +1098,11 @@ where
     // Transferring funds from client1 to client2.
     // Confirming to a quorum of nodes only at the end.
     client1
-        .transfer_to_account_unsafe_unconfirmed(
-            None,
-            Amount::ONE,
-            Account::chain(client2.chain_id),
-            UserData::default(),
-        )
+        .transfer_to_account_unsafe_unconfirmed(None, Amount::ONE, Account::chain(client2.chain_id))
         .await
         .unwrap();
     client1
-        .transfer_to_account_unsafe_unconfirmed(
-            None,
-            Amount::ONE,
-            Account::chain(client2.chain_id),
-            UserData::default(),
-        )
+        .transfer_to_account_unsafe_unconfirmed(None, Amount::ONE, Account::chain(client2.chain_id))
         .await
         .unwrap();
     client1
@@ -1194,7 +1123,6 @@ where
             None,
             Amount::from_tokens(2),
             Account::chain(client3.chain_id),
-            UserData::default(),
         )
         .await,
         Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), ChainExecutionContext::Operation(_)))
@@ -1213,7 +1141,6 @@ where
             None,
             Amount::from_tokens(2),
             Account::chain(client3.chain_id),
-            UserData::default(),
         )
         .await
         .unwrap()
@@ -1293,18 +1220,12 @@ where
             None,
             Amount::from_tokens(2),
             Account::chain(ChainId::root(1)),
-            UserData(None),
         )
         .await
         .unwrap()
         .unwrap();
     admin
-        .transfer_to_account(
-            None,
-            Amount::ONE,
-            Account::chain(ChainId::root(1)),
-            UserData(None),
-        )
+        .transfer_to_account(None, Amount::ONE, Account::chain(ChainId::root(1)))
         .await
         .unwrap()
         .unwrap();
@@ -1342,7 +1263,6 @@ where
             None,
             Amount::from_tokens(2),
             Account::chain(ChainId::root(0)),
-            UserData(None),
         )
         .await
         .unwrap()
@@ -1363,12 +1283,7 @@ where
 
     // Try again to make a transfer back to the admin chain.
     let cert = user
-        .transfer_to_account(
-            None,
-            Amount::ONE,
-            Account::chain(ChainId::root(0)),
-            UserData(None),
-        )
+        .transfer_to_account(None, Amount::ONE, Account::chain(ChainId::root(0)))
         .await
         .unwrap()
         .unwrap();
@@ -1400,7 +1315,6 @@ where
             None,
             Amount::from_tokens(4),
             Account::chain(ChainId::root(2)),
-            UserData(Some(*b"I'm giving away all of my money!")),
         )
         .await;
 
@@ -1418,7 +1332,6 @@ where
             None,
             Amount::from_tokens(3),
             Account::chain(ChainId::root(2)),
-            UserData(Some(*b"I'm giving away all of my money!")),
         )
         .await;
     // TODO(#1649): Make this code nicer.
@@ -1590,7 +1503,7 @@ where
 
     client2_b.synchronize_from_validators().await.unwrap();
     let bt_certificate = client2_b
-        .burn(None, Amount::from_tokens(1), UserData::default())
+        .burn(None, Amount::from_tokens(1))
         .await
         .unwrap()
         .unwrap();
@@ -1610,7 +1523,6 @@ where
             owner: None,
             recipient: Recipient::Burn,
             amount: Amount::from_tokens(1),
-            user_data: UserData::default(),
         })));
 
     // Block before that should be b0
@@ -1734,7 +1646,7 @@ where
     builder.set_fault_type([0, 1, 3], FaultType::Honest).await;
 
     let bt_certificate = client2_b
-        .burn(None, Amount::from_tokens(1), UserData::default())
+        .burn(None, Amount::from_tokens(1))
         .await
         .unwrap()
         .unwrap();
@@ -1754,7 +1666,6 @@ where
             owner: None,
             recipient: Recipient::Burn,
             amount: Amount::from_tokens(1),
-            user_data: UserData::default(),
         })));
 
     // Previous should be the `ChangeOwnership` operation, as the blob operations shouldn't be executed here.
@@ -2012,7 +1923,7 @@ where
 
     client3_c.synchronize_from_validators().await.unwrap();
     let bt_certificate = client3_c
-        .burn(None, Amount::from_tokens(1), UserData::default())
+        .burn(None, Amount::from_tokens(1))
         .await
         .unwrap()
         .unwrap();
@@ -2032,7 +1943,6 @@ where
             owner: None,
             recipient: Recipient::Burn,
             amount: Amount::from_tokens(1),
-            user_data: UserData::default(),
         })));
 
     // Block before that should be b1
@@ -2136,7 +2046,7 @@ where
 
     // The other owner is leader now. Trying to submit a block should return `WaitForTimeout`.
     let result = client
-        .transfer(None, Amount::ONE, Recipient::root(2), UserData::default())
+        .transfer(None, Amount::ONE, Recipient::root(2))
         .await
         .unwrap();
     let timeout = match result {
@@ -2163,7 +2073,7 @@ where
 
     // Now we are the leader, and the transfer should succeed.
     let _certificate = client
-        .transfer(None, Amount::ONE, Recipient::root(2), UserData::default())
+        .transfer(None, Amount::ONE, Recipient::root(2))
         .await
         .unwrap()
         .unwrap();
@@ -2225,9 +2135,7 @@ where
     builder
         .set_fault_type([2], FaultType::OfflineWithInfo)
         .await;
-    let result = client0
-        .burn(None, Amount::from_tokens(3), UserData::default())
-        .await;
+    let result = client0.burn(None, Amount::from_tokens(3)).await;
     assert!(result.is_err());
 
     // Client 1 thinks it is madness to burn 3 tokens! They want to publish a blob instead.
@@ -2264,10 +2172,7 @@ where
 
     // Client 0 now only tries to burn 1 token. Before that, they automatically finalize the
     // pending block, which publishes the blob, leaving 10 - 1 = 9.
-    client0
-        .burn(None, Amount::from_tokens(1), UserData::default())
-        .await
-        .unwrap();
+    client0.burn(None, Amount::from_tokens(1)).await.unwrap();
     client0.synchronize_from_validators().await.unwrap();
     client0.process_inbox().await.unwrap();
     assert_eq!(
@@ -2277,10 +2182,7 @@ where
     assert!(client0.pending_block().is_none());
 
     // Burn another token so Client 1 sees that the blob is already published
-    client1
-        .burn(None, Amount::from_tokens(1), UserData::default())
-        .await
-        .unwrap();
+    client1.burn(None, Amount::from_tokens(1)).await.unwrap();
     client1.synchronize_from_validators().await.unwrap();
     client1.process_inbox().await.unwrap();
     assert_eq!(
@@ -2313,9 +2215,7 @@ where
     builder
         .set_fault_type([2], FaultType::OfflineWithInfo)
         .await;
-    let result = client
-        .burn(None, Amount::from_tokens(3), UserData::default())
-        .await;
+    let result = client.burn(None, Amount::from_tokens(3)).await;
     assert!(result.is_err());
 
     // Now three validators are online again.
@@ -2323,10 +2223,7 @@ where
 
     // The client tries to burn another token. Before that, they automatically finalize the
     // pending block, which burns 3 tokens, leaving 10 - 3 - 1 = 6.
-    client
-        .burn(None, Amount::ONE, UserData::default())
-        .await
-        .unwrap();
+    client.burn(None, Amount::ONE).await.unwrap();
     client.synchronize_from_validators().await.unwrap();
     client.process_inbox().await.unwrap();
     assert_eq!(
@@ -2382,9 +2279,7 @@ where
         .set_fault_type([1, 2], FaultType::DontProcessValidated)
         .await;
     builder.set_fault_type([3], FaultType::Offline).await;
-    let result = client0
-        .burn(None, Amount::from_tokens(3), UserData::default())
-        .await;
+    let result = client0.burn(None, Amount::from_tokens(3)).await;
     assert!(result.is_err());
     let manager = client0
         .chain_info_with_manager_values()
@@ -2421,9 +2316,7 @@ where
     assert!(manager.requested_proposed.is_some());
     assert!(manager.requested_locked.is_none());
     assert_eq!(manager.current_round, Round::MultiLeader(0));
-    let result = client1
-        .burn(None, Amount::from_tokens(2), UserData::default())
-        .await;
+    let result = client1.burn(None, Amount::from_tokens(2)).await;
     assert!(result.is_err());
 
     // Finally, three validators are online and honest again. Client 1 realizes there has been a
@@ -2442,10 +2335,7 @@ where
     );
     assert_eq!(manager.current_round, Round::MultiLeader(1));
     assert!(client1.pending_block().is_some());
-    client1
-        .burn(None, Amount::from_tokens(4), UserData::default())
-        .await
-        .unwrap();
+    client1.burn(None, Amount::from_tokens(4)).await.unwrap();
 
     // Burning 3 and 4 tokens got finalized; the pending 2 tokens got skipped.
     client0.synchronize_from_validators().await.unwrap();
@@ -2474,7 +2364,7 @@ where
         .await?;
     let recipient = Recipient::chain(ChainId::root(2));
     let cert = sender
-        .transfer(None, Amount::ONE, recipient, UserData(None))
+        .transfer(None, Amount::ONE, recipient)
         .await
         .unwrap()
         .unwrap();
@@ -2549,12 +2439,7 @@ where
 
     // Send a message from chain 2 to chain 3.
     client2
-        .transfer(
-            None,
-            Amount::from_millis(1),
-            Recipient::chain(chain_id3),
-            Default::default(),
-        )
+        .transfer(None, Amount::from_millis(1), Recipient::chain(chain_id3))
         .await
         .unwrap()
         .unwrap();

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -22,7 +22,7 @@ use prometheus::HistogramVec;
 use reqwest::{header::CONTENT_TYPE, Client};
 
 use crate::{
-    system::{OpenChainConfig, Recipient, UserData},
+    system::{OpenChainConfig, Recipient},
     util::RespondExt,
     ExecutionError, ExecutionRuntimeContext, ExecutionStateView, RawExecutionOutcome,
     RawOutgoingMessage, SystemExecutionError, SystemMessage, UserApplicationDescription,
@@ -160,7 +160,6 @@ where
                         source.chain_id,
                         Recipient::Account(destination),
                         amount,
-                        UserData::default(),
                     )
                     .await?;
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -117,7 +117,6 @@ pub enum SystemOperation {
         owner: Option<Owner>,
         recipient: Recipient,
         amount: Amount,
-        user_data: UserData,
     },
     /// Claims `amount` units of value from the given owner's account in the remote
     /// `target` chain. Depending on its configuration, the `target` chain may refuse to
@@ -127,7 +126,6 @@ pub enum SystemOperation {
         target_id: ChainId,
         recipient: Recipient,
         amount: Amount,
-        user_data: UserData,
     },
     /// Creates (or activates) a new chain.
     /// This will automatically subscribe to the future committees created by `admin_id`.
@@ -214,7 +212,6 @@ pub enum SystemMessage {
         owner: Owner,
         amount: Amount,
         recipient: Recipient,
-        user_data: UserData,
     },
     /// Creates (or activates) a new chain.
     OpenChain(OpenChainConfig),
@@ -495,7 +492,6 @@ where
                 target_id,
                 recipient,
                 amount,
-                user_data,
             } => {
                 let message = self
                     .claim(
@@ -504,7 +500,6 @@ where
                         target_id,
                         recipient,
                         amount,
-                        user_data,
                     )
                     .await?;
 
@@ -724,7 +719,6 @@ where
         target_id: ChainId,
         recipient: Recipient,
         amount: Amount,
-        user_data: UserData,
     ) -> Result<RawOutgoingMessage<SystemMessage, Amount>, SystemExecutionError> {
         ensure!(
             authenticated_signer.as_ref() == Some(&owner),
@@ -743,7 +737,6 @@ where
             message: SystemMessage::Withdraw {
                 amount,
                 owner,
-                user_data,
                 recipient,
             },
         })
@@ -779,7 +772,6 @@ where
             Withdraw {
                 amount,
                 owner,
-                user_data: _,
                 recipient,
             } => {
                 ensure!(

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -9,11 +9,9 @@ use linera_base::{
     identifiers::{Account, ChainDescription, ChainId, MessageId},
 };
 use linera_execution::{
-    system::{Recipient, UserData},
-    test_utils::SystemExecutionState,
-    ExecutionOutcome, Message, MessageContext, Operation, OperationContext, Query, QueryContext,
-    RawExecutionOutcome, ResourceController, Response, SystemMessage, SystemOperation, SystemQuery,
-    SystemResponse, TransactionTracker,
+    system::Recipient, test_utils::SystemExecutionState, ExecutionOutcome, Message, MessageContext,
+    Operation, OperationContext, Query, QueryContext, RawExecutionOutcome, ResourceController,
+    Response, SystemMessage, SystemOperation, SystemQuery, SystemResponse, TransactionTracker,
 };
 
 #[tokio::test]
@@ -26,7 +24,6 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         owner: None,
         amount: Amount::from_tokens(4),
         recipient: Recipient::Burn,
-        user_data: UserData::default(),
     };
     let context = OperationContext {
         chain_id: ChainId::root(0),

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -872,8 +872,6 @@ SystemMessage:
               TYPENAME: Amount
           - recipient:
               TYPENAME: Recipient
-          - user_data:
-              TYPENAME: UserData
     2:
       OpenChain:
         NEWTYPE:
@@ -928,8 +926,6 @@ SystemOperation:
               TYPENAME: Recipient
           - amount:
               TYPENAME: Amount
-          - user_data:
-              TYPENAME: UserData
     1:
       Claim:
         STRUCT:
@@ -941,8 +937,6 @@ SystemOperation:
               TYPENAME: Recipient
           - amount:
               TYPENAME: Amount
-          - user_data:
-              TYPENAME: UserData
     2:
       OpenChain:
         NEWTYPE:
@@ -1042,12 +1036,6 @@ UserApplicationDescription:
     - required_application_ids:
         SEQ:
           TYPENAME: ApplicationId
-UserData:
-  NEWTYPESTRUCT:
-    OPTION:
-      TUPLEARRAY:
-        CONTENT: U8
-        SIZE: 32
 ValidatorName:
   NEWTYPESTRUCT:
     TYPENAME: PublicKey

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -16,7 +16,7 @@ use linera_chain::data_types::{
     MessageAction, Origin, SignatureAggregator,
 };
 use linera_execution::{
-    system::{Recipient, SystemChannel, SystemOperation, UserData},
+    system::{Recipient, SystemChannel, SystemOperation},
     Operation,
 };
 
@@ -91,7 +91,6 @@ impl BlockBuilder {
             owner: sender,
             recipient,
             amount,
-            user_data: UserData(None),
         })
     }
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -585,13 +585,13 @@ type MutationRoot {
 	Transfers `amount` units of value from the given owner's account to the recipient.
 	If no owner is given, try to take the units out of the unattributed account.
 	"""
-	transfer(chainId: ChainId!, owner: Owner, recipient: Recipient!, amount: Amount!, userData: UserData): CryptoHash!
+	transfer(chainId: ChainId!, owner: Owner, recipient: Recipient!, amount: Amount!): CryptoHash!
 	"""
 	Claims `amount` units of value from the given owner's account in the remote
 	`target` chain. Depending on its configuration, the `target` chain may refuse to
 	process the message.
 	"""
-	claim(chainId: ChainId!, owner: Owner!, targetId: ChainId!, recipient: Recipient!, amount: Amount!, userData: UserData): CryptoHash!
+	claim(chainId: ChainId!, owner: Owner!, targetId: ChainId!, recipient: Recipient!, amount: Amount!): CryptoHash!
 	"""
 	Test if a data blob is readable from a transaction in the current chain.
 	"""
@@ -997,11 +997,6 @@ type TimestampedBundleInInbox {
 Description of the necessary information to run a user application
 """
 scalar UserApplicationDescription
-
-"""
-Optional user message attached to a transfer
-"""
-scalar UserData
 
 """
 The version info of a build of Linera.

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -40,7 +40,6 @@ use linera_core::{
 };
 use linera_execution::{
     committee::{Committee, ValidatorName, ValidatorState},
-    system::UserData,
     Message, ResourceControlPolicy, SystemMessage,
 };
 use linera_service::{
@@ -117,15 +116,7 @@ impl Runnable for Job {
                 sender,
                 recipient,
                 amount,
-                user_data,
             } => {
-                let data = match UserData::from_option_string(user_data) {
-                    Ok(data) => data,
-                    Err(bytes_len) => bail!(
-                        "Failed to parse user data ({} bytes) exceeding max length (32 bytes)",
-                        bytes_len
-                    ),
-                };
                 let chain_client = context.make_chain_client(sender.chain_id);
                 info!(
                     "Starting transfer of {} native tokens from {} to {}",
@@ -135,10 +126,9 @@ impl Runnable for Job {
                 let certificate = context
                     .apply_client_command(&chain_client, |chain_client| {
                         let chain_client = chain_client.clone();
-                        let user_data = data.clone();
                         async move {
                             chain_client
-                                .transfer_to_account(sender.owner, amount, recipient, user_data)
+                                .transfer_to_account(sender.owner, amount, recipient)
                                 .await
                         }
                     })

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -40,7 +40,7 @@ use linera_core::{
 };
 use linera_execution::{
     committee::{Committee, Epoch},
-    system::{AdminOperation, Recipient, SystemChannel, UserData},
+    system::{AdminOperation, Recipient, SystemChannel},
     Operation, Query, Response, SystemOperation,
 };
 use linera_storage::Storage;
@@ -285,18 +285,14 @@ where
         owner: Option<Owner>,
         recipient: Recipient,
         amount: Amount,
-        user_data: Option<UserData>,
     ) -> Result<CryptoHash, Error> {
-        self.apply_client_command(&chain_id, move |client| {
-            let user_data = user_data.clone();
-            async move {
-                let result = client
-                    .transfer(owner, amount, recipient, user_data.unwrap_or_default())
-                    .await
-                    .map_err(Error::from)
-                    .map(|outcome| outcome.map(|certificate| certificate.hash()));
-                (result, client)
-            }
+        self.apply_client_command(&chain_id, move |client| async move {
+            let result = client
+                .transfer(owner, amount, recipient)
+                .await
+                .map_err(Error::from)
+                .map(|outcome| outcome.map(|certificate| certificate.hash()));
+            (result, client)
         })
         .await
     }
@@ -304,7 +300,6 @@ where
     /// Claims `amount` units of value from the given owner's account in the remote
     /// `target` chain. Depending on its configuration, the `target` chain may refuse to
     /// process the message.
-    #[expect(clippy::too_many_arguments)]
     async fn claim(
         &self,
         chain_id: ChainId,
@@ -312,24 +307,14 @@ where
         target_id: ChainId,
         recipient: Recipient,
         amount: Amount,
-        user_data: Option<UserData>,
     ) -> Result<CryptoHash, Error> {
-        self.apply_client_command(&chain_id, move |client| {
-            let user_data = user_data.clone();
-            async move {
-                let result = client
-                    .claim(
-                        owner,
-                        target_id,
-                        recipient,
-                        amount,
-                        user_data.unwrap_or_default(),
-                    )
-                    .await
-                    .map_err(Error::from)
-                    .map(|outcome| outcome.map(|certificate| certificate.hash()));
-                (result, client)
-            }
+        self.apply_client_command(&chain_id, move |client| async move {
+            let result = client
+                .claim(owner, target_id, recipient, amount)
+                .await
+                .map_err(Error::from)
+                .map(|outcome| outcome.map(|certificate| certificate.hash()));
+            (result, client)
         })
         .await
     }


### PR DESCRIPTION
## Motivation

As described in the [issue](https://github.com/linera-io/linera-protocol/issues/2554), we no longer need `UserData` argument. 

Closes https://github.com/linera-io/linera-protocol/issues/2554 .
## Proposal

Remove `UserData` arg from `Transfer`/`Claim` and `Burn` commands.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
