### PR TITLE
`linera_execution::wasm::wasmer`: don't serialize JS modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4229,7 +4229,6 @@ dependencies = [
  "async-graphql",
  "async-trait",
  "bcs",
- "bytes",
  "cfg-if",
  "cfg_aliases",
  "clap",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3334,7 +3334,6 @@ dependencies = [
  "async-graphql",
  "async-trait",
  "bcs",
- "bytes",
  "cfg-if",
  "cfg_aliases",
  "clap",

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -17,7 +17,6 @@ fs = ["tokio/fs"]
 metrics = ["prometheus", "linera-views/metrics"]
 unstable-oracles = []
 wasmer = [
-    "bytes",
     "dep:wasmer",
     "linera-witty/wasmer",
     "wasm-encoder",
@@ -37,7 +36,6 @@ anyhow.workspace = true
 async-graphql.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
-bytes = { workspace = true, optional = true }
 cfg-if.workspace = true
 clap.workspace = true
 custom_debug_derive.workspace = true


### PR DESCRIPTION
## Motivation

We need to do this on native, where we use two different runtimes for compilation and running, but we don't need to (and indeed can't, without storing a copy of the Wasm bytecode separately) do it on the Web.

Failure to do this causes Wasmer to issue the very surprising error:

    RuntimeError: call stack exhausted during Operation(0)

<!--
Briefly describe the goal(s) of this PR.
-->

## Proposal

Conditionally compile the code to deserialize and reserialize the bytecode between `wasmer` backends, and disable it on the Web.

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
