### PR TITLE
Parallelize downloads in synchronize_received_certificates_from_validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4552,7 +4552,6 @@ dependencies = [
  "dashmap 5.5.3",
  "ed25519-dalek",
  "futures",
- "http 1.1.0",
  "insta",
  "linera-base",
  "linera-chain",

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -51,7 +51,6 @@ clap.workspace = true
 dashmap.workspace = true
 ed25519-dalek.workspace = true
 futures.workspace = true
-http.workspace = true
 linera-base.workspace = true
 linera-chain.workspace = true
 linera-core.workspace = true


### PR DESCRIPTION
## Motivation

Synchronizing the admin chain, e.g. using `linera sync-balance`, can be very slow.

## Proposal

Parallelize the certificate download.

## Test Plan

This is only an optimization; CI should catch any regressions.

## Release Plan

- These changes should be ported to main

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
