### PR TITLE
Retry all gRPC requests, not just notification streams.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -111,10 +111,10 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `--cache-size <CACHE_SIZE>` — The maximal number of entries in the storage cache
 
   Default value: `1000`
-* `--notification-retry-delay-ms <NOTIFICATION_RETRY_DELAY>` — Delay increment for retrying to connect to a validator for notifications
+* `--notification-retry-delay-ms <RETRY_DELAY>` — Delay increment for retrying to connect to a validator for notifications
 
   Default value: `1000`
-* `--notification-retries <NOTIFICATION_RETRIES>` — Number of times to retry connecting to a validator for notifications
+* `--max-retries <MAX_RETRIES>` — Number of times to retry connecting to a validator for notifications
 
   Default value: `10`
 * `--wait-for-outgoing-messages` — Whether to wait until a quorum of validators has confirmed that all sent cross-chain messages have been delivered

--- a/CLI.md
+++ b/CLI.md
@@ -111,10 +111,10 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `--cache-size <CACHE_SIZE>` — The maximal number of entries in the storage cache
 
   Default value: `1000`
-* `--notification-retry-delay-ms <RETRY_DELAY>` — Delay increment for retrying to connect to a validator for notifications
+* `--retry-delay-ms <RETRY_DELAY>` — Delay increment for retrying to connect to a validator
 
   Default value: `1000`
-* `--max-retries <MAX_RETRIES>` — Number of times to retry connecting to a validator for notifications
+* `--max-retries <MAX_RETRIES>` — Number of times to retry connecting to a validator
 
   Default value: `10`
 * `--wait-for-outgoing-messages` — Whether to wait until a quorum of validators has confirmed that all sent cross-chain messages have been delivered

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -80,8 +80,8 @@ where
     pub client: Arc<Client<NodeProvider, Storage>>,
     pub send_timeout: Duration,
     pub recv_timeout: Duration,
-    pub notification_retry_delay: Duration,
-    pub notification_retries: u32,
+    pub retry_delay: Duration,
+    pub max_retries: u32,
     pub options: ClientOptions,
     pub chain_listeners: JoinSet,
 }
@@ -149,8 +149,8 @@ where
         let node_options = NodeOptions {
             send_timeout: options.send_timeout,
             recv_timeout: options.recv_timeout,
-            notification_retry_delay: options.notification_retry_delay,
-            notification_retries: options.notification_retries,
+            retry_delay: options.retry_delay,
+            max_retries: options.max_retries,
         };
         let node_provider = NodeProvider::new(node_options);
         let delivery = CrossChainMessageDelivery::new(options.wait_for_outgoing_messages);
@@ -175,8 +175,8 @@ where
             wallet: WalletState::new(wallet),
             send_timeout: options.send_timeout,
             recv_timeout: options.recv_timeout,
-            notification_retry_delay: options.notification_retry_delay,
-            notification_retries: options.notification_retries,
+            retry_delay: options.retry_delay,
+            max_retries: options.max_retries,
             options,
             chain_listeners: JoinSet::default(),
         }
@@ -231,8 +231,8 @@ where
         NodeOptions {
             send_timeout: self.send_timeout,
             recv_timeout: self.recv_timeout,
-            notification_retry_delay: self.notification_retry_delay,
-            notification_retries: self.notification_retries,
+            retry_delay: self.retry_delay,
+            max_retries: self.max_retries,
         }
     }
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -118,11 +118,11 @@ pub struct ClientOptions {
         default_value = "1000",
         value_parser = util::parse_millis
     )]
-    pub notification_retry_delay: Duration,
+    pub retry_delay: Duration,
 
     /// Number of times to retry connecting to a validator for notifications.
     #[arg(long, default_value = "10")]
