### PR TITLE
Shard editing command

### DIFF
--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -481,8 +481,6 @@ fn log_file_name_for(command: &ServerCommand) -> Cow<'static, str> {
 }
 
 async fn run(options: ServerOptions) {
-    linera_version::VERSION_INFO.log();
-
     match options.command {
         ServerCommand::Run {
             server_config_path,
@@ -497,6 +495,8 @@ async fn run(options: ServerOptions) {
             max_stream_queries,
             cache_size,
         } => {
+            linera_version::VERSION_INFO.log();
+
             let genesis_config: GenesisConfig =
                 util::read_json(&genesis_config_path).expect("Failed to read initial chain config");
             let server_config: ValidatorServerConfig =

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -630,17 +630,17 @@ fn generate_shard_configs(
 
     for i in 1u16..=num_shards.into() {
         let index = format!("{i:0len$}", len = len);
-        let host = host.clone().replace(&pattern, &index);
+        let host = host.clone().replacen(&pattern, &index, 1);
         let port = port
             .clone()
-            .replace(&pattern, &index)
+            .replacen(&pattern, &index, 1)
             .parse()
             .context("Failed to decode port into an integers")?;
-        let metrics_host = metrics_host.clone().replace(&pattern, &index);
+        let metrics_host = metrics_host.clone().replacen(&pattern, &index, 1);
         let metrics_port = metrics_port
             .clone()
             .map(|port| {
-                port.replace(&pattern, &index)
+                port.replacen(&pattern, &index, 1)
                     .parse()
                     .context("Failed to decode metrics port into an integers")
             })

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -404,8 +404,8 @@ enum ServerCommand {
         server_config_path: PathBuf,
 
         /// The number N of shard configs to generate, possibly starting with zeroes. If
-        /// `N` was written using `D` digits, we will replace the string `"%" * D` (`%`
-        /// repeated D times) by the shard number.
+        /// `N` was written using `D` digits, we will replace the first occurrence of the
+        /// string `"%" * D` (`%` repeated D times) by the shard number.
         #[arg(long)]
         num_shards: String,
 
@@ -629,16 +629,15 @@ fn generate_shard_configs(
     let pattern = "%".repeat(len);
 
     for i in 1u16..=num_shards.into() {
-        let index = format!("{i:0len$}", len = len);
-        let host = host.clone().replacen(&pattern, &index, 1);
+        let index = format!("{i:0len$}");
+        let host = host.replacen(&pattern, &index, 1);
         let port = port
-            .clone()
             .replacen(&pattern, &index, 1)
             .parse()
             .context("Failed to decode port into an integers")?;
-        let metrics_host = metrics_host.clone().replacen(&pattern, &index, 1);
+        let metrics_host = metrics_host.replacen(&pattern, &index, 1);
         let metrics_port = metrics_port
-            .clone()
+            .as_ref()
             .map(|port| {
                 port.replacen(&pattern, &index, 1)
                     .parse()

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -61,16 +61,6 @@ pub fn read_json<T: serde::de::DeserializeOwned>(
     Ok(serde_json::from_reader(fs_err::File::open(path)?)?)
 }
 
-pub fn write_json<T: serde::Serialize>(
-    path: impl Into<std::path::PathBuf>,
-    value: &T,
-) -> anyhow::Result<()> {
-    Ok(serde_json::to_writer_pretty(
-        fs_err::File::create(path)?,
-        value,
-    )?)
-}
-
 #[cfg(with_testing)]
 use {
     std::io::Write,

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -61,6 +61,16 @@ pub fn read_json<T: serde::de::DeserializeOwned>(
     Ok(serde_json::from_reader(fs_err::File::open(path)?)?)
 }
 
+pub fn write_json<T: serde::Serialize>(
+    path: impl Into<std::path::PathBuf>,
+    value: &T,
+) -> anyhow::Result<()> {
+    Ok(serde_json::to_writer_pretty(
+        fs_err::File::create(path)?,
+        value,
+    )?)
+}
+
 #[cfg(with_testing)]
 use {
     std::io::Write,


### PR DESCRIPTION
## Motivation

Allow editing the number of shard in a validator internal config file.

## Proposal

Create a command `linera-server edit-shards --server file.json --num-shards 4 --host 'shard-%' --port 8000 --metrics-host 'shard-%' --metrics-port 8001`

Because of port numbers, I figured we should use `%` when `num_shards` is written with 1 digits, `%%` for 2 digits, etc.

## Test Plan

```
linera-server generate --validators configuration/local/validator_*.toml --committee committee.json --testing-prng-seed 1

linera-server edit-shards --server server_1.json --num-shards 02 --host 'shard-%%' --port '10000' --metrics-host 'shard-%%' --metrics-port '110%%'
```

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
