### PR TITLE
Create compose-hotfix.sh script for Docker Compose hotfixes

### DIFF
--- a/docker/compose-common.sh
+++ b/docker/compose-common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+build_docker_image() {
+    GIT_COMMIT=$(git rev-parse --short HEAD)
+
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        docker build --build-arg git_commit="$GIT_COMMIT" -f docker/Dockerfile . -t linera
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        CPU_ARCH=$(sysctl -n machdep.cpu.brand_string)
+        if [[ "$CPU_ARCH" == *"Apple"* ]]; then
+            docker build --build-arg git_commit="$GIT_COMMIT" --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera .
+        else
+            echo "Unsupported Architecture: $CPU_ARCH"
+            exit 1
+        fi
+    else
+        echo "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+}
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+ROOT_DIR=$SCRIPT_DIR/..

--- a/docker/compose-hotfix.sh
+++ b/docker/compose-hotfix.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -xe
+
+source ./compose-common.sh
+
+BRANCH_NAME="$1"
+ACTUAL_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
+if [[ "$BRANCH_NAME" != "$ACTUAL_BRANCH_NAME" ]]; then
+    echo "Error: Expected branch '$BRANCH_NAME', but you are on '$ACTUAL_BRANCH_NAME'."
+    exit 1
+fi
+
+cd "$ROOT_DIR"
+git pull
+
+build_docker_image
+
+cd "$SCRIPT_DIR"
+
+SHARDS=$(docker compose config --services | grep '^shard' | grep -v 'shard-init')
+docker compose up --wait $SHARDS proxy

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-ROOT_DIR=$SCRIPT_DIR/..
+set -xe
+
+source ./compose-common.sh
+
 CONF_DIR=$ROOT_DIR/configuration/compose
 
 cleanup_started=false
@@ -33,26 +35,9 @@ fi
 
 cd "$ROOT_DIR"
 
-GIT_COMMIT=$(git rev-parse --short HEAD)
-
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    docker build --build-arg git_commit="$GIT_COMMIT" -f docker/Dockerfile . -t linera
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    CPU_ARCH=$(sysctl -n machdep.cpu.brand_string)
-    if [[ "$CPU_ARCH" == *"Apple"* ]]; then
-        docker build --build-arg git_commit="$GIT_COMMIT" --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera .
-    else
-        echo "Unsupported Architecture: $CPU_ARCH"
-        exit 1
-    fi
-else
-    echo "Unsupported OS: $OSTYPE"
-    exit 1
-fi
+build_docker_image
 
 cd "$SCRIPT_DIR"
-
-set -xe
 
 # Create configuration files.
 # * Private server states are stored in `server.json`.


### PR DESCRIPTION
## Motivation

We need a reproducible way for validators to deploy hotfixes

## Proposal

Write a script for it

## Test Plan

CI should test compose.sh + will try to run the hotfix one either locally (I'm on macOS so it might be more annoying) or on `validator-5`

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
