### PR TITLE
Reduce the number of `send_chain_information` and do them concurrently.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -993,14 +993,14 @@ where
         let local_node = self.client.local_node.clone();
         let nodes = self.make_nodes(committee)?;
         let n_validators = nodes.len();
-        let n_tasks = std::cmp::max(1, CHAIN_WORKER_LIMIT.div_euclid(n_validators));
+        let chain_worker_count = std::cmp::max(1, CHAIN_WORKER_LIMIT / n_validators);
         communicate_with_quorum(
             &nodes,
             committee,
             |_: &()| (),
             |remote_node| {
                 let mut updater = ValidatorUpdater {
-                    n_tasks,
+                    chain_worker_count,
                     remote_node,
                     local_node: local_node.clone(),
                 };
@@ -1030,14 +1030,14 @@ where
         let local_node = self.client.local_node.clone();
         let nodes = self.make_nodes(committee)?;
         let n_validators = nodes.len();
-        let n_tasks = std::cmp::max(1, CHAIN_WORKER_LIMIT.div_euclid(n_validators));
+        let chain_worker_count = std::cmp::max(1, CHAIN_WORKER_LIMIT / n_validators);
         let ((votes_hash, votes_round), votes) = communicate_with_quorum(
             &nodes,
             committee,
             |vote: &LiteVote| (vote.value.value_hash, vote.round),
             |remote_node| {
                 let mut updater = ValidatorUpdater {
-                    n_tasks,
+                    chain_worker_count,
                     remote_node,
                     local_node: local_node.clone(),
                 };

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -159,7 +159,7 @@ mod metrics {
 /// The number of chain workers that can be in memory at the same time. More workers improve
 /// perfomance whenever the client interacts with multiple chains at the same time, but also
 /// increases memory usage.
-const CHAIN_WORKER_LIMIT: usize = 20;
+pub(crate) const CHAIN_WORKER_LIMIT: usize = 20;
 
 /// A builder that creates [`ChainClient`]s which share the cache and notifiers.
 pub struct Client<ValidatorNodeProvider, Storage>

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{btree_map, BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt,
     hash::Hash,
     mem,
@@ -297,17 +297,10 @@ where
                     for certificate in certificates {
                         let block_chain_id = certificate.value().chain_id();
                         let block_height = certificate.value().height();
-                        match chain_heights.entry(block_chain_id) {
-                            btree_map::Entry::Occupied(entry) => {
-                                let entry = entry.into_mut();
-                                if block_height > *entry {
-                                    *entry = block_height;
-                                }
-                            }
-                            btree_map::Entry::Vacant(entry) => {
-                                entry.insert(block_height);
-                            }
-                        }
+                        chain_heights
+                            .entry(block_chain_id)
+                            .and_modify(|h| *h = block_height.max(*h))
+                            .or_insert(block_height);
                     }
                     let stream = stream::iter(chain_heights)
                         .map(|(chain_id, height)| {

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -70,7 +70,7 @@ pub struct ValidatorUpdater<A, S>
 where
     S: Storage,
 {
-    pub n_tasks: usize,
+    pub chain_worker_count: usize,
     pub remote_node: RemoteNode<A>,
     pub local_node: LocalNodeClient<S>,
 }
@@ -316,7 +316,7 @@ where
                                     .await
                             }
                         })
-                        .buffer_unordered(self.n_tasks);
+                        .buffer_unordered(self.chain_worker_count);
                     stream.try_collect::<Vec<_>>().await?;
                 }
                 // Fail immediately on other errors.

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -309,7 +309,6 @@ where
                             }
                         }
                     }
-                    let chain_worker_limit = CHAIN_WORKER_LIMIT;
                     let stream = stream::iter(chain_heights)
                         .map(|(chain_id, height)| {
                             let mut client = self.clone();
@@ -324,7 +323,7 @@ where
                                     .await
                             }
                         })
-                        .buffer_unordered(chain_worker_limit);
+                        .buffer_unordered(CHAIN_WORKER_LIMIT);
                     stream.try_collect::<Vec<_>>().await?;
                 }
                 // Fail immediately on other errors.


### PR DESCRIPTION
## Motivation

Following PR 2800, it was noted that the `send_chain_operations` were done inefficiently.

## Proposal

The following was done:
* Similarly to `send_chain_information_for_senders` a `BTreeMap` is created for the chain/blockheight.
* A stream is created for the sending of the data.
* The `ValidatorUpdater` is now `Clone` in order to be able to create the stream. This was not difficult as the two components of the stream were already clonable.
* The limitation to CHAIN_WORKER_LIMIT is enforced here which may or may not be a good idea.

Maybe the same use of a stream could be done for `send_chain_information_for_senders`.

## Test Plan

The CI should suffice for that. This does not change the organization of the code.

## Release Plan

This could be backported to the TestNet / DevNet.

## Links

None.