### PR TITLE
Make finalize-committee a separate command.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -20,6 +20,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera query-validators`↴](#linera-query-validators)
 * [`linera set-validator`↴](#linera-set-validator)
 * [`linera remove-validator`↴](#linera-remove-validator)
+* [`linera finalize-committee`↴](#linera-finalize-committee)
 * [`linera resource-control-policy`↴](#linera-resource-control-policy)
 * [`linera create-genesis-config`↴](#linera-create-genesis-config)
 * [`linera watch`↴](#linera-watch)
@@ -71,6 +72,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `query-validators` — Show the current set of validators for a chain
 * `set-validator` — Add or modify a validator (admin only)
 * `remove-validator` — Remove a validator (admin only)
+* `finalize-committee` — Deprecates all committees except the last one
 * `resource-control-policy` — View or update the resource control policy
 * `create-genesis-config` — Create genesis configuration for a Linera deployment. Create initial user chains and print information to be used for initialization of validator setup. This will also create an initial wallet for the owner of the initial "root" chains
 * `watch` — Watch the network for notifications
@@ -379,6 +381,14 @@ Remove a validator (admin only)
 ###### **Options:**
 
 * `--name <NAME>` — The public key of the validator
+
+
+
+## `linera finalize-committee`
+
+Deprecates all committees except the last one
+
+**Usage:** `linera finalize-committee`
 
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4552,7 +4552,6 @@ dependencies = [
  "dashmap 5.5.3",
  "ed25519-dalek",
  "futures",
- "http 1.1.0",
  "insta",
  "linera-base",
  "linera-chain",

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -460,6 +460,9 @@ pub enum ClientCommand {
         name: ValidatorName,
     },
 
+    /// Deprecates all committees except the last one.
+    FinalizeCommittee,
+
     /// View or update the resource control policy
     ResourceControlPolicy {
         /// Set the base price for creating a block.

--- a/linera-ethereum/src/client.rs
+++ b/linera-ethereum/src/client.rs
@@ -139,7 +139,11 @@ where
     type Error = EthereumServiceError;
 
     async fn get_accounts(&self) -> Result<Vec<String>, Self::Error> {
-        Ok(self.request("eth_accounts", ()).await?)
+        let results: Vec<String> = self.request("eth_accounts", ()).await?;
+        Ok(results
+            .into_iter()
+            .map(|x| x.to_lowercase())
+            .collect::<Vec<_>>())
     }
 
     async fn get_block_number(&self) -> Result<u64, Self::Error> {

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -51,7 +51,6 @@ clap.workspace = true
 dashmap.workspace = true
 ed25519-dalek.workspace = true
 futures.workspace = true
-http.workspace = true
 linera-base.workspace = true
 linera-chain.workspace = true
 linera-core.workspace = true

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -785,6 +785,15 @@ impl ClientWrapper {
         Ok(())
     }
 
+    pub async fn finalize_committee(&self) -> Result<()> {
+        self.command()
+            .await?
+            .arg("finalize-committee")
+            .spawn_and_wait_for_stdout()
+            .await?;
+        Ok(())
+    }
+
     /// Runs `linera keygen`.
     pub async fn keygen(&self) -> Result<PublicKey> {
         let stdout = self
@@ -975,7 +984,7 @@ impl NodeService {
     }
 
     pub async fn query_node(&self, query: impl AsRef<str>) -> Result<Value> {
-        let n_try = 15;
+        let n_try = 5;
         let query = query.as_ref();
         for i in 0..n_try {
             tokio::time::sleep(Duration::from_secs(i)).await;

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -633,9 +633,20 @@ impl Runnable for Job {
                 let Some(certificate) = maybe_certificate else {
                     return Ok(());
                 };
+                info!("Created new committee:\n{:?}", certificate);
+
+                let time_total = time_start.elapsed();
+                info!("Operations confirmed after {} ms", time_total.as_millis());
+            }
+
+            FinalizeCommittee => {
+                info!("Starting operations to remove old committees");
+                let time_start = Instant::now();
+
+                let chain_client = context.make_chain_client(context.wallet.genesis_admin_chain());
 
                 // Remove the old committee.
-                info!("Finalizing committee:\n{:?}", certificate);
+                info!("Finalizing current committee");
                 context
                     .apply_client_command(&chain_client, |chain_client| {
                         let chain_client = chain_client.clone();


### PR DESCRIPTION
## Motivation

We don't want to deprecate old committees by default, especially on the public devnets and testnets.

## Proposal

Make `finalize-committee` a separate command.

## Test Plan

We use it in the reconfiguration test now, and check that there is only one committee left at the end.

## Release Plan

- This is the backport of https://github.com/linera-io/linera-protocol/pull/2589 to testnet_boole.

## Links

- Original PR: https://github.com/linera-io/linera-protocol/pull/2589
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
