### PR TITLE
Move delivery notifiers to chain worker

### DIFF
--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -117,7 +117,7 @@ where
     /// Handle cross-chain request to confirm that the recipient was updated.
     ConfirmUpdatedRecipient {
         latest_heights: Vec<(Target, BlockHeight)>,
-        callback: oneshot::Sender<Result<BlockHeight, WorkerError>>,
+        callback: oneshot::Sender<Result<(), WorkerError>>,
     },
 
     /// Handle a [`ChainInfoQuery`].

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -28,7 +28,7 @@ use linera_storage::Storage;
 use tokio::sync::{mpsc, oneshot, OwnedRwLockReadGuard};
 use tracing::{instrument, trace, warn};
 
-use super::{config::ChainWorkerConfig, state::ChainWorkerState};
+use super::{config::ChainWorkerConfig, state::ChainWorkerState, DeliveryNotifier};
 use crate::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
     value_cache::ValueCache,
@@ -148,6 +148,7 @@ where
         certificate_value_cache: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
         blob_cache: Arc<ValueCache<BlobId, Blob>>,
         tracked_chains: Option<Arc<RwLock<HashSet<ChainId>>>>,
+        delivery_notifier: DeliveryNotifier,
         chain_id: ChainId,
     ) -> Result<Self, WorkerError> {
         let (service_runtime_thread, service_runtime_endpoint) = {
@@ -165,6 +166,7 @@ where
             certificate_value_cache,
             blob_cache,
             tracked_chains,
+            delivery_notifier,
             chain_id,
             service_runtime_endpoint,
         )

--- a/linera-core/src/chain_worker/delivery_notifier.rs
+++ b/linera-core/src/chain_worker/delivery_notifier.rs
@@ -40,7 +40,7 @@ impl DeliveryNotifier {
     }
 
     /// Registers a delivery `notifier` for a desired [`BlockHeight`].
-    pub fn register(&mut self, height: BlockHeight, notifier: oneshot::Sender<()>) {
+    pub(super) fn register(&mut self, height: BlockHeight, notifier: oneshot::Sender<()>) {
         let mut notifiers = self
             .notifiers
             .lock()
@@ -50,7 +50,7 @@ impl DeliveryNotifier {
     }
 
     /// Notifies that all messages up to `height` have been delivered.
-    pub fn notify(&mut self, height: BlockHeight) {
+    pub(super) fn notify(&mut self, height: BlockHeight) {
         let relevant_notifiers = {
             let mut notifiers = self
                 .notifiers

--- a/linera-core/src/chain_worker/delivery_notifier.rs
+++ b/linera-core/src/chain_worker/delivery_notifier.rs
@@ -1,0 +1,76 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module contains a helper type to notify when cross-chain messages have been
+//! delivered.
+//!
+//! Keeping it in a separate module ensures that only the chain worker is able to call its
+//! methods.
+
+use std::{
+    collections::BTreeMap,
+    mem,
+    sync::{Arc, Mutex},
+};
+
+use linera_base::data_types::BlockHeight;
+use tokio::sync::oneshot;
+use tracing::warn;
+
+/// A set of pending listeners waiting to be notified about the delivery of messages sent
+/// from specific [`BlockHeight`]s.
+///
+/// The notifier instance can be cheaply `clone`d and works as a shared reference.
+/// However, its methods still require `&mut self` to hint that it should only changed by
+/// [`ChainWorkerStateWithAttemptedChanges`][`super::ChainWorkerStateWithAttemptedChanges`].
+#[derive(Clone, Default)]
+pub struct DeliveryNotifier {
+    notifiers: Arc<Mutex<BTreeMap<BlockHeight, Vec<oneshot::Sender<()>>>>>,
+}
+
+impl DeliveryNotifier {
+    /// Returns [`true`] if there are no pending listeners.
+    pub fn is_empty(&self) -> bool {
+        let notifiers = self
+            .notifiers
+            .lock()
+            .expect("Panics should never happen while holding a lock to the `notifiers`");
+
+        notifiers.is_empty()
+    }
+
+    /// Registers a delivery `notifier` for a desired [`BlockHeight`].
+    pub fn register(&mut self, height: BlockHeight, notifier: oneshot::Sender<()>) {
+        let mut notifiers = self
+            .notifiers
+            .lock()
+            .expect("Panics should never happen while holding a lock to the `notifiers`");
+
+        notifiers.entry(height).or_default().push(notifier);
+    }
+
+    /// Notifies that all messages up to `height` have been delivered.
+    pub fn notify(&mut self, height: BlockHeight) {
+        let relevant_notifiers = {
+            let mut notifiers = self
+                .notifiers
+                .lock()
+                .expect("Panics should never happen while holding a lock to the `notifiers`");
+
+            let pending_notifiers = height
+                .try_add_one()
+                .map(|first_still_undelivered_height| {
+                    notifiers.split_off(&first_still_undelivered_height)
+                })
+                .unwrap_or_default();
+
+            mem::replace(&mut *notifiers, pending_notifiers)
+        };
+
+        for notifier in relevant_notifiers.into_values().flatten() {
+            if let Err(()) = notifier.send(()) {
+                warn!("Failed to notify message delivery to caller");
+            }
+        }
+    }
+}

--- a/linera-core/src/chain_worker/delivery_notifier.rs
+++ b/linera-core/src/chain_worker/delivery_notifier.rs
@@ -22,14 +22,14 @@ use tracing::warn;
 ///
 /// The notifier instance can be cheaply `clone`d and works as a shared reference.
 /// However, its methods still require `&mut self` to hint that it should only changed by
-/// [`ChainWorkerStateWithAttemptedChanges`][`super::ChainWorkerStateWithAttemptedChanges`].
+/// [`ChainWorkerStateWithAttemptedChanges`](super::ChainWorkerStateWithAttemptedChanges).
 #[derive(Clone, Default)]
 pub struct DeliveryNotifier {
     notifiers: Arc<Mutex<BTreeMap<BlockHeight, Vec<oneshot::Sender<()>>>>>,
 }
 
 impl DeliveryNotifier {
-    /// Returns [`true`] if there are no pending listeners.
+    /// Returns `true` if there are no pending listeners.
     pub fn is_empty(&self) -> bool {
         let notifiers = self
             .notifiers

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -5,8 +5,10 @@
 
 mod actor;
 mod config;
+mod delivery_notifier;
 mod state;
 
+pub(super) use self::delivery_notifier::DeliveryNotifier;
 #[cfg(test)]
 pub(crate) use self::state::CrossChainUpdateHelper;
 pub use self::{

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -439,7 +439,7 @@ where
     pub(super) async fn confirm_updated_recipient(
         &mut self,
         latest_heights: Vec<(Target, BlockHeight)>,
-    ) -> Result<BlockHeight, WorkerError> {
+    ) -> Result<(), WorkerError> {
         let mut height_with_fully_delivered_messages = BlockHeight::ZERO;
 
         for (target, height) in latest_heights {
@@ -460,7 +460,11 @@ where
 
         self.save().await?;
 
-        Ok(height_with_fully_delivered_messages)
+        self.state
+            .delivery_notifier
+            .notify(height_with_fully_delivered_messages);
+
+        Ok(())
     }
 
     /// Attempts to vote for a leader timeout, if possible.

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -30,7 +30,7 @@ use linera_execution::{
 };
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::{ClonableView, ViewError};
-use tokio::sync::{OwnedRwLockReadGuard, RwLock};
+use tokio::sync::{oneshot, OwnedRwLockReadGuard, RwLock};
 
 #[cfg(test)]
 pub(crate) use self::attempted_changes::CrossChainUpdateHelper;
@@ -242,10 +242,11 @@ where
         &mut self,
         certificate: Certificate,
         blobs: &[Blob],
+        notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         ChainWorkerStateWithAttemptedChanges::new(self)
             .await
-            .process_confirmed_block(certificate, blobs)
+            .process_confirmed_block(certificate, blobs, notify_when_messages_are_delivered)
             .await
     }
 

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -265,7 +265,7 @@ where
     pub(super) async fn confirm_updated_recipient(
         &mut self,
         latest_heights: Vec<(Target, BlockHeight)>,
-    ) -> Result<BlockHeight, WorkerError> {
+    ) -> Result<(), WorkerError> {
         ChainWorkerStateWithAttemptedChanges::new(self)
             .await
             .confirm_updated_recipient(latest_heights)

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -38,7 +38,7 @@ use self::{
     attempted_changes::ChainWorkerStateWithAttemptedChanges,
     temporary_changes::ChainWorkerStateWithTemporaryChanges,
 };
-use super::ChainWorkerConfig;
+use super::{ChainWorkerConfig, DeliveryNotifier};
 use crate::{
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     value_cache::ValueCache,
@@ -58,6 +58,7 @@ where
     recent_hashed_certificate_values: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
     recent_blobs: Arc<ValueCache<BlobId, Blob>>,
     tracked_chains: Option<Arc<sync::RwLock<HashSet<ChainId>>>>,
+    delivery_notifier: DeliveryNotifier,
     knows_chain_is_active: bool,
 }
 
@@ -66,12 +67,14 @@ where
     StorageClient: Storage + Clone + Send + Sync + 'static,
 {
     /// Creates a new [`ChainWorkerState`] using the provided `storage` client.
+    #[allow(clippy::too_many_arguments)]
     pub async fn load(
         config: ChainWorkerConfig,
         storage: StorageClient,
         certificate_value_cache: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
         blob_cache: Arc<ValueCache<BlobId, Blob>>,
         tracked_chains: Option<Arc<sync::RwLock<HashSet<ChainId>>>>,
+        delivery_notifier: DeliveryNotifier,
         chain_id: ChainId,
         service_runtime_endpoint: Option<ServiceRuntimeEndpoint>,
     ) -> Result<Self, WorkerError> {
@@ -86,6 +89,7 @@ where
             recent_hashed_certificate_values: certificate_value_cache,
             recent_blobs: blob_cache,
             tracked_chains,
+            delivery_notifier,
             knows_chain_is_active: false,
         })
     }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -4,7 +4,7 @@
 
 use std::{
     borrow::Cow,
-    collections::{hash_map, HashMap, HashSet, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     num::NonZeroUsize,
     sync::{Arc, Mutex, RwLock},
     time::Duration,
@@ -957,26 +957,13 @@ where
                     .into_iter()
                     .map(|(medium, height)| (Target { recipient, medium }, height))
                     .collect();
-                let height_with_fully_delivered_messages = self
-                    .query_chain_worker(sender, move |callback| {
-                        ChainWorkerRequest::ConfirmUpdatedRecipient {
-                            latest_heights,
-                            callback,
-                        }
-                    })
-                    .await?;
-                // Handle delivery notifiers for this chain, if any.
-                if let hash_map::Entry::Occupied(mut notifier) =
-                    self.delivery_notifiers.lock().unwrap().entry(sender)
-                {
-                    notifier
-                        .get_mut()
-                        .notify(height_with_fully_delivered_messages);
-
-                    if notifier.get().is_empty() {
-                        notifier.remove();
+                self.query_chain_worker(sender, move |callback| {
+                    ChainWorkerRequest::ConfirmUpdatedRecipient {
+                        latest_heights,
+                        callback,
                     }
-                }
+                })
+                .await?;
                 Ok(NetworkActions::default())
             }
         }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -694,15 +694,25 @@ where
         .map_err(|_| WorkerError::FullChainWorkerCache)?;
 
         if let Some(receiver) = new_receiver {
+            let delivery_notifier = self
+                .delivery_notifiers
+                .lock()
+                .unwrap()
+                .entry(chain_id)
+                .or_default()
+                .clone();
+
             let actor = ChainWorkerActor::load(
                 self.chain_worker_config.clone(),
                 self.storage.clone(),
                 self.recent_hashed_certificate_values.clone(),
                 self.recent_blobs.clone(),
                 self.tracked_chains.clone(),
+                delivery_notifier,
                 chain_id,
             )
             .await?;
+
             self.chain_worker_tasks
                 .lock()
                 .unwrap()


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
There was previously a risk of a race condition between registering a new delivery notifier and notifying the registered notifiers. This could lead to notifications being delayed or not being sent.

The race can happen because different `WorkerState` instances could be running and one of them attempts to register the notifier while another notifies that delivery has been made.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Handle the registration and notification inside the chain worker, which runs as an actor in its own task. That means that it isn't possible for the chain worker to race with itself.

To ensure that only the chain worker is able to register and notify, a new `DeliveryNotifier` helper type was created, and its `register` and `notify` methods can only be called by the `ChainWorkerWithAttemptedChanges`.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
CI should catch any regressions caused by this refactor.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->

This fixes a potential bug in the validators, so:

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
