### PR TITLE
Backport some of the PRs from `main`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,8 +51,6 @@ jobs:
       - name: Build client binary
         run: |
           cargo install --path linera-service --bin linera --bin linera-server --debug
-      - name: Build Docker image
-        run: docker build . -f docker/Dockerfile -t linera
       - name: Run Compose
         run: |
           cd docker
@@ -61,6 +59,7 @@ jobs:
         uses: nick-fields/retry@v2
         with:
           # Docker compose can take some time to start
-          max_attempts: 5
+          max_attempts: 10
           timeout_minutes: 2
-          command: sleep 60 && linera --wallet docker/wallet.json --storage rocksdb:docker/linera.db sync-balance
+          retry_wait_seconds: 10
+          command: linera --wallet docker/wallet.json --storage rocksdb:docker/linera.db sync-balance

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,16 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - uses: foundry-rs/foundry-toolchain@v1.2.0
-    - uses: pontem-network/get-solc@master
+    - name: Cache solc
+      id: cache-solc
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/.solc
+        key: solc-v0.8.25
+        restore-keys: solc-
+    - name: Get Solc
+      if: ${{ steps.cache-solc.outputs.cache-hit != 'true' }}
+      uses: pontem-network/get-solc@master
       with:
         version: v0.8.25
     - name: Clear up some space

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -25,7 +25,9 @@ cleanup() {
     docker volume rm $SHARED_VOLUME
 }
 
-if [ "${DOCKER_COMPOSE_WAIT:-false}" = "false" ]; then
+if [ "${DOCKER_COMPOSE_WAIT:-false}" = "true" ]; then
+    trap cleanup INT
+else
     trap cleanup EXIT INT
 fi
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -433,6 +433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "auto_impl"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +454,53 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "axum"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 1.0.1",
+ "tower 0.5.1",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.1",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -1776,6 +1829,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2236,6 +2295,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.5.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,7 +2503,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2448,9 +2526,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2470,6 +2550,19 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2925,7 +3018,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "url",
 ]
@@ -3101,7 +3194,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "url",
  "wasm-bindgen-futures",
 ]
@@ -3116,7 +3209,7 @@ dependencies = [
  "linera-alloy-transport",
  "reqwest 0.12.7",
  "serde_json",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "url",
 ]
