### PR TITLE
Fix some potential `ChainState` issues

### DIFF
--- a/linera-core/src/client/chain_state.rs
+++ b/linera-core/src/client/chain_state.rs
@@ -10,7 +10,7 @@ use std::{
 use linera_base::{
     crypto::{CryptoHash, KeyPair, PublicKey},
     data_types::{Blob, BlockHeight, Timestamp},
-    identifiers::{BlobId, ChainId, Owner},
+    identifiers::{BlobId, Owner},
 };
 use linera_chain::data_types::Block;
 use linera_execution::committee::ValidatorName;
@@ -34,8 +34,6 @@ pub struct ChainState {
     pending_block: Option<Block>,
     /// Known key pairs from present and past identities.
     known_key_pairs: BTreeMap<Owner, KeyPair>,
-    /// The ID of the admin chain.
-    admin_id: ChainId,
 
     /// For each validator, up to which index we have synchronized their
     /// [`ChainStateView::received_log`].
@@ -52,7 +50,6 @@ pub struct ChainState {
 impl ChainState {
     pub fn new(
         known_key_pairs: Vec<KeyPair>,
-        admin_id: ChainId,
         block_hash: Option<CryptoHash>,
         timestamp: Timestamp,
         next_block_height: BlockHeight,
@@ -65,7 +62,6 @@ impl ChainState {
             .collect();
         let mut state = ChainState {
             known_key_pairs,
-            admin_id,
             block_hash,
             timestamp,
             next_block_height,
@@ -90,10 +86,6 @@ impl ChainState {
 
     pub fn next_block_height(&self) -> BlockHeight {
         self.next_block_height
-    }
-
-    pub fn admin_id(&self) -> ChainId {
-        self.admin_id
     }
 
     pub fn pending_block(&self) -> &Option<Block> {

--- a/linera-core/src/client/chain_state.rs
+++ b/linera-core/src/client/chain_state.rs
@@ -11,6 +11,7 @@ use linera_base::{
     crypto::{CryptoHash, KeyPair, PublicKey},
     data_types::{Blob, BlockHeight, Timestamp},
     identifiers::{BlobId, Owner},
+    ownership::ChainOwnership,
 };
 use linera_chain::data_types::Block;
 use linera_execution::committee::ValidatorName;
@@ -114,6 +115,13 @@ impl ChainState {
 
     pub fn known_key_pairs(&self) -> &BTreeMap<Owner, KeyPair> {
         &self.known_key_pairs
+    }
+
+    /// Returns whether the given ownership includes anyone whose secret key we don't have.
+    pub fn has_other_owners(&self, ownership: &ChainOwnership) -> bool {
+        ownership
+            .all_owners()
+            .any(|owner| !self.known_key_pairs.contains_key(owner))
     }
 
     pub(super) fn insert_known_key_pair(&mut self, key_pair: KeyPair) -> PublicKey {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -261,7 +261,6 @@ impl<P, S: Storage + Clone> Client<P, S> {
         if let dashmap::mapref::entry::Entry::Vacant(e) = self.chains.entry(chain_id) {
             e.insert(ChainState::new(
                 known_key_pairs,
-                admin_id,
                 block_hash,
                 timestamp,
                 next_block_height,
@@ -273,6 +272,7 @@ impl<P, S: Storage + Clone> Client<P, S> {
         ChainClient {
             client: self.clone(),
             chain_id,
+            admin_id,
             options: ChainClientOptions {
                 max_pending_message_bundles: self.max_pending_message_bundles,
                 message_policy: self.message_policy.clone(),
@@ -405,6 +405,8 @@ where
     client: Arc<Client<ValidatorNodeProvider, Storage>>,
     /// The off-chain chain ID.
     chain_id: ChainId,
+    /// The ID of the admin chain.
+    admin_id: ChainId,
     /// The client options.
     options: ChainClientOptions,
 }
@@ -417,6 +419,7 @@ where
         Self {
             client: self.client.clone(),
             chain_id: self.chain_id,
+            admin_id: self.admin_id,
             options: self.options.clone(),
         }
     }
@@ -777,7 +780,7 @@ where
         &self,
     ) -> Result<(BTreeMap<Epoch, Committee>, Epoch), LocalNodeError> {
         let (epoch, mut committees) = self.epoch_and_committees(self.chain_id).await?;
-        let admin_id = self.state().admin_id();
+        let admin_id = self.admin_id;
         let (admin_epoch, admin_committees) = self.epoch_and_committees(admin_id).await?;
         committees.extend(admin_committees);
         let epoch = std::cmp::max(epoch.unwrap_or_default(), admin_epoch.unwrap_or_default());
@@ -1275,8 +1278,7 @@ where
         let local_committee = self.local_committee().await?;
         let nodes = self.make_nodes(&local_committee)?;
         // Synchronize the state of the admin chain from the network.
-        let admin_id = self.state().admin_id();
-        self.synchronize_chain_state(&nodes, admin_id).await?;
+        self.synchronize_chain_state(&nodes, self.admin_id).await?;
         let client = self.clone();
         // Proceed to downloading received certificates.
         let result = communicate_with_quorum(
@@ -2473,7 +2475,7 @@ where
             let config = OpenChainConfig {
                 ownership: ownership.clone(),
                 committees,
-                admin_id: self.state().admin_id(),
+                admin_id: self.admin_id,
                 epoch,
                 balance,
                 application_permissions: application_permissions.clone(),
@@ -2720,7 +2722,7 @@ where
         &self,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
         let operation = SystemOperation::Subscribe {
-            chain_id: self.state().admin_id(),
+            chain_id: self.admin_id,
             channel: SystemChannel::Admin,
         };
         self.execute_operation(Operation::System(operation)).await
@@ -2733,7 +2735,7 @@ where
         &self,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
         let operation = SystemOperation::Unsubscribe {
-            chain_id: self.state().admin_id(),
+            chain_id: self.admin_id,
             channel: SystemChannel::Admin,
         };
         self.execute_operation(Operation::System(operation)).await

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -672,10 +672,6 @@ where
     /// local chain.
     #[tracing::instrument(level = "trace")]
     async fn pending_message_bundles(&self) -> Result<Vec<IncomingBundle>, ChainClientError> {
-        if self.next_block_height() != BlockHeight::ZERO && self.options.message_policy.is_ignore()
-        {
-            return Ok(Vec::new()); // OpenChain is already received, other are ignored.
-        }
         let query = ChainInfoQuery::new(self.chain_id).with_pending_message_bundles();
         let info = self
             .client
@@ -683,10 +679,17 @@ where
             .handle_chain_info_query(query)
             .await?
             .info;
-        ensure!(
-            info.next_block_height == self.next_block_height(),
-            ChainClientError::WalletSynchronizationError
-        );
+        {
+            let state = self.state();
+            ensure!(
+                state.has_other_owners(&info.manager.ownership)
+                    || info.next_block_height == state.next_block_height(),
+                ChainClientError::WalletSynchronizationError
+            );
+        }
+        if info.next_block_height != BlockHeight::ZERO && self.options.message_policy.is_ignore() {
+            return Ok(Vec::new()); // OpenChain is already received, others are ignored.
+        }
         let mut requested_pending_message_bundles = info.requested_pending_message_bundles;
         let mut pending_message_bundles = vec![];
         // The first incoming message of any child chain must be `OpenChain`. We must have it in
@@ -780,8 +783,7 @@ where
         &self,
     ) -> Result<(BTreeMap<Epoch, Committee>, Epoch), LocalNodeError> {
         let (epoch, mut committees) = self.epoch_and_committees(self.chain_id).await?;
-        let admin_id = self.admin_id;
-        let (admin_epoch, admin_committees) = self.epoch_and_committees(admin_id).await?;
+        let (admin_epoch, admin_committees) = self.epoch_and_committees(self.admin_id).await?;
         committees.extend(admin_committees);
         let epoch = std::cmp::max(epoch.unwrap_or_default(), admin_epoch.unwrap_or_default());
         Ok((committees, epoch))
@@ -830,11 +832,12 @@ where
             manager.ownership.is_active(),
             LocalNodeError::InactiveChain(self.chain_id)
         );
+        let state = self.state();
         let mut identities = manager
             .ownership
             .all_owners()
             .chain(&manager.leader)
-            .filter(|owner| self.state().known_key_pairs().contains_key(owner));
+            .filter(|owner| state.known_key_pairs().contains_key(owner));
         let Some(identity) = identities.next() else {
             return Err(ChainClientError::CannotFindKeyForChain(self.chain_id));
         };
@@ -886,9 +889,7 @@ where
                 ChainClientError::InternalError("Invalid chain of blocks in local node")
             );
         }
-        let ownership = &info.manager.ownership;
-        let keys: HashSet<_> = self.state().known_key_pairs().keys().cloned().collect();
-        if ownership.all_owners().any(|owner| !keys.contains(owner)) {
+        if self.state().has_other_owners(&info.manager.ownership) {
             let mutex = self.state().client_mutex();
             let _guard = mutex.lock_owned().await;
 
@@ -2245,7 +2246,7 @@ where
                 info = self.chain_info_with_manager_values().await?;
             }
         }
-        self.state_mut().update_from_info(&info);
+        self.update_from_info(&info);
         let manager = *info.manager;
 
         // If there is a validated block in the current round, finalize it.


### PR DESCRIPTION
## Motivation

The admin ID can't change, and we are locking the `ChainState` each time we access it.

We are locking and unlocking the `ChainState` multiple times in some cases to obtain the components of a chain's tip state (block hash, height and timestamp). If the state changed in between those instances, the components won't refer to the same state.

In some cases we return an error if the local node's chain is ahead of the `ChainState`. But in multi-owner chains, this can happen legitimately.

## Proposal

Move `admin_id` out of `ChainState`. Fetch the hash, height and timestamp in one go where necessary. Only do the check for single-owner chains.

Also, don't unnecessarily collect the known keys' owners, and use `contains_key` instead.

## Test Plan

CI should catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
