### PR TITLE
CI: reduce verbosity in long faucet chain test

### DIFF
--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -7,13 +7,16 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   LINERA_STORAGE_SERVICE: 127.0.0.1:1235
+  RUST_LOG: warn
+  RUST_LOG_FORMAT: plain
 
 jobs:
   long-faucet-chain-test:
     runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 180
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v3

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -515,10 +515,8 @@ impl LocalNet {
         let mut client = HealthClient::new(connection);
         linera_base::time::timer::sleep(Duration::from_millis(100)).await;
         for i in 0..10 {
-            warn!("Iteration, i={}", i);
             linera_base::time::timer::sleep(Duration::from_millis(i * 500)).await;
             let result = client.check(HealthCheckRequest::default()).await;
-            warn!("result={:?}", result);
             if result.is_ok() && result.unwrap().get_ref().status() == ServingStatus::Serving {
                 info!("Successfully started {nickname}");
                 return Ok(());


### PR DESCRIPTION
## Motivation

Current logs in the faucet test seems to be approaching 100MB

## Proposal

Reduce log verbosity to `warn`

Also reduce timeout to 60min.

## Test Plan

CI
## Release Plan

- These changes should be backported to the latest `devnet` branch
- These changes should be backported to the latest `testnet` branch
