### PR TITLE
Restructure the composed store adaptors

### DIFF
--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -8,8 +8,8 @@ use linera_execution::WasmRuntime;
 use linera_storage::{DbStorage, Storage};
 #[cfg(feature = "storage-service")]
 use linera_storage_service::{
-    client::{ServiceStoreClient, ServiceStoreConfig},
-    common::ServiceStoreInternalConfig,
+    client::ServiceStoreClient,
+    common::{ServiceStoreConfig, ServiceStoreInternalConfig},
 };
 #[cfg(feature = "dynamodb")]
 use linera_views::dynamo_db::{

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -5,8 +5,11 @@ use std::path::PathBuf;
 
 use clap::Parser as _;
 use linera_views::{
-    rocks_db::{PathWithGuard, RocksDbSpawnMode, RocksDbStore, RocksDbStoreConfig},
-    store::{AdminKeyValueStore, CommonStoreConfig},
+    rocks_db::{
+        PathWithGuard, RocksDbSpawnMode, RocksDbStore, RocksDbStoreConfig,
+        RocksDbStoreInternalConfig,
+    },
+    store::{AdminKeyValueStore, CommonStoreInternalConfig},
 };
 
 use crate::{
@@ -38,20 +41,23 @@ pub type RocksDbRunner = Runner<RocksDbStore, RocksDbConfig>;
 impl RocksDbRunner {
     pub async fn load() -> Result<Self, IndexerError> {
         let config = IndexerConfig::<RocksDbConfig>::parse();
-        let common_config = CommonStoreConfig {
+        let common_config = CommonStoreInternalConfig {
             max_concurrent_queries: config.client.max_concurrent_queries,
             max_stream_queries: config.client.max_stream_queries,
-            cache_size: config.client.cache_size,
         };
         let path_buf = config.client.storage.as_path().to_path_buf();
         let path_with_guard = PathWithGuard::new(path_buf);
         // The tests are run in single threaded mode, therefore we need
         // to use the safe default value of SpawnBlocking.
         let spawn_mode = RocksDbSpawnMode::SpawnBlocking;
-        let store_config = RocksDbStoreConfig {
+        let inner_config = RocksDbStoreInternalConfig {
             path_with_guard,
             spawn_mode,
             common_config,
+        };
+        let store_config = RocksDbStoreConfig {
+            inner_config,
+            cache_size: config.client.cache_size,
         };
         let namespace = config.client.namespace.clone();
         let root_key = &[];

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_views::{
-    scylla_db::{ScyllaDbStore, ScyllaDbStoreConfig},
-    store::{AdminKeyValueStore, CommonStoreConfig},
+    scylla_db::{ScyllaDbStore, ScyllaDbStoreConfig, ScyllaDbStoreInternalConfig},
+    store::{AdminKeyValueStore, CommonStoreInternalConfig},
 };
 
 use crate::{
@@ -35,16 +35,19 @@ pub type ScyllaDbRunner = Runner<ScyllaDbStore, ScyllaDbConfig>;
 impl ScyllaDbRunner {
     pub async fn load() -> Result<Self, IndexerError> {
         let config = <IndexerConfig<ScyllaDbConfig> as clap::Parser>::parse();
-        let common_config = CommonStoreConfig {
+        let common_config = CommonStoreInternalConfig {
             max_concurrent_queries: config.client.max_concurrent_queries,
             max_stream_queries: config.client.max_stream_queries,
-            cache_size: config.client.cache_size,
         };
         let namespace = config.client.table.clone();
         let root_key = &[];
-        let store_config = ScyllaDbStoreConfig {
+        let inner_config = ScyllaDbStoreInternalConfig {
             uri: config.client.uri.clone(),
             common_config,
+        };
+        let store_config = ScyllaDbStoreConfig {
+            inner_config,
+            cache_size: config.client.cache_size,
         };
         let store = ScyllaDbStore::connect(&store_config, &namespace, root_key).await?;
         Self::new(config, store).await

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -85,7 +85,9 @@ async fn make_testing_config(database: Database) -> Result<StorageConfig> {
             #[cfg(feature = "scylladb")]
             {
                 let config = ScyllaDbStore::new_test_config().await?;
-                Ok(StorageConfig::ScyllaDb { uri: config.uri })
+                Ok(StorageConfig::ScyllaDb {
+                    uri: config.inner_config.uri,
+                })
             }
             #[cfg(not(feature = "scylladb"))]
             panic!("Database::ScyllaDb is selected without the feature sctlladb");

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -11,9 +11,9 @@ use linera_views::metering::MeteredStore;
 use linera_views::store::TestKeyValueStore;
 use linera_views::{
     batch::{Batch, WriteOperation},
-    lru_caching::LruCachingStore,
+    lru_caching::{LruCachingStore, LruSplittingConfig},
     store::{
-        AdminKeyValueStore, CommonStoreConfig, ReadableKeyValueStore, WithError,
+        AdminKeyValueStore, CommonStoreInternalConfig, ReadableKeyValueStore, WithError,
         WritableKeyValueStore,
     },
 };
@@ -22,10 +22,8 @@ use tonic::transport::{Channel, Endpoint};
 
 #[cfg(with_testing)]
 use crate::common::storage_service_test_endpoint;
-#[cfg(with_metrics)]
-use crate::common::{LRU_STORAGE_SERVICE_METRICS, STORAGE_SERVICE_METRICS};
 use crate::{
-    common::{KeyTag, ServiceStoreConfig, ServiceStoreError, MAX_PAYLOAD_SIZE},
+    common::{KeyTag, ServiceStoreError, ServiceStoreInternalConfig, MAX_PAYLOAD_SIZE},
     key_value_store::{
         statement::Operation, store_processor_client::StoreProcessorClient, KeyValue,
         KeyValueAppend, ReplyContainsKey, ReplyContainsKeys, ReplyExistsNamespace,
@@ -62,7 +60,6 @@ pub struct ServiceStoreClientInternal {
     channel: Channel,
     semaphore: Option<Arc<Semaphore>>,
     max_stream_queries: usize,
-    cache_size: usize,
     namespace: Vec<u8>,
     start_key: Vec<u8>,
 }
@@ -376,7 +373,11 @@ impl ServiceStoreClientInternal {
 }
 
 impl AdminKeyValueStore for ServiceStoreClientInternal {
-    type Config = ServiceStoreConfig;
+    type Config = ServiceStoreInternalConfig;
+
+    fn get_name() -> String {
+        "service store".to_string()
+    }
 
     async fn connect(
         config: &Self::Config,
@@ -391,7 +392,6 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
             .max_concurrent_queries
             .map(|n| Arc::new(Semaphore::new(n)));
         let max_stream_queries = config.common_config.max_stream_queries;
-        let cache_size = config.common_config.cache_size;
         let namespace = Self::namespace_as_vec(namespace)?;
         let mut start_key = namespace.clone();
         start_key.extend(root_key);
@@ -399,7 +399,6 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
             channel,
             semaphore,
             max_stream_queries,
-            cache_size,
             namespace,
             start_key,
         })
@@ -409,7 +408,6 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
         let channel = self.channel.clone();
         let semaphore = self.semaphore.clone();
         let max_stream_queries = self.max_stream_queries;
-        let cache_size = self.cache_size;
         let namespace = self.namespace.clone();
         let mut start_key = namespace.clone();
         start_key.extend(root_key);
@@ -417,7 +415,6 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
             channel,
             semaphore,
             max_stream_queries,
-            cache_size,
             namespace,
             start_key,
         })
@@ -487,30 +484,22 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
 
 #[cfg(with_testing)]
 impl TestKeyValueStore for ServiceStoreClientInternal {
-    async fn new_test_config() -> Result<ServiceStoreConfig, ServiceStoreError> {
+    async fn new_test_config() -> Result<ServiceStoreInternalConfig, ServiceStoreError> {
         let endpoint = storage_service_test_endpoint()?;
         service_config_from_endpoint(&endpoint)
-    }
-}
-
-/// Creates the `CommonStoreConfig` for the `ServiceStoreClientInternal`.
-pub fn create_service_store_common_config() -> CommonStoreConfig {
-    let max_stream_queries = 100;
-    let cache_size = linera_views::lru_caching::TEST_CACHE_SIZE;
-    CommonStoreConfig {
-        max_concurrent_queries: None,
-        max_stream_queries,
-        cache_size,
     }
 }
 
 /// Creates a `ServiceStoreConfig` from an endpoint.
 pub fn service_config_from_endpoint(
     endpoint: &str,
-) -> Result<ServiceStoreConfig, ServiceStoreError> {
-    let common_config = create_service_store_common_config();
+) -> Result<ServiceStoreInternalConfig, ServiceStoreError> {
+    let common_config = CommonStoreInternalConfig {
+        max_concurrent_queries: None,
+        max_stream_queries: 100,
+    };
     let endpoint = endpoint.to_string();
-    Ok(ServiceStoreConfig {
+    Ok(ServiceStoreInternalConfig {
         endpoint,
         common_config,
     })
@@ -533,137 +522,14 @@ pub async fn storage_service_check_validity(endpoint: &str) -> Result<(), Servic
     Ok(())
 }
 
-#[derive(Clone)]
-pub struct ServiceStoreClient {
-    #[cfg(with_metrics)]
-    store: MeteredStore<LruCachingStore<MeteredStore<ServiceStoreClientInternal>>>,
-    #[cfg(not(with_metrics))]
-    store: LruCachingStore<ServiceStoreClientInternal>,
-}
+/// The service store client with metrics
+#[cfg(with_metrics)]
+pub type ServiceStoreClient =
+    MeteredStore<LruCachingStore<MeteredStore<ServiceStoreClientInternal>>>;
 
-impl WithError for ServiceStoreClient {
-    type Error = ServiceStoreError;
-}
+/// The service store client without metrics
+#[cfg(not(with_metrics))]
+pub type ServiceStoreClient = LruCachingStore<ServiceStoreClientInternal>;
 
-impl ReadableKeyValueStore for ServiceStoreClient {
-    const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
-    type Keys = Vec<Vec<u8>>;
-    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
-
-    fn max_stream_queries(&self) -> usize {
-        self.store.max_stream_queries()
-    }
-
-    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, ServiceStoreError> {
-        self.store.read_value_bytes(key).await
-    }
-
-    async fn contains_key(&self, key: &[u8]) -> Result<bool, ServiceStoreError> {
-        self.store.contains_key(key).await
-    }
-
-    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ServiceStoreError> {
-        self.store.contains_keys(keys).await
-    }
-
-    async fn read_multi_values_bytes(
-        &self,
-        keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<Option<Vec<u8>>>, ServiceStoreError> {
-        self.store.read_multi_values_bytes(keys).await
-    }
-
-    async fn find_keys_by_prefix(
-        &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<Vec<u8>>, ServiceStoreError> {
-        self.store.find_keys_by_prefix(key_prefix).await
-    }
-
-    async fn find_key_values_by_prefix(
-        &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ServiceStoreError> {
-        self.store.find_key_values_by_prefix(key_prefix).await
-    }
-}
-
-impl WritableKeyValueStore for ServiceStoreClient {
-    const MAX_VALUE_SIZE: usize = usize::MAX;
-
-    async fn write_batch(&self, batch: Batch) -> Result<(), ServiceStoreError> {
-        self.store.write_batch(batch).await
-    }
-
-    async fn clear_journal(&self) -> Result<(), ServiceStoreError> {
-        self.store.clear_journal().await
-    }
-}
-
-impl AdminKeyValueStore for ServiceStoreClient {
-    type Config = ServiceStoreConfig;
-
-    async fn connect(
-        config: &Self::Config,
-        namespace: &str,
-        root_key: &[u8],
-    ) -> Result<Self, ServiceStoreError> {
-        let cache_size = config.common_config.cache_size;
-        let store = ServiceStoreClientInternal::connect(config, namespace, root_key).await?;
-        Ok(ServiceStoreClient::from_inner(store, cache_size))
-    }
-
-    fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, ServiceStoreError> {
-        let store = self.inner().clone_with_root_key(root_key)?;
-        let cache_size = self.inner().cache_size;
-        Ok(ServiceStoreClient::from_inner(store, cache_size))
-    }
-
-    async fn list_all(config: &Self::Config) -> Result<Vec<String>, ServiceStoreError> {
-        ServiceStoreClientInternal::list_all(config).await
-    }
-
-    async fn delete_all(config: &Self::Config) -> Result<(), ServiceStoreError> {
-        ServiceStoreClientInternal::delete_all(config).await
-    }
-
-    async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, ServiceStoreError> {
-        ServiceStoreClientInternal::exists(config, namespace).await
-    }
-
-    async fn create(config: &Self::Config, namespace: &str) -> Result<(), ServiceStoreError> {
-        ServiceStoreClientInternal::create(config, namespace).await
-    }
-
-    async fn delete(config: &Self::Config, namespace: &str) -> Result<(), ServiceStoreError> {
-        ServiceStoreClientInternal::delete(config, namespace).await
-    }
-}
-
-#[cfg(with_testing)]
-impl TestKeyValueStore for ServiceStoreClient {
-    async fn new_test_config() -> Result<ServiceStoreConfig, ServiceStoreError> {
-        ServiceStoreClientInternal::new_test_config().await
-    }
-}
-
-impl ServiceStoreClient {
-    #[cfg(with_metrics)]
-    fn inner(&self) -> &ServiceStoreClientInternal {
-        &self.store.store.store.store
-    }
-
-    #[cfg(not(with_metrics))]
-    fn inner(&self) -> &ServiceStoreClientInternal {
-        &self.store.store
-    }
-
-    fn from_inner(store: ServiceStoreClientInternal, cache_size: usize) -> ServiceStoreClient {
-        #[cfg(with_metrics)]
-        let store = MeteredStore::new(&STORAGE_SERVICE_METRICS, store);
-        let store = LruCachingStore::new(store, cache_size);
-        #[cfg(with_metrics)]
-        let store = MeteredStore::new(&LRU_STORAGE_SERVICE_METRICS, store);
-        Self { store }
-    }
-}
+/// The config type
+pub type ServiceStoreConfig = LruSplittingConfig<ServiceStoreInternalConfig>;

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -11,7 +11,7 @@ use linera_views::metering::MeteredStore;
 use linera_views::store::TestKeyValueStore;
 use linera_views::{
     batch::{Batch, WriteOperation},
-    lru_caching::{LruCachingStore, LruSplittingConfig},
+    lru_caching::LruCachingStore,
     store::{
         AdminKeyValueStore, CommonStoreInternalConfig, ReadableKeyValueStore, WithError,
         WritableKeyValueStore,
@@ -530,6 +530,3 @@ pub type ServiceStoreClient =
 /// The service store client without metrics
 #[cfg(not(with_metrics))]
 pub type ServiceStoreClient = LruCachingStore<ServiceStoreClientInternal>;
-
-/// The config type
-pub type ServiceStoreConfig = LruSplittingConfig<ServiceStoreInternalConfig>;

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use linera_base::command::resolve_binary;
 use linera_views::{
+    lru_caching::LruSplittingConfig,
     store::{CommonStoreInternalConfig, KeyValueStoreError},
     views::MIN_VIEW_TAG,
 };
@@ -72,11 +73,14 @@ pub fn storage_service_test_endpoint() -> Result<String, ServiceStoreError> {
 pub struct ServiceStoreInternalConfig {
     /// The endpoint used by the shared store
     pub endpoint: String,
-    /// The common configuration of the key value store
+    /// The common configuration code
     pub common_config: CommonStoreInternalConfig,
 }
 
-impl ServiceStoreConfig {
+/// The config type
+pub type ServiceStoreConfig = LruSplittingConfig<ServiceStoreInternalConfig>;
+
+impl ServiceStoreInternalConfig {
     pub fn http_address(&self) -> String {
         format!("http://{}", self.endpoint)
     }

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -14,7 +14,10 @@ use linera_views::{
 };
 #[cfg(with_rocksdb)]
 use linera_views::{
-    rocks_db::{PathWithGuard, RocksDbSpawnMode, RocksDbStore, RocksDbStoreConfig},
+    rocks_db::{
+        PathWithGuard, RocksDbSpawnMode, RocksDbStore, RocksDbStoreConfig,
+        RocksDbStoreInternalConfig,
+    },
     store::AdminKeyValueStore as _,
 };
 use serde::Serialize;
@@ -585,10 +588,14 @@ async fn main() {
             let path_with_guard = PathWithGuard::new(path_buf);
             // The server is run in multi-threaded mode so we can use the block_in_place.
             let spawn_mode = RocksDbSpawnMode::get_spawn_mode_from_runtime();
-            let config = RocksDbStoreConfig {
+            let inner_config = RocksDbStoreInternalConfig {
                 path_with_guard,
                 spawn_mode,
-                common_config,
+                common_config: common_config.reduced(),
+            };
+            let config = RocksDbStoreConfig {
+                inner_config,
+                cache_size: common_config.cache_size,
             };
             let store = RocksDbStore::maybe_create_and_connect(&config, namespace, root_key)
                 .await

--- a/linera-views/src/backends/dual.rs
+++ b/linera-views/src/backends/dual.rs
@@ -239,6 +239,10 @@ where
 {
     type Config = DualStoreConfig<S1::Config, S2::Config>;
 
+    fn get_name() -> String {
+        format!("dual {} and {}", S1::get_name(), S2::get_name())
+    }
+
     async fn connect(
         config: &Self::Config,
         namespace: &str,

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -228,6 +228,10 @@ impl LocalWritableKeyValueStore for IndexedDbStore {
 impl LocalAdminKeyValueStore for IndexedDbStore {
     type Config = IndexedDbStoreConfig;
 
+    fn get_name() -> String {
+        "indexed db".to_string()
+    }
+
     async fn connect(
         config: &Self::Config,
         namespace: &str,

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -103,7 +103,7 @@ struct JournalHeader {
 #[derive(Clone)]
 pub struct JournalingKeyValueStore<K> {
     /// The inner store.
-    pub store: K,
+    store: K,
 }
 
 impl<K> DeletePrefixExpander for &JournalingKeyValueStore<K>
@@ -179,6 +179,10 @@ where
     K: AdminKeyValueStore + Send + Sync,
 {
     type Config = K::Config;
+
+    fn get_name() -> String {
+        format!("journaling {}", K::get_name())
+    }
 
     async fn connect(
         config: &Self::Config,

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -19,7 +19,7 @@ use crate::{
     batch::{Batch, WriteOperation},
     common::get_interval,
     store::{
-        AdminKeyValueStore, CommonStoreConfig, KeyValueStoreError, ReadableKeyValueStore,
+        AdminKeyValueStore, CommonStoreInternalConfig, KeyValueStoreError, ReadableKeyValueStore,
         WithError, WritableKeyValueStore,
     },
 };
@@ -28,16 +28,15 @@ use crate::{
 #[derive(Debug)]
 pub struct MemoryStoreConfig {
     /// The common configuration of the key value store
-    pub common_config: CommonStoreConfig,
+    pub common_config: CommonStoreInternalConfig,
 }
 
 impl MemoryStoreConfig {
     /// Creates a `MemoryStoreConfig`. `max_concurrent_queries` and `cache_size` are not used.
     pub fn new(max_stream_queries: usize) -> Self {
-        let common_config = CommonStoreConfig {
+        let common_config = CommonStoreInternalConfig {
             max_concurrent_queries: None,
             max_stream_queries,
-            cache_size: 1000,
         };
         Self { common_config }
     }
@@ -277,10 +276,9 @@ impl MemoryStore {
         namespace: &str,
         root_key: &[u8],
     ) -> Result<Self, MemoryStoreError> {
-        let common_config = CommonStoreConfig {
+        let common_config = CommonStoreInternalConfig {
             max_concurrent_queries: None,
             max_stream_queries,
-            cache_size: 1000,
         };
         let config = MemoryStoreConfig { common_config };
         let kill_on_drop = false;
@@ -294,10 +292,9 @@ impl MemoryStore {
         namespace: &str,
         root_key: &[u8],
     ) -> Result<Self, MemoryStoreError> {
-        let common_config = CommonStoreConfig {
+        let common_config = CommonStoreInternalConfig {
             max_concurrent_queries: None,
             max_stream_queries,
-            cache_size: 1000,
         };
         let config = MemoryStoreConfig { common_config };
         let kill_on_drop = true;
@@ -307,6 +304,10 @@ impl MemoryStore {
 
 impl AdminKeyValueStore for MemoryStore {
     type Config = MemoryStoreConfig;
+
+    fn get_name() -> String {
+        "memory".to_string()
+    }
 
     async fn connect(
         config: &Self::Config,
@@ -322,10 +323,9 @@ impl AdminKeyValueStore for MemoryStore {
 
     fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, MemoryStoreError> {
         let max_stream_queries = self.max_stream_queries;
-        let common_config = CommonStoreConfig {
+        let common_config = CommonStoreInternalConfig {
             max_concurrent_queries: None,
             max_stream_queries,
-            cache_size: 1000,
         };
         let config = MemoryStoreConfig { common_config };
         let mut memory_stores = MEMORY_STORES
@@ -371,10 +371,9 @@ impl AdminKeyValueStore for MemoryStore {
 impl TestKeyValueStore for MemoryStore {
     async fn new_test_config() -> Result<MemoryStoreConfig, MemoryStoreError> {
         let max_stream_queries = TEST_MEMORY_MAX_STREAM_QUERIES;
-        let common_config = CommonStoreConfig {
+        let common_config = CommonStoreInternalConfig {
             max_concurrent_queries: None,
             max_stream_queries,
-            cache_size: 1000,
         };
         Ok(MemoryStoreConfig { common_config })
     }

--- a/linera-views/src/backends/metering.rs
+++ b/linera-views/src/backends/metering.rs
@@ -95,7 +95,7 @@ impl KeyValueStoreMetrics {
 
         let entry1 = format!("{}_read_value_bytes_latency", var_name);
         let entry2 = format!("{} read value bytes latency", title_name);
-        let read_value_bytes_latency = register_histogram_vec(&entry1, &entry2, &[], None):
+        let read_value_bytes_latency = register_histogram_vec(&entry1, &entry2, &[], None);
 
         let entry1 = format!("{}_contains_key_latency", var_name);
         let entry2 = format!("{} contains key latency", title_name);

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -15,21 +15,19 @@ use tempfile::TempDir;
 use thiserror::Error;
 
 #[cfg(with_metrics)]
-use crate::metering::{
-    MeteredStore, LRU_CACHING_METRICS, ROCKS_DB_METRICS, VALUE_SPLITTING_METRICS,
-};
+use crate::metering::MeteredStore;
+#[cfg(with_testing)]
+use crate::store::TestKeyValueStore;
 use crate::{
     batch::{Batch, WriteOperation},
     common::get_upper_bound,
-    lru_caching::LruCachingStore,
+    lru_caching::{LruCachingStore, LruSplittingConfig},
     store::{
-        AdminKeyValueStore, CommonStoreConfig, KeyValueStoreError, ReadableKeyValueStore,
+        AdminKeyValueStore, CommonStoreInternalConfig, KeyValueStoreError, ReadableKeyValueStore,
         WithError, WritableKeyValueStore,
     },
     value_splitting::{ValueSplittingError, ValueSplittingStore},
 };
-#[cfg(with_testing)]
-use crate::{lru_caching::TEST_CACHE_SIZE, store::TestKeyValueStore};
 
 /// The number of streams for the test
 #[cfg(with_testing)]
@@ -268,19 +266,18 @@ pub struct RocksDbStoreInternal {
     executor: RocksDbStoreExecutor,
     _path_with_guard: PathWithGuard,
     max_stream_queries: usize,
-    cache_size: usize,
     spawn_mode: RocksDbSpawnMode,
 }
 
 /// The initial configuration of the system
 #[derive(Clone, Debug)]
-pub struct RocksDbStoreConfig {
+pub struct RocksDbStoreInternalConfig {
     /// The path to the storage containing the namespaces
     pub path_with_guard: PathWithGuard,
     /// The spawn_mode that is chosen
     pub spawn_mode: RocksDbSpawnMode,
     /// The common configuration of the key value store
-    pub common_config: CommonStoreConfig,
+    pub common_config: CommonStoreInternalConfig,
 }
 
 impl RocksDbStoreInternal {
@@ -298,7 +295,6 @@ impl RocksDbStoreInternal {
         path_with_guard: PathWithGuard,
         spawn_mode: RocksDbSpawnMode,
         max_stream_queries: usize,
-        cache_size: usize,
         root_key: &[u8],
     ) -> Result<RocksDbStoreInternal, RocksDbStoreInternalError> {
         let path = path_with_guard.path_buf.clone();
@@ -317,7 +313,6 @@ impl RocksDbStoreInternal {
             executor,
             _path_with_guard: path_with_guard,
             max_stream_queries,
-            cache_size,
             spawn_mode,
         })
     }
@@ -438,7 +433,11 @@ impl WritableKeyValueStore for RocksDbStoreInternal {
 }
 
 impl AdminKeyValueStore for RocksDbStoreInternal {
-    type Config = RocksDbStoreConfig;
+    type Config = RocksDbStoreInternalConfig;
+
+    fn get_name() -> String {
+        "rocksdb internal".to_string()
+    }
 
     async fn connect(
         config: &Self::Config,
@@ -451,15 +450,8 @@ impl AdminKeyValueStore for RocksDbStoreInternal {
         path_buf.push(namespace);
         path_with_guard.path_buf = path_buf;
         let max_stream_queries = config.common_config.max_stream_queries;
-        let cache_size = config.common_config.cache_size;
         let spawn_mode = config.spawn_mode;
-        RocksDbStoreInternal::build(
-            path_with_guard,
-            spawn_mode,
-            max_stream_queries,
-            cache_size,
-            root_key,
-        )
+        RocksDbStoreInternal::build(path_with_guard, spawn_mode, max_stream_queries, root_key)
     }
 
     fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, RocksDbStoreInternalError> {
@@ -534,15 +526,14 @@ impl AdminKeyValueStore for RocksDbStoreInternal {
 
 #[cfg(with_testing)]
 impl TestKeyValueStore for RocksDbStoreInternal {
-    async fn new_test_config() -> Result<RocksDbStoreConfig, RocksDbStoreInternalError> {
+    async fn new_test_config() -> Result<RocksDbStoreInternalConfig, RocksDbStoreInternalError> {
         let path_with_guard = create_rocks_db_test_path();
-        let common_config = CommonStoreConfig {
+        let common_config = CommonStoreInternalConfig {
             max_concurrent_queries: None,
             max_stream_queries: TEST_ROCKS_DB_MAX_STREAM_QUERIES,
-            cache_size: TEST_CACHE_SIZE,
         };
         let spawn_mode = RocksDbSpawnMode::get_spawn_mode_from_runtime();
-        Ok(RocksDbStoreConfig {
+        Ok(RocksDbStoreInternalConfig {
             path_with_guard,
             spawn_mode,
             common_config,
@@ -594,21 +585,6 @@ pub enum RocksDbStoreInternalError {
     Bcs(#[from] bcs::Error),
 }
 
-impl KeyValueStoreError for RocksDbStoreInternalError {
-    const BACKEND: &'static str = "rocks_db";
-}
-
-/// A shared DB client for RocksDB implementing LruCaching
-#[derive(Clone)]
-pub struct RocksDbStore {
-    #[cfg(with_metrics)]
-    store: MeteredStore<
-        LruCachingStore<MeteredStore<ValueSplittingStore<MeteredStore<RocksDbStoreInternal>>>>,
-    >,
-    #[cfg(not(with_metrics))]
-    store: LruCachingStore<ValueSplittingStore<RocksDbStoreInternal>>,
-}
-
 /// A path and the guard for the temporary directory if needed
 #[derive(Clone, Debug)]
 pub struct PathWithGuard {
@@ -637,135 +613,22 @@ fn create_rocks_db_test_path() -> PathWithGuard {
     PathWithGuard { path_buf, _dir }
 }
 
-impl RocksDbStore {
-    #[cfg(with_metrics)]
-    fn inner(&self) -> &RocksDbStoreInternal {
-        &self.store.store.store.store.store.store
-    }
-
-    #[cfg(not(with_metrics))]
-    fn inner(&self) -> &RocksDbStoreInternal {
-        &self.store.store.store
-    }
-
-    fn from_inner(store: RocksDbStoreInternal, cache_size: usize) -> RocksDbStore {
-        #[cfg(with_metrics)]
-        let store = MeteredStore::new(&ROCKS_DB_METRICS, store);
-        let store = ValueSplittingStore::new(store);
-        #[cfg(with_metrics)]
-        let store = MeteredStore::new(&VALUE_SPLITTING_METRICS, store);
-        let store = LruCachingStore::new(store, cache_size);
-        #[cfg(with_metrics)]
-        let store = MeteredStore::new(&LRU_CACHING_METRICS, store);
-        Self { store }
-    }
+impl KeyValueStoreError for RocksDbStoreInternalError {
+    const BACKEND: &'static str = "rocks_db";
 }
+
+/// The `RocksDbStore` composed type with metrics
+#[cfg(with_metrics)]
+pub type RocksDbStore = MeteredStore<
+    LruCachingStore<MeteredStore<ValueSplittingStore<MeteredStore<RocksDbStoreInternal>>>>,
+>;
+
+/// The `RocksDbStore` composed type
+#[cfg(not(with_metrics))]
+pub type RocksDbStore = LruCachingStore<ValueSplittingStore<RocksDbStoreInternal>>;
 
 /// The composed error type for the `RocksDbStore`
 pub type RocksDbStoreError = ValueSplittingError<RocksDbStoreInternalError>;
 
-impl WithError for RocksDbStore {
-    type Error = RocksDbStoreError;
-}
-
-impl ReadableKeyValueStore for RocksDbStore {
-    const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
-    type Keys = Vec<Vec<u8>>;
-    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
-
-    fn max_stream_queries(&self) -> usize {
-        self.store.max_stream_queries()
-    }
-
-    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, RocksDbStoreError> {
-        self.store.read_value_bytes(key).await
-    }
-
-    async fn contains_key(&self, key: &[u8]) -> Result<bool, RocksDbStoreError> {
-        self.store.contains_key(key).await
-    }
-
-    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, RocksDbStoreError> {
-        self.store.contains_keys(keys).await
-    }
-
-    async fn read_multi_values_bytes(
-        &self,
-        keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<Option<Vec<u8>>>, RocksDbStoreError> {
-        self.store.read_multi_values_bytes(keys).await
-    }
-
-    async fn find_keys_by_prefix(
-        &self,
-        key_prefix: &[u8],
-    ) -> Result<Self::Keys, RocksDbStoreError> {
-        self.store.find_keys_by_prefix(key_prefix).await
-    }
-
-    async fn find_key_values_by_prefix(
-        &self,
-        key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, RocksDbStoreError> {
-        self.store.find_key_values_by_prefix(key_prefix).await
-    }
-}
-
-impl WritableKeyValueStore for RocksDbStore {
-    const MAX_VALUE_SIZE: usize = usize::MAX;
-
-    async fn write_batch(&self, batch: Batch) -> Result<(), RocksDbStoreError> {
-        self.store.write_batch(batch).await
-    }
-
-    async fn clear_journal(&self) -> Result<(), RocksDbStoreError> {
-        self.store.clear_journal().await
-    }
-}
-
-impl AdminKeyValueStore for RocksDbStore {
-    type Config = RocksDbStoreConfig;
-
-    async fn connect(
-        config: &Self::Config,
-        namespace: &str,
-        root_key: &[u8],
-    ) -> Result<Self, RocksDbStoreError> {
-        let store = RocksDbStoreInternal::connect(config, namespace, root_key).await?;
-        let cache_size = config.common_config.cache_size;
-        Ok(Self::from_inner(store, cache_size))
-    }
-
-    fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, RocksDbStoreError> {
-        let store = self.inner().clone_with_root_key(root_key)?;
-        let cache_size = self.inner().cache_size;
-        Ok(Self::from_inner(store, cache_size))
-    }
-
-    async fn list_all(config: &Self::Config) -> Result<Vec<String>, RocksDbStoreError> {
-        Ok(RocksDbStoreInternal::list_all(config).await?)
-    }
-
-    async fn delete_all(config: &Self::Config) -> Result<(), RocksDbStoreError> {
-        Ok(RocksDbStoreInternal::delete_all(config).await?)
-    }
-
-    async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, RocksDbStoreError> {
-        Ok(RocksDbStoreInternal::exists(config, namespace).await?)
-    }
-
-    async fn create(config: &Self::Config, namespace: &str) -> Result<(), RocksDbStoreError> {
-        Ok(RocksDbStoreInternal::create(config, namespace).await?)
-    }
-
-    async fn delete(config: &Self::Config, namespace: &str) -> Result<(), RocksDbStoreError> {
-        Ok(RocksDbStoreInternal::delete(config, namespace).await?)
-    }
-}
-
-#[cfg(with_testing)]
-impl TestKeyValueStore for RocksDbStore {
-    async fn new_test_config() -> Result<RocksDbStoreConfig, RocksDbStoreError> {
-        Ok(RocksDbStoreInternal::new_test_config().await?)
-    }
-}
+/// The composed config type for the `RocksDbStore`
+pub type RocksDbStoreConfig = LruSplittingConfig<RocksDbStoreInternalConfig>;

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -30,19 +30,19 @@ use scylla::{
 use thiserror::Error;
 
 #[cfg(with_metrics)]
-use crate::metering::{MeteredStore, LRU_CACHING_METRICS, SCYLLA_DB_METRICS};
+use crate::metering::MeteredStore;
+#[cfg(with_testing)]
+use crate::store::TestKeyValueStore;
 use crate::{
-    batch::{Batch, UnorderedBatch},
+    batch::UnorderedBatch,
     common::get_upper_bound_option,
     journaling::{DirectWritableKeyValueStore, JournalConsistencyError, JournalingKeyValueStore},
-    lru_caching::LruCachingStore,
+    lru_caching::{LruCachingStore, LruSplittingConfig},
     store::{
-        AdminKeyValueStore, CommonStoreConfig, KeyValueStoreError, ReadableKeyValueStore,
-        WithError, WritableKeyValueStore,
+        AdminKeyValueStore, CommonStoreInternalConfig, KeyValueStoreError, ReadableKeyValueStore,
+        WithError,
     },
 };
-#[cfg(with_testing)]
-use crate::{lru_caching::TEST_CACHE_SIZE, store::TestKeyValueStore};
 
 /// The client for ScyllaDb.
 /// * The session allows to pass queries
@@ -364,14 +364,6 @@ impl ScyllaDbClient {
     }
 }
 
-/// We limit the number of connections that can be done for tests.
-#[cfg(with_testing)]
-const TEST_SCYLLA_DB_MAX_CONCURRENT_QUERIES: usize = 10;
-
-/// The number of connections in the stream is limited for tests.
-#[cfg(with_testing)]
-const TEST_SCYLLA_DB_MAX_STREAM_QUERIES: usize = 10;
-
 /// The maximal size of an operation on ScyllaDB seems to be 16M
 /// https://www.scylladb.com/2019/03/27/best-practices-for-scylla-applications/
 /// "There is a hard limit at 16MB, and nothing bigger than that can arrive at once
@@ -386,7 +378,6 @@ pub struct ScyllaDbStoreInternal {
     store: Arc<ScyllaDbClient>,
     semaphore: Option<Arc<Semaphore>>,
     max_stream_queries: usize,
-    cache_size: usize,
     root_key: Vec<u8>,
 }
 
@@ -554,8 +545,21 @@ fn get_big_root_key(root_key: &[u8]) -> Vec<u8> {
     big_key
 }
 
+/// The type for building a new ScyllaDB Key Value Store
+#[derive(Debug)]
+pub struct ScyllaDbStoreInternalConfig {
+    /// The url to which the requests have to be sent
+    pub uri: String,
+    /// The common configuration of the key value store
+    pub common_config: CommonStoreInternalConfig,
+}
+
 impl AdminKeyValueStore for ScyllaDbStoreInternal {
-    type Config = ScyllaDbStoreConfig;
+    type Config = ScyllaDbStoreInternalConfig;
+
+    fn get_name() -> String {
+        "scylladb internal".to_string()
+    }
 
     async fn connect(
         config: &Self::Config,
@@ -575,13 +579,11 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
             .max_concurrent_queries
             .map(|n| Arc::new(Semaphore::new(n)));
         let max_stream_queries = config.common_config.max_stream_queries;
-        let cache_size = config.common_config.cache_size;
         let root_key = get_big_root_key(root_key);
         Ok(Self {
             store,
             semaphore,
             max_stream_queries,
-            cache_size,
             root_key,
         })
     }
@@ -590,13 +592,11 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
         let store = self.store.clone();
         let semaphore = self.semaphore.clone();
         let max_stream_queries = self.max_stream_queries;
-        let cache_size = self.cache_size;
         let root_key = get_big_root_key(root_key);
         Ok(Self {
             store,
             semaphore,
             max_stream_queries,
-            cache_size,
             root_key,
         })
     }
@@ -765,160 +765,34 @@ impl ScyllaDbStoreInternal {
     }
 }
 
-/// A shared DB store for ScyllaDB implementing LruCaching
-#[derive(Clone)]
-pub struct ScyllaDbStore {
-    #[cfg(with_metrics)]
-    store:
-        MeteredStore<LruCachingStore<MeteredStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>>>,
-    #[cfg(not(with_metrics))]
-    store: LruCachingStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>,
-}
+/// We limit the number of connections that can be done for tests.
+#[cfg(with_testing)]
+const TEST_SCYLLA_DB_MAX_CONCURRENT_QUERIES: usize = 10;
 
-/// The type for building a new ScyllaDB Key Value Store
-#[derive(Debug)]
-pub struct ScyllaDbStoreConfig {
-    /// The url to which the requests have to be sent
-    pub uri: String,
-    /// The common configuration of the key value store
-    pub common_config: CommonStoreConfig,
-}
-
-impl WithError for ScyllaDbStore {
-    type Error = ScyllaDbStoreError;
-}
-
-impl ReadableKeyValueStore for ScyllaDbStore {
-    const MAX_KEY_SIZE: usize = ScyllaDbStoreInternal::MAX_KEY_SIZE;
-
-    type Keys = <ScyllaDbStoreInternal as ReadableKeyValueStore>::Keys;
-
-    type KeyValues = <ScyllaDbStoreInternal as ReadableKeyValueStore>::KeyValues;
-
-    fn max_stream_queries(&self) -> usize {
-        self.store.max_stream_queries()
-    }
-
-    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, ScyllaDbStoreError> {
-        self.store.read_value_bytes(key).await
-    }
-
-    async fn contains_key(&self, key: &[u8]) -> Result<bool, ScyllaDbStoreError> {
-        self.store.contains_key(key).await
-    }
-
-    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ScyllaDbStoreError> {
-        self.store.contains_keys(keys).await
-    }
-
-    async fn read_multi_values_bytes(
-        &self,
-        keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<Option<Vec<u8>>>, ScyllaDbStoreError> {
-        if keys.is_empty() {
-            return Ok(Vec::new());
-        }
-        Box::pin(self.store.read_multi_values_bytes(keys)).await
-    }
-
-    async fn find_keys_by_prefix(
-        &self,
-        key_prefix: &[u8],
-    ) -> Result<Self::Keys, ScyllaDbStoreError> {
-        self.store.find_keys_by_prefix(key_prefix).await
-    }
-
-    async fn find_key_values_by_prefix(
-        &self,
-        key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, ScyllaDbStoreError> {
-        self.store.find_key_values_by_prefix(key_prefix).await
-    }
-}
-
-impl WritableKeyValueStore for ScyllaDbStore {
-    const MAX_VALUE_SIZE: usize = ScyllaDbStoreInternal::MAX_VALUE_SIZE;
-
-    async fn write_batch(&self, batch: Batch) -> Result<(), ScyllaDbStoreError> {
-        self.store.write_batch(batch).boxed().await
-    }
-
-    async fn clear_journal(&self) -> Result<(), ScyllaDbStoreError> {
-        self.store.clear_journal().boxed().await
-    }
-}
-
-impl AdminKeyValueStore for ScyllaDbStore {
-    type Config = ScyllaDbStoreConfig;
-
-    async fn connect(
-        config: &Self::Config,
-        namespace: &str,
-        root_key: &[u8],
-    ) -> Result<Self, ScyllaDbStoreError> {
-        let cache_size = config.common_config.cache_size;
-        let simple_store = ScyllaDbStoreInternal::connect(config, namespace, root_key).await?;
-        Ok(ScyllaDbStore::from_inner(simple_store, cache_size))
-    }
-
-    fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, ScyllaDbStoreError> {
-        let simple_store = self.inner().clone_with_root_key(root_key)?;
-        let cache_size = self.inner().cache_size;
-        Ok(ScyllaDbStore::from_inner(simple_store, cache_size))
-    }
-
-    async fn list_all(config: &Self::Config) -> Result<Vec<String>, ScyllaDbStoreError> {
-        ScyllaDbStoreInternal::list_all(config).await
-    }
-
-    async fn delete_all(config: &Self::Config) -> Result<(), ScyllaDbStoreError> {
-        ScyllaDbStoreInternal::delete_all(config).await
-    }
-
-    async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, ScyllaDbStoreError> {
-        ScyllaDbStoreInternal::exists(config, namespace).await
-    }
-
-    async fn create(config: &Self::Config, namespace: &str) -> Result<(), ScyllaDbStoreError> {
-        ScyllaDbStoreInternal::create(config, namespace).await
-    }
-
-    async fn delete(config: &Self::Config, namespace: &str) -> Result<(), ScyllaDbStoreError> {
-        ScyllaDbStoreInternal::delete(config, namespace).await
-    }
-}
+/// The number of connections in the stream is limited for tests.
+#[cfg(with_testing)]
+const TEST_SCYLLA_DB_MAX_STREAM_QUERIES: usize = 10;
 
 #[cfg(with_testing)]
-impl TestKeyValueStore for ScyllaDbStore {
-    async fn new_test_config() -> Result<ScyllaDbStoreConfig, ScyllaDbStoreError> {
+impl TestKeyValueStore for JournalingKeyValueStore<ScyllaDbStoreInternal> {
+    async fn new_test_config() -> Result<ScyllaDbStoreInternalConfig, ScyllaDbStoreError> {
         let uri = "localhost:9042".to_string();
-        let common_config = CommonStoreConfig {
+        let common_config = CommonStoreInternalConfig {
             max_concurrent_queries: Some(TEST_SCYLLA_DB_MAX_CONCURRENT_QUERIES),
             max_stream_queries: TEST_SCYLLA_DB_MAX_STREAM_QUERIES,
-            cache_size: TEST_CACHE_SIZE,
         };
-        Ok(ScyllaDbStoreConfig { uri, common_config })
+        Ok(ScyllaDbStoreInternalConfig { uri, common_config })
     }
 }
 
-impl ScyllaDbStore {
-    #[cfg(with_metrics)]
-    fn inner(&self) -> &ScyllaDbStoreInternal {
-        &self.store.store.store.store.store
-    }
+/// The `ScyllaDbStore` composed type with metrics
+#[cfg(with_metrics)]
+pub type ScyllaDbStore =
+    MeteredStore<LruCachingStore<MeteredStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>>>;
 
-    #[cfg(not(with_metrics))]
-    fn inner(&self) -> &ScyllaDbStoreInternal {
-        &self.store.store.store
-    }
+/// The `ScyllaDbStore` composed type
+#[cfg(not(with_metrics))]
+pub type ScyllaDbStore = LruCachingStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>;
 
-    fn from_inner(simple_store: ScyllaDbStoreInternal, cache_size: usize) -> ScyllaDbStore {
-        let store = JournalingKeyValueStore::new(simple_store);
-        #[cfg(with_metrics)]
-        let store = MeteredStore::new(&SCYLLA_DB_METRICS, store);
-        let store = LruCachingStore::new(store, cache_size);
-        #[cfg(with_metrics)]
-        let store = MeteredStore::new(&LRU_CACHING_METRICS, store);
-        Self { store }
-    }
-}
+/// The `ScyllaDbStoreConfig` input type
+pub type ScyllaDbStoreConfig = LruSplittingConfig<ScyllaDbStoreInternalConfig>;

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -13,6 +13,15 @@ use crate::{batch::Batch, common::from_bytes_option, views::ViewError};
 
 /// The common initialization parameters for the `KeyValueStore`
 #[derive(Debug, Clone)]
+pub struct CommonStoreInternalConfig {
+    /// The number of concurrent to a database
+    pub max_concurrent_queries: Option<usize>,
+    /// The number of streams used for the async streams.
+    pub max_stream_queries: usize,
+}
+
+/// The common initialization parameters for the `KeyValueStore`
+#[derive(Debug, Clone)]
 pub struct CommonStoreConfig {
     /// The number of concurrent to a database
     pub max_concurrent_queries: Option<usize>,
@@ -20,6 +29,16 @@ pub struct CommonStoreConfig {
     pub max_stream_queries: usize,
     /// The cache size being used.
     pub cache_size: usize,
+}
+
+impl CommonStoreConfig {
+    /// Gets the reduced `CommonStoreInternalConfig`.
+    pub fn reduced(&self) -> CommonStoreInternalConfig {
+        CommonStoreInternalConfig {
+            max_concurrent_queries: self.max_concurrent_queries,
+            max_stream_queries: self.max_stream_queries,
+        }
+    }
 }
 
 impl Default for CommonStoreConfig {
@@ -144,6 +163,8 @@ pub trait LocalWritableKeyValueStore: WithError {
 pub trait LocalAdminKeyValueStore: WithError + Sized {
     /// The configuration needed to interact with a new store.
     type Config: Send + Sync;
+    /// The name of this class of stores
+    fn get_name() -> String;
 
     /// Connects to an existing namespace using the given configuration.
     async fn connect(


### PR DESCRIPTION
## Motivation

We have the `Journaling`, `ValueSplitting`, `LruCaching` and `MeteredStore` but the potential is not fully exploited with a relatively large quantity of boilerplate code.

## Proposal

The following was done:
* The `get_name()` function is introduced to the `AdminKeyValueStore`. Unfortunately, it was not possible to have a `&'static str` since we want to have composed types and so composed names.
* The introduction of the `get_name()` allows removing all the `KeyValueStoreMetrics` static variables and instead having a global store that contains the `KeyValueStoreMeytrics`.
* That global variable allows to put metrics for the `AdminKeyValueStore` trait function.
* The `AdminKeyValueStore` is added to all the Adaptor.
* For the `LruCaching` this requires the introduction of the `LruSplittingConfig` that contains the configurations in a nested way.
* The `CommonStoreConfig` is split with the `cache_size` being removed from it.
* The `pub store` are systematically changed into `store` in the adaptors.

Possible criticism of the design:
* There is no adaptor for the error types in the `JournalingKeyValueStore`. The rust difficulty was in the `type Keys = K::Keys` since this requires a nested key type and I think it was a little too complicated at this time.
* The `KeyValueStoreMetrics` were previously as `&'static LazyLock<KeyValueStoreMetrics>`. Now they are as `Arc<KeyValueStoreMetrics>`.
* There is no systematic adaptor for the error and config type, like e.g. `LruSplittingError`. But those would be pure boilerplate since for LRU, there is no additional error occurring.
* The input has not changed. The next step is in using YAML file for the input.

## Test Plan

CI. Nothing should be affected by the refactoring.

## Release Plan

Not relevant. 

## Links

None.
