### PR TITLE
Batch queries by chain when synchronizing certificates from validator.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -423,7 +423,7 @@ where
     }
 }
 
-// Tracks which chain_id<>block_height pairs have been successfully downloaded.
+/// Tracks which `(ChainId, BlockHeight)` pairs have been successfully downloaded.
 struct MultichainTracker {
     // Starting tracker index.
     tracker: u64,
@@ -439,7 +439,7 @@ impl MultichainTracker {
         }
     }
 
-    /// Pushes a new chain_id<>block_height pair to the tracker.
+    /// Pushes a new `(ChainId, BlockHeight)` pair to the tracker.
     /// Replaces previous entry if the new height is higher.
     fn push(&mut self, chain_id: ChainId, height: BlockHeight) {
         self.highest_seen
@@ -1267,7 +1267,7 @@ where
         Ok((remote_node.name, new_tracker, certificates))
     }
 
-    // Uses local information (about already-processed blocks) to advance the `block_batch` to a place where only new blocks are left.
+    /// Uses local information (about already-processed blocks) to advance the `block_batch` to a place where only new blocks are left.
     async fn advance_with_local(
         &self,
         chain_id: ChainId,

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -40,6 +40,20 @@ impl BlockHeightRange {
         let limit = Some(1);
         BlockHeightRange { start, limit }
     }
+
+    /// Creates a range starting at the specified block height and containing up to `limit` elements.
+    pub fn multi(start: BlockHeight, limit: u64) -> BlockHeightRange {
+        BlockHeightRange {
+            start,
+            limit: Some(limit),
+        }
+    }
+
+    /// Returns the highest block height in the range.
+    pub fn highest(&self) -> BlockHeight {
+        self.limit
+            .map_or(self.start, |limit| BlockHeight(self.start.0 + limit - 1))
+    }
 }
 
 /// Request information about a chain.


### PR DESCRIPTION
## Motivation
`synchronize_received_certificates_from_validators` synchronizes client's knowledge about a chain, from a validator, by going through incoming messages (from other chains) that node has seen for a chain being synchronized.

Currently, in `main`, we iterate sequentially through the `info.requested_received_log` and for every (`ChainAndHeight`) entry (`chain<>height` tuple) we do the following:
1. query local node (and check if we've already processed that entry)
2. query remote node (and learn a "certificate hash" corresponding to this particular entry)
3. download certificate from a remote node for that certificate hash

Assuming `n` chains with `m` entries (in `requested_received_log`) each we do `n * m` queries (with 2/3 being queries to a remote node). This turns out to be prohibitively slow.

## Proposal

We propose to batch the queries to remote nodes (grouped by chain). In effect, we now do only `3 * n` queries. I.e. for every chain, we do the same 3 queries as above but each contains (up to) `m` entries.

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->

## Test Plan

CI and devnet. 
<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.
- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- Backporting is not possible but we may want to deploy a new `devnet` and release a new
      SDK soon.

## Links
Closes https://github.com/linera-io/linera-protocol/issues/2662

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
