### PR TITLE
Remove random_shuffle in favor of SliceRandom's shuffle

### DIFF
--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -8,7 +8,7 @@ use std::{
     fmt::Debug,
 };
 
-use rand::Rng;
+use rand::{seq::SliceRandom, Rng};
 
 use crate::{
     batch::{
@@ -28,21 +28,6 @@ pub fn get_random_key_prefix() -> Vec<u8> {
     let value: usize = make_nondeterministic_rng().rng_mut().gen();
     bcs::serialize_into(&mut key_prefix, &value).unwrap();
     key_prefix
-}
-
-/// Shuffles the values entries randomly
-pub fn random_shuffle<R: Rng, T: Clone>(rng: &mut R, values: &mut [T]) {
-    let n = values.len();
-    for _ in 0..4 * n {
-        let index1: usize = rng.gen_range(0..n);
-        let index2: usize = rng.gen_range(0..n);
-        if index1 != index2 {
-            let val1 = values.get(index1).unwrap().clone();
-            let val2 = values.get(index2).unwrap().clone();
-            values[index1] = val2;
-            values[index2] = val1;
-        }
-    }
 }
 
 /// Takes a random number generator, a key_prefix and extends it by n random bytes.
@@ -71,7 +56,7 @@ pub fn get_random_kset<R: Rng>(rng: &mut R, n: usize, k: usize) -> Vec<usize> {
     for u in 0..n {
         values.push(u);
     }
-    random_shuffle(rng, &mut values);
+    values.shuffle(rng);
     values[..k].to_vec()
 }
 
@@ -132,7 +117,7 @@ pub fn span_random_reordering_put_delete<R: Rng>(
     for i in 0..n {
         indices.push(i);
     }
-    random_shuffle(rng, &mut indices);
+    indices.shuffle(rng);
     let mut indices_rev = vec![0; n];
     for i in 0..n {
         indices_rev[indices[i]] = i;

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -33,7 +33,7 @@ use linera_views::{
     store::TestKeyValueStore as _,
     test_utils::{
         get_random_byte_vector, get_random_key_value_operations, get_random_key_values,
-        random_shuffle, span_random_reordering_put_delete,
+        span_random_reordering_put_delete,
     },
     views::{CryptoHashRootView, HashableView, Hasher, RootView, View, ViewError},
 };
@@ -1018,6 +1018,8 @@ where
 
 #[cfg(test)]
 async fn compute_hash_view_iter<R: RngCore>(rng: &mut R, n: usize, k: usize) -> Result<()> {
+    use rand::seq::SliceRandom;
+
     let mut unord1_hashes = Vec::new();
     let mut unord2_hashes = Vec::new();
     let mut ord_hashes = Vec::new();
@@ -1026,7 +1028,7 @@ async fn compute_hash_view_iter<R: RngCore>(rng: &mut R, n: usize, k: usize) -> 
     let n_iter = 4;
     for _ in 0..n_iter {
         let mut key_value_vector_b = key_value_vector.clone();
-        random_shuffle(rng, &mut key_value_vector_b);
+        key_value_vector_b.shuffle(rng);
         let operations = span_random_reordering_put_delete(rng, info_op.clone());
         //
         let mut store1 = MemoryTestStorage::new().await;


### PR DESCRIPTION
## Motivation

As much as this approach works, we already have a `shuffle` function in `SliceRandom`. Some points in favor of `SliceRandom`'s `shuffle`:
* This code executes multiple swaps between two randomly selected indices in the array, `SliceRandom::shuffle` performs an optimized Knuth shuffle which does `O(n)` swaps
* Some of these multiple swaps could also be redundant, which is less efficient in number of operations and randomness quality, becase multiple swaps also can potentially create a bias: since some elements can be swapped more times than others, we won't have every permutation be equally likely

## Proposal

Use `SliceRandom::shuffle` instead

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
