### PR TITLE
Make Scylla run in production mode

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,6 +54,8 @@ jobs:
         run: docker build . -f docker/Dockerfile -t linera
       - name: Run Compose
         run: cd docker && ./compose.sh &
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - name: Sync
         uses: nick-fields/retry@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'docker/Dockerfile'
       - 'docker/compose.sh'
+      - 'docker/docker-compose.yml'
       - 'Cargo.toml'
       - '.github/workflows/docker.yml'
   workflow_dispatch:
@@ -59,4 +60,4 @@ jobs:
           # Docker compose can take some time to start
           max_attempts: 5
           timeout_minutes: 2
-          command: sleep 60 && linera --wallet docker/wallet.json --storage rocksdb:docker/linera.db sync-balance
+          command: sleep 120 && linera --wallet docker/wallet.json --storage rocksdb:docker/linera.db sync-balance

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: gcp-large
     timeout-minutes: 60
 
     steps:
@@ -47,6 +47,8 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update aio-max-nr
+        run: echo 1048576 > /proc/sys/fs/aio-max-nr
       - name: Build client binary
         run: |
           cargo install --path linera-service --bin linera --bin linera-server --debug

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,11 @@ services:
       - linera-scylla-data:/var/lib/scylla
     environment:
       SCYLLA_AUTO_CONF: 1
-      SCYLLA_ENABLE_EXPERIMENTAL: 1
+    command:
+      - "--developer-mode"
+      - "0"
+      - "--overprovisioned"
+      - "1"
   proxy:
     image: linera
     container_name: proxy


### PR DESCRIPTION
## Motivation

Scylla is running in developer mode causing performance issues and crashes for docker-compose deployment.

## Proposal

Switch developer mode off. Also enable the `--overprovisioned` flag so that Scylla doesn't hog all the host machine's resources.

## Test Plan

Tested manually. Logs show dev mode is off.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.