@@ -3195,6 +3288,7 @@ dependencies = [
  "linera-chain",
  "linera-execution",
  "linera-storage",
+ "linera-storage-service",
  "linera-version",
  "linera-views",
  "lru",
@@ -3325,6 +3419,28 @@ dependencies = [
  "linera-views",
  "prometheus",
  "serde",
+]
+
+[[package]]
+name = "linera-storage-service"
+version = "0.13.0"
+dependencies = [
+ "anyhow",
+ "async-lock",
+ "bcs",
+ "cfg_aliases",
+ "clap",
+ "linera-base",
+ "linera-version",
+ "linera-views",
+ "prost",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-build",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3641,6 +3757,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3791,6 +3913,12 @@ dependencies = [
  "spin",
  "version_check",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "native-fungible"
@@ -4057,6 +4185,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.5.0",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4132,6 +4270,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4262,6 +4410,59 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
+dependencies = [
+ "bytes",
+ "heck 0.4.1",
+ "itertools 0.10.5",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.77",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -4540,7 +4741,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
@@ -5640,17 +5841,42 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
  "base64 0.22.1",
  "bytes",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
+ "hyper 1.4.1",
+ "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
+ "prost",
+ "socket2",
+ "tokio",
  "tokio-stream",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5661,11 +5887,30 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -56,6 +56,7 @@ use {
         data_types::{BlobBytes, Bytecode},
         identifiers::BytecodeId,
     },
+    linera_core::client::create_bytecode_blobs,
     std::{fs, path::PathBuf},
 };
 
@@ -411,23 +412,24 @@ where
         service: PathBuf,
     ) -> Result<BytecodeId, Error> {
         info!("Loading bytecode files");
-        let contract_bytecode: Bytecode = Bytecode::load_from_file(&contract)
+        let contract_bytecode = Bytecode::load_from_file(&contract)
             .await
             .with_context(|| format!("failed to load contract bytecode from {:?}", &contract))?;
-        let service_bytecode = Bytecode::load_from_file(&service).await.context(format!(
-            "failed to load service bytecode from {:?}",
-            &service
-        ))?;
+        let service_bytecode = Bytecode::load_from_file(&service)
+            .await
+            .with_context(|| format!("failed to load service bytecode from {:?}", &service))?;
 
         info!("Publishing bytecode");
+        let (contract_blob, service_blob, bytecode_id) =
+            create_bytecode_blobs(contract_bytecode, service_bytecode).await;
         let (bytecode_id, _) = self
             .apply_client_command(chain_client, |chain_client| {
-                let contract_bytecode = contract_bytecode.clone();
-                let service_bytecode = service_bytecode.clone();
+                let contract_blob = contract_blob.clone();
+                let service_blob = service_blob.clone();
                 let chain_client = chain_client.clone();
                 async move {
                     chain_client
-                        .publish_bytecode(contract_bytecode, service_bytecode)
+                        .publish_bytecode_blobs(contract_blob, service_blob, bytecode_id)
                         .await
                         .context("Failed to publish bytecode")
                 }

--- a/linera-client/src/util.rs
+++ b/linera-client/src/util.rs
@@ -66,38 +66,3 @@ macro_rules! impl_from_infallible {
 
 pub(crate) use impl_from_dynamic;
 pub(crate) use impl_from_infallible;
-
-pub mod serde_btreemap_keys_as_strings {
-    use std::{collections::BTreeMap, fmt::Display, str::FromStr};
-
-    use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
-
-    pub fn serialize<K, V, S>(map: &BTreeMap<K, V>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        K: Display,
-        V: Serialize,
-        S: Serializer,
-    {
-        let string_map: BTreeMap<String, &V> =
-            map.iter().map(|(k, v)| (k.to_string(), v)).collect();
-        string_map.serialize(serializer)
-    }
-
-    pub fn deserialize<'de, K, V, D>(deserializer: D) -> Result<BTreeMap<K, V>, D::Error>
-    where
-        K: FromStr + Ord,
-        <K as FromStr>::Err: Display,
-        V: Deserialize<'de>,
-        D: Deserializer<'de>,
-    {
-        let string_map: BTreeMap<String, V> = BTreeMap::deserialize(deserializer)?;
-        string_map
-            .into_iter()
-            .map(|(k, v)| {
-                k.parse()
-                    .map(|key| (key, v))
-                    .map_err(serde::de::Error::custom)
-            })
-            .collect()
-    }
-}

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -18,7 +18,7 @@ use linera_storage::Storage;
 use rand::Rng as _;
 use serde::{Deserialize, Serialize};
 
-use crate::{config::GenesisConfig, error, util::serde_btreemap_keys_as_strings, Error};
+use crate::{config::GenesisConfig, error, Error};
 
 #[derive(Serialize, Deserialize)]
 pub struct Wallet {
@@ -210,7 +210,6 @@ pub struct UserChain {
     pub timestamp: Timestamp,
     pub next_block_height: BlockHeight,
     pub pending_block: Option<Block>,
-    #[serde(with = "serde_btreemap_keys_as_strings")]
     pub pending_blobs: BTreeMap<BlobId, Blob>,
 }
 

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -20,6 +20,7 @@ test = [
     "linera-chain/test",
     "linera-execution/test",
     "linera-storage/test",
+    "linera-storage-service/test",
     "linera-views/test",
     "proptest",
     "test-log",

--- a/linera-core/src/chain_worker/delivery_notifier.rs
+++ b/linera-core/src/chain_worker/delivery_notifier.rs
@@ -1,0 +1,76 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module contains a helper type to notify when cross-chain messages have been
+//! delivered.
+//!
+//! Keeping it in a separate module ensures that only the chain worker is able to call its
+//! methods.
+
+use std::{
+    collections::BTreeMap,
+    mem,
+    sync::{Arc, Mutex},
+};
+
+use linera_base::data_types::BlockHeight;
+use tokio::sync::oneshot;
+use tracing::warn;
+
+/// A set of pending listeners waiting to be notified about the delivery of messages sent
+/// from specific [`BlockHeight`]s.
+///
+/// The notifier instance can be cheaply `clone`d and works as a shared reference.
+/// However, its methods still require `&mut self` to hint that it should only changed by
+/// [`ChainWorkerStateWithAttemptedChanges`](super::ChainWorkerStateWithAttemptedChanges).
+#[derive(Clone, Default)]
+pub struct DeliveryNotifier {
+    notifiers: Arc<Mutex<BTreeMap<BlockHeight, Vec<oneshot::Sender<()>>>>>,
+}
+
+impl DeliveryNotifier {
+    /// Returns `true` if there are no pending listeners.
+    pub fn is_empty(&self) -> bool {
+        let notifiers = self
+            .notifiers
+            .lock()
+            .expect("Panics should never happen while holding a lock to the `notifiers`");
+
+        notifiers.is_empty()
+    }
+
+    /// Registers a delivery `notifier` for a desired [`BlockHeight`].
+    pub(super) fn register(&mut self, height: BlockHeight, notifier: oneshot::Sender<()>) {
+        let mut notifiers = self
+            .notifiers
+            .lock()
+            .expect("Panics should never happen while holding a lock to the `notifiers`");
+
+        notifiers.entry(height).or_default().push(notifier);
+    }
+
+    /// Notifies that all messages up to `height` have been delivered.
+    pub(super) fn notify(&mut self, height: BlockHeight) {
+        let relevant_notifiers = {
+            let mut notifiers = self
+                .notifiers
+                .lock()
+                .expect("Panics should never happen while holding a lock to the `notifiers`");
+
+            let pending_notifiers = height
+                .try_add_one()
+                .map(|first_still_undelivered_height| {
+                    notifiers.split_off(&first_still_undelivered_height)
+                })
+                .unwrap_or_default();
+
+            mem::replace(&mut *notifiers, pending_notifiers)
+        };
+
+        for notifier in relevant_notifiers.into_values().flatten() {
+            if let Err(()) = notifier.send(()) {
+                warn!("Failed to notify message delivery to caller");
+            }
+        }
+    }
+}

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -5,8 +5,10 @@
 
 mod actor;
 mod config;
+mod delivery_notifier;
 mod state;
 
+pub(super) use self::delivery_notifier::DeliveryNotifier;
 #[cfg(test)]
 pub(crate) use self::state::CrossChainUpdateHelper;
 pub use self::{

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -27,6 +27,7 @@ use linera_views::{
     context::Context,
     views::{RootView, View},
 };
+use tokio::sync::oneshot;
 use tracing::{debug, warn};
 
 use super::{check_block_epoch, ChainWorkerConfig, ChainWorkerState};
@@ -231,19 +232,21 @@ where
         &mut self,
         certificate: Certificate,
         blobs: &[Blob],
+        notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         let CertificateValue::ConfirmedBlock { executed_block, .. } = certificate.value() else {
             panic!("Expecting a confirmation certificate");
         };
         let block = &executed_block.block;
+        let block_height = block.height;
         // Check that the chain is active and ready for this confirmation.
         let tip = self.state.chain.tip_state.get().clone();
-        if tip.next_block_height < block.height {
+        if tip.next_block_height < block_height {
             return Err(WorkerError::MissingEarlierBlocks {
                 current_block_height: tip.next_block_height,
             });
         }
-        if tip.next_block_height > block.height {
+        if tip.next_block_height > block_height {
             // Block was already confirmed.
             let info = ChainInfoResponse::new(&self.state.chain, self.state.config.key_pair());
             let actions = self.state.create_network_actions().await?;
@@ -348,24 +351,54 @@ where
         let mut actions = self.state.create_network_actions().await?;
         tracing::trace!(
             "Processed confirmed block {} on chain {:.8}",
-            block.height,
+            block_height,
             block.chain_id
         );
         actions.notifications.push(Notification {
             chain_id: block.chain_id,
             reason: Reason::NewBlock {
-                height: block.height,
+                height: block_height,
                 hash: certificate.value.hash(),
             },
         });
         // Persist chain.
         self.save().await?;
+
         self.state
             .recent_hashed_certificate_values
             .insert(Cow::Owned(certificate.value))
             .await;
 
+        self.register_delivery_notifier(block_height, &actions, notify_when_messages_are_delivered)
+            .await;
+
         Ok((info, actions))
+    }
+
+    /// Schedules a notification for when cross-chain messages are delivered up to the given
+    /// `height`.
+    #[tracing::instrument(level = "trace", skip(self, notify_when_messages_are_delivered))]
+    async fn register_delivery_notifier(
+        &mut self,
+        height: BlockHeight,
+        actions: &NetworkActions,
+        notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
+    ) {
+        if let Some(notifier) = notify_when_messages_are_delivered {
+            if actions
+                .cross_chain_requests
+                .iter()
+                .any(|request| request.has_messages_lower_or_equal_than(height))
+            {
+                self.state.delivery_notifier.register(height, notifier);
+            } else {
+                // No need to wait. Also, cross-chain requests may not trigger the
+                // notifier later, even if we register it.
+                if let Err(()) = notifier.send(()) {
+                    warn!("Failed to notify message delivery to caller");
+                }
+            }
+        }
     }
 
     /// Updates the chain's inboxes, receiving messages from a cross-chain update.
@@ -439,7 +472,7 @@ where
     pub(super) async fn confirm_updated_recipient(
         &mut self,
         latest_heights: Vec<(Target, BlockHeight)>,
-    ) -> Result<BlockHeight, WorkerError> {
+    ) -> Result<(), WorkerError> {
         let mut height_with_fully_delivered_messages = BlockHeight::ZERO;
 
         for (target, height) in latest_heights {
@@ -460,7 +493,11 @@ where
 
         self.save().await?;
 
-        Ok(height_with_fully_delivered_messages)
+        self.state
+            .delivery_notifier
+            .notify(height_with_fully_delivered_messages);
+
+        Ok(())
     }
 
     /// Attempts to vote for a leader timeout, if possible.

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -341,7 +341,7 @@ where
             .into_iter()
             .filter(|blob_id| !pending_blobs.contains_key(blob_id))
             .collect::<Vec<_>>();
-        Ok(self.storage.missing_blobs(blob_ids.clone()).await?)
+        Ok(self.storage.missing_blobs(blob_ids).await?)
     }
 
     /// Returns the blobs requested by their `blob_ids` that are either in pending in the
@@ -399,7 +399,7 @@ where
 
     /// Loads pending cross-chain requests.
     async fn create_network_actions(&self) -> Result<NetworkActions, WorkerError> {
-        let mut heights_by_recipient: BTreeMap<_, BTreeMap<_, _>> = Default::default();
+        let mut heights_by_recipient = BTreeMap::<_, BTreeMap<_, _>>::new();
         let mut targets = self.chain.outboxes.indices().await?;
         if let Some(tracked_chains) = self.tracked_chains.as_ref() {
             let tracked_chains = tracked_chains
@@ -494,7 +494,7 @@ where
             targets.retain(|target| tracked_chains.contains(&target.recipient));
         }
         let outboxes = self.chain.outboxes.try_load_entries(&targets).await?;
-        for (_, outbox) in targets.into_iter().zip(outboxes) {
+        for outbox in outboxes {
             let outbox = outbox.expect("Only existing outboxes should be referenced by `indices`");
             let front = outbox.queue.front().await?;
             if front.is_some_and(|key| key <= height) {

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -30,7 +30,7 @@ use linera_execution::{
 };
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::{ClonableView, ViewError};
-use tokio::sync::{OwnedRwLockReadGuard, RwLock};
+use tokio::sync::{oneshot, OwnedRwLockReadGuard, RwLock};
 
 #[cfg(test)]
 pub(crate) use self::attempted_changes::CrossChainUpdateHelper;
@@ -38,7 +38,7 @@ use self::{
     attempted_changes::ChainWorkerStateWithAttemptedChanges,
     temporary_changes::ChainWorkerStateWithTemporaryChanges,
 };
-use super::ChainWorkerConfig;
+use super::{ChainWorkerConfig, DeliveryNotifier};
 use crate::{
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     value_cache::ValueCache,
@@ -58,6 +58,7 @@ where
     recent_hashed_certificate_values: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
     recent_blobs: Arc<ValueCache<BlobId, Blob>>,
     tracked_chains: Option<Arc<sync::RwLock<HashSet<ChainId>>>>,
+    delivery_notifier: DeliveryNotifier,
     knows_chain_is_active: bool,
 }
 
@@ -66,12 +67,14 @@ where
     StorageClient: Storage + Clone + Send + Sync + 'static,
 {
     /// Creates a new [`ChainWorkerState`] using the provided `storage` client.
+    #[allow(clippy::too_many_arguments)]
     pub async fn load(
         config: ChainWorkerConfig,
         storage: StorageClient,
         certificate_value_cache: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
         blob_cache: Arc<ValueCache<BlobId, Blob>>,
         tracked_chains: Option<Arc<sync::RwLock<HashSet<ChainId>>>>,
+        delivery_notifier: DeliveryNotifier,
         chain_id: ChainId,
         service_runtime_endpoint: Option<ServiceRuntimeEndpoint>,
     ) -> Result<Self, WorkerError> {
@@ -86,6 +89,7 @@ where
             recent_hashed_certificate_values: certificate_value_cache,
             recent_blobs: blob_cache,
             tracked_chains,
+            delivery_notifier,
             knows_chain_is_active: false,
         })
     }
@@ -238,10 +242,11 @@ where
         &mut self,
         certificate: Certificate,
         blobs: &[Blob],
+        notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         ChainWorkerStateWithAttemptedChanges::new(self)
             .await
-            .process_confirmed_block(certificate, blobs)
+            .process_confirmed_block(certificate, blobs, notify_when_messages_are_delivered)
             .await
     }
 
@@ -261,7 +266,7 @@ where
     pub(super) async fn confirm_updated_recipient(
         &mut self,
         latest_heights: Vec<(Target, BlockHeight)>,
-    ) -> Result<BlockHeight, WorkerError> {
+    ) -> Result<(), WorkerError> {
         ChainWorkerStateWithAttemptedChanges::new(self)
             .await
             .confirm_updated_recipient(latest_heights)

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -416,11 +416,61 @@ where
                 .or_default()
                 .insert(target.medium, heights);
         }
+        self.create_cross_chain_requests(heights_by_recipient).await
+    }
+
+    async fn create_cross_chain_requests(
+        &self,
+        heights_by_recipient: BTreeMap<ChainId, BTreeMap<Medium, Vec<BlockHeight>>>,
+    ) -> Result<NetworkActions, WorkerError> {
+        // Load all the certificates we will need, regardless of the medium.
+        let heights = BTreeSet::from_iter(
+            heights_by_recipient
+                .iter()
+                .flat_map(|(_, height_map)| height_map.iter().flat_map(|(_, vec)| vec).copied()),
+        );
+        let heights_usize = heights
+            .iter()
+            .copied()
+            .map(usize::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        let hashes = self
+            .chain
+            .confirmed_log
+            .multi_get(heights_usize.clone())
+            .await?
+            .into_iter()
+            .zip(heights_usize)
+            .map(|(maybe_hash, height)| {
+                maybe_hash.ok_or_else(|| ViewError::not_found("confirmed log entry", height))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let certificates = self.storage.read_certificates(hashes).await?;
+        let certificates = heights
+            .into_iter()
+            .zip(certificates)
+            .collect::<HashMap<_, _>>();
+        // For each medium, select the relevant messages.
         let mut actions = NetworkActions::default();
         for (recipient, height_map) in heights_by_recipient {
-            let request = self
-                .create_cross_chain_request(height_map.into_iter().collect(), recipient)
-                .await?;
+            let mut bundle_vecs = Vec::new();
+            for (medium, heights) in height_map {
+                let mut bundles = Vec::new();
+                for height in heights {
+                    let cert = certificates.get(&height).ok_or_else(|| {
+                        ChainError::InternalError("missing certificates".to_string())
+                    })?;
+                    bundles.extend(cert.message_bundles_for(&medium, recipient));
+                }
+                if !bundles.is_empty() {
+                    bundle_vecs.push((medium, bundles));
+                }
+            }
+            let request = CrossChainRequest::UpdateRecipient {
+                sender: self.chain.chain_id(),
+                recipient,
+                bundle_vecs,
+            };
             actions.cross_chain_requests.push(request);
         }
         Ok(actions)
@@ -452,58 +502,6 @@ where
             }
         }
         Ok(true)
-    }
-
-    /// Creates an `UpdateRecipient` request that informs the `recipient` about new
-    /// cross-chain messages from this chain.
-    async fn create_cross_chain_request(
-        &self,
-        height_map: Vec<(Medium, Vec<BlockHeight>)>,
-        recipient: ChainId,
-    ) -> Result<CrossChainRequest, WorkerError> {
-        // Load all the certificates we will need, regardless of the medium.
-        let heights =
-            BTreeSet::from_iter(height_map.iter().flat_map(|(_, heights)| heights).copied());
-        let heights_usize = heights
-            .iter()
-            .copied()
-            .map(usize::try_from)
-            .collect::<Result<Vec<_>, _>>()?;
-        let hashes = self
-            .chain
-            .confirmed_log
-            .multi_get(heights_usize.clone())
-            .await?
-            .into_iter()
-            .zip(heights_usize)
-            .map(|(maybe_hash, height)| {
-                maybe_hash.ok_or_else(|| ViewError::not_found("confirmed log entry", height))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        let certificates = self.storage.read_certificates(hashes).await?;
-        let certificates = heights
-            .into_iter()
-            .zip(certificates)
-            .collect::<HashMap<_, _>>();
-        // For each medium, select the relevant messages.
-        let mut bundle_vecs = Vec::new();
-        for (medium, heights) in height_map {
-            let mut bundles = Vec::new();
-            for height in heights {
-                let cert = certificates
-                    .get(&height)
-                    .ok_or_else(|| ChainError::InternalError("missing certificates".to_string()))?;
-                bundles.extend(cert.message_bundles_for(&medium, recipient));
-            }
-            if !bundles.is_empty() {
-                bundle_vecs.push((medium, bundles));
-            }
-        }
-        Ok(CrossChainRequest::UpdateRecipient {
-            sender: self.chain.chain_id(),
-            recipient,
-            bundle_vecs,
-        })
     }
 }
 

--- a/linera-core/src/client/chain_state.rs
+++ b/linera-core/src/client/chain_state.rs
@@ -10,7 +10,8 @@ use std::{
 use linera_base::{
     crypto::{CryptoHash, KeyPair, PublicKey},
     data_types::{Blob, BlockHeight, Timestamp},
-    identifiers::{BlobId, ChainId, Owner},
+    identifiers::{BlobId, Owner},
+    ownership::ChainOwnership,
 };
 use linera_chain::data_types::Block;
 use linera_execution::committee::ValidatorName;
@@ -34,8 +35,6 @@ pub struct ChainState {
     pending_block: Option<Block>,
     /// Known key pairs from present and past identities.
     known_key_pairs: BTreeMap<Owner, KeyPair>,
-    /// The ID of the admin chain.
-    admin_id: ChainId,
 
     /// For each validator, up to which index we have synchronized their
     /// [`ChainStateView::received_log`].
@@ -52,7 +51,6 @@ pub struct ChainState {
 impl ChainState {
     pub fn new(
         known_key_pairs: Vec<KeyPair>,
-        admin_id: ChainId,
         block_hash: Option<CryptoHash>,
         timestamp: Timestamp,
         next_block_height: BlockHeight,
@@ -65,7 +63,6 @@ impl ChainState {
             .collect();
         let mut state = ChainState {
             known_key_pairs,
-            admin_id,
             block_hash,
             timestamp,
             next_block_height,
@@ -90,10 +87,6 @@ impl ChainState {
 
     pub fn next_block_height(&self) -> BlockHeight {
         self.next_block_height
-    }
-
-    pub fn admin_id(&self) -> ChainId {
-        self.admin_id
     }
 
     pub fn pending_block(&self) -> &Option<Block> {
@@ -122,6 +115,13 @@ impl ChainState {
 
     pub fn known_key_pairs(&self) -> &BTreeMap<Owner, KeyPair> {
         &self.known_key_pairs
+    }
+
+    /// Returns whether the given ownership includes anyone whose secret key we don't have.
+    pub fn has_other_owners(&self, ownership: &ChainOwnership) -> bool {
+        ownership
+            .all_owners()
+            .any(|owner| !self.known_key_pairs.contains_key(owner))
     }
 
     pub(super) fn insert_known_key_pair(&mut self, key_pair: KeyPair) -> PublicKey {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -262,7 +262,6 @@ impl<P, S: Storage + Clone> Client<P, S> {
         if let dashmap::mapref::entry::Entry::Vacant(e) = self.chains.entry(chain_id) {
             e.insert(ChainState::new(
                 known_key_pairs,
-                admin_id,
                 block_hash,
                 timestamp,
                 next_block_height,
@@ -274,6 +273,7 @@ impl<P, S: Storage + Clone> Client<P, S> {
         ChainClient {
             client: self.clone(),
             chain_id,
+            admin_id,
             options: ChainClientOptions {
                 max_pending_message_bundles: self.max_pending_message_bundles,
                 message_policy: self.message_policy.clone(),
@@ -406,6 +406,8 @@ where
     client: Arc<Client<ValidatorNodeProvider, Storage>>,
     /// The off-chain chain ID.
     chain_id: ChainId,
+    /// The ID of the admin chain.
+    admin_id: ChainId,
     /// The client options.
     options: ChainClientOptions,
 }
@@ -418,6 +420,7 @@ where
         Self {
             client: self.client.clone(),
             chain_id: self.chain_id,
+            admin_id: self.admin_id,
             options: self.options.clone(),
         }
     }
@@ -718,10 +721,6 @@ where
     /// local chain.
     #[tracing::instrument(level = "trace")]
     async fn pending_message_bundles(&self) -> Result<Vec<IncomingBundle>, ChainClientError> {
-        if self.next_block_height() != BlockHeight::ZERO && self.options.message_policy.is_ignore()
-        {
-            return Ok(Vec::new()); // OpenChain is already received, other are ignored.
-        }
         let query = ChainInfoQuery::new(self.chain_id).with_pending_message_bundles();
         let info = self
             .client
@@ -729,10 +728,17 @@ where
             .handle_chain_info_query(query)
             .await?
             .info;
-        ensure!(
-            info.next_block_height == self.next_block_height(),
-            ChainClientError::WalletSynchronizationError
-        );
+        {
+            let state = self.state();
+            ensure!(
+                state.has_other_owners(&info.manager.ownership)
+                    || info.next_block_height == state.next_block_height(),
+                ChainClientError::WalletSynchronizationError
+            );
+        }
+        if info.next_block_height != BlockHeight::ZERO && self.options.message_policy.is_ignore() {
+            return Ok(Vec::new()); // OpenChain is already received, others are ignored.
+        }
         let mut requested_pending_message_bundles = info.requested_pending_message_bundles;
         let mut pending_message_bundles = vec![];
         // The first incoming message of any child chain must be `OpenChain`. We must have it in
@@ -826,8 +832,7 @@ where
         &self,
     ) -> Result<(BTreeMap<Epoch, Committee>, Epoch), LocalNodeError> {
         let (epoch, mut committees) = self.epoch_and_committees(self.chain_id).await?;
-        let admin_id = self.state().admin_id();
-        let (admin_epoch, admin_committees) = self.epoch_and_committees(admin_id).await?;
+        let (admin_epoch, admin_committees) = self.epoch_and_committees(self.admin_id).await?;
         committees.extend(admin_committees);
         let epoch = std::cmp::max(epoch.unwrap_or_default(), admin_epoch.unwrap_or_default());
         Ok((committees, epoch))
@@ -876,11 +881,12 @@ where
             manager.ownership.is_active(),
             LocalNodeError::InactiveChain(self.chain_id)
         );
+        let state = self.state();
         let mut identities = manager
             .ownership
             .all_owners()
             .chain(&manager.leader)
-            .filter(|owner| self.state().known_key_pairs().contains_key(owner));
+            .filter(|owner| state.known_key_pairs().contains_key(owner));
         let Some(identity) = identities.next() else {
             return Err(ChainClientError::CannotFindKeyForChain(self.chain_id));
         };
@@ -932,9 +938,7 @@ where
                 ChainClientError::InternalError("Invalid chain of blocks in local node")
             );
         }
-        let ownership = &info.manager.ownership;
-        let keys: HashSet<_> = self.state().known_key_pairs().keys().cloned().collect();
-        if ownership.all_owners().any(|owner| !keys.contains(owner)) {
+        if self.state().has_other_owners(&info.manager.ownership) {
             let mutex = self.state().client_mutex();
             let _guard = mutex.lock_owned().await;
 
@@ -1378,8 +1382,7 @@ where
         let local_committee = self.local_committee().await?;
         let nodes = self.make_nodes(&local_committee)?;
         // Synchronize the state of the admin chain from the network.
-        let admin_id = self.state().admin_id();
-        self.synchronize_chain_state(&nodes, admin_id).await?;
+        self.synchronize_chain_state(&nodes, self.admin_id).await?;
         let client = self.clone();
         // Proceed to downloading received certificates.
         let result = communicate_with_quorum(
@@ -2039,15 +2042,15 @@ where
         incoming_bundles: Vec<IncomingBundle>,
         operations: Vec<Operation>,
     ) -> Result<HashedCertificateValue, ChainClientError> {
-        let timestamp = self.next_timestamp(&incoming_bundles).await;
         let identity = self.identity().await?;
-        let previous_block_hash;
-        let height;
-        {
+        let (previous_block_hash, height, timestamp) = {
             let state = self.state();
-            previous_block_hash = state.block_hash();
-            height = state.next_block_height();
-        }
+            (
+                state.block_hash(),
+                state.next_block_height(),
+                self.next_timestamp(&incoming_bundles, state.timestamp()),
+            )
+        };
         let block = Block {
             epoch: self.epoch().await?,
             chain_id: self.chain_id,
@@ -2073,14 +2076,18 @@ where
     /// This will usually be the current time according to the local clock, but may be slightly
     /// ahead to make sure it's not earlier than the incoming messages or the previous block.
     #[tracing::instrument(level = "trace", skip(incoming_bundles))]
-    async fn next_timestamp(&self, incoming_bundles: &[IncomingBundle]) -> Timestamp {
+    fn next_timestamp(
+        &self,
+        incoming_bundles: &[IncomingBundle],
+        block_time: Timestamp,
+    ) -> Timestamp {
         let local_time = self.storage_client().clock().current_time();
         incoming_bundles
             .iter()
             .map(|msg| msg.bundle.timestamp)
             .max()
             .map_or(local_time, |timestamp| timestamp.max(local_time))
-            .max(self.timestamp())
+            .max(block_time)
     }
 
     /// Queries an application.
@@ -2173,14 +2180,21 @@ where
         owner: Option<Owner>,
     ) -> Result<(Amount, Option<Amount>), ChainClientError> {
         let incoming_bundles = self.pending_message_bundles().await?;
-        let timestamp = self.next_timestamp(&incoming_bundles).await;
+        let (previous_block_hash, height, timestamp) = {
+            let state = self.state();
+            (
+                state.block_hash(),
+                state.next_block_height(),
+                self.next_timestamp(&incoming_bundles, state.timestamp()),
+            )
+        };
         let block = Block {
             epoch: self.epoch().await?,
             chain_id: self.chain_id,
             incoming_bundles,
             operations: Vec::new(),
-            previous_block_hash: self.block_hash(),
-            height: self.next_block_height(),
+            previous_block_hash,
+            height,
             authenticated_signer: owner,
             timestamp,
         };
@@ -2346,7 +2360,7 @@ where
                 info = self.chain_info_with_manager_values().await?;
             }
         }
-        self.state_mut().update_from_info(&info);
+        self.update_from_info(&info);
         let manager = *info.manager;
 
         // If there is a validated block in the current round, finalize it.
@@ -2576,7 +2590,7 @@ where
             let config = OpenChainConfig {
                 ownership: ownership.clone(),
                 committees,
-                admin_id: self.state().admin_id(),
+                admin_id: self.admin_id,
                 epoch,
                 balance,
                 application_permissions: application_permissions.clone(),
@@ -2823,7 +2837,7 @@ where
         &self,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
         let operation = SystemOperation::Subscribe {
-            chain_id: self.state().admin_id(),
+            chain_id: self.admin_id,
             channel: SystemChannel::Admin,
         };
         self.execute_operation(Operation::System(operation)).await
@@ -2836,7 +2850,7 @@ where
         &self,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
         let operation = SystemOperation::Unsubscribe {
-            chain_id: self.state().admin_id(),
+            chain_id: self.admin_id,
             channel: SystemChannel::Admin,
         };
         self.execute_operation(Operation::System(operation)).await

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -404,7 +404,7 @@ where
         notifier: &impl Notifier,
     ) -> Result<Box<ChainInfo>, LocalNodeError> {
         // Sequentially try each validator in random order.
-        let mut validators: Vec<_> = validators.iter().collect();
+        let mut validators = validators.iter().collect::<Vec<_>>();
         validators.shuffle(&mut thread_rng());
         for remote_node in validators {
             let info = self.local_chain_info(chain_id).await?;
@@ -494,7 +494,7 @@ where
         blob_id: BlobId,
     ) -> Option<Blob> {
         // Sequentially try each validator in random order.
-        let mut validators: Vec<_> = validators.iter().collect();
+        let mut validators = validators.iter().collect::<Vec<_>>();
         validators.shuffle(&mut thread_rng());
         for remote_node in validators {
             if let Some(blob) = remote_node.try_download_blob(blob_id).await {
@@ -511,7 +511,7 @@ where
     ) -> FuturesUnordered<impl Future<Output = Option<Certificate>> + '_> {
         let futures = FuturesUnordered::new();
 
-        let mut validators: Vec<_> = validators.iter().collect();
+        let mut validators = validators.iter().collect::<Vec<_>>();
         validators.shuffle(&mut thread_rng());
         for remote_node in validators {
             futures.push(async move {

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -297,7 +297,7 @@ where
             let hash = certificate.hash();
             if !certificate.value().is_confirmed() || certificate.value().chain_id() != chain_id {
                 // The certificate is not as expected. Give up.
-                tracing::warn!("Failed to process network certificate {}", hash);
+                warn!("Failed to process network certificate {}", hash);
                 return info;
             }
             let mut result = self
@@ -324,13 +324,29 @@ where
                 Ok(response) => info = Some(response.info),
                 Err(error) => {
                     // The certificate is not as expected. Give up.
-                    tracing::warn!("Failed to process network certificate {}: {}", hash, error);
+                    warn!("Failed to process network certificate {}: {}", hash, error);
                     return info;
                 }
             };
         }
         // Done with all certificates.
         info
+    }
+
+    /// Returns only after the outbox of the given chain does not contain any entries up to
+    /// `height` anymore.
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub async fn wait_for_outgoing_messages(
+        &self,
+        chain_id: ChainId,
+        height: BlockHeight,
+    ) -> Result<(), LocalNodeError> {
+        // TODO(#2692): Implement this, once #2689 is merged.
+        warn!(
+            "Not waiting for outgoing messages from {chain_id:.8} up to height {height}: \
+            not implemented yet."
+        );
+        Ok(())
     }
 
     /// Returns a read-only view of the [`ChainStateView`] of a chain referenced by its

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -333,22 +333,6 @@ where
         info
     }
 
-    /// Returns only after the outbox of the given chain does not contain any entries up to
-    /// `height` anymore.
-    #[tracing::instrument(level = "trace", skip_all)]
-    pub async fn wait_for_outgoing_messages(
-        &self,
-        chain_id: ChainId,
-        height: BlockHeight,
-    ) -> Result<(), LocalNodeError> {
-        // TODO(#2692): Implement this, once #2689 is merged.
-        warn!(
-            "Not waiting for outgoing messages from {chain_id:.8} up to height {height}: \
-            not implemented yet."
-        );
-        Ok(())
-    }
-
     /// Returns a read-only view of the [`ChainStateView`] of a chain referenced by its
     /// [`ChainId`].
     ///

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -51,7 +51,7 @@ use tonic::{
     Request, Response, Status,
 };
 use tower::{builder::ServiceBuilder, Layer, Service};
-use tracing::{debug, info, instrument, Instrument as _};
+use tracing::{debug, info, instrument, Instrument as _, Level};
 #[cfg(with_metrics)]
 use {
     linera_base::prometheus_util,
@@ -512,7 +512,7 @@ where
         )?))
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(skip_all, err(level = Level::WARN))]
     async fn blob_last_used_by(
         &self,
         request: Request<BlobId>,

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -427,7 +427,7 @@ async fn bucket_queue_view_mutability_check() -> Result<()> {
             let count = view.queue.count();
             if choice == 0 {
                 // inserting random stuff
-                let n_ins = rng.gen_range(0..10);
+                let n_ins = rng.gen_range(0..100);
                 for _ in 0..n_ins {
                     let val = rng.gen::<u8>();
                     view.queue.push_back(val);


### PR DESCRIPTION
I've selectively picked PRs that landed on `main` ([diff](https://github.com/linera-io/linera-protocol/compare/devnet_2024_10_21...main)) that are missing from the `devnet_2024_10_21` branch.

PRs that I've skipped:
- https://github.com/linera-io/linera-protocol/pull/2679 - this adds a unit test (no effect on the release)


Everything else was cherry-picked (maybe we should be simply merging `main` ? that would have kept the history cleaner).

A PR that we definitely need to backport is:
- https://github.com/linera-io/linera-protocol/pull/2696