### PR TITLE
Introduce the `new_benchmark_config` / `new_test_store` / `new_benchmark_store`.

### DIFF
--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -37,10 +37,7 @@ use linera_views::dynamo_db::{
 };
 #[cfg(feature = "scylladb")]
 use linera_views::scylla_db::{create_scylla_db_common_config, ScyllaDbStore, ScyllaDbStoreConfig};
-use linera_views::{
-    memory::{create_memory_store_test_config, MemoryStore},
-    test_utils::generate_test_namespace,
-};
+use linera_views::{memory::MemoryStore, test_utils::generate_test_namespace};
 use tokio::sync::oneshot;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 #[cfg(feature = "rocksdb")]
@@ -891,7 +888,7 @@ impl StorageBuilder for MemoryStorageBuilder {
     type Storage = DbStorage<MemoryStore, TestClock>;
 
     async fn build(&mut self) -> Result<Self::Storage, anyhow::Error> {
-        let store_config = create_memory_store_test_config();
+        let store_config = MemoryStore::new_test_config().await?;
         let namespace = generate_test_namespace();
         let root_key = &[];
         Ok(DbStorage::new_for_testing(

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -45,7 +45,8 @@ use linera_execution::{
 use linera_storage::{DbStorage, Storage, TestClock};
 use linera_views::{
     context::MemoryContext,
-    memory::{create_memory_store_test_config, MemoryStore},
+    memory::MemoryStore,
+    store::AdminKeyValueStore as _,
     test_utils::generate_test_namespace,
     views::{CryptoHashView, RootView},
 };
@@ -2886,7 +2887,7 @@ where
 #[test(tokio::test)]
 async fn test_cross_chain_helper() -> anyhow::Result<()> {
     // Make a committee and worker (only used for signing certificates)
-    let store_config = create_memory_store_test_config();
+    let store_config = MemoryStore::new_test_config().await?;
     let namespace = generate_test_namespace();
     let root_key = &[];
     let store = DbStorage::<MemoryStore, _>::new_for_testing(

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -24,7 +24,7 @@ use linera_execution::ResourceControlPolicy;
 #[cfg(all(feature = "storage-service", with_testing))]
 use linera_storage_service::common::storage_service_test_endpoint;
 #[cfg(all(feature = "scylladb", with_testing))]
-use linera_views::scylla_db::create_scylla_db_test_uri;
+use linera_views::{scylla_db::ScyllaDbStore, store::AdminKeyValueStore as _};
 use tempfile::{tempdir, TempDir};
 use tokio::process::{Child, Command};
 use tonic_health::pb::{
@@ -57,14 +57,14 @@ pub async fn get_node_port() -> u16 {
 }
 
 #[cfg(with_testing)]
-async fn make_testing_config(database: Database) -> StorageConfig {
+async fn make_testing_config(database: Database) -> Result<StorageConfig> {
     match database {
         Database::Service => {
             #[cfg(feature = "storage-service")]
             {
                 let endpoint = storage_service_test_endpoint()
                     .expect("Reading LINERA_STORAGE_SERVICE environment variable");
-                StorageConfig::Service { endpoint }
+                Ok(StorageConfig::Service { endpoint })
             }
             #[cfg(not(feature = "storage-service"))]
             panic!("Database::Service is selected without the feature storage_service");
@@ -73,7 +73,7 @@ async fn make_testing_config(database: Database) -> StorageConfig {
             #[cfg(feature = "dynamodb")]
             {
                 let use_localstack = true;
-                StorageConfig::DynamoDb { use_localstack }
+                Ok(StorageConfig::DynamoDb { use_localstack })
             }
             #[cfg(not(feature = "dynamodb"))]
             panic!("Database::DynamoDb is selected without the feature aws");
@@ -81,8 +81,8 @@ async fn make_testing_config(database: Database) -> StorageConfig {
         Database::ScyllaDb => {
             #[cfg(feature = "scylladb")]
             {
-                let uri = create_scylla_db_test_uri();
-                StorageConfig::ScyllaDb { uri }
+                let config = ScyllaDbStore::new_test_config().await?;
+                Ok(StorageConfig::ScyllaDb { uri: config.uri })
             }
             #[cfg(not(feature = "scylladb"))]
             panic!("Database::ScyllaDb is selected without the feature sctlladb");
@@ -100,11 +100,11 @@ pub enum StorageConfigBuilder {
 
 impl StorageConfigBuilder {
     #[allow(unused_variables)]
-    pub async fn build(self, database: Database) -> StorageConfig {
+    pub async fn build(self, database: Database) -> Result<StorageConfig> {
         match self {
             #[cfg(with_testing)]
             StorageConfigBuilder::TestConfig => make_testing_config(database).await,
-            StorageConfigBuilder::ExistingConfig { storage_config } => storage_config,
+            StorageConfigBuilder::ExistingConfig { storage_config } => Ok(storage_config),
         }
     }
 }
@@ -265,7 +265,7 @@ impl LineraNetConfig for LocalNetConfig {
     type Net = LocalNet;
 
     async fn instantiate(self) -> Result<(Self::Net, ClientWrapper)> {
-        let server_config = self.storage_config_builder.build(self.database).await;
+        let server_config = self.storage_config_builder.build(self.database).await?;
         let mut net = LocalNet::new(
             self.network,
             self.testing_prng_seed,

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -386,6 +386,10 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
         service_config_from_endpoint(&endpoint)
     }
 
+    async fn new_benchmark_config() -> Result<ServiceStoreConfig, ServiceStoreError> {
+        Self::new_test_config().await
+    }
+
     async fn connect(
         config: &Self::Config,
         namespace: &str,
@@ -613,6 +617,10 @@ impl AdminKeyValueStore for ServiceStoreClient {
 
     async fn new_test_config() -> Result<ServiceStoreConfig, ServiceStoreError> {
         ServiceStoreClientInternal::new_test_config().await
+    }
+
+    async fn new_benchmark_config() -> Result<ServiceStoreConfig, ServiceStoreError> {
+        ServiceStoreClientInternal::new_benchmark_config().await
     }
 
     async fn connect(

--- a/linera-views/benches/queue_view.rs
+++ b/linera-views/benches/queue_view.rs
@@ -8,11 +8,11 @@ use std::{
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 #[cfg(with_dynamodb)]
-use linera_views::dynamo_db::create_dynamo_db_test_store;
+use linera_views::dynamo_db::DynamoDbStore;
 #[cfg(with_rocksdb)]
-use linera_views::rocks_db::create_rocks_db_test_store;
+use linera_views::rocks_db::RocksDbStore;
 #[cfg(with_scylladb)]
-use linera_views::scylla_db::create_scylla_db_test_store;
+use linera_views::scylla_db::DynamoDbStore;
 use linera_views::{
     backends::memory::create_test_memory_store,
     bucket_queue_view::BucketQueueView,
@@ -101,7 +101,7 @@ fn bench_queue_view(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_test_memory_store();
+                let store = MemoryStore::new_benchmark_store.await.unwrap();
                 performance_queue_view(store, iterations).await
             })
     });
@@ -111,7 +111,7 @@ fn bench_queue_view(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_test_store().await;
+                let store = RocksDbStore::new_benchmark_store.await.unwrap();
                 performance_queue_view(store, iterations).await
             })
     });
@@ -121,7 +121,7 @@ fn bench_queue_view(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_dynamo_db_test_store().await;
+                let store = DynamoDbStore::new_benchmark_store.await.unwrap();
                 performance_queue_view(store, iterations).await
             })
     });
@@ -131,7 +131,7 @@ fn bench_queue_view(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_scylla_db_test_store().await;
+                let store = ScyllaDbStore::new_benchmark_store.await.unwrap();
                 performance_queue_view(store, iterations).await
             })
     });
@@ -186,7 +186,7 @@ fn bench_bucket_queue_view(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_test_memory_store();
+                let store = MemoryStore::new_benchmark_store.await.unwrap();
                 performance_bucket_queue_view(store, iterations).await
             })
     });
@@ -196,7 +196,7 @@ fn bench_bucket_queue_view(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_test_store().await;
+                let store = RocksDbStore::new_benchmark_store.await.unwrap();
                 performance_bucket_queue_view(store, iterations).await
             })
     });
@@ -206,7 +206,7 @@ fn bench_bucket_queue_view(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_dynamo_db_test_store().await;
+                let store = DynamoDbStore::new_benchmark_store.await.unwrap();
                 performance_bucket_queue_view(store, iterations).await
             })
     });
@@ -216,7 +216,7 @@ fn bench_bucket_queue_view(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_scylla_db_test_store().await;
+                let store = ScyllaDbStore::new_benchmark_store.await.unwrap();
                 performance_bucket_queue_view(store, iterations).await
             })
     });

