### PR TITLE
Make the linera-net-tests run on `remote-net` instead of `storage-service`.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,6 +88,7 @@ jobs:
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown
     - name: Run the remote-net tests
       run: |
+        cargo build --bin linera
         cargo run --bin linera -- faucet --amount 1000 --port 8079 &
         LINERA_FAUCET_URL=http://localhost:8079 cargo test -p linera-service remote_net_grpc --features remote-net
     - name: Check that the WIT files are up-to-date

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,19 +70,23 @@ jobs:
     - name: Run the storage service related tests and then the remote net tests
       run: |
         cargo run --release -p linera-storage-service -- memory --endpoint $LINERA_STORAGE_SERVICE &
-        cargo build --features storage-service
-        mkdir /tmp/WORK
-        cargo run --features storage-service --bin linera -- net up --storage-config-namespace service:tcp:localhost:1235:table --policy-config devnet --path /tmp/WORK &
         cargo test --features storage-service,unstable-oracles -- storage_service --nocapture
-        cargo run --release --bin linera -- faucet --amount 1000 --port 8079 &
-        cargo test -p linera-service remote_net_grpc --features remote-net
     - name: Run Ethereum tests
       run: |
         cargo test -p linera-ethereum --features ethereum
         cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum,storage-service,unstable-oracles
+    - name: Run the validators
+      run: |
+        cargo build --features storage-service
+        mkdir /tmp/WORK
+        cargo run --features storage-service --bin linera -- net up --storage-config-namespace service:tcp:localhost:1235:table --policy-config devnet --path /tmp/WORK &
     - name: Compile Wasm test modules for Witty integration tests
       run: |
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown
+    - name: Run the remote-net tests
+      run: |
+        cargo run --release --bin linera -- faucet --amount 1000 --port 8079 &
+        cargo test -p linera-service remote_net_grpc --features remote-net
     - name: Check that the WIT files are up-to-date
       run: |
         cargo run --bin wit-generator -- -c

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,12 +60,14 @@ jobs:
     - name: Set environment variables
       run: |
         echo "LINERA_STORAGE_SERVICE=127.0.0.1:1235" >> "$GITHUB_ENV"
-
+        echo "LINERA_WALLET=/tmp/WORK/wallet_0.json" >> "$GITHUB_ENV"
+        echo "LINERA_STORAGE=rocksdb:/tmp/WORK/client_0.db" >> "$GITHUB_ENV"
+        echo "LINERA_FAUCET_URL=http://localhost:8079" >> "$GITHUB_ENV"
     - name: Build example applications
       run: |
         cd examples
         cargo build --locked --release --target wasm32-unknown-unknown
-    - name: Run end-to-end tests
+    - name: Run the storage service related tests
       run: |
         cargo run --release -p linera-storage-service -- memory --endpoint $LINERA_STORAGE_SERVICE &
         cargo test --features storage-service,unstable-oracles -- storage_service --nocapture
@@ -73,6 +75,9 @@ jobs:
       run: |
         cargo test -p linera-ethereum --features ethereum
         cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum,storage-service,unstable-oracles
+    - name: Instantiate the set of validators
+      run: |
+        cargo run --bin linera -- --storage service:tcp:127.0.0.1:1235:TEST net up --policy-config devnet --path /tmp/WORK &
     - name: Compile Wasm test modules for Witty integration tests
       run: |
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown
@@ -82,6 +87,10 @@ jobs:
     - name: Run all tests using the default features
       run: |
         cargo test --features unstable-oracles --locked
+    - name: Run linera-net-tests over a single set of validators
+      run: |
+        cargo run --release --bin linera -- faucet --amount 1000 --port 8079 &
+        cargo test -p linera-service remote_net_grpc --features remote-net
     - name: Run some extra execution tests with wasmtime
       run: |
         cargo test --locked -p linera-execution --features wasmtime

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,6 @@ jobs:
         echo "LINERA_STORAGE_SERVICE=127.0.0.1:1235" >> "$GITHUB_ENV"
         echo "LINERA_WALLET=/tmp/WORK/wallet_0.json" >> "$GITHUB_ENV"
         echo "LINERA_STORAGE=rocksdb:/tmp/WORK/client_0.db" >> "$GITHUB_ENV"
-        echo "LINERA_FAUCET_URL=http://localhost:8079" >> "$GITHUB_ENV"
     - name: Build example applications
       run: |
         cd examples
@@ -90,7 +89,7 @@ jobs:
     - name: Run the remote-net tests
       run: |
         cargo run --bin linera -- faucet --amount 1000 --port 8079 &
