### PR TITLE
Use a shorter chain in the long faucet chain test

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2859,7 +2859,7 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
-    let chain_count = test_iterations().unwrap_or(10_000);
+    let chain_count = test_iterations().unwrap_or(3_000);
 
     let (mut net, faucet_client) = config.instantiate().await?;
 


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
The new GitHub Actions workflow to run the long Faucet chain test (PR #2533) was failing because it would exceed the 3 hour limit for the job.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Reduce the chain length so that the test runs in the allocated time limit.

Long term the test execution time should decrease, which should allow using a longer chain again.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
TODO: Manually trigged a CI run, now waiting to check if it passes.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
Nothing to do, this only affects CI and tests.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
