### PR TITLE
Refactor synchronized_received_certificates_from_validator

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1162,7 +1162,6 @@ where
                 .info;
             if !local_response.requested_sent_certificate_hashes.is_empty() {
                 // We've already processed incoming messages for this certificate.
-                // TODO: We verify it's non-empty but how do we make sure we've processed ALL?
                 new_tracker += 1;
                 continue;
             }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1176,7 +1176,7 @@ where
                     }
                     _ => {
                         error!("Validator sent more than one certificate hash for a single block.");
-                        break;
+                        return Err(NodeError::InvalidChainInfoResponse);
                     }
                 };
 
@@ -1239,7 +1239,7 @@ where
             Ok(HandleCertificateResult::New)
         } else {
             // We don't accept a certificate from a committee that was retired.
-            return Ok(HandleCertificateResult::OldEpoch);
+            Ok(HandleCertificateResult::OldEpoch)
         }
     }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1187,7 +1187,7 @@ where
                 .await?;
 
             match self
-                .handle_certificate(max_epoch, &committees, certificate)
+                .check_certificate(max_epoch, &committees, certificate)
                 .await?
             {
                 HandleCertificateResult::FutureEpoch(certificate) => {
@@ -1218,7 +1218,7 @@ where
         Ok((remote_node.name, new_tracker, certificates))
     }
 
-    async fn handle_certificate(
+    async fn check_certificate(
         &self,
         highest_known_epoch: Epoch,
         committees: &BTreeMap<Epoch, Committee>,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -616,6 +616,12 @@ enum ReceiveCertificateMode {
     AlreadyChecked,
 }
 
+enum HandleCertificateResult {
+    OldEpoch(Certificate),
+    New(Certificate),
+    FutureEpoch(Certificate, Epoch),
+}
+
 impl<P, S> ChainClient<P, S>
 where
     P: ValidatorNodeProvider + Sync + 'static,
@@ -1131,19 +1137,23 @@ where
             .get(&remote_node.name)
             .copied()
             .unwrap_or(0);
+
         let (mut committees, mut max_epoch) = self
             .known_committees()
             .await
             .map_err(|_| NodeError::InvalidChainInfoResponse)?;
+
         let admin_id = self.state().admin_id();
         // Retrieve newly received certificates from this validator.
         let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_n(tracker);
         let info = remote_node.handle_chain_info_query(query).await?;
-        let mut certificates = Vec::new();
+        let mut certificates: Vec<Certificate> = Vec::new();
         let mut new_tracker = tracker;
+
         for entry in info.requested_received_log {
             let query = ChainInfoQuery::new(entry.chain_id)
                 .with_sent_certificate_hashes_in_range(BlockHeightRange::single(entry.height));
+
             let local_response = self
                 .client
                 .local_node
@@ -1151,76 +1161,114 @@ where
                 .await
                 .map_err(|error| NodeError::LocalNodeQuery {
                     error: error.to_string(),
-                })?;
-            if !local_response
-                .info
-                .requested_sent_certificate_hashes
-                .is_empty()
-            {
+                })?
+                .info;
+            if !local_response.requested_sent_certificate_hashes.is_empty() {
+                // We've already processed incoming messages for this certificate.
+                // TODO: We verify it's non-empty but how do we make sure we've processed ALL?
                 new_tracker += 1;
                 continue;
             }
 
-            let mut info = remote_node.handle_chain_info_query(query).await?;
-            let Some(certificate_hash) = info.requested_sent_certificate_hashes.pop() else {
-                break;
-            };
+            let remote_response = remote_node.handle_chain_info_query(query).await?;
+            let certificate_hash =
+                match remote_response.requested_sent_certificate_hashes.as_slice() {
+                    &[hash] => hash,
+                    [] => {
+                        warn!("Validator didn't have certificate he claimed to have.");
+                        break;
+                    }
+                    _ => {
+                        error!("Validator sent more than one certificate hash for a single block.");
+                        break;
+                    }
+                };
 
             let certificate = remote_node
                 .node
                 .download_certificate(certificate_hash)
                 .await?;
-            let CertificateValue::ConfirmedBlock { executed_block, .. } = certificate.value()
-            else {
-                return Err(NodeError::InvalidChainInfoResponse);
-            };
-            let block = &executed_block.block;
-            // Check that certificates are valid w.r.t one of our trusted committees.
-            if block.epoch > max_epoch {
-                // Synchronize the state of the admin chain from the validator.
-                self.try_synchronize_chain_state_from(remote_node, admin_id)
-                    .await
-                    .map_err(|_| NodeError::InvalidChainInfoResponse)?;
-                let (new_committees, new_max_epoch) = self
-                    .known_committees()
-                    .await
-                    .map_err(|_| NodeError::InvalidChainInfoResponse)?;
-                committees.extend(new_committees);
-                max_epoch = max_epoch.max(new_max_epoch);
-            }
-            if block.epoch > max_epoch {
-                // We don't accept a certificate from a committee in the future.
-                warn!(
-                    "Postponing received certificate from {:.8} at height {} from future epoch {}",
-                    entry.chain_id, entry.height, block.epoch
-                );
-                // Stop the synchronization here. Do not increment the tracker further so
-                // that this certificate can still be downloaded later, once our committee
-                // is updated.
-                break;
-            }
-            match committees.get(&block.epoch) {
-                Some(committee) => {
-                    // This epoch is recognized by our chain. Let's verify the
-                    // certificate.
-                    certificate.check(committee)?;
-                    certificates.push(certificate);
-                    new_tracker += 1;
+
+            match self
+                .handle_certificate(
+                    admin_id,
+                    max_epoch,
+                    &mut committees,
+                    certificate,
+                    &remote_node,
+                )
+                .await?
+            {
+                HandleCertificateResult::FutureEpoch(certificate, new_max_epoch) => {
+                    max_epoch = new_max_epoch;
+                    warn!("Postponing received certificate from {:.8} at height {} from future epoch {}",
+                          entry.chain_id, entry.height, certificate.value().epoch());
+                    // Stop the synchronization here. Do not increment the tracker further so
+                    // that this certificate can still be downloaded later, once our committee
+                    // is updated.
+                    break;
                 }
-                None => {
+                HandleCertificateResult::OldEpoch(certificate) => {
                     // This epoch is not recognized any more. Let's skip the certificate.
                     // If a higher block with a recognized epoch comes up later from the
                     // same chain, the call to `receive_certificate` below will download
                     // the skipped certificate again.
                     warn!(
                         "Skipping received certificate from past epoch {:?}",
-                        block.epoch
+                        certificate.value().epoch()
                     );
+                    new_tracker += 1;
+                }
+                HandleCertificateResult::New(certificate) => {
+                    certificates.push(certificate);
                     new_tracker += 1;
                 }
             }
         }
         Ok((remote_node.name, new_tracker, certificates))
+    }
+
+    async fn handle_certificate(
+        &self,
+        admin_chain: ChainId,
+        highest_known_epoch: Epoch,
+        committees: &mut BTreeMap<Epoch, Committee>,
+        incoming_certificate: Certificate,
+        remote_node: &RemoteNode<P::Node>,
+    ) -> Result<HandleCertificateResult, NodeError> {
+        let CertificateValue::ConfirmedBlock { executed_block, .. } = incoming_certificate.value()
+        else {
+            return Err(NodeError::InvalidChainInfoResponse);
+        };
+        let block = &executed_block.block;
+        // Check that certificates are valid w.r.t one of our trusted committees.
+        if block.epoch > highest_known_epoch {
+            // Synchronize the state of the admin chain from the validator.
+            self.try_synchronize_chain_state_from(remote_node, admin_chain)
+                .await
+                .map_err(|_| NodeError::InvalidChainInfoResponse)?;
+            let (new_committees, new_max_epoch) = self
+                .known_committees()
+                .await
+                .map_err(|_| NodeError::InvalidChainInfoResponse)?;
+            committees.extend(new_committees);
+            if new_max_epoch > highest_known_epoch {
+                // We don't accept a certificate from a committee in the future.
+                return Ok(HandleCertificateResult::FutureEpoch(
+                    incoming_certificate,
+                    new_max_epoch,
+                ));
+            }
+        }
+        if let Some(known_committee) = committees.get(&block.epoch) {
+            // This epoch is recognized by our chain. Let's verify the
+            // certificate.
+            let _ = incoming_certificate.check(known_committee)?;
+            Ok(HandleCertificateResult::New(incoming_certificate))
+        } else {
+            // We don't accept a certificate from a committee that was retired.
+            return Ok(HandleCertificateResult::OldEpoch(incoming_certificate));
+        }
     }
 
     /// Processes the result of [`synchronize_received_certificates_from_validator`] and updates


### PR DESCRIPTION
## Motivation

Working on adding `download_certificates` endpoint and as part of the work I refactored `synchronized_received_certificates_from_validator` method a bit. Posting this small change as a separate PR to simplify and speedup discussions.

## Proposal

Refactor `synchronized_received_certificates_from_validator`

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do 
## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
