### PR TITLE
Added keepalive timout so that connections are not dropped.

### DIFF
--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -47,3 +47,8 @@ pub const GRPC_MAX_MESSAGE_SIZE: usize = 16 * MEBIBYTE;
 /// Limit of gRPC message size up to which we will try to populate with data when estimating.
 /// We leave 30% of buffer for the rest of the message and potential underestimation.
 pub const GRPC_CHUNKED_MESSAGE_FILL_LIMIT: usize = GRPC_MAX_MESSAGE_SIZE * 7 / 10;
+
+/// This is hard-coded for now. In future implementations it should be negotiated
+/// between client and server. See [specification](https://grpc.io/docs/guides/keepalive/#keepalive-configuration-specification)
+/// for details.
+pub const KEEPALIVE_TIME_MS: u64 = 40 * 1000;

--- a/linera-rpc/src/grpc/transport.rs
+++ b/linera-rpc/src/grpc/transport.rs
@@ -28,6 +28,8 @@ cfg_if::cfg_if! {
         }
     } else {
         pub use tonic::transport::{Channel, Error};
+        use crate::grpc::KEEPALIVE_TIME_MS;
+        use std::time::Duration;
 
         pub fn create_channel(
             address: String,
@@ -42,6 +44,7 @@ cfg_if::cfg_if! {
             if let Some(timeout) = options.timeout {
                 endpoint = endpoint.timeout(timeout);
             }
+            endpoint = endpoint.keep_alive_timeout(Duration::from_millis(KEEPALIVE_TIME_MS));
             Ok(endpoint.connect_lazy())
         }
     }


### PR DESCRIPTION
## Motivation

Connections with validators are dropped after 1 minute due to connections being inactive.

## Proposal

Use gRPC keep-alive to send ping frames every 40 seconds to keep the connections alive.

This is hard-coded for now. Future improvement involves client <> server negotation of the keepalive timeout value per-validator.

## Test Plan

Manually tested. CI will catch regressions.

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a client hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a client hotfix.

## Links

https://grpc.io/docs/guides/keepalive/#keepalive-configuration-specification
