### PR TITLE
Make the `cargo +nightly test` compile correctly.

### DIFF
--- a/linera-sdk/src/log.rs
+++ b/linera-sdk/src/log.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    panic::{self, PanicInfo},
+    panic::{self, PanicHookInfo},
     sync::Once,
 };
 
@@ -70,6 +70,6 @@ impl Log for ServiceLogger {
 }
 
 /// Logs a panic using the [`log`] API.
-fn log_panic(info: &PanicInfo<'_>) {
+fn log_panic(info: &PanicHookInfo<'_>) {
     log::error!("{info}");
 }

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -1988,6 +1988,7 @@ mod graphql {
     }
 }
 
+/// The tests for `Borrow` and `bcs`.
 #[cfg(test)]
 pub mod tests {
     use std::borrow::Borrow;


### PR DESCRIPTION
## Motivation

The search for higher performance requires better timings. Some of those are accessible only on nightly compiles, which is not the case right now.

## Proposal

Two changes are made:
* Add documentation in `map:view.rs`.
* Replace `PanicInfo` by `PanicHookInfo` following the warnings.

With those changes, the following command
```
cargo +nightly test -- --report-time -Z unstable-options
```
is now working fine and reporting the times of the tests.

## Test Plan

The CI.

## Release Plan

Not relevant

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
