### PR TITLE
Use scylla production mode but disable it in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,7 @@ on:
       - 'docker/Dockerfile'
       - 'docker/docker-compose.yml'
       - 'docker/compose.sh'
+      - 'docker/docker-compose.yml'
       - 'Cargo.toml'
       - '.github/workflows/docker.yml'
   workflow_dispatch:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: gcp-large
     timeout-minutes: 60
 
     steps:
@@ -49,6 +49,8 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update aio-max-nr
+        run: echo 1048576 > /proc/sys/fs/aio-max-nr
       - name: Build client binary
         run: |
           cargo install --path linera-service --bin linera --bin linera-server --debug

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,6 +56,8 @@ jobs:
         run: |
           cd docker
           ./compose.sh
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - name: Sync
         uses: nick-fields/retry@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,6 +54,10 @@ jobs:
       - name: Build client binary
         run: |
           cargo install --path linera-service --bin linera --bin linera-server --debug
+      - name: Patch Docker compose file to run ScyllaDB in developer mode
+        run: |
+          sed -i -e '/SCYLLA_AUTO_CONF/{N;s/command:/  SCYLLA_ENABLE_EXPERIMENTAL: 1/p;N;N;N;N;d}' \
+            docker/docker-compose.yml
       - name: Run Compose
         run: |
           cd docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,8 +62,8 @@ jobs:
         run: |
           cd docker
           ./compose.sh
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+      # - name: Setup upterm session
+        # uses: lhotari/action-upterm@v1
       - name: Sync
         uses: nick-fields/retry@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,11 +49,13 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      # TODO(#2709): Uncomment once this workflow runs in a custom runner
       # - name: Update aio-max-nr
         # run: echo 1048576 > /proc/sys/fs/aio-max-nr
       - name: Build client binary
         run: |
           cargo install --path linera-service --bin linera --bin linera-server --debug
+      # TODO(#2709): Remove this step once this workflow runs in a custom runner
       - name: Patch Docker compose file to run ScyllaDB in developer mode
         run: |
           sed -i -e '/SCYLLA_AUTO_CONF/{N;s/command:/  SCYLLA_ENABLE_EXPERIMENTAL: 1/p;N;N;N;N;d}' \
@@ -62,6 +64,7 @@ jobs:
         run: |
           cd docker
           ./compose.sh
+      # TODO(#2709): Uncomment once this workflow runs in a custom runner
       # - name: Setup upterm session
         # uses: lhotari/action-upterm@v1
       - name: Sync

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: gcp-large
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,8 +49,8 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Update aio-max-nr
-        run: echo 1048576 > /proc/sys/fs/aio-max-nr
+      # - name: Update aio-max-nr
+        # run: echo 1048576 > /proc/sys/fs/aio-max-nr
       - name: Build client binary
         run: |
           cargo install --path linera-service --bin linera --bin linera-server --debug

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,11 @@ services:
       - linera-scylla-data:/var/lib/scylla
     environment:
       SCYLLA_AUTO_CONF: 1
-      SCYLLA_ENABLE_EXPERIMENTAL: 1
+    command:
+      - "--developer-mode"
+      - "0"
+      - "--overprovisioned"
+      - "1"
   proxy:
     image: linera
     container_name: proxy


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
PR #2603 is failing in CI because our custom runners isn't fully operational.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Tweak the CI workflow to not run in our custom runner.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
CI should pass after this change.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.
- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- Backporting is not possible but we may want to deploy a new `devnet` and release a new
      SDK soon.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
