### PR TITLE
Compute which sender chains' message deliveries to wait for.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1160,7 +1160,8 @@ where
         self.client
             .download_certificates(&nodes, block.chain_id, block.height)
             .await?;
-        // Process the received operations. Download required hashed certificate values if necessary.
+        // Process the received operations. Download required hashed certificate values if
+        // necessary.
         if let Err(err) = self.process_certificate(certificate.clone(), vec![]).await {
             match &err {
                 LocalNodeError::WorkerError(WorkerError::BlobsNotFound(blob_ids)) => {
@@ -1228,7 +1229,8 @@ where
                 // In that case, move to the next chain batch.
                 continue;
             };
-            let batch_size = block_batch.last().unwrap().saturating_sub(*first_block).0 + 1; // safe to unwrap because we checked that the vec is not empty.
+            // Safe to unwrap because we checked that the vec is not empty:
+            let batch_size = block_batch.last().unwrap().saturating_sub(*first_block).0 + 1;
             let block_batch_range = BlockHeightRange::multi(*first_block, batch_size);
             let query = ChainInfoQuery::new(chain_id)
                 .with_sent_certificate_hashes_in_range(block_batch_range.clone());
@@ -1259,8 +1261,13 @@ where
                     .await?
                 {
                     HandleCertificateResult::FutureEpoch => {
-                        warn!("Postponing received certificate from {:.8} at height {} from future epoch {}",
-                              chain_id, certificate.value().height(), certificate.value().epoch());
+                        warn!(
+                            "Postponing received certificate from {:.8} at height {} \
+                            from future epoch {}",
+                            chain_id,
+                            certificate.value().height(),
+                            certificate.value().epoch()
+                        );
                         // Stop the synchronization here. Do not increment the tracker further so
                         // that this certificate can still be downloaded later, once our committee
                         // is updated.
@@ -1287,7 +1294,8 @@ where
         Ok((remote_node.name, new_tracker, certificates))
     }
 
-    /// Uses local information (about already-processed blocks) to advance the `block_batch` to a place where only new blocks are left.
+    /// Uses local information (about already-processed blocks) to advance the `block_batch` to a
+    /// place where only new blocks are left.
     async fn advance_with_local(
         &self,
         chain_id: ChainId,
@@ -1305,8 +1313,8 @@ where
         // Find the first block in the batch that is higher than the highest block known locally.
         match block_batch.iter().position(|b| b >= &local_next) {
             None => {
-                // Our highest, locally-known block is higher than any block height from the current batch.
-                // Move to the next chain batch.
+                // Our highest, locally-known block is higher than any block height from the
+                // current batch. Move to the next chain batch.
                 block_batch.clear();
             }
             Some(index) => {

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -297,7 +297,7 @@ where
             let hash = certificate.hash();
             if !certificate.value().is_confirmed() || certificate.value().chain_id() != chain_id {
                 // The certificate is not as expected. Give up.
-                tracing::warn!("Failed to process network certificate {}", hash);
+                warn!("Failed to process network certificate {}", hash);
                 return info;
             }
             let mut result = self
@@ -324,13 +324,29 @@ where
                 Ok(response) => info = Some(response.info),
                 Err(error) => {
                     // The certificate is not as expected. Give up.
-                    tracing::warn!("Failed to process network certificate {}: {}", hash, error);
+                    warn!("Failed to process network certificate {}: {}", hash, error);
                     return info;
                 }
             };
         }
         // Done with all certificates.
         info
+    }
+
+    /// Returns only after the outbox of the given chain does not contain any entries up to
+    /// `height` anymore.
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub async fn wait_for_outgoing_messages(
+        &self,
+        chain_id: ChainId,
+        height: BlockHeight,
+    ) -> Result<(), LocalNodeError> {
+        // TODO(#2692): Implement this, once #2689 is merged.
+        warn!(
+            "Not waiting for outgoing messages from {chain_id:.8} up to height {height}: \
+            not implemented yet."
+        );
+        Ok(())
     }
 
     /// Returns a read-only view of the [`ChainStateView`] of a chain referenced by its


### PR DESCRIPTION
## Motivation

Due to #2692, it is not guaranteed (although very likely) that `process_inbox` will process a message even if a quorum of validators have it.

Fully fixing this will require #2689 to be merged first.

## Proposal

Prepare for the fix by computing the sender chains that we need to wait for after synchronizing received certificates from validators.

## Test Plan

This doesn't fully fix the issue yet. Once #2692 is fixed, we should be able to remove two of the `client_mutex` locked without making the tests flaky again.

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK.

## Links

- Part of #2692.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
