### PR TITLE
Some optimizations on our Docker github workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,8 +51,6 @@ jobs:
       - name: Build client binary
         run: |
           cargo install --path linera-service --bin linera --bin linera-server --debug
-      - name: Build Docker image
-        run: docker build . -f docker/Dockerfile -t linera
       - name: Run Compose
         run: |
           cd docker
@@ -61,6 +59,7 @@ jobs:
         uses: nick-fields/retry@v2
         with:
           # Docker compose can take some time to start
-          max_attempts: 5
+          max_attempts: 10
           timeout_minutes: 2
-          command: sleep 60 && linera --wallet docker/wallet.json --storage rocksdb:docker/linera.db sync-balance
+          retry_wait_seconds: 10
+          command: linera --wallet docker/wallet.json --storage rocksdb:docker/linera.db sync-balance

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -25,7 +25,9 @@ cleanup() {
     docker volume rm $SHARED_VOLUME
 }
 
-if [ "${DOCKER_COMPOSE_WAIT:-false}" = "false" ]; then
+if [ "${DOCKER_COMPOSE_WAIT:-false}" = "true" ]; then
+    trap cleanup INT
+else
     trap cleanup EXIT INT
 fi
 


### PR DESCRIPTION
## Motivation

While getting #2683 across the finish line, I noticed some speed ups we could do to our Docker github workflow

## Proposal

We already build the docker image in `compose.sh`, so no need to do it again before running it.

## Test Plan

#2683 made Docker CI last 20+ minutes. This brings it back to around 10 minutes. Docker CI should be sufficient testing here

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
