### PR TITLE
tracing::instrument -> instrument

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -22,7 +22,7 @@ use linera_core::{
 };
 use linera_execution::{Message, SystemMessage};
 use linera_storage::{Clock as _, Storage};
-use tracing::{debug, error, info, warn, Instrument as _};
+use tracing::{debug, error, info, instrument, warn, Instrument as _};
 
 use crate::{wallet::Wallet, Error};
 
@@ -117,7 +117,7 @@ impl ChainListener {
         }
     }
 
-    #[tracing::instrument(level = "trace", skip_all, fields(?chain_id))]
+    #[instrument(level = "trace", skip_all, fields(?chain_id))]
     fn run_with_chain_id<C>(
         chain_id: ChainId,
         context: Arc<Mutex<C>>,
@@ -139,7 +139,7 @@ impl ChainListener {
         );
     }
 
-    #[tracing::instrument(level = "trace", skip_all, fields(?chain_id))]
+    #[instrument(level = "trace", skip_all, fields(?chain_id))]
     async fn run_client_stream<C>(
         chain_id: ChainId,
         context: Arc<Mutex<C>>,

--- a/linera-client/src/persistent/indexed_db.rs
+++ b/linera-client/src/persistent/indexed_db.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use indexed_db_futures::prelude::*;
+use tracing::instrument;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::wasm_bindgen;
 use web_sys::DomException;
@@ -63,7 +64,7 @@ async fn open_database() -> Result<IdbDatabase, Error> {
 }
 
 impl<T> IndexedDb<T> {
-    #[tracing::instrument(level = "trace", skip(value))]
+    #[instrument(level = "trace", skip(value))]
     pub async fn new(key: &str, value: T) -> Result<Self, Error> {
         Ok(Self {
             key: key.to_owned(),
@@ -75,7 +76,7 @@ impl<T> IndexedDb<T> {
 }
 
 impl<T: serde::de::DeserializeOwned> IndexedDb<T> {
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn read(key: &str) -> Result<Option<Self>, Error> {
         let database = open_database().await?;
         let tx =
@@ -93,7 +94,7 @@ impl<T: serde::de::DeserializeOwned> IndexedDb<T> {
         }))
     }
 
-    #[tracing::instrument(level = "trace", fields(value = &serde_json::to_string(&value).unwrap()))]
+    #[instrument(level = "trace", fields(value = &serde_json::to_string(&value).unwrap()))]
     pub async fn read_or_create(key: &str, value: T) -> Result<Self, Error>
     where
         T: serde::Serialize,
@@ -111,7 +112,7 @@ impl<T: serde::de::DeserializeOwned> IndexedDb<T> {
 impl<T: serde::Serialize> LocalPersist for IndexedDb<T> {
     type Error = Error;
 
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     fn as_mut(&mut self) -> &mut T {
         *self.dirty = true;
         &mut self.value
@@ -121,7 +122,7 @@ impl<T: serde::Serialize> LocalPersist for IndexedDb<T> {
         self.value
     }
 
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     async fn persist(&mut self) -> Result<(), Error> {
         let serializer =
             serde_wasm_bindgen::Serializer::new().serialize_large_number_types_as_bigints(true);

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -28,7 +28,7 @@ use linera_views::{
     views::{RootView, View},
 };
 use tokio::sync::oneshot;
-use tracing::{debug, warn};
+use tracing::{debug, instrument, trace, warn};
 
 use super::{check_block_epoch, ChainWorkerConfig, ChainWorkerState};
 use crate::{
@@ -355,7 +355,7 @@ where
         let info = ChainInfoResponse::new(&self.state.chain, self.state.config.key_pair());
         self.state.track_newly_created_chains(executed_block);
         let mut actions = self.state.create_network_actions().await?;
-        tracing::trace!(
+        trace!(
             "Processed confirmed block {} on chain {:.8}",
             block_height,
             block.chain_id
@@ -383,7 +383,7 @@ where
 
     /// Schedules a notification for when cross-chain messages are delivered up to the given
     /// `height`.
-    #[tracing::instrument(level = "trace", skip(self, notify_when_messages_are_delivered))]
+    #[instrument(level = "trace", skip(self, notify_when_messages_are_delivered))]
     async fn register_delivery_notifier(
         &mut self,
         height: BlockHeight,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -62,7 +62,7 @@ use serde::Serialize;
 use thiserror::Error;
 use tokio::sync::OwnedRwLockReadGuard;
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{debug, error, info, warn, Instrument as _};
+use tracing::{debug, error, info, instrument, warn, Instrument as _};
 
 use crate::{
     data_types::{
@@ -193,7 +193,7 @@ where
 
 impl<P, S: Storage + Clone> Client<P, S> {
     /// Creates a new `Client` with a new cache and notifiers.
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub fn new(
         validator_node_provider: P,
         storage: S,
@@ -229,19 +229,19 @@ impl<P, S: Storage + Clone> Client<P, S> {
     }
 
     /// Returns the storage client used by this client's local node.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub fn storage_client(&self) -> &S {
         &self.storage
     }
 
     /// Returns a reference to the [`LocalNodeClient`] of the client.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub fn local_node(&self) -> &LocalNodeClient<S> {
         &self.local_node
     }
 
     /// Adds a chain to the set of chains tracked by the local node.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub fn track_chain(&self, chain_id: ChainId) {
         self.tracked_chains
             .write()
@@ -250,7 +250,7 @@ impl<P, S: Storage + Clone> Client<P, S> {
     }
 
     /// Creates a new `ChainClient`.
-    #[tracing::instrument(level = "trace", skip_all, fields(chain_id, next_block_height))]
+    #[instrument(level = "trace", skip_all, fields(chain_id, next_block_height))]
     #[expect(clippy::too_many_arguments)]
     pub fn create_chain_client(
         self: &Arc<Self>,
@@ -361,7 +361,7 @@ impl MessagePolicy {
         }
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     fn handle(&self, bundle: &mut IncomingBundle) -> bool {
         if self.is_reject() {
             if bundle.bundle.is_skippable() {
@@ -377,12 +377,12 @@ impl MessagePolicy {
         }
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     fn is_ignore(&self) -> bool {
         matches!(self.blanket, BlanketMessagePolicy::Ignore)
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     fn is_reject(&self) -> bool {
         matches!(self.blanket, BlanketMessagePolicy::Reject)
     }
@@ -544,7 +544,7 @@ pub type ChainGuardMapped<'a, T> = Unsend<DashMapMappedRef<'a, ChainId, ChainCli
 
 impl<P: 'static, S: Storage> ChainClient<P, S> {
     /// Gets a shared reference to the chain's state.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub fn state(&self) -> ChainGuard<ChainClientState> {
         Unsend::new(
             self.client
@@ -556,7 +556,7 @@ impl<P: 'static, S: Storage> ChainClient<P, S> {
 
     /// Gets a mutable reference to the state.
     /// Beware: this will block any other reference to any chain's state!
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     fn state_mut(&self) -> ChainGuardMut<ChainClientState> {
         Unsend::new(
             self.client
@@ -567,43 +567,43 @@ impl<P: 'static, S: Storage> ChainClient<P, S> {
     }
 
     /// Gets the per-`ChainClient` options.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub fn options_mut(&mut self) -> &mut ChainClientOptions {
         &mut self.options
     }
 
     /// Gets the ID of the associated chain.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub fn chain_id(&self) -> ChainId {
         self.chain_id
     }
 
     /// Gets the hash of the latest known block.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub fn block_hash(&self) -> Option<CryptoHash> {
         self.state().block_hash()
     }
 
     /// Gets the earliest possible timestamp for the next block.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub fn timestamp(&self) -> Timestamp {
         self.state().timestamp()
     }
 
     /// Gets the next block height.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub fn next_block_height(&self) -> BlockHeight {
         self.state().next_block_height()
     }
 
     /// Gets a guarded reference to the next pending block.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub fn pending_block(&self) -> ChainGuardMapped<Option<Block>> {
         Unsend::new(self.state().inner.map(|state| state.pending_block()))
     }
 
     /// Gets a guarded reference to the set of pending blobs.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub fn pending_blobs(&self) -> ChainGuardMapped<BTreeMap<BlobId, Blob>> {
         Unsend::new(self.state().inner.map(|state| state.pending_blobs()))
     }
@@ -642,7 +642,7 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     /// Obtains a `ChainStateView` for a given `ChainId`.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn chain_state_view(
         &self,
     ) -> Result<OwnedRwLockReadGuard<ChainStateView<S::Context>>, LocalNodeError> {
@@ -654,7 +654,7 @@ where
     }
 
     /// Subscribes to notifications from this client's chain.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn subscribe(&self) -> Result<NotificationStream, LocalNodeError> {
         Ok(Box::pin(UnboundedReceiverStream::new(
             self.client.notifier.subscribe(vec![self.chain_id]),
@@ -662,13 +662,13 @@ where
     }
 
     /// Returns the storage client used by this client's local node.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub fn storage_client(&self) -> S {
         self.client.storage_client().clone()
     }
 
     /// Obtains the basic `ChainInfo` data for the local chain.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn chain_info(&self) -> Result<Box<ChainInfo>, LocalNodeError> {
         let query = ChainInfoQuery::new(self.chain_id);
         let response = self
@@ -680,7 +680,7 @@ where
     }
 
     /// Obtains the basic `ChainInfo` data for the local chain, with chain manager values.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn chain_info_with_manager_values(&self) -> Result<Box<ChainInfo>, LocalNodeError> {
         let query = ChainInfoQuery::new(self.chain_id).with_manager_values();
         let response = self
@@ -693,7 +693,7 @@ where
 
     /// Obtains up to `self.options.max_pending_message_bundles` pending message bundles for the
     /// local chain.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     async fn pending_message_bundles(&self) -> Result<Vec<IncomingBundle>, ChainClientError> {
         let query = ChainInfoQuery::new(self.chain_id).with_pending_message_bundles();
         let info = self
@@ -760,7 +760,7 @@ where
     }
 
     /// Obtains the current epoch of the given chain as well as its set of trusted committees.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn epoch_and_committees(
         &self,
         chain_id: ChainId,
@@ -780,14 +780,14 @@ where
     }
 
     /// Obtains the epochs of the committees trusted by the local chain.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn epochs(&self) -> Result<Vec<Epoch>, LocalNodeError> {
         let (_epoch, committees) = self.epoch_and_committees(self.chain_id).await?;
         Ok(committees.into_keys().collect())
     }
 
     /// Obtains the committee for the current epoch of the local chain.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn local_committee(&self) -> Result<Committee, LocalNodeError> {
         let (epoch, mut committees) = self.epoch_and_committees(self.chain_id).await?;
         committees
@@ -801,7 +801,7 @@ where
 
     /// Obtains all the committees trusted by either the local chain or its admin chain. Also
     /// return the latest trusted epoch.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     async fn known_committees(
         &self,
     ) -> Result<(BTreeMap<Epoch, Committee>, Epoch), LocalNodeError> {
@@ -812,7 +812,7 @@ where
         Ok((committees, epoch))
     }
 
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     fn make_nodes(&self, committee: &Committee) -> Result<Vec<RemoteNode<P::Node>>, NodeError> {
         Ok(self
             .client
@@ -823,7 +823,7 @@ where
     }
 
     /// Obtains the validators trusted by the local chain.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     async fn validator_nodes(&self) -> Result<Vec<RemoteNode<P::Node>>, ChainClientError> {
         match self.local_committee().await {
             Ok(committee) => Ok(self.make_nodes(&committee)?),
@@ -838,7 +838,7 @@ where
     }
 
     /// Obtains the current epoch of the local chain.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     async fn epoch(&self) -> Result<Epoch, LocalNodeError> {
         self.chain_info()
             .await?
@@ -848,7 +848,7 @@ where
 
     /// Obtains the identity of the current owner of the chain. Returns an error if we have the
     /// private key for more than one identity.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn identity(&self) -> Result<Owner, ChainClientError> {
         let manager = self.chain_info().await?.manager;
         ensure!(
@@ -872,7 +872,7 @@ where
     }
 
     /// Obtains the key pair associated to the current identity.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn key_pair(&self) -> Result<KeyPair, ChainClientError> {
         let id = self.identity().await?;
         Ok(self
@@ -884,14 +884,14 @@ where
     }
 
     /// Obtains the public key associated to the current identity.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn public_key(&self) -> Result<PublicKey, ChainClientError> {
         Ok(self.key_pair().await?.public())
     }
 
     /// Prepares the chain for the next operation, i.e. makes sure we have synchronized it up to
     /// its current height.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     async fn prepare_chain(&self) -> Result<Box<ChainInfo>, ChainClientError> {
         #[cfg(with_metrics)]
         let _latency = metrics::PREPARE_CHAIN_LATENCY.measure_latency();
@@ -924,7 +924,7 @@ where
     }
 
     /// Submits a validated block for finalization and returns the confirmed block certificate.
-    #[tracing::instrument(level = "trace", skip(committee, certificate))]
+    #[instrument(level = "trace", skip(committee, certificate))]
     async fn finalize_block(
         &self,
         committee: &Committee,
@@ -952,7 +952,7 @@ where
 
     /// Submits a block proposal to the validators. If it is a slow round, also submits the
     /// validated block for finalization. Returns the confirmed block certificate.
-    #[tracing::instrument(level = "trace", skip(committee, proposal, value))]
+    #[instrument(level = "trace", skip(committee, proposal, value))]
     async fn submit_block_proposal(
         &self,
         committee: &Committee,
@@ -979,7 +979,7 @@ where
     }
 
     /// Broadcasts certified blocks to validators.
-    #[tracing::instrument(level = "trace", skip(committee, delivery))]
+    #[instrument(level = "trace", skip(committee, delivery))]
     async fn communicate_chain_updates(
         &self,
         committee: &Committee,
@@ -1014,7 +1014,7 @@ where
     ///
     /// In that case, it verifies that the validator votes are for the provided value,
     /// and returns a certificate.
-    #[tracing::instrument(level = "trace", skip(committee, action, value))]
+    #[instrument(level = "trace", skip(committee, action, value))]
     async fn communicate_chain_action(
         &self,
         committee: &Committee,
@@ -1058,7 +1058,7 @@ where
 
     /// Processes the confirmed block certificate and its ancestors in the local node, then
     /// updates the validators up to that certificate.
-    #[tracing::instrument(level = "trace", skip(certificate, mode))]
+    #[instrument(level = "trace", skip(certificate, mode))]
     async fn receive_certificate_and_update_validators_internal(
         &self,
         certificate: Certificate,
@@ -1084,7 +1084,7 @@ where
 
     /// Processes the confirmed block certificate in the local node. Also downloads and processes
     /// all ancestors that are still missing.
-    #[tracing::instrument(level = "trace", skip(certificate, mode))]
+    #[instrument(level = "trace", skip(certificate, mode))]
     async fn receive_certificate_internal(
         &self,
         certificate: Certificate,
@@ -1138,7 +1138,7 @@ where
 
     /// Downloads and processes all confirmed block certificates that sent any message to this
     /// chain, including their ancestors.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     async fn synchronize_received_certificates_from_validator(
         &self,
         chain_id: ChainId,
@@ -1264,7 +1264,7 @@ where
             })
     }
 
-    #[tracing::instrument(
+    #[instrument(
         level = "trace", skip_all,
         fields(certificate_hash = ?incoming_certificate.hash()),
     )]
@@ -1296,7 +1296,7 @@ where
 
     /// Processes the result of [`synchronize_received_certificates_from_validator`] and updates
     /// the tracker for this validator.
-    #[tracing::instrument(level = "trace", skip(tracker, certificates, other_sender_chains))]
+    #[instrument(level = "trace", skip(tracker, certificates, other_sender_chains))]
     async fn receive_certificates_from_validator(
         &self,
         ReceivedCertificatesFromValidator {
@@ -1344,7 +1344,7 @@ where
     ///
     /// However, this should be the case whenever a sender's chain is still in use and
     /// is regularly upgraded to new committees.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     async fn find_received_certificates(&self) -> Result<(), ChainClientError> {
         #[cfg(with_metrics)]
         let _latency = metrics::FIND_RECEIVED_CERTIFICATES_LATENCY.measure_latency();
@@ -1397,7 +1397,7 @@ where
     }
 
     /// Sends money.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn transfer(
         &self,
         owner: Option<Owner>,
@@ -1415,7 +1415,7 @@ where
 
     /// Verify if a data blob is readable from storage.
     // TODO(#2490): Consider removing or renaming this.
-    #[tracing::instrument(level = "trace", skip(hash))]
+    #[instrument(level = "trace", skip(hash))]
     pub async fn read_data_blob(
         &self,
         hash: CryptoHash,
@@ -1429,7 +1429,7 @@ where
     }
 
     /// Claims money in a remote chain.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn claim(
         &self,
         owner: Owner,
@@ -1447,7 +1447,7 @@ where
     }
 
     /// Handles the certificate in the local node and the resulting notifications.
-    #[tracing::instrument(level = "trace", skip(certificate))]
+    #[instrument(level = "trace", skip(certificate))]
     async fn process_certificate(
         &self,
         certificate: Certificate,
@@ -1463,7 +1463,7 @@ where
     }
 
     /// Updates the latest block and next block height and round information from the chain info.
-    #[tracing::instrument(level = "trace", skip(info))]
+    #[instrument(level = "trace", skip(info))]
     fn update_from_info(&self, info: &ChainInfo) {
         if info.chain_id == self.chain_id {
             self.state_mut().update_from_info(info);
@@ -1472,7 +1472,7 @@ where
 
     /// Requests a leader timeout vote from all validators. If a quorum signs it, creates a
     /// certificate and sends it to all validators, to make them enter the next round.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn request_leader_timeout(&self) -> Result<Certificate, ChainClientError> {
         let chain_id = self.chain_id;
         let query = ChainInfoQuery::new(chain_id).with_committees();
@@ -1513,7 +1513,7 @@ where
     }
 
     /// Downloads and processes any certificates we are missing for the given chain.
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub async fn synchronize_chain_state(
         &self,
         validators: &[RemoteNode<P::Node>],
@@ -1553,7 +1553,7 @@ where
 
     /// Downloads any certificates from the specified validator that we are missing for the given
     /// chain, and processes them.
-    #[tracing::instrument(level = "trace", skip(self, remote_node, chain_id))]
+    #[instrument(level = "trace", skip(self, remote_node, chain_id))]
     async fn try_synchronize_chain_state_from(
         &self,
         remote_node: &RemoteNode<P::Node>,
@@ -1707,7 +1707,7 @@ where
     /// Attempts to execute the block locally. If any incoming message execution fails, that
     /// message is rejected and execution is retried, until the block accepts only messages
     /// that succeed.
-    #[tracing::instrument(level = "trace", skip(block))]
+    #[instrument(level = "trace", skip(block))]
     async fn stage_block_execution_and_discard_failing_messages(
         &self,
         mut block: Block,
@@ -1748,7 +1748,7 @@ where
 
     /// Attempts to execute the block locally. If any attempt to read a blob fails, the blob is
     /// downloaded and execution is retried.
-    #[tracing::instrument(level = "trace", skip(block))]
+    #[instrument(level = "trace", skip(block))]
     async fn stage_block_execution(
         &self,
         block: Block,
@@ -1771,7 +1771,7 @@ where
 
     /// Tries to read blobs from either the pending blobs or the local node's cache, or
     /// storage
-    #[tracing::instrument(level = "trace", skip(blob_ids))]
+    #[instrument(level = "trace", skip(blob_ids))]
     async fn read_local_blobs(
         &self,
         blob_ids: impl IntoIterator<Item = BlobId>,
@@ -1815,7 +1815,7 @@ where
     }
 
     /// Executes (or retries) a regular block proposal. Updates local balance.
-    #[tracing::instrument(level = "trace", skip(block, round, manager))]
+    #[instrument(level = "trace", skip(block, round, manager))]
     async fn propose_block(
         &self,
         block: Block,
@@ -1937,7 +1937,7 @@ where
     }
 
     /// Executes a list of operations.
-    #[tracing::instrument(level = "trace", skip(operations))]
+    #[instrument(level = "trace", skip(operations))]
     pub async fn execute_operations(
         &self,
         operations: Vec<Operation>,
@@ -1947,7 +1947,7 @@ where
     }
 
     /// Executes a list of operations, without calling `prepare_chain`.
-    #[tracing::instrument(level = "trace", skip(operations))]
+    #[instrument(level = "trace", skip(operations))]
     pub async fn execute_without_prepare(
         &self,
         operations: Vec<Operation>,
@@ -1972,7 +1972,7 @@ where
     }
 
     /// Executes an operation.
-    #[tracing::instrument(level = "trace", skip(operation))]
+    #[instrument(level = "trace", skip(operation))]
     pub async fn execute_operation(
         &self,
         operation: Operation,
@@ -1983,7 +1983,7 @@ where
     /// Executes a new block.
     ///
     /// This must be preceded by a call to `prepare_chain()`.
-    #[tracing::instrument(level = "trace", skip(operations))]
+    #[instrument(level = "trace", skip(operations))]
     async fn execute_block(
         &self,
         operations: Vec<Operation>,
@@ -2025,7 +2025,7 @@ where
 
     /// Sets the pending block, so that next time `process_pending_block_without_prepare` is
     /// called, it will be proposed to the validators.
-    #[tracing::instrument(level = "trace", skip(incoming_bundles, operations))]
+    #[instrument(level = "trace", skip(incoming_bundles, operations))]
     async fn set_pending_block(
         &self,
         incoming_bundles: Vec<IncomingBundle>,
@@ -2064,7 +2064,7 @@ where
     ///
     /// This will usually be the current time according to the local clock, but may be slightly
     /// ahead to make sure it's not earlier than the incoming messages or the previous block.
-    #[tracing::instrument(level = "trace", skip(incoming_bundles))]
+    #[instrument(level = "trace", skip(incoming_bundles))]
     fn next_timestamp(
         &self,
         incoming_bundles: &[IncomingBundle],
@@ -2080,7 +2080,7 @@ where
     }
 
     /// Queries an application.
-    #[tracing::instrument(level = "trace", skip(query))]
+    #[instrument(level = "trace", skip(query))]
     pub async fn query_application(&self, query: Query) -> Result<Response, ChainClientError> {
         let response = self
             .client
@@ -2091,7 +2091,7 @@ where
     }
 
     /// Queries a system application.
-    #[tracing::instrument(level = "trace", skip(query))]
+    #[instrument(level = "trace", skip(query))]
     pub async fn query_system_application(
         &self,
         query: SystemQuery,
@@ -2110,7 +2110,7 @@ where
     }
 
     /// Queries a user application.
-    #[tracing::instrument(level = "trace", skip(application_id, query))]
+    #[instrument(level = "trace", skip(application_id, query))]
     pub async fn query_user_application<A: Abi>(
         &self,
         application_id: UserApplicationId<A>,
@@ -2136,7 +2136,7 @@ where
     /// Does not attempt to synchronize with validators. The result will reflect up to
     /// `max_pending_message_bundles` incoming message bundles and the execution fees for a single
     /// block.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn query_balance(&self) -> Result<Amount, ChainClientError> {
         let (balance, _) = self.query_balances_with_owner(None).await?;
         Ok(balance)
@@ -2148,7 +2148,7 @@ where
     /// Does not attempt to synchronize with validators. The result will reflect up to
     /// `max_pending_message_bundles` incoming message bundles and the execution fees for a single
     /// block.
-    #[tracing::instrument(level = "trace", skip(owner))]
+    #[instrument(level = "trace", skip(owner))]
     pub async fn query_owner_balance(&self, owner: Owner) -> Result<Amount, ChainClientError> {
         Ok(self
             .query_balances_with_owner(Some(owner))
@@ -2163,7 +2163,7 @@ where
     /// Does not attempt to synchronize with validators. The result will reflect up to
     /// `max_pending_message_bundles` incoming message bundles and the execution fees for a single
     /// block.
-    #[tracing::instrument(level = "trace", skip(owner))]
+    #[instrument(level = "trace", skip(owner))]
     async fn query_balances_with_owner(
         &self,
         owner: Option<Owner>,
@@ -2217,7 +2217,7 @@ where
     /// Reads the local balance of the chain account.
     ///
     /// Does not process the inbox or attempt to synchronize with validators.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn local_balance(&self) -> Result<Amount, ChainClientError> {
         let (balance, _) = self.local_balances_with_owner(None).await?;
         Ok(balance)
@@ -2226,7 +2226,7 @@ where
     /// Reads the local balance of a user account.
     ///
     /// Does not process the inbox or attempt to synchronize with validators.
-    #[tracing::instrument(level = "trace", skip(owner))]
+    #[instrument(level = "trace", skip(owner))]
     pub async fn local_owner_balance(&self, owner: Owner) -> Result<Amount, ChainClientError> {
         Ok(self
             .local_balances_with_owner(Some(owner))
@@ -2238,7 +2238,7 @@ where
     /// Reads the local balance of the chain account and optionally another user.
     ///
     /// Does not process the inbox or attempt to synchronize with validators.
-    #[tracing::instrument(level = "trace", skip(owner))]
+    #[instrument(level = "trace", skip(owner))]
     async fn local_balances_with_owner(
         &self,
         owner: Option<Owner>,
@@ -2262,7 +2262,7 @@ where
     }
 
     /// Attempts to update all validators about the local chain.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn update_validators(&self) -> Result<(), ChainClientError> {
         let committee = self.local_committee().await?;
         let next_block_height = self.next_block_height();
@@ -2278,7 +2278,7 @@ where
 
     /// Requests a `RegisterApplications` message from another chain so the application can be used
     /// on this one.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn request_application(
         &self,
         application_id: UserApplicationId,
@@ -2293,7 +2293,7 @@ where
     }
 
     /// Sends tokens to a chain.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn transfer_to_account(
         &self,
         owner: Option<Owner>,
@@ -2305,7 +2305,7 @@ where
     }
 
     /// Burns tokens.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn burn(
         &self,
         owner: Option<Owner>,
@@ -2319,14 +2319,14 @@ where
     ///
     /// To create a block that actually executes the messages in the inbox,
     /// `process_inbox` must be called separately.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn synchronize_from_validators(&self) -> Result<Box<ChainInfo>, ChainClientError> {
         self.find_received_certificates().await?;
         self.prepare_chain().await
     }
 
     /// Processes the last pending block
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn process_pending_block(
         &self,
     ) -> Result<ClientOutcome<Option<Certificate>>, ChainClientError> {
@@ -2335,7 +2335,7 @@ where
     }
 
     /// Processes the last pending block. Assumes that the local chain is up to date.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     async fn process_pending_block_without_prepare(
         &self,
     ) -> Result<ClientOutcome<Option<Certificate>>, ChainClientError> {
@@ -2432,13 +2432,13 @@ where
     }
 
     /// Clears the information on any operation that previously failed.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub fn clear_pending_block(&self) {
         self.state_mut().clear_pending_block();
     }
 
     /// Processes a confirmed block for which this chain is a recipient and updates validators.
-    #[tracing::instrument(
+    #[instrument(
         level = "trace",
         skip(certificate),
         fields(certificate_hash = ?certificate.hash()),
@@ -2455,7 +2455,7 @@ where
     }
 
     /// Processes confirmed operation for which this chain is a recipient.
-    #[tracing::instrument(
+    #[instrument(
         level = "trace",
         skip(certificate),
         fields(certificate_hash = ?certificate.hash()),
@@ -2469,7 +2469,7 @@ where
     }
 
     /// Rotates the key of the chain.
-    #[tracing::instrument(level = "trace", skip(key_pair))]
+    #[instrument(level = "trace", skip(key_pair))]
     pub async fn rotate_key_pair(
         &self,
         key_pair: KeyPair,
@@ -2479,7 +2479,7 @@ where
     }
 
     /// Transfers ownership of the chain to a single super owner.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn transfer_ownership(
         &self,
         new_public_key: PublicKey,
@@ -2494,7 +2494,7 @@ where
     }
 
     /// Adds another owner to the chain, and turns existing super owners into regular owners.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn share_ownership(
         &self,
         new_public_key: PublicKey,
@@ -2540,7 +2540,7 @@ where
 
     /// Changes the ownership of this chain. Fails if it would remove existing owners, unless
     /// `remove_owners` is `true`.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn change_ownership(
         &self,
         ownership: ChainOwnership,
@@ -2555,7 +2555,7 @@ where
     }
 
     /// Changes the application permissions configuration on this chain.
-    #[tracing::instrument(level = "trace", skip(application_permissions))]
+    #[instrument(level = "trace", skip(application_permissions))]
     pub async fn change_application_permissions(
         &self,
         application_permissions: ApplicationPermissions,
@@ -2565,7 +2565,7 @@ where
     }
 
     /// Opens a new chain with a derived UID.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub async fn open_chain(
         &self,
         ownership: ChainOwnership,
@@ -2611,7 +2611,7 @@ where
     }
 
     /// Closes the chain (and loses everything in it!!).
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn close_chain(&self) -> Result<ClientOutcome<Certificate>, ChainClientError> {
         self.execute_operation(Operation::System(SystemOperation::CloseChain))
             .await
@@ -2619,7 +2619,7 @@ where
 
     /// Publishes some bytecode.
     #[cfg(not(target_arch = "wasm32"))]
-    #[tracing::instrument(level = "trace", skip(contract, service))]
+    #[instrument(level = "trace", skip(contract, service))]
     pub async fn publish_bytecode(
         &self,
         contract: Bytecode,
@@ -2633,7 +2633,7 @@ where
 
     /// Publishes some bytecode.
     #[cfg(not(target_arch = "wasm32"))]
-    #[tracing::instrument(level = "trace", skip(contract_blob, service_blob, bytecode_id))]
+    #[instrument(level = "trace", skip(contract_blob, service_blob, bytecode_id))]
     pub async fn publish_bytecode_blobs(
         &self,
         contract_blob: Blob,
@@ -2649,7 +2649,7 @@ where
     }
 
     /// Publishes some data blobs.
-    #[tracing::instrument(level = "trace", skip(bytes))]
+    #[instrument(level = "trace", skip(bytes))]
     pub async fn publish_data_blobs(
         &self,
         bytes: Vec<Vec<u8>>,
@@ -2668,7 +2668,7 @@ where
     }
 
     /// Publishes some data blob.
-    #[tracing::instrument(level = "trace", skip(bytes))]
+    #[instrument(level = "trace", skip(bytes))]
     pub async fn publish_data_blob(
         &self,
         bytes: Vec<u8>,
@@ -2685,7 +2685,7 @@ where
     }
 
     /// Creates an application by instantiating some bytecode.
-    #[tracing::instrument(
+    #[instrument(
         level = "trace",
         skip(self, parameters, instantiation_argument, required_application_ids)
     )]
@@ -2714,7 +2714,7 @@ where
     }
 
     /// Creates an application by instantiating some bytecode.
-    #[tracing::instrument(
+    #[instrument(
         level = "trace",
         skip(
             self,
@@ -2756,7 +2756,7 @@ where
     }
 
     /// Creates a new committee and starts using it (admin chains only).
-    #[tracing::instrument(level = "trace", skip(committee))]
+    #[instrument(level = "trace", skip(committee))]
     pub async fn stage_new_committee(
         &self,
         committee: Committee,
@@ -2789,7 +2789,7 @@ where
     ///
     /// If not all certificates could be processed due to a timeout, the timestamp for when to retry
     /// is returned, too.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn process_inbox(
         &self,
     ) -> Result<(Vec<Certificate>, Option<RoundTimeout>), ChainClientError> {
@@ -2802,7 +2802,7 @@ where
     ///
     /// If not all certificates could be processed due to a timeout, the timestamp for when to retry
     /// is returned, too.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn process_inbox_without_prepare(
         &self,
     ) -> Result<(Vec<Certificate>, Option<RoundTimeout>), ChainClientError> {
@@ -2828,7 +2828,7 @@ where
 
     /// Starts listening to the admin chain for new committees. (This is only useful for
     /// other genesis chains or for testing.)
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn subscribe_to_new_committees(
         &self,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
@@ -2841,7 +2841,7 @@ where
 
     /// Stops listening to the admin chain for new committees. (This is only useful for
     /// testing.)
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn unsubscribe_from_new_committees(
         &self,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
@@ -2856,7 +2856,7 @@ where
     /// only). Currently, each individual chain is still entitled to wait before accepting
     /// this command. However, it is expected that deprecated validators stop functioning
     /// shortly after such command is issued.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn finalize_committee(&self) -> Result<ClientOutcome<Certificate>, ChainClientError> {
         self.prepare_chain().await?;
         let (current_epoch, committees) = self.epoch_and_committees(self.chain_id).await?;
@@ -2879,7 +2879,7 @@ where
     /// Sends money to a chain.
     /// Do not check balance. (This may block the client)
     /// Do not confirm the transaction.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn transfer_to_account_unsafe_unconfirmed(
         &self,
         owner: Option<Owner>,
@@ -2894,7 +2894,7 @@ where
         .await
     }
 
-    #[tracing::instrument(level = "trace", skip(hash))]
+    #[instrument(level = "trace", skip(hash))]
     pub async fn read_hashed_certificate_value(
         &self,
         hash: CryptoHash,
@@ -2906,7 +2906,7 @@ where
     }
 
     /// Handles any cross-chain requests for any pending outgoing messages.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub async fn retry_pending_outgoing_messages(&self) -> Result<(), ChainClientError> {
         self.client
             .local_node
@@ -2915,7 +2915,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip(from, limit))]
+    #[instrument(level = "trace", skip(from, limit))]
     pub async fn read_hashed_certificate_values_downward(
         &self,
         from: CryptoHash,
@@ -2927,7 +2927,7 @@ where
             .await
     }
 
-    #[tracing::instrument(level = "trace", skip(local_node))]
+    #[instrument(level = "trace", skip(local_node))]
     async fn local_chain_info(
         &self,
         chain_id: ChainId,
@@ -2942,7 +2942,7 @@ where
         Some(info)
     }
 
-    #[tracing::instrument(level = "trace", skip(chain_id, local_node))]
+    #[instrument(level = "trace", skip(chain_id, local_node))]
     async fn local_next_block_height(
         &self,
         chain_id: ChainId,
@@ -2952,7 +2952,7 @@ where
         Some(info.next_block_height)
     }
 
-    #[tracing::instrument(level = "trace", skip(remote_node, local_node, notification))]
+    #[instrument(level = "trace", skip(remote_node, local_node, notification))]
     async fn process_notification(
         &self,
         remote_node: RemoteNode<P::Node>,
@@ -3036,7 +3036,7 @@ where
 
     /// Spawns a task that listens to notifications about the current chain from all validators,
     /// and synchronizes the local state accordingly.
-    #[tracing::instrument(level = "trace", fields(chain_id = ?self.chain_id))]
+    #[instrument(level = "trace", fields(chain_id = ?self.chain_id))]
     pub async fn listen(
         &self,
     ) -> Result<(impl Future<Output = ()>, AbortOnDrop, NotificationStream), ChainClientError> {
@@ -3108,7 +3108,7 @@ where
         Ok((update_streams, AbortOnDrop(abort), notifications))
     }
 
-    #[tracing::instrument(level = "trace", skip(senders))]
+    #[instrument(level = "trace", skip(senders))]
     async fn update_streams(
         &self,
         senders: &mut HashMap<ValidatorName, AbortHandle>,
@@ -3172,7 +3172,7 @@ where
     ///
     /// This is similar to `find_received_certificates` but for only one validator.
     /// We also don't try to synchronize the admin chain.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     async fn find_received_certificates_from_validator(
         &self,
         remote_node: RemoteNode<P::Node>,
@@ -3249,7 +3249,7 @@ enum ExecuteBlockOutcome {
 pub struct AbortOnDrop(AbortHandle);
 
 impl Drop for AbortOnDrop {
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     fn drop(&mut self) {
         self.0.abort();
     }

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -12,7 +12,7 @@ use linera_base::{
 };
 use linera_chain::data_types::{BlockProposal, Certificate, LiteCertificate};
 use linera_execution::committee::ValidatorName;
-use tracing::warn;
+use tracing::{instrument, warn};
 
 use crate::{
     data_types::{BlockHeightRange, ChainInfo, ChainInfoQuery, ChainInfoResponse},
@@ -45,7 +45,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
         self.check_and_return_info(response, chain_id)
     }
 
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub(crate) async fn handle_block_proposal(
         &self,
         proposal: Box<BlockProposal>,
@@ -55,7 +55,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
         self.check_and_return_info(response, chain_id)
     }
 
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub(crate) async fn handle_certificate(
         &self,
         certificate: Certificate,
@@ -70,7 +70,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
         self.check_and_return_info(response, chain_id)
     }
 
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub(crate) async fn handle_lite_certificate(
         &self,
         certificate: LiteCertificate<'_>,
@@ -102,7 +102,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
         Ok(response.info)
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub(crate) async fn try_query_certificates_from(
         &self,
         chain_id: ChainId,
@@ -126,7 +126,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
         }
     }
 
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub(crate) async fn download_certificate_for_blob(
         &self,
         blob_id: BlobId,
@@ -143,7 +143,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
         Ok(certificate)
     }
 
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub(crate) async fn try_download_blobs(&self, blob_ids: &[BlobId]) -> Vec<Blob> {
         future::join_all(
             blob_ids
@@ -156,7 +156,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
         .collect::<Vec<_>>()
     }
 
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub(crate) async fn try_download_blob(&self, blob_id: BlobId) -> Option<Blob> {
         match self.node.download_blob_content(blob_id).await {
             Ok(blob) => {
@@ -214,7 +214,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
 
     /// Returns the list of certificate hashes on the given chain in the given range of heights.
     /// Returns an error if the number of hashes does not match the size of the range.
-    #[tracing::instrument(level = "trace")]
+    #[instrument(level = "trace")]
     pub(crate) async fn fetch_sent_certificate_hashes(
         &self,
         chain_id: ChainId,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -223,7 +223,7 @@ pub enum WorkerError {
 }
 
 impl From<linera_chain::ChainError> for WorkerError {
-    #[tracing::instrument(level = "trace", skip(chain_error))]
+    #[instrument(level = "trace", skip(chain_error))]
     fn from(chain_error: linera_chain::ChainError) -> Self {
         WorkerError::ChainError(Box::new(chain_error))
     }
@@ -266,7 +266,7 @@ impl<StorageClient> WorkerState<StorageClient>
 where
     StorageClient: Storage,
 {
-    #[tracing::instrument(level = "trace", skip(nickname, key_pair, storage))]
+    #[instrument(level = "trace", skip(nickname, key_pair, storage))]
     pub fn new(
         nickname: String,
         key_pair: Option<KeyPair>,
@@ -286,7 +286,7 @@ where
         }
     }
 
-    #[tracing::instrument(level = "trace", skip(nickname, storage))]
+    #[instrument(level = "trace", skip(nickname, storage))]
     pub fn new_for_client(
         nickname: String,
         storage: StorageClient,
@@ -306,26 +306,26 @@ where
         }
     }
 
-    #[tracing::instrument(level = "trace", skip(self, value))]
+    #[instrument(level = "trace", skip(self, value))]
     pub fn with_allow_inactive_chains(mut self, value: bool) -> Self {
         self.chain_worker_config.allow_inactive_chains = value;
         self
     }
 
-    #[tracing::instrument(level = "trace", skip(self, value))]
+    #[instrument(level = "trace", skip(self, value))]
     pub fn with_allow_messages_from_deprecated_epochs(mut self, value: bool) -> Self {
         self.chain_worker_config
             .allow_messages_from_deprecated_epochs = value;
         self
     }
 
-    #[tracing::instrument(level = "trace", skip(self, value))]
+    #[instrument(level = "trace", skip(self, value))]
     pub fn with_long_lived_services(mut self, value: bool) -> Self {
         self.chain_worker_config.long_lived_services = value;
         self
     }
 
-    #[tracing::instrument(level = "trace", skip(self, tracked_chains))]
+    #[instrument(level = "trace", skip(self, tracked_chains))]
     /// Configures the subset of chains that this worker is tracking.
     pub fn with_tracked_chains(
         mut self,
@@ -339,24 +339,24 @@ where
     ///
     /// Blocks with a timestamp this far in the future will still be accepted, but the validator
     /// will wait until that timestamp before voting.
-    #[tracing::instrument(level = "trace", skip(self, grace_period))]
+    #[instrument(level = "trace", skip(self, grace_period))]
     pub fn with_grace_period(mut self, grace_period: Duration) -> Self {
         self.chain_worker_config.grace_period = grace_period;
         self
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub fn nickname(&self) -> &str {
         &self.nickname
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub fn recent_blobs(&self) -> Arc<ValueCache<BlobId, Blob>> {
         self.recent_blobs.clone()
     }
 
     /// Returns the storage client so that it can be manipulated or queried.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     #[cfg(not(feature = "test"))]
     pub(crate) fn storage_client(&self) -> &StorageClient {
         &self.storage
@@ -364,13 +364,13 @@ where
 
     /// Returns the storage client so that it can be manipulated or queried by tests in other
     /// crates.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     #[cfg(feature = "test")]
     pub fn storage_client(&self) -> &StorageClient {
         &self.storage
     }
 
-    #[tracing::instrument(level = "trace", skip(self, key_pair))]
+    #[instrument(level = "trace", skip(self, key_pair))]
     #[cfg(test)]
     pub(crate) async fn with_key_pair(mut self, key_pair: Option<Arc<KeyPair>>) -> Self {
         self.chain_worker_config.key_pair = key_pair;
@@ -378,7 +378,7 @@ where
         self
     }
 
-    #[tracing::instrument(level = "trace", skip(self, certificate))]
+    #[instrument(level = "trace", skip(self, certificate))]
     pub(crate) async fn full_certificate(
         &self,
         certificate: LiteCertificate<'_>,
@@ -388,7 +388,7 @@ where
             .await
     }
 
-    #[tracing::instrument(level = "trace", skip(self, hash))]
+    #[instrument(level = "trace", skip(self, hash))]
     pub(crate) async fn recent_hashed_certificate_value(
         &self,
         hash: &CryptoHash,
@@ -396,7 +396,7 @@ where
         self.recent_hashed_certificate_values.get(hash).await
     }
 
-    #[tracing::instrument(level = "trace", skip(self, blob_id))]
+    #[instrument(level = "trace", skip(self, blob_id))]
     pub(crate) async fn recent_blob(&self, blob_id: &BlobId) -> Option<Blob> {
         self.recent_blobs.get(blob_id).await
     }
@@ -407,7 +407,7 @@ where
     StorageClient: Storage + Clone + Send + Sync + 'static,
 {
     // NOTE: This only works for non-sharded workers!
-    #[tracing::instrument(level = "trace", skip(self, certificate, blobs))]
+    #[instrument(level = "trace", skip(self, certificate, blobs))]
     #[cfg(with_testing)]
     pub async fn fully_handle_certificate(
         &self,
@@ -418,7 +418,7 @@ where
             .await
     }
 
-    #[tracing::instrument(level = "trace", skip(self, certificate, blobs, notifier))]
+    #[instrument(level = "trace", skip(self, certificate, blobs, notifier))]
     #[inline]
     pub(crate) async fn fully_handle_certificate_with_notifications(
         &self,
@@ -444,7 +444,7 @@ where
     }
 
     /// Tries to execute a block proposal without any verification other than block execution.
-    #[tracing::instrument(level = "trace", skip(self, block))]
+    #[instrument(level = "trace", skip(self, block))]
     pub async fn stage_block_execution(
         &self,
         block: Block,
@@ -456,7 +456,7 @@ where
     }
 
     /// Executes a [`Query`] for an application's state on a specific chain.
-    #[tracing::instrument(level = "trace", skip(self, chain_id, query))]
+    #[instrument(level = "trace", skip(self, chain_id, query))]
     pub async fn query_application(
         &self,
         chain_id: ChainId,
@@ -468,7 +468,7 @@ where
         .await
     }
 
-    #[tracing::instrument(level = "trace", skip(self, chain_id, application_id))]
+    #[instrument(level = "trace", skip(self, chain_id, application_id))]
     pub async fn describe_application(
         &self,
         chain_id: ChainId,
@@ -484,7 +484,7 @@ where
     }
 
     /// Processes a confirmed block (aka a commit).
-    #[tracing::instrument(
+    #[instrument(
         level = "trace",
         skip(self, certificate, blobs, notify_when_messages_are_delivered)
     )]
@@ -517,7 +517,7 @@ where
     }
 
     /// Processes a validated block issued from a multi-owner chain.
-    #[tracing::instrument(level = "trace", skip(self, certificate))]
+    #[instrument(level = "trace", skip(self, certificate))]
     async fn process_validated_block(
         &self,
         certificate: Certificate,
@@ -540,7 +540,7 @@ where
     }
 
     /// Processes a leader timeout issued from a multi-owner chain.
-    #[tracing::instrument(level = "trace", skip(self, certificate))]
+    #[instrument(level = "trace", skip(self, certificate))]
     async fn process_timeout(
         &self,
         certificate: Certificate,
@@ -557,7 +557,7 @@ where
         .await
     }
 
-    #[tracing::instrument(level = "trace", skip(self, origin, recipient, bundles))]
+    #[instrument(level = "trace", skip(self, origin, recipient, bundles))]
     async fn process_cross_chain_update(
         &self,
         origin: Origin,
@@ -575,7 +575,7 @@ where
     }
 
     /// Inserts a [`HashedCertificateValue`] into the worker's cache.
-    #[tracing::instrument(level = "trace", skip(self, value))]
+    #[instrument(level = "trace", skip(self, value))]
     pub(crate) async fn cache_recent_hashed_certificate_value<'a>(
         &self,
         value: Cow<'a, HashedCertificateValue>,
@@ -584,13 +584,13 @@ where
     }
 
     /// Inserts a [`Blob`] into the worker's cache.
-    #[tracing::instrument(level = "trace", skip(self, blob))]
+    #[instrument(level = "trace", skip(self, blob))]
     pub async fn cache_recent_blob<'a>(&self, blob: Cow<'a, Blob>) -> bool {
         self.recent_blobs.insert(blob).await
     }
 
     /// Returns a stored [`Certificate`] for a chain's block.
-    #[tracing::instrument(level = "trace", skip(self, chain_id, height))]
+    #[instrument(level = "trace", skip(self, chain_id, height))]
     #[cfg(with_testing)]
     pub async fn read_certificate(
         &self,
@@ -608,7 +608,7 @@ where
     ///
     /// The returned view holds a lock on the chain state, which prevents the worker from changing
     /// the state of that chain.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub async fn chain_state_view(
         &self,
         chain_id: ChainId,
@@ -619,7 +619,7 @@ where
         .await
     }
 
-    #[tracing::instrument(level = "trace", skip(self, request_builder))]
+    #[instrument(level = "trace", skip(self, request_builder))]
     /// Sends a request to the [`ChainWorker`] for a [`ChainId`] and waits for the `Response`.
     async fn query_chain_worker<Response>(
         &self,
@@ -642,7 +642,7 @@ where
 
     /// Retrieves an endpoint to a [`ChainWorkerActor`] from the cache, creating one and adding it
     /// to the cache if needed.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     async fn get_chain_worker_endpoint(
         &self,
         chain_id: ChainId,
@@ -692,7 +692,7 @@ where
     /// and add it to the cache if needed.
     ///
     /// Returns [`None`] if the cache is full and no candidate for eviction was found.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     #[expect(clippy::type_complexity)]
     fn try_get_chain_worker_endpoint(
         &self,
@@ -946,7 +946,7 @@ where
     /// # Panics
     ///
     /// If the validator doesn't have a key pair assigned to it.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub fn public_key(&self) -> PublicKey {
         self.chain_worker_config
             .key_pair()

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -360,7 +360,7 @@ impl ValidatorNode for GrpcClient {
 #[cfg(not(web))]
 #[async_trait::async_trait]
 impl mass_client::MassClient for GrpcClient {
-    #[tracing::instrument(skip_all, err)]
+    #[instrument(skip_all, err)]
     async fn send(
         &self,
         requests: Vec<RpcMessage>,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -47,7 +47,7 @@ use thiserror::Error as ThisError;
 use tokio::sync::OwnedRwLockReadGuard;
 use tokio_stream::StreamExt;
 use tower_http::cors::CorsLayer;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, instrument};
 
 use crate::util;
 
@@ -961,7 +961,7 @@ where
     }
 
     /// Runs the node service.
-    #[tracing::instrument(name = "node_service", level = "info", skip(self), fields(port = ?self.port))]
+    #[instrument(name = "node_service", level = "info", skip(self), fields(port = ?self.port))]
     pub async fn run(self) -> Result<(), anyhow::Error> {
         let port = self.port.get();
         let index_handler = axum::routing::get(util::graphiql).post(Self::index_handler);


### PR DESCRIPTION
## Motivation

Right now we use either `tracing::instrument` or `instrument` in different places.

## Proposal

For consistency (and grepability) it might be better to just do `instrument` everywhere.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
