### PR TITLE
Fix unordered application registration messages (port to testnet)

### DIFF
--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -6,7 +6,7 @@ use std::{
     mem, vec,
 };
 
-use futures::{stream::FuturesUnordered, FutureExt, StreamExt, TryStreamExt};
+use futures::{stream::FuturesOrdered, FutureExt, StreamExt, TryStreamExt};
 use linera_base::{
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, ChainId, Destination, Owner},
@@ -271,7 +271,7 @@ where
                     message: SystemMessage::RegisterApplications { applications },
                 })
             })
-            .collect::<FuturesUnordered<_>>()
+            .collect::<FuturesOrdered<_>>()
             .try_collect::<Vec<_>>()
             .await?;
 


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
This is a port of #2621 to the testnet branch.

Sending messages to multiple applications could lead to non-deterministic execution outcomes (issue #2615).

This was caused by the incorrect usage of `FuturesUnordered`, which led to a non-deterministic order of application registration messages.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Use `FuturesOrdered` instead in order to provide a deterministic order.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
This can be tested manually with a block that sends messages to at least two different destinations or that requires two different applications to be registered on the receiving chain.

Unit tests should be added later (#2624).

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
This is a backport of #2621, and should be included in the next release.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
