### PR TITLE
Push docker images from CI

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -1,0 +1,60 @@
+name: Docker Image
+
+on:
+  push:
+    branches: [ 'devnet_*', 'testnet_*' ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Auth service account
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_SA_ACTIONS_RUNNER_KEY }}
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+    
+      - name: Authenticate Docker with GCP
+        run: |
+          gcloud auth configure-docker us-docker.pkg.dev
+  
+      - name: Set env variables
+        run: |
+          echo "GIT_COMMIT_SHORT=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+          echo "GIT_COMMIT_LONG=${GITHUB_SHA}" >> $GITHUB_ENV
+          if [ -n "${{ github.head_ref }}" ]; then
+            echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
+          else
+            echo "BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+          fi
+
+      - name: Set docker image env variable
+        run: |
+          echo "DOCKER_IMAGE=us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera" >> $GITHUB_ENV
+  
+      - name: Build Docker image
+        run: |
+          docker build --build-arg git_commit=${{ env.GIT_COMMIT_LONG }} \
+            -f docker/Dockerfile . \
+            -t ${{ env.DOCKER_IMAGE }}:${{ env.BRANCH_NAME }} \
+            -t ${{ env.DOCKER_IMAGE }}:${{ env.GIT_COMMIT_SHORT }} \
+            -t ${{ env.DOCKER_IMAGE }}:${{ env.GIT_COMMIT_LONG }}
+  
+      - name: Push Docker image to Google Artifact Registry
+        run: |
+          docker push -a ${{ env.DOCKER_IMAGE }}


### PR DESCRIPTION
## Motivation

There's a lot of time in our release process that is used building docker images, so we should do something about that to speed up our process.

## Proposal

Create a public registry with https://github.com/linera-io/linera-infra/pull/97
And use a CI job to build and push docker images to this public registry

## Test Plan

Modified the CI workflow to trigger for this PR, changed it to publish to a test image. Made sure CI was green, and the docker image was visible and pullable from the public registry:


![Screenshot 2024-10-29 at 19.06.12.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/3ab377b6-ce75-44b3-82c1-63e6524a07e3.png)

Example successful run with the test code: https://github.com/linera-io/linera-protocol/actions/runs/11583023872/job/32247304661

Test code: https://github.com/linera-io/linera-protocol/commit/78c30d528b90dcf8f64494c1abe55f6443dd2bef

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
