### PR TITLE
`.github/workflows/rust.yml`: use newer `wasm-pack` syntax

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -148,7 +148,7 @@ jobs:
     - name: Run the browser tests
       run: |
         cd linera-views
-        WASM_BINDGEN_TEST_TIMEOUT=300 wasm-pack test --chrome --headless --features web,indexeddb
+        WASM_BINDGEN_TEST_TIMEOUT=300 wasm-pack test --chrome --headless -- --features web-default
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

Old `wasm-pack` accepted a `--features` argument directly, but newer `wasm-pack` requires it be passed through escaped with a leading double-hyphen.  Sometimes we get one version or the other, for reasons I'm unsure of, but the older `wasm-pack` we have pinned also accepts the newer syntax, so let's just always pass it.  This should fix the flakiness we've been seeing with `wasm-pack` refusing to execute the test.

<!--
Briefly describe the goal(s) of this PR.
-->

## Proposal

Add double hyphens to the invocation of `wasm-pack test` in CI for `linera-views`.

While we're at it, take the opportunity to test the `web-default` feature rather than hardcoding `web,indexeddb`.

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->

## Test Plan

CI.

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

Nothing special required, since this is a CI-only change.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
