### PR TITLE
Improve the `get_blobs` function

### DIFF
--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -353,31 +353,25 @@ where
         let pending_blobs = &self.chain.manager.get().pending_blobs;
 
         let mut found_blobs = Vec::new();
-        let mut missing_indices = Vec::new();
         let mut missing_blob_ids = Vec::new();
-        for (index, blob_id) in blob_ids.iter().enumerate() {
+        for blob_id in blob_ids {
             if let Some(blob) = pending_blobs.get(blob_id) {
-                found_blobs.push(Some(blob.clone()));
+                found_blobs.push(blob.clone());
             } else {
-                found_blobs.push(None);
-                missing_indices.push(index);
                 missing_blob_ids.push(*blob_id);
             }
         }
         let blobs = self.storage.read_blobs(&missing_blob_ids).await?;
         let mut not_found_blob_ids = Vec::new();
-        for ((index, blob), blob_id) in missing_indices.iter().zip(blobs).zip(missing_blob_ids) {
+        for (blob, blob_id) in blobs.into_iter().zip(missing_blob_ids) {
             match blob {
                 None => not_found_blob_ids.push(blob_id),
-                Some(blob) => *found_blobs.get_mut(*index).unwrap() = Some(blob),
+                Some(blob) => found_blobs.push(blob),
             }
         }
 
         if not_found_blob_ids.is_empty() {
-            Ok(found_blobs
-                .into_iter()
-                .map(|x| x.unwrap())
-                .collect::<Vec<_>>())
+            Ok(found_blobs)
         } else {
             Err(WorkerError::BlobsNotFound(not_found_blob_ids))
         }


### PR DESCRIPTION
## Motivation

The `get_blobs` function is iterating some `read_blob` operations, which are inefficient.

## Proposal

The chosen solution is simply to identify the missing blobs and then do a single storage query.

## Test Plan

The CI.

## Release Plan

This could be included in TestNet / DevNet upgrades as it does not impact the storage, just the way the queries are organized.

## Links

None.