### PR TITLE
Return from sync_chain_state after a quorum has finished. (#2653)

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -842,7 +842,7 @@ where
         // Replay the certificates locally.
         for certificate in certificates {
             // No required certificates from other chains: This is only used with benchmark.
-            node.handle_certificate(certificate, vec![], &mut vec![])
+            node.handle_certificate(certificate, vec![], &())
                 .await
                 .unwrap();
         }

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -214,6 +214,8 @@ pub enum NodeError {
     BlobNotFoundOnRead(BlobId),
     #[error("Node failed to provide a 'last used by' certificate for the blob")]
     InvalidCertificateForBlob(BlobId),
+    #[error("Local error handling validator response")]
+    LocalError { error: String },
 }
 
 impl From<tonic::Status> for NodeError {

--- a/linera-core/src/notifier.rs
+++ b/linera-core/src/notifier.rs
@@ -1,21 +1,25 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use dashmap::DashMap;
 use linera_base::identifiers::ChainId;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::trace;
+
+use crate::worker;
 
 // TODO(#2171): replace this with a Tokio broadcast channel
 
 /// A `Notifier` holds references to clients waiting to receive notifications
 /// from the validator.
 /// Clients will be evicted if their connections are terminated.
-pub struct Notifier<N> {
+pub struct ChannelNotifier<N> {
     inner: DashMap<ChainId, Vec<UnboundedSender<N>>>,
 }
 
-impl<N> Default for Notifier<N> {
+impl<N> Default for ChannelNotifier<N> {
     fn default() -> Self {
         Self {
             inner: DashMap::default(),
@@ -23,7 +27,7 @@ impl<N> Default for Notifier<N> {
     }
 }
 
-impl<N> Notifier<N> {
+impl<N> ChannelNotifier<N> {
     /// Creates a subscription given a collection of ChainIds and a sender to the client.
     pub fn subscribe(&self, chain_ids: Vec<ChainId>) -> UnboundedReceiver<N> {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
@@ -35,12 +39,12 @@ impl<N> Notifier<N> {
     }
 }
 
-impl<N> Notifier<N>
+impl<N> ChannelNotifier<N>
 where
     N: Clone,
 {
     /// Notifies all the clients waiting for a notification from a given chain.
-    pub fn notify(&self, chain_id: &ChainId, notification: &N) {
+    pub fn notify_chain(&self, chain_id: &ChainId, notification: &N) {
         let senders_is_empty = {
             let Some(mut senders) = self.inner.get_mut(chain_id) else {
                 trace!("Chain {chain_id:?} has no subscribers.");
@@ -70,12 +74,27 @@ where
     }
 }
 
-impl Notifier<crate::worker::Notification> {
-    /// Process multiple notifications of type [`crate::worker::Notification`].
-    pub fn handle_notifications(&self, notifications: &[crate::worker::Notification]) {
+pub trait Notifier: Clone + Send + 'static {
+    fn notify(&self, notifications: &[worker::Notification]);
+}
+
+impl Notifier for Arc<ChannelNotifier<worker::Notification>> {
+    fn notify(&self, notifications: &[worker::Notification]) {
         for notification in notifications {
-            self.notify(&notification.chain_id, notification);
+            self.notify_chain(&notification.chain_id, notification);
         }
+    }
+}
+
+impl Notifier for () {
+    fn notify(&self, _notifications: &[worker::Notification]) {}
+}
+
+#[cfg(with_testing)]
+impl Notifier for Arc<std::sync::Mutex<Vec<worker::Notification>>> {
+    fn notify(&self, notifications: &[worker::Notification]) {
+        let mut guard = self.lock().unwrap();
+        guard.extend(notifications.iter().cloned())
     }
 }
 
@@ -90,7 +109,7 @@ pub mod tests {
 
     #[test]
     fn test_concurrent() {
-        let notifier = Notifier::default();
+        let notifier = ChannelNotifier::default();
 
         let chain_a = ChainId::root(0);
         let chain_b = ChainId::root(1);
@@ -133,13 +152,13 @@ pub mod tests {
         let a_notifier = notifier.clone();
         let handle_a = std::thread::spawn(move || {
             for _ in 0..NOTIFICATIONS_A {
-                a_notifier.notify(&chain_a, &());
+                a_notifier.notify_chain(&chain_a, &());
             }
         });
 
         let handle_b = std::thread::spawn(move || {
             for _ in 0..NOTIFICATIONS_B {
-                notifier.notify(&chain_b, &());
+                notifier.notify_chain(&chain_b, &());
             }
         });
 
@@ -160,7 +179,7 @@ pub mod tests {
 
     #[test]
     fn test_eviction() {
-        let notifier = Notifier::default();
+        let notifier = ChannelNotifier::default();
 
         let chain_a = ChainId::root(0);
         let chain_b = ChainId::root(1);
@@ -180,22 +199,22 @@ pub mod tests {
         assert_eq!(notifier.inner.len(), 4);
 
         rx_c.close();
-        notifier.notify(&chain_c, &());
+        notifier.notify_chain(&chain_c, &());
         assert_eq!(notifier.inner.len(), 3);
 
         rx_a.close();
-        notifier.notify(&chain_a, &());
+        notifier.notify_chain(&chain_a, &());
         assert_eq!(notifier.inner.len(), 3);
 
         rx_b.close();
-        notifier.notify(&chain_b, &());
+        notifier.notify_chain(&chain_b, &());
         assert_eq!(notifier.inner.len(), 2);
 
-        notifier.notify(&chain_a, &());
+        notifier.notify_chain(&chain_a, &());
         assert_eq!(notifier.inner.len(), 1);
 
         rx_d.close();
-        notifier.notify(&chain_d, &());
+        notifier.notify_chain(&chain_d, &());
         assert_eq!(notifier.inner.len(), 0);
     }
 }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -57,7 +57,7 @@ use crate::{
         CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
         ValidatorNodeProvider,
     },
-    notifier::Notifier,
+    notifier::ChannelNotifier,
     worker::{NetworkActions, Notification, WorkerState},
 };
 
@@ -84,7 +84,7 @@ where
 {
     state: WorkerState<S>,
     fault_type: FaultType,
-    notifier: Notifier<Notification>,
+    notifier: Arc<ChannelNotifier<Notification>>,
 }
 
 #[derive(Clone)]
@@ -199,7 +199,7 @@ where
         let client = LocalValidator {
             fault_type: FaultType::Honest,
             state,
-            notifier: Notifier::default(),
+            notifier: Arc::new(ChannelNotifier::default()),
         };
         Self {
             name,
@@ -299,7 +299,6 @@ where
     async fn handle_certificate(
         certificate: Certificate,
         validator: &mut MutexGuard<'_, LocalValidator<S>>,
-        notifications: &mut Vec<Notification>,
         blobs: Vec<Blob>,
     ) -> Option<Result<ChainInfoResponse, NodeError>> {
         match validator.fault_type {
@@ -314,7 +313,7 @@ where
                     .fully_handle_certificate_with_notifications(
                         certificate,
                         blobs,
-                        Some(notifications),
+                        &validator.notifier,
                     )
                     .await
                     .map_err(Into::into),
@@ -345,11 +344,10 @@ where
         validator: &mut MutexGuard<'_, LocalValidator<S>>,
         blobs: Vec<Blob>,
     ) -> Result<ChainInfoResponse, NodeError> {
-        let mut notifications = Vec::new();
         let is_validated = certificate.value().is_validated();
         let handle_certificate_result =
-            Self::handle_certificate(certificate, validator, &mut notifications, blobs).await;
-        let result = match handle_certificate_result {
+            Self::handle_certificate(certificate, validator, blobs).await;
+        match handle_certificate_result {
             Some(Err(NodeError::BlobsNotFound(_) | NodeError::BlobNotFoundOnRead(_))) => {
                 handle_certificate_result.expect("handle_certificate_result should be Some")
             }
@@ -372,9 +370,7 @@ where
                     error: "offline".to_string(),
                 }),
             },
-        };
-        validator.notifier.handle_notifications(&notifications);
-        result
+        }
     }
 
     async fn do_handle_certificate(

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -11,6 +11,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     iter,
     num::NonZeroUsize,
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -772,23 +773,15 @@ where
     );
 
     // Run transfers
-    let mut notifications = Vec::new();
+    let notifications = Arc::new(Mutex::new(Vec::new()));
     worker
-        .fully_handle_certificate_with_notifications(
-            certificate0.clone(),
-            vec![],
-            Some(&mut notifications),
-        )
+        .fully_handle_certificate_with_notifications(certificate0.clone(), vec![], &notifications)
         .await?;
     worker
-        .fully_handle_certificate_with_notifications(
-            certificate1.clone(),
-            vec![],
-            Some(&mut notifications),
-        )
+        .fully_handle_certificate_with_notifications(certificate1.clone(), vec![], &notifications)
         .await?;
     assert_eq!(
-        notifications,
+        *notifications.lock().unwrap(),
         vec![
             Notification {
                 chain_id: ChainId::root(1),

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -47,6 +47,7 @@ use crate::{
     chain_worker::{ChainWorkerActor, ChainWorkerConfig, ChainWorkerRequest},
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     join_set_ext::JoinSetExt,
+    notifier::Notifier,
     value_cache::ValueCache,
 };
 
@@ -212,6 +213,8 @@ pub enum WorkerError {
     InvalidBlockProposal(String),
     #[error("The worker is too busy to handle new chains")]
     FullChainWorkerCache,
+    #[error("Failed to join spawned worker task")]
+    JoinError,
 }
 
 impl From<linera_chain::ChainError> for WorkerError {
@@ -407,35 +410,33 @@ where
         certificate: Certificate,
         blobs: Vec<Blob>,
     ) -> Result<ChainInfoResponse, WorkerError> {
-        self.fully_handle_certificate_with_notifications(
-            certificate,
-            blobs,
-            None::<&mut Vec<Notification>>,
-        )
-        .await
+        self.fully_handle_certificate_with_notifications(certificate, blobs, &())
+            .await
     }
 
-    #[tracing::instrument(level = "trace", skip(self, certificate, blobs, notifications))]
+    #[tracing::instrument(level = "trace", skip(self, certificate, blobs, notifier))]
     #[inline]
     pub(crate) async fn fully_handle_certificate_with_notifications(
         &self,
         certificate: Certificate,
         blobs: Vec<Blob>,
-        mut notifications: Option<&mut impl Extend<Notification>>,
+        notifier: &impl Notifier,
     ) -> Result<ChainInfoResponse, WorkerError> {
-        let (response, actions) = self.handle_certificate(certificate, blobs, None).await?;
-        if let Some(ref mut notifications) = notifications {
-            notifications.extend(actions.notifications);
-        }
-        let mut requests = VecDeque::from(actions.cross_chain_requests);
-        while let Some(request) = requests.pop_front() {
-            let actions = self.handle_cross_chain_request(request).await?;
-            requests.extend(actions.cross_chain_requests);
-            if let Some(ref mut notifications) = notifications {
-                notifications.extend(actions.notifications);
+        let notifications = (*notifier).clone();
+        let this = self.clone();
+        linera_base::task::spawn(async move {
+            let (response, actions) = this.handle_certificate(certificate, blobs, None).await?;
+            notifications.notify(&actions.notifications);
+            let mut requests = VecDeque::from(actions.cross_chain_requests);
+            while let Some(request) = requests.pop_front() {
+                let actions = this.handle_cross_chain_request(request).await?;
+                requests.extend(actions.cross_chain_requests);
+                notifications.notify(&actions.notifications);
             }
-        }
-        Ok(response)
+            Ok(response)
+        })
+        .await
+        .unwrap_or_else(|_| Err(WorkerError::JoinError))
     }
 
     /// Tries to execute a block proposal without any verification other than block execution.

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -597,6 +597,10 @@ NodeError:
       InvalidCertificateForBlob:
         NEWTYPE:
           TYPENAME: BlobId
+    22:
+      LocalError:
+        STRUCT:
+          - error: STR
 OpenChainConfig:
   STRUCT:
     - ownership:

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1167,7 +1167,7 @@ impl Job {
         // Download the parent chain.
         let target_height = message_id.height.try_add_one()?;
         node_client
-            .download_certificates(&nodes, message_id.chain_id, target_height, &mut vec![])
+            .download_certificates(&nodes, message_id.chain_id, target_height, &())
             .await
             .context("Failed to download parent chain")?;
 

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use futures::{future::BoxFuture, FutureExt as _};
 use linera_base::identifiers::ChainId;
 use linera_client::config::GenesisConfig;
-use linera_core::{notifier::Notifier, JoinSetExt as _};
+use linera_core::{notifier::ChannelNotifier, JoinSetExt as _};
 use linera_rpc::{
     config::{
         ShardConfig, TlsConfig, ValidatorInternalNetworkConfig, ValidatorPublicNetworkConfig,
@@ -154,7 +154,7 @@ struct GrpcProxyInner<S> {
     internal_config: ValidatorInternalNetworkConfig,
     genesis_config: GenesisConfig,
     worker_connection_pool: GrpcConnectionPool,
-    notifier: Notifier<Result<Notification, Status>>,
+    notifier: ChannelNotifier<Result<Notification, Status>>,
     tls: TlsConfig,
     storage: S,
 }
@@ -179,7 +179,7 @@ where
             worker_connection_pool: GrpcConnectionPool::default()
                 .with_connect_timeout(connect_timeout)
                 .with_timeout(timeout),
-            notifier: Notifier::default(),
+            notifier: ChannelNotifier::default(),
             tls,
             storage,
         }))
@@ -499,7 +499,7 @@ where
             .clone()
             .ok_or_else(|| Status::invalid_argument("Missing field: chain_id."))?
             .try_into()?;
-        self.0.notifier.notify(&chain_id, &Ok(notification));
+        self.0.notifier.notify_chain(&chain_id, &Ok(notification));
         Ok(Response::new(()))
     }
 }


### PR DESCRIPTION
## Motivation

The `join_all` in `synchronize_chain_state` returns only after the task associated with the last validator returns. So a single slow or faulty validator can slow down the client a lot.

## Proposal

Return from `sync_chain_state` once a quorum has finished.

## Test Plan

CI should catch any regressions.

On `testnet_boole`, this [this approach](https://github.com/afck/linera-protocol/commit/b20b4ae43888662630bf19df206184cd0f40ed6e) made `test_wasm_end_to_end_fungible::remote_net_grpc` pass after 37 seconds. Without it, it fails after 15 minutes.

## Release Plan

- This is the `testnet_boole` backport of https://github.com/linera-io/linera-protocol/pull/2653.
- It should be released in a new SDK.

## Links

- `main` version: https://github.com/linera-io/linera-protocol/pull/2653
- Fixes https://github.com/linera-io/linera-protocol/issues/2629.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
