### PR TITLE
Serialize BTreeMap with keys as strings

### DIFF
--- a/linera-client/src/util.rs
+++ b/linera-client/src/util.rs
@@ -66,3 +66,38 @@ macro_rules! impl_from_infallible {
 
 pub(crate) use impl_from_dynamic;
 pub(crate) use impl_from_infallible;
+
+pub mod serde_btreemap_keys_as_strings {
+    use std::{collections::BTreeMap, fmt::Display, str::FromStr};
+
+    use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<K, V, S>(map: &BTreeMap<K, V>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        K: Display,
+        V: Serialize,
+        S: Serializer,
+    {
+        let string_map: BTreeMap<String, &V> =
+            map.iter().map(|(k, v)| (k.to_string(), v)).collect();
+        string_map.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, K, V, D>(deserializer: D) -> Result<BTreeMap<K, V>, D::Error>
+    where
+        K: FromStr + Ord,
+        <K as FromStr>::Err: Display,
+        V: Deserialize<'de>,
+        D: Deserializer<'de>,
+    {
+        let string_map: BTreeMap<String, V> = BTreeMap::deserialize(deserializer)?;
+        string_map
+            .into_iter()
+            .map(|(k, v)| {
+                k.parse()
+                    .map(|key| (key, v))
+                    .map_err(serde::de::Error::custom)
+            })
+            .collect()
+    }
+}

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -18,7 +18,7 @@ use linera_storage::Storage;
 use rand::Rng as _;
 use serde::{Deserialize, Serialize};
 
-use crate::{config::GenesisConfig, error, Error};
+use crate::{config::GenesisConfig, error, util::serde_btreemap_keys_as_strings, Error};
 
 #[derive(Serialize, Deserialize)]
 pub struct Wallet {
@@ -210,6 +210,7 @@ pub struct UserChain {
     pub timestamp: Timestamp,
     pub next_block_height: BlockHeight,
     pub pending_block: Option<Block>,
+    #[serde(with = "serde_btreemap_keys_as_strings")]
     pub pending_blobs: BTreeMap<BlobId, Blob>,
 }
 


### PR DESCRIPTION
## Motivation

When we try to save the wallet, the `pending_blobs` inside of `UserChain` will need to be serialized to JSON, but that map is currently a `BlobId`.

## Proposal

Write a custom serialization module for BTreeMaps that will serialize the keys as strings
Fixes #2665

## Test Plan

CI + stacked #2646 on top of this and ran the benchmark test, it did not fail in the serialization anymore

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

