### PR TITLE
Improve the `publish_bytecode` functionality.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -949,6 +949,7 @@ pub enum BlobContent {
 }
 
 /// Compressed contract, service and bytecode_id.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone)]
 pub struct CompressedContractService {
     /// The contract blob
@@ -959,6 +960,7 @@ pub struct CompressedContractService {
     pub bytecode_id: BytecodeId,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl CompressedContractService {
     /// Creates a compressed Contract, Service and bytecode.
     pub async fn new(contract: Bytecode, service: Bytecode) -> Self {

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -948,38 +948,6 @@ pub enum BlobContent {
     ServiceBytecode(CompressedBytecode),
 }
 
-/// Compressed contract, service and bytecode_id.
-#[cfg(not(target_arch = "wasm32"))]
-#[derive(Clone)]
-pub struct CompressedContractService {
-    /// The contract blob
-    pub contract_blob: Blob,
-    /// The service blob.
-    pub service_blob: Blob,
-    /// The bytecode_id.
-    pub bytecode_id: BytecodeId,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl CompressedContractService {
-    /// Creates a compressed Contract, Service and bytecode.
-    pub async fn new(contract: Bytecode, service: Bytecode) -> Self {
-        let (compressed_contract, compressed_service) =
-            tokio::task::spawn_blocking(move || (contract.compress(), service.compress()))
-                .await
-                .expect("Compression should not panic");
-        let contract_blob = Blob::new_contract_bytecode(compressed_contract);
-        let service_blob = Blob::new_service_bytecode(compressed_service);
-
-        let bytecode_id = BytecodeId::new(contract_blob.id().hash, service_blob.id().hash);
-        Self {
-            contract_blob,
-            service_blob,
-            bytecode_id,
-        }
-    }
-}
-
 impl fmt::Debug for BlobContent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -948,6 +948,36 @@ pub enum BlobContent {
     ServiceBytecode(CompressedBytecode),
 }
 
+/// Compressed contract, service and bytecode_id.
+#[derive(Clone)]
+pub struct CompressedContractService {
+    /// The contract blob
+    pub contract_blob: Blob,
+    /// The service blob.
+    pub service_blob: Blob,
+    /// The bytecode_id.
+    pub bytecode_id: BytecodeId,
+}
+
+impl CompressedContractService {
+    /// Creates a compressed Contract, Service and bytecode.
+    pub async fn new(contract: Bytecode, service: Bytecode) -> Self {
+        let (compressed_contract, compressed_service) =
+            tokio::task::spawn_blocking(move || (contract.compress(), service.compress()))
+                .await
+                .expect("Compression should not panic");
+        let contract_blob = Blob::new_contract_bytecode(compressed_contract);
+        let service_blob = Blob::new_service_bytecode(compressed_service);
+
+        let bytecode_id = BytecodeId::new(contract_blob.id().hash, service_blob.id().hash);
+        Self {
+            contract_blob,
+            service_blob,
+            bytecode_id,
+        }
+    }
+}
+
 impl fmt::Debug for BlobContent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -56,7 +56,7 @@ use {
         data_types::{BlobBytes, Bytecode},
         identifiers::BytecodeId,
     },
-    linera_core::client::create_compressed_bytecodes,
+    linera_core::client::create_bytecode_blobs,
     std::{fs, path::PathBuf},
 };
 
@@ -421,7 +421,7 @@ where
 
         info!("Publishing bytecode");
         let (contract_blob, service_blob, bytecode_id) =
-            create_compressed_bytecodes(contract_bytecode, service_bytecode).await;
+            create_bytecode_blobs(contract_bytecode, service_bytecode).await;
         let (bytecode_id, _) = self
             .apply_client_command(chain_client, |chain_client| {
                 let contract_blob = contract_blob.clone();
@@ -429,7 +429,7 @@ where
                 let chain_client = chain_client.clone();
                 async move {
                     chain_client
-                        .publish_compressed_bytecode(contract_blob, service_blob, bytecode_id)
+                        .publish_bytecode_blobs(contract_blob, service_blob, bytecode_id)
                         .await
                         .context("Failed to publish bytecode")
                 }

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -411,13 +411,12 @@ where
         service: PathBuf,
     ) -> Result<BytecodeId, Error> {
         info!("Loading bytecode files");
-        let contract_bytecode: Bytecode = Bytecode::load_from_file(&contract)
+        let contract_bytecode = Bytecode::load_from_file(&contract)
             .await
             .with_context(|| format!("failed to load contract bytecode from {:?}", &contract))?;
-        let service_bytecode = Bytecode::load_from_file(&service).await.context(format!(
-            "failed to load service bytecode from {:?}",
-            &service
-        ))?;
+        let service_bytecode = Bytecode::load_from_file(&service)
+            .await
+            .with_context(|| format!("failed to load service bytecode from {:?}", &service))?;
 
         info!("Publishing bytecode");
         let (bytecode_id, _) = self

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use futures::Future;
 use linera_base::{
     crypto::KeyPair,
-    data_types::{BlockHeight, CompressedContractService, Timestamp},
+    data_types::{BlockHeight, Timestamp},
     identifiers::{Account, ChainId},
     ownership::ChainOwnership,
     time::{Duration, Instant},
@@ -53,7 +53,7 @@ use {
 use {
     linera_base::{
         crypto::CryptoHash,
-        data_types::{BlobBytes, Bytecode},
+        data_types::{BlobBytes, Bytecode, CompressedContractService},
         identifiers::BytecodeId,
     },
     std::{fs, path::PathBuf},

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use futures::Future;
 use linera_base::{
     crypto::KeyPair,
-    data_types::{BlockHeight, Timestamp},
+    data_types::{BlockHeight, CompressedContractService, Timestamp},
     identifiers::{Account, ChainId},
     ownership::ChainOwnership,
     time::{Duration, Instant},
@@ -419,14 +419,15 @@ where
             .with_context(|| format!("failed to load service bytecode from {:?}", &service))?;
 
         info!("Publishing bytecode");
+        let compressed_contract_service =
+            CompressedContractService::new(contract_bytecode, service_bytecode).await;
         let (bytecode_id, _) = self
             .apply_client_command(chain_client, |chain_client| {
-                let contract_bytecode = contract_bytecode.clone();
-                let service_bytecode = service_bytecode.clone();
+                let compressed_contract_service = compressed_contract_service.clone();
                 let chain_client = chain_client.clone();
                 async move {
                     chain_client
-                        .publish_bytecode(contract_bytecode, service_bytecode)
+                        .publish_compressed_bytecode(compressed_contract_service)
                         .await
                         .context("Failed to publish bytecode")
                 }

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -399,7 +399,7 @@ where
 
     /// Loads pending cross-chain requests.
     async fn create_network_actions(&self) -> Result<NetworkActions, WorkerError> {
-        let mut heights_by_recipient: BTreeMap<_, BTreeMap<_, _>> = Default::default();
+        let mut heights_by_recipient = BTreeMap::<_, BTreeMap<_,_>>::new();
         let mut targets = self.chain.outboxes.indices().await?;
         if let Some(tracked_chains) = self.tracked_chains.as_ref() {
             let tracked_chains = tracked_chains

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -341,7 +341,7 @@ where
             .into_iter()
             .filter(|blob_id| !pending_blobs.contains_key(blob_id))
             .collect::<Vec<_>>();
-        Ok(self.storage.missing_blobs(blob_ids.clone()).await?)
+        Ok(self.storage.missing_blobs(blob_ids).await?)
     }
 
     /// Returns the blobs requested by their `blob_ids` that are either in pending in the

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -444,7 +444,7 @@ where
             targets.retain(|target| tracked_chains.contains(&target.recipient));
         }
         let outboxes = self.chain.outboxes.try_load_entries(&targets).await?;
-        for (_, outbox) in targets.into_iter().zip(outboxes) {
+        for outbox in outboxes {
             let outbox = outbox.expect("Only existing outboxes should be referenced by `indices`");
             let front = outbox.queue.front().await?;
             if front.is_some_and(|key| key <= height) {

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -399,7 +399,7 @@ where
 
     /// Loads pending cross-chain requests.
     async fn create_network_actions(&self) -> Result<NetworkActions, WorkerError> {
-        let mut heights_by_recipient = BTreeMap::<_, BTreeMap<_,_>>::new();
+        let mut heights_by_recipient = BTreeMap::<_, BTreeMap<_, _>>::new();
         let mut targets = self.chain.outboxes.indices().await?;
         if let Some(tracked_chains) = self.tracked_chains.as_ref() {
             let tracked_chains = tracked_chains

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -615,7 +615,7 @@ enum HandleCertificateResult {
 
 /// Creates a compressed Contract, Service and bytecode.
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn create_compressed_bytecodes(
+pub async fn create_bytecode_blobs(
     contract: Bytecode,
     service: Bytecode,
 ) -> (Blob, Blob, BytecodeId) {
@@ -2550,15 +2550,15 @@ where
         service: Bytecode,
     ) -> Result<ClientOutcome<(BytecodeId, Certificate)>, ChainClientError> {
         let (contract_blob, service_blob, bytecode_id) =
-            create_compressed_bytecodes(contract, service).await;
-        self.publish_compressed_bytecode(contract_blob, service_blob, bytecode_id)
+            create_bytecode_blobs(contract, service).await;
+        self.publish_bytecode_blobs(contract_blob, service_blob, bytecode_id)
             .await
     }
 
     /// Publishes some bytecode.
     #[cfg(not(target_arch = "wasm32"))]
     #[tracing::instrument(level = "trace", skip(contract_blob, service_blob, bytecode_id))]
-    pub async fn publish_compressed_bytecode(
+    pub async fn publish_bytecode_blobs(
         &self,
         contract_blob: Blob,
         service_blob: Blob,

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -404,7 +404,7 @@ where
         notifier: &impl Notifier,
     ) -> Result<Box<ChainInfo>, LocalNodeError> {
         // Sequentially try each validator in random order.
-        let mut validators: Vec<_> = validators.iter().collect();
+        let mut validators = validators.iter().collect::<Vec<_>>();
         validators.shuffle(&mut thread_rng());
         for remote_node in validators {
             let info = self.local_chain_info(chain_id).await?;
@@ -494,7 +494,7 @@ where
         blob_id: BlobId,
     ) -> Option<Blob> {
         // Sequentially try each validator in random order.
-        let mut validators: Vec<_> = validators.iter().collect();
+        let mut validators = validators.iter().collect::<Vec<_>>();
         validators.shuffle(&mut thread_rng());
         for remote_node in validators {
             if let Some(blob) = remote_node.try_download_blob(blob_id).await {
@@ -511,7 +511,7 @@ where
     ) -> FuturesUnordered<impl Future<Output = Option<Certificate>> + '_> {
         let futures = FuturesUnordered::new();
 
-        let mut validators: Vec<_> = validators.iter().collect();
+        let mut validators = validators.iter().collect::<Vec<_>>();
         validators.shuffle(&mut thread_rng());
         for remote_node in validators {
             futures.push(async move {


### PR DESCRIPTION
## Motivation

The `publish_bytecode` of the `client_context` is calling the `publish_bytecode` of the `chain_client`.

However, the `publish_bytecode` might be called several times via the `apply_client_command`. The problem is that the compression of the contract/service and the hash computation was done in the `publish_bytecode` of the `chain_client`. This means that the compression is done several times which is suboptimal.

## Proposal

The following was done:
* The `CompressedContractService` data type was introduced in the `linera-base`.
* The compression is done in the same way as in the `publish_bytecode` of the `chain_client`, that is panicking in case of error.
* The `publish_compressed_bytecode` is introduced to the `chain_client`.

This work was motivated by the problem of addressing timeout issues for the `publishBytecode` of the AMM smart contract when running the `linera_net_tests` without the `INTEGRATION_TEST_GUARD`. It is possible that the change addresses the problem, but it is also possible that the problem remains after the change. Nevertheless, the change appears needed as it does not make sense to compress again and again the same code.

While investigating for this problem, several issues were identified with the code:
* A `blob_ids.clone()` where the clone was not needed.
* An inconsistent reading of the bytecodes.
* Some other stylistic inconsistencies with respect to our standard.

## Test Plan

The CI should do the job.

## Release Plan

It does not appear to have some impact on TestNet / DevMet.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
