### PR TITLE
`Cargo.toml`: require tonic ≥ 0.12.3, below which we are not compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,8 +137,8 @@ test-log = { version = "0.2.15", default-features = false, features = ["trace"] 
 test-strategy = "0.3.1"
 thiserror = "1.0.65"
 thiserror-context = "0.1.1"
-tonic = { version = "0.12", default-features = false }
-tonic-build = { version = "0.12", default-features = false }
+tonic = { version = "0.12.3", default-features = false }
+tonic-build = { version = "0.12.3", default-features = false }
 tonic-health = "0.12"
 tonic-reflection = "0.12"
 tonic-web = "0.12"


### PR DESCRIPTION
## Motivation

Our `Cargo.lock` locks us to Tonic 0.12.3, which is fine.  But since this version introduced backwards-incompatible API changes, and our `Cargo.toml` only specifies that we need version `0.12.0`, our build may break when building from a different workspace.

<!--
Briefly describe the goal(s) of this PR.
-->

## Proposal

Upgrade Tonic to a minimum version of 0.12.3 in `Cargo.toml`. 

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->

## Test Plan

CI, and `linera-web`.

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
