### PR TITLE
`linera-execution`: disable multithreading in `wasmer-compiler-singlepass`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4243,6 +4243,7 @@ dependencies = [
  "linera-views",
  "linera-views-derive",
  "linera-wasmer",
+ "linera-wasmer-compiler-singlepass",
  "linera-witty",
  "lru",
  "oneshot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ wasm-encoder = "0.24.1"
 wasm-instrument = "0.4.0"
 wasm_thread = "0.3.0"
 wasmer = { package = "linera-wasmer", version = "4.4.0-linera.5", default-features = false }
-wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", version = "4.4.0-linera.5", default-features = false }
+wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", version = "4.4.0-linera.5", default-features = false, features = ["std", "unwind", "avx"] }
 wasmparser = "0.101.1"
 wasmtime = { version = "25.0.0", default-features = false, features = ["cranelift", "runtime", "std"] }
 wasmtimer = "0.2.0"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3253,6 +3253,7 @@ dependencies = [
  "linera-views",
  "linera-views-derive",
  "linera-wasmer",
+ "linera-wasmer-compiler-singlepass",
  "linera-witty",
  "lru",
  "oneshot",

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -66,6 +66,7 @@ wasmtime = { workspace = true, optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 wasmer = { workspace = true, optional = true, features = ["cranelift", "singlepass"] }
+wasmer-compiler-singlepass.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { workspace = true, features = ["rt"] }

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -258,7 +258,7 @@ impl CachedContractModule {
     fn create_compilation_engine() -> Engine {
         #[cfg(not(web))]
         {
-            let mut compiler_config = wasmer::Singlepass::default();
+            let mut compiler_config = wasmer_compiler_singlepass::Singlepass::default();
             compiler_config.canonicalize_nans(true);
 
             wasmer::sys::EngineBuilder::new(compiler_config).into()


### PR DESCRIPTION
## Motivation

We see a segfault in `wasmer-compiler-singlepass` code generation very occasionally in some cases.  In case it is the cause, and because we want this to be as predictable as possible anyway, disable multithreading for the `Singlepass` compiler.

<!--
Briefly describe the goal(s) of this PR.
-->

## Proposal

Replace our dependency on `wasmer/singlepass` with a direct dependency on `wasmer-compiler-singlepass`, and turn off the `rayon` feature.

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

@afck needs to run the test many times as the only person who can reproduce the segfault. :)

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
