### PR TITLE
Pin ScyllaDB Helm chart versions.

### DIFF
--- a/kubernetes/linera-validator/helmfile.yaml
+++ b/kubernetes/linera-validator/helmfile.yaml
@@ -33,6 +33,7 @@ releases:
       - name: validatorDomainName
         value: {{ env "LINERA_HELMFILE_VALIDATOR_DOMAIN_NAME" | default "" }}
   - name: scylla
+    version: v1.13.0
     namespace: scylla
     chart: scylla/scylla
     timeout: 900
@@ -42,12 +43,14 @@ releases:
     values:
       - {{ env "LINERA_HELMFILE_VALUES_SCYLLA" | default "scylla.values.yaml" }}
   - name: scylla-manager
+    version: v1.13.0
     namespace: scylla-manager
     chart: scylla/scylla-manager
     timeout: 900
     needs:
       - scylla-operator/scylla-operator
   - name: scylla-operator
+    version: v1.13.0
     namespace: scylla-operator
     chart: scylla/scylla-operator
     timeout: 900
@@ -56,6 +59,7 @@ releases:
     values:
       - {{ env "LINERA_HELMFILE_VALUES_SCYLLA_OPERATOR" | default "scylla-operator.values.yaml" }}
   - name: cert-manager
+    version: v1.15.3
     namespace: cert-manager
     chart: jetstack/cert-manager
     timeout: 900


### PR DESCRIPTION
## Motivation

If no version is specified, the latest version of a Helm Chart is used, unintentionally breaking our validator deployment.

## Proposal

Pin ScyllaDB (and its dependency Cert Manager).

The pinned versions are what is used in `testnet-boole`.

## Test Plan

Tested manually.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

- These changes should be backported to the latest `devnet` branch, then
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.
