### PR TITLE
Use name in the code when generating new linera project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4669,6 +4669,7 @@ dependencies = [
  "clap-markdown",
  "colored",
  "comfy-table",
+ "convert_case 0.6.0",
  "counter",
  "criterion",
  "crowd-funding",

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -69,6 +69,7 @@ clap.workspace = true
 clap-markdown.workspace = true
 colored.workspace = true
 comfy-table.workspace = true
+convert_case.workspace = true
 current_platform = "0.2.0"
 fs-err = { workspace = true, features = ["tokio"] }
 fs_extra = { workspace = true, optional = true }

--- a/linera-service/src/project.rs
+++ b/linera-service/src/project.rs
@@ -9,6 +9,7 @@ use std::{
 
 use anyhow::{ensure, Context, Result};
 use cargo_toml::Manifest;
+use convert_case::{Case, Casing};
 use current_platform::CURRENT_PLATFORM;
 use fs_err::File;
 use tracing::debug;
@@ -160,7 +161,7 @@ impl Project {
     }
 
     fn create_state_file(source_directory: &Path, project_name: &str) -> Result<()> {
-        let project_name = Self::to_pascal_case(project_name);
+        let project_name = project_name.to_case(Case::Pascal);
         let state_path = source_directory.join("state.rs");
         let file_content = format!(
             include_str!("../template/state.rs.template"),
@@ -170,7 +171,7 @@ impl Project {
     }
 
     fn create_lib_file(source_directory: &Path, project_name: &str) -> Result<()> {
-        let project_name = Self::to_pascal_case(project_name);
+        let project_name = project_name.to_case(Case::Pascal);
         let state_path = source_directory.join("lib.rs");
         let file_content = format!(
             include_str!("../template/lib.rs.template"),
@@ -180,7 +181,7 @@ impl Project {
     }
 
     fn create_contract_file(source_directory: &Path, name: &str) -> Result<()> {
-        let project_name = Self::to_pascal_case(name);
+        let project_name = name.to_case(Case::Pascal);
         let contract_path = source_directory.join("contract.rs");
         let contract_contents = format!(
             include_str!("../template/contract.rs.template"),
@@ -191,7 +192,7 @@ impl Project {
     }
 
     fn create_service_file(source_directory: &Path, name: &str) -> Result<()> {
-        let project_name = Self::to_pascal_case(name);
+        let project_name = name.to_case(Case::Pascal);
         let service_path = source_directory.join("service.rs");
         let service_contents = format!(
             include_str!("../template/service.rs.template"),
@@ -242,26 +243,6 @@ impl Project {
         (linera_sdk_dep, linera_sdk_dev_dep)
     }
 
-    /// Converts a string to PascalCase.
-    fn to_pascal_case(s: &str) -> String {
-        let mut result = String::new();
-        // Start a word with capital letter.
-        let mut capitalize = true;
-        for c in s.chars() {
-            if c == '-' {
-                // New word incoming.
-                capitalize = true;
-            } else if capitalize {
-                result.push(c.to_ascii_uppercase());
-                // If we capitalize a letter, we should not capitalize the next one.
-                capitalize = false;
-            } else {
-                result.push(c);
-            }
-        }
-        result
-    }
-
     pub fn build(&self, name: Option<String>) -> Result<(PathBuf, PathBuf), anyhow::Error> {
         let name = match name {
             Some(name) => name,
@@ -297,20 +278,5 @@ impl Project {
 
     fn cargo_toml_path(&self) -> PathBuf {
         self.root.join("Cargo.toml")
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::Project;
-
-    #[test]
-    fn test_to_pascal_case() {
-        assert_eq!(Project::to_pascal_case("foo-bar"), "FooBar");
-        assert_eq!(Project::to_pascal_case("foo-bar-baz"), "FooBarBaz");
-        assert_eq!(Project::to_pascal_case("foo"), "Foo");
-        assert_eq!(Project::to_pascal_case("foo-"), "Foo");
-        assert_eq!(Project::to_pascal_case("-foo"), "Foo");
-        assert_eq!(Project::to_pascal_case("-foo-"), "Foo");
     }
 }

--- a/linera-service/template/contract.rs.template
+++ b/linera-service/template/contract.rs.template
@@ -8,29 +8,29 @@ use linera_sdk::{{
     Contract, ContractRuntime,
 }};
 
-use self::state::Application;
+use self::state::{project_name};
 
-pub struct ApplicationContract {{
-    state: Application,
+pub struct {project_name}Contract {{
+    state: {project_name},
     runtime: ContractRuntime<Self>,
 }}
 
-linera_sdk::contract!(ApplicationContract);
+linera_sdk::contract!({project_name}Contract);
 
-impl WithContractAbi for ApplicationContract {{
-    type Abi = {project_name}::ApplicationAbi;
+impl WithContractAbi for {project_name}Contract {{
+    type Abi = {module_name}::{project_name}Abi;
 }}
 
-impl Contract for ApplicationContract {{
+impl Contract for {project_name}Contract {{
     type Message = ();
     type Parameters = ();
     type InstantiationArgument = ();
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {{
-        let state = Application::load(runtime.root_view_storage_context())
+        let state = {project_name}::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
-        ApplicationContract {{ state, runtime }}
+        {project_name}Contract {{ state, runtime }}
     }}
 
     async fn instantiate(&mut self, _argument: Self::InstantiationArgument) {{}}

--- a/linera-service/template/lib.rs.template
+++ b/linera-service/template/lib.rs.template
@@ -1,13 +1,13 @@
-use linera_sdk::base::{ContractAbi, ServiceAbi};
+use linera_sdk::base::{{ContractAbi, ServiceAbi}};
 
-pub struct ApplicationAbi;
+pub struct {project_name}Abi;
 
-impl ContractAbi for ApplicationAbi {
+impl ContractAbi for {project_name}Abi {{
     type Operation = ();
     type Response = ();
-}
+}}
 
-impl ServiceAbi for ApplicationAbi {
+impl ServiceAbi for {project_name}Abi {{
     type Query = ();
     type QueryResponse = ();
-}
+}}

--- a/linera-service/template/service.rs.template
+++ b/linera-service/template/service.rs.template
@@ -2,32 +2,32 @@
 
 mod state;
 
-use self::state::Application;
+use self::state::{project_name};
 use linera_sdk::{{
     base::WithServiceAbi,
     views::{{View, ViewStorageContext}},
     Service, ServiceRuntime,
 }};
 
-pub struct ApplicationService {{
-    state: Application,
+pub struct {project_name}Service {{
+    state: {project_name},
     runtime: ServiceRuntime<Self>,
 }}
 
-linera_sdk::service!(ApplicationService);
+linera_sdk::service!({project_name}Service);
 
-impl WithServiceAbi for ApplicationService {{
-    type Abi = {project_name}::ApplicationAbi;
+impl WithServiceAbi for {project_name}Service {{
+    type Abi = {module_name}::{project_name}Abi;
 }}
 
-impl Service for ApplicationService {{
+impl Service for {project_name}Service {{
     type Parameters = ();
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {{
-        let state = Application::load(runtime.root_view_storage_context())
+        let state = {project_name}::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
-        ApplicationService {{ state, runtime }}
+        {project_name}Service {{ state, runtime }}
     }}
 
     async fn handle_query(&self, _query: Self::Query) -> Self::QueryResponse {{

--- a/linera-service/template/state.rs.template
+++ b/linera-service/template/state.rs.template
@@ -1,8 +1,8 @@
-use linera_sdk::views::{linera_views, RegisterView, RootView, ViewStorageContext};
+use linera_sdk::views::{{linera_views, RegisterView, RootView, ViewStorageContext}};
 
 #[derive(RootView, async_graphql::SimpleObject)]
 #[view(context = "ViewStorageContext")]
-pub struct Application {
+pub struct {project_name} {{
     pub value: RegisterView<u64>,
     // Add fields here.
-}
+}}


### PR DESCRIPTION
## Motivation

When generating a new linera project we were using generic `Application` as the name for `struct`s, `trait`s, etc rather than given project name (used when calling `linera project new <name>` command).

## Proposal

Parse given project name to PascalCase and use where appropriate.

Closes https://github.com/linera-io/linera-protocol/issues/2577
## Test Plan

Built the `linera` binary locally and run `linera project new my-counter`. The project builds correctly (after fixing dependencies' versions) and and the `my-counter` is used properly:
* `my_counter` as a module name.
* `MyCounter` as a name in `trait`s and `struct`s.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.
## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
