### PR TITLE
Disable `ed25519-dalek` default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ dashmap = "5.5.3"
 derive_more = "1.0.0"
 dirs = "5.0.1"
 dyn-clone = "1.0.17"
-ed25519-dalek = { version = "2.1.1", features = ["batch", "serde"] }
+ed25519-dalek = { version = "2.1.1", default-features = false, features = ["batch", "serde"] }
 either = "1.10.0"
 ethers = { version = "2.0.14", features = ["solc"] }
 flarch = "0.7.0"

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -30,11 +30,17 @@ pub enum GrpcProtoConversionError {
     #[error("Conversion failed due to missing field")]
     MissingField,
     #[error("Signature error: {0}")]
-    SignatureError(#[from] ed25519_dalek::SignatureError),
+    SignatureError(ed25519_dalek::SignatureError),
     #[error("Cryptographic error: {0}")]
     CryptoError(#[from] CryptoError),
     #[error("Inconsistent outer/inner chain ids")]
     InconsistentChainId,
+}
+
+impl From<ed25519_dalek::SignatureError> for GrpcProtoConversionError {
+    fn from(signature_error: ed25519_dalek::SignatureError) -> Self {
+        GrpcProtoConversionError::SignatureError(signature_error)
+    }
 }
 
 /// Extracts an optional field from a Proto type and tries to map it.


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
While working on the airdrop demo, I couldn't compile the application for `wasm32-unknown-unknown` after enabling `alloy-primitives`'s `k256` feature. The build failed because `getrandom` was included as a dependency.

After investigating the issue, it seems like not disabling `ed25519-dalek`'s default features in `linera-sdk` causes it to enable one of `k256` features that eventually includes `getrandom`.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Disable default features of the `ed25519-dalek` dependency.

A consequence of disabling the `std` feature from `ed25519-dalek` is that the `std::error::Error` trait isn't implemented for `ed25519_dalek::SignatureError`. Therefore, the `#[from]` attribute was removed from within the `GrpcProtoConversionError::SignatureError` variant. That means that it no longer uses a source error.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
After this change, I was able to compile the airdrop demo for the `wasm32-unknown-unknown` target.

CI should catch any regressions.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle, because this is a backwards compatible change.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
