### PR TITLE
Fix insufficient balance error messages in long faucet chain test

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2868,7 +2868,7 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
     // Use the faucet directly to initialize many chains
     for _ in 0..chain_count {
         faucet_client
-            .open_chain(faucet_chain, None, Amount::ZERO)
+            .open_chain(faucet_chain, None, Amount::ONE)
             .await?;
     }
 


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
The long faucet chain test prints a lot of error messages reporting insufficient balance. This happens because the test creates many new chains with an empty balance, which prevents the chains from creating their genesis block receiving the current epoch.

These errors are useless, because those chains don't actually affect anything in the test, they only need to simulate a long faucet chain.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Add some tokens to the newly created chains.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
Tested manually to see that the error messages disappear.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- These changes should be backported to the latest `devnet` and `testnet` branch, to help with debugging any problems in the long faucet chain test

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Closes #2645 
