### PR TITLE
Always serialize BlobId as string if is_human_readable

### DIFF
--- a/linera-client/src/util.rs
+++ b/linera-client/src/util.rs
@@ -66,38 +66,3 @@ macro_rules! impl_from_infallible {
 
 pub(crate) use impl_from_dynamic;
 pub(crate) use impl_from_infallible;
-
-pub mod serde_btreemap_keys_as_strings {
-    use std::{collections::BTreeMap, fmt::Display, str::FromStr};
-
-    use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
-
-    pub fn serialize<K, V, S>(map: &BTreeMap<K, V>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        K: Display,
-        V: Serialize,
-        S: Serializer,
-    {
-        let string_map: BTreeMap<String, &V> =
-            map.iter().map(|(k, v)| (k.to_string(), v)).collect();
-        string_map.serialize(serializer)
-    }
-
-    pub fn deserialize<'de, K, V, D>(deserializer: D) -> Result<BTreeMap<K, V>, D::Error>
-    where
-        K: FromStr + Ord,
-        <K as FromStr>::Err: Display,
-        V: Deserialize<'de>,
-        D: Deserializer<'de>,
-    {
-        let string_map: BTreeMap<String, V> = BTreeMap::deserialize(deserializer)?;
-        string_map
-            .into_iter()
-            .map(|(k, v)| {
-                k.parse()
-                    .map(|key| (key, v))
-                    .map_err(serde::de::Error::custom)
-            })
-            .collect()
-    }
-}

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -18,7 +18,7 @@ use linera_storage::Storage;
 use rand::Rng as _;
 use serde::{Deserialize, Serialize};
 
-use crate::{config::GenesisConfig, error, util::serde_btreemap_keys_as_strings, Error};
+use crate::{config::GenesisConfig, error, Error};
 
 #[derive(Serialize, Deserialize)]
 pub struct Wallet {
@@ -210,7 +210,6 @@ pub struct UserChain {
     pub timestamp: Timestamp,
     pub next_block_height: BlockHeight,
     pub pending_block: Option<Block>,
-    #[serde(with = "serde_btreemap_keys_as_strings")]
     pub pending_blobs: BTreeMap<BlobId, Blob>,
 }
 


### PR DESCRIPTION
## Motivation

#2668 was not necessarily the best way we can fix this issue.

## Proposal

Always serialize `BlobId` as string if `is_human_readable`. Fixes #2671

## Test Plan

Reverted #2668, made sure the `test_save_wallet_with_pending_blobs` test failed, and made sure it went back to passing with the new serialization implementation.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
