### PR TITLE
Push all tags individually

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -57,4 +57,6 @@ jobs:
   
       - name: Push Docker image to Google Artifact Registry
         run: |
-          docker push -a ${{ env.DOCKER_IMAGE }}
+          docker push ${{ env.DOCKER_IMAGE }}:${{ env.BRANCH_NAME }}
+          docker push ${{ env.DOCKER_IMAGE }}:${{ env.GIT_COMMIT_SHORT }}
+          docker push ${{ env.DOCKER_IMAGE }}:${{ env.GIT_COMMIT_LONG }}


### PR DESCRIPTION
## Motivation

There seems to be some evidence online that `docker push -a` doesn't seem to be 100% reliable. We're seeing some images not have all the tags they're supposed to have.

## Proposal

`docker push` each tag individually, so we know for sure everything is being pushed and tagged properly.

## Test Plan

Will push this to `devnet_2024_10_21`, which was the branch that we saw had this issue in the latest image.

## Release Plan

- These changes should be backported to the latest `devnet` branch
- These changes should be backported to the latest `testnet` branch

