### PR TITLE
Store crate version in the wallet.

### DIFF
--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -15,6 +15,7 @@ use linera_base::{
 use linera_chain::data_types::Block;
 use linera_core::{client::ChainClient, node::ValidatorNodeProvider};
 use linera_storage::Storage;
+use linera_version::{CrateVersion, VERSION_INFO};
 use rand::Rng as _;
 use serde::{Deserialize, Serialize};
 
@@ -26,6 +27,7 @@ pub struct Wallet {
     pub unassigned_key_pairs: HashMap<PublicKey, KeyPair>,
     pub default: Option<ChainId>,
     pub genesis_config: GenesisConfig,
+    pub crate_version: CrateVersion,
     pub testing_prng_seed: Option<u64>,
 }
 
@@ -50,8 +52,17 @@ impl Wallet {
             unassigned_key_pairs: HashMap::new(),
             default: None,
             genesis_config,
+            crate_version: VERSION_INFO.crate_version.value.clone(),
             testing_prng_seed,
         }
+    }
+
+    pub fn has_compatible_version(&self) -> bool {
+        (self.crate_version.major, self.crate_version.minor)
+            == (
+                VERSION_INFO.crate_version.value.major,
+                VERSION_INFO.crate_version.value.minor,
+            )
     }
 
     pub fn get(&self, chain_id: ChainId) -> Option<&UserChain> {

--- a/linera-version/src/version_info/type.rs
+++ b/linera-version/src/version_info/type.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{io::Read as _, path::PathBuf};
+use std::{fmt, io::Read as _, path::PathBuf};
 
 #[cfg(linera_version_building)]
 use crate::serde_pretty::Pretty;
@@ -40,6 +40,12 @@ impl From<CrateVersion> for semver::Version {
         }: CrateVersion,
     ) -> Self {
         Self::new(major as u64, minor as u64, patch as u64)
+    }
+}
+
+impl fmt::Display for CrateVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
     }
 }
 


### PR DESCRIPTION
## Motivation

If a wallet was created by a different version, the network it was created for is probably not compatible with the current software version.

## Proposal

Add the crate version to the wallet file, and make sure it is compatible.

## Test Plan

I changed the version in the file locally and it printed the error message.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- We _could_ backport this, but it is not critical. If we do, we need to handle the case where there is no version in the wallet file at all.

## Links

- Fixes #2818
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
