### PR TITLE
Ensure received certificates' messages are delivered.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1394,6 +1394,9 @@ where
             }
         }
         for chain_id in other_sender_chains {
+            // Certificates for this chain were omitted from `certificates` because they were
+            // already processed locally. If they were processed in a concurrent task, it is not
+            // guaranteed that their cross-chain messages were already handled.
             if let Err(error) = self
                 .client
                 .local_node

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -955,9 +955,6 @@ where
             );
         }
         if self.state().has_other_owners(&info.manager.ownership) {
-            let mutex = self.state().client_mutex();
-            let _guard = mutex.lock_owned().await;
-
             // For chains with any owner other than ourselves, we could be missing recent
             // certificates created by other owners. Further synchronize blocks from the network.
             // This is a best-effort that depends on network conditions.
@@ -1403,7 +1400,7 @@ where
                 .retry_pending_cross_chain_requests(chain_id)
                 .await
             {
-                error!("Failed trying to wait for outgoing messages from {chain_id}: {error}");
+                error!("Failed to retry outgoing messages from {chain_id}: {error}");
             }
         }
         // Update tracker.
@@ -3233,16 +3230,11 @@ where
         &self,
         remote_node: RemoteNode<P::Node>,
     ) -> Result<(), ChainClientError> {
-        let mutex = self.state().client_mutex();
-        let _guard = mutex.lock_owned().await;
-
         let chain_id = self.chain_id;
         // Proceed to downloading received certificates.
         let received_certificates = self
             .synchronize_received_certificates_from_validator(chain_id, &remote_node)
             .await?;
-
-        drop(_guard);
         // Process received certificates. If the client state has changed during the
         // network calls, we should still be fine.
         self.receive_certificates_from_validator(received_certificates)

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -333,22 +333,6 @@ where
         info
     }
 
-    /// Returns only after the outbox of the given chain does not contain any entries up to
-    /// `height` anymore.
-    #[tracing::instrument(level = "trace", skip_all)]
-    pub async fn wait_for_outgoing_messages(
-        &self,
-        chain_id: ChainId,
-        height: BlockHeight,
-    ) -> Result<(), LocalNodeError> {
-        // TODO(#2692): Implement this, once #2689 is merged.
-        warn!(
-            "Not waiting for outgoing messages from {chain_id:.8} up to height {height}: \
-            not implemented yet."
-        );
-        Ok(())
-    }
-
     /// Returns a read-only view of the [`ChainStateView`] of a chain referenced by its
     /// [`ChainId`].
     ///


### PR DESCRIPTION
## Motivation

Due to https://github.com/linera-io/linera-protocol/issues/2692 `process_inbox` can in some cases return without processing a message, even though a quorum of validators already had the sending certificate.

The client mutex fixed this in most cases, but causes unnecessary contention.

## Proposal

Ensure that the messages are delivered using `retry_pending_cross_chain_requests`.

## Test Plan

The tests should not be flaky anymore despite the removal of the two client locks.

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK.

## Links

- closes #2692 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
