### PR TITLE
Don't keep the client mutex longer than necessary.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -871,9 +871,6 @@ where
         #[cfg(with_metrics)]
         let _latency = metrics::PREPARE_CHAIN_LATENCY.measure_latency();
 
-        let mutex = self.state().client_mutex();
-        let _guard = mutex.lock_owned().await;
-
         // Verify that our local storage contains enough history compared to the
         // expected block height. Otherwise, download the missing history from the
         // network.
@@ -893,6 +890,9 @@ where
         let ownership = &info.manager.ownership;
         let keys: HashSet<_> = self.state().known_key_pairs().keys().cloned().collect();
         if ownership.all_owners().any(|owner| !keys.contains(owner)) {
+            let mutex = self.state().client_mutex();
+            let _guard = mutex.lock_owned().await;
+
             // For chains with any owner other than ourselves, we could be missing recent
             // certificates created by other owners. Further synchronize blocks from the network.
             // This is a best-effort that depends on network conditions.
@@ -3016,6 +3016,8 @@ where
         let (name, tracker, certificates) = self
             .synchronize_received_certificates_from_validator(chain_id, &remote_node)
             .await?;
+
+        drop(_guard);
         // Process received certificates. If the client state has changed during the
         // network calls, we should still be fine.
         self.receive_certificates_from_validator(name, tracker, certificates)


### PR DESCRIPTION
## Motivation

I'm seeing what looks like sporadic deadlocks in the end-to-end tests (mostly fungible and matching engine) if I run them locally with the storage service.

## Proposal

Hold the client mutex only as long as needed.

## Test Plan

Running this locally for ~50 times I couldn't reproduce the deadlock issue.

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK.

## Links

- The PR that presumably caused the issue: https://github.com/linera-io/linera-protocol/pull/2567
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
