### PR TITLE
Move functions between Client and LocalNode as appropriate

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1129,7 +1129,7 @@ where
         if let Err(err) = self.process_certificate(certificate.clone(), vec![]).await {
             match &err {
                 LocalNodeError::WorkerError(WorkerError::BlobsNotFound(blob_ids)) => {
-                    let blobs = LocalNodeClient::<S>::download_blobs(blob_ids, &nodes).await;
+                    let blobs = RemoteNode::download_blobs(blob_ids, &nodes).await;
 
                     ensure!(blobs.len() == blob_ids.len(), err);
                     self.process_certificate(certificate.clone(), blobs).await?;
@@ -1710,7 +1710,7 @@ where
 
             tasks.insert(
                 blob_id,
-                LocalNodeClient::<S>::download_certificate_for_blob_from_validators_futures(
+                RemoteNode::download_certificate_for_blob_from_validators_futures(
                     &validators,
                     blob_id,
                 )

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -56,6 +56,7 @@ use linera_execution::{
 };
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::ViewError;
+use rand::prelude::SliceRandom as _;
 use serde::Serialize;
 use thiserror::Error;
 use tokio::sync::OwnedRwLockReadGuard;
@@ -292,26 +293,119 @@ where
     P: ValidatorNodeProvider + Sync + 'static,
     S: Storage + Sync + Send + Clone + 'static,
 {
-    async fn download_certificates(
+    /// Downloads and processes all certificates up to (excluding) the specified height.
+    #[instrument(level = "trace", skip(self, validators))]
+    pub async fn download_certificates(
         &self,
-        nodes: &[RemoteNode<P::Node>],
+        validators: &[RemoteNode<impl ValidatorNode>],
         chain_id: ChainId,
-        height: BlockHeight,
-    ) -> Result<Box<ChainInfo>, LocalNodeError> {
-        self.local_node
-            .download_certificates(nodes, chain_id, height, &self.notifier)
-            .await
+        target_next_block_height: BlockHeight,
+    ) -> Result<Box<ChainInfo>, ChainClientError> {
+        // Sequentially try each validator in random order.
+        let mut validators = validators.iter().collect::<Vec<_>>();
+        validators.shuffle(&mut rand::thread_rng());
+        for remote_node in validators {
+            let info = self.local_node.local_chain_info(chain_id).await?;
+            if target_next_block_height <= info.next_block_height {
+                return Ok(info);
+            }
+            self.try_download_certificates_from(
+                remote_node,
+                chain_id,
+                info.next_block_height,
+                target_next_block_height,
+            )
+            .await?;
+        }
+        let info = self.local_node.local_chain_info(chain_id).await?;
+        if target_next_block_height <= info.next_block_height {
+            Ok(info)
+        } else {
+            Err(ChainClientError::CannotDownloadCertificates {
+                chain_id,
+                target_next_block_height,
+            })
+        }
     }
 
-    async fn try_process_certificates(
+    /// Downloads and processes all certificates up to (excluding) the specified height from the
+    /// given validator.
+    #[instrument(level = "trace", skip_all)]
+    async fn try_download_certificates_from(
         &self,
-        remote_node: &RemoteNode<P::Node>,
+        remote_node: &RemoteNode<impl ValidatorNode>,
+        chain_id: ChainId,
+        mut start: BlockHeight,
+        stop: BlockHeight,
+    ) -> Result<(), ChainClientError> {
+        while start < stop {
+            // TODO(#2045): Analyze network errors instead of guessing the batch size.
+            let limit = u64::from(stop)
+                .checked_sub(u64::from(start))
+                .ok_or(ArithmeticError::Overflow)?
+                .min(1000);
+            let Some(certificates) = remote_node
+                .try_query_certificates_from(chain_id, start, limit)
+                .await?
+            else {
+                break;
+            };
+            let Some(info) = self
+                .try_process_certificates(remote_node, chain_id, certificates)
+                .await
+            else {
+                break;
+            };
+            assert!(info.next_block_height > start);
+            start = info.next_block_height;
+        }
+        Ok(())
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    pub async fn try_process_certificates(
+        &self,
+        remote_node: &RemoteNode<impl ValidatorNode>,
         chain_id: ChainId,
         certificates: Vec<Certificate>,
     ) -> Option<Box<ChainInfo>> {
-        self.local_node
-            .try_process_certificates(remote_node, chain_id, certificates, &self.notifier)
-            .await
+        let mut info = None;
+        for certificate in certificates {
+            let hash = certificate.hash();
+            if !certificate.value().is_confirmed() || certificate.value().chain_id() != chain_id {
+                // The certificate is not as expected. Give up.
+                warn!("Failed to process network certificate {}", hash);
+                return info;
+            }
+            let mut result = self.handle_certificate(certificate.clone(), vec![]).await;
+
+            result = match &result {
+                Err(err) => {
+                    if let Some(blob_ids) = err.get_blobs_not_found() {
+                        let blobs = remote_node.try_download_blobs(blob_ids.as_slice()).await;
+                        if blobs.len() != blob_ids.len() {
+                            result
+                        } else {
+                            self.handle_certificate(certificate, blobs).await
+                        }
+                    } else {
+                        result
+                    }
+                }
+                _ => result,
+            };
+
+            match result {
+                Ok(response) => info = Some(response.info),
+                Err(error) => {
+                    // The certificate is not as expected. Give up.
+                    warn!("Failed to process network certificate {}: {}", hash, error);
+                    return info;
+                }
+            };
+        }
+        // Done with all certificates.
+        info
     }
 
     async fn handle_certificate(
@@ -498,6 +592,15 @@ pub enum ChainClientError {
 
     #[error("Blobs not found: {0:?}")]
     BlobsNotFound(Vec<BlobId>),
+
+    #[error(
+        "Failed to download certificates and update local node to the next height \
+         {target_next_block_height} of chain {chain_id:?}"
+    )]
+    CannotDownloadCertificates {
+        chain_id: ChainId,
+        target_next_block_height: BlockHeight,
+    },
 }
 
 impl From<Infallible> for ChainClientError {
@@ -903,7 +1006,7 @@ where
     // Verifies that our local storage contains enough history compared to the
     // expected block height. Otherwise, downloads the missing history from the
     // network.
-    async fn synchronize_until(
+    pub async fn synchronize_until(
         &self,
         next_block_height: BlockHeight,
     ) -> Result<Box<ChainInfo>, ChainClientError> {

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use linera_base::{
-    data_types::{ArithmeticError, Blob, BlockHeight, UserApplicationDescription},
+    data_types::{ArithmeticError, Blob, UserApplicationDescription},
     identifiers::{BlobId, ChainId, MessageId, UserApplicationId},
 };
 use linera_chain::{
@@ -20,16 +20,14 @@ use linera_chain::{
 use linera_execution::{ExecutionError, Query, Response, SystemExecutionError};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
-use rand::{prelude::SliceRandom, thread_rng};
 use thiserror::Error;
 use tokio::sync::OwnedRwLockReadGuard;
 use tracing::{instrument, warn};
 
 use crate::{
     data_types::{BlockHeightRange, ChainInfo, ChainInfoQuery, ChainInfoResponse},
-    node::{NodeError, ValidatorNode},
+    node::NodeError,
     notifier::Notifier,
-    remote_node::RemoteNode,
     worker::{WorkerError, WorkerState},
 };
 
@@ -62,15 +60,6 @@ pub enum LocalNodeError {
     #[error("Local node operation failed: {0}")]
     WorkerError(#[from] WorkerError),
 
-    #[error(
-        "Failed to download certificates and update local node to the next height \
-         {target_next_block_height} of chain {chain_id:?}"
-    )]
-    CannotDownloadCertificates {
-        chain_id: ChainId,
-        target_next_block_height: BlockHeight,
-    },
-
     #[error("Failed to read blob {blob_id:?} of chain {chain_id:?}")]
     CannotReadLocalBlob { chain_id: ChainId, blob_id: BlobId },
 
@@ -79,9 +68,6 @@ pub enum LocalNodeError {
 
     #[error("The chain info response received from the local node is invalid")]
     InvalidChainInfoResponse,
-
-    #[error(transparent)]
-    NodeError(#[from] NodeError),
 }
 
 impl LocalNodeError {
@@ -105,10 +91,6 @@ impl LocalNodeError {
             LocalNodeError::WorkerError(WorkerError::BlobsNotFound(blob_ids)) => {
                 Some(blob_ids.clone())
             }
-            LocalNodeError::NodeError(NodeError::BlobNotFoundOnRead(blob_id)) => {
-                Some(vec![*blob_id])
-            }
-            LocalNodeError::NodeError(NodeError::BlobsNotFound(blob_ids)) => Some(blob_ids.clone()),
             _ => None,
         }
     }
@@ -269,55 +251,6 @@ where
         Ok(found_blobs)
     }
 
-    #[instrument(level = "trace", skip_all)]
-    pub async fn try_process_certificates(
-        &self,
-        remote_node: &RemoteNode<impl ValidatorNode>,
-        chain_id: ChainId,
-        certificates: Vec<Certificate>,
-        notifier: &impl Notifier,
-    ) -> Option<Box<ChainInfo>> {
-        let mut info = None;
-        for certificate in certificates {
-            let hash = certificate.hash();
-            if !certificate.value().is_confirmed() || certificate.value().chain_id() != chain_id {
-                // The certificate is not as expected. Give up.
-                warn!("Failed to process network certificate {}", hash);
-                return info;
-            }
-            let mut result = self
-                .handle_certificate(certificate.clone(), vec![], notifier)
-                .await;
-
-            result = match &result {
-                Err(err) => {
-                    if let Some(blob_ids) = err.get_blobs_not_found() {
-                        let blobs = remote_node.try_download_blobs(blob_ids.as_slice()).await;
-                        if blobs.len() != blob_ids.len() {
-                            result
-                        } else {
-                            self.handle_certificate(certificate, blobs, notifier).await
-                        }
-                    } else {
-                        result
-                    }
-                }
-                _ => result,
-            };
-
-            match result {
-                Ok(response) => info = Some(response.info),
-                Err(error) => {
-                    // The certificate is not as expected. Give up.
-                    warn!("Failed to process network certificate {}: {}", hash, error);
-                    return info;
-                }
-            };
-        }
-        // Done with all certificates.
-        info
-    }
-
     /// Returns a read-only view of the [`ChainStateView`] of a chain referenced by its
     /// [`ChainId`].
     ///
@@ -364,43 +297,6 @@ where
         Ok(response)
     }
 
-    /// Downloads and processes all certificates up to (excluding) the specified height.
-    #[instrument(level = "trace", skip(self, validators, notifier))]
-    pub async fn download_certificates(
-        &self,
-        validators: &[RemoteNode<impl ValidatorNode>],
-        chain_id: ChainId,
-        target_next_block_height: BlockHeight,
-        notifier: &impl Notifier,
-    ) -> Result<Box<ChainInfo>, LocalNodeError> {
-        // Sequentially try each validator in random order.
-        let mut validators = validators.iter().collect::<Vec<_>>();
-        validators.shuffle(&mut thread_rng());
-        for remote_node in validators {
-            let info = self.local_chain_info(chain_id).await?;
-            if target_next_block_height <= info.next_block_height {
-                return Ok(info);
-            }
-            self.try_download_certificates_from(
-                remote_node,
-                chain_id,
-                info.next_block_height,
-                target_next_block_height,
-                notifier,
-            )
-            .await?;
-        }
-        let info = self.local_chain_info(chain_id).await?;
-        if target_next_block_height <= info.next_block_height {
-            Ok(info)
-        } else {
-            Err(LocalNodeError::CannotDownloadCertificates {
-                chain_id,
-                target_next_block_height,
-            })
-        }
-    }
-
     /// Obtains the certificate containing the specified message.
     #[instrument(level = "trace", skip(self))]
     pub async fn certificate_for(
@@ -421,41 +317,6 @@ where
                 ViewError::not_found("could not find certificate with message {}", message_id)
             })?;
         Ok(certificate)
-    }
-
-    /// Downloads and processes all certificates up to (excluding) the specified height from the
-    /// given validator.
-    #[instrument(level = "trace", skip_all)]
-    async fn try_download_certificates_from(
-        &self,
-        remote_node: &RemoteNode<impl ValidatorNode>,
-        chain_id: ChainId,
-        mut start: BlockHeight,
-        stop: BlockHeight,
-        notifier: &impl Notifier,
-    ) -> Result<(), LocalNodeError> {
-        while start < stop {
-            // TODO(#2045): Analyze network errors instead of guessing the batch size.
-            let limit = u64::from(stop)
-                .checked_sub(u64::from(start))
-                .ok_or(ArithmeticError::Overflow)?
-                .min(1000);
-            let Some(certificates) = remote_node
-                .try_query_certificates_from(chain_id, start, limit)
-                .await?
-            else {
-                break;
-            };
-            let Some(info) = self
-                .try_process_certificates(remote_node, chain_id, certificates, notifier)
-                .await
-            else {
-                break;
-            };
-            assert!(info.next_block_height > start);
-            start = info.next_block_height;
-        }
-        Ok(())
     }
 
     /// Handles any pending local cross-chain requests.

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -5,10 +5,7 @@
 #![recursion_limit = "256"]
 #![deny(clippy::large_futures)]
 
-use std::{
-    borrow::Cow, collections::HashMap, env, num::NonZeroUsize, path::PathBuf, sync::Arc,
-    time::Instant,
-};
+use std::{borrow::Cow, collections::HashMap, env, path::PathBuf, sync::Arc, time::Instant};
 
 use anyhow::{anyhow, bail, ensure, Context};
 use async_trait::async_trait;
@@ -34,10 +31,9 @@ use linera_client::{
 use linera_core::{
     client,
     data_types::{ChainInfoQuery, ClientOutcome},
-    local_node::LocalNodeClient,
     node::{CrossChainMessageDelivery, ValidatorNodeProvider},
     remote_node::RemoteNode,
-    worker::{Reason, WorkerState},
+    worker::Reason,
     JoinSetExt as _,
 };
 use linera_execution::{
@@ -1152,33 +1148,31 @@ impl Job {
     where
         S: Storage + Clone + Send + Sync + 'static,
     {
-        let state = WorkerState::new(
-            "Local node".to_string(),
-            None,
-            storage.clone(),
-            NonZeroUsize::new(10).expect("Chain worker limit should not be zero"),
-        )
-        .with_tracked_chains([message_id.chain_id, chain_id])
-        .with_allow_inactive_chains(true)
-        .with_allow_messages_from_deprecated_epochs(true);
-        let node_client = LocalNodeClient::new(state);
+        let node_provider = context.make_node_provider();
+        let client = client::Client::new(
+            node_provider,
+            storage,
+            100,
+            CrossChainMessageDelivery::Blocking,
+            false,
+            vec![message_id.chain_id, chain_id],
+            "Temporary client for fetching the parent chain",
+        );
 
         // Take the latest committee we know of.
         let admin_chain_id = context.wallet.genesis_admin_chain();
         let query = ChainInfoQuery::new(admin_chain_id).with_committees();
         let nodes: Vec<_> = if let Some(validators) = validators {
-            context
-                .make_node_provider()
+            node_provider
                 .make_nodes_from_list(validators)?
                 .map(|(name, node)| RemoteNode { name, node })
                 .collect()
         } else {
-            let info = node_client.handle_chain_info_query(query).await?;
+            let info = client.local_node().handle_chain_info_query(query).await?;
             let committee = info
                 .latest_committee()
                 .context("Invalid chain info response; missing latest committee")?;
-            context
-                .make_node_provider()
+            node_provider
                 .make_nodes(committee)?
                 .map(|(name, node)| RemoteNode { name, node })
                 .collect()
@@ -1186,21 +1180,14 @@ impl Job {
 
         // Download the parent chain.
         let target_height = message_id.height.try_add_one()?;
-        client::Client::new(
-            context.make_node_provider(),
-            storage,
-            1,
-            CrossChainMessageDelivery::NonBlocking,
-            false,
-            vec![message_id.chain_id, chain_id],
-            "Temporary client for fetching the parent chain",
-        )
-        .download_certificates(&nodes, message_id.chain_id, target_height)
-        .await
-        .context("Failed to download parent chain")?;
+        client
+            .download_certificates(&nodes, message_id.chain_id, target_height)
+            .await
+            .context("Failed to download parent chain")?;
 
         // The initial timestamp for the new chain is taken from the block with the message.
-        let certificate = node_client
+        let certificate = client
+            .local_node()
             .certificate_for(&message_id)
             .await
             .context("could not find OpenChain message")?;


### PR DESCRIPTION
## Motivation

Some methods of `LocalNode` use `RemoteNode` (and some don't even use `LocalNode` itself). The fact that there is a `LocalNodeError::NodeError` shows that these don't belong into that module at all.

## Proposal

Move functions that only use the remote node to `RemoteNode`. Move functions that use both the remote and the local node to `Client`. Remove `LocalNodeError::NodeError`.

(Further cleanups to distinguish between local and remote errors, especially in `communicate_with_quorum`, will be done in a follow-up PR.)

## Test Plan

This is only a refactoring, so CI should catch any regressions.

## Release Plan


- Nothing to do / These changes follow the usual release cycle.
- We _could_ backport these to devnet and testnet, to facilitate any future backports.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
