### PR TITLE
`linera-rpc`: manually configure TLS for the client as required by Tonic ≥ 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6111,7 +6111,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -7576,6 +7576,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
@@ -8615,6 +8616,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -77,7 +77,7 @@ serde-reflection.workspace = true
 test-strategy.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tonic = { workspace = true, features = ["tls", "prost", "codegen", "transport"] }
+tonic = { workspace = true, features = ["tls", "tls-webpki-roots", "prost", "codegen", "transport"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tonic = { workspace = true, features = ["codegen", "prost"] }

--- a/linera-rpc/src/grpc/transport.rs
+++ b/linera-rpc/src/grpc/transport.rs
@@ -34,7 +34,7 @@ cfg_if::cfg_if! {
             options: &Options,
         ) -> Result<Channel, Error> {
             let mut endpoint = tonic::transport::Endpoint::from_shared(address)?
-                .tls_config(Default::default())?;
+                .tls_config(tonic::transport::channel::ClientTlsConfig::default().with_webpki_roots())?;
 
             if let Some(timeout) = options.connect_timeout {
                 endpoint = endpoint.connect_timeout(timeout);

--- a/linera-rpc/src/grpc/transport.rs
+++ b/linera-rpc/src/grpc/transport.rs
@@ -33,7 +33,9 @@ cfg_if::cfg_if! {
             address: String,
             options: &Options,
         ) -> Result<Channel, Error> {
-            let mut endpoint = tonic::transport::Endpoint::from_shared(address)?;
+            let mut endpoint = tonic::transport::Endpoint::from_shared(address)?
+                .tls_config(Default::default())?;
+
             if let Some(timeout) = options.connect_timeout {
                 endpoint = endpoint.connect_timeout(timeout);
             }


### PR DESCRIPTION
## Motivation

TLS is broken for our client because we bumped Tonic, and Tonic 0.12 disables automatic TLS configuration when you use the `tls-roots` feature.

<!--
Briefly describe the goal(s) of this PR.
-->

## Proposal

Enable TLS in `linera-rpc` when connecting, adding CA roots from `webpki-roots`.

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
