### PR TITLE
Don't fallback to hardcoded devnet Faucet URL

### DIFF
--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -32,7 +32,7 @@ impl RemoteNetTestingConfig {
             faucet: Faucet::new(
                 faucet_url
                     .or_else(|| env::var("LINERA_FAUCET_URL").ok())
-                    .unwrap_or_else(|| "https://faucet.devnet.linera.net".to_owned()),
+                    .expect("Missing `LINERA_FAUCET_URL` environment variable"),
             ),
         }
     }


### PR DESCRIPTION
The URL is currently incorrect, and changes often. It makes more sense to require the user to specify it when running the tests.

## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
While running some tests with the `remote-net` feature enabled, they failed due to DNS issues. That was caused by an incorrect fallback URL that was hardcoded in the test.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Remove the fallback URL, and require the user to specify the remote URL.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
Tested manually, checking that a test passes when `LINERA_FAUCET_URL` is properly configured and failing with the expected message when it's missing.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do, as this only affects tests.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