-    pub notification_retries: u32,
+    pub max_retries: u32,
 
     /// Whether to wait until a quorum of validators has confirmed that all sent cross-chain
     /// messages have been delivered.

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -112,15 +112,15 @@ pub struct ClientOptions {
     #[command(subcommand)]
     pub command: ClientCommand,
 
-    /// Delay increment for retrying to connect to a validator for notifications.
+    /// Delay increment for retrying to connect to a validator.
     #[arg(
-        long = "notification-retry-delay-ms",
+        long = "retry-delay-ms",
         default_value = "1000",
         value_parser = util::parse_millis
     )]
     pub retry_delay: Duration,
 
-    /// Number of times to retry connecting to a validator for notifications.
+    /// Number of times to retry connecting to a validator.
     #[arg(long, default_value = "10")]
     pub max_retries: u32,
 

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -17,7 +17,7 @@ use linera_core::{
 };
 use linera_version::VersionInfo;
 use tonic::{Code, IntoRequest, Request, Status};
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, instrument};
 #[cfg(not(web))]
 use {
     super::GrpcProtoConversionError,
@@ -139,13 +139,13 @@ impl GrpcClient {
         match inner {
             Inner::ChainInfoResponse(response) => {
                 Ok(response.try_into().map_err(|err| NodeError::GrpcError {
-                    error: format!("failed to marshal response: {}", err),
+                    error: format!("failed to unmarshal response: {}", err),
                 })?)
             }
             Inner::Error(error) => {
                 Err(
                     bincode::deserialize(&error).map_err(|err| NodeError::GrpcError {
-                        error: format!("failed to marshal error message: {}", err),
+                        error: format!("failed to unmarshal error message: {}", err),
                     })?,
                 )
             }

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -95,15 +95,15 @@ impl GrpcClient {
         }
     }
 
-    async fn delegate<F, FUT, R, S>(
+    async fn delegate<F, Fut, R, S>(
         &self,
         f: F,
         request: impl TryInto<R> + fmt::Debug + Clone,
         handler: &str,
     ) -> Result<S, NodeError>
     where
-        F: Fn(ValidatorNodeClient<transport::Channel>, Request<R>) -> FUT,
-        FUT: Future<Output = Result<tonic::Response<S>, Status>>,
+        F: Fn(ValidatorNodeClient<transport::Channel>, Request<R>) -> Fut,
+        Fut: Future<Output = Result<tonic::Response<S>, Status>>,
         R: IntoRequest<R> + Clone,
     {
         debug!(request = ?request, "sending gRPC request");

--- a/linera-rpc/src/node_provider.rs
+++ b/linera-rpc/src/node_provider.rs
@@ -50,6 +50,6 @@ impl ValidatorNodeProvider for NodeProvider {
 pub struct NodeOptions {
     pub send_timeout: Duration,
     pub recv_timeout: Duration,
-    pub notification_retry_delay: Duration,
-    pub notification_retries: u32,
+    pub retry_delay: Duration,
+    pub max_retries: u32,
 }

--- a/linera-rpc/tests/transport.rs
+++ b/linera-rpc/tests/transport.rs
@@ -22,8 +22,8 @@ async fn client() {
     let node_options = linera_rpc::node_provider::NodeOptions {
         send_timeout: Duration::from_millis(100),
         recv_timeout: Duration::from_millis(100),
-        notification_retry_delay: Duration::from_millis(100),
-        notification_retries: 5,
+        retry_delay: Duration::from_millis(100),
+        max_retries: 5,
     };
 
     let _ = linera_rpc::grpc::GrpcClient::new(network_config, node_options)


### PR DESCRIPTION
## Motivation

When running `test_wasm_end_to_end_fungible::storage_service_grpc` locally I get a failure almost 10% of the time because of a gRPC error with status code `Unknown`. We consider these (and a few other) errors to be retryable when they occur in notification streams, but not in other requests.

## Proposal

Make the gRPC client retry all requests if the status code is considered retryable.

## Test Plan

With this I ran the test 76 times without failure.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
