### PR TITLE
Synchronize chain state only on startup and when not listening to notifications.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,10 +59,12 @@ jobs:
         cargo build --features storage-service
         mkdir /tmp/local-linera-net
         cargo run --features storage-service --bin linera -- net up --storage service:tcp:localhost:1235:table --policy-config devnet --path /tmp/local-linera-net --validators 4 --shards 4 &
-    - name: Run the faucet
+    - name: Create two epochs and run the faucet
       run: |
         cargo build --bin linera
-        cargo run --bin linera -- faucet --amount 1000 --port 8079 &
+        cargo run --bin linera -- resource-control-policy --block 0.0000001
+        cargo run --bin linera -- resource-control-policy --block 0.000000
+        cargo run --bin linera -- faucet --amount 1000 --port 8079 69705f85ac4c9fef6c02b4d83426aaaf05154c645ec1c61665f8e450f0468bc0 &
     - name: Run the remote-net tests
       run: |
         cargo test -p linera-service remote_net_grpc --features remote-net

--- a/CLI.md
+++ b/CLI.md
@@ -135,6 +135,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
     Don't include any messages in blocks, and don't make any decision whether to accept or reject
 
 * `--restrict-chain-ids-to <RESTRICT_CHAIN_IDS_TO>` — A set of chains to restrict incoming messages from. By default, messages from all chains are accepted. To reject messages from all chains, specify an empty string
+* `--skip-incoming-message-sync` — Skip synchronizing incoming messages before executing the command
 
 
 

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -177,7 +177,7 @@ impl ChainListener {
                         continue;
                     }
                     debug!("Processing inbox");
