### PR TITLE
Group download operations in `updater.rs`.

### DIFF
--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -287,12 +287,11 @@ where
                         .collect::<Vec<_>>()
                         .await;
                     let local_storage = self.local_node.storage_client();
-
-                    
-                    for blob_id in missing_blob_ids {
-                        let last_used_by_hash =
-                            local_storage.read_blob_state(blob_id).await?.last_used_by;
-                        let certificate = local_storage.read_certificate(last_used_by_hash).await?;
+                    let blob_states = local_storage.read_blob_states(&missing_blob_ids).await?;
+                    let certificates = local_storage
+                        .read_certificates(blob_states.into_iter().map(|x| x.last_used_by))
+                        .await?;
+                    for certificate in certificates {
                         let block_chain_id = certificate.value().chain_id();
                         let block_height = certificate.value().height();
                         self.send_chain_information(

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -287,6 +287,8 @@ where
                         .collect::<Vec<_>>()
                         .await;
                     let local_storage = self.local_node.storage_client();
+
+                    
                     for blob_id in missing_blob_ids {
                         let last_used_by_hash =
                             local_storage.read_blob_state(blob_id).await?.last_used_by;

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -98,6 +98,9 @@ pub trait Storage: Sized {
     /// Reads the blob state with the given blob ID.
     async fn read_blob_state(&self, blob_id: BlobId) -> Result<BlobState, ViewError>;
 
+    /// Reads the blob states with the given blob IDs.
+    async fn read_blob_states(&self, blob_ids: &[BlobId]) -> Result<Vec<BlobState>, ViewError>;
+
     /// Reads the hashed certificate values in descending order from the given hash.
     async fn read_hashed_certificate_values_downward(
         &self,


### PR DESCRIPTION
## Motivation

The `updater.rs` has some issues with `read_blob_state` and `read_certificate` being used in loops while it is readily possible to use single operations.

## Proposal

The changes are straightforward:
* The `read_blob_states` is introduced in `linera-storage`.
* The `read_blob_states` is used on `missing_blob_ids` in the `updater.rs` code.
* The certificates are then read by the `read_certificates`.

There are other potential changes that could be done:
* `send_chain_information` could be grouped as well.
* `send_certificate` could be grouped as we

However, those require more discussion as they may impact the protocol.

## Test Plan

The CI should be the one doing it.

The `read_multi_values` are checked in the `linera-views`.

## Release Plan

That could be merged into the TestNet / DevNet as it does not change the way data is stored, only how it is accessed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
