### PR TITLE
Depend on other services based on health checks for docker compose

### DIFF
--- a/docker/compose-proxy-entrypoint.sh
+++ b/docker/compose-proxy-entrypoint.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-while [ ! -f /shared/init_done ]; do
-  echo "waiting for db init"
-  sleep 5
-done
-
 exec ./linera-proxy \
   --storage scylladb:tcp:scylla:9042 \
   --genesis /config/genesis.json \

--- a/docker/compose-server-entrypoint.sh
+++ b/docker/compose-server-entrypoint.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-while [ ! -f /shared/init_done ]; do
-  echo "waiting for db init"
-  sleep 5
-done
-
 exec ./linera-server run \
   --storage scylladb:tcp:scylla:9042 \
   --server /config/server.json \

--- a/docker/compose-server-init.sh
+++ b/docker/compose-server-init.sh
@@ -13,7 +13,6 @@ while true; do
       --storage scylladb:tcp:scylla:9042 \
       --genesis /config/genesis.json; then
       echo "Initialization successful."
-      touch /shared/init_done
       exit 0
     else
       echo "Initialization failed, retrying in 5 seconds..."

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,9 @@ services:
     command: [ "./compose-proxy-entrypoint.sh" ]
     volumes:
       - .:/config
-      - linera-shared:/shared
+    depends_on:
+      shard-init:
+        condition: service_completed_successfully
   shard:
     image: linera
     deploy:
@@ -28,16 +30,15 @@ services:
     command: [ "./compose-server-entrypoint.sh" ]
     volumes:
       - .:/config
-      - linera-shared:/shared
     depends_on:
-      - shard-init
+      shard-init:
+        condition: service_completed_successfully
   shard-init:
     image: linera
     container_name: shard-init
     command: [ "./compose-server-init.sh" ]
     volumes:
       - .:/config
-      - linera-shared:/shared
     depends_on:
       - scylla
 
@@ -64,5 +65,4 @@ services:
 volumes:
   linera-scylla-data:
     driver: local
-  linera-shared: # used for cross-container comms.
   grafana-storage:


### PR DESCRIPTION
## Motivation

When using Docker Compose, we're not currently properly waiting for the service dependencies.

## Proposal

Add a health check, and remove the `init_done` file

## Test Plan

CI: we can see from the Docker CI logs that both the `proxy` and `shard`s services only get created after `shard-init` exits:
```
Network docker_default  Creating
 Network docker_default  Created
 Volume "docker_grafana-storage"  Creating
 Volume "docker_grafana-storage"  Created
 Volume "docker_linera-scylla-data"  Creating
 Volume "docker_linera-scylla-data"  Created
 Container scylla  Creating
 Container prometheus  Creating
 Container grafana  Creating
 Container prometheus  Created
 Container scylla  Created
 Container grafana  Created
 Container shard-init  Creating
 Container shard-init  Created
 Container proxy  Creating
 Container docker-shard-4  Creating
 Container docker-shard-2  Creating
 Container docker-shard-1  Creating
 Container docker-shard-3  Creating
 Container docker-shard-1  Created               <----  Creations
 Container proxy  Created                               <----
 Container docker-shard-4  Created              <----
 Container docker-shard-3  Created              <----
 Container docker-shard-2  Created              <----
 Container grafana  Starting
 Container prometheus  Starting
 Container scylla  Starting
 Container scylla  Started
 Container grafana  Started
 Container shard-init  Starting
 Container prometheus  Started
 Container shard-init  Started
 Container shard-init  Waiting
 Container shard-init  Waiting
 Container shard-init  Exited                           <----    Exits
 Container proxy  Starting                               <----   Starts
 Container shard-init  Exited
 Container docker-shard-4  Starting              <----
 Container proxy  Started
 Container docker-shard-4  Started
 Container docker-shard-1  Starting               <----
 Container docker-shard-1  Started
 Container docker-shard-3  Starting               <----
 Container docker-shard-3  Started
 Container docker-shard-2  Starting                <----
 Container docker-shard-2  Started
 Container prometheus  Waiting
 Container grafana  Waiting
 Container scylla  Waiting
 Container proxy  Waiting
 Container docker-shard-4  Waiting
 Container docker-shard-1  Waiting
 Container docker-shard-3  Waiting
 Container docker-shard-2  Waiting
 Container shard-init  Waiting
 Container docker-shard-4  Healthy
 Container docker-shard-1  Healthy
 Container docker-shard-3  Healthy
 Container docker-shard-2  Healthy
 Container proxy  Healthy
 Container shard-init  Exited
 Container scylla  Healthy
 Container grafana  Healthy
 Container prometheus  Healthy
```

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
