### PR TITLE
[devnet-backport] Batch queries by chain when synchronizing certificates from validator

### DIFF
--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -40,6 +40,20 @@ impl BlockHeightRange {
         let limit = Some(1);
         BlockHeightRange { start, limit }
     }
+
+    /// Creates a range starting at the specified block height and containing up to `limit` elements.
+    pub fn multi(start: BlockHeight, limit: u64) -> BlockHeightRange {
+        BlockHeightRange {
+            start,
+            limit: Some(limit),
+        }
+    }
+
+    /// Returns the highest block height in the range.
+    pub fn highest(&self) -> BlockHeight {
+        self.limit
+            .map_or(self.start, |limit| BlockHeight(self.start.0 + limit - 1))
+    }
 }
 
 /// Request information about a chain.


### PR DESCRIPTION
## Motivation

Backporting #2666 to the lastest devnet branch. This PR makes use of the new `download_certificates` (plural) endpoint when synchronizing certificates from validator. This is a client-only change but we want to test how much it improves performance of a syncing client nevertheless.

## Proposal
## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.
## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
