### PR TITLE
Don't cache blobs that are too large.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1062,6 +1062,17 @@ impl BlobContent {
     pub fn blob_bytes(&self) -> BlobBytes {
         BlobBytes(self.inner_bytes())
     }
+
+    /// Returns the size of the blob content in bytes.
+    pub fn size(&self) -> usize {
+        match self {
+            BlobContent::Data(bytes) => bytes.len(),
+            BlobContent::ContractBytecode(compressed_bytecode)
+            | BlobContent::ServiceBytecode(compressed_bytecode) => {
+                compressed_bytecode.compressed_bytes.len()
+            }
+        }
+    }
 }
 
 impl From<Blob> for BlobContent {

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -3,7 +3,7 @@
 
 //! Operations that don't persist any changes to the chain state.
 
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::BTreeSet};
 
 use linera_base::{
     data_types::{ArithmeticError, BlobContent, Timestamp, UserApplicationDescription},
@@ -17,7 +17,7 @@ use linera_chain::{
     },
     manager,
 };
-use linera_execution::{ChannelSubscription, Query, Response};
+use linera_execution::{ChannelSubscription, Query, ResourceControlPolicy, Response};
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::View;
 #[cfg(with_testing)]
@@ -178,9 +178,8 @@ where
             .system
             .current_committee()
             .expect("chain is active");
+        let policy = committee.policy().clone();
         check_block_epoch(epoch, block)?;
-        let maximum_blob_size = committee.policy().maximum_blob_size;
-        let maximum_bytecode_size = committee.policy().maximum_bytecode_size;
         // Check the authentication of the block.
         let public_key = self
             .0
@@ -209,30 +208,19 @@ where
         self.0.chain.remove_bundles_from_inboxes(block).await?;
         // Verify that all required bytecode hashed certificate values and blobs are available, and no
         // unrelated ones provided.
+        let published_blob_ids = block.published_blob_ids();
         self.0
-            .check_no_missing_blobs(block.published_blob_ids(), blobs)
+            .check_no_missing_blobs(published_blob_ids.clone(), blobs)
             .await?;
         for blob in blobs {
+            Self::check_blob_size(blob.content(), &policy)?;
             self.0.cache_recent_blob(Cow::Borrowed(blob)).await;
         }
-        for blob in self.0.get_blobs(block.published_blob_ids()).await? {
-            let blob_size = match blob.content() {
-                BlobContent::Data(bytes) => bytes.len(),
-                BlobContent::ContractBytecode(compressed_bytecode)
-                | BlobContent::ServiceBytecode(compressed_bytecode) => {
-                    ensure!(
-                        compressed_bytecode.decompressed_size_at_most(maximum_bytecode_size)?,
-                        WorkerError::BytecodeTooLarge
-                    );
-                    compressed_bytecode.compressed_bytes.len()
-                }
-            };
-            ensure!(
-                u64::try_from(blob_size)
-                    .ok()
-                    .is_some_and(|size| size <= maximum_blob_size),
-                WorkerError::BlobTooLarge
-            )
+        let checked_blobs = blobs.iter().map(|blob| blob.id()).collect::<BTreeSet<_>>();
+        for blob in self.0.get_blobs(published_blob_ids).await? {
+            if !checked_blobs.contains(&blob.id()) {
+                Self::check_blob_size(blob.content(), &policy)?;
+            }
         }
 
         let local_time = self.0.storage.clock().current_time();
@@ -353,6 +341,30 @@ where
             info.manager.add_values(chain.manager.get());
         }
         Ok(ChainInfoResponse::new(info, self.0.config.key_pair()))
+    }
+
+    fn check_blob_size(
+        content: &BlobContent,
+        policy: &ResourceControlPolicy,
+    ) -> Result<(), WorkerError> {
+        let blob_size = match content {
+            BlobContent::Data(bytes) => bytes.len(),
+            BlobContent::ContractBytecode(compressed_bytecode)
+            | BlobContent::ServiceBytecode(compressed_bytecode) => {
+                ensure!(
+                    compressed_bytecode.decompressed_size_at_most(policy.maximum_bytecode_size)?,
+                    WorkerError::BytecodeTooLarge
+                );
+                compressed_bytecode.compressed_bytes.len()
+            }
+        };
+        ensure!(
+            u64::try_from(blob_size)
+                .ok()
+                .is_some_and(|size| size <= policy.maximum_blob_size),
+            WorkerError::BlobTooLarge
+        );
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Motivation

In https://github.com/linera-io/linera-protocol/pull/2705 blob size limits were added. But blobs are put into the cache before their size is checked. If they are too large, they are now in the cache but will never be used.

## Proposal

Do the check before putting them in the cache.

## Test Plan

This only avoids unnecessary caching. CI should catch any regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Related to https://github.com/linera-io/linera-protocol/pull/2705.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
