### PR TITLE
deploy-validator.sh script uses 4 shards.

### DIFF
--- a/scripts/deploy-validator.sh
+++ b/scripts/deploy-validator.sh
@@ -74,10 +74,29 @@ internal_port = 20100
 Grpc = "ClearText"
 [internal_protocol]
 Grpc = "ClearText"
+
 [[shards]]
-host = "shard"
+host = "docker-shard-1"
 port = $PORT
-metrics_host = "shard"
+metrics_host = "docker-shard-1"
+metrics_port = $METRICS_PORT
+
+[[shards]]
+host = "docker-shard-2"
+port = $PORT
+metrics_host = "docker-shard-2"
+metrics_port = $METRICS_PORT
+
+[[shards]]
+host = "docker-shard-3"
+port = $PORT
+metrics_host = "docker-shard-3"
+metrics_port = $METRICS_PORT
+
+[[shards]]
+host = "docker-shard-4"
+port = $PORT
+metrics_host = "docker-shard-4"
 metrics_port = $METRICS_PORT
 EOL
 


### PR DESCRIPTION
## Motivation

The deploy-validator script was not updated to use 4 shards.

## Proposal

Update deploy-validator script to use 4 shards.

## Test Plan

Manually tested.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- These changes should be backported to the latest `devnet` branch, then
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.
