### PR TITLE
Cache solc on CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,16 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - uses: foundry-rs/foundry-toolchain@v1.2.0
-    - uses: pontem-network/get-solc@master
+    - name: Cache solc
+      id: cache-solc
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/.solc
+        key: solc-v0.8.25
+        restore-keys: solc-
+    - name: Get Solc
+      if: ${{ steps.cache-solc.outputs.cache-hit != 'true' }}
+      uses: pontem-network/get-solc@master
       with:
         version: v0.8.25
     - name: Clear up some space


### PR DESCRIPTION
## Motivation

This step sometimes fails with API rate limit exceeded, but we don't actually need to run this from scratch everytime. Example failure: https://github.com/linera-io/linera-protocol/runs/31950311713

## Proposal

Cache this step

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
