### PR TITLE
Don't fail if removed committee doesn't exist.

### DIFF
--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -806,10 +806,7 @@ where
                 }
             }
             RemoveCommittee { epoch } => {
-                ensure!(
-                    self.committees.get_mut().remove(&epoch).is_some(),
-                    SystemExecutionError::InvalidCommitteeRemoval
-                );
+                self.committees.get_mut().remove(&epoch);
             }
             RegisterApplications { applications } => {
                 for application in applications {


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
PR #2790 fixes a bug (issue #2791) where old `CreateCommittee` messages are rejected by the worker, and therefore prevents a chain from receiving newer epoch change messages. However, the fix led to a similar issue with the `RemoveCommittee` message, where the execution fails if the removed committee was not already in the set of known committees.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Don't fail if a `RemoveCommittee` message is received for a committee epoch that isn't in the chain's state.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
CI will check this for regressions after PR #2797 is merged, which includes an end-to-end test for this issue.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- These changes should be backported to the latest `devnet` and `testnet` branches, because they contain a critical fix.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
