### PR TITLE
Improve system api to perform HTTP requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,6 +4050,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "rand",
+ "reqwest 0.11.27",
  "ruzstd",
  "serde",
  "serde-name",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4032,7 +4032,6 @@ dependencies = [
  "async-graphql",
  "async-graphql-derive",
  "async-trait",
- "base64 0.22.1",
  "bcs",
  "cfg-if",
  "cfg_aliases",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3129,7 +3129,6 @@ dependencies = [
  "async-graphql",
  "async-graphql-derive",
  "async-trait",
- "base64 0.22.1",
  "bcs",
  "cfg-if",
  "cfg_aliases",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3144,6 +3144,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "rand",
+ "reqwest 0.11.27",
  "ruzstd",
  "serde",
  "serde-name",

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -33,7 +33,6 @@ anyhow.workspace = true
 async-graphql.workspace = true
 async-graphql-derive.workspace = true
 async-trait.workspace = true
-base64.workspace = true
 bcs.workspace = true
 cfg-if.workspace = true
 chrono.workspace = true

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -13,6 +13,7 @@ version.workspace = true
 
 [features]
 metrics = ["prometheus"]
+reqwest = ["dep:reqwest"]
 test = ["test-strategy", "proptest"]
 web = [
     "futures",
@@ -47,6 +48,7 @@ linera-witty = { workspace = true, features = ["macros"] }
 prometheus = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true, features = ["alloc"] }
 rand.workspace = true
+reqwest = { workspace = true, optional = true }
 serde.workspace = true
 serde-name.workspace = true
 serde_bytes.workspace = true

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-test = ["test-strategy", "proptest"]
 metrics = ["prometheus"]
+test = ["test-strategy", "proptest"]
 web = [
     "futures",
     "getrandom/js",

--- a/linera-base/build.rs
+++ b/linera-base/build.rs
@@ -6,6 +6,7 @@ fn main() {
         web: { all(target_arch = "wasm32", feature = "web") },
         chain: { all(target_arch = "wasm32", not(web)) },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
+        with_reqwest: { feature = "reqwest" },
         with_testing: { any(test, feature = "test") },
 
         // the old version of `getrandom` we pin here is available on all targets, but

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -30,7 +30,7 @@ use thiserror::Error;
 use crate::prometheus_util::{self, MeasureLatency};
 use crate::{
     crypto::BcsHashable,
-    doc_scalar, hex_debug,
+    doc_scalar, hex_debug, http,
     identifiers::{
         ApplicationId, BlobId, BlobType, BytecodeId, Destination, GenericApplicationId, MessageId,
         UserApplicationId,
@@ -735,7 +735,7 @@ pub enum OracleResponse {
     /// The response from a service query.
     Service(Vec<u8>),
     /// The response from an HTTP request.
-    Http(Vec<u8>),
+    Http(http::Response),
     /// A successful read or write of a blob.
     Blob(BlobId),
     /// An assertion oracle that passed.

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -736,8 +736,8 @@ impl ApplicationPermissions {
 pub enum OracleResponse {
     /// The response from a service query.
     Service(Vec<u8>),
-    /// The response from an HTTP POST request.
-    Post(Vec<u8>),
+    /// The response from an HTTP request.
+    Http(Vec<u8>),
     /// A successful read or write of a blob.
     Blob(BlobId),
     /// An assertion oracle that passed.
@@ -757,7 +757,7 @@ impl Display for OracleResponse {
             OracleResponse::Service(bytes) => {
                 write!(f, "Service:{}", STANDARD_NO_PAD.encode(bytes))?
             }
-            OracleResponse::Post(bytes) => write!(f, "Post:{}", STANDARD_NO_PAD.encode(bytes))?,
+            OracleResponse::Http(bytes) => write!(f, "Http:{}", STANDARD_NO_PAD.encode(bytes))?,
             OracleResponse::Blob(blob_id) => write!(f, "Blob:{}", blob_id)?,
             OracleResponse::Assert => write!(f, "Assert")?,
         };
@@ -775,8 +775,8 @@ impl FromStr for OracleResponse {
                 STANDARD_NO_PAD.decode(string).context("Invalid base64")?,
             ));
         }
-        if let Some(string) = s.strip_prefix("Post:") {
-            return Ok(OracleResponse::Post(
+        if let Some(string) = s.strip_prefix("Http:") {
+            return Ok(OracleResponse::Http(
                 STANDARD_NO_PAD.decode(string).context("Invalid base64")?,
             ));
         }

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -18,9 +18,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::Context as _;
 use async_graphql::InputObject;
-use base64::engine::{general_purpose::STANDARD_NO_PAD, Engine as _};
 use custom_debug_derive::Debug;
 use linera_witty::{WitLoad, WitStore, WitType};
 #[cfg(with_metrics)]
@@ -748,44 +746,6 @@ impl OracleResponse {
     /// Wether an `OracleResponse` is permitted in fast blocks or not.
     pub fn is_permitted_in_fast_blocks(&self) -> bool {
         matches!(self, OracleResponse::Blob(_))
-    }
-}
-
-impl Display for OracleResponse {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            OracleResponse::Service(bytes) => {
-                write!(f, "Service:{}", STANDARD_NO_PAD.encode(bytes))?
-            }
-            OracleResponse::Http(bytes) => write!(f, "Http:{}", STANDARD_NO_PAD.encode(bytes))?,
-            OracleResponse::Blob(blob_id) => write!(f, "Blob:{}", blob_id)?,
-            OracleResponse::Assert => write!(f, "Assert")?,
-        };
-
-        Ok(())
-    }
-}
-
-impl FromStr for OracleResponse {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Some(string) = s.strip_prefix("Service:") {
-            return Ok(OracleResponse::Service(
-                STANDARD_NO_PAD.decode(string).context("Invalid base64")?,
-            ));
-        }
-        if let Some(string) = s.strip_prefix("Http:") {
-            return Ok(OracleResponse::Http(
-                STANDARD_NO_PAD.decode(string).context("Invalid base64")?,
-            ));
-        }
-        if let Some(string) = s.strip_prefix("Blob:") {
-            return Ok(OracleResponse::Blob(
-                BlobId::from_str(string).context("Invalid BlobId")?,
-            ));
-        }
-        Err(anyhow::anyhow!("Invalid enum! Enum: {}", s))
     }
 }
 

--- a/linera-base/src/http.rs
+++ b/linera-base/src/http.rs
@@ -56,6 +56,12 @@ impl Request {
             body: serde_json::to_vec(payload)?,
         })
     }
+
+    /// Adds a header to this [`Request`].
+    pub fn with_header(mut self, name: impl Into<String>, value: impl Into<Vec<u8>>) -> Self {
+        self.headers.push((name.into(), value.into()));
+        self
+    }
 }
 
 /// The method used in an HTTP request.

--- a/linera-base/src/http.rs
+++ b/linera-base/src/http.rs
@@ -4,6 +4,7 @@
 //! Types used when performing HTTP requests.
 
 use linera_witty::{WitLoad, WitStore, WitType};
+use serde::{Deserialize, Serialize};
 
 /// The method used in an HTTP request.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, WitLoad, WitStore, WitType)]
@@ -50,5 +51,37 @@ impl From<Method> for reqwest::Method {
             Method::Patch => reqwest::Method::PATCH,
             Method::Trace => reqwest::Method::TRACE,
         }
+    }
+}
+
+/// A response for an HTTP request.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize, WitLoad, WitStore, WitType)]
+pub struct Response {
+    /// The status code of the HTTP response.
+    pub status: u16,
+
+    /// The headers included in the response.
+    pub headers: Vec<(String, Vec<u8>)>,
+
+    /// The body of the response.
+    pub body: Vec<u8>,
+}
+
+#[cfg(with_reqwest)]
+impl Response {
+    /// Creates a [`Response`] from a [`reqwest::Response`], waiting for it to be fully
+    /// received.
+    pub async fn from_reqwest(response: reqwest::Response) -> reqwest::Result<Self> {
+        let headers = response
+            .headers()
+            .into_iter()
+            .map(|(name, value)| (name.to_string(), value.as_bytes().to_owned()))
+            .collect();
+
+        Ok(Response {
+            status: response.status().as_u16(),
+            headers,
+            body: response.bytes().await?.to_vec(),
+        })
     }
 }

--- a/linera-base/src/http.rs
+++ b/linera-base/src/http.rs
@@ -7,7 +7,7 @@ use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Serialize};
 
 /// An HTTP request.
-#[derive(Clone, Debug, WitLoad, WitStore, WitType)]
+#[derive(Clone, Debug, Eq, PartialEq, WitLoad, WitStore, WitType)]
 pub struct Request {
     /// The [`Method`] used for the HTTP request.
     pub method: Method,

--- a/linera-base/src/http.rs
+++ b/linera-base/src/http.rs
@@ -22,6 +22,42 @@ pub struct Request {
     pub body: Vec<u8>,
 }
 
+impl Request {
+    /// Creates an HTTP GET [`Request`] for a `url`.
+    pub fn get(url: impl Into<String>) -> Self {
+        Request {
+            method: Method::Get,
+            url: url.into(),
+            headers: vec![],
+            body: vec![],
+        }
+    }
+
+    /// Creates an HTTP POST [`Request`] for a `url` with a `payload` that's an arbitrary bytes.
+    pub fn post(url: impl Into<String>, payload: impl Into<Vec<u8>>) -> Self {
+        Request {
+            method: Method::Post,
+            url: url.into(),
+            headers: vec![],
+            body: payload.into(),
+        }
+    }
+
+    /// Creates an HTTP POST [`Request`] for a `url` with a body that's the `payload` serialized to
+    /// JSON.
+    pub fn post_json(
+        url: impl Into<String>,
+        payload: &impl Serialize,
+    ) -> Result<Self, serde_json::Error> {
+        Ok(Request {
+            method: Method::Post,
+            url: url.into(),
+            headers: vec![("Content-Type".to_owned(), b"application/json".to_vec())],
+            body: serde_json::to_vec(payload)?,
+        })
+    }
+}
+
 /// The method used in an HTTP request.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, WitLoad, WitStore, WitType)]
 pub enum Method {

--- a/linera-base/src/http.rs
+++ b/linera-base/src/http.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types used when performing HTTP requests.
+
+use linera_witty::{WitLoad, WitStore, WitType};
+
+/// The method used in an HTTP request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitLoad, WitStore, WitType)]
+pub enum Method {
+    /// A GET request.
+    Get,
+
+    /// A POST request.
+    Post,
+
+    /// A PUT request.
+    Put,
+
+    /// A DELETE request.
+    Delete,
+
+    /// A HEAD request.
+    Head,
+
+    /// A OPTIONS request.
+    Options,
+
+    /// A CONNECT request.
+    Connect,
+
+    /// A PATCH request.
+    Patch,
+
+    /// A TRACE request.
+    Trace,
+}
+
+#[cfg(with_reqwest)]
+impl From<Method> for reqwest::Method {
+    fn from(method: Method) -> Self {
+        match method {
+            Method::Get => reqwest::Method::GET,
+            Method::Post => reqwest::Method::POST,
+            Method::Put => reqwest::Method::PUT,
+            Method::Delete => reqwest::Method::DELETE,
+            Method::Head => reqwest::Method::HEAD,
+            Method::Options => reqwest::Method::OPTIONS,
+            Method::Connect => reqwest::Method::CONNECT,
+            Method::Patch => reqwest::Method::PATCH,
+            Method::Trace => reqwest::Method::TRACE,
+        }
+    }
+}

--- a/linera-base/src/http.rs
+++ b/linera-base/src/http.rs
@@ -6,6 +6,22 @@
 use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Serialize};
 
+/// An HTTP request.
+#[derive(Clone, Debug, WitLoad, WitStore, WitType)]
+pub struct Request {
+    /// The [`Method`] used for the HTTP request.
+    pub method: Method,
+
+    /// The URL this request is intended to.
+    pub url: String,
+
+    /// The headers that should be included in the request.
+    pub headers: Vec<(String, Vec<u8>)>,
+
+    /// The body of the request.
+    pub body: Vec<u8>,
+}
+
 /// The method used in an HTTP request.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, WitLoad, WitStore, WitType)]
 pub enum Method {

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -17,6 +17,7 @@ pub mod command;
 pub mod crypto;
 pub mod data_types;
 mod graphql;
+pub mod http;
 pub mod identifiers;
 pub mod ownership;
 #[cfg(not(target_arch = "wasm32"))]

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -45,7 +45,7 @@ dashmap.workspace = true
 derive_more = { workspace = true, features = ["display"] }
 dyn-clone.workspace = true
 futures.workspace = true
-linera-base.workspace = true
+linera-base = { workspace = true, features = ["reqwest"] }
 linera-views.workspace = true
 linera-views-derive.workspace = true
 linera-witty = { workspace = true, features = ["log", "macros"] }

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -12,6 +12,7 @@ use futures::channel::mpsc;
 use linera_base::prometheus_util::{self, MeasureLatency as _};
 use linera_base::{
     data_types::{Amount, ApplicationPermissions, BlobContent, Timestamp},
+    http,
     identifiers::{Account, BlobId, MessageId, Owner},
     ownership::ChainOwnership,
 };
@@ -289,13 +290,14 @@ where
             }
 
             HttpRequest {
+                method,
                 url,
                 content_type,
                 payload,
                 callback,
             } => {
                 let res = Client::new()
-                    .post(url)
+                    .request(method.into(), url)
                     .body(payload)
                     .header(CONTENT_TYPE, content_type)
                     .send()
@@ -438,6 +440,7 @@ pub enum ExecutionRequest {
     },
 
     HttpRequest {
+        method: http::Method,
         url: String,
         content_type: String,
         payload: Vec<u8>,
@@ -579,9 +582,13 @@ impl Debug for ExecutionRequest {
                 .finish_non_exhaustive(),
 
             ExecutionRequest::HttpRequest {
-                url, content_type, ..
+                method,
+                url,
+                content_type,
+                ..
             } => formatter
                 .debug_struct("ExecutionRequest::HttpRequest")
+                .field("method", method)
                 .field("url", url)
                 .field("content_type", content_type)
                 .finish_non_exhaustive(),

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -301,15 +301,13 @@ where
                     .map(|(name, value)| Ok((name.parse()?, value.try_into()?)))
                     .collect::<Result<HeaderMap, ExecutionError>>()?;
 
-                let res = Client::new()
+                let response = Client::new()
                     .request(method.into(), url)
                     .body(payload)
                     .headers(headers)
                     .send()
                     .await?;
-                let body = res.bytes().await?;
-                let bytes = body.as_ref().to_vec();
-                callback.respond(bytes);
+                callback.respond(http::Response::from_reqwest(response).await?);
             }
 
             ReadBlobContent { blob_id, callback } => {
@@ -449,7 +447,7 @@ pub enum ExecutionRequest {
         url: String,
         headers: Vec<(String, Vec<u8>)>,
         payload: Vec<u8>,
-        callback: oneshot::Sender<Vec<u8>>,
+        callback: oneshot::Sender<http::Response>,
     },
 
     ReadBlobContent {

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -288,7 +288,7 @@ where
                 callback.respond(bytes);
             }
 
-            HttpPost {
+            HttpRequest {
                 url,
                 content_type,
                 payload,
@@ -437,7 +437,7 @@ pub enum ExecutionRequest {
         callback: Sender<Vec<u8>>,
     },
 
-    HttpPost {
+    HttpRequest {
         url: String,
         content_type: String,
         payload: Vec<u8>,
@@ -578,10 +578,10 @@ impl Debug for ExecutionRequest {
                 .field("url", url)
                 .finish_non_exhaustive(),
 
-            ExecutionRequest::HttpPost {
+            ExecutionRequest::HttpRequest {
                 url, content_type, ..
             } => formatter
-                .debug_struct("ExecutionRequest::HttpPost")
+                .debug_struct("ExecutionRequest::HttpRequest")
                 .field("url", url)
                 .field("content_type", content_type)
                 .finish_non_exhaustive(),

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -516,7 +516,7 @@ pub trait BaseRuntime {
         url: &str,
         headers: Vec<(String, Vec<u8>)>,
         payload: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError>;
+    ) -> Result<http::Response, ExecutionError>;
 
     /// Ensures that the current time at block validation is `< timestamp`. Note that block
     /// validation happens at or after the block timestamp, but isn't necessarily the same.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -36,7 +36,7 @@ use linera_base::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, DecompressionError,
         Resources, SendMessageRequest, Timestamp, UserApplicationDescription,
     },
-    doc_scalar, hex_debug,
+    doc_scalar, hex_debug, http,
     identifiers::{
         Account, ApplicationId, BlobId, BytecodeId, ChainId, ChannelName, Destination,
         GenericApplicationId, MessageId, Owner, StreamName, UserApplicationId,
@@ -504,9 +504,10 @@ pub trait BaseRuntime {
         query: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError>;
 
-    /// Makes a POST request to the given URL and returns the answer, if any.
+    /// Makes an HTTP request to the given URL and returns the answer, if any.
     fn http_request(
         &mut self,
+        method: http::Method,
         url: &str,
         content_type: String,
         payload: Vec<u8>,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -510,13 +510,7 @@ pub trait BaseRuntime {
     ) -> Result<Vec<u8>, ExecutionError>;
 
     /// Makes an HTTP request to the given URL and returns the answer, if any.
-    fn http_request(
-        &mut self,
-        method: http::Method,
-        url: &str,
-        headers: Vec<(String, Vec<u8>)>,
-        payload: Vec<u8>,
-    ) -> Result<http::Response, ExecutionError>;
+    fn http_request(&mut self, request: http::Request) -> Result<http::Response, ExecutionError>;
 
     /// Ensures that the current time at block validation is `< timestamp`. Note that block
     /// validation happens at or after the block timestamp, but isn't necessarily the same.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -205,6 +205,11 @@ pub enum ExecutionError {
     // and enforced limits for all oracles.
     #[error("Unstable oracles are disabled on this network.")]
     UnstableOracle,
+
+    #[error("Invalid HTTP header name used for HTTP request")]
+    InvalidHeaderName(#[from] reqwest::header::InvalidHeaderName),
+    #[error("Invalid HTTP header value used for HTTP request")]
+    InvalidHeaderValue(#[from] reqwest::header::InvalidHeaderValue),
 }
 
 /// The public entry points provided by the contract part of an application.
@@ -509,7 +514,7 @@ pub trait BaseRuntime {
         &mut self,
         method: http::Method,
         url: &str,
-        content_type: String,
+        headers: Vec<(String, Vec<u8>)>,
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError>;
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -505,7 +505,7 @@ pub trait BaseRuntime {
     ) -> Result<Vec<u8>, ExecutionError>;
 
     /// Makes a POST request to the given URL and returns the answer, if any.
-    fn http_post(
+    fn http_request(
         &mut self,
         url: &str,
         content_type: String,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -15,7 +15,7 @@ use linera_base::{
         Amount, ApplicationPermissions, ArithmeticError, BlockHeight, OracleResponse, Resources,
         SendMessageRequest, Timestamp,
     },
-    ensure,
+    ensure, http,
     identifiers::{
         Account, ApplicationId, BlobId, BlobType, ChainId, ChannelName, MessageId, Owner,
         StreamName,
@@ -676,11 +676,13 @@ impl<UserInstance> BaseRuntime for SyncRuntimeHandle<UserInstance> {
 
     fn http_request(
         &mut self,
+        method: http::Method,
         url: &str,
         content_type: String,
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
-        self.inner().http_request(url, content_type, payload)
+        self.inner()
+            .http_request(method, url, content_type, payload)
     }
 
     fn assert_before(&mut self, timestamp: Timestamp) -> Result<(), ExecutionError> {
@@ -954,6 +956,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
 
     fn http_request(
         &mut self,
+        method: http::Method,
         url: &str,
         content_type: String,
         payload: Vec<u8>,
@@ -972,6 +975,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
                 let url = url.to_string();
                 self.execution_state_sender
                     .send_request(|callback| ExecutionRequest::HttpRequest {
+                        method,
                         url,
                         content_type,
                         payload,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -674,13 +674,13 @@ impl<UserInstance> BaseRuntime for SyncRuntimeHandle<UserInstance> {
         self.inner().query_service(application_id, query)
     }
 
-    fn http_post(
+    fn http_request(
         &mut self,
         url: &str,
         content_type: String,
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
-        self.inner().http_post(url, content_type, payload)
+        self.inner().http_request(url, content_type, payload)
     }
 
     fn assert_before(&mut self, timestamp: Timestamp) -> Result<(), ExecutionError> {
@@ -952,7 +952,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         Ok(response)
     }
 
-    fn http_post(
+    fn http_request(
         &mut self,
         url: &str,
         content_type: String,
@@ -971,7 +971,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
             } else {
                 let url = url.to_string();
                 self.execution_state_sender
-                    .send_request(|callback| ExecutionRequest::HttpPost {
+                    .send_request(|callback| ExecutionRequest::HttpRequest {
                         url,
                         content_type,
                         payload,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -680,7 +680,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeHandle<UserInstance> {
         url: &str,
         headers: Vec<(String, Vec<u8>)>,
         payload: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError> {
+    ) -> Result<http::Response, ExecutionError> {
         self.inner().http_request(method, url, headers, payload)
     }
 
@@ -959,15 +959,15 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         url: &str,
         headers: Vec<(String, Vec<u8>)>,
         payload: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError> {
+    ) -> Result<http::Response, ExecutionError> {
         ensure!(
             cfg!(feature = "unstable-oracles"),
             ExecutionError::UnstableOracle
         );
-        let bytes =
+        let response =
             if let Some(response) = self.transaction_tracker.next_replayed_oracle_response()? {
                 match response {
-                    OracleResponse::Http(bytes) => bytes,
+                    OracleResponse::Http(response) => response,
                     _ => return Err(ExecutionError::OracleResponseMismatch),
                 }
             } else {
@@ -983,8 +983,8 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
                     .recv_response()?
             };
         self.transaction_tracker
-            .add_oracle_response(OracleResponse::Http(bytes.clone()));
-        Ok(bytes)
+            .add_oracle_response(OracleResponse::Http(response.clone()));
+        Ok(response)
     }
 
     fn assert_before(&mut self, timestamp: Timestamp) -> Result<(), ExecutionError> {

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -674,14 +674,8 @@ impl<UserInstance> BaseRuntime for SyncRuntimeHandle<UserInstance> {
         self.inner().query_service(application_id, query)
     }
 
-    fn http_request(
-        &mut self,
-        method: http::Method,
-        url: &str,
-        headers: Vec<(String, Vec<u8>)>,
-        payload: Vec<u8>,
-    ) -> Result<http::Response, ExecutionError> {
-        self.inner().http_request(method, url, headers, payload)
+    fn http_request(&mut self, request: http::Request) -> Result<http::Response, ExecutionError> {
+        self.inner().http_request(request)
     }
 
     fn assert_before(&mut self, timestamp: Timestamp) -> Result<(), ExecutionError> {
@@ -953,13 +947,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         Ok(response)
     }
 
-    fn http_request(
-        &mut self,
-        method: http::Method,
-        url: &str,
-        headers: Vec<(String, Vec<u8>)>,
-        payload: Vec<u8>,
-    ) -> Result<http::Response, ExecutionError> {
+    fn http_request(&mut self, request: http::Request) -> Result<http::Response, ExecutionError> {
         ensure!(
             cfg!(feature = "unstable-oracles"),
             ExecutionError::UnstableOracle
@@ -971,15 +959,8 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
                     _ => return Err(ExecutionError::OracleResponseMismatch),
                 }
             } else {
-                let url = url.to_string();
                 self.execution_state_sender
-                    .send_request(|callback| ExecutionRequest::HttpRequest {
-                        method,
-                        url,
-                        headers,
-                        payload,
-                        callback,
-                    })?
+                    .send_request(|callback| ExecutionRequest::HttpRequest { request, callback })?
                     .recv_response()?
             };
         self.transaction_tracker

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -678,11 +678,10 @@ impl<UserInstance> BaseRuntime for SyncRuntimeHandle<UserInstance> {
         &mut self,
         method: http::Method,
         url: &str,
-        content_type: String,
+        headers: Vec<(String, Vec<u8>)>,
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
-        self.inner()
-            .http_request(method, url, content_type, payload)
+        self.inner().http_request(method, url, headers, payload)
     }
 
     fn assert_before(&mut self, timestamp: Timestamp) -> Result<(), ExecutionError> {
@@ -958,7 +957,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         &mut self,
         method: http::Method,
         url: &str,
-        content_type: String,
+        headers: Vec<(String, Vec<u8>)>,
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
         ensure!(
@@ -977,7 +976,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
                     .send_request(|callback| ExecutionRequest::HttpRequest {
                         method,
                         url,
-                        content_type,
+                        headers,
                         payload,
                         callback,
                     })?

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -967,7 +967,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         let bytes =
             if let Some(response) = self.transaction_tracker.next_replayed_oracle_response()? {
                 match response {
-                    OracleResponse::Post(bytes) => bytes,
+                    OracleResponse::Http(bytes) => bytes,
                     _ => return Err(ExecutionError::OracleResponseMismatch),
                 }
             } else {
@@ -983,7 +983,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
                     .recv_response()?
             };
         self.transaction_tracker
-            .add_oracle_response(OracleResponse::Post(bytes.clone()));
+            .add_oracle_response(OracleResponse::Http(bytes.clone()));
         Ok(bytes)
     }
 

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -345,7 +345,7 @@ where
         query: String,
         headers: Vec<(String, Vec<u8>)>,
         payload: Vec<u8>,
-    ) -> Result<Vec<u8>, RuntimeError> {
+    ) -> Result<http::Response, RuntimeError> {
         caller
             .user_data_mut()
             .runtime
@@ -549,7 +549,7 @@ where
         query: String,
         headers: Vec<(String, Vec<u8>)>,
         payload: Vec<u8>,
-    ) -> Result<Vec<u8>, RuntimeError> {
+    ) -> Result<http::Response, RuntimeError> {
         caller
             .user_data_mut()
             .runtime

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -338,7 +338,7 @@ where
     }
 
     /// Makes a POST request to the given URL and returns the response body.
-    fn http_post(
+    fn http_request(
         caller: &mut Caller,
         query: String,
         content_type: String,
@@ -347,7 +347,7 @@ where
         caller
             .user_data_mut()
             .runtime
-            .http_post(&query, content_type, payload)
+            .http_request(&query, content_type, payload)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
@@ -541,7 +541,7 @@ where
     }
 
     /// Makes a POST request to the given URL and returns the response body.
-    fn http_post(
+    fn http_request(
         caller: &mut Caller,
         query: String,
         content_type: String,
@@ -550,7 +550,7 @@ where
         caller
             .user_data_mut()
             .runtime
-            .http_post(&query, content_type, payload)
+            .http_request(&query, content_type, payload)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -6,6 +6,7 @@ use std::{any::Any, collections::HashMap, marker::PhantomData};
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, ApplicationPermissions, BlockHeight, SendMessageRequest, Timestamp},
+    http,
     identifiers::{Account, ApplicationId, ChainId, ChannelName, MessageId, Owner, StreamName},
     ownership::{ChainOwnership, CloseChainError},
 };
@@ -337,9 +338,10 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
-    /// Makes a POST request to the given URL and returns the response body.
+    /// Makes an HTTP request to the given URL and returns the response body.
     fn http_request(
         caller: &mut Caller,
+        method: http::Method,
         query: String,
         content_type: String,
         payload: Vec<u8>,
@@ -347,7 +349,7 @@ where
         caller
             .user_data_mut()
             .runtime
-            .http_request(&query, content_type, payload)
+            .http_request(method, &query, content_type, payload)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
@@ -540,9 +542,10 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
-    /// Makes a POST request to the given URL and returns the response body.
+    /// Makes an HTTP request to the given URL and returns the response body.
     fn http_request(
         caller: &mut Caller,
+        method: http::Method,
         query: String,
         content_type: String,
         payload: Vec<u8>,
@@ -550,7 +553,7 @@ where
         caller
             .user_data_mut()
             .runtime
-            .http_request(&query, content_type, payload)
+            .http_request(method, &query, content_type, payload)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -341,15 +341,12 @@ where
     /// Makes an HTTP request to the given URL and returns the response body.
     fn http_request(
         caller: &mut Caller,
-        method: http::Method,
-        query: String,
-        headers: Vec<(String, Vec<u8>)>,
-        payload: Vec<u8>,
+        request: http::Request,
     ) -> Result<http::Response, RuntimeError> {
         caller
             .user_data_mut()
             .runtime
-            .http_request(method, &query, headers, payload)
+            .http_request(request)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
@@ -545,15 +542,12 @@ where
     /// Makes an HTTP request to the given URL and returns the response body.
     fn http_request(
         caller: &mut Caller,
-        method: http::Method,
-        query: String,
-        headers: Vec<(String, Vec<u8>)>,
-        payload: Vec<u8>,
+        request: http::Request,
     ) -> Result<http::Response, RuntimeError> {
         caller
             .user_data_mut()
             .runtime
-            .http_request(method, &query, headers, payload)
+            .http_request(request)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -343,13 +343,13 @@ where
         caller: &mut Caller,
         method: http::Method,
         query: String,
-        content_type: String,
+        headers: Vec<(String, Vec<u8>)>,
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, RuntimeError> {
         caller
             .user_data_mut()
             .runtime
-            .http_request(method, &query, content_type, payload)
+            .http_request(method, &query, headers, payload)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
@@ -547,13 +547,13 @@ where
         caller: &mut Caller,
         method: http::Method,
         query: String,
-        content_type: String,
+        headers: Vec<(String, Vec<u8>)>,
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, RuntimeError> {
         caller
             .user_data_mut()
             .runtime
-            .http_request(method, &query, content_type, payload)
+            .http_request(method, &query, headers, payload)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -6,6 +6,7 @@
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
     data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
+    http,
     identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, CloseChainError, TimeoutConfig},
 };
@@ -145,6 +146,16 @@ impl From<wit_system_api::CloseChainError> for CloseChainError {
     fn from(guest: wit_system_api::CloseChainError) -> Self {
         match guest {
             wit_system_api::CloseChainError::NotPermitted => CloseChainError::NotPermitted,
+        }
+    }
+}
+
+impl From<wit_system_api::Response> for http::Response {
+    fn from(guest: wit_system_api::Response) -> http::Response {
+        http::Response {
+            status: guest.status,
+            headers: guest.headers,
+            body: guest.body,
         }
     }
 }

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -9,6 +9,7 @@ use linera_base::{
         Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, TimeDelta,
         Timestamp,
     },
+    http,
     identifiers::{
         Account, ApplicationId, BytecodeId, ChainId, ChannelName, Destination, MessageId, Owner,
         StreamName,
@@ -166,6 +167,22 @@ impl From<Resources> for wit_system_api::Resources {
             messages: resources.messages,
             message_size: resources.message_size,
             storage_size_delta: resources.storage_size_delta,
+        }
+    }
+}
+
+impl From<http::Method> for wit_system_api::Method {
+    fn from(method: http::Method) -> Self {
+        match method {
+            http::Method::Get => wit_system_api::Method::Get,
+            http::Method::Post => wit_system_api::Method::Post,
+            http::Method::Put => wit_system_api::Method::Put,
+            http::Method::Delete => wit_system_api::Method::Delete,
+            http::Method::Head => wit_system_api::Method::Head,
+            http::Method::Options => wit_system_api::Method::Options,
+            http::Method::Connect => wit_system_api::Method::Connect,
+            http::Method::Patch => wit_system_api::Method::Patch,
+            http::Method::Trace => wit_system_api::Method::Trace,
         }
     }
 }

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -171,6 +171,17 @@ impl From<Resources> for wit_system_api::Resources {
     }
 }
 
+impl From<http::Request> for wit_system_api::Request {
+    fn from(request: http::Request) -> Self {
+        wit_system_api::Request {
+            method: request.method.into(),
+            url: request.url,
+            headers: request.headers,
+            body: request.body,
+        }
+    }
+}
+
 impl From<http::Method> for wit_system_api::Method {
     fn from(method: http::Method) -> Self {
         match method {

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -275,10 +275,10 @@ where
         &mut self,
         method: http::Method,
         url: &str,
-        content_type: &str,
+        headers: Vec<(String, Vec<u8>)>,
         payload: Vec<u8>,
     ) -> Vec<u8> {
-        wit::http_request(url, content_type, &payload)
+        wit::http_request(method.into(), url, &headers, &payload)
     }
 
     /// Panics if the current time at block validation is `>= timestamp`. Note that block

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -277,8 +277,8 @@ where
         url: &str,
         headers: Vec<(String, Vec<u8>)>,
         payload: Vec<u8>,
-    ) -> Vec<u8> {
-        wit::http_request(method.into(), url, &headers, &payload)
+    ) -> http::Response {
+        wit::http_request(method.into(), url, &headers, &payload).into()
     }
 
     /// Panics if the current time at block validation is `>= timestamp`. Note that block

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -264,21 +264,15 @@ where
         serde_json::from_slice(&response).expect("Failed to deserialize service response")
     }
 
-    /// Makes an HTTP request to the given URL as an oracle and returns the answer, if any.
+    /// Makes an HTTP `request` as an oracle and returns the HTTP response.
     ///
     /// Should only be used with queries where it is very likely that all validators will receive
     /// the same response, otherwise most block proposals will fail.
     ///
     /// Cannot be used in fast blocks: A block using this call should be proposed by a regular
     /// owner, not a super owner.
-    pub fn http_request(
-        &mut self,
-        method: http::Method,
-        url: &str,
-        headers: Vec<(String, Vec<u8>)>,
-        payload: Vec<u8>,
-    ) -> http::Response {
-        wit::http_request(method.into(), url, &headers, &payload).into()
+    pub fn http_request(&mut self, request: http::Request) -> http::Response {
+        wit::http_request(&request.into()).into()
     }
 
     /// Panics if the current time at block validation is `>= timestamp`. Note that block

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -270,8 +270,8 @@ where
     ///
     /// Cannot be used in fast blocks: A block using this call should be proposed by a regular
     /// owner, not a super owner.
-    pub fn http_post(&mut self, url: &str, content_type: &str, payload: Vec<u8>) -> Vec<u8> {
-        wit::http_post(url, content_type, &payload)
+    pub fn http_request(&mut self, url: &str, content_type: &str, payload: Vec<u8>) -> Vec<u8> {
+        wit::http_request(url, content_type, &payload)
     }
 
     /// Panics if the current time at block validation is `>= timestamp`. Note that block

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -8,6 +8,7 @@ use linera_base::{
     data_types::{
         Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, Timestamp,
     },
+    http,
     identifiers::{
         Account, ApplicationId, ChainId, ChannelName, Destination, MessageId, Owner, StreamName,
     },
@@ -263,14 +264,20 @@ where
         serde_json::from_slice(&response).expect("Failed to deserialize service response")
     }
 
-    /// Makes a POST request to the given URL as an oracle and returns the answer, if any.
+    /// Makes an HTTP request to the given URL as an oracle and returns the answer, if any.
     ///
     /// Should only be used with queries where it is very likely that all validators will receive
     /// the same response, otherwise most block proposals will fail.
     ///
     /// Cannot be used in fast blocks: A block using this call should be proposed by a regular
     /// owner, not a super owner.
-    pub fn http_request(&mut self, url: &str, content_type: &str, payload: Vec<u8>) -> Vec<u8> {
+    pub fn http_request(
+        &mut self,
+        method: http::Method,
+        url: &str,
+        content_type: &str,
+        payload: Vec<u8>,
+    ) -> Vec<u8> {
         wit::http_request(url, content_type, &payload)
     }
 

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -50,7 +50,7 @@ where
     events: Vec<(StreamName, Vec<u8>, Vec<u8>)>,
     claim_requests: Vec<ClaimRequest>,
     expected_service_queries: VecDeque<(ApplicationId, String, String)>,
-    expected_http_requests: VecDeque<(http::Method, String, Vec<u8>, Vec<u8>)>,
+    expected_http_requests: VecDeque<(http::Method, String, Vec<u8>, http::Response)>,
     expected_read_data_blob_requests: VecDeque<(DataBlobHash, Vec<u8>)>,
     expected_assert_data_blob_exists_requests: VecDeque<(DataBlobHash, Option<()>)>,
     expected_open_chain_calls:
@@ -682,7 +682,7 @@ where
         method: http::Method,
         url: String,
         payload: Vec<u8>,
-        response: Vec<u8>,
+        response: http::Response,
     ) {
         self.expected_http_requests
             .push_back((method, url, payload, response));
@@ -725,14 +725,19 @@ where
         serde_json::from_str(&response).expect("Failed to deserialize response")
     }
 
-    /// Makes an HTTP request to the given URL as an oracle and returns the JSON part, if any.
+    /// Makes an HTTP request to the given URL as an oracle and returns the response.
     ///
     /// Should only be used with queries where it is very likely that all validators will receive
     /// the same response, otherwise most block proposals will fail.
     ///
     /// Cannot be used in fast blocks: A block using this call should be proposed by a regular
     /// owner, not a super owner.
-    pub fn http_request(&mut self, method: http::Method, url: &str, payload: Vec<u8>) -> Vec<u8> {
+    pub fn http_request(
+        &mut self,
+        method: http::Method,
+        url: &str,
+        payload: Vec<u8>,
+    ) -> http::Response {
         let maybe_request = self.expected_http_requests.pop_front();
         let (expected_method, expected_url, expected_payload, response) =
             maybe_request.expect("Unexpected HTTP request");

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -50,7 +50,7 @@ where
     events: Vec<(StreamName, Vec<u8>, Vec<u8>)>,
     claim_requests: Vec<ClaimRequest>,
     expected_service_queries: VecDeque<(ApplicationId, String, String)>,
-    expected_http_requests: VecDeque<(http::Method, String, Vec<u8>, http::Response)>,
+    expected_http_requests: VecDeque<(http::Request, http::Response)>,
     expected_read_data_blob_requests: VecDeque<(DataBlobHash, Vec<u8>)>,
     expected_assert_data_blob_exists_requests: VecDeque<(DataBlobHash, Option<()>)>,
     expected_open_chain_calls:
@@ -677,15 +677,8 @@ where
     }
 
     /// Adds an expected `http_request` call, and the response it should return in the test.
-    pub fn add_expected_http_request(
-        &mut self,
-        method: http::Method,
-        url: String,
-        payload: Vec<u8>,
-        response: http::Response,
-    ) {
-        self.expected_http_requests
-            .push_back((method, url, payload, response));
+    pub fn add_expected_http_request(&mut self, request: http::Request, response: http::Response) {
+        self.expected_http_requests.push_back((request, response));
     }
 
     /// Adds an expected `read_data_blob` call, and the response it should return in the test.
@@ -725,25 +718,17 @@ where
         serde_json::from_str(&response).expect("Failed to deserialize response")
     }
 
-    /// Makes an HTTP request to the given URL as an oracle and returns the response.
+    /// Makes an HTTP `request` as an oracle and returns the HTTP response.
     ///
     /// Should only be used with queries where it is very likely that all validators will receive
     /// the same response, otherwise most block proposals will fail.
     ///
     /// Cannot be used in fast blocks: A block using this call should be proposed by a regular
     /// owner, not a super owner.
-    pub fn http_request(
-        &mut self,
-        method: http::Method,
-        url: &str,
-        payload: Vec<u8>,
-    ) -> http::Response {
+    pub fn http_request(&mut self, request: http::Request) -> http::Response {
         let maybe_request = self.expected_http_requests.pop_front();
-        let (expected_method, expected_url, expected_payload, response) =
-            maybe_request.expect("Unexpected HTTP request");
-        assert_eq!(method, expected_method);
-        assert_eq!(*url, expected_url);
-        assert_eq!(payload, expected_payload);
+        let (expected_request, response) = maybe_request.expect("Unexpected HTTP request");
+        assert_eq!(request, expected_request);
         response
     }
 

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -13,6 +13,7 @@ use linera_base::{
     data_types::{
         Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, Timestamp,
     },
+    http,
     identifiers::{
         Account, ApplicationId, ChainId, ChannelName, Destination, MessageId, Owner, StreamName,
     },
@@ -49,7 +50,7 @@ where
     events: Vec<(StreamName, Vec<u8>, Vec<u8>)>,
     claim_requests: Vec<ClaimRequest>,
     expected_service_queries: VecDeque<(ApplicationId, String, String)>,
-    expected_http_requests: VecDeque<(String, Vec<u8>, Vec<u8>)>,
+    expected_http_requests: VecDeque<(http::Method, String, Vec<u8>, Vec<u8>)>,
     expected_read_data_blob_requests: VecDeque<(DataBlobHash, Vec<u8>)>,
     expected_assert_data_blob_exists_requests: VecDeque<(DataBlobHash, Option<()>)>,
     expected_open_chain_calls:
@@ -676,9 +677,15 @@ where
     }
 
     /// Adds an expected `http_request` call, and the response it should return in the test.
-    pub fn add_expected_http_request(&mut self, url: String, payload: Vec<u8>, response: Vec<u8>) {
+    pub fn add_expected_http_request(
+        &mut self,
+        method: http::Method,
+        url: String,
+        payload: Vec<u8>,
+        response: Vec<u8>,
+    ) {
         self.expected_http_requests
-            .push_back((url, payload, response));
+            .push_back((method, url, payload, response));
     }
 
     /// Adds an expected `read_data_blob` call, and the response it should return in the test.
@@ -718,17 +725,18 @@ where
         serde_json::from_str(&response).expect("Failed to deserialize response")
     }
 
-    /// Makes a GET request to the given URL as an oracle and returns the JSON part, if any.
+    /// Makes an HTTP request to the given URL as an oracle and returns the JSON part, if any.
     ///
     /// Should only be used with queries where it is very likely that all validators will receive
     /// the same response, otherwise most block proposals will fail.
     ///
     /// Cannot be used in fast blocks: A block using this call should be proposed by a regular
     /// owner, not a super owner.
-    pub fn http_request(&mut self, url: &str, payload: Vec<u8>) -> Vec<u8> {
+    pub fn http_request(&mut self, method: http::Method, url: &str, payload: Vec<u8>) -> Vec<u8> {
         let maybe_request = self.expected_http_requests.pop_front();
-        let (expected_url, expected_payload, response) =
-            maybe_request.expect("Unexpected POST request");
+        let (expected_method, expected_url, expected_payload, response) =
+            maybe_request.expect("Unexpected HTTP request");
+        assert_eq!(method, expected_method);
         assert_eq!(*url, expected_url);
         assert_eq!(payload, expected_payload);
         response

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -49,7 +49,7 @@ where
     events: Vec<(StreamName, Vec<u8>, Vec<u8>)>,
     claim_requests: Vec<ClaimRequest>,
     expected_service_queries: VecDeque<(ApplicationId, String, String)>,
-    expected_post_requests: VecDeque<(String, Vec<u8>, Vec<u8>)>,
+    expected_http_requests: VecDeque<(String, Vec<u8>, Vec<u8>)>,
     expected_read_data_blob_requests: VecDeque<(DataBlobHash, Vec<u8>)>,
     expected_assert_data_blob_exists_requests: VecDeque<(DataBlobHash, Option<()>)>,
     expected_open_chain_calls:
@@ -95,7 +95,7 @@ where
             events: Vec::new(),
             claim_requests: Vec::new(),
             expected_service_queries: VecDeque::new(),
-            expected_post_requests: VecDeque::new(),
+            expected_http_requests: VecDeque::new(),
             expected_read_data_blob_requests: VecDeque::new(),
             expected_assert_data_blob_exists_requests: VecDeque::new(),
             expected_open_chain_calls: VecDeque::new(),
@@ -675,9 +675,9 @@ where
             .push_back((application_id.forget_abi(), query, response));
     }
 
-    /// Adds an expected `http_post` call, and the response it should return in the test.
-    pub fn add_expected_post_request(&mut self, url: String, payload: Vec<u8>, response: Vec<u8>) {
-        self.expected_post_requests
+    /// Adds an expected `http_request` call, and the response it should return in the test.
+    pub fn add_expected_http_request(&mut self, url: String, payload: Vec<u8>, response: Vec<u8>) {
+        self.expected_http_requests
             .push_back((url, payload, response));
     }
 
@@ -725,8 +725,8 @@ where
     ///
     /// Cannot be used in fast blocks: A block using this call should be proposed by a regular
     /// owner, not a super owner.
-    pub fn http_post(&mut self, url: &str, payload: Vec<u8>) -> Vec<u8> {
-        let maybe_request = self.expected_post_requests.pop_front();
+    pub fn http_request(&mut self, url: &str, payload: Vec<u8>) -> Vec<u8> {
+        let maybe_request = self.expected_http_requests.pop_front();
         let (expected_url, expected_payload, response) =
             maybe_request.expect("Unexpected POST request");
         assert_eq!(*url, expected_url);

--- a/linera-sdk/src/ethereum.rs
+++ b/linera-sdk/src/ethereum.rs
@@ -41,11 +41,10 @@ impl JsonRpcClient for EthereumClient {
     }
 
     async fn request_inner(&self, payload: Vec<u8>) -> Result<Vec<u8>, Self::Error> {
-        let content_type = "application/json";
         Ok(contract_system_api::http_request(
             http::Method::Post.into(),
             &self.url,
-            content_type,
+            &[("Content-Type".to_owned(), b"application/json".to_vec())],
             &payload,
         ))
     }

--- a/linera-sdk/src/ethereum.rs
+++ b/linera-sdk/src/ethereum.rs
@@ -41,7 +41,7 @@ impl JsonRpcClient for EthereumClient {
 
     async fn request_inner(&self, payload: Vec<u8>) -> Result<Vec<u8>, Self::Error> {
         let content_type = "application/json";
-        Ok(contract_system_api::http_post(
+        Ok(contract_system_api::http_request(
             &self.url,
             content_type,
             &payload,

--- a/linera-sdk/src/ethereum.rs
+++ b/linera-sdk/src/ethereum.rs
@@ -42,10 +42,13 @@ impl JsonRpcClient for EthereumClient {
 
     async fn request_inner(&self, payload: Vec<u8>) -> Result<Vec<u8>, Self::Error> {
         let response = contract_system_api::http_request(
-            http::Method::Post.into(),
-            &self.url,
-            &[("Content-Type".to_owned(), b"application/json".to_vec())],
-            &payload,
+            &http::Request {
+                method: http::Method::Post,
+                url: self.url.clone(),
+                headers: Vec::from([("Content-Type".to_owned(), b"application/json".to_vec())]),
+                body: payload,
+            }
+            .into(),
         );
 
         Ok(response.body)

--- a/linera-sdk/src/ethereum.rs
+++ b/linera-sdk/src/ethereum.rs
@@ -7,6 +7,7 @@ use std::fmt::Debug;
 
 use async_graphql::scalar;
 use async_trait::async_trait;
+use linera_base::http;
 pub use linera_ethereum::{
     client::EthereumQueries,
     common::{EthereumDataType, EthereumEvent},
@@ -42,6 +43,7 @@ impl JsonRpcClient for EthereumClient {
     async fn request_inner(&self, payload: Vec<u8>) -> Result<Vec<u8>, Self::Error> {
         let content_type = "application/json";
         Ok(contract_system_api::http_request(
+            http::Method::Post.into(),
             &self.url,
             content_type,
             &payload,

--- a/linera-sdk/src/ethereum.rs
+++ b/linera-sdk/src/ethereum.rs
@@ -41,11 +41,13 @@ impl JsonRpcClient for EthereumClient {
     }
 
     async fn request_inner(&self, payload: Vec<u8>) -> Result<Vec<u8>, Self::Error> {
-        Ok(contract_system_api::http_request(
+        let response = contract_system_api::http_request(
             http::Method::Post.into(),
             &self.url,
             &[("Content-Type".to_owned(), b"application/json".to_vec())],
             &payload,
-        ))
+        );
+
+        Ok(response.body)
     }
 }

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -135,6 +135,17 @@ where
             .expect("Failed to deserialize query response from application")
     }
 
+    /// Makes an HTTP request to the given URL as an oracle and returns the answer, if any.
+    ///
+    /// Should only be used with queries where it is very likely that all validators will receive
+    /// the same response, otherwise most block proposals will fail.
+    ///
+    /// Cannot be used in fast blocks: A block using this call should be proposed by a regular
+    /// owner, not a super owner.
+    pub fn http_request(&mut self, request: http::Request) -> http::Response {
+        wit::http_request(&request.into()).into()
+    }
+
     /// Fetches a blob of bytes from a given URL.
     pub fn fetch_url(&self, url: &str) -> Vec<u8> {
         wit::fetch_url(url)

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -24,7 +24,7 @@ interface contract-system-api {
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
     emit: func(name: stream-name, key: list<u8>, value: list<u8>);
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
-    http-request: func(method: method, query: string, content-type: string, payload: list<u8>) -> list<u8>;
+    http-request: func(method: method, query: string, headers: list<tuple<string, list<u8>>>, payload: list<u8>) -> list<u8>;
     assert-before: func(timestamp: timestamp);
     read-data-blob: func(hash: crypto-hash) -> list<u8>;
     assert-data-blob-exists: func(hash: crypto-hash);

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -24,7 +24,7 @@ interface contract-system-api {
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
     emit: func(name: stream-name, key: list<u8>, value: list<u8>);
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
-    http-request: func(method: method, query: string, headers: list<tuple<string, list<u8>>>, payload: list<u8>) -> response;
+    http-request: func(request: request) -> response;
     assert-before: func(timestamp: timestamp);
     read-data-blob: func(hash: crypto-hash) -> list<u8>;
     assert-data-blob-exists: func(hash: crypto-hash);
@@ -126,6 +126,13 @@ interface contract-system-api {
         part2: u64,
         part3: u64,
         part4: u64,
+    }
+
+    record request {
+        method: method,
+        url: string,
+        headers: list<tuple<string, list<u8>>>,
+        body: list<u8>,
     }
 
     record resources {

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -24,7 +24,7 @@ interface contract-system-api {
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
     emit: func(name: stream-name, key: list<u8>, value: list<u8>);
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
-    http-request: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
+    http-request: func(method: method, query: string, content-type: string, payload: list<u8>) -> list<u8>;
     assert-before: func(timestamp: timestamp);
     read-data-blob: func(hash: crypto-hash) -> list<u8>;
     assert-data-blob-exists: func(hash: crypto-hash);
@@ -103,6 +103,18 @@ interface contract-system-api {
         chain-id: chain-id,
         height: block-height,
         index: u32,
+    }
+
+    enum method {
+        get,
+        post,
+        put,
+        delete,
+        head,
+        options,
+        connect,
+        patch,
+        trace,
     }
 
     record owner {

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -24,7 +24,7 @@ interface contract-system-api {
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
     emit: func(name: stream-name, key: list<u8>, value: list<u8>);
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
-    http-request: func(method: method, query: string, headers: list<tuple<string, list<u8>>>, payload: list<u8>) -> list<u8>;
+    http-request: func(method: method, query: string, headers: list<tuple<string, list<u8>>>, payload: list<u8>) -> response;
     assert-before: func(timestamp: timestamp);
     read-data-blob: func(hash: crypto-hash) -> list<u8>;
     assert-data-blob-exists: func(hash: crypto-hash);
@@ -137,6 +137,12 @@ interface contract-system-api {
         messages: u32,
         message-size: u32,
         storage-size-delta: u32,
+    }
+
+    record response {
+        status: u16,
+        headers: list<tuple<string, list<u8>>>,
+        body: list<u8>,
     }
 
     record send-message-request {

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -24,7 +24,7 @@ interface contract-system-api {
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
     emit: func(name: stream-name, key: list<u8>, value: list<u8>);
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
-    http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
+    http-request: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
     assert-before: func(timestamp: timestamp);
     read-data-blob: func(hash: crypto-hash) -> list<u8>;
     assert-data-blob-exists: func(hash: crypto-hash);

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -14,7 +14,7 @@ interface service-system-api {
     try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
     fetch-url: func(url: string) -> list<u8>;
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
-    http-request: func(method: method, query: string, headers: list<tuple<string, list<u8>>>, payload: list<u8>) -> response;
+    http-request: func(request: request) -> response;
     read-data-blob: func(hash: crypto-hash) -> list<u8>;
     assert-data-blob-exists: func(hash: crypto-hash);
     assert-before: func(timestamp: timestamp);
@@ -77,6 +77,13 @@ interface service-system-api {
 
     record owner {
         inner0: crypto-hash,
+    }
+
+    record request {
+        method: method,
+        url: string,
+        headers: list<tuple<string, list<u8>>>,
+        body: list<u8>,
     }
 
     record response {

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -14,7 +14,7 @@ interface service-system-api {
     try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
     fetch-url: func(url: string) -> list<u8>;
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
-    http-request: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
+    http-request: func(method: method, query: string, content-type: string, payload: list<u8>) -> list<u8>;
     read-data-blob: func(hash: crypto-hash) -> list<u8>;
     assert-data-blob-exists: func(hash: crypto-hash);
     assert-before: func(timestamp: timestamp);
@@ -61,6 +61,18 @@ interface service-system-api {
         chain-id: chain-id,
         height: block-height,
         index: u32,
+    }
+
+    enum method {
+        get,
+        post,
+        put,
+        delete,
+        head,
+        options,
+        connect,
+        patch,
+        trace,
     }
 
     record owner {

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -14,7 +14,7 @@ interface service-system-api {
     try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
     fetch-url: func(url: string) -> list<u8>;
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
-    http-request: func(method: method, query: string, content-type: string, payload: list<u8>) -> list<u8>;
+    http-request: func(method: method, query: string, headers: list<tuple<string, list<u8>>>, payload: list<u8>) -> list<u8>;
     read-data-blob: func(hash: crypto-hash) -> list<u8>;
     assert-data-blob-exists: func(hash: crypto-hash);
     assert-before: func(timestamp: timestamp);

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -14,7 +14,7 @@ interface service-system-api {
     try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
     fetch-url: func(url: string) -> list<u8>;
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
-    http-request: func(method: method, query: string, headers: list<tuple<string, list<u8>>>, payload: list<u8>) -> list<u8>;
+    http-request: func(method: method, query: string, headers: list<tuple<string, list<u8>>>, payload: list<u8>) -> response;
     read-data-blob: func(hash: crypto-hash) -> list<u8>;
     assert-data-blob-exists: func(hash: crypto-hash);
     assert-before: func(timestamp: timestamp);
@@ -77,6 +77,12 @@ interface service-system-api {
 
     record owner {
         inner0: crypto-hash,
+    }
+
+    record response {
+        status: u16,
+        headers: list<tuple<string, list<u8>>>,
+        body: list<u8>,
     }
 
     record timestamp {

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -14,7 +14,7 @@ interface service-system-api {
     try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
     fetch-url: func(url: string) -> list<u8>;
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
-    http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
+    http-request: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
     read-data-blob: func(hash: crypto-hash) -> list<u8>;
     assert-data-blob-exists: func(hash: crypto-hash);
     assert-before: func(timestamp: timestamp);


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
Linera applications can perform HTTP requests to external services, but the available `http_post` API was very limited, and prevented applications from configuring the request. This is often needed in order to add custom headers, for example for authentication.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Replace the `http_post` API with a broader `http_request` API, which allows sending more configurable `http::Request`s, and returns a more detailed `http::Response`.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
TODO

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Backporting is not possible but we may want to deploy a new `devnet` and release a new
      SDK soon.
- Contains breaking changes to the WIT interface and to the `linera-sdk` API.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
