### PR TITLE
Make storage-service a default feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -106,9 +106,10 @@ jobs:
     - name: Run the remote-net tests
       run: |
         cargo test -p linera-service remote_net_grpc --features remote-net
-    - name: Run all tests using the default features
+    - name: Run all tests using the default features (plus unstable-oracles, except storage-service)
       run: |
-        cargo test --features unstable-oracles --locked
+        # TODO(#2764): Actually link this to the default features
+        cargo test --no-default-features --features fs,macros,wasmer,rocksdb,unstable-oracles --locked
     - name: Run some extra execution tests with wasmtime
       run: |
         cargo test --locked -p linera-execution --features wasmtime

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ linera-witty = { version = "0.14.0", path = "./linera-witty" }
 linera-witty-macros = { version = "0.14.0", path = "./linera-witty-macros" }
 linera-witty-test-modules  = { version = "0.14.0", path = "./linera-witty/test-modules" }
 linera-sdk-derive = { version = "0.14.0", path = "./linera-sdk-derive" }
-linera-service = { version = "0.14.0", path = "./linera-service" }
+linera-service = { version = "0.14.0", path = "./linera-service", default-features = false }
 linera-service-graphql-client = { version = "0.14.0", path = "./linera-service-graphql-client" }
 
 counter = { path = "./examples/counter" }

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -75,7 +75,7 @@ port-selector.workspace = true
 zstd.workspace = true
 
 [dev-dependencies]
-linera-base = { path = ".", features = ["test"] }
+linera-base = { path = ".", default-features = false, features = ["test"] }
 linera-witty = { workspace = true, features = ["test"] }
 test-case.workspace = true
 

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -35,7 +35,7 @@ tracing.workspace = true
 [dev-dependencies]
 assert_matches.workspace = true
 bcs.workspace = true
-linera-chain = { path = ".", features = ["test"] }
+linera-chain = { path = ".", default-features = false, features = ["test"] }
 
 [build-dependencies]
 cfg_aliases.workspace = true

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -107,7 +107,7 @@ fungible.workspace = true
 linera-alloy = { workspace = true, default-features = false, features = [ "rpc-types-eth" ] }
 linera-base = { workspace = true, features = ["test"] }
 linera-chain = { workspace = true, features = ["test"] }
-linera-client = { path = ".", features = ["test"] }
+linera-client = { path = ".", default-features = false, features = ["test"] }
 linera-core = { workspace = true, features = ["test"] }
 linera-ethereum.workspace = true
 linera-execution = { workspace = true, features = ["test"] }

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -90,7 +90,7 @@ assert_matches.workspace = true
 counter.workspace = true
 criterion.workspace = true
 fungible.workspace = true
-linera-core = { path = ".", features = ["test"] }
+linera-core = { path = ".", default-features = false, features = ["test"] }
 linera-views.workspace = true
 meta-counter.workspace = true
 serde_json.workspace = true

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -76,7 +76,7 @@ assert_matches.workspace = true
 bcs.workspace = true
 counter.workspace = true
 linera-base = { workspace = true, features = ["test"] }
-linera-execution = { path = ".", features = ["test"] }
+linera-execution = { path = ".", default-features = false, features = ["test"] }
 linera-witty = { workspace = true, features = ["log", "macros", "test"] }
 test-case.workspace = true
 test-log = { workspace = true, features = ["trace"] }

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -71,7 +71,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 insta = { workspace = true, features = ["yaml"] }
-linera-rpc = { path = ".", features = ["test"] }
+linera-rpc = { path = ".", default-features = false, features = ["test"] }
 proptest.workspace = true
 serde-reflection.workspace = true
 test-strategy.workspace = true

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -72,7 +72,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 wasmtime.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-linera-sdk = { path = ".", features = ["test"] }
+linera-sdk = { path = ".", default-features = false, features = ["test"] }
 tokio-test.workspace = true
 
 [build-dependencies]

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -13,7 +13,7 @@ version.workspace = true
 
 [features]
 ethereum = []
-default = ["wasmer", "rocksdb"]
+default = ["wasmer", "rocksdb", "storage-service"]
 test = [
     "linera-base/test",
     "linera-views/test",

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -133,7 +133,7 @@ linera-ethereum.workspace = true
 linera-execution = { workspace = true, features = ["test"] }
 linera-rpc = { workspace = true, features = ["test"] }
 linera-sdk = { workspace = true, features = ["wasmer", "test"] }
-linera-service = { path = ".", features = ["test"] }
+linera-service = { path = ".", default-features = false, features = ["test"] }
 linera-storage = { workspace = true, features = ["test"] }
 linera-views = { workspace = true, features = ["test"] }
 matching-engine.workspace = true

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -39,7 +39,7 @@ tracing-subscriber = { workspace = true, features = ["fmt"] }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
-linera-storage-service = { path = ".", features = ["test"] }
+linera-storage-service = { path = ".", default-features = false, features = ["test"] }
 proptest = { workspace = true, features = ["alloc"] }
 serde-reflection.workspace = true
 serde_yaml.workspace = true

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -42,7 +42,7 @@ serde.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true
-linera-storage = { path = ".", features = ["test"] }
+linera-storage = { path = ".", default-features = false, features = ["test"] }
 
 [build-dependencies]
 cfg_aliases.workspace = true

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -68,7 +68,7 @@ wasm-bindgen-test.workspace = true
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
-linera-views = { path = ".", features = ["test"] }
+linera-views = { path = ".", default-features = false, features = ["test"] }
 rand.workspace = true
 test-case.workspace = true
 tokio-test.workspace = true

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -43,7 +43,7 @@ features = ["singlepass"]
 [dev-dependencies]
 assert_matches.workspace = true
 insta.workspace = true
-linera-witty = { path = ".", features = ["macros", "test"] }
+linera-witty = { path = ".", default-features = false, features = ["macros", "test"] }
 test-case.workspace = true
 tracing.workspace = true
 


### PR DESCRIPTION
## Motivation

Users should be able to use `linera net up` after `cargo install linera-storage-service linera-service` (without passing additional features).

## Proposal

Make `storage-service` a default feature

Caveat: `cargo test -p linera-service` will not pass anymore. Fixing this is a longer discussion (see e.g. #2699)

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
