### PR TITLE
Skip reading environment variable and allocating a `String` if possible

### DIFF
--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -29,10 +29,11 @@ impl RemoteNetTestingConfig {
     /// variable, or the default devnet faucet URL.
     pub fn new(faucet_url: Option<String>) -> Self {
         Self {
-            faucet: Faucet::new(faucet_url
-                .or_else(|| env::var("LINERA_FAUCET_URL"))
-                .unwrap_or_else(|_| "https://faucet.devnet.linera.net".to_owned())
-            )),
+            faucet: Faucet::new(
+                faucet_url
+                    .or_else(|| env::var("LINERA_FAUCET_URL").ok())
+                    .unwrap_or_else(|| "https://faucet.devnet.linera.net".to_owned()),
+            ),
         }
     }
 }

--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -20,6 +20,13 @@ pub struct RemoteNetTestingConfig {
 }
 
 impl RemoteNetTestingConfig {
+    /// Creates a new [`RemoteNetTestingConfig`] for running tests with an external Linera
+    /// network.
+    ///
+    /// The `faucet_url` is used to connect to the network and obtain its configuration,
+    /// as well as to create microchains used for testing. If the parameter is [`None`],
+    /// then it falls back to the URL specified in the `LINERA_FAUCET_URL` environment
+    /// variable, or the default devnet faucet URL.
     pub fn new(faucet_url: Option<String>) -> Self {
         Self {
             faucet: Faucet::new(faucet_url.unwrap_or_else(|| {

--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -22,12 +22,10 @@ pub struct RemoteNetTestingConfig {
 impl RemoteNetTestingConfig {
     pub fn new(faucet_url: Option<String>) -> Self {
         Self {
-            faucet: Faucet::new(
-                faucet_url.unwrap_or(
-                    env::var("LINERA_FAUCET_URL")
-                        .unwrap_or("https://faucet.devnet.linera.net".to_string()),
-                ),
-            ),
+            faucet: Faucet::new(faucet_url.unwrap_or_else(|| {
+                env::var("LINERA_FAUCET_URL")
+                    .unwrap_or("https://faucet.devnet.linera.net".to_string())
+            })),
         }
     }
 }

--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -24,7 +24,7 @@ impl RemoteNetTestingConfig {
         Self {
             faucet: Faucet::new(faucet_url.unwrap_or_else(|| {
                 env::var("LINERA_FAUCET_URL")
-                    .unwrap_or_else(|_| "https://faucet.devnet.linera.net".to_string())
+                    .unwrap_or_else(|_| "https://faucet.devnet.linera.net".to_owned())
             })),
         }
     }

--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -29,10 +29,10 @@ impl RemoteNetTestingConfig {
     /// variable, or the default devnet faucet URL.
     pub fn new(faucet_url: Option<String>) -> Self {
         Self {
-            faucet: Faucet::new(faucet_url.unwrap_or_else(|| {
-                env::var("LINERA_FAUCET_URL")
-                    .unwrap_or_else(|_| "https://faucet.devnet.linera.net".to_owned())
-            })),
+            faucet: Faucet::new(faucet_url
+                .or_else(|| env::var("LINERA_FAUCET_URL"))
+                .unwrap_or_else(|_| "https://faucet.devnet.linera.net".to_owned())
+            )),
         }
     }
 }

--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -24,7 +24,7 @@ impl RemoteNetTestingConfig {
         Self {
             faucet: Faucet::new(faucet_url.unwrap_or_else(|| {
                 env::var("LINERA_FAUCET_URL")
-                    .unwrap_or("https://faucet.devnet.linera.net".to_string())
+                    .unwrap_or_else(|_| "https://faucet.devnet.linera.net".to_string())
             })),
         }
     }


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
A tiny optimization was found for the testing code. It's possible to use `unwrap_or_else` instead of `unwrap_or` in order to only execute the fallback option if the first option is unavailable.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Replace usage of `unwrap_or` which requires its argument to have been executed with `unwrap_or_else` which will only execute its argument if needed.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
CI should catch any regressions, as this is a small refactor of the testing infrastructure.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do, because this only affects tests.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
