### PR TITLE
Fix name of "long-faucet-chain-test" job in CI

### DIFF
--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -11,7 +11,7 @@ env:
   LINERA_STORAGE_SERVICE: 127.0.0.1:1235
 
 jobs:
-  benchmark:
+  long-faucet-chain-test:
     runs-on: ubuntu-latest-16-cores
     timeout-minutes: 180
 


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
The workflow file for the long faucet chain test had a job that was incorrectly named "benchmark". Which made CI summaries confusing.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Rename it to "long-faucet-chain-test".

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
CI should show the updated name.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do because this only affects CI.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
