### PR TITLE
ValidatorName->ValidatorPublicKey

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -354,7 +354,7 @@ Show the version and genesis config hash of a new validator, and print a warning
 
 ###### **Options:**
 
-* `--name <NAME>` — The public key of the validator. If given, the signature of the chain query info will be checked
+* `--public-key <PUBLIC_KEY>` — The public key of the validator. If given, the signature of the chain query info will be checked
 
 
 
@@ -374,11 +374,11 @@ Show the current set of validators for a chain. Also print some information abou
 
 Add or modify a validator (admin only)
 
-**Usage:** `linera set-validator [OPTIONS] --name <NAME> --address <ADDRESS>`
+**Usage:** `linera set-validator [OPTIONS] --public-key <PUBLIC_KEY> --address <ADDRESS>`
 
 ###### **Options:**
 
-* `--name <NAME>` — The public key of the validator
+* `--public-key <PUBLIC_KEY>` — The public key of the validator
 * `--address <ADDRESS>` — Network address
 * `--votes <VOTES>` — Voting power
 
@@ -391,11 +391,11 @@ Add or modify a validator (admin only)
 
 Remove a validator (admin only)
 
-**Usage:** `linera remove-validator --name <NAME>`
+**Usage:** `linera remove-validator --public-key <PUBLIC_KEY>`
 
 ###### **Options:**
 
-* `--name <NAME>` — The public key of the validator
+* `--public-key <PUBLIC_KEY>` — The public key of the validator
 
 
 

--- a/linera-chain/src/certificate.rs
+++ b/linera-chain/src/certificate.rs
@@ -12,7 +12,7 @@ use linera_base::{
     data_types::Round,
     identifiers::{BlobId, ChainId, MessageId},
 };
