### PR TITLE
Add the storage-service feature to run the benchmark test in CI.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,8 +88,8 @@ jobs:
         cargo test --locked -p linera-execution --features wasmtime
     - name: Run the benchmark test
       run: |
-        cargo build --locked -p linera-service --bin linera-benchmark --features benchmark
-        cargo test --locked -p linera-service --features benchmark benchmark
+        cargo build --locked -p linera-service --bin linera-benchmark --features benchmark,storage-service
+        cargo test --locked -p linera-service --features benchmark,storage-service benchmark
     - name: Run Wasm application tests
       run: |
         cd examples

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -226,6 +226,7 @@ async fn benchmark_with_fungible(
                     if expected_balance == Amount::ZERO {
                         return Ok(()); // No transfers: The app won't be registered on this chain.
                     }
+                    node_service.process_inbox(&context.default_chain).await?;
                     let app = FungibleApp(
                         node_service
                             .make_application(

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2876,7 +2876,7 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) -> Result<()> {
+async fn test_end_to_end_fungible_client_benchmark(config: impl LineraNetConfig) -> Result<()> {
     use linera_base::command::CommandExt;
     use tokio::process::Command;
 


### PR DESCRIPTION
## Motivation

The benchmark test doesn't run in CI at all, because it needs the `storage-service` feature.

## Proposal

Enable the feature.

## Test Plan

This should now run the test in CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- I forgot to add that in #2596.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
