### PR TITLE
Return WARN if blob_last_used_by returns an Err in validators

### DIFF
--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -51,7 +51,7 @@ use tonic::{
     Request, Response, Status,
 };
 use tower::{builder::ServiceBuilder, Layer, Service};
-use tracing::{debug, info, instrument, Instrument as _};
+use tracing::{debug, info, instrument, Instrument as _, Level};
 #[cfg(with_metrics)]
 use {
     linera_base::prometheus_util,
@@ -512,7 +512,7 @@ where
         )?))
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(skip_all, err(level = Level::WARN))]
     async fn blob_last_used_by(
         &self,
         request: Request<BlobId>,


### PR DESCRIPTION
## Motivation

Currently if a call to `blob_last_used_by` returns an `Err`, we'll print a `ERROR` level log. That is not very accurate because validators could still be not fully in sync and some of them could be missing some blobs.

## Proposal

Change log level to `WARN`

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
