### PR TITLE
Run long faucet chain test in release mode

### DIFF
--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Run end-to-end tests
       run: |
         cargo run --release -p linera-storage-service -- memory --endpoint $LINERA_STORAGE_SERVICE &
-        cargo test -p linera-service --features storage-service -- --ignored test_end_to_end_faucet_with_long_chains --nocapture
+        cargo test --release -p linera-service --features storage-service -- --ignored test_end_to_end_faucet_with_long_chains --nocapture


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
The long faucet chain test job in CI takes a long time and the chain isn't even very long (currently at 3000 blocks). When running the test locally, I realized it was a lot faster, and when investigating I realized that CI was running in `debug` mode.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Run the test in `release` mode.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
CI should now show that long faucet chain test is faster.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do because this only affects CI.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
