### PR TITLE
Correct 2828 issue.

### DIFF
--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -586,7 +586,7 @@ pub enum RocksDbStoreInternalError {
     AlreadyExistingDatabase,
 
     /// Filesystem error
-    #[error("Filesystem error")]
+    #[error("Filesystem error: {0}")]
     FsError(#[from] std::io::Error),
 
     /// BCS serialization error.

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -23,7 +23,7 @@ use crate::{
 #[derive(Error, Debug)]
 pub enum ValueSplittingError<E> {
     /// inner store error
-    #[error("inner store error")]
+    #[error(transparent)]
     InnerStoreError(#[from] E),
 
     /// The key is of length less than 4, so we cannot extract the first byte


### PR DESCRIPTION
## Motivation

Issue #2828 is addressed here and only that issue.

## Proposal

Two changes are needed:
* Having `#[error(transparent)]. An alternative would have been `#[error("Inner store error: {0}")]`.
* Precising the `FilesystemError`.

There are other possibilities of improvement of the error handling, but this is for further PRs.

## Test Plan

The CI is just what we need.

## Release Plan

I think this kind of correction is useful for TestNet / DevNet operators.

## Links

None.