### PR TITLE
Port long faucet chain test fixes to devnet

### DIFF
--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -702,6 +702,16 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera wallet forget-chain CHAIN_ID`.
+    pub async fn forget_chain(&self, chain_id: ChainId) -> Result<()> {
+        let mut command = self.command().await?;
+        command
+            .args(["wallet", "forget-chain"])
+            .arg(chain_id.to_string());
+        command.spawn_and_wait_for_stdout().await?;
+        Ok(())
+    }
+
     pub async fn retry_pending_block(
         &self,
         chain_id: Option<ChainId>,

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2867,9 +2867,10 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
 
     // Use the faucet directly to initialize many chains
     for _ in 0..chain_count {
-        faucet_client
+        let (_, new_chain_id) = faucet_client
             .open_chain(faucet_chain, None, Amount::ONE)
             .await?;
+        faucet_client.forget_chain(new_chain_id).await?;
     }
 
     let amount = Amount::ONE;

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2868,7 +2868,7 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
     // Use the faucet directly to initialize many chains
     for _ in 0..chain_count {
         faucet_client
-            .open_chain(faucet_chain, None, Amount::ZERO)
+            .open_chain(faucet_chain, None, Amount::ONE)
             .await?;
     }
 


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
The long faucet chain test had two issues. One of them was that it printed a lot of useless "insufficient balance" errors. The second was that it wasn't stable, and would sometimes fail due to a timeout to obtain a new chain while the faucet was starting up.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Port the fixes on `main` to the `devnet_2024_10_21` branch:

- #2718
- #2721 

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
CI should show that test is more stable and less verbose.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do, this is the backport PR.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
