### PR TITLE
Optimize `synchronize_received_certificates_from_validator`.

### DIFF
--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -380,7 +380,11 @@ where
         self.recent_blobs.insert(blob).await
     }
 
-    /// Adds any newly created chains to the set of `tracked_chains`.
+    /// Adds any newly created chains to the set of `tracked_chains`, if the parent chain is
+    /// also tracked.
+    ///
+    /// Chains that are not tracked are usually processed only because they sent some message
+    /// to one of the tracked chains. In most use cases, their children won't be of interest.
     fn track_newly_created_chains(&self, executed_block: &ExecutedBlock) {
         if let Some(tracked_chains) = self.tracked_chains.as_ref() {
             if !tracked_chains
@@ -388,7 +392,7 @@ where
                 .expect("Panics should not happen while holding a lock to `tracked_chains`")
                 .contains(&executed_block.block.chain_id)
             {
-                return;
+                return; // The parent chain is not tracked; don't track the child.
             }
             let messages = executed_block.messages().iter().flatten();
             let open_chain_message_indices =

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -166,7 +166,7 @@ mod metrics {
 }
 
 /// The number of chain workers that can be in memory at the same time.
-const CHAIN_WORKER_LIMIT: usize = 100;
+const CHAIN_WORKER_LIMIT: usize = 20;
 
 /// A builder that creates [`ChainClient`]s which share the cache and notifiers.
 pub struct Client<ValidatorNodeProvider, Storage>

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -165,7 +165,9 @@ mod metrics {
     });
 }
 
-/// The number of chain workers that can be in memory at the same time.
+/// The number of chain workers that can be in memory at the same time. More workers improve
+/// perfomance whenever the client interacts with multiple chains at the same time, but also
+/// increases memory usage.
 const CHAIN_WORKER_LIMIT: usize = 20;
 
 /// A builder that creates [`ChainClient`]s which share the cache and notifiers.


### PR DESCRIPTION
## Motivation

Synchronizing the admin chain on devnet-2024-10-21 is very slow.

## Proposal

In `synchronize_received_certificates_from_validator`:
* Make multiple requests for the _local_ chain infos of sender chains concurrently, but don't exceed the number of available chain workers.
* Fetch the _remote_ chain infos concurrently.
* Only make a single call to `download_certificates`, not one per sender chain.
* Don't track new chains unless they were created by one of our tracked chains.
* Simplifications: only take into account the highest sending block on each chain, rather than the list of sending blocks; update the tracker afterwards based on downloaded block heights.

## Test Plan

This is only an optimization; CI should catch any regressions.

I ran locally, in release mode:

```
linera wallet init --with-other-chains e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65 --faucet https://faucet.devnet-2024-10-21.linera.net/

linera sync-balance
```

and got `Operation confirmed` 115 seconds, compared to 274 seconds without this change.

## Release Plan

- These changes should be released in a new SDK.
- These changes should be backported to the `main` branch.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
