### PR TITLE
Add download certificates endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4518,6 +4518,7 @@ dependencies = [
  "port-selector",
  "prometheus",
  "proptest",
+ "prost",
  "rand",
  "reqwest 0.11.27",
  "serde",

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -75,6 +75,7 @@ use crate::{
     remote_node::RemoteNode,
     updater::{communicate_with_quorum, CommunicateAction, CommunicationError, ValidatorUpdater},
     worker::{Notification, Reason, WorkerError, WorkerState},
+    CERTIFICATE_BATCH_SIZE,
 };
 
 mod chain_state;
@@ -1492,12 +1493,20 @@ where
             .with_manager_values();
         let info = remote_node.handle_chain_info_query(query).await?;
 
-        let certificates = future::try_join_all(
+        let certificates: Vec<Certificate> = future::try_join_all(
             info.requested_sent_certificate_hashes
-                .into_iter()
-                .map(move |hash| async move { remote_node.node.download_certificate(hash).await }),
+                .chunks(CERTIFICATE_BATCH_SIZE)
+                .map(move |hashes| async move {
+                    remote_node
+                        .node
+                        .download_certificates(hashes.to_vec())
+                        .await
+                }),
         )
-        .await?;
+        .await?
+        .into_iter()
+        .flatten()
+        .collect();
 
         if !certificates.is_empty()
             && self

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -22,4 +22,7 @@ pub mod worker;
 pub(crate) mod updater;
 pub(crate) mod value_cache;
 
+// TODO: Move to env vars or config.
+pub const CERTIFICATE_BATCH_SIZE: usize = 10;
+
 pub use crate::join_set_ext::{JoinSetExt, TaskHandle};

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -22,7 +22,4 @@ pub mod worker;
 pub(crate) mod updater;
 pub(crate) mod value_cache;
 
-// TODO: Move to env vars or config.
-pub const CERTIFICATE_BATCH_SIZE: usize = 10;
-
 pub use crate::join_set_ext::{JoinSetExt, TaskHandle};

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -95,6 +95,12 @@ pub trait ValidatorNode {
 
     async fn download_certificate(&self, hash: CryptoHash) -> Result<Certificate, NodeError>;
 
+    /// Requests a batch of certificates from the validator.
+    async fn download_certificates(
+        &self,
+        hashes: Vec<CryptoHash>,
+    ) -> Result<Vec<Certificate>, NodeError>;
+
     /// Returns the hash of the `Certificate` that last used a blob.
     async fn blob_last_used_by(&self, blob_id: BlobId) -> Result<CryptoHash, NodeError>;
 }

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -64,8 +64,21 @@ service ValidatorNode {
   // Downloads a certificate.
   rpc DownloadCertificate(CryptoHash) returns (Certificate);
 
+  // Downloads a batch of certificates.
+  rpc DownloadCertificates(CertificatesBatchRequest) returns (CertificatesBatchResponse);
+
   // Returns the hash of the `Certificate` that last used a blob.
   rpc BlobLastUsedBy(BlobId) returns (CryptoHash);
+}
+
+// A request for a batch of certificates.
+message CertificatesBatchRequest {
+  repeated CryptoHash hashes = 1;
+}
+
+// A batch of certificates.
+message CertificatesBatchResponse {
+  repeated Certificate certificates = 1;
 }
 
 // Information about the Linera crate version the validator is running

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -165,6 +165,18 @@ impl ValidatorNode for Client {
         })
     }
 
+    async fn download_certificates(
+        &self,
+        hashes: Vec<CryptoHash>,
+    ) -> Result<Vec<Certificate>, NodeError> {
+        Ok(match self {
+            Client::Grpc(grpc_client) => grpc_client.download_certificates(hashes).await?,
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => simple_client.download_certificates(hashes).await?,
+        })
+    }
+
     async fn blob_last_used_by(&self, blob_id: BlobId) -> Result<CryptoHash, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => grpc_client.blob_last_used_by(blob_id).await?,

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -317,6 +317,14 @@ impl ValidatorNode for GrpcClient {
     }
 
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
+    async fn download_certificates(
+        &self,
+        hashes: Vec<CryptoHash>,
+    ) -> Result<Vec<Certificate>, NodeError> {
+        Ok(client_delegate!(self, download_certificates, hashes)?.try_into()?)
+    }
+
+    #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
     async fn blob_last_used_by(&self, blob_id: BlobId) -> Result<CryptoHash, NodeError> {
         let req = api::BlobId::try_from(blob_id)?;
         Ok(client_delegate!(self, blob_last_used_by, req)?.try_into()?)

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeSet, fmt, future::Future, iter};
+use std::{fmt, future::Future, iter};
 
 use futures::{future, stream, StreamExt};
 use linera_base::{
@@ -334,11 +334,8 @@ impl ValidatorNode for GrpcClient {
                 break;
             }
 
-            // Remove ones we've just received.
-            let received_hashes: BTreeSet<CryptoHash> =
-                received.iter().map(|cert| cert.hash()).collect();
-            missing_hashes.retain(|hash| !received_hashes.contains(hash));
-
+            // Honest validator should return certificates in the same order as the requested hashes.
+            missing_hashes = missing_hashes[received.len()..].to_vec();
             certs_collected.append(&mut received);
         }
         Ok(certs_collected)

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -617,6 +617,39 @@ impl From<CryptoHash> for api::CryptoHash {
     }
 }
 
