### PR TITLE
Make all_messages_delivered_up_to take tracked_chains into account.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -427,7 +427,7 @@ where
                 .checked_sub(1)
                 .expect("message counter should not underflow");
             if *counter == 0 {
-                // Important for the test in `all_messages_delivered_up_to`.
+                // Important for the test in `ChainWorkerState::all_messages_delivered_up_to`.
                 self.outbox_counters.get_mut().remove(&update);
             }
         }
@@ -435,21 +435,6 @@ where
             self.outboxes.remove_entry(target)?;
         }
         Ok(true)
-    }
-
-    /// Returns true if there are no more outgoing messages in flight up to the given
-    /// block height.
-    pub fn all_messages_delivered_up_to(&mut self, height: BlockHeight) -> bool {
-        tracing::debug!(
-            "Messages left in {:.8}'s outbox: {:?}",
-            self.chain_id(),
-            self.outbox_counters.get()
-        );
-        if let Some((key, _)) = self.outbox_counters.get().first_key_value() {
-            key > &height
-        } else {
-            true
-        }
     }
 
     /// Invariant for the states of active chains.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -427,7 +427,7 @@ where
                 .checked_sub(1)
                 .expect("message counter should not underflow");
             if *counter == 0 {
-                // Important for the test in `ChainWorkerState::all_messages_delivered_up_to`.
+                // Important for the test in `all_messages_delivered_up_to`.
                 self.outbox_counters.get_mut().remove(&update);
             }
         }
@@ -435,6 +435,21 @@ where
             self.outboxes.remove_entry(target)?;
         }
         Ok(true)
+    }
+
+    /// Returns true if there are no more outgoing messages in flight up to the given
+    /// block height.
+    pub fn all_messages_delivered_up_to(&mut self, height: BlockHeight) -> bool {
+        tracing::debug!(
+            "Messages left in {:.8}'s outbox: {:?}",
+            self.chain_id(),
+            self.outbox_counters.get()
+        );
+        if let Some((key, _)) = self.outbox_counters.get().first_key_value() {
+            key > &height
+        } else {
+            true
+        }
     }
 
     /// Invariant for the states of active chains.

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -448,7 +448,7 @@ where
                 .chain
                 .mark_messages_as_received(&target, height)
                 .await?
-                && self.state.chain.all_messages_delivered_up_to(height);
+                && self.state.all_messages_delivered_up_to(height).await?;
 
             if fully_delivered && height > height_with_fully_delivered_messages {
                 height_with_fully_delivered_messages = height;

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -448,7 +448,10 @@ where
                 .chain
                 .mark_messages_as_received(&target, height)
                 .await?
-                && self.state.all_messages_delivered_up_to(height).await?;
+                && self
+                    .state
+                    .all_messages_to_tracked_chains_delivered_up_to(height)
+                    .await?;
 
             if fully_delivered && height > height_with_fully_delivered_messages {
                 height_with_fully_delivered_messages = height;

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -426,6 +426,44 @@ where
         Ok(actions)
     }
 
+    /// Returns true if there are no more outgoing messages in flight up to the given
+    /// block height.
+    pub async fn all_messages_delivered_up_to(
+        &mut self,
+        height: BlockHeight,
+    ) -> Result<bool, WorkerError> {
+        tracing::debug!(
+            "Messages left in {:.8}'s outbox: {:?}",
+            self.chain_id(),
+            self.chain.outbox_counters.get()
+        );
+        let Some((key, _)) = self.chain.outbox_counters.get().first_key_value() else {
+            return Ok(true);
+        };
+        if key > &height {
+            return Ok(true);
+        }
+        if let Some(tracked_chains) = self.tracked_chains.as_ref() {
+            let mut targets = self.chain.outboxes.indices().await?;
+            {
+                let tracked_chains = tracked_chains
+                    .read()
+                    .expect("Panics should not happen while holding a lock to `tracked_chains`");
+                targets.retain(|target| tracked_chains.contains(&target.recipient));
+            }
+            let outboxes = self.chain.outboxes.try_load_entries(&targets).await?;
+            for (_, outbox) in targets.into_iter().zip(outboxes) {
+                let outbox =
+                    outbox.expect("Only existing outboxes should be referenced by `indices`");
+                let front = outbox.queue.front().await?;
+                if front.is_some_and(|key| key <= height) {
+                    return Ok(false);
+                }
+            }
+        }
+        Ok(true)
+    }
+
     /// Creates an `UpdateRecipient` request that informs the `recipient` about new
     /// cross-chain messages from this chain.
     async fn create_cross_chain_request(


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/2035 introduced a list of "tracked chains": In the local node, messages to non-tracked chains are not delivered and stay in the outbox.

However, `all_messages_delivered_up_to` doesn't take that into account yet, so if a chain is sending a message to a non-tracked chain, it would never return `true`, and if `wait_for_outgoing_messages` is `true`, `handle_certificate` could wait forever.

## Proposal

Return `true` from `all_messages_delivered_up_to` if all messages to _tracked_ chains have been delivered, ignoring remaining outbox entries for untracked chains.

TBD: This makes `wait_for_outgoing_messages` async and potentially much slower. We could instead add `tracked_outbox_counters` that count only messages to tracked chains. This would need to be updated when the set of tracked chains changes, however.

## Test Plan

TBD: I should add a regression test for this.

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,

## Links

- Tracked chains PR: https://github.com/linera-io/linera-protocol/pull/2035
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
