### PR TITLE
Fix performance regression caused by disabling `ed25519-dalek`'s `fast` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ dashmap = "5.5.3"
 derive_more = "1.0.0"
 dirs = "5.0.1"
 dyn-clone = "1.0.17"
-ed25519-dalek = { version = "2.1.1", default-features = false, features = ["batch", "serde"] }
+ed25519-dalek = { version = "2.1.1", default-features = false, features = ["batch", "fast", "serde"] }
 either = "1.10.0"
 ethers = { version = "2.0.14", features = ["solc"] }
 flarch = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ dashmap = "5.5.3"
 derive_more = "1.0.0"
 dirs = "5.0.1"
 dyn-clone = "1.0.17"
-ed25519-dalek = { version = "2.1.1", default-features = false, features = ["batch", "fast", "serde"] }
+ed25519-dalek = { version = "2.1.1", default-features = false, features = ["batch", "fast", "serde", "zeroize"] }
 either = "1.10.0"
 ethers = { version = "2.0.14", features = ["solc"] }
 flarch = "0.7.0"


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
`ed25519-dalek`'s `default` features ended up transitively including `getrandom` as a dependency, which was an issue for Linera Wasm applications that use `linera-sdk`. Therefore, it was disabled by PR #2602. However, that also disabled the `fast` feature, was caused a performance regression.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Re-enable the `fast` feature, together with the `zeroize` feature which is also important.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
The long faucet chain test should now not timeout in CI.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle, because this fixes a regression for an issue that is not present in any released version.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
