### PR TITLE
Inject git commit into Docker image.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,7 @@ env:
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
   RUST_LOG: warn
+  DOCKER_COMPOSE_WAIT: "true"
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,9 @@ jobs:
       - name: Build Docker image
         run: docker build . -f docker/Dockerfile -t linera
       - name: Run Compose
-        run: cd docker && ./compose.sh &
+        run: |
+          cd docker
+          ./compose.sh
       - name: Sync
         uses: nick-fields/retry@v2
         with:

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 ROOT_DIR=$SCRIPT_DIR/..
 CONF_DIR=$ROOT_DIR/configuration/compose
 
@@ -8,21 +8,21 @@ cleanup_started=false
 
 # Clean up hanging volumes when the script is terminated.
 cleanup() {
-  if [ "$cleanup_started" = true ]; then
-      exit 0
+    if [ "$cleanup_started" = true ]; then
+        exit 0
     fi
-  cleanup_started=true
-  rm committee.json
-  rm genesis.json
-  rm -r linera.db
-  rm server.json
-  rm wallet.json
-  SCYLLA_VOLUME=docker_linera-scylla-data
-  SHARED_VOLUME=docker_linera-shared
-  docker rm -f $(docker ps -a -q --filter volume=$SCYLLA_VOLUME)
-  docker volume rm $SCYLLA_VOLUME
-  docker rm -f $(docker ps -a -q --filter volume=$SHARED_VOLUME)
-  docker volume rm $SHARED_VOLUME
+    cleanup_started=true
+    rm committee.json
+    rm genesis.json
+    rm -r linera.db
+    rm server.json
+    rm wallet.json
+    SCYLLA_VOLUME=docker_linera-scylla-data
+    SHARED_VOLUME=docker_linera-shared
+    docker rm -f $(docker ps -a -q --filter volume=$SCYLLA_VOLUME)
+    docker volume rm $SCYLLA_VOLUME
+    docker rm -f $(docker ps -a -q --filter volume=$SHARED_VOLUME)
+    docker volume rm $SHARED_VOLUME
 }
 
 trap cleanup EXIT INT
@@ -34,16 +34,16 @@ GIT_COMMIT=$(git rev-parse --short HEAD)
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     docker build --build-arg git_commit="$GIT_COMMIT" -f docker/Dockerfile . -t linera
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-        CPU_ARCH=$(sysctl -n machdep.cpu.brand_string)
-        if [[ "$CPU_ARCH" == *"Apple"* ]]; then
-            docker build --build-arg git_commit="$GIT_COMMIT" --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera .
-        else
-            echo "Unsupported Architecture: $CPU_ARCH"
-            exit 1;
-        fi
+    CPU_ARCH=$(sysctl -n machdep.cpu.brand_string)
+    if [[ "$CPU_ARCH" == *"Apple"* ]]; then
+        docker build --build-arg git_commit="$GIT_COMMIT" --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera .
+    else
+        echo "Unsupported Architecture: $CPU_ARCH"
+        exit 1
+    fi
 else
     echo "Unsupported OS: $OSTYPE"
-    exit 1;
+    exit 1
 fi
 
 cd "$SCRIPT_DIR"
@@ -61,4 +61,8 @@ linera-server generate --validators "$CONF_DIR/validator.toml" --committee commi
 
 linera --wallet wallet.json --storage rocksdb:linera.db create-genesis-config 10 --genesis genesis.json --initial-funding 10 --committee committee.json --testing-prng-seed 2
 
-docker compose up
+if [ "${DOCKER_COMPOSE_WAIT:-false}" = "true" ]; then
+    docker compose up --wait
+else
+    docker compose up
+fi

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -29,12 +29,14 @@ trap cleanup EXIT INT
 
 cd "$ROOT_DIR"
 
+GIT_COMMIT=$(git rev-parse --short HEAD)
+
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    docker build -f docker/Dockerfile . -t linera
+    docker build --build-arg git_commit="$GIT_COMMIT" -f docker/Dockerfile . -t linera
 elif [[ "$OSTYPE" == "darwin"* ]]; then
         CPU_ARCH=$(sysctl -n machdep.cpu.brand_string)
         if [[ "$CPU_ARCH" == *"Apple"* ]]; then
-            docker build --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera .
+            docker build --build-arg git_commit="$GIT_COMMIT" --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera .
         else
             echo "Unsupported Architecture: $CPU_ARCH"
             exit 1;

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -25,7 +25,9 @@ cleanup() {
     docker volume rm $SHARED_VOLUME
 }
 
-trap cleanup EXIT INT
+if [ "${DOCKER_COMPOSE_WAIT:-false}" = "false" ]; then
+    trap cleanup EXIT INT
+fi
 
 cd "$ROOT_DIR"
 

--- a/scripts/deploy-validator.sh
+++ b/scripts/deploy-validator.sh
@@ -42,6 +42,7 @@ HOST="$1"
 # Get the current branch name and replace underscores with dashes
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 FORMATTED_BRANCH_NAME="${BRANCH_NAME//_/-}"
+GIT_COMMIT=$(git rev-parse --short HEAD)
 
 # Variables
 PORT="19100"
@@ -57,7 +58,7 @@ cargo install --locked --path linera-service
 
 # Build Docker image
 echo "Building Linera docker image"
-docker build -f docker/Dockerfile . -t linera
+docker build --build-arg git_commit="$GIT_COMMIT" -f  docker/Dockerfile . -t linera
 
 # Create validator configuration file
 echo "Creating validator configuration..."


### PR DESCRIPTION
## Motivation

Docker validators should provide their git commit when queried.

## Proposal

Inject the git commit into the docker build process.

## Test Plan

Tested manually.

```
$ linera --wallet wallet.json --storage rocksdb:linera.db query-validator grpc:localhost:19100
2024-10-22T19:34:21.838756Z  INFO linera::main: linera: Version information for new validator: Linera protocol: v0.13.0
RPC API hash: ZqNY7r+amtHKJVYpUngy/+yu/YXNTTgqJR17YOyWQtQ
GraphQL API hash: s/zNt/rFKTb63M7N6/Gfdmw4lRe+6+s8diGn6+A/Myk
WIT API hash: DTU+YHsJxaXJVywyYChS0/Kzu1lmAjAlUjtdayBz2hk
Source code: https://github.com/linera-io/linera-protocol/tree/fcdcd93a

9c46bc873013efc162f4e2a63cc27d7de9e4178297f898f426503c6d86c7dcc4
```

## Release Plan

This generally concerns only bug fixes.

- These changes should be backported to the latest `devnet` branch, then
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.
