### PR TITLE
Remove version from docker-compose.yml.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   scylla:
     image: scylladb/scylla:latest


### PR DESCRIPTION
## Motivation

Docker compose shows a warning whens starting that explicit versions are no longer supported.

## Proposal

Remove the explicit version number.

## Test Plan

CI will catch regressions.