### PR TITLE
Introduce blob_bytes function

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1030,6 +1030,11 @@ impl BlobContent {
         }
         .clone()
     }
+
+    /// Gets the `BlobBytes` for this `BlobContent`.
+    pub fn blob_bytes(&self) -> BlobBytes {
+        BlobBytes(self.inner_bytes())
+    }
 }
 
 impl From<Blob> for BlobContent {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     bcs_scalar,
     crypto::{BcsHashable, CryptoError, CryptoHash, PublicKey},
-    data_types::{BlobBytes, BlobContent, BlockHeight},
+    data_types::{BlobContent, BlockHeight},
     doc_scalar,
 };
 
@@ -228,7 +228,7 @@ impl BlobId {
     /// Creates a new `BlobId` from a `BlobContent`
     pub fn from_content(content: &BlobContent) -> Self {
         Self {
-            hash: CryptoHash::new(&BlobBytes(content.inner_bytes())),
+            hash: CryptoHash::new(&content.blob_bytes()),
             blob_type: content.into(),
         }
     }


### PR DESCRIPTION
## Motivation

As we start adding new blob types, it would be good to have a common abstraction for how we generate the hashable bytes for blobs

## Proposal

Create the `blob_bytes` function. This will be more used also in following PRs.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
