### PR TITLE
Get rid of get_blobs_not_found and unify blob errors

### DIFF
--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -25,7 +25,7 @@ use data_types::{MessageBundle, Origin, PostedMessage};
 use linera_base::{
     crypto::{CryptoError, CryptoHash},
     data_types::{ArithmeticError, BlockHeight, Round, Timestamp},
-    identifiers::{ApplicationId, ChainId},
+    identifiers::{ApplicationId, BlobId, ChainId},
 };
 use linera_execution::ExecutionError;
 use linera_views::views::ViewError;
@@ -39,7 +39,7 @@ pub enum ChainError {
     #[error("Arithmetic error: {0}")]
     ArithmeticError(#[from] ArithmeticError),
     #[error("Error in view operation: {0}")]
-    ViewError(#[from] ViewError),
+    ViewError(ViewError),
     #[error("Execution error: {0} during {1:?}")]
     ExecutionError(Box<ExecutionError>, ChainExecutionContext),
 
@@ -157,6 +157,17 @@ pub enum ChainError {
         expected: CryptoHash,
         actual: CryptoHash,
     },
+    #[error("Blobs not found: {0:?}")]
+    BlobsNotFound(Vec<BlobId>),
+}
+
+impl From<ViewError> for ChainError {
+    fn from(error: ViewError) -> Self {
+        match error {
+            ViewError::BlobsNotFound(blob_ids) => ChainError::BlobsNotFound(blob_ids),
+            error => ChainError::ViewError(error),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -19,7 +19,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Committee, ValidatorName},
-    ExecutionError, SystemExecutionError,
+    ExecutionError,
 };
 use linera_version::VersionInfo;
 use linera_views::views::ViewError;
@@ -182,7 +182,7 @@ pub enum NodeError {
         height: BlockHeight,
     },
 
-    #[error("The following blobs are missing: {0:?}.")]
+    #[error("Blobs not found: {0:?}")]
     BlobsNotFound(Vec<BlobId>),
 
     // This error must be normalized during conversions.
@@ -220,8 +220,6 @@ pub enum NodeError {
     #[error("Failed to make a chain info query on the local node: {error}")]
     LocalNodeQuery { error: String },
 
-    #[error("Blob not found on storage read: {0}")]
-    BlobNotFoundOnRead(BlobId),
     #[error("Node failed to provide a 'last used by' certificate for the blob")]
     InvalidCertificateForBlob(BlobId),
     #[error("Local error handling validator response")]
@@ -255,8 +253,11 @@ impl CrossChainMessageDelivery {
 
 impl From<ViewError> for NodeError {
     fn from(error: ViewError) -> Self {
-        Self::ViewError {
-            error: error.to_string(),
+        match error {
+            ViewError::BlobsNotFound(blob_ids) => Self::BlobsNotFound(blob_ids),
+            error => Self::ViewError {
+                error: error.to_string(),
+            },
         }
     }
 }
@@ -290,16 +291,16 @@ impl From<ChainError> for NodeError {
                 height,
             },
             ChainError::InactiveChain(chain_id) => Self::InactiveChain(chain_id),
-            ChainError::ExecutionError(execution_error, context) => match *execution_error {
-                ExecutionError::SystemError(SystemExecutionError::BlobNotFoundOnRead(blob_id))
-                | ExecutionError::ViewError(ViewError::BlobNotFoundOnRead(blob_id)) => {
-                    Self::BlobNotFoundOnRead(blob_id)
+            ChainError::BlobsNotFound(blob_ids) => Self::BlobsNotFound(blob_ids),
+            ChainError::ExecutionError(execution_error, context) => {
+                if let ExecutionError::BlobsNotFound(blob_ids) = *execution_error {
+                    Self::BlobsNotFound(blob_ids)
+                } else {
+                    Self::ChainError {
+                        error: ChainError::ExecutionError(execution_error, context).to_string(),
+                    }
                 }
-                execution_error => Self::ChainError {
-                    error: ChainError::ExecutionError(Box::new(execution_error), context)
-                        .to_string(),
-                },
-            },
+            }
             error => Self::ChainError {
                 error: error.to_string(),
             },
@@ -312,7 +313,7 @@ impl From<WorkerError> for NodeError {
         match error {
             WorkerError::ChainError(error) => (*error).into(),
             WorkerError::MissingCertificateValue => Self::MissingCertificateValue,
-            WorkerError::BlobsNotFound(blob_ids) => NodeError::BlobsNotFound(blob_ids),
+            WorkerError::BlobsNotFound(blob_ids) => Self::BlobsNotFound(blob_ids),
             error => Self::WorkerError {
                 error: error.to_string(),
             },

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -275,7 +275,7 @@ where
         let handle_block_proposal_result =
             Self::handle_block_proposal(proposal, &mut validator).await;
         let result = match handle_block_proposal_result {
-            Some(Err(NodeError::BlobsNotFound(_) | NodeError::BlobNotFoundOnRead(_))) => {
+            Some(Err(NodeError::BlobsNotFound(_))) => {
                 handle_block_proposal_result.expect("handle_block_proposal_result should be Some")
             }
             _ => match validator.fault_type {
@@ -367,7 +367,7 @@ where
         let handle_certificate_result =
             Self::handle_certificate(certificate, validator, blobs).await;
         match handle_certificate_result {
-            Some(Err(NodeError::BlobsNotFound(_) | NodeError::BlobNotFoundOnRead(_))) => {
+            Some(Err(NodeError::BlobsNotFound(_))) => {
                 handle_certificate_result.expect("handle_certificate_result should be Some")
             }
             _ => match validator.fault_type {

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -278,8 +278,8 @@ where
                     // synchronize them now and retry.
                     self.send_chain_information_for_senders(chain_id).await?;
                 }
-                Err(NodeError::BlobNotFoundOnRead(_)) if !blob_ids.is_empty() => {
-                    // For `BlobNotFoundOnRead`, we assume that the local node should already be
+                Err(NodeError::BlobsNotFound(_)) if !blob_ids.is_empty() => {
+                    // For `BlobsNotFound`, we assume that the local node should already be
                     // updated with the needed blobs, so sending the chain information about the
                     // certificates that last used the blobs to the validator node should be enough.
                     let missing_blob_ids = stream::iter(mem::take(&mut blob_ids))

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -305,11 +305,7 @@ where
             }
 
             ReadBlobContent { blob_id, callback } => {
-                let blob = self
-                    .system
-                    .read_blob_content(blob_id)
-                    .await
-                    .map_err(|_| SystemExecutionError::BlobNotFoundOnRead(blob_id))?;
+                let blob = self.system.read_blob_content(blob_id).await?;
                 callback.respond(blob);
             }
 

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -594,14 +594,10 @@ NodeError:
         STRUCT:
           - error: STR
     20:
-      BlobNotFoundOnRead:
-        NEWTYPE:
-          TYPENAME: BlobId
-    21:
       InvalidCertificateForBlob:
         NEWTYPE:
           TYPENAME: BlobId
-    22:
+    21:
       LocalError:
         STRUCT:
           - error: STR

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -420,7 +420,7 @@ where
         let maybe_blob_bytes = self.store.read_value::<Vec<u8>>(&blob_key).await?;
         #[cfg(with_metrics)]
         READ_BLOB_COUNTER.with_label_values(&[]).inc();
-        let blob_bytes = maybe_blob_bytes.ok_or_else(|| ViewError::BlobNotFoundOnRead(blob_id))?;
+        let blob_bytes = maybe_blob_bytes.ok_or_else(|| ViewError::BlobsNotFound(vec![blob_id]))?;
         Ok(Blob::new_with_id_unchecked(blob_id, blob_bytes))
     }
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -385,8 +385,8 @@ where
         }
     }
 
-    async fn get_blob(&self, blob_id: BlobId) -> Result<Blob, ExecutionError> {
-        Ok(self.storage.read_blob(blob_id).await?)
+    async fn get_blob(&self, blob_id: BlobId) -> Result<Blob, ViewError> {
+        self.storage.read_blob(blob_id).await
     }
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -155,9 +155,9 @@ pub enum ViewError {
     #[error("The value is too large for the client")]
     TooLargeValue,
 
-    /// Blob not found when trying to read it.
-    #[error("Blob not found on storage read: {0}")]
-    BlobNotFoundOnRead(BlobId),
+    /// Some blobs were not found.
+    #[error("Blobs not found: {0:?}")]
+    BlobsNotFound(Vec<BlobId>),
 }
 
 impl ViewError {


### PR DESCRIPTION
## Motivation

We've had these two different error variants for blobs for a while: `BlobNotFoundOnRead` and `BlobsNotFound`. The motivation was to differentiate between errors when doing a storage read, and everything else. In the current state of the code, I don't think this distinction is really giving us much, and it complicates the code more.

We also have this `get_blobs_not_found` function that abstracts away the different nested error types.

## Proposal

Remove `BlobNotFoundOnRead`, and simplify things a bit. Wrote custom/manual `From` implementations for these different error types, so we can have a `BlobsNotFound` error everywhere and can get rid of `get_blobs_not_found`.
Fixes #2628

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
