### PR TITLE
In prepare_chain, ensure validate_incoming_bundles is OK.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,10 +59,12 @@ jobs:
         cargo build --features storage-service
         mkdir /tmp/local-linera-net
         cargo run --features storage-service --bin linera -- net up --storage service:tcp:localhost:1235:table --policy-config devnet --path /tmp/local-linera-net --validators 4 --shards 4 &
-    - name: Run the faucet
+    - name: Create two epochs and run the faucet
       run: |
         cargo build --bin linera
-        cargo run --bin linera -- faucet --amount 1000 --port 8079 &
+        cargo run --bin linera -- resource-control-policy --block 0.0000001
+        cargo run --bin linera -- resource-control-policy --block 0.000000
+        cargo run --bin linera -- faucet --amount 1000 --port 8079 69705f85ac4c9fef6c02b4d83426aaaf05154c645ec1c61665f8e450f0468bc0 &
     - name: Run the remote-net tests
       run: |
         cargo test -p linera-service remote_net_grpc --features remote-net

--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -126,8 +126,8 @@ impl From<(ChainId, Origin, InboxError)> for ChainError {
             } => ChainError::UnexpectedMessage {
                 chain_id,
                 origin: origin.into(),
-                bundle,
-                previous_bundle,
+                bundle: Box::new(bundle),
+                previous_bundle: Box::new(previous_bundle),
             },
             InboxError::IncorrectOrder {
                 bundle,
@@ -135,14 +135,14 @@ impl From<(ChainId, Origin, InboxError)> for ChainError {
             } => ChainError::IncorrectMessageOrder {
                 chain_id,
                 origin: origin.into(),
-                bundle,
+                bundle: Box::new(bundle),
                 next_height: next_cursor.height,
                 next_index: next_cursor.index,
             },
             InboxError::UnskippableBundle { bundle } => ChainError::CannotSkipMessage {
                 chain_id,
                 origin: origin.into(),
-                bundle,
+                bundle: Box::new(bundle),
             },
         }
     }

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -34,7 +34,7 @@ pub enum ChainError {
     #[error("Error in view operation: {0}")]
     ViewError(#[from] ViewError),
     #[error("Execution error: {0} during {1:?}")]
-    ExecutionError(ExecutionError, ChainExecutionContext),
+    ExecutionError(Box<ExecutionError>, ChainExecutionContext),
 
     #[error("The chain being queried is not active {0:?}")]
     InactiveChain(ChainId),
@@ -54,8 +54,8 @@ pub enum ChainError {
     UnexpectedMessage {
         chain_id: ChainId,
         origin: Box<Origin>,
-        bundle: MessageBundle,
-        previous_bundle: MessageBundle,
+        bundle: Box<MessageBundle>,
+        previous_bundle: Box<MessageBundle>,
     },
     #[error(
         "Message in block proposed to {chain_id:?} is out of order compared to previous messages \
@@ -65,7 +65,7 @@ pub enum ChainError {
     IncorrectMessageOrder {
         chain_id: ChainId,
         origin: Box<Origin>,
-        bundle: MessageBundle,
+        bundle: Box<MessageBundle>,
         next_height: BlockHeight,
         next_index: u32,
     },
@@ -76,7 +76,7 @@ pub enum ChainError {
     CannotRejectMessage {
         chain_id: ChainId,
         origin: Box<Origin>,
-        posted_message: PostedMessage,
+        posted_message: Box<PostedMessage>,
     },
     #[error(
         "Block proposed to {chain_id:?} is attempting to skip a message bundle \
@@ -85,7 +85,7 @@ pub enum ChainError {
     CannotSkipMessage {
         chain_id: ChainId,
         origin: Box<Origin>,
-        bundle: MessageBundle,
+        bundle: Box<MessageBundle>,
     },
     #[error(
         "Incoming message bundle in block proposed to {chain_id:?} has timestamp \
@@ -159,4 +159,17 @@ pub enum ChainExecutionContext {
     IncomingBundle(u32),
     Operation(u32),
     Block,
+}
+
+trait ExecutionResultExt<T> {
+    fn with_execution_context(self, context: ChainExecutionContext) -> Result<T, ChainError>;
+}
+
+impl<T, E> ExecutionResultExt<T> for Result<T, E>
+where
+    E: Into<ExecutionError>,
+{
+    fn with_execution_context(self, context: ChainExecutionContext) -> Result<T, ChainError> {
+        self.map_err(|error| ChainError::ExecutionError(Box::new(error.into()), context))
+    }
 }

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -162,9 +162,9 @@ async fn test_block_size_limit() {
     assert_matches!(
         result,
         Err(ChainError::ExecutionError(
-            ExecutionError::ExecutedBlockTooLarge,
+            execution_error,
             ChainExecutionContext::Operation(1),
-        ))
+        )) if matches!(*execution_error, ExecutionError::ExecutedBlockTooLarge)
     );
 
     // The valid block is accepted...

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -343,8 +343,8 @@ where
         ensure!(
             executed_block.outcome == verified_outcome,
             WorkerError::IncorrectOutcome {
-                submitted: executed_block.outcome.clone(),
-                computed: verified_outcome,
+                submitted: Box::new(executed_block.outcome.clone()),
+                computed: Box::new(verified_outcome),
             }
         );
         // Advance to next block height.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -881,7 +881,7 @@ where
     }
 
     /// Prepares the chain for the next operation, i.e. makes sure we have synchronized it up to
-    /// its current height.
+    /// its current height and are not missing any received messages from the inbox.
     #[instrument(level = "trace")]
     async fn prepare_chain(&self) -> Result<Box<ChainInfo>, ChainClientError> {
         #[cfg(with_metrics)]

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -896,6 +896,15 @@ where
             let nodes = self.validator_nodes().await?;
             info = self.synchronize_chain_state(&nodes, self.chain_id).await?;
         }
+
+        let result = self
+            .chain_state_view()
+            .await?
+            .validate_incoming_bundles()
+            .await;
+        if matches!(result, Err(ChainError::MissingCrossChainUpdate { .. })) {
+            self.find_received_certificates().await?;
+        }
         self.update_from_info(&info);
         Ok(info)
     }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2239,13 +2239,13 @@ where
             Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(
                 WorkerError::ChainError(error),
             ))) if matches!(
-                *error,
+                &*error,
                 ChainError::ExecutionError(
-                    ExecutionError::SystemError(
-                        SystemExecutionError::InsufficientFundingForFees { .. }
-                    ),
+                    execution_error,
                     ChainExecutionContext::Block
-                )
+                ) if matches!(**execution_error, ExecutionError::SystemError(
+                    SystemExecutionError::InsufficientFundingForFees { .. }
+                ))
             ) =>
             {
                 // We can't even pay for the execution of one empty block. Let's return zero.

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -327,7 +327,6 @@ impl<T> ClientOutcome<T> {
         }
     }
 
