### PR TITLE
Add the forgotten entry to the parsing code.

### DIFF
--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -312,6 +312,8 @@ example service:tcp:127.0.0.1:7878:table_do_my_test"
             });
         }
         error!("available storage: memory");
+        #[cfg(feature = "storage-service")]
+        error!("Also available is linera-storage-service");
         #[cfg(feature = "rocksdb")]
         error!("Also available is RocksDB");
         #[cfg(feature = "dynamodb")]


### PR DESCRIPTION
## Motivation

In the case of the wrong entry for the parsing but that `storage-service` was available as an instance

## Proposal

Simply add the missing code.

## Test Plan

The CI.

## Release Plan

There is the possibility of having `storage-service` as a default feature. However, the correction is still relevant.

## Links

None.