### PR TITLE
Don't create 10 chains for each remote-net test.

### DIFF
--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -50,8 +50,8 @@ impl LineraNetConfig for RemoteNetTestingConfig {
             .await
             .unwrap();
 
-        // And the remaining 9 here
-        for _ in 0..9 {
+        // And the remaining 2 here
+        for _ in 0..2 {
             client
                 .open_and_assign(&client, Amount::from_tokens(10))
                 .await


### PR DESCRIPTION
## Motivation

Each `remote-net` test requests 10 new chains from the faucet, even though none use that many.

## Proposal

Only request three chains.

## Test Plan

The tests passed for me locally this way. It should also make the daily test run against devnet and testnet more stable.

## Release Plan

- These changes should be ported to the main branch.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
