### PR TITLE
Use the configured nightly version in the pre-push hook.

### DIFF
--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -10,7 +10,9 @@ if cat <<EOF > $ROOT_DIR/.git/hooks/pre-push
 
 cargo clippy --all-targets || { echo "Error: clippy did not pass - aborting push. Please run 'cargo clippy --all-targets'." ; exit 1 ; }
 
-cargo +nightly fmt -- --check --config unstable_features=true --config imports_granularity=Crate || { echo "Error: format check failed - aborting push. Please run 'cargo +nightly fmt'." ; exit 1 ; }
+ln -sf toolchains/nightly/rust-toolchain.toml
+cargo fmt -- --check --config unstable_features=true --config imports_granularity=Crate || { echo "Error: format check failed - aborting push. Please run 'cargo +nightly fmt'." ; exit 1 ; }
+ln -sf toolchains/stable/rust-toolchain.toml
 
 cargo machete || { echo "Error: dependency check failed - aborting push." ; exit 1 ; }
 EOF

--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -10,9 +10,9 @@ if cat <<EOF > $ROOT_DIR/.git/hooks/pre-push
 
 cargo clippy --all-targets || { echo "Error: clippy did not pass - aborting push. Please run 'cargo clippy --all-targets'." ; exit 1 ; }
 
+trap "ln -sf toolchains/stable/rust-toolchain.toml" EXIT
 ln -sf toolchains/nightly/rust-toolchain.toml
 cargo fmt -- --check --config unstable_features=true --config imports_granularity=Crate || { echo "Error: format check failed - aborting push. Please run 'cargo +nightly fmt'." ; exit 1 ; }
-ln -sf toolchains/stable/rust-toolchain.toml
 
 cargo machete || { echo "Error: dependency check failed - aborting push." ; exit 1 ; }
 EOF


### PR DESCRIPTION
## Motivation

The git pre-push hook runs `cargo +nightly fmt`. If one has a nightly version locally that is different from the one in the toolchain file, this can fail.

## Proposal

Use the toolchain file instead.

## Test Plan

It worked for me locally.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