-        cargo test -p linera-service remote_net_grpc --features remote-net
+        LINERA_FAUCET_URL=http://localhost:8079 cargo test -p linera-service remote_net_grpc --features remote-net
     - name: Check that the WIT files are up-to-date
       run: |
         cargo run --bin wit-generator -- -c

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,8 @@ jobs:
         cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum,storage-service,unstable-oracles
     - name: Instantiate the set of validators
       run: |
-        cargo run --bin linera -- --storage service:tcp:127.0.0.1:1235:TEST net up --policy-config devnet --path /tmp/WORK &
+        cargo build --features storage-service
+        cargo run --features storage-service --bin linera -- net up --storage-config-namespace service:tcp:localhost:1235:table --policy-config devnet --path /tmp/WORK &
     - name: Compile Wasm test modules for Witty integration tests
       run: |
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,7 +67,7 @@ jobs:
       run: |
         cd examples
         cargo build --locked --release --target wasm32-unknown-unknown
-    - name: Run the storage service related tests and then the remote net tests
+    - name: Run the storage-service instance and the storage-service tests
       run: |
         cargo run --release -p linera-storage-service -- memory --endpoint $LINERA_STORAGE_SERVICE &
         cargo test --features storage-service,unstable-oracles -- storage_service --nocapture
@@ -85,7 +85,7 @@ jobs:
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown
     - name: Run the remote-net tests
       run: |
-        cargo run --release --bin linera -- faucet --amount 1000 --port 8079 &
+        cargo run --bin linera -- faucet --amount 1000 --port 8079 &
         cargo test -p linera-service remote_net_grpc --features remote-net
     - name: Check that the WIT files are up-to-date
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,18 +67,18 @@ jobs:
       run: |
         cd examples
         cargo build --locked --release --target wasm32-unknown-unknown
-    - name: Run the storage service related tests
+    - name: Run the storage service related tests and then the remote net tests
       run: |
         cargo run --release -p linera-storage-service -- memory --endpoint $LINERA_STORAGE_SERVICE &
+        cargo build --features storage-service
+        cargo run --features storage-service --bin linera -- net up --storage-config-namespace service:tcp:localhost:1235:table --policy-config devnet --path /tmp/WORK &
         cargo test --features storage-service,unstable-oracles -- storage_service --nocapture
+        cargo run --release --bin linera -- faucet --amount 1000 --port 8079 &
+        cargo test -p linera-service remote_net_grpc --features remote-net
     - name: Run Ethereum tests
       run: |
         cargo test -p linera-ethereum --features ethereum
         cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum,storage-service,unstable-oracles
-    - name: Instantiate the set of validators
-      run: |
-        cargo build --features storage-service
-        cargo run --features storage-service --bin linera -- net up --storage-config-namespace service:tcp:localhost:1235:table --policy-config devnet --path /tmp/WORK &
     - name: Compile Wasm test modules for Witty integration tests
       run: |
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown
@@ -88,10 +88,6 @@ jobs:
     - name: Run all tests using the default features
       run: |
         cargo test --features unstable-oracles --locked
-    - name: Run linera-net-tests over a single set of validators
-      run: |
-        cargo run --release --bin linera -- faucet --amount 1000 --port 8079 &
-        cargo test -p linera-service remote_net_grpc --features remote-net
     - name: Run some extra execution tests with wasmtime
       run: |
         cargo test --locked -p linera-execution --features wasmtime

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,8 +60,8 @@ jobs:
     - name: Set environment variables
       run: |
         echo "LINERA_STORAGE_SERVICE=127.0.0.1:1235" >> "$GITHUB_ENV"
-        echo "LINERA_WALLET=/tmp/WORK/wallet_0.json" >> "$GITHUB_ENV"
-        echo "LINERA_STORAGE=rocksdb:/tmp/WORK/client_0.db" >> "$GITHUB_ENV"
+        echo "LINERA_WALLET=/tmp/local-linera-net/wallet_0.json" >> "$GITHUB_ENV"
+        echo "LINERA_STORAGE=rocksdb:/tmp/local-linera-net/client_0.db" >> "$GITHUB_ENV"
     - name: Build example applications
       run: |
         cd examples
@@ -81,8 +81,8 @@ jobs:
     - name: Run the validators
       run: |
         cargo build --features storage-service
