### PR TITLE
Return from sync_chain_state after a quorum has finished.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -841,7 +841,7 @@ where
         // Replay the certificates locally.
         for certificate in certificates {
             // No required certificates from other chains: This is only used with benchmark.
-            node.handle_certificate(certificate, vec![], &mut vec![])
+            node.handle_certificate(certificate, vec![], &())
                 .await
                 .unwrap();
         }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -293,13 +293,9 @@ where
         chain_id: ChainId,
         height: BlockHeight,
     ) -> Result<Box<ChainInfo>, LocalNodeError> {
-        let mut notifications = Vec::<Notification>::new();
-        let info = self
-            .local_node
-            .download_certificates(nodes, chain_id, height, &mut notifications)
-            .await?;
-        self.notifier.handle_notifications(&notifications);
-        Ok(info)
+        self.local_node
+            .download_certificates(nodes, chain_id, height, &self.notifier)
+            .await
     }
 
     async fn try_process_certificates(
@@ -308,13 +304,9 @@ where
         chain_id: ChainId,
         certificates: Vec<Certificate>,
     ) -> Option<Box<ChainInfo>> {
-        let mut notifications = Vec::<Notification>::new();
-        let result = self
-            .local_node
-            .try_process_certificates(remote_node, chain_id, certificates, &mut notifications)
-            .await;
-        self.notifier.handle_notifications(&notifications);
-        result
+        self.local_node
+            .try_process_certificates(remote_node, chain_id, certificates, &self.notifier)
+            .await
     }
 
     async fn handle_certificate(
@@ -322,13 +314,9 @@ where
         certificate: Certificate,
         blobs: Vec<Blob>,
     ) -> Result<ChainInfoResponse, LocalNodeError> {
-        let mut notifications = Vec::<Notification>::new();
-        let result = self
-            .local_node
-            .handle_certificate(certificate, blobs, &mut notifications)
-            .await;
-        self.notifier.handle_notifications(&notifications);
-        result
+        self.local_node
+            .handle_certificate(certificate, blobs, &self.notifier)
+            .await
     }
 }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -71,7 +71,7 @@ use crate::{
         CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
         ValidatorNodeProvider,
     },
-    notifier::Notifier,
+    notifier::ChannelNotifier,
     remote_node::RemoteNode,
     updater::{communicate_with_quorum, CommunicateAction, CommunicationError, ValidatorUpdater},
     worker::{Notification, Reason, WorkerError, WorkerState},
@@ -176,7 +176,7 @@ where
     // TODO(#2412): Merge with set of chains the client is receiving notifications from validators
     tracked_chains: Arc<RwLock<HashSet<ChainId>>>,
     /// References to clients waiting for chain notifications.
-    notifier: Arc<Notifier<Notification>>,
+    notifier: Arc<ChannelNotifier<Notification>>,
     /// A copy of the storage client so that we don't have to lock the local node client
     /// to retrieve it.
     storage: Storage,
