### PR TITLE
Fix query target in `ContractRuntime::query_service` documentation

### DIFF
--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -246,7 +246,7 @@ where
         wit::emit(&name.into(), key, value);
     }
 
-    /// Queries our application service as an oracle and returns the response.
+    /// Queries an application service as an oracle and returns the response.
     ///
     /// Should only be used with queries where it is very likely that all validators will compute
     /// the same result, otherwise most block proposals will fail.

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -697,7 +697,7 @@ where
             .push_back((hash, response));
     }
 
-    /// Queries our application service as an oracle and returns the response.
+    /// Queries an application service as an oracle and returns the response.
     ///
     /// Should only be used with queries where it is very likely that all validators will compute
     /// the same result, otherwise most block proposals will fail.


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
The documentation for `ContractRuntime::query_service` was incorrect, because it led the reader to believe that it was only possible to query the current application's service, while in fact it could be used to query any application's service.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Fix the documentation.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
Nothing needed, because this only affects documentation.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do, because the updated documentation should be released with the next version automatically.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
