### PR TITLE
Test receipt of old epoch change messages

### DIFF
--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -22,7 +22,9 @@ use linera_base::{
 };
 use linera_service::{
     cli_wrappers::{
-        local_net::{get_node_port, Database, LocalNetConfig, PathProvider, ProcessInbox},
+        local_net::{
+            get_node_port, Database, LocalNet, LocalNetConfig, PathProvider, ProcessInbox,
+        },
         ClientWrapper, FaucetOption, LineraNet, LineraNetConfig, Network,
     },
     test_name,
@@ -70,7 +72,6 @@ impl Drop for RestoreVarOnDrop {
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
     use linera_base::{crypto::KeyPair, identifiers::Owner};
-    use linera_service::cli_wrappers::local_net::LocalNet;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -325,6 +325,136 @@ async fn test_end_to_end_receipt_of_old_create_committee_messages(
     Ok(())
 }
 
+/// Test if it's possible to receive epoch change messages for past epochs, even if they have been
+/// deprecated.
+///
+/// The epoch change messages are protected, and can't be rejected.
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Tcp) ; "storage_service_tcp"))]
+#[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Tcp) ; "scylladb_tcp"))]
+#[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Tcp) ; "aws_tcp"))]
+#[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Udp) ; "aws_udp"))]
+#[test_log::test(tokio::test)]
+async fn test_end_to_end_receipt_of_old_remove_committee_messages(
+    config: LocalNetConfig,
+) -> Result<()> {
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let network = config.network.external;
+    let (mut net, client) = config.instantiate().await?;
+
+    let faucet_client = net.make_client().await;
+    faucet_client.wallet_init(&[], FaucetOption::None).await?;
+
+    let faucet_chain = client
+        .open_and_assign(&faucet_client, Amount::from_tokens(1_000u128))
+        .await?;
+
+    if matches!(network, Network::Grpc) {
+        let mut faucet_service = faucet_client
+            .run_faucet(None, faucet_chain, Amount::from_tokens(2))
+            .await?;
+
+        faucet_service.ensure_is_running()?;
+
+        let faucet = faucet_service.instance();
+        assert_eq!(faucet.current_validators().await?.len(), 4);
+
+        faucet_service.terminate().await?;
+    }
+
+    client.query_validators(None).await?;
+
+    // Start a new validator
+    net.generate_validator_config(4).await?;
+    net.start_validator(4).await?;
+
+    let address = format!("{}:localhost:{}", network.short(), LocalNet::proxy_port(4));
+    assert_eq!(
+        client.query_validator(&address).await?,
+        net.genesis_config()?.hash()
+    );
+
+    // Add 5th validator to the network
+    client
+        .set_validator(net.validator_name(4).unwrap(), LocalNet::proxy_port(4), 100)
+        .await?;
+    client.finalize_committee().await?;
+
+    client.query_validators(None).await?;
+
+    // Ensure the faucet is on the new epoch
+    faucet_client.process_inbox(faucet_chain).await?;
+
+    if matches!(network, Network::Grpc) {
+        let mut faucet_service = faucet_client
+            .run_faucet(None, faucet_chain, Amount::from_tokens(2))
+            .await?;
+
+        faucet_service.ensure_is_running()?;
+
+        let faucet = faucet_service.instance();
+        assert_eq!(faucet.current_validators().await?.len(), 5);
+
+        faucet_service.terminate().await?;
+    }
+
+    // We need the epoch before the latest to still be active, so that it can send all the epoch
+    // change messages in a batch where the latest message is signed by a committee that the
+    // receiving chain trusts.
+
+    // Start another new validator
+    net.generate_validator_config(5).await?;
+    net.start_validator(5).await?;
+
+    let address = format!("{}:localhost:{}", network.short(), LocalNet::proxy_port(5));
+    assert_eq!(
+        client.query_validator(&address).await?,
+        net.genesis_config()?.hash()
+    );
+
+    // Add 6th validator to the network
+    client
+        .set_validator(net.validator_name(5).unwrap(), LocalNet::proxy_port(5), 100)
+        .await?;
+
+    client.query_validators(None).await?;
+
+    // Ensure the faucet is on the new epoch
+    faucet_client.process_inbox(faucet_chain).await?;
+
+    let mut faucet_service = faucet_client
+        .run_faucet(None, faucet_chain, Amount::from_tokens(2))
+        .await?;
+
+    faucet_service.ensure_is_running()?;
+
+    let faucet = faucet_service.instance();
+
+    if matches!(network, Network::Grpc) {
+        assert_eq!(faucet.current_validators().await?.len(), 6);
+    }
+
+    // Create a new chain starting on the new epoch
+    let new_owner_key = client.keygen().await?;
+    let ClaimOutcome {
+        chain_id,
+        message_id,
+        ..
+    } = faucet.claim(&new_owner_key).await?;
+    client.assign(new_owner_key, message_id).await?;
+
+    // Attempt to receive the existing epoch change messages
+    client.process_inbox(chain_id).await?;
+
+    net.ensure_is_running().await?;
+    net.terminate().await?;
+
+    Ok(())
+}
+
 #[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
New chains were failing to process their inboxes because they attempted to accept old messages to change the epoch. However, the chain was already on a newer epoch, so the worker rejected those protected messages, which caused the error. The issue is described in more detail in #2791.

PRs #2790 and #2799 implement fixes for the issue, and this PR includes two regression tests for them.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Add two end-to-end tests to reproduce a minimal scenarios where the bug occurs.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
CI should now reproduce the issue and pass after the fixes from #2790 and #2799.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do, as the important fix is in #2790 and #2799.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
