### PR TITLE
`linera-execution`: remove unnecessary `Arc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4424,6 +4424,7 @@ dependencies = [
  "custom_debug_derive",
  "dashmap 5.5.3",
  "derive_more 1.0.0",
+ "dyn-clone",
  "futures",
  "linera-base",
  "linera-execution",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ custom_debug_derive = "0.6.1"
 dashmap = "5.5.3"
 derive_more = "1.0.0"
 dirs = "5.0.1"
+dyn-clone = "1.0.17"
 ed25519-dalek = { version = "2.1.1", features = ["batch", "serde"] }
 either = "1.10.0"
 ethers = { version = "2.0.14", features = ["solc"] }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3438,6 +3438,7 @@ dependencies = [
  "custom_debug_derive",
  "dashmap 5.5.3",
  "derive_more 1.0.0",
+ "dyn-clone",
  "futures",
  "linera-base",
  "linera-views",

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::large_futures)]
 
-use std::{collections::BTreeMap, iter, sync::Arc};
+use std::{collections::BTreeMap, iter};
 
 use assert_matches::assert_matches;
 use linera_base::{
@@ -184,11 +184,11 @@ async fn test_application_permissions() {
     // Create a mock application.
     let app_description = make_app_description();
     let application_id = ApplicationId::from(&app_description);
-    let application = Arc::new(MockApplication::default());
+    let application = MockApplication::default();
     let extra = &chain.context().extra();
     extra
         .user_contracts()
-        .insert(application_id, application.clone());
+        .insert(application_id, application.clone().into());
     let contract_blob = Blob::new_contract_bytecode(Bytecode::new(b"contract".into()).compress());
     extra.add_blob(contract_blob);
     let service_blob = Blob::new_service_bytecode(Bytecode::new(b"service".into()).compress());

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::large_futures)]
 #![cfg(any(feature = "wasmer", feature = "wasmtime"))]
 
-use std::{borrow::Cow, sync::Arc};
+use std::borrow::Cow;
 
 use linera_base::{
     crypto::KeyPair,
@@ -125,7 +125,7 @@ where
     let service_blob_hash = service_blob_id.hash;
 
     let bytecode_id = BytecodeId::new(contract_blob_hash, service_blob_hash);
-    let contract = Arc::new(WasmContractModule::new(contract_bytecode, wasm_runtime).await?);
+    let contract = WasmContractModule::new(contract_bytecode, wasm_runtime).await?;
 
     // Publish some bytecode.
     let publish_operation = SystemOperation::PublishBytecode { bytecode_id };
@@ -211,7 +211,7 @@ where
     let mut creator_state = creator_system_state.into_view().await;
     creator_state
         .simulate_instantiation(
-            contract,
+            contract.into(),
             Timestamp::from(2),
             application_description,
             initial_value_bytes.clone(),

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -43,6 +43,7 @@ clap.workspace = true
 custom_debug_derive.workspace = true
 dashmap.workspace = true
 derive_more = { workspace = true, features = ["display"] }
+dyn-clone.workspace = true
 futures.workspace = true
 linera-base.workspace = true
 linera-views.workspace = true

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -75,10 +75,10 @@ where
     for (id, mock_application) in &mock_applications {
         extra
             .user_contracts()
-            .insert(*id, Arc::new(mock_application.clone()));
+            .insert(*id, mock_application.clone().into());
         extra
             .user_services()
-            .insert(*id, Arc::new(mock_application.clone()));
+            .insert(*id, mock_application.clone().into());
     }
 
     Ok(mock_applications.into_iter())

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -53,14 +53,14 @@ async fn test_fuel_for_counter_wasm_application(
     view.context()
         .extra()
         .user_contracts()
-        .insert(app_id, Arc::new(contract));
+        .insert(app_id, contract.into());
 
     let service =
         WasmServiceModule::from_file("tests/fixtures/counter_service.wasm", wasm_runtime).await?;
     view.context()
         .extra()
         .user_services()
-        .insert(app_id, Arc::new(service));
+        .insert(app_id, service.into());
 
     let app_id = app_id.with_abi::<CounterAbi>();
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -301,9 +301,9 @@ pub trait Storage: Sized {
         let contract_bytecode =
             linera_base::task::spawn_blocking(move || compressed_contract_bytecode.decompress())
                 .await??;
-        Ok(Arc::new(
-            WasmContractModule::new(contract_bytecode, wasm_runtime).await?,
-        ))
+        Ok(WasmContractModule::new(contract_bytecode, wasm_runtime)
+            .await?
+            .into())
     }
 
     #[cfg(not(with_wasm_runtime))]
@@ -340,9 +340,9 @@ pub trait Storage: Sized {
         let service_bytecode =
             linera_base::task::spawn_blocking(move || compressed_service_bytecode.decompress())
                 .await??;
-        Ok(Arc::new(
-            WasmServiceModule::new(service_bytecode, wasm_runtime).await?,
-        ))
+        Ok(WasmServiceModule::new(service_bytecode, wasm_runtime)
+            .await?
+            .into())
     }
 
     #[cfg(not(with_wasm_runtime))]


### PR DESCRIPTION
## Motivation

We are `Arc`ing a type that is already internally an `Arc` and therefore has cheap `Clone`.

<!--
Briefly describe the goal(s) of this PR.
-->

## Proposal

Remove the `Arc` (using `dyn-clone` to forward cloning to the boxed trait objects instead). 

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->

## Test Plan

CI.

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