@@ -216,7 +216,7 @@ impl<P, S: Storage + Clone> Client<P, S> {
             message_policy: MessagePolicy::new(BlanketMessagePolicy::Accept, None),
             cross_chain_message_delivery,
             tracked_chains,
-            notifier: Arc::new(Notifier::default()),
+            notifier: Arc::new(ChannelNotifier::default()),
             storage,
         }
     }

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -31,7 +31,7 @@ use tracing::warn;
 use crate::{
     data_types::{BlockHeightRange, ChainInfo, ChainInfoQuery, ChainInfoResponse},
     node::{NodeError, ValidatorNode},
-    notifier::NotificationSink,
+    notifier::Notifier,
     remote_node::RemoteNode,
     value_cache::ValueCache,
     worker::{WorkerError, WorkerState},
@@ -136,7 +136,7 @@ where
     pub async fn handle_lite_certificate(
         &self,
         certificate: LiteCertificate<'_>,
-        notifier: &impl NotificationSink,
+        notifier: &impl Notifier,
     ) -> Result<ChainInfoResponse, LocalNodeError> {
         let full_cert = self.node.state.full_certificate(certificate).await?;
         let response = self
@@ -152,7 +152,7 @@ where
         &self,
         certificate: Certificate,
         blobs: Vec<Blob>,
-        notifier: &impl NotificationSink,
+        notifier: &impl Notifier,
     ) -> Result<ChainInfoResponse, LocalNodeError> {
         let response = Box::pin(self.node.state.fully_handle_certificate_with_notifications(
             certificate,
@@ -290,7 +290,7 @@ where
         remote_node: &RemoteNode<impl ValidatorNode>,
         chain_id: ChainId,
         certificates: Vec<Certificate>,
-        notifier: &impl NotificationSink,
+        notifier: &impl Notifier,
     ) -> Option<Box<ChainInfo>> {
         let mut info = None;
         for certificate in certificates {
@@ -401,7 +401,7 @@ where
         validators: &[RemoteNode<impl ValidatorNode>],
         chain_id: ChainId,
         target_next_block_height: BlockHeight,
-        notifier: &impl NotificationSink,
+        notifier: &impl Notifier,
     ) -> Result<Box<ChainInfo>, LocalNodeError> {
         // Sequentially try each validator in random order.
         let mut validators: Vec<_> = validators.iter().collect();
@@ -462,7 +462,7 @@ where
         chain_id: ChainId,
         mut start: BlockHeight,
         stop: BlockHeight,
-        notifier: &impl NotificationSink,
+        notifier: &impl Notifier,
     ) -> Result<(), LocalNodeError> {
         while start < stop {
             // TODO(#2045): Analyze network errors instead of guessing the batch size.

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -136,13 +136,13 @@ where
     pub async fn handle_lite_certificate(
         &self,
         certificate: LiteCertificate<'_>,
-        notifications: &impl NotificationSink<Notification>,
+        notifier: &impl NotificationSink<Notification>,
     ) -> Result<ChainInfoResponse, LocalNodeError> {
         let full_cert = self.node.state.full_certificate(certificate).await?;
         let response = self
             .node
             .state
-            .fully_handle_certificate_with_notifications(full_cert, vec![], notifications)
+            .fully_handle_certificate_with_notifications(full_cert, vec![], notifier)
             .await?;
         Ok(response)
     }
@@ -152,12 +152,12 @@ where
         &self,
         certificate: Certificate,
         blobs: Vec<Blob>,
-        notifications: &impl NotificationSink<Notification>,
+        notifier: &impl NotificationSink<Notification>,
     ) -> Result<ChainInfoResponse, LocalNodeError> {
         let response = Box::pin(self.node.state.fully_handle_certificate_with_notifications(
             certificate,
             blobs,
-            notifications,
+            notifier,
         ))
         .await?;
         Ok(response)
@@ -290,7 +290,7 @@ where
         remote_node: &RemoteNode<impl ValidatorNode>,
         chain_id: ChainId,
         certificates: Vec<Certificate>,
-        notifications: &impl NotificationSink<Notification>,
+        notifier: &impl NotificationSink<Notification>,
     ) -> Option<Box<ChainInfo>> {
         let mut info = None;
         for certificate in certificates {
@@ -301,7 +301,7 @@ where
                 return info;
             }
             let mut result = self
-                .handle_certificate(certificate.clone(), vec![], notifications)
+                .handle_certificate(certificate.clone(), vec![], notifier)
                 .await;
 
             result = match &result {
@@ -311,8 +311,7 @@ where
                         if blobs.len() != blob_ids.len() {
                             result
                         } else {
-                            self.handle_certificate(certificate, blobs, notifications)
-                                .await
+                            self.handle_certificate(certificate, blobs, notifier).await
                         }
                     } else {
                         result
@@ -396,13 +395,13 @@ where
     }
 
     /// Downloads and processes all certificates up to (excluding) the specified height.
-    #[tracing::instrument(level = "trace", skip(self, validators, notifications))]
+    #[tracing::instrument(level = "trace", skip(self, validators, notifier))]
     pub async fn download_certificates(
         &self,
         validators: &[RemoteNode<impl ValidatorNode>],
         chain_id: ChainId,
         target_next_block_height: BlockHeight,
-        notifications: &impl NotificationSink<Notification>,
+        notifier: &impl NotificationSink<Notification>,
     ) -> Result<Box<ChainInfo>, LocalNodeError> {
         // Sequentially try each validator in random order.
         let mut validators: Vec<_> = validators.iter().collect();
@@ -417,7 +416,7 @@ where
                 chain_id,
                 info.next_block_height,
                 target_next_block_height,
-                notifications,
+                notifier,
             )
             .await?;
         }
@@ -463,7 +462,7 @@ where
         chain_id: ChainId,
         mut start: BlockHeight,
         stop: BlockHeight,
-        notifications: &impl NotificationSink<Notification>,
+        notifier: &impl NotificationSink<Notification>,
     ) -> Result<(), LocalNodeError> {
         while start < stop {
             // TODO(#2045): Analyze network errors instead of guessing the batch size.
@@ -478,7 +477,7 @@ where
                 break;
             };
             let Some(info) = self
-                .try_process_certificates(remote_node, chain_id, certificates, notifications)
+                .try_process_certificates(remote_node, chain_id, certificates, notifier)
                 .await
             else {
                 break;

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -34,7 +34,7 @@ use crate::{
     notifier::NotificationSink,
     remote_node::RemoteNode,
     value_cache::ValueCache,
-    worker::{Notification, WorkerError, WorkerState},
+    worker::{WorkerError, WorkerState},
 };
 
 /// A local node with a single worker, typically used by clients.
@@ -136,7 +136,7 @@ where
     pub async fn handle_lite_certificate(
         &self,
         certificate: LiteCertificate<'_>,
-        notifier: &impl NotificationSink<Notification>,
+        notifier: &impl NotificationSink,
     ) -> Result<ChainInfoResponse, LocalNodeError> {
         let full_cert = self.node.state.full_certificate(certificate).await?;
         let response = self
@@ -152,7 +152,7 @@ where
         &self,
         certificate: Certificate,
         blobs: Vec<Blob>,
-        notifier: &impl NotificationSink<Notification>,
+        notifier: &impl NotificationSink,
     ) -> Result<ChainInfoResponse, LocalNodeError> {
         let response = Box::pin(self.node.state.fully_handle_certificate_with_notifications(
             certificate,
@@ -290,7 +290,7 @@ where
         remote_node: &RemoteNode<impl ValidatorNode>,
         chain_id: ChainId,
         certificates: Vec<Certificate>,
-        notifier: &impl NotificationSink<Notification>,
+        notifier: &impl NotificationSink,
     ) -> Option<Box<ChainInfo>> {
         let mut info = None;
         for certificate in certificates {
@@ -401,7 +401,7 @@ where
         validators: &[RemoteNode<impl ValidatorNode>],
         chain_id: ChainId,
         target_next_block_height: BlockHeight,
-        notifier: &impl NotificationSink<Notification>,
+        notifier: &impl NotificationSink,
     ) -> Result<Box<ChainInfo>, LocalNodeError> {
         // Sequentially try each validator in random order.
         let mut validators: Vec<_> = validators.iter().collect();
@@ -462,7 +462,7 @@ where
         chain_id: ChainId,
         mut start: BlockHeight,
         stop: BlockHeight,
-        notifier: &impl NotificationSink<Notification>,
+        notifier: &impl NotificationSink,
     ) -> Result<(), LocalNodeError> {
         while start < stop {
             // TODO(#2045): Analyze network errors instead of guessing the batch size.

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -220,6 +220,8 @@ pub enum NodeError {
     BlobNotFoundOnRead(BlobId),
     #[error("Node failed to provide a 'last used by' certificate for the blob")]
     InvalidCertificateForBlob(BlobId),
+    #[error("Local error handling validator response")]
+    LocalError { error: String },
 }
 
 impl From<tonic::Status> for NodeError {

--- a/linera-core/src/notifier.rs
+++ b/linera-core/src/notifier.rs
@@ -83,7 +83,7 @@ impl Notifier<worker::Notification> {
     }
 }
 
-pub trait NotificationSink<N: Clone>: Clone + 'static {
+pub trait NotificationSink<N: Clone>: Clone + Send + 'static {
     fn handle_notifications(&self, notifications: &[N]);
 }
 
@@ -98,7 +98,7 @@ impl<N: Clone + 'static> NotificationSink<N> for () {
 }
 
 #[cfg(with_testing)]
-impl<N: Clone + 'static> NotificationSink<N> for Arc<std::sync::Mutex<Vec<N>>> {
+impl<N: Clone + Send + 'static> NotificationSink<N> for Arc<std::sync::Mutex<Vec<N>>> {
     fn handle_notifications(&self, notifications: &[N]) {
         let mut guard = self.lock().unwrap();
         guard.extend(notifications.iter().cloned())

--- a/linera-core/src/notifier.rs
+++ b/linera-core/src/notifier.rs
@@ -83,23 +83,23 @@ impl Notifier<worker::Notification> {
     }
 }
 
-pub trait NotificationSink<N: Clone>: Clone + Send + 'static {
-    fn handle_notifications(&self, notifications: &[N]);
+pub trait NotificationSink: Clone + Send + 'static {
+    fn handle_notifications(&self, notifications: &[worker::Notification]);
 }
 
-impl NotificationSink<worker::Notification> for Arc<Notifier<worker::Notification>> {
+impl NotificationSink for Arc<Notifier<worker::Notification>> {
     fn handle_notifications(&self, notifications: &[worker::Notification]) {
         (**self).handle_notifications(notifications);
     }
 }
 
-impl<N: Clone + 'static> NotificationSink<N> for () {
-    fn handle_notifications(&self, _notifications: &[N]) {}
+impl NotificationSink for () {
+    fn handle_notifications(&self, _notifications: &[worker::Notification]) {}
 }
 
 #[cfg(with_testing)]
-impl<N: Clone + Send + 'static> NotificationSink<N> for Arc<std::sync::Mutex<Vec<N>>> {
-    fn handle_notifications(&self, notifications: &[N]) {
+impl NotificationSink for Arc<std::sync::Mutex<Vec<worker::Notification>>> {
+    fn handle_notifications(&self, notifications: &[worker::Notification]) {
         let mut guard = self.lock().unwrap();
         guard.extend(notifications.iter().cloned())
     }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -53,7 +53,7 @@ use crate::{
         CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
         ValidatorNodeProvider,
     },
-    notifier::Notifier,
+    notifier::ChannelNotifier,
     worker::{NetworkActions, Notification, WorkerState},
 };
 
@@ -80,7 +80,7 @@ where
 {
     state: WorkerState<S>,
     fault_type: FaultType,
-    notifier: Arc<Notifier<Notification>>,
+    notifier: Arc<ChannelNotifier<Notification>>,
 }
 
 #[derive(Clone)]
@@ -205,7 +205,7 @@ where
         let client = LocalValidator {
             fault_type: FaultType::Honest,
             state,
-            notifier: Arc::new(Notifier::default()),
+            notifier: Arc::new(ChannelNotifier::default()),
         };
         Self {
             name,

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -80,7 +80,7 @@ where
 {
     state: WorkerState<S>,
     fault_type: FaultType,
-    notifier: Notifier<Notification>,
+    notifier: Arc<Notifier<Notification>>,
 }
 
 #[derive(Clone)]
@@ -205,7 +205,7 @@ where
         let client = LocalValidator {
             fault_type: FaultType::Honest,
             state,
-            notifier: Notifier::default(),
+            notifier: Arc::new(Notifier::default()),
         };
         Self {
             name,
@@ -305,7 +305,6 @@ where
     async fn handle_certificate(
         certificate: Certificate,
         validator: &mut MutexGuard<'_, LocalValidator<S>>,
-        notifications: &mut Vec<Notification>,
         blobs: Vec<Blob>,
     ) -> Option<Result<ChainInfoResponse, NodeError>> {
         match validator.fault_type {
@@ -320,7 +319,7 @@ where
                     .fully_handle_certificate_with_notifications(
                         certificate,
                         blobs,
-                        Some(notifications),
+                        &validator.notifier,
                     )
                     .await
                     .map_err(Into::into),
@@ -351,11 +350,10 @@ where
         validator: &mut MutexGuard<'_, LocalValidator<S>>,
         blobs: Vec<Blob>,
     ) -> Result<ChainInfoResponse, NodeError> {
-        let mut notifications = Vec::new();
         let is_validated = certificate.value().is_validated();
         let handle_certificate_result =
-            Self::handle_certificate(certificate, validator, &mut notifications, blobs).await;
-        let result = match handle_certificate_result {
+            Self::handle_certificate(certificate, validator, blobs).await;
+        match handle_certificate_result {
             Some(Err(NodeError::BlobsNotFound(_) | NodeError::BlobNotFoundOnRead(_))) => {
                 handle_certificate_result.expect("handle_certificate_result should be Some")
             }
@@ -378,9 +376,7 @@ where
                     error: "offline".to_string(),
                 }),
             },
-        };
-        validator.notifier.handle_notifications(&notifications);
-        result
+        }
     }
 
     async fn do_handle_certificate(

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -11,6 +11,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     iter,
     num::NonZeroUsize,
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -773,23 +774,15 @@ where
     );
 
     // Run transfers
-    let mut notifications = Vec::new();
+    let notifications = Arc::new(Mutex::new(Vec::new()));
     worker
-        .fully_handle_certificate_with_notifications(
-            certificate0.clone(),
-            vec![],
-            Some(&mut notifications),
-        )
+        .fully_handle_certificate_with_notifications(certificate0.clone(), vec![], &notifications)
         .await?;
     worker
-        .fully_handle_certificate_with_notifications(
-            certificate1.clone(),
-            vec![],
-            Some(&mut notifications),
-        )
+        .fully_handle_certificate_with_notifications(certificate1.clone(), vec![], &notifications)
         .await?;
     assert_eq!(
-        notifications,
+        *notifications.lock().unwrap(),
         vec![
             Notification {
                 chain_id: ChainId::root(1),

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -411,15 +411,15 @@ where
             .await
     }
 
-    #[tracing::instrument(level = "trace", skip(self, certificate, blobs, notifications))]
+    #[tracing::instrument(level = "trace", skip(self, certificate, blobs, notifier))]
     #[inline]
     pub(crate) async fn fully_handle_certificate_with_notifications(
         &self,
         certificate: Certificate,
         blobs: Vec<Blob>,
-        notifications: &impl NotificationSink<Notification>,
+        notifier: &impl NotificationSink<Notification>,
     ) -> Result<ChainInfoResponse, WorkerError> {
-        let notifications = (*notifications).clone();
+        let notifications = (*notifier).clone();
         let this = self.clone();
         linera_base::task::spawn(async move {
             let (response, actions) = this.handle_certificate(certificate, blobs, None).await?;

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -417,7 +417,7 @@ where
         &self,
         certificate: Certificate,
         blobs: Vec<Blob>,
-        notifier: &impl NotificationSink<Notification>,
+        notifier: &impl NotificationSink,
     ) -> Result<ChainInfoResponse, WorkerError> {
         let notifications = (*notifier).clone();
         let this = self.clone();

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -604,6 +604,10 @@ NodeError:
       InvalidCertificateForBlob:
         NEWTYPE:
           TYPENAME: BlobId
+    22:
+      LocalError:
+        STRUCT:
+          - error: STR
 OpenChainConfig:
   STRUCT:
     - ownership:

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1129,7 +1129,7 @@ impl Job {
         // Download the parent chain.
         let target_height = message_id.height.try_add_one()?;
         node_client
-            .download_certificates(&nodes, message_id.chain_id, target_height, &mut vec![])
+            .download_certificates(&nodes, message_id.chain_id, target_height, &())
             .await
             .context("Failed to download parent chain")?;
 

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -21,7 +21,7 @@ use async_trait::async_trait;
 use futures::{future::BoxFuture, FutureExt as _};
 use linera_base::identifiers::ChainId;
 use linera_client::config::GenesisConfig;
-use linera_core::{notifier::Notifier, JoinSetExt as _};
+use linera_core::{notifier::ChannelNotifier, JoinSetExt as _};
 use linera_rpc::{
     config::{
         ShardConfig, TlsConfig, ValidatorInternalNetworkConfig, ValidatorPublicNetworkConfig,
@@ -157,7 +157,7 @@ struct GrpcProxyInner<S> {
     internal_config: ValidatorInternalNetworkConfig,
     genesis_config: GenesisConfig,
     worker_connection_pool: GrpcConnectionPool,
-    notifier: Notifier<Result<Notification, Status>>,
+    notifier: ChannelNotifier<Result<Notification, Status>>,
     tls: TlsConfig,
     storage: S,
 }
@@ -182,7 +182,7 @@ where
             worker_connection_pool: GrpcConnectionPool::default()
                 .with_connect_timeout(connect_timeout)
                 .with_timeout(timeout),
-            notifier: Notifier::default(),
+            notifier: ChannelNotifier::default(),
             tls,
             storage,
         }))
@@ -539,7 +539,7 @@ where
             .clone()
             .ok_or_else(|| Status::invalid_argument("Missing field: chain_id."))?
             .try_into()?;
-        self.0.notifier.notify(&chain_id, &Ok(notification));
+        self.0.notifier.notify_chain(&chain_id, &Ok(notification));
         Ok(Response::new(()))
     }
 }


### PR DESCRIPTION
## Motivation

The `join_all` in `synchronize_chain_state` returns only after the task associated with the last validator returns. So a single slow or faulty validator can slow down the client a lot.

## Proposal

Return from `sync_chain_state` once a quorum has finished.

## Test Plan

CI should catch any regressions.

On `testnet_boole`, this [this approach](https://github.com/afck/linera-protocol/commit/b20b4ae43888662630bf19df206184cd0f40ed6e) made `test_wasm_end_to_end_fungible::remote_net_grpc` pass after 37 seconds. Without it, it fails after 15 minutes.

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK.

## Links

- Fixes https://github.com/linera-io/linera-protocol/issues/2629.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
