### PR TITLE
Retry node service queries if they timeout

### DIFF
--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -1009,17 +1009,21 @@ impl NodeService {
             linera_base::time::timer::sleep(Duration::from_secs(i)).await;
             let url = format!("http://localhost:{}/", self.port);
             let client = reqwest_client();
-            let response = client
+            let result = client
                 .post(url)
                 .json(&json!({ "query": query }))
                 .send()
-                .await
-                .with_context(|| {
-                    format!(
-                        "query_node: failed to post query={}",
-                        truncate_query_output(query)
-                    )
-                })?;
+                .await;
+            if matches!(result, Err(ref error) if error.is_timeout()) {
+                warn!("Timeout when sending query {query:?} to the node service");
+                continue;
+            }
+            let response = result.with_context(|| {
+                format!(
+                    "query_node: failed to post query={}",
+                    truncate_query_output(query)
+                )
+            })?;
             anyhow::ensure!(
                 response.status().is_success(),
                 "Query \"{}\" failed: {}",


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
The long faucet chain test is failing due to query timeouts when initializing the wallet from the faucet. This happens because the faucet is still busy processing blocks.

The `cli_wrappers::wallet::NodeService::query_node()` method automatically retries for a few attempts on certain errors, in order to prevent failures due to race conditions. However, it did not retry in case of a timeout.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Treat `reqwest` timeout errors the same as errors reported through GraphQL.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
CI should show that the long faucet chain test no longer fails because of the query timing out while initializing the wallet.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do because these changes only affect CI and tests.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
