### PR TITLE
Accept past CreateCommittee messages.

### DIFF
--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -795,12 +795,15 @@ where
                 }
             }
             CreateCommittee { epoch, committee } => {
+                let chain_next_epoch = self.epoch.get().expect("chain is active").try_add_one()?;
                 ensure!(
-                    epoch == self.epoch.get().expect("chain is active").try_add_one()?,
+                    epoch <= chain_next_epoch,
                     SystemExecutionError::InvalidCommitteeCreation
                 );
-                self.committees.get_mut().insert(epoch, committee.clone());
-                self.epoch.set(Some(epoch));
+                if epoch == chain_next_epoch {
+                    self.committees.get_mut().insert(epoch, committee.clone());
+                    self.epoch.set(Some(epoch));
+                }
             }
             RemoveCommittee { epoch } => {
                 ensure!(


### PR DESCRIPTION
## Motivation

Since `Subscribe` messages are handled off-chain, and trigger sending all previous messages in that channel, every newly created chain in an epoch greater than 0 will receive `CreateCommittee` messages for past epochs. These currently fail to execute.

## Proposal

Silently ignore past `CreateCommittee` messages instead.

## Test Plan

https://github.com/linera-io/linera-protocol/issues/2772 is failing because of this, so it will test this fix.

## Release Plan

- These changes should be ported to `main`,
- released in a new SDK,
- released in a validator hotfix.

## Links

- https://github.com/linera-io/linera-protocol/issues/2772 uncovered this issue.
- Bug ticket: https://github.com/linera-io/linera-protocol/issues/2791 (Will close when ported to main.)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