+impl From<Vec<CryptoHash>> for api::CertificatesBatchRequest {
+    fn from(certs: Vec<CryptoHash>) -> Self {
+        Self {
+            hashes: certs.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl TryFrom<Vec<Certificate>> for api::CertificatesBatchResponse {
+    type Error = GrpcProtoConversionError;
+
+    fn try_from(certs: Vec<Certificate>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            certificates: certs
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<_, _>>()?,
+        })
+    }
+}
+
+impl TryFrom<api::CertificatesBatchResponse> for Vec<Certificate> {
+    type Error = GrpcProtoConversionError;
+
+    fn try_from(response: api::CertificatesBatchResponse) -> Result<Self, Self::Error> {
+        response
+            .certificates
+            .into_iter()
+            .map(Certificate::try_from)
+            .collect()
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
     use std::{borrow::Cow, fmt::Debug};

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -43,3 +43,7 @@ pub enum GrpcError {
 
 const MEBIBYTE: usize = 1024 * 1024;
 pub const GRPC_MAX_MESSAGE_SIZE: usize = 16 * MEBIBYTE;
+
+/// Limit of gRPC message size up to which we will try to populate with data when estimating.
+/// We leave 30% of buffer for the rest of the message and potential underestimation.
+pub const GRPC_CHUNKED_MESSAGE_FILL_LIMIT: usize = GRPC_MAX_MESSAGE_SIZE * 7 / 10;

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -156,6 +156,14 @@ impl ValidatorNode for SimpleClient {
             .await
     }
 
+    async fn download_certificates(
+        &self,
+        hashes: Vec<CryptoHash>,
+    ) -> Result<Vec<Certificate>, NodeError> {
+        self.query(RpcMessage::DownloadCertificates(Box::new(hashes)))
+            .await
+    }
+
     async fn blob_last_used_by(&self, blob_id: BlobId) -> Result<CryptoHash, NodeError> {
         self.query(RpcMessage::BlobLastUsedBy(Box::new(blob_id)))
             .await

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -309,7 +309,9 @@ where
             | RpcMessage::BlobLastUsedBy(_)
             | RpcMessage::BlobLastUsedByResponse(_)
             | RpcMessage::DownloadCertificate(_)
-            | RpcMessage::DownloadCertificateResponse(_) => Err(NodeError::UnexpectedMessage),
+            | RpcMessage::DownloadCertificates(_)
+            | RpcMessage::DownloadCertificateResponse(_)
+            | RpcMessage::DownloadCertificatesResponse(_) => Err(NodeError::UnexpectedMessage),
         };
 
         self.server.packets_processed += 1;

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -786,50 +786,60 @@ RpcMessage:
         NEWTYPE:
           TYPENAME: CryptoHash
     7:
+      DownloadCertificates:
+        NEWTYPE:
+          SEQ:
+            TYPENAME: CryptoHash
+    8:
       BlobLastUsedBy:
         NEWTYPE:
           TYPENAME: BlobId
-    8:
-      VersionInfoQuery: UNIT
     9:
-      GenesisConfigHashQuery: UNIT
+      VersionInfoQuery: UNIT
     10:
+      GenesisConfigHashQuery: UNIT
+    11:
       Vote:
         NEWTYPE:
           TYPENAME: LiteVote
-    11:
+    12:
       ChainInfoResponse:
         NEWTYPE:
           TYPENAME: ChainInfoResponse
-    12:
+    13:
       Error:
         NEWTYPE:
           TYPENAME: NodeError
-    13:
+    14:
       VersionInfoResponse:
         NEWTYPE:
           TYPENAME: VersionInfo
-    14:
+    15:
       GenesisConfigHashResponse:
         NEWTYPE:
           TYPENAME: CryptoHash
-    15:
+    16:
       DownloadBlobContentResponse:
         NEWTYPE:
           TYPENAME: BlobContent
-    16:
+    17:
       DownloadCertificateValueResponse:
         NEWTYPE:
           TYPENAME: CertificateValue
-    17:
+    18:
       DownloadCertificateResponse:
         NEWTYPE:
           TYPENAME: Certificate
-    18:
+    19:
+      DownloadCertificatesResponse:
+        NEWTYPE:
+          SEQ:
+            TYPENAME: Certificate
+    20:
       BlobLastUsedByResponse:
         NEWTYPE:
           TYPENAME: CryptoHash
-    19:
+    21:
       CrossChainRequest:
         NEWTYPE:
           TYPENAME: CrossChainRequest

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -92,6 +92,7 @@ linera-views.workspace = true
 pathdiff = { workspace = true, optional = true }
 port-selector.workspace = true
 prometheus = { workspace = true, optional = true }
+prost = { workspace = true }
 rand.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 serde.workspace = true

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -505,8 +505,6 @@ where
             Ok(prost::Message::encode(&grpc_response, &mut buff).is_ok())
         }
 
-        // Reverse the order to drop from the back.
-        certificates.reverse();
         // Keep dropping elements until we fit in the limited message size.
         while !try_proto_serialize::<
             Vec<linera_chain::data_types::Certificate>,
@@ -517,8 +515,6 @@ where
             let _ = certificates.pop();
         }
 
-        // Reverse again to bring back the original order.
-        certificates.reverse();
         let grpc_response = CertificatesBatchResponse::try_from(certificates)?;
         Ok(Response::new(grpc_response))
     }

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -314,6 +314,9 @@ where
             DownloadCertificate(hash) => {
                 Ok(Some(self.storage.read_certificate(*hash).await?.into()))
             }
+            DownloadCertificates(hashes) => {
+                Ok(Some(self.storage.read_certificates(*hashes).await?.into()))
+            }
             BlobLastUsedBy(blob_id) => Ok(Some(RpcMessage::BlobLastUsedByResponse(Box::new(
                 self.storage.read_blob_state(*blob_id).await?.last_used_by,
             )))),
@@ -330,7 +333,8 @@ where
             | DownloadBlobContentResponse(_)
             | BlobLastUsedByResponse(_)
             | DownloadCertificateValueResponse(_)
-            | DownloadCertificateResponse(_) => {
+            | DownloadCertificateResponse(_)
+            | DownloadCertificatesResponse(_) => {
                 Err(anyhow::Error::from(NodeError::UnexpectedMessage))
             }
         }

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -93,6 +93,13 @@ impl ValidatorNode for DummyValidatorNode {
         Err(NodeError::UnexpectedMessage)
     }
 
+    async fn download_certificates(
+        &self,
+        _: Vec<CryptoHash>,
+    ) -> Result<Vec<Certificate>, NodeError> {
+        Err(NodeError::UnexpectedMessage)
+    }
+
     async fn blob_last_used_by(&self, _: BlobId) -> Result<CryptoHash, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }


