### PR TITLE
Unify HashedCertificateValue with Hashed<T>

### DIFF
--- a/linera-chain/src/certificate.rs
+++ b/linera-chain/src/certificate.rs
@@ -206,11 +206,10 @@ impl From<TimeoutCertificate> for Certificate {
     }
 }
 
-// In practice, it should be HashedCertificateValue = Hashed<CertificateValue>
-// but [`HashedCertificateValue`] is used in too many places to change it now.
 /// Wrapper type around hashed instance of `T` type.
 pub struct Hashed<T> {
     value: T,
+    /// Hash of the value (used as key for storage).
     hash: CryptoHash,
 }
 


### PR DESCRIPTION
## Motivation

In the process of adding separate types to discriminate between various types of certificate we have, a new generic type was introduct - `Hashed<T>`. That type had the same structure as already-existing `HashedCertificateValue` but it was generic of a value type it holds. This duplication was unnecessary.

<!--
Briefly describe the goal(s) of this PR.
-->

## Proposal

Replace a `struct HashedCertificateValue` with a type alias `type HashedCertificateValue = Hashed<CertificateValue>`

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

CI should catch any regressions.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.

## Links

Closes #2842 

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
