### PR TITLE
tentatively fix #2735

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -3210,9 +3210,7 @@ where
             })
             .filter_map(move |result| async move {
                 if let Err(error) = &result {
-                    warn!(?error, "Could not connect to validator {name}");
-                } else {
-                    info!("Connected to validator {name}");
+                    info!(?error, "Could not connect to validator {name}");
                 }
                 result.ok()
             })

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -158,12 +158,13 @@ impl GrpcClient {
 
 macro_rules! client_delegate {
     ($self:ident, $handler:ident, $req:ident) => {{
+        let address = $self.address.clone();
         $self
             .delegate(
                 |mut client, req| async move { client.$handler(req).await },
                 $req,
                 stringify!($handler),
-                &$self.address,
+                &address,
             )
             .await
     }};

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -48,6 +48,7 @@ const CLIENT_SERVICE_ENV: &str = "LINERA_CLIENT_SERVICE_PARAMS";
 fn reqwest_client() -> reqwest::Client {
     reqwest::ClientBuilder::new()
         .timeout(Duration::from_secs(30))
+        .pool_max_idle_per_host(0)
         .build()
         .unwrap()
 }

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -49,6 +49,8 @@ fn reqwest_client() -> reqwest::Client {
     reqwest::ClientBuilder::new()
         .timeout(Duration::from_secs(30))
         .pool_max_idle_per_host(0)
+        .tcp_keepalive(Duration::from_secs(45))
+        .http2_keep_alive_while_idle(false)
         .build()
         .unwrap()
 }


### PR DESCRIPTION
## Motivation

unbreak CI

## Proposal

Avoid holding &self longer than before in the macro

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