--- a/linera-views/benches/stores.rs
+++ b/linera-views/benches/stores.rs
@@ -8,11 +8,11 @@ use std::{
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 #[cfg(with_dynamodb)]
-use linera_views::dynamo_db::create_dynamo_db_test_store;
+use linera_views::dynamo_db::DynamoDbStore;
 #[cfg(with_rocksdb)]
-use linera_views::rocks_db::create_rocks_db_benchmark_store;
+use linera_views::rocks_db::RocksDbStore;
 #[cfg(with_scylladb)]
-use linera_views::scylla_db::create_scylla_db_test_store;
+use linera_views::scylla_db::ScyllaDbStore;
 use linera_views::{
     batch::Batch,
     memory::create_test_memory_store,
@@ -91,7 +91,7 @@ fn bench_contains_key(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_benchmark_store().await;
+                let store = RocksDbStore::new_benchmark_store().await.unwrap();
                 performance_contains_key(store, iterations).await
             })
     });
@@ -101,7 +101,7 @@ fn bench_contains_key(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_dynamo_db_test_store().await;
+                let store = DynamoDbStore::new_benchmark_store().await.unwrap();
                 performance_contains_key(store, iterations).await
             })
     });
@@ -111,7 +111,7 @@ fn bench_contains_key(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_scylla_db_test_store().await;
+                let store = ScyllaDbStore::new_benchmark_store().await.unwrap();
                 performance_contains_key(store, iterations).await
             })
     });
