### PR TITLE
Some fixes on README's

### DIFF
--- a/examples/amm/README.md
+++ b/examples/amm/README.md
@@ -183,7 +183,7 @@ mutation {
 Note: The above mutation has to be performed from `http://localhost:8080`.
 
 Before performing any operation we need to provide liquidity to it, so we will use the `AddLiquidity` operation,
-navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID`.
+navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID"`.
 
 To perform `AddLiquidity` operation:
 
@@ -209,7 +209,7 @@ mutation {
 
 Note: The above mutation has to be performed from `http://localhost:8080`.
 
-To perform `Swap` operation, navigate to `http://localhost:8080/chains/$CHAIN_2/applications/$AMM_APPLICATION_ID` and
+To perform `Swap` operation, navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_2/applications/$AMM_APPLICATION_ID"` and
 perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$AMM_APPLICATION_ID
@@ -222,7 +222,7 @@ mutation {
 }
 ```
 
-To perform the `RemoveLiquidity` operation, navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID` and
+To perform the `RemoveLiquidity` operation, navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID"` and
 perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
@@ -235,7 +235,7 @@ mutation {
 }
 ```
 
-To perform the `RemoveAllAddedLiquidity` operation, navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID` and
+To perform the `RemoveAllAddedLiquidity` operation, navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID"` and
 perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
@@ -275,8 +275,8 @@ linera --wait-for-outgoing-messages change-application-permissions \
 linera service --port $PORT &
 ```
 
-First, let's add some liquidity again to the AMM. Navigate to
-`http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID` and perform the following mutation:
+First, let's add some liquidity again to the AMM. Navigate to the URL you get by running
+`echo "http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID"` and perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
 mutation {
@@ -288,15 +288,15 @@ mutation {
 }
 ```
 
-The only way to close the chain is via the application. Navigate to
-`http://localhost:8080/chains/$CHAIN_AMM/applications/$AMM_APPLICATION_ID` and perform the following mutation:
+The only way to close the chain is via the application. Navigate to the URL you get by running
+`echo "http://localhost:8080/chains/$CHAIN_AMM/applications/$AMM_APPLICATION_ID"` and perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_AMM/applications/$AMM_APPLICATION_ID
 mutation { closeChain }
 ```
 
 Owner 1 should now get back their tokens, and have around 49 FUN1 left and 51 FUN2 left. To check that, navigate
-to `http://localhost:8080/chains/$CHAIN_1/applications/$FUN1_APP_ID`, and perform the following mutation:
+to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$FUN1_APP_ID"`, and perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$FUN1_APP_ID
 query {
@@ -310,7 +310,7 @@ query {
 }
 ```
 
-Then navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$FUN2_APP_ID`, and perform the following mutation:
+Then navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$FUN2_APP_ID"`, and perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$FUN2_APP_ID
 query {

--- a/examples/amm/src/lib.rs
+++ b/examples/amm/src/lib.rs
@@ -187,7 +187,7 @@ mutation {
 Note: The above mutation has to be performed from `http://localhost:8080`.
 
 Before performing any operation we need to provide liquidity to it, so we will use the `AddLiquidity` operation,
-navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID`.
+navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID"`.
 
 To perform `AddLiquidity` operation:
 
@@ -213,7 +213,7 @@ mutation {
 
 Note: The above mutation has to be performed from `http://localhost:8080`.
 
-To perform `Swap` operation, navigate to `http://localhost:8080/chains/$CHAIN_2/applications/$AMM_APPLICATION_ID` and
+To perform `Swap` operation, navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_2/applications/$AMM_APPLICATION_ID"` and
 perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$AMM_APPLICATION_ID
@@ -226,7 +226,7 @@ mutation {
 }
 ```
 
-To perform the `RemoveLiquidity` operation, navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID` and
+To perform the `RemoveLiquidity` operation, navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID"` and
 perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
@@ -239,7 +239,7 @@ mutation {
 }
 ```
 
-To perform the `RemoveAllAddedLiquidity` operation, navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID` and
+To perform the `RemoveAllAddedLiquidity` operation, navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID"` and
 perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
@@ -279,8 +279,8 @@ linera --wait-for-outgoing-messages change-application-permissions \
 linera service --port $PORT &
 ```
 
-First, let's add some liquidity again to the AMM. Navigate to
-`http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID` and perform the following mutation:
+First, let's add some liquidity again to the AMM. Navigate to the URL you get by running
+`echo "http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID"` and perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
 mutation {
@@ -292,15 +292,15 @@ mutation {
 }
 ```
 
-The only way to close the chain is via the application. Navigate to
-`http://localhost:8080/chains/$CHAIN_AMM/applications/$AMM_APPLICATION_ID` and perform the following mutation:
+The only way to close the chain is via the application. Navigate to the URL you get by running
+`echo "http://localhost:8080/chains/$CHAIN_AMM/applications/$AMM_APPLICATION_ID"` and perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_AMM/applications/$AMM_APPLICATION_ID
 mutation { closeChain }
 ```
 
 Owner 1 should now get back their tokens, and have around 49 FUN1 left and 51 FUN2 left. To check that, navigate
-to `http://localhost:8080/chains/$CHAIN_1/applications/$FUN1_APP_ID`, and perform the following mutation:
+to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$FUN1_APP_ID"`, and perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$FUN1_APP_ID
 query {
@@ -314,7 +314,7 @@ query {
 }
 ```
 
-Then navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$FUN2_APP_ID`, and perform the following mutation:
+Then navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$FUN2_APP_ID"`, and perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$FUN2_APP_ID
 query {

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -68,7 +68,7 @@ linera service --port $PORT &
 
 Type each of these in the GraphiQL interface and substitute the env variables with their actual values that we've defined above.
 
-- Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$APPLICATION_ID`.
+- Navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$APPLICATION_ID"`.
 - To get the current value of `counter`, run the query:
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APPLICATION_ID
     query {

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -72,7 +72,7 @@ linera service --port $PORT &
 
 Type each of these in the GraphiQL interface and substitute the env variables with their actual values that we've defined above.
 
-- Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$APPLICATION_ID`.
+- Navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$APPLICATION_ID"`.
 - To get the current value of `counter`, run the query:
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APPLICATION_ID
     query {

--- a/examples/crowd-funding/README.md
+++ b/examples/crowd-funding/README.md
@@ -186,16 +186,11 @@ On both http://localhost:8080 and http://localhost:8081, you recognize the crowd
 application by its ID. The entry also has a field `link`. If you open that in a new tab, you
 see the GraphQL API for that application on that chain.
 
-Let's pledge 30 tokens by the campaign creator themself, i.e.
-[`$OWNER_0` on 8080](http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_1):
+Let's pledge 30 tokens by the campaign creator themself.
+For `$OWNER_0` on 8080, run `echo "http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_1"` to get the URL, open it
+and run the following query:
 
-Let's give it a variable for testing (for instance with `curl -g -X POST -H "Content-Type: application/json" -d '{ "query": "'$QUERY'" }' $URI | jq -e .data`):
-
-```bash
-CAMPAIGN=http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_1
-```
-
-```gql,uri=$CAMPAIGN
+```gql,uri=http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_1
 mutation { pledge(
     owner:"User:$OWNER_0",
     amount:"30."
@@ -204,20 +199,16 @@ mutation { pledge(
 
 This will make the owner show up if we list everyone who has made a pledge so far:
 
-```gql,uri=$CAMPAIGN
+```gql,uri=http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_1
 query { pledges { keys } }
 ```
 
 To also have `$OWNER_1` make a pledge, they first need to claim their tokens. Those are still
-on the other chain, where the application was created. Find the [link on 8081
-for the fungible application](http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_0),
-open it and run the following query.
+on the other chain, where the application was created. To get the link on 8081
+for the fungible application, run `echo "http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_0"`,
+open it and run the following query:
 
-```bash
-TOKEN1=http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_0
-```
-
-```gql,uri=$TOKEN1
+```gql,uri=http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_0
 mutation { claim(
   sourceAccount: {
     owner: "User:$OWNER_1",
@@ -233,21 +224,17 @@ mutation { claim(
 
 You can check that the 200 tokens have arrived:
 
-```gql,uri=$TOKEN1
+```gql,uri=http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_0
 query {
     accounts { entry(key: "User:$OWNER_1") { value } }
 }
 ```
 
-Now, also on 8081, you can open the [link for the crowd-funding
-application](http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_1)
+Now, also on 8081, you can open the link for the crowd-funding
+application you get when you run `echo "http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_1"`
 and run:
 
-```bash
-PLEDGE1=http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_1
-```
-
-```gql,uri=$PLEDGE1
+```gql,uri=http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_1
 mutation { pledge(
   owner:"User:$OWNER_1",
   amount:"80."
@@ -257,14 +244,14 @@ mutation { pledge(
 This pledges another 80 tokens. With 110 pledged in total, we have now reached the campaign
 goal. Now the campaign owner (on 8080) can collect the funds:
 
-```gql,uri=$CAMPAIGN
+```gql,uri=http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_1
 mutation { collect }
 ```
 
-[In the fungible application on
-8080](http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_0),
-check that we have received 110 tokens, in addition to the
-70 that we had left after pledging 30:
+Get the fungible application on
+8080 URL by running `echo "http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_0"`,
+then check that we have received 110 tokens, in addition to the
+70 that we had left after pledging 30 by running the following query:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_0
 query {

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -194,16 +194,11 @@ On both http://localhost:8080 and http://localhost:8081, you recognize the crowd
 application by its ID. The entry also has a field `link`. If you open that in a new tab, you
 see the GraphQL API for that application on that chain.
 
-Let's pledge 30 tokens by the campaign creator themself, i.e.
-[`$OWNER_0` on 8080](http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_1):
+Let's pledge 30 tokens by the campaign creator themself.
+For `$OWNER_0` on 8080, run `echo "http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_1"` to get the URL, open it
+and run the following query:
 
-Let's give it a variable for testing (for instance with `curl -g -X POST -H "Content-Type: application/json" -d '{ "query": "'$QUERY'" }' $URI | jq -e .data`):
-
-```bash
-CAMPAIGN=http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_1
-```
-
-```gql,uri=$CAMPAIGN
+```gql,uri=http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_1
 mutation { pledge(
     owner:"User:$OWNER_0",
     amount:"30."
@@ -212,20 +207,16 @@ mutation { pledge(
 
 This will make the owner show up if we list everyone who has made a pledge so far:
 
-```gql,uri=$CAMPAIGN
+```gql,uri=http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_1
 query { pledges { keys } }
 ```
 
 To also have `$OWNER_1` make a pledge, they first need to claim their tokens. Those are still
-on the other chain, where the application was created. Find the [link on 8081
-for the fungible application](http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_0),
-open it and run the following query.
+on the other chain, where the application was created. To get the link on 8081
+for the fungible application, run `echo "http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_0"`,
+open it and run the following query:
 
-```bash
-TOKEN1=http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_0
-```
-
-```gql,uri=$TOKEN1
+```gql,uri=http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_0
 mutation { claim(
   sourceAccount: {
     owner: "User:$OWNER_1",
@@ -241,21 +232,17 @@ mutation { claim(
 
 You can check that the 200 tokens have arrived:
 
-```gql,uri=$TOKEN1
+```gql,uri=http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_0
 query {
     accounts { entry(key: "User:$OWNER_1") { value } }
 }
 ```
 
-Now, also on 8081, you can open the [link for the crowd-funding
-application](http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_1)
+Now, also on 8081, you can open the link for the crowd-funding
+application you get when you run `echo "http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_1"`
 and run:
 
-```bash
-PLEDGE1=http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_1
-```
-
-```gql,uri=$PLEDGE1
+```gql,uri=http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID_1
 mutation { pledge(
   owner:"User:$OWNER_1",
   amount:"80."
@@ -265,14 +252,14 @@ mutation { pledge(
 This pledges another 80 tokens. With 110 pledged in total, we have now reached the campaign
 goal. Now the campaign owner (on 8080) can collect the funds:
 
-```gql,uri=$CAMPAIGN
+```gql,uri=http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_1
 mutation { collect }
 ```
 
-[In the fungible application on
-8080](http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_0),
-check that we have received 110 tokens, in addition to the
-70 that we had left after pledging 30:
+Get the fungible application on
+8080 URL by running `echo "http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_0"`,
+then check that we have received 110 tokens, in addition to the
+70 that we had left after pledging 30 by running the following query:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_0
 query {

--- a/examples/fungible/README.md
+++ b/examples/fungible/README.md
@@ -129,7 +129,7 @@ linera service --port $PORT &
 
 Type each of these in the GraphiQL interface and substitute the env variables with their actual values that we've defined above.
 
-- Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID`.
+- Navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID"`.
 - To get the current balance of user $OWNER_1, run the query:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -133,7 +133,7 @@ linera service --port $PORT &
 
 Type each of these in the GraphiQL interface and substitute the env variables with their actual values that we've defined above.
 
-- Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID`.
+- Navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID"`.
 - To get the current balance of user $OWNER_1, run the query:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID

--- a/examples/gen-nft/README.md
+++ b/examples/gen-nft/README.md
@@ -86,7 +86,7 @@ linera service --port $PORT &
 
 Type each of these in the GraphiQL interface and substitute the env variables with their actual values that we've defined above.
 
-- Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID`.
+- Navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID"`.
 - To mint an NFT, run the query:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
@@ -105,6 +105,9 @@ Type each of these in the GraphiQL interface and substitute the env variables wi
         ownedNfts(owner: "User:$OWNER_1")
     }
 ```
+
+Set the `QUERY_RESULT` variable to have the result returned by the previous query, and `TOKEN_ID` will be properly set for you.
+Alternatively you can set the `TOKEN_ID` variable to the `tokenId` value returned by the previous query yourself.
 
 ```bash
 TOKEN_ID=$(echo "$QUERY_RESULT" | jq -r '.ownedNfts[].tokenId')

--- a/examples/gen-nft/src/lib.rs
+++ b/examples/gen-nft/src/lib.rs
@@ -90,7 +90,7 @@ linera service --port $PORT &
 
 Type each of these in the GraphiQL interface and substitute the env variables with their actual values that we've defined above.
 
-- Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID`.
+- Navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID"`.
 - To mint an NFT, run the query:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
@@ -109,6 +109,9 @@ Type each of these in the GraphiQL interface and substitute the env variables wi
         ownedNfts(owner: "User:$OWNER_1")
     }
 ```
+
+Set the `QUERY_RESULT` variable to have the result returned by the previous query, and `TOKEN_ID` will be properly set for you.
+Alternatively you can set the `TOKEN_ID` variable to the `tokenId` value returned by the previous query yourself.
 
 ```bash
 TOKEN_ID=$(echo "$QUERY_RESULT" | jq -r '.ownedNfts[].tokenId')

--- a/examples/hex-game/README.md
+++ b/examples/hex-game/README.md
@@ -73,7 +73,7 @@ sleep 1
 Type each of these in the GraphiQL interface and substitute the env variables with their actual values that we've defined above.
 
 The `start` mutation starts a new game. We specify the two players using their new public keys,
-on [`http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID`][main_chain]:
+on the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID"`:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
 mutation {
@@ -112,13 +112,15 @@ query {
 }
 ```
 
+Set the `QUERY_RESULT` variable to have the result returned by the previous query, and `HEX_CHAIN` and `MESSAGE_ID` will be properly set for you.
+Alternatively you can set the variables to the `chainId` and `messageId` values, respectively, returned by the previous query yourself.
 Using the message ID, we can assign the new chain to the key in each wallet:
 
 ```bash
 kill %% && sleep 1    # Kill the service so we can use CLI commands for wallet 0.
 
-HEX_CHAIN=ae41b40b288a1e7ed064e2ff749a9ce3e780a5742dca074e6015e77e9dd373f8
-MESSAGE_ID=e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65040000000000000000000000
+HEX_CHAIN=$(echo "$QUERY_RESULT" | jq -r '.gameChains.entry.value[0].chainId')
+MESSAGE_ID=$(echo "$QUERY_RESULT" | jq -r '.gameChains.entry.value[0].messageId')
 
 linera -w0 assign --key $PUB_KEY_1 --message-id $MESSAGE_ID
 linera -w1 assign --key $PUB_KEY_2 --message-id $MESSAGE_ID
@@ -130,20 +132,16 @@ sleep 1
 
 ## Playing the Game
 
-Now the first player can make a move by navigating to [`http://localhost:8080/chains/$HEX_CHAIN/applications/$APP_ID`][first_player]
+Now the first player can make a move by navigating to the URL you get by running `echo "http://localhost:8080/chains/$HEX_CHAIN/applications/$APP_ID"`:
 
 ```gql,uri=http://localhost:8080/chains/$HEX_CHAIN/applications/$APP_ID
 mutation { makeMove(x: 4, y: 4) }
 ```
 
-And the second player player at [`http://localhost:8080/chains/$HEX_CHAIN/applications/$APP_ID`][second_player]
+And the second player player at the URL you get by running `echo "http://localhost:8080/chains/$HEX_CHAIN/applications/$APP_ID"`:
 
 ```gql,uri=http://localhost:8081/chains/$HEX_CHAIN/applications/$APP_ID
 mutation { makeMove(x: 4, y: 5) }
 ```
-
-[main_chain]: http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
-[first_player]: http://localhost:8080/chains/$HEX_CHAIN/applications/$APP_ID
-[second_player]: http://localhost:8081/chains/$HEX_CHAIN/applications/$APP_ID
 
 <!-- cargo-rdme end -->

--- a/examples/hex-game/src/lib.rs
+++ b/examples/hex-game/src/lib.rs
@@ -77,7 +77,7 @@ sleep 1
 Type each of these in the GraphiQL interface and substitute the env variables with their actual values that we've defined above.
 
 The `start` mutation starts a new game. We specify the two players using their new public keys,
-on [`http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID`][main_chain]:
+on the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID"`:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
 mutation {
@@ -116,13 +116,15 @@ query {
 }
 ```
 
+Set the `QUERY_RESULT` variable to have the result returned by the previous query, and `HEX_CHAIN` and `MESSAGE_ID` will be properly set for you.
+Alternatively you can set the variables to the `chainId` and `messageId` values, respectively, returned by the previous query yourself.
 Using the message ID, we can assign the new chain to the key in each wallet:
 
 ```bash
 kill %% && sleep 1    # Kill the service so we can use CLI commands for wallet 0.
 
-HEX_CHAIN=ae41b40b288a1e7ed064e2ff749a9ce3e780a5742dca074e6015e77e9dd373f8
-MESSAGE_ID=e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65040000000000000000000000
+HEX_CHAIN=$(echo "$QUERY_RESULT" | jq -r '.gameChains.entry.value[0].chainId')
+MESSAGE_ID=$(echo "$QUERY_RESULT" | jq -r '.gameChains.entry.value[0].messageId')
 
 linera -w0 assign --key $PUB_KEY_1 --message-id $MESSAGE_ID
 linera -w1 assign --key $PUB_KEY_2 --message-id $MESSAGE_ID
@@ -134,21 +136,17 @@ sleep 1
 
 ## Playing the Game
 
-Now the first player can make a move by navigating to [`http://localhost:8080/chains/$HEX_CHAIN/applications/$APP_ID`][first_player]
+Now the first player can make a move by navigating to the URL you get by running `echo "http://localhost:8080/chains/$HEX_CHAIN/applications/$APP_ID"`:
 
 ```gql,uri=http://localhost:8080/chains/$HEX_CHAIN/applications/$APP_ID
 mutation { makeMove(x: 4, y: 4) }
 ```
 
-And the second player player at [`http://localhost:8080/chains/$HEX_CHAIN/applications/$APP_ID`][second_player]
+And the second player player at the URL you get by running `echo "http://localhost:8080/chains/$HEX_CHAIN/applications/$APP_ID"`:
 
 ```gql,uri=http://localhost:8081/chains/$HEX_CHAIN/applications/$APP_ID
 mutation { makeMove(x: 4, y: 5) }
 ```
-
-[main_chain]: http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
-[first_player]: http://localhost:8080/chains/$HEX_CHAIN/applications/$APP_ID
-[second_player]: http://localhost:8081/chains/$HEX_CHAIN/applications/$APP_ID
 */
 
 use std::iter;

--- a/examples/matching-engine/README.md
+++ b/examples/matching-engine/README.md
@@ -124,7 +124,7 @@ linera service --port $PORT &
 
 Type each of these in the GraphiQL interface and substitute the env variables with their actual values that we've defined above.
 
-Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$MATCHING_ENGINE`:
+Navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$MATCHING_ENGINE"`:
 
 To create a `Bid` order as owner 1, offering to buy 1 FUN1 for 5 FUN2:
 
@@ -181,7 +181,7 @@ linera --wait-for-outgoing-messages change-application-permissions \
 linera service --port $PORT &
 ```
 
-First, owner 2 should claim their tokens. Navigate to `http://localhost:8080/chains/$CHAIN_2/applications/$FUN1_APP_ID`:
+First, owner 2 should claim their tokens. Navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_2/applications/$FUN1_APP_ID"`:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$FUN1_APP_ID
 mutation {
@@ -199,7 +199,7 @@ mutation {
 }
 ```
 
-And to `http://localhost:8080/chains/$CHAIN_2/applications/$FUN2_APP_ID`:
+And to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_2/applications/$FUN2_APP_ID"`:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$FUN2_APP_ID
 mutation {
@@ -218,7 +218,7 @@ mutation {
 ```
 
 Owner 2 offers to buy 2 FUN1 for 10 FUN2. This gets partially filled, and they buy 1 FUN1
-for 5 FUN2 from owner 1. This leaves 5 FUN2 of owner 2 on chain 1. On `http://localhost:8080/chains/$CHAIN_2/applications/$MATCHING_ENGINE`:
+for 5 FUN2 from owner 1. This leaves 5 FUN2 of owner 2 on chain 1. On the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_2/applications/$MATCHING_ENGINE"`:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$MATCHING_ENGINE
 mutation {
@@ -237,13 +237,13 @@ mutation {
 }
 ```
 
-The only way to close the chain is via the application now. On `http://localhost:8080/chains/$CHAIN_1/applications/$MATCHING_ENGINE`:
+The only way to close the chain is via the application now. On the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$MATCHING_ENGINE"`:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$MATCHING_ENGINE
 mutation { closeChain }
 ```
 
-Owner 2 should now get back their tokens, and have 145 FUN2 left. On `http://localhost:8080/chains/$CHAIN_2/applications/$FUN2_APP_ID`
+Owner 2 should now get back their tokens, and have 145 FUN2 left. On the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_2/applications/$FUN2_APP_ID"`
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$FUN2_APP_ID
 query {

--- a/examples/matching-engine/src/lib.rs
+++ b/examples/matching-engine/src/lib.rs
@@ -128,7 +128,7 @@ linera service --port $PORT &
 
 Type each of these in the GraphiQL interface and substitute the env variables with their actual values that we've defined above.
 
-Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$MATCHING_ENGINE`:
+Navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$MATCHING_ENGINE"`:
 
 To create a `Bid` order as owner 1, offering to buy 1 FUN1 for 5 FUN2:
 
@@ -185,7 +185,7 @@ linera --wait-for-outgoing-messages change-application-permissions \
 linera service --port $PORT &
 ```
 
-First, owner 2 should claim their tokens. Navigate to `http://localhost:8080/chains/$CHAIN_2/applications/$FUN1_APP_ID`:
+First, owner 2 should claim their tokens. Navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_2/applications/$FUN1_APP_ID"`:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$FUN1_APP_ID
 mutation {
@@ -203,7 +203,7 @@ mutation {
 }
 ```
 
-And to `http://localhost:8080/chains/$CHAIN_2/applications/$FUN2_APP_ID`:
+And to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_2/applications/$FUN2_APP_ID"`:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$FUN2_APP_ID
 mutation {
@@ -222,7 +222,7 @@ mutation {
 ```
 
 Owner 2 offers to buy 2 FUN1 for 10 FUN2. This gets partially filled, and they buy 1 FUN1
-for 5 FUN2 from owner 1. This leaves 5 FUN2 of owner 2 on chain 1. On `http://localhost:8080/chains/$CHAIN_2/applications/$MATCHING_ENGINE`:
+for 5 FUN2 from owner 1. This leaves 5 FUN2 of owner 2 on chain 1. On the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_2/applications/$MATCHING_ENGINE"`:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$MATCHING_ENGINE
 mutation {
@@ -241,13 +241,13 @@ mutation {
 }
 ```
 
-The only way to close the chain is via the application now. On `http://localhost:8080/chains/$CHAIN_1/applications/$MATCHING_ENGINE`:
+The only way to close the chain is via the application now. On the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$MATCHING_ENGINE"`:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$MATCHING_ENGINE
 mutation { closeChain }
 ```
 
-Owner 2 should now get back their tokens, and have 145 FUN2 left. On `http://localhost:8080/chains/$CHAIN_2/applications/$FUN2_APP_ID`
+Owner 2 should now get back their tokens, and have 145 FUN2 left. On the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_2/applications/$FUN2_APP_ID"`
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$FUN2_APP_ID
 query {

--- a/examples/native-fungible/README.md
+++ b/examples/native-fungible/README.md
@@ -70,7 +70,7 @@ linera service --port $PORT &
 
 Type each of these in the GraphiQL interface and substitute the env variables with their actual values that we've defined above.
 
-- Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID`.
+- Navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID"`.
 - To get the current balance of user $OWNER_1, run the query:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID

--- a/examples/native-fungible/src/lib.rs
+++ b/examples/native-fungible/src/lib.rs
@@ -74,7 +74,7 @@ linera service --port $PORT &
 
 Type each of these in the GraphiQL interface and substitute the env variables with their actual values that we've defined above.
 
-- Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID`.
+- Navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID"`.
 - To get the current balance of user $OWNER_1, run the query:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID

--- a/examples/non-fungible/README.md
+++ b/examples/non-fungible/README.md
@@ -98,11 +98,14 @@ Type each of these in the GraphiQL interface and substitute the env variables wi
     }
 ```
 
+Set the `QUERY_RESULT` variable to have the result returned by the previous query, and `BLOB_HASH` will be properly set for you.
+Alternatively you can set the `BLOB_HASH` variable to the hash returned by the previous query yourself.
+
 ```bash
 BLOB_HASH=$(echo "$QUERY_RESULT" | jq -r '.publishDataBlob')
 ```
 
-- Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID`.
+- Run `echo "http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID"` to print the URL to navigate to.
 - To mint an NFT, run the mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
@@ -122,6 +125,9 @@ BLOB_HASH=$(echo "$QUERY_RESULT" | jq -r '.publishDataBlob')
         ownedNfts(owner: "User:$OWNER_1")
     }
 ```
+
+Set the `QUERY_RESULT` variable to have the result returned by the previous query, and `TOKEN_ID` will be properly set for you.
+Alternatively you can set the `TOKEN_ID` variable to the `tokenId` value returned by the previous query yourself.
 
 ```bash
 TOKEN_ID=$(echo "$QUERY_RESULT" | jq -r '.ownedNfts[].tokenId')

--- a/examples/non-fungible/src/lib.rs
+++ b/examples/non-fungible/src/lib.rs
@@ -102,11 +102,14 @@ Type each of these in the GraphiQL interface and substitute the env variables wi
     }
 ```
 
+Set the `QUERY_RESULT` variable to have the result returned by the previous query, and `BLOB_HASH` will be properly set for you.
+Alternatively you can set the `BLOB_HASH` variable to the hash returned by the previous query yourself.
+
 ```bash
 BLOB_HASH=$(echo "$QUERY_RESULT" | jq -r '.publishDataBlob')
 ```
 
-- Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID`.
+- Run `echo "http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID"` to print the URL to navigate to.
 - To mint an NFT, run the mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
@@ -126,6 +129,9 @@ BLOB_HASH=$(echo "$QUERY_RESULT" | jq -r '.publishDataBlob')
         ownedNfts(owner: "User:$OWNER_1")
     }
 ```
+
+Set the `QUERY_RESULT` variable to have the result returned by the previous query, and `TOKEN_ID` will be properly set for you.
+Alternatively you can set the `TOKEN_ID` variable to the `tokenId` value returned by the previous query yourself.
 
 ```bash
 TOKEN_ID=$(echo "$QUERY_RESULT" | jq -r '.ownedNfts[].tokenId')

--- a/examples/social/README.md
+++ b/examples/social/README.md
@@ -112,8 +112,8 @@ query {
 ```
 
 Open both URLs under the entry `link`. Now you can use the application on each chain.
-E.g. [in the 8081 tab](http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID)
-subscribe to the other chain:
+For the 8081 tab, you can run `echo "http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID"`
+to print the URL to navigate to, then subscribe to the other chain using the following query:
 
 ```gql,uri=http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID
 mutation {
@@ -123,7 +123,7 @@ mutation {
 }
 ```
 
-Now make a post [in the 8080 tab](http://localhost:8080/chains/$CHAIN_2/applications/$APP_ID):
+Run `echo "http://localhost:8080/chains/$CHAIN_2/applications/$APP_ID"` to print the URL to navigate to, then make a post:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$APP_ID
 mutation {

--- a/examples/social/src/lib.rs
+++ b/examples/social/src/lib.rs
@@ -121,8 +121,8 @@ query {
 ```
 
 Open both URLs under the entry `link`. Now you can use the application on each chain.
-E.g. [in the 8081 tab](http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID)
-subscribe to the other chain:
+For the 8081 tab, you can run `echo "http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID"`
+to print the URL to navigate to, then subscribe to the other chain using the following query:
 
 ```gql,uri=http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID
 mutation {
@@ -132,7 +132,7 @@ mutation {
 }
 ```
 
-Now make a post [in the 8080 tab](http://localhost:8080/chains/$CHAIN_2/applications/$APP_ID):
+Run `echo "http://localhost:8080/chains/$CHAIN_2/applications/$APP_ID"` to print the URL to navigate to, then make a post:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$APP_ID
 mutation {


### PR DESCRIPTION
## Motivation

There are several links in the README's that don't actually link to a valid URL as they have environment variables within them.
Also `QUERY_RESULT` appears in the README's but we don't explain what it is or how to use it.

## Proposal

Fix the README's so that the user is instructed to run `echo` commands to get the proper URLs that need to be used.
Explain how to use `QUERY_RESULT` also.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

