### PR TITLE
Remove unnecessary linera-storage dev dependency

### DIFF
--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -49,7 +49,6 @@ serde.workspace = true
 anyhow.workspace = true
 linera-base = { workspace = true, features = ["test"] }
 linera-chain = { workspace = true, features = ["test"] }
-linera-execution = { workspace = true, features = ["test"] }
 linera-storage = { path = ".", features = ["test"] }
 linera-views = { workspace = true, features = ["test"] }
 


### PR DESCRIPTION
## Motivation

This dependency was unnecessaryly added on as an oversight https://github.com/linera-io/linera-protocol/pull/2627

## Proposal

Remove it

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