### PR DESCRIPTION
## Motivation
Running `linera sync-balance` command (on admin chain) takes a long time. Some metering and debugging revealed that majority of that time is spent downloading certificates from validators. This process is sequential in the scope of syncing a single chain – i.e. we iterate over all (missing) blocks from that chain and synchronize all the state which is required to properly validate the chain (including chains that sent messages to the chain-being-synced).

A quick, back-of-the-hand experiments showed that parallelising `synchronize_received_certificates_from_validator` increases the performance by the order of magnitude.

## Proposal
As part of that sequential process we fetch chains' certificates, one by one. We introduce a new `download_certificates(hashes)` endpoint to the `ValidatorNode` which can return multiple certificates at once. 

Due to a gRPC message size limits, we need to make sure that we never try to request/send any collection of certificates bigger than what can fit into a message size. To achieve that the following changes were made:
- [[link](https://github.com/linera-io/linera-protocol/blob/0fdaae0d92d91707bedd589e307d79c28a1307c8/linera-service/src/proxy/grpc.rs#L493-L505)] On the server side (proxy) we return as many certificates as could fit into the gRPC message limit size (leaving 30% of the limit as a buffer).
- [[link](https://github.com/linera-io/linera-protocol/blob/a43f8e0356200c05dccff74fd4b1cf4e0ff72fde/linera-rpc/src/grpc/client.rs#L320)] On the client side we send all requested hashes and collect the responses, re-requesting the missing certificates. If server returns empty collection, we break the loop and return what was collected until this moment.

Note that this particular PR isn't replacing the certificate synchronization in `synchronize_received_certificates_from_validator` just yet, it does use the new endpoint in other places, mainly b/c that particular method will require bigger rewrite to be correct.

## Test Plan

CI should catch any regressions. When it comes to measuring how it behaves on longer sequences of certificates I'll run some tests locally.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.
- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- Backporting is not possible but we may want to deploy a new `devnet` and release a new
      SDK soon.

## Links

Partially closes https://github.com/linera-io/linera-protocol/issues/2633 . There will be a follow-up work to use the new endpoints in `synchronize_received_certificates_from_validator`.

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
