### PR TITLE
Better logging for subscriptions

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -3034,7 +3034,9 @@ where
             })
             .filter_map(move |result| async move {
                 if let Err(error) = &result {
-                    info!(?error, "Could not connect to validator {name}");
+                    warn!(?error, "Could not connect to validator {name}");
+                } else {
+                    info!("Connected to validator {name}");
                 }
                 result.ok()
             })

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -69,9 +69,7 @@ impl GrpcClient {
     fn is_retryable(status: &Status, address: &str) -> bool {
         match status.code() {
             Code::DeadlineExceeded | Code::Aborted | Code::Unavailable | Code::Unknown => {
-                info!(
-                    "gRPC request to {address} interrupted: {status}; retrying"
-                );
+                info!("gRPC request to {address} interrupted: {status}; retrying");
                 true
             }
             Code::Ok

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -90,7 +90,7 @@ impl GrpcClient {
             | Code::Internal
             | Code::DataLoss
             | Code::Unauthenticated => {
-                error!("Unexpected gRPC status received from {address}: {}", status);
+                error!("Unexpected gRPC status received from {address}: {status}");
                 false
             }
         }

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -80,10 +80,7 @@ impl GrpcClient {
             | Code::NotFound
             | Code::AlreadyExists
             | Code::ResourceExhausted => {
-                error!(
-                    "Unexpected gRPC status received from {address}: {}; retrying",
-                    status
-                );
+                error!("gRPC request to {address} interrupted: {status}; retrying");
                 true
             }
             Code::InvalidArgument

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -70,8 +70,7 @@ impl GrpcClient {
         match status.code() {
             Code::DeadlineExceeded | Code::Aborted | Code::Unavailable | Code::Unknown => {
                 info!(
-                    "gRPC request to {address} interrupted: {}; retrying",
-                    status
+                    "gRPC request to {address} interrupted: {status}; retrying"
                 );
                 true
             }


### PR DESCRIPTION
## Motivation

Increase verbosity of logs re: subscriptions

## Proposal

* Add one argument to `is_retryable`
* Report connection errors as warnings

## Test Plan

CI + run a node service manually

## Release Plan

[currently on the testnet branch]

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
