### PR TITLE
Client grace period is configurable.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -135,6 +135,9 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
     Don't include any messages in blocks, and don't make any decision whether to accept or reject
 
 * `--restrict-chain-ids-to <RESTRICT_CHAIN_IDS_TO>` — A set of chains to restrict incoming messages from. By default, messages from all chains are accepted. To reject messages from all chains, specify an empty string
+* `--grace-period <GRACE_PERIOD>` — The amount of time we wait for additional validators to contribute to the result, as a fraction of how long it took to reach a quorum
+
+  Default value: `0.1`
 
 
 

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -170,6 +170,7 @@ where
             options.long_lived_services,
             chain_ids,
             name,
+            options.grace_period,
         );
 
         ClientContext {
@@ -205,7 +206,16 @@ where
             1 => format!("Client node for {:.8}", chain_ids[0]),
             n => format!("Client node for {:.8} and {} others", chain_ids[0], n - 1),
         };
-        let client = Client::new(node_provider, storage, 10, delivery, false, chain_ids, name);
+        let client = Client::new(
+            node_provider,
+            storage,
+            10,
+            delivery,
+            false,
+            chain_ids,
+            name,
+            0.1,
+        );
 
         ClientContext {
             client: Arc::new(client),

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -146,6 +146,11 @@ pub struct ClientOptions {
     /// an empty string.
     #[arg(long, value_parser = util::parse_chain_set)]
     pub restrict_chain_ids_to: Option<HashSet<ChainId>>,
+
+    /// The amount of time we wait for additional validators to contribute to the result,
+    /// as a fraction of how long it took to reach a quorum.
+    #[arg(long, default_value = "0.1")]
+    pub grace_period: f64,
 }
 
 impl ClientOptions {

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -134,6 +134,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
             false,
             [chain_id0],
             format!("Client node for {:.8}", chain_id0),
+            0.1,
         )),
     };
     let key_pair = KeyPair::generate_from(&mut rng);

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -807,6 +807,7 @@ where
             false,
             [chain_id],
             format!("Client node for {:.8}", chain_id),
+            0.1,
         ));
         Ok(builder.create_chain_client(
             chain_id,

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -30,9 +30,6 @@ use crate::{
     remote_node::RemoteNode,
 };
 
-/// The amount of time we wait for additional validators to contribute to the result, as a fraction
-/// of how long it took to reach a quorum.
-const GRACE_PERIOD: f64 = 0.2;
 /// The maximum timeout for `communicate_with_quorum` if no quorum is reached.
 const MAX_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24); // 1 day.
 
@@ -100,6 +97,7 @@ pub async fn communicate_with_quorum<'a, A, V, K, F, R, G>(
     committee: &Committee,
     group_by: G,
     execute: F,
+    grace_period: f64,
 ) -> Result<(K, Vec<V>), CommunicationError<NodeError>>
 where
     A: ValidatorNode + Clone + 'static,
@@ -161,7 +159,7 @@ where
             && (highest_key_score >= committee.quorum_threshold()
                 || highest_key_score + remaining_votes < committee.quorum_threshold())
         {
-            end_time = Some(Instant::now() + start_time.elapsed().mul_f64(GRACE_PERIOD));
+            end_time = Some(Instant::now() + start_time.elapsed().mul_f64(grace_period));
         }
     }
 


### PR DESCRIPTION
## Motivation

The grace period, which is the amount of time we wait for validators to respond after achieving a quorum, is hard coded to 20% which is not optimal for all client use-cases, i.e. when optimising for low latency.

## Proposal

Make the grace period configurable as a client option.

## Test Plan

Tested manually. 20% improvement (when set to 0) in performance in non-ideal networks, that is, networks which have one or more validators which are slower than a quorum.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