-use linera_execution::committee::{Committee, Epoch, ValidatorName};
+use linera_execution::committee::{Committee, Epoch, ValidatorPublicKey};
 use serde::{
     ser::{Serialize, SerializeStruct, Serializer},
     Deserialize, Deserializer,
@@ -40,7 +40,7 @@ pub type TimeoutCertificate = GenericCertificate<Timeout>;
 pub struct GenericCertificate<T> {
     value: Hashed<T>,
     pub round: Round,
-    signatures: Vec<(ValidatorName, Signature)>,
+    signatures: Vec<(ValidatorPublicKey, Signature)>,
 }
 
 impl<T> GenericCertificate<T> {
@@ -115,7 +115,7 @@ impl<'de> Deserialize<'de> for ValidatedBlockCertificate {
         struct Inner {
             value: ValidatedBlock,
             round: Round,
-            signatures: Vec<(ValidatorName, Signature)>,
+            signatures: Vec<(ValidatorPublicKey, Signature)>,
         }
         let inner = Inner::deserialize(deserializer)?;
         let validated_hashed: HashedCertificateValue = inner.value.clone().into();
@@ -137,7 +137,7 @@ impl<'de> Deserialize<'de> for TimeoutCertificate {
         struct Inner {
             value: Timeout,
             round: Round,
-            signatures: Vec<(ValidatorName, Signature)>,
+            signatures: Vec<(ValidatorPublicKey, Signature)>,
         }
         let inner = Inner::deserialize(deserializer)?;
         let timeout_hashed: HashedCertificateValue = inner.value.clone().into();
@@ -270,7 +270,7 @@ impl<T> GenericCertificate<T> {
     pub fn new(
         value: Hashed<T>,
         round: Round,
-        mut signatures: Vec<(ValidatorName, Signature)>,
+        mut signatures: Vec<(ValidatorPublicKey, Signature)>,
     ) -> Self
     where
         T: BcsHashable,
@@ -283,12 +283,12 @@ impl<T> GenericCertificate<T> {
         }
     }
 
-    pub fn signatures(&self) -> &Vec<(ValidatorName, Signature)> {
+    pub fn signatures(&self) -> &Vec<(ValidatorPublicKey, Signature)> {
         &self.signatures
     }
 
     #[cfg(with_testing)]
-    pub fn signatures_mut(&mut self) -> &mut Vec<(ValidatorName, Signature)> {
+    pub fn signatures_mut(&mut self) -> &mut Vec<(ValidatorPublicKey, Signature)> {
         &mut self.signatures
     }
 
@@ -296,8 +296,8 @@ impl<T> GenericCertificate<T> {
     /// It's the responsibility of the caller to not insert duplicates
     pub fn add_signature(
         &mut self,
-        signature: (ValidatorName, Signature),
-    ) -> &Vec<(ValidatorName, Signature)> {
+        signature: (ValidatorPublicKey, Signature),
+    ) -> &Vec<(ValidatorPublicKey, Signature)> {
         let index = self
             .signatures
             .binary_search_by(|(name, _)| name.cmp(&signature.0))
@@ -307,7 +307,7 @@ impl<T> GenericCertificate<T> {
     }
 
     /// Returns whether the validator is among the signatories of this certificate.
-    pub fn is_signed_by(&self, validator_name: &ValidatorName) -> bool {
+    pub fn is_signed_by(&self, validator_name: &ValidatorPublicKey) -> bool {
         self.signatures
             .binary_search_by(|(name, _)| name.cmp(validator_name))
             .is_ok()

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -16,7 +16,7 @@ use linera_base::{
     ownership::ChainOwnership,
 };
 use linera_execution::{
-    committee::{Committee, Epoch, ValidatorName, ValidatorState},
+    committee::{Committee, Epoch, ValidatorPublicKey, ValidatorState},
     system::{OpenChainConfig, Recipient},
     test_utils::{ExpectedCall, MockApplication},
     ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message, MessageKind,
@@ -118,7 +118,7 @@ async fn test_block_size_limit() {
         Epoch(0),
         Committee::new(
             BTreeMap::from([(
-                ValidatorName(PublicKey::test_key(1)),
+                ValidatorPublicKey(PublicKey::test_key(1)),
                 ValidatorState {
                     network_address: PublicKey::test_key(1).to_string(),
                     votes: 1,

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -11,7 +11,7 @@ use crate::test::{make_first_block, BlockTestExt};
 fn test_signed_values() {
     let key1 = KeyPair::generate();
     let key2 = KeyPair::generate();
-    let name1 = ValidatorName(key1.public());
+    let public_key1 = ValidatorPublicKey(key1.public());
 
     let block =
         make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(2), Amount::ONE);
@@ -28,7 +28,7 @@ fn test_signed_values() {
     assert!(v.check().is_ok());
 
     let mut v = LiteVote::new(value.lite(), Round::Fast, &key2);
-    v.validator = name1;
+    v.validator = public_key1;
     assert!(v.check().is_err());
 }
 
@@ -37,10 +37,10 @@ fn test_certificates() {
     let key1 = KeyPair::generate();
     let key2 = KeyPair::generate();
     let key3 = KeyPair::generate();
-    let name1 = ValidatorName(key1.public());
-    let name2 = ValidatorName(key2.public());
+    let public_key1 = ValidatorPublicKey(key1.public());
+    let public_key2 = ValidatorPublicKey(key2.public());
 
-    let committee = Committee::make_simple(vec![name1, name2]);
+    let committee = Committee::make_simple(vec![public_key1, public_key2]);
 
     let block =
         make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(1), Amount::ONE);

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -20,7 +20,7 @@ use linera_base::{
 };
 use linera_core::client::BlanketMessagePolicy;
 use linera_execution::{
-    committee::ValidatorName, ResourceControlPolicy, WasmRuntime, WithWasmDefault as _,
+    committee::ValidatorPublicKey, ResourceControlPolicy, WasmRuntime, WithWasmDefault as _,
 };
 use linera_views::store::CommonStoreConfig;
 
@@ -444,7 +444,7 @@ pub enum ClientCommand {
         /// The public key of the validator. If given, the signature of the chain query
         /// info will be checked.
         #[arg(long)]
-        name: Option<ValidatorName>,
+        public_key: Option<ValidatorPublicKey>,
     },
 
     /// Show the current set of validators for a chain. Also print some information about
@@ -458,7 +458,7 @@ pub enum ClientCommand {
     SetValidator {
         /// The public key of the validator.
         #[arg(long)]
-        name: ValidatorName,
+        public_key: ValidatorPublicKey,
 
         /// Network address
         #[arg(long)]
@@ -477,7 +477,7 @@ pub enum ClientCommand {
     RemoveValidator {
         /// The public key of the validator.
         #[arg(long)]
-        name: ValidatorName,
+        public_key: ValidatorPublicKey,
     },
 
     /// Deprecates all committees except the last one.

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -13,7 +13,7 @@ use linera_base::{
     identifiers::{ChainDescription, ChainId},
 };
 use linera_execution::{
-    committee::{Committee, ValidatorName, ValidatorState},
+    committee::{Committee, ValidatorPublicKey, ValidatorState},
     ResourceControlPolicy,
 };
 use linera_rpc::config::{ValidatorInternalNetworkConfig, ValidatorPublicNetworkConfig};
@@ -45,7 +45,7 @@ util::impl_from_dynamic!(Error:Persistence, persistent::file::Error);
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidatorConfig {
     /// The public key of the validator.
-    pub name: ValidatorName,
+    pub public_key: ValidatorPublicKey,
     /// The network configuration for the validator.
     pub network: ValidatorPublicNetworkConfig,
 }
@@ -76,7 +76,7 @@ impl CommitteeConfig {
             .into_iter()
             .map(|v| {
                 (
-                    v.name,
+                    v.public_key,
                     ValidatorState {
                         network_address: v.network.to_string(),
                         votes: 100,

--- a/linera-client/src/unit_tests/util.rs
+++ b/linera-client/src/unit_tests/util.rs
@@ -20,7 +20,7 @@ pub fn make_genesis_config(builder: &TestBuilder<MemoryStorageBuilder>) -> Genes
     let validator_names = builder.initial_committee.validators().keys();
     let validators = validator_names
         .map(|name| ValidatorConfig {
-            name: *name,
+            public_key: *name,
             network: network.clone(),
         })
         .collect();

--- a/linera-core/src/client/chain_client_state.rs
+++ b/linera-core/src/client/chain_client_state.rs
@@ -14,7 +14,7 @@ use linera_base::{
     ownership::ChainOwnership,
 };
 use linera_chain::data_types::Block;
-use linera_execution::committee::ValidatorName;
+use linera_execution::committee::ValidatorPublicKey;
 use tokio::sync::Mutex;
 
 use crate::data_types::ChainInfo;
@@ -38,7 +38,7 @@ pub struct ChainClientState {
 
     /// For each validator, up to which index we have synchronized their
     /// [`ChainStateView::received_log`].
-    received_certificate_trackers: HashMap<ValidatorName, u64>,
+    received_certificate_trackers: HashMap<ValidatorPublicKey, u64>,
     /// This contains blobs belonging to our `pending_block` that may not even have
     /// been processed by (i.e. been proposed to) our own local chain manager yet.
     pending_blobs: BTreeMap<BlobId, Blob>,
@@ -130,17 +130,17 @@ impl ChainClientState {
         new_public_key
     }
 
-    pub fn received_certificate_trackers(&self) -> &HashMap<ValidatorName, u64> {
+    pub fn received_certificate_trackers(&self) -> &HashMap<ValidatorPublicKey, u64> {
         &self.received_certificate_trackers
     }
 
     pub(super) fn update_received_certificate_tracker(
         &mut self,
-        name: ValidatorName,
+        validator_public_key: ValidatorPublicKey,
         tracker: u64,
     ) {
         self.received_certificate_trackers
-            .entry(name)
+            .entry(validator_public_key)
             .and_modify(|t| {
                 // Because several synchronizations could happen in parallel, we need to make
                 // sure to never go backward.

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -15,7 +15,7 @@ use linera_chain::{
     ChainStateView,
 };
 use linera_execution::{
-    committee::{Committee, Epoch, ValidatorName},
+    committee::{Committee, Epoch, ValidatorPublicKey},
     ExecutionRuntimeContext,
 };
 use linera_storage::ChainRuntimeContext;
@@ -271,8 +271,12 @@ impl ChainInfoResponse {
         self.signature = Some(Signature::new(&*self.info, key_pair));
     }
 
-    pub fn check(&self, name: &ValidatorName) -> Result<(), CryptoError> {
-        Signature::check_optional_signature(self.signature.as_ref(), &*self.info, &name.0)
+    pub fn check(&self, validator_public_key: &ValidatorPublicKey) -> Result<(), CryptoError> {
+        Signature::check_optional_signature(
+            self.signature.as_ref(),
+            &*self.info,
+            &validator_public_key.0,
+        )
     }
 
     /// Returns the committee in the latest epoch.

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -17,7 +17,7 @@ use linera_chain::{
     ChainError,
 };
 use linera_execution::{
-    committee::{Committee, ValidatorName},
+    committee::{Committee, ValidatorPublicKey},
     ExecutionError, SystemExecutionError,
 };
 use linera_version::VersionInfo;
@@ -122,24 +122,24 @@ pub trait ValidatorNodeProvider: 'static {
     fn make_nodes(
         &self,
         committee: &Committee,
-    ) -> Result<impl Iterator<Item = (ValidatorName, Self::Node)> + '_, NodeError> {
+    ) -> Result<impl Iterator<Item = (ValidatorPublicKey, Self::Node)> + '_, NodeError> {
         let validator_addresses: Vec<_> = committee
             .validator_addresses()
-            .map(|(node, name)| (node, name.to_owned()))
+            .map(|(public_key, node)| (public_key, node.to_owned()))
             .collect();
         self.make_nodes_from_list(validator_addresses)
     }
 
     fn make_nodes_from_list<A>(
         &self,
-        validators: impl IntoIterator<Item = (ValidatorName, A)>,
-    ) -> Result<impl Iterator<Item = (ValidatorName, Self::Node)>, NodeError>
+        validators: impl IntoIterator<Item = (ValidatorPublicKey, A)>,
+    ) -> Result<impl Iterator<Item = (ValidatorPublicKey, Self::Node)>, NodeError>
     where
         A: AsRef<str>,
     {
         Ok(validators
             .into_iter()
-            .map(|(name, address)| Ok((name, self.make_node(address.as_ref())?)))
+            .map(|(public_key, address)| Ok((public_key, self.make_node(address.as_ref())?)))
             .collect::<Result<Vec<_>, NodeError>>()?
             .into_iter())
     }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -35,7 +35,7 @@ use linera_chain::{
     ChainError, ChainExecutionContext,
 };
 use linera_execution::{
-    committee::{Committee, Epoch, ValidatorName},
+    committee::{Committee, Epoch, ValidatorPublicKey},
     system::{
         AdminOperation, OpenChainConfig, Recipient, SystemChannel, SystemMessage, SystemOperation,
     },
@@ -85,7 +85,7 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let key_pair = KeyPair::generate();
-    let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
+    let committee = Committee::make_simple(vec![ValidatorPublicKey(key_pair.public())]);
     let worker = WorkerState::new(
         "Single validator node".to_string(),
         Some(key_pair),
@@ -1110,7 +1110,7 @@ where
         .into_fast_proposal(&sender_key_pair);
 
     let (chain_info_response, _actions) = worker.handle_block_proposal(block_proposal).await?;
-    chain_info_response.check(&ValidatorName(worker.public_key()))?;
+    chain_info_response.check(&ValidatorPublicKey(worker.public_key()))?;
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
     let pending_value = chain.manager.get().pending().unwrap().lite();
@@ -1153,7 +1153,7 @@ where
         .into_fast_proposal(&sender_key_pair);
 
     let (response, _actions) = worker.handle_block_proposal(block_proposal.clone()).await?;
-    response.check(&ValidatorName(worker.public_key()))?;
+    response.check(&ValidatorPublicKey(worker.public_key()))?;
     let (replay_response, _actions) = worker.handle_block_proposal(block_proposal).await?;
     // Workaround lack of equality.
     assert_eq!(

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -12,7 +12,7 @@ use linera_base::{
 use linera_views::{context::Context, map_view::MapView};
 
 use crate::{
-    committee::{Committee, Epoch, ValidatorName, ValidatorState},
+    committee::{Committee, Epoch, ValidatorPublicKey, ValidatorState},
     system::{Recipient, UserData},
     ChannelSubscription, ExecutionStateView, SystemExecutionStateView,
 };
@@ -23,12 +23,12 @@ doc_scalar!(
 );
 doc_scalar!(Recipient, "The recipient of a transfer");
 doc_scalar!(UserData, "Optional user message attached to a transfer");
-doc_scalar!(ValidatorName, "The identity of a validator");
+doc_scalar!(ValidatorPublicKey, "The identity of a validator");
 
 #[async_graphql::Object(cache_control(no_cache))]
 impl Committee {
     #[graphql(derived(name = "validators"))]
-    async fn _validators(&self) -> &BTreeMap<ValidatorName, ValidatorState> {
+    async fn _validators(&self) -> &BTreeMap<ValidatorPublicKey, ValidatorState> {
         self.validators()
     }
 

--- a/linera-rpc/src/config.rs
+++ b/linera-rpc/src/config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_base::identifiers::ChainId;
-use linera_execution::committee::ValidatorName;
+use linera_execution::committee::ValidatorPublicKey;
 use serde::{Deserialize, Serialize};
 
 #[cfg(with_simple_network)]
@@ -103,8 +103,8 @@ pub type ValidatorPublicNetworkConfig = ValidatorPublicNetworkPreConfig<NetworkP
 /// The network configuration for all shards.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ValidatorInternalNetworkPreConfig<P> {
-    /// The name of the validator.
-    pub name: ValidatorName,
+    /// The public key of the validator.
+    pub public_key: ValidatorPublicKey,
     /// The network protocol to use for all shards.
     pub protocol: P,
     /// The available shards. Each chain UID is mapped to a unique shard in the vector in
@@ -123,7 +123,7 @@ pub struct ValidatorInternalNetworkPreConfig<P> {
 impl<P> ValidatorInternalNetworkPreConfig<P> {
     pub fn clone_with_protocol<Q>(&self, protocol: Q) -> ValidatorInternalNetworkPreConfig<Q> {
         ValidatorInternalNetworkPreConfig {
-            name: self.name,
+            public_key: self.public_key,
             protocol,
             shards: self.shards.clone(),
             host: self.host.clone(),
@@ -235,7 +235,7 @@ impl<P> ValidatorInternalNetworkPreConfig<P> {
         use std::hash::{Hash, Hasher};
         let mut s = std::collections::hash_map::DefaultHasher::new();
         // Use the validator public key to randomise shard assignment.
-        self.name.hash(&mut s);
+        self.public_key.hash(&mut s);
         chain_id.hash(&mut s);
         (s.finish() as ShardId) % self.shards.len()
     }

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -16,7 +16,7 @@ use linera_core::{
     node::NodeError,
     worker::Notification,
 };
-use linera_execution::committee::ValidatorName;
+use linera_execution::committee::ValidatorPublicKey;
 use thiserror::Error;
 use tonic::{Code, Status};
 
@@ -457,19 +457,19 @@ impl TryFrom<api::PublicKey> for PublicKey {
     }
 }
 
-impl From<ValidatorName> for api::PublicKey {
-    fn from(validator_name: ValidatorName) -> Self {
+impl From<ValidatorPublicKey> for api::PublicKey {
+    fn from(public_key: ValidatorPublicKey) -> Self {
         Self {
-            bytes: validator_name.0 .0.to_vec(),
+            bytes: public_key.0 .0.to_vec(),
         }
     }
 }
 
-impl TryFrom<api::PublicKey> for ValidatorName {
+impl TryFrom<api::PublicKey> for ValidatorPublicKey {
     type Error = GrpcProtoConversionError;
 
     fn try_from(public_key: api::PublicKey) -> Result<Self, Self::Error> {
-        Ok(ValidatorName(public_key.try_into()?))
+        Ok(ValidatorPublicKey(public_key.try_into()?))
     }
 }
 
@@ -766,11 +766,11 @@ pub mod tests {
     }
 
     #[test]
-    pub fn validator_name() {
-        let validator_name = ValidatorName::from(KeyPair::generate().public());
-        // This is a correct comparison - `ValidatorNameRpc` does not exist in our
+    pub fn validator_public_key() {
+        let validator_public_key = ValidatorPublicKey::from(KeyPair::generate().public());
+        // This is a correct comparison - `ValidatorPublicKeyRpc` does not exist in our
         // proto definitions.
-        round_trip_check::<_, api::PublicKey>(validator_name);
+        round_trip_check::<_, api::PublicKey>(validator_public_key);
     }
 
     #[test]
@@ -849,7 +849,7 @@ pub mod tests {
             },
             round: Round::MultiLeader(2),
             signatures: Cow::Owned(vec![(
-                ValidatorName::from(key_pair.public()),
+                ValidatorPublicKey::from(key_pair.public()),
                 Signature::new(&Foo("test".into()), &key_pair),
             )]),
         };
@@ -874,7 +874,7 @@ pub mod tests {
             ),
             Round::MultiLeader(3),
             vec![(
-                ValidatorName::from(key_pair.public()),
+                ValidatorPublicKey::from(key_pair.public()),
                 Signature::new(&Foo("test".into()), &key_pair),
             )],
         );
@@ -923,7 +923,7 @@ pub mod tests {
             ),
             Round::SingleLeader(2),
             vec![(
-                ValidatorName::from(key_pair.public()),
+                ValidatorPublicKey::from(key_pair.public()),
                 Signature::new(&Foo("signed".into()), &key_pair),
             )],
         )

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -145,7 +145,7 @@ Certificate:
     - signatures:
         SEQ:
           TUPLE:
-            - TYPENAME: ValidatorName
+            - TYPENAME: ValidatorPublicKey
             - TYPENAME: Signature
 CertificateValue:
   ENUM:
@@ -327,7 +327,7 @@ Committee:
     - validators:
         MAP:
           KEY:
-            TYPENAME: ValidatorName
+            TYPENAME: ValidatorPublicKey
           VALUE:
             TYPENAME: ValidatorState
     - policy:
@@ -442,7 +442,7 @@ LiteCertificate:
     - signatures:
         SEQ:
           TUPLE:
-            - TYPENAME: ValidatorName
+            - TYPENAME: ValidatorPublicKey
             - TYPENAME: Signature
 LiteValue:
   STRUCT:
@@ -457,7 +457,7 @@ LiteVote:
     - round:
         TYPENAME: Round
     - validator:
-        TYPENAME: ValidatorName
+        TYPENAME: ValidatorPublicKey
     - signature:
         TYPENAME: Signature
 Medium:
@@ -1093,7 +1093,7 @@ ValidatedBlockCertificate:
           TUPLE:
             - TYPENAME: ValidatorName
             - TYPENAME: Signature
-ValidatorName:
+ValidatorPublicKey:
   NEWTYPESTRUCT:
     TYPENAME: PublicKey
 ValidatorState:

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -18,7 +18,7 @@ use linera_base::{
 };
 use linera_core::worker::WorkerState;
 use linera_execution::{
-    committee::{Committee, Epoch, ValidatorName},
+    committee::{Committee, Epoch, ValidatorPublicKey},
     system::{OpenChainConfig, SystemOperation, OPEN_CHAIN_MESSAGE_INDEX},
     WasmRuntime,
 };
@@ -66,7 +66,7 @@ impl TestValidator {
     /// Creates a new [`TestValidator`].
     pub async fn new() -> Self {
         let key_pair = KeyPair::generate();
-        let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
+        let committee = Committee::make_simple(vec![ValidatorPublicKey(key_pair.public())]);
         let wasm_runtime = Some(WasmRuntime::default());
         let storage = DbStorage::<MemoryStore, _>::make_test_storage(wasm_runtime)
             .now_or_never()

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -18,7 +18,7 @@ use linera_client::{
     config::GenesisConfig,
 };
 use linera_core::data_types::ClientOutcome;
-use linera_execution::committee::ValidatorName;
+use linera_execution::committee::ValidatorPublicKey;
 use linera_storage::{Clock as _, Storage};
 use serde::Deserialize;
 use tower_http::cors::CorsLayer;
@@ -60,7 +60,7 @@ pub struct ClaimOutcome {
 
 #[derive(Debug, Deserialize, SimpleObject)]
 pub struct Validator {
-    pub name: ValidatorName,
+    pub public_key: ValidatorPublicKey,
     pub network_address: String,
 }
 
@@ -87,7 +87,7 @@ where
             .validators()
             .iter()
             .map(|(name, validator)| Validator {
-                name: *name,
+                public_key: *name,
                 network_address: validator.network_address.clone(),
             })
             .collect())

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -606,14 +606,14 @@ mod proto_message_cap {
     use linera_chain::data_types::{
         BlockExecutionOutcome, Certificate, ExecutedBlock, HashedCertificateValue,
     };
-    use linera_execution::committee::ValidatorName;
+    use linera_execution::committee::ValidatorPublicKey;
     use linera_sdk::base::{ChainId, TestString};
 
     use super::{CertificatesBatchResponse, GrpcMessageLimiter};
 
     fn test_certificate() -> Certificate {
         let keypair = KeyPair::generate();
-        let validator = ValidatorName(keypair.public());
+        let validator = ValidatorPublicKey(keypair.public());
         let signature = Signature::new(&TestString::new("Test"), &keypair);
         let executed_block = ExecutedBlock {
             block: linera_chain::test::make_first_block(ChainId::root(0)),

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -354,7 +354,7 @@ fn main() -> Result<()> {
     let options = <ProxyOptions as clap::Parser>::parse();
     let server_config: ValidatorServerConfig =
         util::read_json(&options.config_path).expect("Fail to read server config");
-    let name = &server_config.validator.name;
+    let name = &server_config.validator.public_key;
 
     linera_base::tracing::init(&format!("validator-{name}-proxy"));
 

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -23,7 +23,7 @@ use linera_core::{
         ValidatorNodeProvider,
     },
 };
-use linera_execution::committee::{Committee, ValidatorName};
+use linera_execution::committee::{Committee, ValidatorPublicKey};
 use linera_service::node_service::NodeService;
 use linera_storage::{DbStorage, Storage};
 use linera_version::VersionInfo;
@@ -121,7 +121,7 @@ impl ValidatorNodeProvider for DummyValidatorNodeProvider {
     fn make_nodes(
         &self,
         _committee: &Committee,
-    ) -> Result<impl Iterator<Item = (ValidatorName, Self::Node)> + '_, NodeError> {
+    ) -> Result<impl Iterator<Item = (ValidatorPublicKey, Self::Node)> + '_, NodeError> {
         Err::<std::iter::Empty<_>, _>(NodeError::UnexpectedMessage)
     }
 }

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -21,7 +21,7 @@ use linera_client::{
     storage::{full_initialize_storage, run_with_storage, Runnable, StorageConfigNamespace},
 };
 use linera_core::{worker::WorkerState, JoinSetExt as _};
-use linera_execution::{committee::ValidatorName, WasmRuntime, WithWasmDefault};
+use linera_execution::{committee::ValidatorPublicKey, WasmRuntime, WithWasmDefault};
 use linera_rpc::{
     config::{
         CrossChainConfig, NetworkProtocol, NotificationConfig, ShardConfig, ShardId, TlsConfig,
@@ -280,14 +280,14 @@ fn make_server_config<R: CryptoRng>(
     options: ValidatorOptions,
 ) -> anyhow::Result<persistent::File<ValidatorServerConfig>> {
     let key = KeyPair::generate_from(rng);
-    let name = ValidatorName(key.public());
+    let public_key = ValidatorPublicKey(key.public());
     let network = ValidatorPublicNetworkConfig {
         protocol: options.external_protocol,
         host: options.host,
         port: options.port,
     };
     let internal_network = ValidatorInternalNetworkConfig {
-        name,
+        public_key,
         protocol: options.internal_protocol,
         shards: options.shards,
         host: options.internal_host,
@@ -295,7 +295,10 @@ fn make_server_config<R: CryptoRng>(
         metrics_host: options.metrics_host,
         metrics_port: options.metrics_port,
     };
-    let validator = ValidatorConfig { network, name };
+    let validator = ValidatorConfig {
+        network,
+        public_key,
+    };
     Ok(persistent::File::new(
         path,
         ValidatorServerConfig {
@@ -471,7 +474,7 @@ fn log_file_name_for(command: &ServerCommand) -> Cow<'static, str> {
         } => {
             let server_config: ValidatorServerConfig =
                 util::read_json(server_config_path).expect("Failed to read server config");
-            let name = &server_config.validator.name;
+            let name = &server_config.validator.public_key;
 
             if let Some(shard) = shard {
                 format!("validator-{name}-shard-{shard}")
@@ -561,7 +564,7 @@ async fn run(options: ServerOptions) {
                     .await
                     .expect("Unable to write server config file");
                 info!("Wrote server config {}", path.to_str().unwrap());
-                println!("{}", server.validator.name);
+                println!("{}", server.validator.public_key);
                 config_validators.push(Persist::into_value(server).validator);
             }
             if let Some(committee) = committee {


### PR DESCRIPTION
## Motivation

`ValidatorName` seems confusing, because we have actual names for validators now (`azurenode`, `lavanderfive`, etc), and this is not it. It's the public key of the validator.

## Proposal

Change `ValidatorName` to `ValidatorPublicKey`.
If you disagree with this, speak now or forever hold your peace :)
Fixes #2820

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
