### PR TITLE
Immediately acknowledge GRPC subscriptions

### DIFF
--- a/linera-core/src/notifier.rs
+++ b/linera-core/src/notifier.rs
@@ -28,7 +28,7 @@ impl<N> Default for ChannelNotifier<N> {
 }
 
 impl<N> ChannelNotifier<N> {
-    fn add_sender(&self, chain_ids: Vec<ChainId>, sender: &tokio::sync::mpsc::UnboundedSender<N>) {
+    fn add_sender(&self, chain_ids: Vec<ChainId>, sender: &UnboundedSender<N>) {
         for id in chain_ids {
             let mut senders = self.inner.entry(id).or_default();
             senders.push(sender.clone());

--- a/linera-core/src/notifier.rs
+++ b/linera-core/src/notifier.rs
@@ -37,6 +37,19 @@ impl<N> ChannelNotifier<N> {
         }
         rx
     }
+
+    /// Creates a subscription given a collection of ChainIds and a sender to the client.
+    /// Immediately posts a first notification as a ACK.
+    pub fn subscribe_with_ack(&self, chain_ids: Vec<ChainId>, ack: N) -> UnboundedReceiver<N> {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        for id in chain_ids {
+            let mut senders = self.inner.entry(id).or_default();
+            senders.push(tx.clone());
+        }
+        tx.send(ack)
+            .expect("pushing to a new channel should succeed");
+        rx
+    }
 }
 
 impl<N> ChannelNotifier<N>

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -147,13 +147,13 @@ impl TryFrom<api::Notification> for Option<Notification> {
     type Error = GrpcProtoConversionError;
 
     fn try_from(notification: api::Notification) -> Result<Self, Self::Error> {
-        if let Some(chain_id) = notification.chain_id {
+        if notification.chain_id.is_none() && notification.reason.is_empty() {
+            Ok(None)
+        } else {
             Ok(Some(Notification {
-                chain_id: chain_id.try_into()?,
+                chain_id: try_proto_convert(notification.chain_id)?,
                 reason: bincode::deserialize(&notification.reason)?,
             }))
-        } else {
-            Ok(None)
         }
     }
 }

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -406,8 +406,8 @@ where
             .into_iter()
             .map(ChainId::try_from)
             .collect::<Result<Vec<ChainId>, _>>()?;
-        // The empty Notification seems to be needed in some configuration to force
-        // completion of http2 headers.
+        // The empty notification seems to be needed in some cases to force
+        // completion of HTTP2 headers.
         let rx = self
             .0
             .notifier

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -406,7 +406,12 @@ where
             .into_iter()
             .map(ChainId::try_from)
             .collect::<Result<Vec<ChainId>, _>>()?;
-        let rx = self.0.notifier.subscribe(chain_ids);
+        // The empty Notification seems to be needed in some configuration to force
+        // completion of http2 headers.
+        let rx = self
+            .0
+            .notifier
+            .subscribe_with_ack(chain_ids, Ok(Notification::default()));
         Ok(Response::new(UnboundedReceiverStream::new(rx)))
     }
 


### PR DESCRIPTION
## Motivation

We observe timeouts in GRPC clients when subscribing to a Linera proxy behind Nginx instances.

## Proposal

Make sure the GRPC `subscribe` immediately returns an empty value. This should force completion of the HTTP2 header and prevent the bug

## Test Plan

* CI should catch any regression
* will need to be manually tested

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
