### PR TITLE
Accept past CreateCommittee messages. (#2790)

### DIFF
--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -795,12 +795,15 @@ where
                 }
             }
             CreateCommittee { epoch, committee } => {
+                let chain_next_epoch = self.epoch.get().expect("chain is active").try_add_one()?;
                 ensure!(
-                    epoch == self.epoch.get().expect("chain is active").try_add_one()?,
+                    epoch <= chain_next_epoch,
                     SystemExecutionError::InvalidCommitteeCreation
                 );
-                self.committees.get_mut().insert(epoch, committee.clone());
-                self.epoch.set(Some(epoch));
+                if epoch == chain_next_epoch {
+                    self.committees.get_mut().insert(epoch, committee.clone());
+                    self.epoch.set(Some(epoch));
+                }
             }
             RemoveCommittee { epoch } => {
                 ensure!(


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/2790 fixes a bug related to `CreateCommittee` messages.

## Proposal

Port it to `main`.

## Test Plan

See https://github.com/linera-io/linera-protocol/pull/2790.

## Release Plan

- These changes are applied to the devnet in https://github.com/linera-io/linera-protocol/pull/2790. They should be
- released in a new SDK,
- released in a validator hotfix.

## Links

- Fixes https://github.com/linera-io/linera-protocol/issues/2791.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