-    #[expect(clippy::result_large_err)]
     pub fn try_map<F, S>(self, f: F) -> Result<ClientOutcome<S>, ChainClientError>
     where
         F: FnOnce(T) -> Result<S, ChainClientError>,

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -90,17 +90,16 @@ impl LocalNodeError {
     pub fn get_blobs_not_found(&self) -> Option<Vec<BlobId>> {
         match self {
             LocalNodeError::WorkerError(WorkerError::ChainError(chain_error)) => {
-                match **chain_error {
-                    ChainError::ExecutionError(
+                match &**chain_error {
+                    ChainError::ExecutionError(execution_error, _) => match **execution_error {
                         ExecutionError::SystemError(SystemExecutionError::BlobNotFoundOnRead(
                             blob_id,
-                        )),
-                        _,
-                    )
-                    | ChainError::ExecutionError(
-                        ExecutionError::ViewError(ViewError::BlobNotFoundOnRead(blob_id)),
-                        _,
-                    ) => Some(vec![blob_id]),
+                        ))
+                        | ExecutionError::ViewError(ViewError::BlobNotFoundOnRead(blob_id)) => {
+                            Some(vec![blob_id])
+                        }
+                        _ => None,
+                    },
                     _ => None,
                 }
             }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -482,13 +482,11 @@ where
         .await,
         Err(
             WorkerError::ChainError(error)
-        ) if matches!(
-            *error,
-            ChainError::ExecutionError(
-                ExecutionError::SystemError(SystemExecutionError::IncorrectTransferAmount),
-                ChainExecutionContext::Operation(_)
-            )
-        )
+        ) if matches!(&*error, ChainError::ExecutionError(
+            execution_error, ChainExecutionContext::Operation(_)
+        ) if matches!(**execution_error, ExecutionError::SystemError(
+            SystemExecutionError::IncorrectTransferAmount
+        )))
     );
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
@@ -823,15 +821,11 @@ where
                 worker.handle_block_proposal(block_proposal).await,
                 Err(
                     WorkerError::ChainError(error)
-                ) if matches!(
-                    *error,
-                    ChainError::ExecutionError(
-                        ExecutionError::SystemError(
-                            SystemExecutionError::InsufficientFunding { .. }
-                        ),
-                        ChainExecutionContext::Operation(_)
-                    )
-                )
+                ) if matches!(&*error, ChainError::ExecutionError(
+                    execution_error, ChainExecutionContext::Operation(_)
+                ) if matches!(**execution_error, ExecutionError::SystemError(
+                    SystemExecutionError::InsufficientFunding { .. }
+                )))
         );
     }
     {
@@ -1066,13 +1060,11 @@ where
         worker.handle_block_proposal(block_proposal).await,
         Err(
             WorkerError::ChainError(error)
-        ) if matches!(
-            *error,
-            ChainError::ExecutionError(
-                ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }),
-                ChainExecutionContext::Operation(_)
-            )
-        )
+        ) if matches!(&*error, ChainError::ExecutionError(
+                execution_error, ChainExecutionContext::Operation(_)
+        ) if matches!(**execution_error, ExecutionError::SystemError(
+            SystemExecutionError::InsufficientFunding { .. }
+        )))
     );
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -188,8 +188,8 @@ pub enum WorkerError {
     "
     )]
     IncorrectOutcome {
-        computed: BlockExecutionOutcome,
-        submitted: BlockExecutionOutcome,
+        computed: Box<BlockExecutionOutcome>,
+        submitted: Box<BlockExecutionOutcome>,
     },
     #[error("The timestamp of a Tick operation is in the future.")]
     InvalidTimestamp,

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -431,8 +431,11 @@ impl ActiveChain {
                 if matches!(
                     &*boxed_chain_error,
                     ChainError::ExecutionError(
-                        ExecutionError::SystemError(SystemExecutionError::UnknownApplicationId(_)),
+                        execution_error,
                         ChainExecutionContext::DescribeApplication,
+                    ) if matches!(
+                        **execution_error,
+                        ExecutionError::SystemError(SystemExecutionError::UnknownApplicationId(_))
                     )
                 ) =>
             {


### PR DESCRIPTION
## Motivation

The `test_end_to_end_open_multi_owner_chain` test fails against a network with multiple epochs, because the `transfer` command doesn't cause the client to download the received certificates.

## Proposal

In `prepare_chain`, check if `validated_incoming_bundles` is `Ok`.

If it is `Err`, that means we are missing some entries from the inbox that have already been received. In that situation, it is impossible for us to create a new block: our local node would not accept the proposal. So we have to call `find_received_certificates` to synchronize all the sender chains.

It's appropriate to add that to `prepare_chain`, because that function is meant to prepare us for adding a new block.

The added method call triggered a stack overflow in one test. This is because the `tracing::instrument` attribute seems to suppress lint warnings about large error variants, and some of them had grown quite large. I used `RUSTFLAGS=-Zprint-type-sizes cargo +nightly build` to find the worst offenders, and put them in `Box`es accordingly.

## Test Plan

I verified locally that it fixes the `test_end_to_end_open_multi_owner_chain`. CI now also creates two epochs before running the faucet, as a regression test.

I inspected the type sizes with `RUSTFLAGS=-Zprint-type-sizes cargo +nightly-2024-07-11 build -p linera-core`. Filtering the output with e.g. `top-type-sizes -h8 -f "ChainClientError"` yields:

```
80 client::ChainClientError align=8
     79 variant LocalNodeError, ChainError
     63 variant RemoteNodeError, CommunicationError, ViewError
     32 variant CannotFindKeyForChain, FoundMultipleKeysForChain
     31 variant BlobsNotFound
     23 variant InternalError, BlockProposalError, ProtocolError
     15 variant JsonError
      1 variant ArithmeticError
      0 variant CommitteeSynchronizationError, WalletSynchronizationError, CommitteeDeprecationError
```

Before the last commit it was:

```
464 client::ChainClientError align=16
    464 variant ChainError
    224 variant LocalNodeError, RemoteNodeError, CommunicationError
          8 <padding>
        216 0 align=8
     64 variant ViewError
          8 <padding>
         56 0 align=8
     33 variant CannotFindKeyForChain, FoundMultipleKeysForChain
     32 variant BlobsNotFound
          8 <padding>
         24 0 align=8
     24 variant InternalError, BlockProposalError, ProtocolError
          8 <padding>
         16 0 align=8
     16 variant JsonError
          8 <padding>
          8 0 align=8
      2 variant ArithmeticError
      0 variant CommitteeSynchronizationError, WalletSynchronizationError, CommitteeDeprecationError
```

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- These changes _could_ be backported to the latest `devnet` and `testnet` branches, then be released in a new SDK. This is not critical, however: A user can always run the `sync` command to work around this.

## Links

- Related change to the sync policy: https://github.com/linera-io/linera-protocol/pull/2816
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
