### PR TITLE
Allow creating a ChainClient if the chain is already in the map.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,8 +87,8 @@ jobs:
         cargo test --locked -p linera-execution --features wasmtime
     - name: Run the benchmark test
       run: |
-        cargo build --locked -p linera-service --bin linera-benchmark --features benchmark
-        cargo test --locked -p linera-service --features benchmark benchmark
+        cargo build --locked -p linera-service --bin linera-benchmark --features benchmark,storage-service
+        cargo test --locked -p linera-service --features benchmark,storage-service benchmark
     - name: Run Wasm application tests
       run: |
         cd examples

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -503,6 +503,7 @@ where
             let chain_client = self.make_chain_client(chain_id);
             self.process_inbox(&chain_client).await.unwrap();
             chain_client.update_validators().await.unwrap();
+            self.update_wallet_from_client(&chain_client).await.unwrap();
         }
     }
 
@@ -576,6 +577,7 @@ where
                     .await?;
             }
         }
+        self.update_wallet_from_client(&chain_client).await?;
         let updated_chain_client = self.make_chain_client(default_chain_id);
         updated_chain_client
             .retry_pending_outgoing_messages()

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -268,6 +268,7 @@ impl<P, S: Storage + Clone> Client<P, S> {
                 ));
             }
             dashmap::mapref::entry::Entry::Occupied(e) => {
+                // TODO(#2600): Find a better way to handle this case.
                 let state = e.get();
                 let owners = known_key_pairs
                     .into_iter()

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -226,6 +226,7 @@ async fn benchmark_with_fungible(
                     if expected_balance == Amount::ZERO {
                         return Ok(()); // No transfers: The app won't be registered on this chain.
                     }
+                    node_service.process_inbox(&context.default_chain).await?;
                     let app = FungibleApp(
                         node_service
                             .make_application(

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2912,7 +2912,7 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) -> Result<()> {
+async fn test_end_to_end_fungible_client_benchmark(config: impl LineraNetConfig) -> Result<()> {
     use linera_base::command::CommandExt;
     use tokio::process::Command;
 


### PR DESCRIPTION
## Motivation

The `test_end_to_end_benchmark::storage_service_grpc` fails, because `make_chain_client` is called multiple times for the same chain.

## Proposal

Don't fail in that case, but compare the chain state to make sure it is up-to-date.
The latter also revealed that we missed some `update_wallet_from_client` calls.

Creating multiple chain clients is okay: `ChainClient` is already `Clone` anyway. Also, in the test the one chain client is dropped before the other one is created.

## Test Plan

I ran the test 20 times in a loop and it didn't fail.

## Release Plan

This is the port of https://github.com/linera-io/linera-protocol/pull/2596 to `main`.

## Links

- `testnet_boole` version: https://github.com/linera-io/linera-protocol/pull/2596
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
