### PR TITLE
Allow creating a ChainClient if the chain is already in the map.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -471,6 +471,7 @@ where
             let chain_client = self.make_chain_client(chain_id);
             self.process_inbox(&chain_client).await.unwrap();
             chain_client.update_validators().await.unwrap();
+            self.update_wallet_from_client(&chain_client).await;
         }
     }
 
@@ -543,6 +544,7 @@ where
                 self.update_wallet_for_new_chain(chain_id, Some(key_pair.copy()), timestamp);
             }
         }
+        self.update_wallet_from_client(&chain_client).await;
         let updated_chain_client = self.make_chain_client(default_chain_id);
         updated_chain_client
             .retry_pending_outgoing_messages()


### PR DESCRIPTION
## Motivation

The `test_end_to_end_benchmark::storage_service_grpc` fails, because `make_chain_client` is called multiple times for the same chain.

## Proposal

Don't fail in that case, but compare the chain state to make sure it is up-to-date.
The latter also revealed that we missed some `update_wallet_from_client` calls.

Creating multiple chain clients is okay: `ChainClient` is already `Clone` anyway. Also, in the test the one chain client is dropped before the other one is created.

## Test Plan

I ran the test 100 times in a loop and it didn't fail anymore.

## Release Plan

- These changes should be ported to the `main` branch.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
