### PR TITLE
Follow new chains only if we own them.

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -273,15 +273,17 @@ where
                 let key_pair = owners
                     .iter()
                     .find_map(|public_key| context_guard.wallet().key_pair_for_pk(public_key));
-                context_guard.update_wallet_for_new_chain(new_id, key_pair, timestamp);
-                Self::run_with_chain_id(
-                    new_id,
-                    clients.clone(),
-                    context.clone(),
-                    storage.clone(),
-                    config.clone(),
-                    listening.clone(),
-                );
+                if key_pair.is_some() {
+                    context_guard.update_wallet_for_new_chain(new_id, key_pair, timestamp);
+                    Self::run_with_chain_id(
+                        new_id,
+                        clients.clone(),
+                        context.clone(),
+                        storage.clone(),
+                        config.clone(),
+                        listening.clone(),
+                    );
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
## Motivation

When a new chain is opened, the chain listener starts subscribing for notifications from all validators for the new chain.

In some cases, like the faucet, that will create a lot of connections.

## Proposal

Only subscribe if we own the new chain.

## Test Plan

This should reduce the number of connections the faucet creates. CI should catch any regressions.

## Release Plan

- These changes should be ported to main.
- We should release a new SDK, or at least use this version for the faucet.
 
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
