### PR TITLE
Restructuration of the `get_blobs` code.

### DIFF
--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -206,8 +206,7 @@ where
         let required_blob_ids = executed_block.required_blob_ids();
         // Verify that no unrelated blobs were provided.
         self.state
-            .check_for_unneeded_blobs(&required_blob_ids, blobs)
-            .await?;
+            .check_for_unneeded_blobs(&required_blob_ids, blobs)?;
         let remaining_required_blob_ids = required_blob_ids
             .difference(&blobs.iter().map(|blob| blob.id()).collect())
             .cloned()
@@ -300,13 +299,15 @@ where
         let required_blob_ids = executed_block.required_blob_ids();
         // Verify that no unrelated blobs were provided.
         self.state
-            .check_for_unneeded_blobs(&required_blob_ids, blobs)
-            .await?;
+            .check_for_unneeded_blobs(&required_blob_ids, blobs)?;
         let remaining_required_blob_ids = required_blob_ids
             .difference(&blobs.iter().map(|blob| blob.id()).collect())
             .cloned()
             .collect();
-        let mut blobs_in_block = self.state.get_blobs(&remaining_required_blob_ids).await?;
+        let mut blobs_in_block = self
+            .state
+            .get_blobs_and_checks_storage(&remaining_required_blob_ids)
+            .await?;
         blobs_in_block.extend_from_slice(blobs);
 
         let certificate_hash = certificate.hash();

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -41,7 +41,7 @@ impl<'state, StorageClient> ChainWorkerStateWithTemporaryChanges<'state, Storage
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
 {
-    /// Creates a new [`ChainWorkerStateWithAttemptedChanges`] instance to temporarily change the
+    /// Creates a new [`ChainWorkerStateWithTemporaryChanges`] instance to temporarily change the
     /// `state`.
     pub(super) async fn new(state: &'state mut ChainWorkerState<StorageClient>) -> Self {
         assert!(
@@ -207,8 +207,7 @@ where
         // Verify that no unrelated blobs were provided.
         let published_blob_ids = block.published_blob_ids();
         self.0
-            .check_for_unneeded_blobs(&published_blob_ids, blobs)
-            .await?;
+            .check_for_unneeded_blobs(&published_blob_ids, blobs)?;
         let missing_published_blob_ids = published_blob_ids
             .difference(&blobs.iter().map(|blob| blob.id()).collect())
             .cloned()


### PR DESCRIPTION
## Motivation

The `get_blobs` was a code smell as it downloads blobs and then write them down just after.

## Proposal

The following was done:
* Rename the `get_blobs` into `get_blobs_and_checks_storage`, that is checks the presence of the blobs in the storage 
* The `blobs_in_block`is kept. It is now smaller as we do not need to write to storage what has just been downloaded.
* The `check_for_unneeded_blobs` is no longer async as it does not have any await in its code.
* A typo in `temporary_changes.rs` has been corrected.

## Test Plan

The CI should be doing the job. But maybe we should expand the testing of the blobs.

## Release Plan

The correction could be ported to TestNet / DevNet as they are not changing the use of the system.

## Links

None.