### PR TITLE
Don't use glob imports for fieldless enums

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -819,10 +819,9 @@ impl MessageBundle {
 
 impl PostedMessage {
     pub fn is_skippable(&self) -> bool {
-        use MessageKind::*;
         match self.kind {
-            Protected | Tracked => false,
-            Simple | Bouncing => self.grant == Amount::ZERO,
+            MessageKind::Protected | MessageKind::Tracked => false,
+            MessageKind::Simple | MessageKind::Bouncing => self.grant == Amount::ZERO,
         }
     }
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -949,13 +949,12 @@ pub enum ResourceControlPolicyConfig {
 
 impl ResourceControlPolicyConfig {
     pub fn into_policy(self) -> ResourceControlPolicy {
-        use ResourceControlPolicyConfig::*;
         match self {
-            Default => ResourceControlPolicy::default(),
-            OnlyFuel => ResourceControlPolicy::only_fuel(),
-            FuelAndBlock => ResourceControlPolicy::fuel_and_block(),
-            AllCategories => ResourceControlPolicy::all_categories(),
-            Devnet => ResourceControlPolicy::devnet(),
+            ResourceControlPolicyConfig::Default => ResourceControlPolicy::default(),
+            ResourceControlPolicyConfig::OnlyFuel => ResourceControlPolicy::only_fuel(),
+            ResourceControlPolicyConfig::FuelAndBlock => ResourceControlPolicy::fuel_and_block(),
+            ResourceControlPolicyConfig::AllCategories => ResourceControlPolicy::all_categories(),
+            ResourceControlPolicyConfig::Devnet => ResourceControlPolicy::devnet(),
         }
     }
 }

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -241,10 +241,9 @@ impl CrossChainMessageDelivery {
     }
 
     pub fn wait_for_outgoing_messages(self) -> bool {
-        use CrossChainMessageDelivery::*;
         match self {
-            NonBlocking => false,
-            Blocking => true,
+            CrossChainMessageDelivery::NonBlocking => false,
+            CrossChainMessageDelivery::Blocking => true,
         }
     }
 }


### PR DESCRIPTION
## Motivation

For fieldless enums, if we use glob imports before a match statement, and then remove one of the enum variants, that removed enum variant silently becomes a catch all in the match statement.
The compiler shows no errors for it.

## Proposal

Stop using glob imports for fieldless enums. Now removing a variant should cause a compilation error for these, as expected.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
