### PR TITLE
Run tests without --nocapture in CI.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Run end-to-end tests
       run: |
         cargo run --release -p linera-storage-service -- memory --endpoint $LINERA_STORAGE_SERVICE &
-        cargo test --features storage-service,unstable-oracles -- storage_service --nocapture
+        cargo test --features storage-service,unstable-oracles -- storage_service
     - name: Run Ethereum tests
       run: |
         cargo test -p linera-ethereum --features ethereum

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -56,4 +56,4 @@ jobs:
         docker run --name my_scylla_container -d -p 9042:9042 scylladb/scylla
     - name: Run ScyllaDB tests
       run: |
-        RUST_LOG=linera=info cargo test --locked --features scylladb -- scylla --nocapture
+        RUST_LOG=linera=info cargo test --locked --features scylladb -- scylla


### PR DESCRIPTION
## Motivation

The test logs are very noisy and slow to download.

## Proposal

Remove `--nocapture`, so that only the logs from failing tests are printed.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