-        mkdir /tmp/WORK
-        cargo run --features storage-service --bin linera -- net up --storage service:tcp:localhost:1235:table --policy-config devnet --path /tmp/WORK --validators 4 --shards 4 &
+        mkdir /tmp/local-linera-net
+        cargo run --features storage-service --bin linera -- net up --storage service:tcp:localhost:1235:table --policy-config devnet --path /tmp/local-linera-net --validators 4 --shards 4 &
     - name: Compile Wasm test modules for Witty integration tests
       run: |
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,6 +71,7 @@ jobs:
       run: |
         cargo run --release -p linera-storage-service -- memory --endpoint $LINERA_STORAGE_SERVICE &
         cargo build --features storage-service
+        mkdir /tmp/WORK
         cargo run --features storage-service --bin linera -- net up --storage-config-namespace service:tcp:localhost:1235:table --policy-config devnet --path /tmp/WORK &
         cargo test --features storage-service,unstable-oracles -- storage_service --nocapture
         cargo run --release --bin linera -- faucet --amount 1000 --port 8079 &

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,6 +75,10 @@ jobs:
       run: |
         cargo test -p linera-ethereum --features ethereum
         cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum,storage-service,unstable-oracles
+    - name: Run the benchmark test
+      run: |
+        cargo build --locked -p linera-service --bin linera-benchmark --features benchmark,storage-service
+        cargo test --locked -p linera-service --features benchmark,storage-service benchmark
     - name: Run the validators
       run: |
         cargo build --features storage-service
@@ -96,10 +100,6 @@ jobs:
     - name: Run some extra execution tests with wasmtime
       run: |
         cargo test --locked -p linera-execution --features wasmtime
-    - name: Run the benchmark test
-      run: |
-        cargo build --locked -p linera-service --bin linera-benchmark --features benchmark,storage-service
-        cargo test --locked -p linera-service --features benchmark,storage-service benchmark
     - name: Run Wasm application tests
       run: |
         cd examples

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,7 +79,7 @@ jobs:
       run: |
         cargo build --features storage-service
         mkdir /tmp/WORK
-        cargo run --features storage-service --bin linera -- net up --storage-config-namespace service:tcp:localhost:1235:table --policy-config devnet --path /tmp/WORK &
+        cargo run --features storage-service --bin linera -- net up --storage-config-namespace service:tcp:localhost:1235:table --policy-config devnet --path /tmp/WORK --validators 4 --shards 4 &
     - name: Compile Wasm test modules for Witty integration tests
       run: |
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,7 +79,7 @@ jobs:
       run: |
         cargo build --features storage-service
         mkdir /tmp/WORK
-        cargo run --features storage-service --bin linera -- net up --storage-config-namespace service:tcp:localhost:1235:table --policy-config devnet --path /tmp/WORK --validators 4 --shards 4 &
+        cargo run --features storage-service --bin linera -- net up --storage service:tcp:localhost:1235:table --policy-config devnet --path /tmp/WORK --validators 4 --shards 4 &
     - name: Compile Wasm test modules for Witty integration tests
       run: |
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown

--- a/CLI.md
+++ b/CLI.md
@@ -869,7 +869,7 @@ Start a Local Linera Network
 
 * `--testing-prng-seed <TESTING_PRNG_SEED>` — Force this wallet to generate keys using a PRNG and a given seed. USE FOR TESTING ONLY
 * `--path <PATH>` — Run with a specific path where the wallet and validator input files are. If none, then a temporary directory is created
-* `--storage-config-namespace <STORAGE_CONFIG_NAMESPACE>` — Run with a specific storage. If none, then a linera-storage-service is spanned on a random free port
+* `--storage <STORAGE>` — Run with a specific storage. If none, then a linera-storage-service is spanned on a random free port
 
 
 

--- a/CLI.md
+++ b/CLI.md
@@ -869,7 +869,7 @@ Start a Local Linera Network
 
 * `--testing-prng-seed <TESTING_PRNG_SEED>` — Force this wallet to generate keys using a PRNG and a given seed. USE FOR TESTING ONLY
 * `--path <PATH>` — Run with a specific path where the wallet and validator input files are. If none, then a temporary directory is created
