### PR TITLE
Docker validator has 4 shards.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,7 @@ on:
       - "**"
     paths:
       - 'docker/Dockerfile'
+      - 'docker/docker-compose.yml'
       - 'docker/compose.sh'
       - 'Cargo.toml'
       - '.github/workflows/docker.yml'

--- a/configuration/compose/validator.toml
+++ b/configuration/compose/validator.toml
@@ -16,7 +16,25 @@ Grpc = "ClearText"
 Grpc = "ClearText"
 
 [[shards]]
-host = "shard"
+host = "docker-shard-1"
 port = 19100
-metrics_host = "shard"
+metrics_host = "docker-shard-1"
+metrics_port = 21100
+
+[[shards]]
+host = "docker-shard-2"
+port = 19100
+metrics_host = "docker-shard-2"
+metrics_port = 21100
+
+[[shards]]
+host = "docker-shard-3"
+port = 19100
+metrics_host = "docker-shard-3"
+metrics_port = 21100
+
+[[shards]]
+host = "docker-shard-4"
+port = 19100
+metrics_host = "docker-shard-4"
 metrics_port = 21100

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,8 @@ services:
       - linera-shared:/shared
   shard:
     image: linera
-    container_name: shard
+    deploy:
+      replicas: 4
     command: [ "./compose-server-entrypoint.sh" ]
     volumes:
       - .:/config


### PR DESCRIPTION
## Motivation

Docker validators had 1 shard which was a potential performance bottleneck.

## Proposal

Docker validators now have 4 shards using the deploy replica strategy.

## Test Plan

Regressions will be caught by CI.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.