### PR TITLE
Use the validator name to shuffle shards per validator.

### DIFF
--- a/linera-rpc/src/config.rs
+++ b/linera-rpc/src/config.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_base::identifiers::ChainId;
+use linera_execution::committee::ValidatorName;
 use serde::{Deserialize, Serialize};
 
 #[cfg(with_simple_network)]
@@ -102,6 +103,8 @@ pub type ValidatorPublicNetworkConfig = ValidatorPublicNetworkPreConfig<NetworkP
 /// The network configuration for all shards.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ValidatorInternalNetworkPreConfig<P> {
+    /// The name of the validator.
+    pub name: ValidatorName,
     /// The network protocol to use for all shards.
     pub protocol: P,
     /// The available shards. Each chain UID is mapped to a unique shard in the vector in
@@ -120,6 +123,7 @@ pub struct ValidatorInternalNetworkPreConfig<P> {
 impl<P> ValidatorInternalNetworkPreConfig<P> {
     pub fn clone_with_protocol<Q>(&self, protocol: Q) -> ValidatorInternalNetworkPreConfig<Q> {
         ValidatorInternalNetworkPreConfig {
+            name: self.name,
             protocol,
             shards: self.shards.clone(),
             host: self.host.clone(),
@@ -230,6 +234,8 @@ impl<P> ValidatorInternalNetworkPreConfig<P> {
     pub fn get_shard_id(&self, chain_id: ChainId) -> ShardId {
         use std::hash::{Hash, Hasher};
         let mut s = std::collections::hash_map::DefaultHasher::new();
+        // Use the validator public key to randomise shard assignment.
+        self.name.hash(&mut s);
         chain_id.hash(&mut s);
         (s.finish() as ShardId) % self.shards.len()
     }

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -278,12 +278,15 @@ fn make_server_config<R: CryptoRng>(
     rng: &mut R,
     options: ValidatorOptions,
 ) -> anyhow::Result<persistent::File<ValidatorServerConfig>> {
+    let key = KeyPair::generate_from(rng);
+    let name = ValidatorName(key.public());
     let network = ValidatorPublicNetworkConfig {
         protocol: options.external_protocol,
         host: options.host,
         port: options.port,
     };
     let internal_network = ValidatorInternalNetworkConfig {
+        name,
         protocol: options.internal_protocol,
         shards: options.shards,
         host: options.internal_host,
@@ -291,8 +294,6 @@ fn make_server_config<R: CryptoRng>(
         metrics_host: options.metrics_host,
         metrics_port: options.metrics_port,
     };
-    let key = KeyPair::generate_from(rng);
-    let name = ValidatorName(key.public());
     let validator = ValidatorConfig { network, name };
     Ok(persistent::File::new(
         path,


### PR DESCRIPTION
## Motivation

If every validator has the same shard configuration all shards will be hot against all validators.

## Proposal

Use the validator name to shuffle chain allocation amongst shards.

## Test Plan

CI will catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