-                    match client.process_inbox_without_prepare().await {
+                    match client.process_inbox().await {
                         Err(ChainClientError::CannotFindKeyForChain(_)) => {}
                         Err(error) => warn!(%error, "Failed to process inbox."),
                         Ok((certs, None)) => {

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -146,6 +146,10 @@ pub struct ClientOptions {
     /// an empty string.
     #[arg(long, value_parser = util::parse_chain_set)]
     pub restrict_chain_ids_to: Option<HashSet<ChainId>>,
+
+    /// Skip synchronizing incoming messages before executing the command.
+    #[arg(long)]
+    pub skip_incoming_message_sync: bool,
 }
 
 impl ClientOptions {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -882,7 +882,7 @@ where
     /// Prepares the chain for the next operation, i.e. makes sure we have synchronized it up to
     /// its current height.
     #[instrument(level = "trace")]
-    async fn prepare_chain(&self) -> Result<Box<ChainInfo>, ChainClientError> {
+    pub async fn prepare_chain(&self) -> Result<Box<ChainInfo>, ChainClientError> {
         #[cfg(with_metrics)]
         let _latency = metrics::PREPARE_CHAIN_LATENCY.measure_latency();
 
@@ -1379,7 +1379,7 @@ where
     /// However, this should be the case whenever a sender's chain is still in use and
     /// is regularly upgraded to new committees.
     #[instrument(level = "trace")]
-    async fn find_received_certificates(&self) -> Result<(), ChainClientError> {
+    pub async fn find_received_certificates(&self) -> Result<(), ChainClientError> {
         #[cfg(with_metrics)]
         let _latency = metrics::FIND_RECEIVED_CERTIFICATES_LATENCY.measure_latency();
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1446,6 +1446,7 @@ where
     // Try to read the blob. This is a different client but on the same chain, so when we synchronize this with the validators
     // before executing the block, we'll actually download and cache locally the blobs that were published by `client_a`.
     // So this will succeed.
+    client1_b.synchronize_from_validators().await.unwrap();
     let certificate = client1_b
         .execute_operation(SystemOperation::ReadBlob { blob_id: blob0_id }.into())
         .await?
@@ -1567,6 +1568,7 @@ where
         multi_leader_rounds: 10,
         timeout_config: TimeoutConfig::default(),
     });
+    client2_a.prepare_chain().await.unwrap();
     client2_a
         .execute_operation(owner_change_op.clone())
         .await
@@ -1590,6 +1592,7 @@ where
     );
 
     // Publish blob on chain 1
+    client1.prepare_chain().await.unwrap();
     let publish_certificate = client1
         .publish_data_blob(blob0_bytes)
         .await
@@ -1645,6 +1648,7 @@ where
     builder.set_fault_type([2], FaultType::Offline).await;
     builder.set_fault_type([0, 1, 3], FaultType::Honest).await;
 
+    client2_b.synchronize_from_validators().await.unwrap();
     let bt_certificate = client2_b
         .burn(None, Amount::from_tokens(1))
         .await
@@ -2120,6 +2124,7 @@ where
         },
     }
     .into();
+    client0.synchronize_from_validators().await.unwrap();
     client0.execute_operation(owner_change_op).await.unwrap();
     let client1 = builder
         .make_client(
@@ -2182,6 +2187,7 @@ where
     assert!(client0.pending_block().is_none());
 
     // Burn another token so Client 1 sees that the blob is already published
+    client1.synchronize_from_validators().await.unwrap();
     client1.burn(None, Amount::from_tokens(1)).await.unwrap();
     client1.synchronize_from_validators().await.unwrap();
     client1.process_inbox().await.unwrap();

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -544,8 +544,8 @@ impl ClientWrapper {
         Ok(())
     }
 
-    /// Runs `linera transfer` with no logging.
-    pub async fn transfer_with_silent_logs(
+    /// Runs `linera transfer` with no logging and without synchronizing incoming messages.
+    pub async fn transfer_with_silent_logs_no_sync(
         &self,
         amount: Amount,
         from: ChainId,
@@ -554,6 +554,7 @@ impl ClientWrapper {
         self.command()
             .await?
             .env("RUST_LOG", "off")
+            .arg("--skip-incoming-message-sync")
             .arg("transfer")
             .arg(amount.to_string())
             .args(["--from", &from.to_string()])

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -321,7 +321,7 @@ impl Runnable for Job {
                 info!("Synchronizing chain information and querying the local balance");
                 warn!("This command is deprecated. Use `linera sync && linera query-balance` instead.");
                 let time_start = Instant::now();
-                chain_client.synchronize_from_validators().await?;
+                context.synchronize_from_validators(&chain_client).await?;
                 let result = match account.owner {
                     Some(owner) => chain_client.query_owner_balance(owner).await,
                     None => chain_client.query_balance().await,
@@ -338,7 +338,7 @@ impl Runnable for Job {
                 let chain_client = context.make_chain_client(chain_id)?;
                 info!("Synchronizing chain information");
                 let time_start = Instant::now();
-                chain_client.synchronize_from_validators().await?;
+                context.synchronize_from_validators(&chain_client).await?;
                 context.update_and_save_wallet(&chain_client).await?;
                 let time_total = time_start.elapsed();
                 info!(

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -234,7 +234,7 @@ where
         loop {
             let client = self.context.lock().await.make_chain_client(chain_id)?;
             client.synchronize_from_validators().await?;
-            let result = client.process_inbox_without_prepare().await;
+            let result = client.process_inbox().await;
             self.context.lock().await.update_wallet(&client).await?;
             let (certificates, maybe_timeout) = result?;
             hashes.extend(certificates.into_iter().map(|cert| cert.hash()));

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -534,7 +534,7 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetConfig) -> Result<(
         net.remove_validator(i)?;
     }
     let result = client
-        .transfer_with_silent_logs(Amount::from_tokens(2), chain_id, ChainId::root(1))
+        .transfer_with_silent_logs_no_sync(Amount::from_tokens(2), chain_id, ChainId::root(1))
         .await;
     assert!(result.is_err());
     // The transfer didn't get confirmed.


### PR DESCRIPTION
## Motivation

The `test_end_to_end_open_multi_owner_chain` test fails against a network with multiple epochs, because the `transfer` command doesn't cause the client to download the received certificates.

On the other hand, we call `prepare_chain` and `synchronize_from_validators` in a few places where it isn't actually needed, because we are listening to notifications.

## Proposal

Call `synchronize_from_validator` before any CLI command, but don't automatically call `prepare_chain` in `ChainClient::execute_operations`.

## Test Plan

CI should catch any regressions. I verified locally that it fixes the `test_end_to_end_open_multi_owner_chain`. CI now also creates two epochs before running the faucet, as a regression test.

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
