### PR TITLE
Add GRPC test to `linera query-validator(s)`

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -68,8 +68,8 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `sync-balance` — (DEPRECATED) Synchronize the local state of the chain with a quorum validators, then query the local balance
 * `sync` — Synchronize the local state of the chain with a quorum validators
 * `process-inbox` — Process all pending incoming messages from the inbox of the given chain by creating as many blocks as needed to execute all (non-failing) messages. Failing messages will be marked as rejected and may bounce to their sender depending on their configuration
-* `query-validator` — Show the version and genesis config hash of a new validator, and print a warning if it is incompatible
-* `query-validators` — Show the current set of validators for a chain
+* `query-validator` — Show the version and genesis config hash of a new validator, and print a warning if it is incompatible. Also print some information about the given chain while we are it
+* `query-validators` — Show the current set of validators for a chain. Also print some information about the given chain while we are it
 * `set-validator` — Add or modify a validator (admin only)
 * `remove-validator` — Remove a validator (admin only)
 * `finalize-committee` — Deprecates all committees except the last one
@@ -332,19 +332,20 @@ Process all pending incoming messages from the inbox of the given chain by creat
 
 ## `linera query-validator`
 
-Show the version and genesis config hash of a new validator, and print a warning if it is incompatible
+Show the version and genesis config hash of a new validator, and print a warning if it is incompatible. Also print some information about the given chain while we are it
 
-**Usage:** `linera query-validator <ADDRESS>`
+**Usage:** `linera query-validator <ADDRESS> [CHAIN_ID]`
 
 ###### **Arguments:**
 
 * `<ADDRESS>` — The new validator's address
+* `<CHAIN_ID>` — The chain to query. If omitted, query the default chain of the wallet
 
 
 
 ## `linera query-validators`
 
-Show the current set of validators for a chain
+Show the current set of validators for a chain. Also print some information about the given chain while we are it
 
 **Usage:** `linera query-validators [CHAIN_ID]`
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -426,13 +426,16 @@ pub enum ClientCommand {
     },
 
     /// Show the version and genesis config hash of a new validator, and print a warning if it is
-    /// incompatible.
+    /// incompatible. Also print some information about the given chain while we are it.
     QueryValidator {
         /// The new validator's address.
         address: String,
+        /// The chain to query. If omitted, query the default chain of the wallet.
+        chain_id: Option<ChainId>,
     },
 
-    /// Show the current set of validators for a chain.
+    /// Show the current set of validators for a chain. Also print some information about
+    /// the given chain while we are it.
     QueryValidators {
         /// The chain to query. If omitted, query the default chain of the wallet.
         chain_id: Option<ChainId>,

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -430,7 +430,7 @@ impl ClientWrapper {
         let hash = stdout
             .trim()
             .parse()
-            .context("error while parsing the result of `linera local-balance`")?;
+            .context("error while parsing the result of `linera query-validator`")?;
         Ok(hash)
     }
 

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -430,16 +430,17 @@ impl Runnable for Job {
                 );
                 let node_provider = context.make_node_provider();
                 for (name, state) in committee.validators() {
-                    let node = node_provider.make_node(&state.network_address)?;
+                    let address = &state.network_address;
+                    let node = node_provider.make_node(address)?;
                     match node.get_version_info().await {
                         Ok(version_info) => {
                             info!(
-                                "Version information for validator {name:?}:{}",
+                                "Version information for validator {name:?} at {address}:{}",
                                 version_info
                             );
                         }
                         Err(e) => {
-                            warn!("Failed to get version information for validator {name:?}:\n{e}");
+                            warn!("Failed to get version information for validator {name:?} at {address}:\n{e}");
                             continue;
                         }
                     }
@@ -447,13 +448,13 @@ impl Runnable for Job {
                     match node.handle_chain_info_query(query).await {
                         Ok(response) => {
                             info!(
-                                "Validator {name:?} sees chain {chain_id} at block height {} and epoch {:?}",
+                                "Validator {name:?} at {address} sees chain {chain_id} at block height {} and epoch {:?}",
                                 response.info.next_block_height,
                                 response.info.epoch,
                             );
                         }
                         Err(e) => {
-                            warn!("Failed to get chain info for validator {name:?} and chain {chain_id}:\n{e}");
+                            warn!("Failed to get chain info for validator {name:?} at {address} and chain {chain_id}:\n{e}");
                             continue;
                         }
                     }
@@ -487,7 +488,7 @@ impl Runnable for Job {
                             linera_version::VERSION_INFO
                         ),
                         Err(error) => bail!(
-                            "Failed to get version information for validator {name:?}:\n{error}"
+                            "Failed to get version information for validator {name:?} at {address}:\n{error}"
                         ),
                     }
                     let genesis_config_hash = context.wallet().genesis_config().hash();
@@ -499,7 +500,7 @@ impl Runnable for Job {
                             genesis_config_hash
                         ),
                         Err(error) => bail!(
-                            "Failed to get genesis config hash for validator {name:?}:\n{error}"
+                            "Failed to get genesis config hash for validator {name:?} at {address}:\n{error}"
                         ),
                     }
                 }


### PR DESCRIPTION
## Motivation

The commands `linera query-validator(s)` only superficially test validators.

## Proposal

Add a simple chain-info-query to the chain in use.

## Test Plan

* CI
* manually tested a backport

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
