### PR TITLE
Deliver messages to untracked publisher chains. (#2768)

### DIFF
--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -409,10 +409,22 @@ where
         let mut heights_by_recipient = BTreeMap::<_, BTreeMap<_, _>>::new();
         let mut targets = self.chain.outboxes.indices().await?;
         if let Some(tracked_chains) = self.tracked_chains.as_ref() {
+            let publishers = self
+                .chain
+                .execution_state
+                .system
+                .subscriptions
+                .indices()
+                .await?
+                .iter()
+                .map(|subscription| subscription.chain_id)
+                .collect::<HashSet<_>>();
             let tracked_chains = tracked_chains
                 .read()
                 .expect("Panics should not happen while holding a lock to `tracked_chains`");
-            targets.retain(|target| tracked_chains.contains(&target.recipient));
+            targets.retain(|target| {
+                tracked_chains.contains(&target.recipient) || publishers.contains(&target.recipient)
+            });
         }
         let outboxes = self.chain.outboxes.try_load_entries(&targets).await?;
         for (target, outbox) in targets.into_iter().zip(outboxes) {


### PR DESCRIPTION
## Motivation

If a tracked chain A subscribes to another chain B, we need to process that `Subscribe` message from A to B, otherwise we won't locally create the cross-chain messages back from B to A.

https://github.com/linera-io/linera-protocol/pull/2768 fixes this on devnet.

## Proposal

Port https://github.com/linera-io/linera-protocol/pull/2768 to main.

## Test Plan

Already in use on devnet.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- `devnet_2024_10_21` version: https://github.com/linera-io/linera-protocol/pull/2768
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
