### PR TITLE
Introduces the `maybe_write_blob_state` and uses it.

### DIFF
--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -544,6 +544,42 @@ where
         Ok(latest_epoch)
     }
 
+    async fn maybe_write_blob_states(
+        &self,
+        blob_ids: &[BlobId],
+        blob_state: BlobState,
+    ) -> Result<Vec<Epoch>, ViewError> {
+        let blob_state_keys = blob_ids
+            .iter()
+            .map(|blob_id| bcs::to_bytes(&BaseKey::BlobState(*blob_id)))
+            .collect::<Result<_, _>>()?;
+        let maybe_blob_states = self
+            .store
+            .read_multi_values::<BlobState>(blob_state_keys)
+            .await?;
+        let mut latest_epoches = Vec::new();
+        let mut batch = Batch::new();
+        let mut need_write = false;
+        for (maybe_blob_state, blob_id) in maybe_blob_states.iter().zip(blob_ids) {
+            let (should_write, latest_epoch) = match maybe_blob_state {
+                None => (true, blob_state.epoch),
+                Some(current_blob_state) => (
+                    current_blob_state.epoch < blob_state.epoch,
+                    current_blob_state.epoch.max(blob_state.epoch),
+                ),
+            };
+            if should_write {
+                Self::add_blob_state_to_batch(*blob_id, &blob_state, &mut batch)?;
+                need_write = true;
+            }
+            latest_epoches.push(latest_epoch);
+        }
+        if need_write {
+            self.write_batch(batch).await?;
+        }
+        Ok(latest_epoches)
+    }
+
     async fn write_blob_state(
         &self,
         blob_id: BlobId,

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -135,6 +135,13 @@ pub trait Storage: Sized {
         blob_state: BlobState,
     ) -> Result<Epoch, ViewError>;
 
+    /// Attempts to write the given blob state. Returns the latest `Epoch` to have used this blob.
+    async fn maybe_write_blob_states(
+        &self,
+        blob_ids: &[BlobId],
+        blob_state: BlobState,
+    ) -> Result<Vec<Epoch>, ViewError>;
+
     /// Writes several hashed certificate values.
     async fn write_hashed_certificate_values(
         &self,


### PR DESCRIPTION
## Motivation

The `maybe_write_blob_state` is used in the `try_join_all` which is suboptimal.

## Proposal

The following is done:
* The `maybe_write_blob_states` is introduced. Note that we do not use the `read_blob_states` introduced in another PR because whether we get a `None` or a `Some(x)` is directly used. This is better than matching specific error patterns.
* The `maybe_write_blob_states` is used in the `attempted_change.rs`.

Arguably, we could remove the `maybe_write_blob_state`.

## Test Plan

The CI.

## Release Plan

This could be included in TestNet / DevNet as it does not change the data, just how it is accessed.

## Links

None.