### PR TITLE
Add blob size limits. (#2705)

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1062,6 +1062,17 @@ impl BlobContent {
     pub fn blob_bytes(&self) -> BlobBytes {
         BlobBytes(self.inner_bytes())
     }
+
+    /// Returns the size of the blob content in bytes.
+    pub fn size(&self) -> usize {
+        match self {
+            BlobContent::Data(bytes) => bytes.len(),
+            BlobContent::ContractBytecode(compressed_bytecode)
+            | BlobContent::ServiceBytecode(compressed_bytecode) => {
+                compressed_bytecode.compressed_bytes.len()
+            }
+        }
+    }
 }
 
 impl From<Blob> for BlobContent {

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -18,6 +18,7 @@ pub mod crypto;
 pub mod data_types;
 mod graphql;
 pub mod identifiers;
+mod limited_writer;
 pub mod ownership;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod port;

--- a/linera-base/src/limited_writer.rs
+++ b/linera-base/src/limited_writer.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::{self, Write};
+
+use thiserror::Error;
+
+use crate::ensure;
+
+#[derive(Error, Debug)]
+#[error("Writer limit exceeded")]
+pub struct LimitedWriterError;
+
+/// Custom writer that enforces a byte limit.
+pub struct LimitedWriter<W: Write> {
+    inner: W,
+    limit: usize,
+    written: usize,
+}
+
+impl<W: Write> LimitedWriter<W> {
+    pub fn new(inner: W, limit: usize) -> Self {
+        Self {
+            inner,
+            limit,
+            written: 0,
+        }
+    }
+}
+
+impl<W: Write> Write for LimitedWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // Calculate the number of bytes we can write without exceeding the limit.
+        // Fail if the buffer doesn't fit.
+        ensure!(
+            self.limit
+                .checked_sub(self.written)
+                .is_some_and(|remaining| buf.len() <= remaining),
+            io::Error::other(LimitedWriterError)
+        );
+        // Forward to the inner writer.
+        let n = self.inner.write(buf)?;
+        self.written += n;
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_limited_writer() {
+        let mut out_buffer = Vec::new();
+        let mut writer = LimitedWriter::new(&mut out_buffer, 5);
+        assert_eq!(writer.write(b"foo").unwrap(), 3);
+        assert_eq!(writer.write(b"ba").unwrap(), 2);
+        assert!(writer
+            .write(b"r")
+            .unwrap_err()
+            .downcast::<LimitedWriterError>()
+            .is_ok());
+    }
+}

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -83,6 +83,13 @@ mod chain_state;
 #[path = "../unit_tests/client_tests.rs"]
 mod client_tests;
 
+const MEBIBYTE: u64 = 1024 * 1024;
+
+/// The maximum size of a data or bytecode blob, in bytes.
+pub(crate) const MAXIMUM_BLOB_SIZE: u64 = 3 * MEBIBYTE;
+/// The maximum size of decompressed bytecode, in bytes.
+pub(crate) const MAXIMUM_BYTECODE_SIZE: u64 = 30 * MEBIBYTE;
+
 #[cfg(with_metrics)]
 mod metrics {
     use std::sync::LazyLock;

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -41,7 +41,7 @@ use crate::test_utils::ServiceStorageBuilder;
 use crate::{
     client::{
         BlanketMessagePolicy, ChainClient, ChainClientError, ClientOutcome, MessageAction,
-        MessagePolicy,
+        MessagePolicy, MAXIMUM_BLOB_SIZE,
     },
     local_node::LocalNodeError,
     node::{
@@ -2457,6 +2457,10 @@ where
     let executed_block = certificate.value().executed_block().unwrap();
     assert_eq!(executed_block.block.incoming_bundles.len(), 1);
     assert_eq!(executed_block.required_blob_ids().len(), 1);
+
+    let large_blob_bytes = vec![0; MAXIMUM_BLOB_SIZE as usize + 1];
+    let result = client1.publish_data_blob(large_blob_bytes).await;
+    assert_matches!(result, Err(ChainClientError::LocalNodeError(_)));
 
     Ok(())
 }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -14,7 +14,9 @@ use std::{
 use linera_base::crypto::PublicKey;
 use linera_base::{
     crypto::{CryptoHash, KeyPair},
-    data_types::{ArithmeticError, Blob, BlockHeight, Round, UserApplicationDescription},
+    data_types::{
+        ArithmeticError, Blob, BlockHeight, DecompressionError, Round, UserApplicationDescription,
+    },
     doc_scalar,
     identifiers::{BlobId, ChainId, Owner, UserApplicationId},
     time::timer::{sleep, timeout},
@@ -212,6 +214,12 @@ pub enum WorkerError {
     FullChainWorkerCache,
     #[error("Failed to join spawned worker task")]
     JoinError,
+    #[error("Blob exceeds size limit")]
+    BlobTooLarge,
+    #[error("Bytecode exceeds size limit")]
+    BytecodeTooLarge,
+    #[error(transparent)]
+    Decompression(#[from] DecompressionError),
 }
 
 impl From<linera_chain::ChainError> for WorkerError {


### PR DESCRIPTION
## Motivation

Large blobs can make messages containing them exceed the gRPC message limit, and require a lot of storage and bandwidth.

In addition, we need to guard against small compressed bytecode that is excessively large when decompressed.

On testnet-boole, I successfully published a 6 MiB blob, but failed with 8 MiB.

## Proposal

Backport https://github.com/linera-io/linera-protocol/pull/2705, but hard-code the limits to remain backwards-compatible.

Make the blob limit 3 MiB, so that _two_ blobs (e.g. contract and service bytecode) fit in a block.

Make the bytecode limit 30 MiB.

## Test Plan

The tests were backported, too.

## Release Plan

This is the backport of https://github.com/linera-io/linera-protocol/pull/2705 to `devnet_2024_10_21`.

## Links

- `main` version: https://github.com/linera-io/linera-protocol/pull/2705
- `testnet_boole` version: https://github.com/linera-io/linera-protocol/pull/2720
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
