### PR TITLE
Stop updating tracker on first entry we couldn't get or verify

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1247,6 +1247,8 @@ where
                 .is_some_and(|h| *h >= entry.height)
             {
                 tracker += 1;
+            } else {
+                break;
             }
         }
 


### PR DESCRIPTION
## Motivation

We are currently continuing updating the tracker, even when we see an entry that we couldn't get or verify.

## Proposal

Break early to fix that

## Test Plan

CI but maybe we should add a test that would catch this?

## Release Plan

- These changes should be backported to the latest `devnet` branch
- These changes should be backported to the latest `testnet` branch

