### PR TITLE
`linera-execution`: remove unnecessary `Arc` from the module cache

### DIFF
--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -20,7 +20,6 @@ mod wasmer;
 #[cfg(with_wasmtime)]
 mod wasmtime;
 
-use std::sync::Arc;
 #[cfg(with_metrics)]
 use std::sync::LazyLock;
 
@@ -80,7 +79,7 @@ pub enum WasmContractModule {
         module: ::wasmer::Module,
     },
     #[cfg(with_wasmtime)]
-    Wasmtime { module: Arc<::wasmtime::Module> },
+    Wasmtime { module: ::wasmtime::Module },
 }
 
 impl WasmContractModule {
@@ -152,9 +151,9 @@ impl UserContractModule for WasmContractModule {
 #[derive(Clone)]
 pub enum WasmServiceModule {
     #[cfg(with_wasmer)]
-    Wasmer { module: Arc<::wasmer::Module> },
+    Wasmer { module: ::wasmer::Module },
     #[cfg(with_wasmtime)]
-    Wasmtime { module: Arc<::wasmtime::Module> },
+    Wasmtime { module: ::wasmtime::Module },
 }
 
 impl WasmServiceModule {


### PR DESCRIPTION
## Motivation

Modules in both `wasmer` and `wasmtime` are cheap to clone already, being essentially `Arc`s inside.

<!--
Briefly describe the goal(s) of this PR.
-->

## Proposal

Remove the unnecessary `Arc`, replacing it with a `Clone` bound.

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->

## Test Plan

CI.

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
