### PR TITLE
Parameterise docker compose image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "--overprovisioned"
       - "1"
   proxy:
-    image: linera
+    image: "${LINERA_IMAGE:-linera}"
     container_name: proxy
     ports:
       - "19100:19100"
@@ -23,7 +23,7 @@ services:
       shard-init:
         condition: service_completed_successfully
   shard:
-    image: linera
+    image: "${LINERA_IMAGE:-linera}"
     deploy:
       replicas: 4
     command: [ "./compose-server-entrypoint.sh" ]
@@ -33,7 +33,7 @@ services:
       shard-init:
         condition: service_completed_successfully
   shard-init:
-    image: linera
+    image: "${LINERA_IMAGE:-linera}"
     container_name: shard-init
     command: [ "./compose-server-init.sh" ]
     volumes:

--- a/scripts/deploy-validator.sh
+++ b/scripts/deploy-validator.sh
@@ -57,10 +57,6 @@ GENESIS_CONFIG="docker/genesis.json"
 echo "Building Linera binaries"
 cargo install --locked --path linera-service
 
-# Build Docker image
-echo "Building Linera docker image"
-docker build --build-arg git_commit="$GIT_COMMIT" -f  docker/Dockerfile . -t linera
-
 # Create validator configuration file
 echo "Creating validator configuration..."
 cat > $VALIDATOR_CONFIG <<EOL
@@ -114,6 +110,7 @@ PUBLIC_KEY=$(linera-server generate --validators validator-config.toml)
 echo "Validator setup completed successfully."
 echo "Starting docker compose..."
 
+export LINERA_IMAGE="us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:$BRANCH_NAME"
 docker compose up --wait
 
 echo "Public Key: $PUBLIC_KEY"


### PR DESCRIPTION
## Motivation

The linera docker image used with Docker compose is hard-coded to a local linera image. This forces validators to build images.

## Proposal

Use the pre-built images in artifact registry which are tagged with the branch name.

## Test Plan

CI will catch regressions. Tested manually with `testnet_archimedes`.

## Release Plan
- Nothing to do / These changes follow the usual release cycle.
