### PR TITLE
Fix some potential `ChainState` issues

### DIFF
--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -169,14 +169,15 @@ impl Wallet {
     {
         let key_pair = chain_client.key_pair().await.map(|k| k.copy()).ok();
         let state = chain_client.state();
+        let (next_block_height, block_hash, timestamp) = state.tip();
         self.chains.insert(
             chain_client.chain_id(),
             UserChain {
                 chain_id: chain_client.chain_id(),
                 key_pair,
-                block_hash: state.block_hash(),
-                next_block_height: state.next_block_height(),
-                timestamp: state.timestamp(),
+                block_hash,
+                next_block_height,
+                timestamp,
                 pending_block: state.pending_block().clone(),
                 pending_blobs: state.pending_blobs().clone(),
             },

--- a/linera-core/src/client/chain_state.rs
+++ b/linera-core/src/client/chain_state.rs
@@ -77,12 +77,8 @@ impl ChainState {
         state
     }
 
-    pub fn block_hash(&self) -> Option<CryptoHash> {
-        self.block_hash
-    }
-
-    pub fn timestamp(&self) -> Timestamp {
-        self.timestamp
+    pub fn tip(&self) -> (BlockHeight, Option<CryptoHash>, Timestamp) {
+        (self.next_block_height, self.block_hash, self.timestamp)
     }
 
     pub fn next_block_height(&self) -> BlockHeight {

--- a/linera-core/src/client/chain_state.rs
+++ b/linera-core/src/client/chain_state.rs
@@ -10,7 +10,7 @@ use std::{
 use linera_base::{
     crypto::{CryptoHash, KeyPair, PublicKey},
     data_types::{Blob, BlockHeight, Timestamp},
-    identifiers::{BlobId, ChainId, Owner},
+    identifiers::{BlobId, Owner},
 };
 use linera_chain::data_types::Block;
 use linera_execution::committee::ValidatorName;
@@ -34,8 +34,6 @@ pub struct ChainState {
     pending_block: Option<Block>,
     /// Known key pairs from present and past identities.
     known_key_pairs: BTreeMap<Owner, KeyPair>,
-    /// The ID of the admin chain.
-    admin_id: ChainId,
 
     /// For each validator, up to which index we have synchronized their
     /// [`ChainStateView::received_log`].
@@ -52,7 +50,6 @@ pub struct ChainState {
 impl ChainState {
     pub fn new(
         known_key_pairs: Vec<KeyPair>,
-        admin_id: ChainId,
         block_hash: Option<CryptoHash>,
         timestamp: Timestamp,
         next_block_height: BlockHeight,
@@ -65,7 +62,6 @@ impl ChainState {
             .collect();
         let mut state = ChainState {
             known_key_pairs,
-            admin_id,
             block_hash,
             timestamp,
             next_block_height,
@@ -90,10 +86,6 @@ impl ChainState {
 
     pub fn next_block_height(&self) -> BlockHeight {
         self.next_block_height
-    }
-
-    pub fn admin_id(&self) -> ChainId {
-        self.admin_id
     }
 
     pub fn pending_block(&self) -> &Option<Block> {

--- a/linera-core/src/client/chain_state.rs
+++ b/linera-core/src/client/chain_state.rs
@@ -11,6 +11,7 @@ use linera_base::{
     crypto::{CryptoHash, KeyPair, PublicKey},
     data_types::{Blob, BlockHeight, Timestamp},
     identifiers::{BlobId, Owner},
+    ownership::ChainOwnership,
 };
 use linera_chain::data_types::Block;
 use linera_execution::committee::ValidatorName;
@@ -114,6 +115,13 @@ impl ChainState {
 
     pub fn known_key_pairs(&self) -> &BTreeMap<Owner, KeyPair> {
         &self.known_key_pairs
+    }
+
+    /// Returns whether the given ownership includes anyone whose secret key we don't have.
+    pub fn has_other_owners(&self, ownership: &ChainOwnership) -> bool {
+        ownership
+            .all_owners()
+            .any(|owner| !self.known_key_pairs.contains_key(owner))
     }
 
     pub(super) fn insert_known_key_pair(&mut self, key_pair: KeyPair) -> PublicKey {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -885,7 +885,7 @@ where
         // Verify that our local storage contains enough history compared to the
         // expected block height. Otherwise, download the missing history from the
         // network.
-        let (next_block_height, block_hash, tip_time) = self.state().tip();
+        let (next_block_height, block_hash, _) = self.state().tip();
         let nodes = self.validator_nodes().await?;
         let mut info = self
             .client
@@ -894,7 +894,7 @@ where
         if info.next_block_height == next_block_height {
             // Check that our local node has the expected block hash.
             ensure!(
-                (info.block_hash, info.timestamp) == (block_hash, tip_time),
+                info.block_hash == block_hash,
                 ChainClientError::InternalError("Invalid chain of blocks in local node")
             );
         }

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -165,6 +165,12 @@ pub struct ChainInfo {
     pub requested_received_log: Vec<ChainAndHeight>,
 }
 
+impl ChainInfo {
+    pub fn tip(&self) -> (BlockHeight, Option<CryptoHash>, Timestamp) {
+        (self.next_block_height, self.block_hash, self.timestamp)
+    }
+}
+
 /// The response to an `ChainInfoQuery`
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]


### PR DESCRIPTION
## Motivation

The admin ID can't change, and we are locking the `ChainState` each time we access it.

We are locking and unlocking the `ChainState` multiple times in some cases to obtain the components of a chain's tip state (block hash, height and timestamp). If the state changed in between those instances, the components won't refer to the same state.

In some cases we return an error if the local node's chain is ahead of the `ChainState`. But in multi-owner chains, this can happen legitimately.

## Proposal

Move `admin_id` out of `ChainState`. Fetch the tip state in one go. Only do the check for single-owner chains.

Also, don't unnecessarily collect the known keys' owners, and use `contains_key` instead.

## Test Plan

CI should catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
