### PR TITLE
allow deployment script to run from the source of the repo

### DIFF
--- a/scripts/check_chain_loads.sh
+++ b/scripts/check_chain_loads.sh
@@ -8,6 +8,9 @@
 
 USAGES_FILE="$(mktemp)"
 
+# Make sure we're at the source of the repo.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
 grep -R '\<\(create_chain\|load_chain\|load_active_chain\)\>' linera-* > "$USAGES_FILE"
 
 # linera-storage contains the implementation of the methods

--- a/scripts/deploy-validator.sh
+++ b/scripts/deploy-validator.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Make sure we're at the source of the repo.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
 # Function to check if a command exists
 command_exists() {
     command -v "$1" >/dev/null 2>&1
@@ -50,8 +53,6 @@ METRICS_PORT="21100"
 GENESIS_URL="https://storage.googleapis.com/linera-io-dev-public/$FORMATTED_BRANCH_NAME/genesis.json"
 VALIDATOR_CONFIG="docker/validator-config.toml"
 GENESIS_CONFIG="docker/genesis.json"
-
-cd ..
 
 echo "Building Linera binaries"
 cargo install --locked --path linera-service


### PR DESCRIPTION
## Motivation

Fix `scripts/deploy-validator.sh`

## Proposal

Replace `cd ..` by the appropriate command

## Test Plan

Run similar code in `scripts/check_chain_loads.sh`

## Release Plan

- These changes should be backported to the latest `devnet` branch
- These changes should be backported to the latest `testnet` branch