### PR TITLE
Don't put new chains in wallet if we don't own them.

### DIFF
--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -176,9 +176,11 @@ impl Runnable for Job {
                     } => block.timestamp,
                     _ => panic!("Unexpected certificate."),
                 };
-                context
-                    .update_wallet_for_new_chain(id, key_pair, timestamp)
-                    .await?;
+                if key_pair.is_some() {
+                    context
+                        .update_wallet_for_new_chain(id, key_pair, timestamp)
+                        .await?;
+                }
                 let time_total = time_start.elapsed();
                 info!("Operation confirmed after {} ms", time_total.as_millis());
                 debug!("{:?}", certificate);

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -631,10 +631,8 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
 
     // The returned hash should now be the latest one.
     let query = format!("query {{ chain(chainId: \"{chain2}\") {{ tipState {{ blockHash }} }} }}");
-    for node_service in [&node_service2, &node_service1] {
-        let response = node_service.query_node(&query).await?;
-        assert_eq!(hash, response["chain"]["tipState"]["blockHash"]);
-    }
+    let response = node_service2.query_node(&query).await?;
+    assert_eq!(hash, response["chain"]["tipState"]["blockHash"]);
 
     let mut notifications = Box::pin(node_service2.notifications(chain2).await?);
 

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -33,7 +33,10 @@ use linera_base::{
 };
 use linera_chain::data_types::{Medium, Origin};
 use linera_core::worker::{Notification, Reason};
-use linera_sdk::{base::BlockHeight, DataBlobHash};
+use linera_sdk::{
+    base::{BlockHeight, PublicKey},
+    DataBlobHash,
+};
 #[cfg(any(
     feature = "dynamodb",
     feature = "scylladb",
@@ -2867,10 +2870,9 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
 
     // Use the faucet directly to initialize many chains
     for _ in 0..chain_count {
-        let (_, new_chain_id) = faucet_client
-            .open_chain(faucet_chain, None, Amount::ONE)
+        faucet_client
+            .open_chain(faucet_chain, Some(PublicKey::test_key(1)), Amount::ONE)
             .await?;
-        faucet_client.forget_chain(new_chain_id).await?;
     }
 
     let amount = Amount::ONE;


### PR DESCRIPTION
## Motivation

The long chain faucet test fails (`os error 16` for me) unless we explicitly forget the opened chains.

It looks like we can't use a faucet with a wallet with 1000 chains in it fails. (I suspect the same would apply to the node service.) This is something we should look into as well.

## Proposal

Make the `open-chain` CLI command not add new chains to the wallet if we don't own them.

Keeping this as a draft for now:
* It's maybe debatable what the desired behavior for the CLI command is.
* The node service mutation doesn't seem to ever add the new chain to the wallet? (Will look into this and create an issue on Monday.)
* We should investigate _why_ the faucet fails if it has 1000 chains in the wallet.

## Test Plan

I removed the `forget_chain` from the test and it still passes now.

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK.

## Links

- Fixes https://github.com/linera-io/linera-protocol/issues/2723
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
