### PR TITLE
Remove blobs cache

### DIFF
--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -12,7 +12,7 @@ use std::{
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Blob, BlockHeight, Timestamp, UserApplicationDescription},
-    identifiers::{BlobId, ChainId, UserApplicationId},
+    identifiers::{ChainId, UserApplicationId},
 };
 use linera_chain::{
     data_types::{
@@ -147,7 +147,6 @@ where
         config: ChainWorkerConfig,
         storage: StorageClient,
         certificate_value_cache: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
-        blob_cache: Arc<ValueCache<BlobId, Blob>>,
         tracked_chains: Option<Arc<RwLock<HashSet<ChainId>>>>,
         delivery_notifier: DeliveryNotifier,
         chain_id: ChainId,
@@ -165,7 +164,6 @@ where
             config,
             storage,
             certificate_value_cache,
-            blob_cache,
             tracked_chains,
             delivery_notifier,
             chain_id,

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -3,8 +3,6 @@
 
 //! Operations that don't persist any changes to the chain state.
 
-use std::{borrow::Cow, collections::BTreeSet};
-
 use linera_base::{
     data_types::{ArithmeticError, BlobContent, Timestamp, UserApplicationDescription},
     ensure,
@@ -206,22 +204,21 @@ where
         // legitimately required.
         // Actual execution happens below, after other validity checks.
         self.0.chain.remove_bundles_from_inboxes(block).await?;
-        // Verify that all required bytecode hashed certificate values and blobs are available, and no
-        // unrelated ones provided.
+        // Verify that no unrelated blobs were provided.
         let published_blob_ids = block.published_blob_ids();
         self.0
             .check_for_unneeded_blobs(&published_blob_ids, blobs)
             .await?;
+        let missing_published_blob_ids = published_blob_ids
+            .difference(&blobs.iter().map(|blob| blob.id()).collect())
+            .cloned()
+            .collect::<Vec<_>>();
+        ensure!(
+            missing_published_blob_ids.is_empty(),
+            WorkerError::BlobsNotFound(missing_published_blob_ids)
+        );
         for blob in blobs {
             Self::check_blob_size(blob.content(), &policy)?;
-            self.0.cache_recent_blob(Cow::Borrowed(blob)).await;
-        }
-
-        let checked_blobs = blobs.iter().map(|blob| blob.id()).collect::<BTreeSet<_>>();
-        for blob in self.0.get_cached_blobs(published_blob_ids).await? {
-            if !checked_blobs.contains(&blob.id()) {
-                Self::check_blob_size(blob.content(), &policy)?;
-            }
         }
 
         let local_time = self.0.storage.clock().current_time();

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -10,8 +10,6 @@
 #![allow(clippy::large_futures)]
 #![cfg(any(feature = "wasmer", feature = "wasmtime"))]
 
-use std::borrow::Cow;
-
 use linera_base::{
     crypto::KeyPair,
     data_types::{
@@ -153,12 +151,11 @@ where
     );
     let publish_certificate = make_certificate(&committee, &worker, publish_block_proposal);
 
-    worker
-        .cache_recent_blob(Cow::Borrowed(&contract_blob))
-        .await;
-
     let info = worker
-        .fully_handle_certificate(publish_certificate.clone(), vec![service_blob.clone()])
+        .fully_handle_certificate(
+            publish_certificate.clone(),
+            vec![contract_blob.clone(), service_blob.clone()],
+        )
         .await
         .unwrap()
         .info;


### PR DESCRIPTION
## Motivation

This cache isn't needed, and actually was incorrect in how we were using it: the cache wrongfully technically gave access to unpublished blobs to any chain in the client, as well as masked a bug (we needed to be checking the chain manager's pending blobs in `get_blobs` also).

## Proposal

Remove the cache

## Test Plan

Existing ts in CI should pass and confirm that this indeed wasn't needed.

## Release Plan
I feel like this should probably be backported everywhere?

- These changes should be backported to the latest `devnet` branch
- These changes should be backported to the latest `testnet` branch

