### PR TITLE
Add unit test for saving wallet with pending blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4142,6 +4142,7 @@ dependencies = [
  "serde-wasm-bindgen 0.6.5",
  "serde_json",
  "social",
+ "tempfile",
  "test-case",
  "test-log",
  "test-strategy",

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -120,6 +120,7 @@ non-fungible.workspace = true
 proptest.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 social.workspace = true
+tempfile.workspace = true
 test-case.workspace = true
 test-log = { workspace = true, features = ["trace"] }
 test-strategy.workspace = true

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -26,10 +26,6 @@ use tracing::{debug, error, info, warn, Instrument as _};
 
 use crate::{wallet::Wallet, Error};
 
-#[cfg(test)]
-#[path = "unit_tests/chain_listener.rs"]
-mod tests;
-
 #[derive(Debug, Default, Clone, clap::Args)]
 pub struct ChainListenerConfig {
     /// Do not create blocks automatically to receive incoming messages. Instead, wait for

--- a/linera-client/src/lib.rs
+++ b/linera-client/src/lib.rs
@@ -16,4 +16,7 @@ pub mod storage;
 pub mod util;
 pub mod wallet;
 
+#[cfg(test)]
+mod unit_tests;
+
 pub use error::Error;

--- a/linera-client/src/unit_tests/mod.rs
+++ b/linera-client/src/unit_tests/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod chain_listener;
+mod util;
+mod wallet;

--- a/linera-client/src/unit_tests/util.rs
+++ b/linera-client/src/unit_tests/util.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use linera_base::data_types::Timestamp;
+use linera_core::test_utils::{MemoryStorageBuilder, TestBuilder};
+use linera_execution::ResourceControlPolicy;
+use linera_rpc::{
+    config::{NetworkProtocol, ValidatorPublicNetworkPreConfig},
+    simple::TransportProtocol,
+};
+
+use crate::config::{CommitteeConfig, GenesisConfig, ValidatorConfig};
+
+pub fn make_genesis_config(builder: &TestBuilder<MemoryStorageBuilder>) -> GenesisConfig {
+    let network = ValidatorPublicNetworkPreConfig {
+        protocol: NetworkProtocol::Simple(TransportProtocol::Tcp),
+        host: "localhost".to_string(),
+        port: 8080,
+    };
+    let validator_names = builder.initial_committee.validators().keys();
+    let validators = validator_names
+        .map(|name| ValidatorConfig {
+            name: *name,
+            network: network.clone(),
+        })
+        .collect();
+    let mut genesis_config = GenesisConfig::new(
+        CommitteeConfig { validators },
+        builder.admin_id(),
+        Timestamp::from(0),
+        ResourceControlPolicy::default(),
+        "test network".to_string(),
+    );
+    genesis_config.chains.extend(builder.genesis_chains());
+    genesis_config
+}

--- a/linera-client/src/unit_tests/wallet.rs
+++ b/linera-client/src/unit_tests/wallet.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use anyhow::anyhow;
+use linera_base::{
+    crypto::KeyPair,
+    data_types::{Amount, Blob},
+    identifiers::{ChainDescription, ChainId},
+};
+use linera_core::test_utils::{MemoryStorageBuilder, StorageBuilder, TestBuilder};
+use rand::SeedableRng as _;
+
+use super::util::make_genesis_config;
+use crate::{client_context::ClientContext, config::WalletState, wallet::Wallet};
+
+/// Tests wether we can correctly save a wallet that contains pending blobs.
+#[test_log::test(tokio::test)]
+async fn test_save_wallet_with_pending_blobs() -> anyhow::Result<()> {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+    let storage_builder = MemoryStorageBuilder::default();
+    let clock = storage_builder.clock().clone();
+    let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
+    let description = ChainDescription::Root(0);
+    let chain_id = ChainId::from(description);
+    builder.add_initial_chain(description, Amount::ONE).await?;
+    let storage = builder.make_storage().await?;
+    let key_pair = KeyPair::generate_from(&mut rng);
+
+    let genesis_config = make_genesis_config(&builder);
+
+    let tmp_dir = tempfile::tempdir()?;
+    let mut config_dir = tmp_dir.into_path();
+    config_dir.push("linera");
+    if !config_dir.exists() {
+        tracing::debug!("{} does not exist, creating", config_dir.display());
+        fs_err::create_dir(&config_dir)?;
+        tracing::debug!("{} created.", config_dir.display());
+    }
+    let wallet_path = config_dir.join("wallet.json");
+    if wallet_path.exists() {
+        return Err(anyhow!("Wallet already exists!"));
+    }
+    let wallet =
+        WalletState::create_from_file(&wallet_path, Wallet::new(genesis_config, Some(37)))?;
+    let mut context = ClientContext::new_test_client_context(storage, wallet);
+    let blob = Blob::new_data(b"blob".to_vec());
+    let mut pending_blobs = BTreeMap::new();
+    pending_blobs.insert(blob.id(), blob);
+    context
+        .update_wallet_for_new_chain_with_pending_blobs(
+            chain_id,
+            Some(key_pair),
+            clock.current_time(),
+            pending_blobs,
+        )
+        .await?;
+    context.save_wallet().await?;
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

CI was failing on PR #2646 with a JSON serialization failure. That was fixed by PR #2668 but we realized none of our tests covered this case.

## Proposal

Create a test that tries to save a wallet with pending blobs in it. Verified that before #2668 this test fails, and now it succeeds.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
