### PR TITLE
Update the error types

### DIFF
--- a/linera-base/src/crypto.rs
+++ b/linera-base/src/crypto.rs
@@ -53,7 +53,7 @@ pub enum CryptoError {
     InvalidSignature { error: String, type_name: String },
     #[error("Signature for object {type_name} is missing")]
     MissingSignature { type_name: String },
-    #[error("String contains non-hexadecimal digits")]
+    #[error("String {0} contains non-hexadecimal digits")]
     NonHexDigits(#[from] hex::FromHexError),
     #[error(
         "Byte slice has length {0} but a `CryptoHash` requires exactly {expected} bytes",
@@ -65,7 +65,7 @@ pub enum CryptoError {
         expected = dalek::PUBLIC_KEY_LENGTH,
     )]
     IncorrectPublicKeySize(usize),
-    #[error("Could not parse integer")]
+    #[error("Could not parse integer {0}")]
     ParseIntError(#[from] ParseIntError),
 }
 

--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -73,9 +73,9 @@ pub struct Cursor {
 
 #[derive(Error, Debug)]
 pub(crate) enum InboxError {
-    #[error(transparent)]
+    #[error("View error: {0}")]
     ViewError(#[from] ViewError),
-    #[error(transparent)]
+    #[error("Arithmetic error: {0}")]
     ArithmeticError(#[from] ArithmeticError),
     #[error("Cannot reconcile {bundle:?} with {previous_bundle:?}")]
     UnexpectedBundle {

--- a/linera-client/src/error.rs
+++ b/linera-client/src/error.rs
@@ -13,7 +13,7 @@ pub(crate) enum Inner {
     #[error("chain client error: {0}")]
     ChainClient(#[from] linera_core::client::ChainClientError),
     #[error("options error: {0}")]
-    Options(#[from] crate::client_options::Error),
+    Options(#[from] crate::client_options::OptionError),
     #[error("persistence error: {0}")]
     Persistence(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("view error: {0}")]

--- a/linera-client/src/persistent/file.rs
+++ b/linera-client/src/persistent/file.rs
@@ -15,14 +15,14 @@ use super::{Dirty, Persist};
 struct Lock(fs_err::File);
 
 #[derive(Debug, thiserror::Error)]
-enum ErrorInner {
+enum FileError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
     #[error("JSON error: {0}")]
     Serde(#[from] serde_json::Error),
 }
 
-thiserror_context::impl_context!(Error(ErrorInner));
+thiserror_context::impl_context!(Error(FileError));
 
 /// Utility: run a fallible cleanup function if an operation failed, attaching the
 /// original operation as context to its error.

--- a/linera-client/src/persistent/indexed_db.rs
+++ b/linera-client/src/persistent/indexed_db.rs
@@ -34,7 +34,7 @@ const STORE_NAME: &str = "linera-wallet";
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("marshalling error: {0}")]
+    #[error("Marshalling error: {0}")]
     Marshalling(#[source] gloo_utils::errors::JsError),
     #[error("DOM exception: {0:?}")]
     DomException(#[source] gloo_utils::errors::JsError),

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -451,7 +451,7 @@ pub enum ChainClientError {
     #[error("Remote node operation failed: {0}")]
     RemoteNodeError(#[from] NodeError),
 
-    #[error(transparent)]
+    #[error("Arithmetic error: {0}")]
     ArithmeticError(#[from] ArithmeticError),
 
     #[error("JSON (de)serialization error: {0}")]
@@ -460,7 +460,7 @@ pub enum ChainClientError {
     #[error("Chain operation failed: {0}")]
     ChainError(#[from] ChainError),
 
-    #[error(transparent)]
+    #[error("Communication error: {0}")]
     CommunicationError(#[from] CommunicationError<NodeError>),
 
     #[error("Internal error within chain client: {0}")]
@@ -493,7 +493,7 @@ pub enum ChainClientError {
     #[error("Found several possible identities to interact with chain {0}")]
     FoundMultipleKeysForChain(ChainId),
 
-    #[error(transparent)]
+    #[error("View error: {0}")]
     ViewError(#[from] ViewError),
 
     #[error("Blobs not found: {0:?}")]

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -55,10 +55,10 @@ where
 /// Error type for the operations on a local node.
 #[derive(Debug, Error)]
 pub enum LocalNodeError {
-    #[error(transparent)]
+    #[error("Arithmetic error: {0}")]
     ArithmeticError(#[from] ArithmeticError),
 
-    #[error(transparent)]
+    #[error("View error: {0}")]
     ViewError(#[from] linera_views::views::ViewError),
 
     #[error("Local node operation failed: {0}")]
@@ -82,7 +82,7 @@ pub enum LocalNodeError {
     #[error("The chain info response received from the local node is invalid")]
     InvalidChainInfoResponse,
 
-    #[error(transparent)]
+    #[error("Node error: {0}")]
     NodeError(#[from] NodeError),
 }
 

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -218,9 +218,9 @@ pub enum NodeError {
 
     #[error("Blob not found on storage read: {0}")]
     BlobNotFoundOnRead(BlobId),
-    #[error("Node failed to provide a 'last used by' certificate for the blob")]
+    #[error("Node failed to provide a 'last used by' certificate for the blob {0}")]
     InvalidCertificateForBlob(BlobId),
-    #[error("Local error handling validator response")]
+    #[error("Local error handling validator response: {error}")]
     LocalError { error: String },
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -139,23 +139,23 @@ pub enum Reason {
 /// Error type for worker operations..
 #[derive(Debug, Error)]
 pub enum WorkerError {
-    #[error(transparent)]
+    #[error("Crypto error: {0}")]
     CryptoError(#[from] linera_base::crypto::CryptoError),
 
-    #[error(transparent)]
+    #[error("Arithmetic error: {0}")]
     ArithmeticError(#[from] ArithmeticError),
 
-    #[error(transparent)]
+    #[error("View error: {0}")]
     ViewError(#[from] linera_views::views::ViewError),
 
-    #[error(transparent)]
+    #[error("Chain error: {0}")]
     ChainError(#[from] Box<linera_chain::ChainError>),
 
     // Chain access control
     #[error("Block was not signed by an authorized owner")]
     InvalidOwner,
 
-    #[error("Operations in the block are not authenticated by the proper signer")]
+    #[error("Operations in the block are not authenticated by the proper signer, owner={0}")]
     InvalidSigner(Owner),
 
     // Chaining
@@ -217,7 +217,7 @@ pub enum WorkerError {
     BlobTooLarge,
     #[error("Bytecode exceeds size limit")]
     BytecodeTooLarge,
-    #[error(transparent)]
+    #[error("Decompression error: {0}")]
     Decompression(#[from] DecompressionError),
 }
 

--- a/linera-ethereum/src/common.rs
+++ b/linera-ethereum/src/common.rs
@@ -28,11 +28,11 @@ pub enum EthereumQueryError {
 #[derive(Debug, Error)]
 pub enum EthereumServiceError {
     /// The database is not coherent
-    #[error(transparent)]
+    #[error("Ethereum query error: {0}")]
     EthereumQueryError(#[from] EthereumQueryError),
 
     /// Parsing error
-    #[error(transparent)]
+    #[error("Parsing integer error: {0}")]
     ParseIntError(#[from] ParseIntError),
 
     #[error("Failed to deploy the smart contract")]
@@ -48,7 +48,7 @@ pub enum EthereumServiceError {
     EventParsingError,
 
     /// Parse big int error
-    #[error(transparent)]
+    #[error("Parsing big integer error: {0}")]
     ParseBigIntError(#[from] num_bigint::ParseBigIntError),
 
     /// Ethereum parsing error
@@ -60,25 +60,25 @@ pub enum EthereumServiceError {
     ParseBoolError,
 
     /// Hex parsing error
-    #[error(transparent)]
+    #[error("From hexadecimal integer error: {0}")]
     FromHexError(#[from] linera_alloy::primitives::hex::FromHexError),
 
     /// `serde_json` error
-    #[error(transparent)]
+    #[error("JSON error: {0}")]
     SerdeJsonError(#[from] serde_json::Error),
 
     /// RPC error
-    #[error(transparent)]
+    #[error("RPC error: {0}")]
     #[cfg(not(target_arch = "wasm32"))]
     RpcError(#[from] json_rpc::RpcError<linera_alloy::transports::TransportErrorKind>),
 
     /// URL parsing error
-    #[error(transparent)]
+    #[error("URL parsing error: {0}")]
     #[cfg(not(target_arch = "wasm32"))]
     UrlParseError(#[from] url::ParseError),
 
     /// Alloy Reqwest error
-    #[error(transparent)]
+    #[error("Alloy reqwest error: {0}")]
     #[cfg(not(target_arch = "wasm32"))]
     AlloyReqwestError(#[from] linera_alloy::transports::http::reqwest::Error),
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -189,20 +189,20 @@ const _: () = {
 /// A type for errors happening during execution.
 #[derive(Error, Debug)]
 pub enum ExecutionError {
-    #[error(transparent)]
+    #[error("View error: {0}")]
     ViewError(#[from] ViewError),
-    #[error(transparent)]
+    #[error("Arithmetic error: {0}")]
     ArithmeticError(#[from] ArithmeticError),
-    #[error(transparent)]
+    #[error("System error: {0}")]
     SystemError(#[from] SystemExecutionError),
     #[error("User application reported an error: {0}")]
     UserError(String),
     #[cfg(any(with_wasmer, with_wasmtime))]
-    #[error(transparent)]
+    #[error("Wasm error: {0}")]
     WasmError(#[from] WasmExecutionError),
-    #[error(transparent)]
+    #[error("Join error: {0}")]
     JoinError(#[from] linera_base::task::Error),
-    #[error(transparent)]
+    #[error("Decompression error: {0}")]
     DecompressionError(#[from] DecompressionError),
     #[error("The given promise is invalid or was polled once already")]
     InvalidPromise,
@@ -240,13 +240,13 @@ pub enum ExecutionError {
     UnauthorizedApplication(UserApplicationId),
     #[error("Failed to make network reqwest")]
     ReqwestError(#[from] reqwest::Error),
-    #[error("Encountered IO error")]
+    #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
     #[error("More recorded oracle responses than expected")]
     UnexpectedOracleResponse,
-    #[error("Invalid JSON: {}", .0)]
+    #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
-    #[error(transparent)]
+    #[error("BCS error: {0}")]
     Bcs(#[from] bcs::Error),
     #[error("Recorded response for oracle query has the wrong type")]
     OracleResponseMismatch,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -333,9 +333,9 @@ impl UserData {
 
 #[derive(Error, Debug)]
 pub enum SystemExecutionError {
-    #[error(transparent)]
+    #[error("Arithmetic error: {0}")]
     ArithmeticError(#[from] ArithmeticError),
-    #[error(transparent)]
+    #[error("View error: {0}")]
     ViewError(#[from] ViewError),
 
     #[error("Invalid admin ID in new chain: {0}")]

--- a/linera-indexer/lib/src/common.rs
+++ b/linera-indexer/lib/src/common.rs
@@ -14,21 +14,21 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum IndexerError {
-    #[error(transparent)]
+    #[error("View error: {0}")]
     ViewError(#[from] linera_views::views::ViewError),
-    #[error(transparent)]
+    #[error("Reqwest error: {0}")]
     ReqwestError(#[from] reqwest::Error),
-    #[error(transparent)]
+    #[error("GraphQL error: {0}")]
     GraphQLError(#[from] graphql_ws_client::Error),
-    #[error(transparent)]
+    #[error("Tungstenite error: {0}")]
     TungsteniteError(#[from] async_tungstenite::tungstenite::Error),
-    #[error(transparent)]
+    #[error("Invalid header value: {0}")]
     InvalidHeader(#[from] InvalidHeaderValue),
-    #[error(transparent)]
+    #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),
-    #[error(transparent)]
+    #[error("Parse error: {0}")]
     ParserError(#[from] AddrParseError),
-    #[error(transparent)]
+    #[error("Server error: {0}")]
     ServerError(#[from] hyper::Error),
     #[error("Null GraphQL data: {0:?}")]
     NullData(Option<Vec<graphql_client::Error>>),
@@ -50,10 +50,10 @@ pub enum IndexerError {
     CloneWithRootKeyError,
 
     #[cfg(feature = "rocksdb")]
-    #[error(transparent)]
+    #[error("RocksDB error: {0}")]
     RocksDbError(#[from] linera_views::rocks_db::RocksDbStoreError),
     #[cfg(feature = "scylladb")]
-    #[error(transparent)]
+    #[error("ScyllaDB error: {0}")]
     ScyllaDbError(#[from] linera_views::scylla_db::ScyllaDbStoreError),
 }
 

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -25,7 +25,7 @@ use crate::{HandleCertificateRequest, HandleLiteCertRequest};
 
 #[derive(Error, Debug)]
 pub enum GrpcProtoConversionError {
-    #[error(transparent)]
+    #[error("Bincode error: {0}")]
     BincodeError(#[from] bincode::Error),
     #[error("Conversion failed due to missing field")]
     MissingField,

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -21,23 +21,23 @@ pub mod api {
 
 #[derive(thiserror::Error, Debug)]
 pub enum GrpcError {
-    #[error("failed to connect to address: {0}")]
+    #[error("Failed to connect to address: {0}")]
     ConnectionFailed(#[from] transport::Error),
 
-    #[error("failed to communicate cross-chain queries: {0}")]
+    #[error("Failed to communicate cross-chain queries: {0}")]
     CrossChain(#[from] tonic::Status),
 
-    #[error("failed to execute task to completion")]
+    #[error("Failed to execute task to completion")]
     Join(#[from] futures::channel::oneshot::Canceled),
 
-    #[error("failed to parse socket address: {0}")]
+    #[error("Failed to parse socket address: {0}")]
     SocketAddr(#[from] std::net::AddrParseError),
 
-    #[error(transparent)]
+    #[error("Invalid URI error: {0}")]
     InvalidUri(#[from] tonic::codegen::http::uri::InvalidUri),
 
     #[cfg(with_server)]
-    #[error(transparent)]
+    #[error("Tonic reflection error: {0}")]
     Reflection(#[from] tonic_reflection::server::Error),
 }
 

--- a/linera-rpc/src/mass_client.rs
+++ b/linera-rpc/src/mass_client.rs
@@ -8,13 +8,13 @@ use crate::RpcMessage;
 
 #[derive(Error, Debug)]
 pub enum MassClientError {
-    #[error("io error: {0}")]
+    #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("tonic transport: {0}")]
+    #[error("Tonic transport error: {0}")]
     TonicTransport(#[from] crate::grpc::transport::Error),
-    #[error("conversion error: {0}")]
+    #[error("Conversion error: {0}")]
     Conversion(#[from] crate::grpc::GrpcProtoConversionError),
-    #[error("error while making a remote call: {0}")]
+    #[error("RPC error: {0}")]
     Rpc(#[from] tonic::Status),
 }
 

--- a/linera-service-graphql-client/src/utils.rs
+++ b/linera-service-graphql-client/src/utils.rs
@@ -6,14 +6,14 @@ use reqwest::Client;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum Error {
-    #[error(transparent)]
+pub enum GraphQlClientError {
+    #[error("Reqwest error: {0}")]
     ReqwestError(#[from] reqwest::Error),
     #[error("GraphQL errors: {0:?}")]
     GraphQLError(Vec<graphql_client::Error>),
 }
 
-impl From<Option<Vec<graphql_client::Error>>> for Error {
+impl From<Option<Vec<graphql_client::Error>>> for GraphQlClientError {
     fn from(val: Option<Vec<graphql_client::Error>>) -> Self {
         Self::GraphQLError(val.unwrap_or_default())
     }
@@ -23,7 +23,7 @@ pub async fn request<T, V>(
     client: &Client,
     url: &str,
     variables: V,
-) -> Result<T::ResponseData, Error>
+) -> Result<T::ResponseData, GraphQlClientError>
 where
     T: GraphQLQuery<Variables = V> + Send + Unpin + 'static,
     V: Send + Unpin,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -76,31 +76,31 @@ pub struct MutationRoot<C> {
 
 #[derive(Debug, ThisError)]
 enum NodeServiceError {
-    #[error(transparent)]
+    #[error("Chain client error: {0}")]
     ChainClientError(#[from] ChainClientError),
-    #[error(transparent)]
+    #[error("BCS hex error: {0}")]
     BcsHexError(#[from] BcsHexParseError),
-    #[error("could not decode query string")]
+    #[error("Query string error: {0}")]
     QueryStringError(#[from] hex::FromHexError),
-    #[error(transparent)]
+    #[error("BCS error: {0}")]
     BcsError(#[from] bcs::Error),
-    #[error(transparent)]
+    #[error("JSON error: {0}")]
     JsonError(#[from] serde_json::Error),
-    #[error("missing GraphQL operation")]
+    #[error("Missing GraphQL operation")]
     MissingOperation,
-    #[error("unsupported query type: subscription")]
+    #[error("Unsupported query type: subscription")]
     UnsupportedQueryType,
     #[error("GraphQL operations of different types submitted")]
     HeterogeneousOperations,
-    #[error("failed to parse GraphQL query: {error}")]
+    #[error("Failed to parse GraphQL query: {error}")]
     GraphQLParseError { error: String },
-    #[error("malformed application response")]
+    #[error("Malformed application response")]
     MalformedApplicationResponse,
-    #[error("application service error")]
+    #[error("Application service errors: {errors:?}")]
     ApplicationServiceError { errors: Vec<String> },
-    #[error("chain ID not found")]
+    #[error("Chain ID not found: {chain_id}")]
     UnknownChainId { chain_id: String },
-    #[error("malformed chain ID")]
+    #[error("Malformed chain ID: {0}")]
     InvalidChainId(CryptoError),
 }
 

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -54,7 +54,7 @@ pub enum ServiceStoreError {
     FailedToFindStorageServerBinary,
 
     /// gRPC error
-    #[error(transparent)]
+    #[error("GRPC error: {0}")]
     GrpcError(#[from] Status),
 
     /// The key size must be at most 1 MB
@@ -62,15 +62,15 @@ pub enum ServiceStoreError {
     KeyTooLong,
 
     /// Transport error
-    #[error(transparent)]
+    #[error("Transport error: {0}")]
     TransportError(#[from] tonic::transport::Error),
 
     /// Var error
-    #[error(transparent)]
+    #[error("Var error: {0}")]
     VarError(#[from] std::env::VarError),
 
-    /// An error occurred during BCS serialization
-    #[error("An error occurred during BCS serialization")]
+    /// BCS serialization error
+    #[error("BCS serialization error: {0}")]
     Serialization(#[from] bcs::Error),
 }
 

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -1018,27 +1018,27 @@ pub enum InvalidTableName {
 #[derive(Debug, Error)]
 pub enum DynamoDbStoreInternalError {
     /// An error occurred while getting the item.
-    #[error(transparent)]
+    #[error("Get item error: {0}")]
     Get(#[from] Box<SdkError<GetItemError>>),
 
     /// An error occurred while writing a batch of items.
-    #[error(transparent)]
+    #[error("Batch write item error: {0}")]
     BatchWriteItem(#[from] Box<SdkError<BatchWriteItemError>>),
 
     /// An error occurred while writing a transaction of items.
-    #[error(transparent)]
+    #[error("Transact write item error: {0}")]
     TransactWriteItem(#[from] Box<SdkError<TransactWriteItemsError>>),
 
     /// An error occurred while doing a Query.
-    #[error(transparent)]
+    #[error("Query error: {0}")]
     Query(#[from] Box<SdkError<QueryError>>),
 
     /// An error occurred while deleting a table
-    #[error(transparent)]
+    #[error("Delete table error: {0}")]
     DeleteTable(#[from] Box<SdkError<DeleteTableError>>),
 
     /// An error occurred while listing tables
-    #[error(transparent)]
+    #[error("List table error: {0}")]
     ListTables(#[from] Box<SdkError<ListTablesError>>),
 
     /// The transact maximum size is MAX_TRANSACT_WRITE_ITEM_SIZE.
@@ -1066,11 +1066,11 @@ pub enum DynamoDbStoreInternalError {
     DatabaseRecoveryFailed,
 
     /// The journal is not coherent
-    #[error(transparent)]
+    #[error("Journal consistency error: {0}")]
     JournalConsistencyError(#[from] JournalConsistencyError),
 
     /// Missing database
-    #[error("Missing database")]
+    #[error("Missing database: {0}")]
     MissingDatabase(String),
 
     /// Already existing database
@@ -1098,19 +1098,19 @@ pub enum DynamoDbStoreInternalError {
     WrongValueType(String),
 
     /// A BCS error occurred.
-    #[error(transparent)]
+    #[error("BCS error: {0}")]
     BcsError(#[from] bcs::Error),
 
     /// A wrong table name error occurred
-    #[error(transparent)]
+    #[error("Invalid table name error: {0}")]
     InvalidTableName(#[from] InvalidTableName),
 
     /// An error occurred while creating the table.
-    #[error(transparent)]
+    #[error("Create table error: {0}")]
     CreateTable(#[from] SdkError<CreateTableError>),
 
     /// An error occurred while building an object
-    #[error(transparent)]
+    #[error("Build error: {0}")]
     Build(#[from] Box<BuildError>),
 }
 

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -566,7 +566,7 @@ pub enum RocksDbStoreInternalError {
     NonDirectoryNamespace,
 
     /// Error converting `OsString` to `String`
-    #[error("error in the conversion from OsString")]
+    #[error("String conversion error from OsString: {0:?}")]
     IntoStringError(OsString),
 
     /// The key must have at most 8M
@@ -574,7 +574,7 @@ pub enum RocksDbStoreInternalError {
     KeyTooLong,
 
     /// Missing database
-    #[error("Missing database")]
+    #[error("Missing database: {0}")]
     MissingDatabase(String),
 
     /// Invalid namespace
@@ -586,7 +586,7 @@ pub enum RocksDbStoreInternalError {
     AlreadyExistingDatabase,
 
     /// Filesystem error
-    #[error("Filesystem error")]
+    #[error("Filesystem error: {0}")]
     FsError(#[from] std::io::Error),
 
     /// BCS serialization error.

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -402,15 +402,15 @@ pub enum ScyllaDbStoreError {
     KeyTooLong,
 
     /// A row error in ScyllaDB
-    #[error(transparent)]
+    #[error("ScyllaDB Row error: {0}")]
     ScyllaDbRowError(#[from] scylla::cql_to_rust::FromRowError),
 
     /// A query error in ScyllaDB
-    #[error(transparent)]
+    #[error("ScyllaDB query error: {0}")]
     ScyllaDbQueryError(#[from] scylla::transport::errors::QueryError),
 
     /// A query error in ScyllaDB
-    #[error(transparent)]
+    #[error("ScyllaDB new session error: {0}")]
     ScyllaDbNewSessionError(#[from] scylla::transport::errors::NewSessionError),
 
     /// Table name contains forbidden characters
@@ -418,7 +418,7 @@ pub enum ScyllaDbStoreError {
     InvalidTableName,
 
     /// Missing database
-    #[error("Missing database")]
+    #[error("Missing database: {0}")]
     MissingDatabase(String),
 
     /// Already existing database
@@ -426,7 +426,7 @@ pub enum ScyllaDbStoreError {
     AlreadyExistingDatabase,
 
     /// The journal is not coherent
-    #[error(transparent)]
+    #[error("Journal consistency error: {0}")]
     JournalConsistencyError(#[from] JournalConsistencyError),
 }
 

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -23,7 +23,7 @@ use crate::{
 #[derive(Error, Debug)]
 pub enum ValueSplittingError<E> {
     /// inner store error
-    #[error("inner store error")]
+    #[error("Inner store error: {0}")]
     InnerStoreError(#[from] E),
 
     /// The key is of length less than 4, so we cannot extract the first byte

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -1214,7 +1214,7 @@ impl<C> WithError for ViewContainer<C> {
 #[derive(Error, Debug)]
 pub enum ViewContainerError {
     /// View error.
-    #[error(transparent)]
+    #[error("View error: {0}")]
     ViewError(#[from] ViewError),
 
     /// BCS serialization error.

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -99,7 +99,7 @@ pub trait View<C>: Sized {
 #[derive(Error, Debug)]
 pub enum ViewError {
     /// An error occurred during BCS serialization.
-    #[error("failed to serialize value to calculate its hash")]
+    #[error("Serialization error: {0}")]
     Serialization(#[from] bcs::Error),
 
     /// We failed to acquire an entry in a CollectionView or a ReentrantCollectionView.
@@ -107,11 +107,11 @@ pub enum ViewError {
     CannotAcquireCollectionEntry,
 
     /// Input output error.
-    #[error("IO error")]
+    #[error("I/O error")]
     Io(#[from] std::io::Error),
 
     /// Arithmetic error
-    #[error("Arithmetic error")]
+    #[error("Arithmetic error: {0}")]
     ArithmeticError(#[from] ArithmeticError),
 
     /// An error happened while trying to lock.

--- a/linera-witty/src/runtime/error.rs
+++ b/linera-witty/src/runtime/error.rs
@@ -39,11 +39,11 @@ pub enum RuntimeError {
     NotMemory,
 
     /// Attempt to load a string from a sequence of bytes that doesn't contain a UTF-8 string.
-    #[error("Failed to load string from non-UTF-8 bytes")]
+    #[error("Failed to load string from non-UTF-8 bytes: {0}")]
     InvalidString(#[from] FromUtf8Error),
 
     /// Attempt to create a `GuestPointer` from an invalid address representation.
-    #[error("Invalid address read")]
+    #[error("Invalid address read: {0}")]
     InvalidNumber(#[from] TryFromIntError),
 
     /// Attempt to load an `enum` type but the discriminant doesn't match any of the variants.
@@ -61,21 +61,21 @@ pub enum RuntimeError {
 
     /// Wasmer runtime error.
     #[cfg(with_wasmer)]
-    #[error(transparent)]
+    #[error("Wasmer runtime error: {0}")]
     Wasmer(#[from] wasmer::RuntimeError),
 
     /// Attempt to access an invalid memory address using Wasmer.
     #[cfg(with_wasmer)]
-    #[error(transparent)]
+    #[error("Wasmer memory access error: {0}")]
     WasmerMemory(#[from] wasmer::MemoryAccessError),
 
     /// Wasmtime error.
     #[cfg(with_wasmtime)]
-    #[error(transparent)]
+    #[error("Wasmtime error: {0}")]
     Wasmtime(anyhow::Error),
 
     /// Wasmtime trap during execution.
     #[cfg(with_wasmtime)]
-    #[error(transparent)]
+    #[error("Wasmtime trap error: {0}")]
     WasmtimeTrap(#[from] wasmtime::Trap),
 }


### PR DESCRIPTION
## Motivation

Issue #2828 showed that the errors were not passed adequately. This PR sought to standardize the errors.

## Proposal

The following was done:
* The types named "Error" have been renamed to more specific names for clarity.
* The `#[error(transparent)]` have been renamed as `#[error("Something wrong error {0}")]` or similar.
* Everytime an error contains some inner information, that information is printed.
* The first character of the error is now a capital.
* There is some unification of the errors. For example `ArithmeticError` was sometimes processed as transparent and sometimes as `#[error("Arithmetic error: {0}")]`. This is now unified as the latter.

The error of the initial issue can be triggered via
```sh
./linera --storage rocksdb:foo.db --wallet /tmp/WORK/wallet_0.json process-inbox
```

Before the PR, the error was `backend error: inner store error` and now it is `backend error: Inner store error: Filesystem error: No such file or directory (os error 2)`.

## Test Plan

The CI

## Release Plan

Having better errors might be helpful for TestNet / DevNet operations.

## Links

None