### PR TITLE
Refactor how native token authentication is verified

### DIFF
--- a/linera-execution/src/authenticated_account.rs
+++ b/linera-execution/src/authenticated_account.rs
@@ -19,6 +19,19 @@ pub struct AuthenticatedAccount {
 }
 
 impl AuthenticatedAccount {
+    /// Creates a new [`AuthenticatedAccount`] from an [`Account`]'s elements, if the `owner` can
+    /// be authenticated by the system application's [`OperationContext`].
+    pub(crate) fn new_in_system_application(
+        context: &OperationContext,
+        chain_id: ChainId,
+        owner: Owner,
+    ) -> Result<Self, UnauthorizedError> {
+        Ok(AuthenticatedAccount {
+            chain_id,
+            owner: AuthenticatedAccountOwner::new_in_system_application(context, Some(owner))?,
+        })
+    }
+
     /// Creates a new [`AuthenticatedAccount`] from an [`Account`], if its `owner` can be
     /// authenticated by the user application runtime's [`ApplicationStatus`].
     pub(crate) fn new_in_user_application(

--- a/linera-execution/src/authenticated_account.rs
+++ b/linera-execution/src/authenticated_account.rs
@@ -4,6 +4,8 @@
 use linera_base::{ensure, identifiers::Owner};
 use thiserror::Error;
 
+use crate::runtime::ApplicationStatus;
+
 /// An account owner that has been successfully authenticated to manage tokens.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum AuthenticatedAccountOwner {
@@ -15,6 +17,15 @@ pub enum AuthenticatedAccountOwner {
 }
 
 impl AuthenticatedAccountOwner {
+    /// Creates a new [`AuthenticatedAccountOwner`], if the `owner` can be authenticated by the
+    /// user application runtime's [`ApplicationStatus`].
+    pub(crate) fn new_in_user_application(
+        application_status: &ApplicationStatus,
+        owner: Option<Owner>,
+    ) -> Result<Self, UnauthorizedError> {
+        Self::new_internal(application_status.authenticated_signer(), owner)
+    }
+
     /// Creates a new [`AuthenticatedAccountOwner`], if the `owner` can be authenticated by the
     /// `authenticated_signer`.
     fn new_internal(

--- a/linera-execution/src/authenticated_account.rs
+++ b/linera-execution/src/authenticated_account.rs
@@ -4,7 +4,7 @@
 use linera_base::{ensure, identifiers::Owner};
 use thiserror::Error;
 
-use crate::runtime::ApplicationStatus;
+use crate::{runtime::ApplicationStatus, OperationContext};
 
 /// An account owner that has been successfully authenticated to manage tokens.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -17,6 +17,15 @@ pub enum AuthenticatedAccountOwner {
 }
 
 impl AuthenticatedAccountOwner {
+    /// Creates a new [`AuthenticatedAccountOwner`], if the `owner` can be authenticated by the
+    /// system application's [`OperationContext`].
+    pub(crate) fn new_in_system_application(
+        context: &OperationContext,
+        owner: Option<Owner>,
+    ) -> Result<Self, UnauthorizedError> {
+        Self::new_internal(context.authenticated_signer, owner)
+    }
+
     /// Creates a new [`AuthenticatedAccountOwner`], if the `owner` can be authenticated by the
     /// user application runtime's [`ApplicationStatus`].
     pub(crate) fn new_in_user_application(

--- a/linera-execution/src/authenticated_account.rs
+++ b/linera-execution/src/authenticated_account.rs
@@ -19,6 +19,21 @@ pub struct AuthenticatedAccount {
 }
 
 impl AuthenticatedAccount {
+    /// Creates a new [`AuthenticatedAccount`] from an [`Account`], if its `owner` can be
+    /// authenticated by the user application runtime's [`ApplicationStatus`].
+    pub(crate) fn new_in_user_application(
+        application_status: &ApplicationStatus,
+        account: Account,
+    ) -> Result<Self, UnauthorizedError> {
+        Ok(AuthenticatedAccount {
+            chain_id: account.chain_id,
+            owner: AuthenticatedAccountOwner::new_in_user_application(
+                application_status,
+                account.owner,
+            )?,
+        })
+    }
+
     /// Returns the [`ChainId`] of the chain that has this account.
     pub fn chain_id(self) -> ChainId {
         self.chain_id

--- a/linera-execution/src/authenticated_account.rs
+++ b/linera-execution/src/authenticated_account.rs
@@ -1,10 +1,42 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_base::{ensure, identifiers::Owner};
+use linera_base::{
+    ensure,
+    identifiers::{Account, ChainId, Owner},
+};
 use thiserror::Error;
 
 use crate::{runtime::ApplicationStatus, OperationContext};
+
+/// An account that has been successfully authenticated to manage tokens.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct AuthenticatedAccount {
+    /// The chain where this account is located.
+    chain_id: ChainId,
+    /// The owner of the account.
+    owner: AuthenticatedAccountOwner,
+}
+
+impl AuthenticatedAccount {
+    /// Returns the [`ChainId`] of the chain that has this account.
+    pub fn chain_id(self) -> ChainId {
+        self.chain_id
+    }
+
+    /// Returns the [`AuthenticatedAccountOwner`] of this account.
+    pub fn owner(self) -> AuthenticatedAccountOwner {
+        self.owner
+    }
+
+    /// Returns the [`Account`] without authentication.
+    pub fn without_authentication(self) -> Account {
+        Account {
+            chain_id: self.chain_id,
+            owner: self.owner.without_authentication(),
+        }
+    }
+}
 
 /// An account owner that has been successfully authenticated to manage tokens.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/linera-execution/src/authenticated_account.rs
+++ b/linera-execution/src/authenticated_account.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use linera_base::{ensure, identifiers::Owner};
+use thiserror::Error;
+
+/// An account owner that has been successfully authenticated to manage tokens.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum AuthenticatedAccountOwner {
+    /// Shared ownership among all chain owners.
+    Chain,
+    /// A user represented by a single public key.
+    User(Owner),
+    // TODO(#2608): Support application accounts
+}
+
+impl AuthenticatedAccountOwner {
+    /// Creates a new [`AuthenticatedAccountOwner`], if the `owner` can be authenticated by the
+    /// `authenticated_signer`.
+    fn new_internal(
+        authenticated_signer: Option<Owner>,
+        owner: Option<Owner>,
+    ) -> Result<Self, UnauthorizedError> {
+        if owner.is_some() {
+            ensure!(authenticated_signer == owner, UnauthorizedError::new(owner));
+        }
+
+        match owner {
+            Some(owner) => Ok(AuthenticatedAccountOwner::User(owner)),
+            None => Ok(AuthenticatedAccountOwner::Chain),
+        }
+    }
+
+    /// Returns the account without authentication.
+    pub fn without_authentication(self) -> Option<Owner> {
+        match self {
+            AuthenticatedAccountOwner::Chain => None,
+            AuthenticatedAccountOwner::User(owner) => Some(owner),
+        }
+    }
+}
+
+/// A failure to authenticate usage of an account.
+#[derive(Clone, Debug, Error)]
+#[error("Unauthorized to perform movement of tokens owned by {account_owner}")]
+pub struct UnauthorizedError {
+    account_owner: String,
+}
+
+impl UnauthorizedError {
+    /// Creates a new [`UnauthorizedError`] with a readable [`String`] to represent the
+    /// account.
+    pub fn new(account: Option<Owner>) -> Self {
+        let account_owner = account
+            .as_ref()
+            .map(Owner::to_string)
+            .unwrap_or_else(|| "the chain owners".to_owned());
+
+        UnauthorizedError { account_owner }
+    }
+}

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -149,18 +149,10 @@ where
                 amount,
                 callback,
             } => {
-                let source = source.without_authentication();
-                let owner = source.owner.ok_or(ExecutionError::OwnerIsNone)?;
                 let mut execution_outcome = RawExecutionOutcome::default();
                 let message = self
                     .system
-                    .claim(
-                        Some(owner),
-                        owner,
-                        source.chain_id,
-                        Recipient::Account(destination),
-                        amount,
-                    )
+                    .claim(source, Recipient::Account(destination), amount)
                     .await?;
 
                 execution_outcome.messages.push(message);

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -131,10 +131,9 @@ where
                 callback,
             } => {
                 let mut execution_outcome = RawExecutionOutcome::default();
-                let source = source.without_authentication();
                 let message = self
                     .system
-                    .transfer(source, source, Recipient::Account(destination), amount)
+                    .transfer(source, Recipient::Account(destination), amount)
                     .await?;
 
                 if let Some(message) = message {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -176,6 +176,8 @@ pub enum ExecutionError {
     InvalidBytecodeId(BytecodeId),
     #[error("Owner is None")]
     OwnerIsNone,
+    #[error("Unauthorized attempt to transfer tokens")]
+    UnauthorizedTransfer(#[from] authenticated_account::UnauthorizedError),
     #[error("Application is not authorized to perform system operations on this chain: {0:}")]
     UnauthorizedApplication(UserApplicationId),
     #[error("Failed to make network reqwest")]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -49,7 +49,9 @@ use serde::{Deserialize, Serialize};
 use system::OpenChainConfig;
 use thiserror::Error;
 
-pub(crate) use self::authenticated_account::{AuthenticatedAccountOwner, UnauthorizedError};
+pub(crate) use self::authenticated_account::{
+    AuthenticatedAccount, AuthenticatedAccountOwner, UnauthorizedError,
+};
 #[cfg(with_testing)]
 pub use crate::applications::ApplicationRegistry;
 use crate::runtime::ContractSyncRuntime;

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -7,6 +7,7 @@
 #![deny(clippy::large_futures)]
 
 mod applications;
+mod authenticated_account;
 pub mod committee;
 mod execution;
 mod execution_state_actor;
@@ -48,6 +49,7 @@ use serde::{Deserialize, Serialize};
 use system::OpenChainConfig;
 use thiserror::Error;
 
+pub(crate) use self::authenticated_account::{AuthenticatedAccountOwner, UnauthorizedError};
 #[cfg(with_testing)]
 pub use crate::applications::ApplicationRegistry;
 use crate::runtime::ContractSyncRuntime;

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1223,7 +1223,6 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             self.inner().current_application(),
             source,
         )?;
-        let source = source.without_authentication();
         let execution_outcome = self
             .inner()
             .execution_state_sender
@@ -1231,7 +1230,6 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
                 source,
                 destination,
                 amount,
-                signer: source,
                 callback,
             })?
             .recv_response()?;

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -30,10 +30,10 @@ use crate::{
     execution_state_actor::{ExecutionRequest, ExecutionStateSender},
     resources::ResourceController,
     util::{ReceiverExt, UnboundedSenderExt},
-    AuthenticatedAccountOwner, BaseRuntime, ContractRuntime, ExecutionError, FinalizeContext,
-    MessageContext, OperationContext, QueryContext, RawExecutionOutcome, ServiceRuntime,
-    TransactionTracker, UserApplicationDescription, UserApplicationId, UserContractInstance,
-    UserServiceInstance, MAX_EVENT_KEY_LEN, MAX_STREAM_NAME_LEN,
+    AuthenticatedAccount, AuthenticatedAccountOwner, BaseRuntime, ContractRuntime, ExecutionError,
+    FinalizeContext, MessageContext, OperationContext, QueryContext, RawExecutionOutcome,
+    ServiceRuntime, TransactionTracker, UserApplicationDescription, UserApplicationId,
+    UserContractInstance, UserServiceInstance, MAX_EVENT_KEY_LEN, MAX_STREAM_NAME_LEN,
 };
 
 #[cfg(test)]
@@ -1246,6 +1246,11 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         amount: Amount,
     ) -> Result<(), ExecutionError> {
         let signer = self.inner().current_application().signer;
+        let source = AuthenticatedAccount::new_in_user_application(
+            self.inner().current_application(),
+            source,
+        )?;
+        let source = source.without_authentication();
         let execution_outcome = self
             .inner()
             .execution_state_sender

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1250,7 +1250,6 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             self.inner().current_application(),
             source,
         )?;
-        let source = source.without_authentication();
         let execution_outcome = self
             .inner()
             .execution_state_sender
@@ -1258,7 +1257,6 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
                 source,
                 destination,
                 amount,
-                signer,
                 callback,
             })?
             .recv_response()?

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -101,7 +101,7 @@ pub struct SyncRuntimeInternal<UserInstance> {
 
 /// The runtime status of an application.
 #[derive(Debug)]
-struct ApplicationStatus {
+pub(crate) struct ApplicationStatus {
     /// The caller application ID, if forwarded during the call.
     caller_id: Option<UserApplicationId>,
     /// The application ID.
@@ -112,6 +112,13 @@ struct ApplicationStatus {
     signer: Option<Owner>,
     /// The current execution outcome of the application.
     outcome: RawExecutionOutcome<Vec<u8>>,
+}
+
+impl ApplicationStatus {
+    /// Returns the authenticated signer for the execution thread, if any.
+    pub fn authenticated_signer(&self) -> Option<Owner> {
+        self.signer
+    }
 }
 
 /// A loaded application instance.

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -761,9 +761,11 @@ where
                 owner,
                 recipient,
             } => {
-                ensure!(
-                    context.authenticated_signer == Some(owner),
-                    SystemExecutionError::UnauthenticatedClaimOwner
+                assert_eq!(
+                    context.authenticated_signer,
+                    Some(owner),
+                    "Message should be sent after checking the claimer's authentication \
+                    and include the `authenticated_signer`"
                 );
 
                 let balance = self.balances.get_mut_or_default(&owner).await?;


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
The rules for authentication to access native tokens will be changed soon to make them stricter, preventing access to the chain's balance shared by owners to be transferred by incoming messages. With the goal of making that change simpler and hopefully easier to audit, the authentication for native tokens can be centralized in a single location of the code before it is changed.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Create new `AuthenticatedAccount` and `AuthenticatedAccountOwner` types that represent in compile time when an `Account` and `Option<Owner>` have been successfully authorized to move native tokens.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
CI should catch any regressions.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- These changes follow the usual release cycle, because they are just an internal refactor.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