@@ -162,7 +162,7 @@ fn bench_contains_keys(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_benchmark_store().await;
+                let store = RocksDbStore::new_benchmark_store().await.unwrap();
                 performance_contains_keys(store, iterations).await
             })
     });
@@ -172,7 +172,7 @@ fn bench_contains_keys(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_dynamo_db_test_store().await;
+                let store = DynamoDbStore::new_benchmark_store().await.unwrap();
                 performance_contains_keys(store, iterations).await
             })
     });
@@ -182,7 +182,7 @@ fn bench_contains_keys(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_scylla_db_test_store().await;
+                let store = ScyllaDbStore::new_benchmark_store().await.unwrap();
                 performance_contains_keys(store, iterations).await
             })
     });
@@ -232,7 +232,7 @@ fn bench_find_keys_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_benchmark_store().await;
+                let store = RocksDbStore::new_benchmark_store().await.unwrap();
                 performance_find_keys_by_prefix(store, iterations).await
             })
     });
@@ -242,7 +242,7 @@ fn bench_find_keys_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_dynamo_db_test_store().await;
+                let store = DynamoDbStore::new_benchmark_store().await.unwrap();
                 performance_find_keys_by_prefix(store, iterations).await
             })
     });
@@ -252,7 +252,7 @@ fn bench_find_keys_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_scylla_db_test_store().await;
+                let store = ScyllaDbStore::new_benchmark_store().await.unwrap();
                 performance_find_keys_by_prefix(store, iterations).await
             })
     });
@@ -307,7 +307,7 @@ fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_benchmark_store().await;
+                let store = RocksDbStore::new_benchmark_store().await.unwrap();
                 performance_find_key_values_by_prefix(store, iterations).await
             })
     });
@@ -317,7 +317,7 @@ fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_dynamo_db_test_store().await;
+                let store = DynamoDbStore::new_benchmark_store().await.unwrap();
                 performance_find_key_values_by_prefix(store, iterations).await
             })
     });
@@ -327,7 +327,7 @@ fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_scylla_db_test_store().await;
+                let store = ScyllaDbStore::new_benchmark_store().await.unwrap();
                 performance_find_key_values_by_prefix(store, iterations).await
             })
     });
@@ -379,7 +379,7 @@ fn bench_read_value_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_benchmark_store().await;
+                let store = RocksDbStore::new_benchmark_store().await.unwrap();
                 performance_read_value_bytes(store, iterations).await
             })
     });
@@ -389,7 +389,7 @@ fn bench_read_value_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_dynamo_db_test_store().await;
+                let store = DynamoDbStore::new_benchmark_store().await.unwrap();
                 performance_read_value_bytes(store, iterations).await
             })
     });
@@ -399,7 +399,7 @@ fn bench_read_value_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_scylla_db_test_store().await;
+                let store = ScyllaDbStore::new_benchmark_store().await.unwrap();
                 performance_read_value_bytes(store, iterations).await
             })
     });
@@ -453,7 +453,7 @@ fn bench_read_multi_values_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_benchmark_store().await;
+                let store = RocksDbStore::new_benchmark_store().await.unwrap();
                 performance_read_multi_values_bytes(store, iterations).await
             })
     });
@@ -463,7 +463,7 @@ fn bench_read_multi_values_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_dynamo_db_test_store().await;
+                let store = DynamoDbStore::new_benchmark_store().await.unwrap();
                 performance_read_multi_values_bytes(store, iterations).await
             })
     });
@@ -473,7 +473,7 @@ fn bench_read_multi_values_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_scylla_db_test_store().await;
+                let store = ScyllaDbStore::new_benchmark_store().await.unwrap();
                 performance_read_multi_values_bytes(store, iterations).await
             })
     });
@@ -519,7 +519,7 @@ fn bench_write_batch(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_rocks_db_benchmark_store().await;
+                let store = RocksDbStore::new_benchmark_store().await.unwrap();
                 performance_write_batch(store, iterations).await
             })
     });
@@ -529,7 +529,7 @@ fn bench_write_batch(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_dynamo_db_test_store().await;
+                let store = DynamoDbStore::new_benchmark_store().await.unwrap();
                 performance_write_batch(store, iterations).await
             })
     });
@@ -539,7 +539,7 @@ fn bench_write_batch(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = create_scylla_db_test_store().await;
+                let store = ScyllaDbStore::new_benchmark_store().await.unwrap();
                 performance_write_batch(store, iterations).await
             })
     });

--- a/linera-views/src/backends/dual.rs
+++ b/linera-views/src/backends/dual.rs
@@ -248,6 +248,17 @@ where
         })
     }
 
