### PR TITLE
`scripts/linera_net_helper.sh`: also print out the environment variables

### DIFF
--- a/scripts/linera_net_helper.sh
+++ b/scripts/linera_net_helper.sh
@@ -20,6 +20,9 @@ function linera_spawn_and_read_wallet_variables() {
     # Read from LINERA_TMP_ERR until the string "READY!" is found.
     sed '/^READY!/q' <"$LINERA_TMP_ERR" || exit 1
 
+    # Output the commands for reading.
+    cat "$LINERA_TMP_OUT"
+
     # Source the Bash commands output by the server.
     source "$LINERA_TMP_OUT"
 


### PR DESCRIPTION
## Motivation

Often when I launch a net with `linera_spawn_and_read_wallet_variables`, I also want to know the produced wallet variables.  Besides, it makes the output rather confusing, as it heralds some variables that are not forthcoming.

<!--
Briefly describe the goal(s) of this PR.
-->

## Proposal

Print the variables, as well as sourcing them.

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->

## Test Plan

I tried it locally.

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
