### PR TITLE
chore: Remove pinned version of cargo-local-registry

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -67,8 +67,7 @@ jobs:
     - name: Install cargo tools
       run: |
         cargo install --locked cargo-index
-        # TODO(#2338): Remove the pinned Git URL and revision
-        cargo install --locked cargo-local-registry --git https://github.com/dhovart/cargo-local-registry --rev 2b20904a
+        cargo install --locked cargo-local-registry
     - name: Setup git committer information
       run: |
         git config --global user.email "ci@linera.io"

--- a/scripts/test_publish.sh
+++ b/scripts/test_publish.sh
@@ -3,8 +3,7 @@
 # Use a local registry to simulate publishing crates from the current workspace.
 #
 # Requirements (MacOS):
-#   # TODO(#2338): remove the pinned revision
-#   cargo install --locked cargo-local-registry --git https://github.com/dhovart/cargo-local-registry --rev 2b20904a
+#   cargo install cargo-local-registry
 #   cargo install cargo-index
 #   brew install jq
 #


### PR DESCRIPTION
cargo-local-registry builds fine on rust 1.81.0

- Updated `test_publish.sh` script to document use the latest version of `cargo-local-registry`.
- Modified GitHub actions workflow `documentation.yml` to install latest `cargo-local-registry` version.
- Fixes #2338