+    async fn new_benchmark_config() -> Result<Self::Config, Self::Error> {
+        let first_config = S1::new_benchmark_config().await.map_err(DualStoreError::First)?;
+        let second_config = S2::new_benchmark_config()
+            .await
+            .map_err(DualStoreError::Second)?;
+        Ok(DualStoreConfig {
+            first_config,
+            second_config,
+        })
+    }
+
     async fn connect(
         config: &Self::Config,
         namespace: &str,

--- a/linera-views/src/backends/dual.rs
+++ b/linera-views/src/backends/dual.rs
@@ -249,7 +249,9 @@ where
     }
 
     async fn new_benchmark_config() -> Result<Self::Config, Self::Error> {
-        let first_config = S1::new_benchmark_config().await.map_err(DualStoreError::First)?;
+        let first_config = S1::new_benchmark_config()
+            .await
+            .map_err(DualStoreError::First)?;
         let second_config = S2::new_benchmark_config()
             .await
             .map_err(DualStoreError::Second)?;

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -354,7 +354,11 @@ impl AdminKeyValueStore for DynamoDbStoreInternal {
     type Config = DynamoDbStoreConfig;
 
     async fn new_test_config() -> Result<DynamoDbStoreConfig, DynamoDbStoreInternalError> {
-        let common_config = create_dynamo_db_common_config();
+        let common_config = CommonStoreConfig {
+            max_concurrent_queries: Some(TEST_DYNAMO_DB_MAX_CONCURRENT_QUERIES),
+            max_stream_queries: TEST_DYNAMO_DB_MAX_STREAM_QUERIES,
+            cache_size: TEST_CACHE_SIZE,
+        };
         let use_localstack = true;
         let config = get_config_internal(use_localstack).await?;
         Ok(DynamoDbStoreConfig {
@@ -1335,15 +1339,6 @@ impl DynamoDbStore {
 /// time.
 #[cfg(with_testing)]
 static LOCALSTACK_GUARD: Mutex<()> = Mutex::const_new(());
-
-/// Creates the common initialization for RocksDB
-pub fn create_dynamo_db_common_config() -> CommonStoreConfig {
-    CommonStoreConfig {
-        max_concurrent_queries: Some(TEST_DYNAMO_DB_MAX_CONCURRENT_QUERIES),
-        max_stream_queries: TEST_DYNAMO_DB_MAX_STREAM_QUERIES,
-        cache_size: TEST_CACHE_SIZE,
-    }
-}
 
 /// Creates a basic client that can be used for tests.
 #[cfg(with_testing)]

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -31,7 +31,6 @@ use linera_base::ensure;
 use thiserror::Error;
 #[cfg(with_testing)]
 use {
-    crate::test_utils::generate_test_namespace,
     anyhow::Error,
     tokio::sync::{Mutex, MutexGuard},
 };
@@ -1339,17 +1338,6 @@ impl DynamoDbStore {
 /// time.
 #[cfg(with_testing)]
 static LOCALSTACK_GUARD: Mutex<()> = Mutex::const_new(());
-
-/// Creates a basic client that can be used for tests.
-#[cfg(with_testing)]
-pub async fn create_dynamo_db_test_store() -> DynamoDbStore {
-    let config = DynamoDbStore::new_test_config().await.expect("config");
-    let namespace = generate_test_namespace();
-    let root_key = &[];
-    DynamoDbStore::recreate_and_connect(&config, &namespace, root_key)
-        .await
-        .expect("key_value_store")
-}
 
 #[cfg(test)]
 mod tests {

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -363,6 +363,10 @@ impl AdminKeyValueStore for DynamoDbStoreInternal {
         })
     }
 
+    async fn new_benchmark_config() -> Result<DynamoDbStoreConfig, DynamoDbStoreInternalError> {
+        Self::new_test_config().await
+    }
+
     async fn connect(
         config: &Self::Config,
         namespace: &str,
@@ -1259,6 +1263,10 @@ impl AdminKeyValueStore for DynamoDbStore {
 
     async fn new_test_config() -> Result<DynamoDbStoreConfig, DynamoDbStoreError> {
         Ok(DynamoDbStoreInternal::new_test_config().await?)
+    }
+
+    async fn new_benchmark_config() -> Result<DynamoDbStoreConfig, DynamoDbStoreError> {
+        Ok(DynamoDbStoreInternal::new_benchmark_config().await?)
     }
 
     async fn connect(

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -232,6 +232,10 @@ impl LocalAdminKeyValueStore for IndexedDbStore {
         Ok(IndexedDbStoreConfig::new(TEST_INDEX_DB_MAX_STREAM_QUERIES))
     }
 
+    async fn new_benchmark_config() -> Result<IndexedDbStoreConfig, IndexedDbStoreError> {
+        Self::new_test_config().await
+    }
+
     async fn connect(
         config: &Self::Config,
         namespace: &str,

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -184,6 +184,10 @@ where
         K::new_test_config().await
     }
 
+    async fn new_benchmark_config() -> Result<K::Config, Self::Error> {
+        K::new_benchmark_config().await
+    }
+
     async fn connect(
         config: &Self::Config,
         namespace: &str,

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -316,6 +316,10 @@ impl AdminKeyValueStore for MemoryStore {
         Ok(MemoryStoreConfig { common_config })
     }
 
+    async fn new_benchmark_config() -> Result<MemoryStoreConfig, MemoryStoreError> {
+        Self::new_test_config().await
+    }
+
     async fn connect(
         config: &Self::Config,
         namespace: &str,

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -379,17 +379,6 @@ impl AdminKeyValueStore for MemoryStore {
     }
 }
 
-/// Creates a default memory test config
-pub fn create_memory_store_test_config() -> MemoryStoreConfig {
-    let max_stream_queries = TEST_MEMORY_MAX_STREAM_QUERIES;
-    let common_config = CommonStoreConfig {
-        max_concurrent_queries: None,
-        max_stream_queries,
-        cache_size: 1000,
-    };
-    MemoryStoreConfig { common_config }
-}
-
 /// Creates a test memory store for working.
 #[cfg(with_testing)]
 pub fn create_test_memory_store() -> MemoryStore {

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -450,6 +450,17 @@ impl AdminKeyValueStore for RocksDbStoreInternal {
         })
     }
 
+    async fn new_benchmark_config() -> Result<RocksDbStoreConfig, RocksDbStoreInternalError> {
+        let path_with_guard = create_rocks_db_test_path();
+        let common_config = create_rocks_db_common_config();
+        let spawn_mode = RocksDbSpawnMode::BlockInPlace;
+        Ok(RocksDbStoreConfig {
+            path_with_guard,
+            spawn_mode,
+            common_config,
+        })
+    }
+
     async fn connect(
         config: &Self::Config,
         namespace: &str,
@@ -755,6 +766,10 @@ impl AdminKeyValueStore for RocksDbStore {
 
     async fn new_test_config() -> Result<RocksDbStoreConfig, RocksDbStoreError> {
         Ok(RocksDbStoreInternal::new_test_config().await?)
+    }
+
+    async fn new_benchmark_config() -> Result<RocksDbStoreConfig, RocksDbStoreError> {
+        Ok(RocksDbStoreInternal::new_benchmark_config().await?)
     }
 
     async fn connect(

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -641,7 +641,7 @@ impl PathWithGuard {
 }
 
 /// Returns the test path for RocksDB without common config.
-pub fn create_rocks_db_test_path() -> PathWithGuard {
+fn create_rocks_db_test_path() -> PathWithGuard {
     let dir = TempDir::new().unwrap();
     let path_buf = dir.path().to_path_buf();
     let _dir = Some(Arc::new(dir));

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -18,8 +18,6 @@ use thiserror::Error;
 use crate::metering::{
     MeteredStore, LRU_CACHING_METRICS, ROCKS_DB_METRICS, VALUE_SPLITTING_METRICS,
 };
-#[cfg(with_testing)]
-use crate::test_utils::generate_test_namespace;
 use crate::{
     batch::{Batch, WriteOperation},
     common::get_upper_bound,
@@ -646,33 +644,6 @@ fn create_rocks_db_test_path() -> PathWithGuard {
     let path_buf = dir.path().to_path_buf();
     let _dir = Some(Arc::new(dir));
     PathWithGuard { path_buf, _dir }
-}
-
-/// Creates a RocksDB database client to be used for tests.
-/// The temporary directory has to be carried because if it goes
-/// out of scope then the RocksDB client can become unstable.
-#[cfg(with_testing)]
-pub async fn create_rocks_db_test_store() -> RocksDbStore {
-    let config = RocksDbStore::new_test_config().await.expect("config");
-    let namespace = generate_test_namespace();
-    let root_key = &[];
-    RocksDbStore::recreate_and_connect(&config, &namespace, root_key)
-        .await
-        .expect("store")
-}
-
-/// Creates a RocksDB database client to be used for benchmarks.
-/// The temporary directory has to be carried because if it goes
-/// out of scope then the RocksDB client can become unstable.
-#[cfg(with_testing)]
-pub async fn create_rocks_db_benchmark_store() -> RocksDbStore {
-    let mut config = RocksDbStore::new_test_config().await.expect("config");
-    config.spawn_mode = RocksDbSpawnMode::BlockInPlace;
-    let namespace = generate_test_namespace();
-    let root_key = &[];
-    RocksDbStore::recreate_and_connect(&config, &namespace, root_key)
-        .await
-        .expect("store")
 }
 
 impl RocksDbStore {

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -556,7 +556,7 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
     type Config = ScyllaDbStoreConfig;
 
     async fn new_test_config() -> Result<ScyllaDbStoreConfig, ScyllaDbStoreError> {
-        let uri = create_scylla_db_test_uri();
+        let uri = "localhost:9042".to_string();
         let common_config = CommonStoreConfig {
             max_concurrent_queries: Some(TEST_SCYLLA_DB_MAX_CONCURRENT_QUERIES),
             max_stream_queries: TEST_SCYLLA_DB_MAX_STREAM_QUERIES,
@@ -928,11 +928,6 @@ impl ScyllaDbStore {
         let store = MeteredStore::new(&LRU_CACHING_METRICS, store);
         Self { store }
     }
-}
-
-/// Creates the URI used for the tests.
-pub fn create_scylla_db_test_uri() -> String {
-    "localhost:9042".to_string()
 }
 
 /// Creates a ScyllaDB test store.

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -557,7 +557,11 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
 
     async fn new_test_config() -> Result<ScyllaDbStoreConfig, ScyllaDbStoreError> {
         let uri = create_scylla_db_test_uri();
-        let common_config = create_scylla_db_common_config();
+        let common_config = CommonStoreConfig {
+            max_concurrent_queries: Some(TEST_SCYLLA_DB_MAX_CONCURRENT_QUERIES),
+            max_stream_queries: TEST_SCYLLA_DB_MAX_STREAM_QUERIES,
+            cache_size: TEST_CACHE_SIZE,
+        };
         Ok(ScyllaDbStoreConfig { uri, common_config })
     }
 
@@ -923,15 +927,6 @@ impl ScyllaDbStore {
         #[cfg(with_metrics)]
         let store = MeteredStore::new(&LRU_CACHING_METRICS, store);
         Self { store }
-    }
-}
-
-/// Creates the common initialization for RocksDB.
-pub fn create_scylla_db_common_config() -> CommonStoreConfig {
-    CommonStoreConfig {
-        max_concurrent_queries: Some(TEST_SCYLLA_DB_MAX_CONCURRENT_QUERIES),
-        max_stream_queries: TEST_SCYLLA_DB_MAX_STREAM_QUERIES,
-        cache_size: TEST_CACHE_SIZE,
     }
 }
 

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -561,6 +561,10 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
         Ok(ScyllaDbStoreConfig { uri, common_config })
     }
 
+    async fn new_benchmark_config() -> Result<ScyllaDbStoreConfig, ScyllaDbStoreError> {
+        Self::new_test_config().await
+    }
+
     async fn connect(
         config: &Self::Config,
         namespace: &str,
@@ -857,6 +861,10 @@ impl AdminKeyValueStore for ScyllaDbStore {
 
     async fn new_test_config() -> Result<ScyllaDbStoreConfig, ScyllaDbStoreError> {
         ScyllaDbStoreInternal::new_test_config().await
+    }
+
+    async fn new_benchmark_config() -> Result<ScyllaDbStoreConfig, ScyllaDbStoreError> {
+        ScyllaDbStoreInternal::new_benchmark_config().await
     }
 
     async fn connect(

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -31,8 +31,6 @@ use thiserror::Error;
 
 #[cfg(with_metrics)]
 use crate::metering::{MeteredStore, LRU_CACHING_METRICS, SCYLLA_DB_METRICS};
-#[cfg(with_testing)]
-use crate::test_utils::generate_test_namespace;
 use crate::{
     batch::{Batch, UnorderedBatch},
     common::get_upper_bound_option,
@@ -928,15 +926,4 @@ impl ScyllaDbStore {
         let store = MeteredStore::new(&LRU_CACHING_METRICS, store);
         Self { store }
     }
-}
-
-/// Creates a ScyllaDB test store.
-#[cfg(with_testing)]
-pub async fn create_scylla_db_test_store() -> ScyllaDbStore {
-    let config = ScyllaDbStore::new_test_config().await.expect("config");
-    let namespace = generate_test_namespace();
-    let root_key = &[];
-    ScyllaDbStore::recreate_and_connect(&config, &namespace, root_key)
-        .await
-        .expect("store")
 }

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -146,6 +146,9 @@ pub trait LocalAdminKeyValueStore: WithError + Sized {
     /// Obtains a test config
     async fn new_test_config() -> Result<Self::Config, Self::Error>;
 
+    /// Obtains a benchmark config
+    async fn new_benchmark_config() -> Result<Self::Config, Self::Error>;
+
     /// Connects to an existing namespace using the given configuration.
     async fn connect(
         config: &Self::Config,

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -8,6 +8,7 @@ use std::{fmt::Debug, future::Future};
 use serde::de::DeserializeOwned;
 
 use crate::{batch::Batch, common::from_bytes_option, views::ViewError};
+use crate::test_utils::generate_test_namespace;
 
 /// The common initialization parameters for the `KeyValueStore`
 #[derive(Debug, Clone)]
@@ -208,6 +209,26 @@ pub trait LocalAdminKeyValueStore: WithError + Sized {
             }
             Self::create(config, namespace).await?;
             Self::connect(config, namespace, root_key).await
+        }
+    }
+
+    /// Creates a store for testing purposes
+    fn new_test_store() -> impl Future<Output = Result<Self, Self::Error>> {
+        async {
+            let config = Self::new_test_config().await?;
+            let namespace = generate_test_namespace();
+            let root_key = &[];
+            Self::recreate_and_connect(&config, &namespace, root_key).await
+        }
+    }
+
+    /// Creates a store for benchmarking purposes
+    fn new_benchmark_store() -> impl Future<Output = Result<Self, Self::Error>> {
+        async {
+            let config = Self::new_benchmark_config().await?;
+            let namespace = generate_test_namespace();
+            let root_key = &[];
+            Self::recreate_and_connect(&config, &namespace, root_key).await
         }
     }
 }

--- a/linera-views/src/views/unit_tests/views.rs
+++ b/linera-views/src/views/unit_tests/views.rs
@@ -8,9 +8,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use test_case::test_case;
 
 #[cfg(with_dynamodb)]
-use crate::dynamo_db::{
-    create_dynamo_db_common_config, DynamoDbStore, DynamoDbStoreConfig, LocalStackTestContext,
-};
+use crate::dynamo_db::DynamoDbStore;
 #[cfg(with_rocksdb)]
 use crate::rocks_db::RocksDbStore;
 #[cfg(with_scylladb)]
@@ -206,7 +204,7 @@ impl TestContextFactory for MemoryContextFactory {
 
 #[cfg(with_rocksdb)]
 #[derive(Default)]
-struct RocksDbContextFactory {}
+struct RocksDbContextFactory;
 
 #[cfg(with_rocksdb)]
 #[async_trait]
@@ -226,9 +224,7 @@ impl TestContextFactory for RocksDbContextFactory {
 
 #[cfg(with_dynamodb)]
 #[derive(Default)]
-struct DynamoDbContextFactory {
-    localstack: Option<LocalStackTestContext>,
-}
+struct DynamoDbContextFactory;
 
 #[cfg(with_dynamodb)]
 #[async_trait]
@@ -236,20 +232,10 @@ impl TestContextFactory for DynamoDbContextFactory {
     type Context = ViewContext<(), DynamoDbStore>;
 
     async fn new_context(&mut self) -> Result<Self::Context, anyhow::Error> {
-        if self.localstack.is_none() {
-            self.localstack = Some(LocalStackTestContext::new().await?);
-        }
-        let config = self.localstack.as_ref().unwrap().dynamo_db_config();
-
+        let config = DynamoDbStore::new_test_config().await?;
         let namespace = generate_test_namespace();
         let root_key = &[];
-        let common_config = create_dynamo_db_common_config();
-        let store_config = DynamoDbStoreConfig {
-            config,
-            common_config,
-        };
-        let store =
-            DynamoDbStore::recreate_and_connect(&store_config, &namespace, root_key).await?;
+        let store = DynamoDbStore::recreate_and_connect(&config, &namespace, root_key).await?;
         Ok(ViewContext::create_root_context(store, ()).await?)
     }
 }

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -12,6 +12,8 @@ use linera_views::{
     },
     value_splitting::create_value_splitting_memory_store,
 };
+use linera_views::store::{AdminKeyValueStore as _};
+
 #[cfg(web)]
 use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -38,8 +40,8 @@ async fn test_reads_memory() {
 #[tokio::test]
 async fn test_reads_rocks_db() {
     for scenario in get_random_test_scenarios() {
-        let key_value_store = linera_views::rocks_db::create_rocks_db_test_store().await;
-        run_reads(key_value_store, scenario).await;
+        let store = linera_views::rocks_db::RocksDbStore::new_test_store().await.unwrap();
+        run_reads(store, scenario).await;
     }
 }
 
@@ -47,8 +49,8 @@ async fn test_reads_rocks_db() {
 #[tokio::test]
 async fn test_reads_dynamo_db() {
     for scenario in get_random_test_scenarios() {
-        let key_value_store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
-        run_reads(key_value_store, scenario).await;
+        let store = linera_views::dynamo_db::DynamoDbStore::new_test_store().await.unwrap();
+        run_reads(store, scenario).await;
     }
 }
 
@@ -56,8 +58,8 @@ async fn test_reads_dynamo_db() {
 #[tokio::test]
 async fn test_reads_scylla_db() {
     for scenario in get_random_test_scenarios() {
-        let key_value_store = linera_views::scylla_db::create_scylla_db_test_store().await;
-        run_reads(key_value_store, scenario).await;
+        let store = linera_views::scylla_db::ScyllaDbStore::new_test_store().await.unwrap();
+        run_reads(store, scenario).await;
     }
 }
 
@@ -113,22 +115,22 @@ async fn test_key_value_store_view_memory_writes_from_blank() {
 #[cfg(with_rocksdb)]
 #[tokio::test]
 async fn test_rocks_db_writes_from_blank() {
-    let key_value_store = linera_views::rocks_db::create_rocks_db_test_store().await;
-    run_writes_from_blank(&key_value_store).await;
+    let store = linera_views::rocks_db::RocksDbStore::new_test_store().await.unwrap();
+    run_writes_from_blank(&store).await;
 }
 
 #[cfg(with_dynamodb)]
 #[tokio::test]
 async fn test_dynamo_db_writes_from_blank() {
-    let key_value_store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
-    run_writes_from_blank(&key_value_store).await;
+    let store = linera_views::dynamo_db::DynamoDbStore::new_test_store().await.unwrap();
+    run_writes_from_blank(&store).await;
 }
 
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_writes_from_blank() {
-    let key_value_store = linera_views::scylla_db::create_scylla_db_test_store().await;
-    run_writes_from_blank(&key_value_store).await;
+    let store = linera_views::scylla_db::ScyllaDbStore::new_test_store().await.unwrap();
+    run_writes_from_blank(&store).await;
 }
 
 #[cfg(with_indexeddb)]
@@ -161,17 +163,17 @@ async fn test_big_value_read_write() {
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn scylla_db_tombstone_triggering_test() {
-    let key_value_store = linera_views::scylla_db::create_scylla_db_test_store().await;
-    linera_views::test_utils::tombstone_triggering_test(key_value_store).await;
+    let store = linera_views::scylla_db::ScyllaDbStore::new_test_store().await.unwrap();
+    linera_views::test_utils::tombstone_triggering_test(store).await;
 }
 
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_big_write_read() {
-    let key_value_store = linera_views::scylla_db::create_scylla_db_test_store().await;
+    let store = linera_views::scylla_db::ScyllaDbStore::new_test_store().await.unwrap();
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
-    run_big_write_read(key_value_store, target_size, value_sizes).await;
+    run_big_write_read(store, target_size, value_sizes).await;
 }
 
 #[tokio::test]
@@ -185,10 +187,10 @@ async fn test_memory_big_write_read() {
 #[cfg(with_rocksdb)]
 #[tokio::test]
 async fn test_rocks_db_big_write_read() {
-    let key_value_store = linera_views::rocks_db::create_rocks_db_test_store().await;
+    let store = linera_views::rocks_db::RocksDbStore::new_test_store().await.unwrap();
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
-    run_big_write_read(key_value_store, target_size, value_sizes).await;
+    run_big_write_read(store, target_size, value_sizes).await;
 }
 
 #[cfg(with_indexeddb)]
@@ -203,10 +205,10 @@ async fn test_indexed_db_big_write_read() {
 #[cfg(with_dynamodb)]
 #[tokio::test]
 async fn test_dynamo_db_big_write_read() {
-    let key_value_store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
+    let store = linera_views::dynamo_db::DynamoDbStore::new_test_store().await.unwrap();
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
-    run_big_write_read(key_value_store, target_size, value_sizes).await;
+    run_big_write_read(store, target_size, value_sizes).await;
 }
 
 #[tokio::test]
@@ -218,8 +220,8 @@ async fn test_memory_writes_from_state() {
 #[cfg(with_rocksdb)]
 #[tokio::test]
 async fn test_rocks_db_writes_from_state() {
-    let key_value_store = linera_views::rocks_db::create_rocks_db_test_store().await;
-    run_writes_from_state(&key_value_store).await;
+    let store = linera_views::rocks_db::RocksDbStore::new_test_store().await.unwrap();
+    run_writes_from_state(&store).await;
 }
 
 #[cfg(with_indexeddb)]
@@ -232,13 +234,13 @@ async fn test_indexed_db_writes_from_state() {
 #[cfg(with_dynamodb)]
 #[tokio::test]
 async fn test_dynamo_db_writes_from_state() {
-    let key_value_store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
-    run_writes_from_state(&key_value_store).await;
+    let store = linera_views::dynamo_db::DynamoDbStore::new_test_store().await.unwrap();
+    run_writes_from_state(&store).await;
 }
 
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_writes_from_state() {
-    let key_value_store = linera_views::scylla_db::create_scylla_db_test_store().await;
-    run_writes_from_state(&key_value_store).await;
+    let store = linera_views::scylla_db::ScyllaDbStore::new_test_store().await.unwrap();
+    run_writes_from_state(&store).await;
 }

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -6,11 +6,11 @@ use std::collections::BTreeSet;
 use anyhow::Result;
 use async_trait::async_trait;
 #[cfg(with_rocksdb)]
-use linera_views::rocks_db::{create_rocks_db_test_store, RocksDbStore};
+use linera_views::rocks_db::RocksDbStore;
 #[cfg(with_scylladb)]
-use linera_views::scylla_db::{create_scylla_db_test_store, ScyllaDbStore};
+use linera_views::scylla_db::ScyllaDbStore;
 #[cfg(with_dynamodb)]
-use linera_views::dynamo_db::{create_dynamo_db_test_store, DynamoDbStore};
+use linera_views::dynamo_db::DynamoDbStore;
 #[cfg(any(with_dynamodb, with_rocksdb, with_scylladb))]
 use linera_views::store::{AdminKeyValueStore as _};
 use linera_views::{
@@ -158,7 +158,7 @@ impl StateStorage for RocksDbTestStorage {
     type Context = ViewContext<usize, RocksDbStore>;
 
     async fn new() -> Self {
-        let store = create_rocks_db_test_store().await;
+        let store = RocksDbStore::new_test_store().await.unwrap();
         let accessed_chains = BTreeSet::new();
         RocksDbTestStorage {
             store,
@@ -187,7 +187,7 @@ impl StateStorage for ScyllaDbTestStorage {
     type Context = ViewContext<usize, ScyllaDbStore>;
 
     async fn new() -> Self {
-        let store = create_scylla_db_test_store().await;
+        let store = ScyllaDbStore::new_test_store().await.unwrap();
         let accessed_chains = BTreeSet::new();
         ScyllaDbTestStorage {
             store,
@@ -216,7 +216,7 @@ impl StateStorage for DynamoDbTestStorage {
     type Context = ViewContext<usize, DynamoDbStore>;
 
     async fn new() -> Self {
-        let store = create_dynamo_db_test_store().await;
+        let store = DynamoDbStore::new_test_store().await.unwrap();
         let accessed_chains = BTreeSet::new();
         DynamoDbTestStorage {
             store,


### PR DESCRIPTION
## Motivation

There is much code that is something like `create_scylla_db_test_store` and similar, that is copy pasted
all over.

## Proposal

The following was done:
* The `new_benchmark_config` is introduced since for some stores, the test is not the same as the store.
* The function `new_test_store` and similar are added to the trait.

Other simplifications are done along the way.

## Test Plan

The CI should be what is relevant. No performance issues here.

## Release Plan

The documentation should probably evolve because of that develoipment.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
