### PR TITLE
Deliver messages to untracked publisher chains.

### DIFF
--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -418,16 +418,16 @@ where
         let mut heights_by_recipient = BTreeMap::<_, BTreeMap<_, _>>::new();
         let mut targets = self.chain.outboxes.indices().await?;
         if let Some(tracked_chains) = self.tracked_chains.as_ref() {
-            let mut publishers = HashSet::new();
-            self.chain
+            let publishers = self
+                .chain
                 .execution_state
                 .system
                 .subscriptions
-                .for_each_index(|subscription| {
-                    publishers.insert(subscription.chain_id);
-                    Ok(())
-                })
-                .await?;
+                .indices()
+                .await?
+                .iter()
+                .map(|subscription| subscription.chain_id)
+                .collect::<HashSet<_>>();
             let tracked_chains = tracked_chains
                 .read()
                 .expect("Panics should not happen while holding a lock to `tracked_chains`");


### PR DESCRIPTION
## Motivation

If a tracked chain A subscribes to another chain B, we need to process that `Subscribe` message from A to B, otherwise we won't locally create the cross-chain messages back from B to A.

## Proposal

Deliver messages if their target is tracked _or_ if the sender is subscribed to the target.

## Test Plan

TBD

## Release Plan

- These changes should be ported to `main`.
- They should be released in a new SDK.

## Links

- This is a (better?) alternative to https://github.com/linera-io/linera-protocol/pull/2767.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