-* `--storage <STORAGE>` — Run with a specific storage. If none, then a linera-storage-service is spanned on a random free port
+* `--storage <STORAGE>` — Run with a specific storage. If none, then a linera-storage-service is started on a random free port
 
 
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -899,7 +899,7 @@ pub enum NetCommand {
         path: Option<String>,
 
         /// Run with a specific storage.
-        /// If none, then a linera-storage-service is spanned on a random free port.
+        /// If none, then a linera-storage-service is started on a random free port.
         #[arg(long)]
         storage: Option<String>,
     },

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -901,7 +901,7 @@ pub enum NetCommand {
         /// Run with a specific storage.
         /// If none, then a linera-storage-service is spanned on a random free port.
         #[arg(long)]
-        storage_config_namespace: Option<String>,
+        storage: Option<String>,
     },
 
     /// Print a bash helper script to make `linera net up` easier to use. The script is

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1430,7 +1430,7 @@ async fn run(options: &ClientOptions) -> anyhow::Result<()> {
                 kubernetes: true,
                 binaries,
                 path: _,
-                storage_config_namespace: _,
+                storage: _,
             } => {
                 net_up_utils::handle_net_up_kubernetes(
                     *extra_wallets,
@@ -1455,7 +1455,7 @@ async fn run(options: &ClientOptions) -> anyhow::Result<()> {
                 testing_prng_seed,
                 policy_config,
                 path,
-                storage_config_namespace,
+                storage,
                 ..
             } => {
                 net_up_utils::handle_net_up_service(
@@ -1467,7 +1467,7 @@ async fn run(options: &ClientOptions) -> anyhow::Result<()> {
                     *testing_prng_seed,
                     policy_config.into_policy(),
                     path,
-                    storage_config_namespace,
+                    storage,
                 )
                 .boxed()
                 .await

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -370,7 +370,7 @@ impl AmmApp {
 }
 
 #[cfg(feature = "ethereum")]
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -468,7 +468,7 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -521,7 +521,7 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -571,7 +571,7 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -675,8 +675,8 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
 // TODO(#2051): Enable the test `test_wasm_end_to_end_fungible::scylladb_grpc` that is frequently failing.
 // The failure is `Error: Could not find application URI: .... after 15 tries`.
 //#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc), "fungible" ; "scylladb_grpc"))]
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "fungible" ; "storage_service_grpc"))]
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "native-fungible" ; "native_storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "fungible" ; "storage_test_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "native-fungible" ; "native_storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc), "native-fungible" ; "native_scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc), "fungible" ; "aws_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc), "native-fungible" ; "native_aws_grpc"))]
@@ -838,8 +838,8 @@ async fn test_wasm_end_to_end_fungible(
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "fungible" ; "storage_service_grpc"))]
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "native-fungible" ; "native_storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "fungible" ; "storage_test_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "native-fungible" ; "native_storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc), "fungible" ; "scylladb_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc), "native-fungible" ; "native_scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc), "fungible" ; "aws_grpc"))]
@@ -965,7 +965,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -1243,7 +1243,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -1379,7 +1379,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -1671,7 +1671,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -2414,7 +2414,7 @@ async fn test_resolve_binary() -> Result<()> {
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -2536,7 +2536,7 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()
     panic!("Failed to receive new block");
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -2582,7 +2582,7 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) -> Resul
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -2651,7 +2651,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) ->
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -2693,7 +2693,7 @@ async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Resul
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -2739,7 +2739,7 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -2771,7 +2771,7 @@ async fn test_end_to_end_publish_data_blob_in_cli(config: impl LineraNetConfig) 
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -2848,7 +2848,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
 }
 
 /// Tests creating a new wallet using a Faucet that has already created a lot of microchains.
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -2951,7 +2951,7 @@ async fn test_end_to_end_fungible_client_benchmark(config: impl LineraNetConfig)
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -3023,13 +3023,13 @@ async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> 
 /// ```bash
 /// RUST_LOG=info cargo test -p linera-service \
 ///     --features storage-service
-///     test_end_to_end_repeated_transfers::storage_service_grpc \
+///     test_end_to_end_repeated_transfers::storage_test_service_grpc \
 ///     -- --nocapture
 /// ```
 ///
 /// It will print the average end-to-end transfer latency, including creating the sending block,
 /// the receiving block, and the resulting `NewBlock` notification.
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]


### PR DESCRIPTION
## Motivation

It is a long running objective to have the `linera-net-tests` running on a single set of validators.

## Proposal

The following was done:
* The `storage-service` tests are disabled in `linera_net_tests.rs` by renaming their title from `storage_service_grpc` to `storage_test_service_grpc`.
* The related work for making the `remote-net` are added to the CI file.

## Test Plan

(A) The CI should pass. The change is that some tests pass from running on the `storage-service` to running on the `remote-net`.

(B) The runtime of the 20 tests of linera_net_tests.rs is 691 seconds on the `storage-service` and 345 seconds on the `remote-net` by using 1 validator and 1 shard. However, when running on 4 validators and 4 shards, the gains are much more modest with 638 seconds. Due to the additional compilation work this translates into an increase of the CI runtime.

## Release Plan

None of the changes affect the `testnet` and `devnet`.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
