### PR TITLE
Close chains after tests finish

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -708,11 +708,15 @@ Show the contents of the wallet
 
 Show the contents of the wallet
 
-**Usage:** `linera wallet show [CHAIN_ID]`
+**Usage:** `linera wallet show [OPTIONS] [CHAIN_ID]`
 
 ###### **Arguments:**
 
-* `<CHAIN_ID>`
+* `<CHAIN_ID>` — The chain to show the metadata
+
+###### **Options:**
+
+* `--short` — Only print a non-formatted list of the wallet's chain IDs
 
 
 

--- a/CLI.md
+++ b/CLI.md
@@ -256,11 +256,11 @@ Close an existing chain.
 
 A closed chain cannot execute operations or accept messages anymore. It can still reject incoming messages, so they bounce back to the sender.
 
-**Usage:** `linera close-chain --from <CHAIN_ID>`
+**Usage:** `linera close-chain <CHAIN_ID>`
 
-###### **Options:**
+###### **Arguments:**
 
-* `--from <CHAIN_ID>` — Chain ID (must be one of our chains)
+* `<CHAIN_ID>` — Chain ID (must be one of our chains)
 
 
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -369,7 +369,6 @@ pub enum ClientCommand {
     /// It can still reject incoming messages, so they bounce back to the sender.
     CloseChain {
         /// Chain ID (must be one of our chains)
-        #[arg(long = "from")]
         chain_id: ChainId,
     },
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -975,7 +975,13 @@ impl fmt::Display for ResourceControlPolicyConfig {
 #[derive(Clone, clap::Subcommand)]
 pub enum WalletCommand {
     /// Show the contents of the wallet.
-    Show { chain_id: Option<ChainId> },
+    Show {
+        /// The chain to show the metadata.
+        chain_id: Option<ChainId>,
+        /// Only print a non-formatted list of the wallet's chain IDs.
+        #[arg(long)]
+        short: bool,
+    },
 
     /// Change the wallet default chain.
     SetDefault { chain_id: ChainId },

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -28,7 +28,7 @@ use crate::cli_wrappers::{
     kubectl::KubectlInstance,
     local_net::PathProvider,
     util::get_github_root,
-    ClientWrapper, LineraNet, LineraNetConfig, Network,
+    ClientWrapper, LineraNet, LineraNetConfig, Network, OnClientDrop,
 };
 
 #[cfg(with_testing)]
@@ -257,6 +257,7 @@ impl LineraNet for LocalKubernetesNet {
             self.network,
             self.testing_prng_seed,
             self.next_client_id,
+            OnClientDrop::LeakChains,
         );
         if let Some(seed) = self.testing_prng_seed {
             self.testing_prng_seed = Some(seed + 1);

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -34,7 +34,9 @@ use tonic_health::pb::{
 use tracing::{info, warn};
 
 use crate::{
-    cli_wrappers::{ClientWrapper, LineraNet, LineraNetConfig, Network, NetworkConfig},
+    cli_wrappers::{
+        ClientWrapper, LineraNet, LineraNetConfig, Network, NetworkConfig, OnClientDrop,
+    },
     util::ChildExt,
 };
 
@@ -317,6 +319,7 @@ impl LineraNet for LocalNet {
             self.network.external,
             self.testing_prng_seed,
             self.next_client_id,
+            OnClientDrop::LeakChains,
         );
         if let Some(seed) = self.testing_prng_seed {
             self.testing_prng_seed = Some(seed + 1);

--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -34,7 +34,9 @@ mod wallet;
 use anyhow::Result;
 use async_trait::async_trait;
 use linera_execution::ResourceControlPolicy;
-pub use wallet::{ApplicationWrapper, ClientWrapper, Faucet, FaucetOption, NodeService};
+pub use wallet::{
+    ApplicationWrapper, ClientWrapper, Faucet, FaucetOption, NodeService, OnClientDrop,
+};
 
 /// The information needed to start a Linera net of a particular kind.
 #[async_trait]

--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -12,7 +12,7 @@ use tempfile::{tempdir, TempDir};
 
 use super::{
     local_net::PathProvider, ClientWrapper, Faucet, FaucetOption, LineraNet, LineraNetConfig,
-    Network,
+    Network, OnClientDrop,
 };
 
 pub struct RemoteNetTestingConfig {
@@ -103,6 +103,7 @@ impl LineraNet for RemoteNet {
             self.network,
             self.testing_prng_seed,
             self.next_client_id,
+            OnClientDrop::CloseChains,
         );
         if let Some(seed) = self.testing_prng_seed {
             self.testing_prng_seed = Some(seed + 1);

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -63,9 +63,11 @@ pub struct ClientWrapper {
     max_pending_message_bundles: usize,
     network: Network,
     pub path_provider: PathProvider,
+    on_drop: OnClientDrop,
 }
 
 /// Action to perform when the [`ClientWrapper`] is dropped.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum OnClientDrop {
     /// Close all the chains on the wallet.
     CloseChains,
@@ -79,6 +81,7 @@ impl ClientWrapper {
         network: Network,
         testing_prng_seed: Option<u64>,
         id: usize,
+        on_drop: OnClientDrop,
     ) -> Self {
         let storage = format!(
             "rocksdb:{}/client_{}.db",
@@ -94,6 +97,7 @@ impl ClientWrapper {
             max_pending_message_bundles: 10_000,
             network,
             path_provider,
+            on_drop,
         }
     }
 

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -65,6 +65,14 @@ pub struct ClientWrapper {
     pub path_provider: PathProvider,
 }
 
+/// Action to perform when the [`ClientWrapper`] is dropped.
+pub enum OnClientDrop {
+    /// Close all the chains on the wallet.
+    CloseChains,
+    /// Do not close any chains, leaving them active.
+    LeakChains,
+}
+
 impl ClientWrapper {
     pub fn new(
         path_provider: PathProvider,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1536,8 +1536,14 @@ async fn run(options: &ClientOptions) -> anyhow::Result<()> {
         },
 
         ClientCommand::Wallet(wallet_command) => match wallet_command {
-            WalletCommand::Show { chain_id } => {
-                wallet::pretty_print(&*options.wallet().await?, *chain_id);
+            WalletCommand::Show { chain_id, short } => {
+                if *short {
+                    for chain_id in options.wallet().await?.chains.keys() {
+                        println!("{chain_id}");
+                    }
+                } else {
+                    wallet::pretty_print(&*options.wallet().await?, *chain_id);
+                }
                 Ok(())
             }
 

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -25,7 +25,7 @@ use linera_service::{
         local_net::{
             get_node_port, Database, LocalNet, LocalNetConfig, PathProvider, ProcessInbox,
         },
-        ClientWrapper, FaucetOption, LineraNet, LineraNetConfig, Network,
+        ClientWrapper, FaucetOption, LineraNet, LineraNetConfig, Network, OnClientDrop,
     },
     faucet::ClaimOutcome,
     test_name,
@@ -640,7 +640,13 @@ async fn test_project_new() -> Result<()> {
     let _rustflags_override = override_disable_warnings_as_errors();
     let path_provider = PathProvider::create_temporary_directory()?;
     let id = 0;
-    let client = ClientWrapper::new(path_provider, Network::Grpc, None, id);
+    let client = ClientWrapper::new(
+        path_provider,
+        Network::Grpc,
+        None,
+        id,
+        OnClientDrop::LeakChains,
+    );
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let linera_root = manifest_dir
         .parent()
@@ -658,7 +664,13 @@ async fn test_project_new() -> Result<()> {
 async fn test_project_test() -> Result<()> {
     let path_provider = PathProvider::create_temporary_directory()?;
     let id = 0;
-    let client = ClientWrapper::new(path_provider, Network::Grpc, None, id);
+    let client = ClientWrapper::new(
+        path_provider,
+        Network::Grpc,
+        None,
+        id,
+        OnClientDrop::LeakChains,
+    );
     client
         .project_test(&ClientWrapper::example_path("counter")?)
         .await?;


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
When we run the end-to-end tests against devnet or testnet, they create many temporary chains. Unfortunately, right now these chains never unsubscribes from the admin chain, which increases the load when advancing epochs.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Close the chains when the test finish, so that they don't stay subscribed to the admin chain for epoch changes.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
A manual test is needed to check if the chains are really being closed. Maybe after running the end-to-end tests we can check if there are any open chains.

CI should catch regressions.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- These changes should be backported to the latest `devnet` branch and `testnet` branches so that the tests can run with the new code to close chains when they have finished.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- Closes #2772
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
