### PR TITLE
Switch position of expect statement for metrics.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1221,7 +1221,6 @@ static BYTECODE_COMPRESSION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
             1.0, 2.5, 5.0, 10.0,
         ]),
     )
-    .expect("Histogram creation should not fail")
 });
 
 /// The time it takes to decompress a bytecode.
@@ -1236,7 +1235,6 @@ static BYTECODE_DECOMPRESSION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(||
             1.0, 2.5, 5.0, 10.0,
         ]),
     )
-    .expect("Histogram creation should not fail")
 });
 
 #[cfg(test)]

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -4,8 +4,8 @@
 //! This module defines util functions for interacting with Prometheus (logging metrics, etc)
 
 use prometheus::{
-    histogram_opts, register_histogram_vec, register_int_counter_vec, Error, HistogramVec,
-    IntCounterVec, Opts,
+    histogram_opts, register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounterVec,
+    Opts,
 };
 
 use crate::time::Instant;
@@ -17,9 +17,9 @@ pub fn register_int_counter_vec(
     name: &str,
     description: &str,
     label_names: &[&str],
-) -> Result<IntCounterVec, Error> {
+) -> IntCounterVec {
     let counter_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
-    register_int_counter_vec!(counter_opts, label_names)
+    register_int_counter_vec!(counter_opts, label_names).expect("IntCounter can be created")
 }
 
 /// Wrapper arount prometheus register_histogram_vec! macro which also sets the linera namespace
@@ -28,14 +28,14 @@ pub fn register_histogram_vec(
     description: &str,
     label_names: &[&str],
     buckets: Option<Vec<f64>>,
-) -> Result<HistogramVec, Error> {
+) -> HistogramVec {
     let histogram_opts = if let Some(buckets) = buckets {
         histogram_opts!(name, description, buckets).namespace(LINERA_NAMESPACE)
     } else {
         histogram_opts!(name, description).namespace(LINERA_NAMESPACE)
     };
 
-    register_histogram_vec!(histogram_opts, label_names)
+    register_histogram_vec!(histogram_opts, label_names).expect("Histogram can be created")
 }
 
 /// A guard for an active latency measurement.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -66,7 +66,6 @@ static NUM_BLOCKS_EXECUTED: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "Number of blocks executed",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -80,7 +79,6 @@ static BLOCK_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
             1.0, 2.5, 5.0, 10.0, 25.0, 50.0,
         ]),
     )
-    .expect("Histogram creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -94,7 +92,6 @@ static MESSAGE_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
             1.0, 2.5,
         ]),
     )
-    .expect("Histogram creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -108,7 +105,6 @@ static OPERATION_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
             1.0, 2.5,
         ]),
     )
-    .expect("Histogram creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -122,7 +118,6 @@ static WASM_FUEL_USED_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
             100_000.0, 250_000.0, 500_000.0,
         ]),
     )
-    .expect("Histogram creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -133,7 +128,6 @@ static WASM_NUM_READS_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
         &[],
         Some(vec![0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0, 50.0, 100.0]),
     )
-    .expect("Histogram creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -160,7 +154,6 @@ static WASM_BYTES_READ_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
             8_388_608.0,
         ]),
     )
-    .expect("Histogram creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -187,7 +180,6 @@ static WASM_BYTES_WRITTEN_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
             8_388_608.0,
         ]),
     )
-    .expect("Histogram creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -200,7 +192,6 @@ static STATE_HASH_COMPUTATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(||
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Histogram can be created")
 });
 
 /// The BCS-serialized size of an empty `ExecutedBlock`.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -101,7 +101,6 @@ mod metrics {
                     25.0, 50.0, 100.0, 250.0, 500.0,
                 ]),
             )
-            .expect("Histogram creation should not fail")
         });
 
     pub static PREPARE_CHAIN_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
@@ -114,7 +113,6 @@ mod metrics {
                 25.0, 50.0, 100.0, 250.0, 500.0,
             ]),
         )
-        .expect("Histogram creation should not fail")
     });
 
     pub static SYNCHRONIZE_CHAIN_STATE_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
@@ -127,7 +125,6 @@ mod metrics {
                 25.0, 50.0, 100.0, 250.0, 500.0,
             ]),
         )
-        .expect("Histogram creation should not fail")
     });
 
     pub static EXECUTE_BLOCK_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
@@ -140,7 +137,6 @@ mod metrics {
                 25.0, 50.0, 100.0, 250.0, 500.0,
             ]),
         )
-        .expect("Histogram creation should not fail")
     });
 
     pub static FIND_RECEIVED_CERTIFICATES_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
@@ -153,7 +149,6 @@ mod metrics {
                 25.0, 50.0, 100.0, 250.0, 500.0,
             ]),
         )
-        .expect("Histogram creation should not fail")
     });
 }
 

--- a/linera-core/src/value_cache.rs
+++ b/linera-core/src/value_cache.rs
@@ -31,7 +31,6 @@ static CACHE_HIT_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "Cache hits in `ValueCache`",
         &["key_type", "value_type"],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// A counter metric for the number of cache misses in the [`ValueCache`].
@@ -42,7 +41,6 @@ static CACHE_MISS_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "Cache misses in `ValueCache`",
         &["key_type", "value_type"],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// A least-recently used cache of a value.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -63,7 +63,6 @@ static NUM_ROUNDS_IN_CERTIFICATE: LazyLock<HistogramVec> = LazyLock::new(|| {
             0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 10.0, 15.0, 25.0, 50.0,
         ]),
     )
-    .expect("Counter creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -76,19 +75,16 @@ static NUM_ROUNDS_IN_BLOCK_PROPOSAL: LazyLock<HistogramVec> = LazyLock::new(|| {
             0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 10.0, 15.0, 25.0, 50.0,
         ]),
     )
-    .expect("Counter creation should not fail")
 });
 
 #[cfg(with_metrics)]
 static TRANSACTION_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
     prometheus_util::register_int_counter_vec("transaction_count", "Transaction count", &[])
-        .expect("Counter creation should not fail")
 });
 
 #[cfg(with_metrics)]
 static NUM_BLOCKS: LazyLock<IntCounterVec> = LazyLock::new(|| {
     prometheus_util::register_int_counter_vec("num_blocks", "Number of blocks added to chains", &[])
-        .expect("Counter creation should not fail")
 });
 
 /// Instruct the networking layer to send cross-chain requests and/or push notifications.

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -41,7 +41,6 @@ static LOAD_CONTRACT_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
             100.0, 250.0,
         ]),
     )
-    .expect("Histogram creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -56,7 +55,6 @@ static LOAD_SERVICE_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
             100.0, 250.0,
         ]),
     )
-    .expect("Histogram creation should not fail")
 });
 
 pub(crate) type ExecutionStateSender = mpsc::UnboundedSender<ExecutionRequest>;

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -59,7 +59,6 @@ static OPEN_CHAIN_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "The number of times the `OpenChain` operation was executed",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// A view accessing the execution state of the system of a chain.

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -53,7 +53,6 @@ static CONTRACT_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(||
             0.000_1, 0.000_3, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
         ]),
     )
-    .expect("Histogram creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -66,7 +65,6 @@ static SERVICE_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| 
             0.000_1, 0.000_3, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
         ]),
     )
-    .expect("Histogram creation should not fail")
 });
 
 /// A user contract in a compiled WebAssembly module.

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -61,13 +61,11 @@ static SERVER_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         &[],
         Some(vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0]),
     )
-    .expect("Counter creation should not fail")
 });
 
 #[cfg(with_metrics)]
 static SERVER_REQUEST_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
     prometheus_util::register_int_counter_vec("server_request_count", "Server request count", &[])
-        .expect("Counter creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -77,7 +75,6 @@ static SERVER_REQUEST_SUCCESS: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "Server request success",
         &["method_name"],
     )
-    .expect("Counter creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -87,7 +84,6 @@ static SERVER_REQUEST_ERROR: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "Server request error",
         &["method_name"],
     )
-    .expect("Counter creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -98,7 +94,6 @@ static SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE: LazyLock<HistogramVec> = LazyLoc
         &["method_name"],
         Some(vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0]),
     )
-    .expect("Counter creation should not fail")
 });
 
 #[derive(Clone)]

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -72,13 +72,11 @@ static PROXY_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
             50.0, 100.0, 200.0, 300.0, 400.0,
         ]),
     )
-    .expect("Counter creation should not fail")
 });
 
 #[cfg(with_metrics)]
 static PROXY_REQUEST_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
     prometheus_util::register_int_counter_vec("proxy_request_count", "Proxy request count", &[])
-        .expect("Counter creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -88,7 +86,6 @@ static PROXY_REQUEST_SUCCESS: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "Proxy request success",
         &["method_name"],
     )
-    .expect("Counter creation should not fail")
 });
 
 #[cfg(with_metrics)]
@@ -98,7 +95,6 @@ static PROXY_REQUEST_ERROR: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "Proxy request error",
         &["method_name"],
     )
-    .expect("Counter creation should not fail")
 });
 
 #[derive(Clone)]

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -50,7 +50,6 @@ static CONTAINS_HASHED_CERTIFICATE_VALUE_COUNTER: LazyLock<IntCounterVec> = Lazy
         "The metric counting how often a hashed certificate value is tested for existence from storage",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often a blob is tested for existence from storage
@@ -61,7 +60,6 @@ static CONTAINS_BLOB_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "The metric counting how often a blob is tested for existence from storage",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often multiple blobs are tested for existence from storage
@@ -72,7 +70,6 @@ static CONTAINS_BLOBS_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "The metric counting how often multiple blobs are tested for existence from storage",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often a blob state is tested for existence from storage
@@ -83,7 +80,6 @@ static CONTAINS_BLOB_STATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "The metric counting how often a blob state is tested for existence from storage",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often a certificate is tested for existence from storage.
@@ -94,7 +90,6 @@ static CONTAINS_CERTIFICATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| 
         "The metric counting how often a certificate is tested for existence from storage",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often a hashed certificate value is read from storage.
@@ -106,7 +101,6 @@ pub static READ_HASHED_CERTIFICATE_VALUE_COUNTER: LazyLock<IntCounterVec> = Lazy
         "The metric counting how often a hashed certificate value is read from storage",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often a blob is read from storage.
@@ -118,7 +112,6 @@ pub static READ_BLOB_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "The metric counting how often a blob is read from storage",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often a blob state is read from storage.
@@ -130,7 +123,6 @@ pub static READ_BLOB_STATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "The metric counting how often a blob state is read from storage",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often blob states are read from storage.
@@ -142,7 +134,6 @@ pub static READ_BLOB_STATES_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| 
         "The metric counting how often blob states are read from storage",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often a hashed certificate value is written to storage.
@@ -154,7 +145,6 @@ pub static WRITE_HASHED_CERTIFICATE_VALUE_COUNTER: LazyLock<IntCounterVec> = Laz
         "The metric counting how often a hashed certificate value is written to storage",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often a blob is written to storage.
@@ -166,7 +156,6 @@ pub static WRITE_BLOB_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "The metric counting how often a blob is written to storage",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often a certificate is read from storage.
@@ -178,7 +167,6 @@ pub static READ_CERTIFICATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| 
         "The metric counting how often a certificate is read from storage",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often certificates are read from storage.
@@ -190,7 +178,6 @@ pub static READ_CERTIFICATES_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(||
         "The metric counting how often certificate are read from storage",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often a certificate is written to storage.
@@ -202,7 +189,6 @@ pub static WRITE_CERTIFICATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(||
         "The metric counting how often a certificate is written to storage",
         &[],
     )
-    .expect("Counter creation should not fail")
 });
 
 /// The latency to load a chain state.
@@ -217,7 +203,6 @@ pub static LOAD_CHAIN_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
             0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
         ]),
     )
-    .expect("Histogram creation should not fail")
 });
 
 /// Main implementation of the [`Storage`] trait.

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -29,14 +29,12 @@ use crate::{
 /// The total number of cache faults
 static NUM_CACHE_FAULT: LazyLock<IntCounterVec> = LazyLock::new(|| {
     prometheus_util::register_int_counter_vec("num_cache_fault", "Number of cache faults", &[])
-        .expect("Counter creation should not fail")
 });
 
 #[cfg(with_metrics)]
 /// The total number of cache successes
 static NUM_CACHE_SUCCESS: LazyLock<IntCounterVec> = LazyLock::new(|| {
     prometheus_util::register_int_counter_vec("num_cache_success", "Number of cache success", &[])
-        .expect("Counter creation should not fail")
 });
 
 /// The `LruPrefixCache` stores the data for simple `read_values` queries

--- a/linera-views/src/backends/metering.rs
+++ b/linera-views/src/backends/metering.rs
@@ -82,63 +82,52 @@ impl KeyValueStoreMetrics {
         let read_value_bytes1 = format!("{}_read_value_bytes_latency", var_name);
         let read_value_bytes2 = format!("{} read value bytes latency", title_name);
         let read_value_bytes =
-            register_histogram_vec(&read_value_bytes1, &read_value_bytes2, &[], None)
-                .expect("Counter creation should not fail");
+            register_histogram_vec(&read_value_bytes1, &read_value_bytes2, &[], None);
 
         let contains_key1 = format!("{}_contains_key_latency", var_name);
         let contains_key2 = format!("{} contains key latency", title_name);
-        let contains_key = register_histogram_vec(&contains_key1, &contains_key2, &[], None)
-            .expect("Counter creation should not fail");
+        let contains_key = register_histogram_vec(&contains_key1, &contains_key2, &[], None);
 
         let contains_keys1 = format!("{}_contains_keys_latency", var_name);
         let contains_keys2 = format!("{} contains keys latency", title_name);
-        let contains_keys = register_histogram_vec(&contains_keys1, &contains_keys2, &[], None)
-            .expect("Counter creation should not fail");
+        let contains_keys = register_histogram_vec(&contains_keys1, &contains_keys2, &[], None);
 
         let read_multi_values1 = format!("{}_read_multi_value_bytes_latency", var_name);
         let read_multi_values2 = format!("{} read multi value bytes latency", title_name);
         let read_multi_values_bytes =
-            register_histogram_vec(&read_multi_values1, &read_multi_values2, &[], None)
-                .expect("Counter creation should not fail");
+            register_histogram_vec(&read_multi_values1, &read_multi_values2, &[], None);
 
         let find_keys1 = format!("{}_find_keys_by_prefix_latency", var_name);
         let find_keys2 = format!("{} find keys by prefix latency", title_name);
-        let find_keys_by_prefix = register_histogram_vec(&find_keys1, &find_keys2, &[], None)
-            .expect("Counter creation should not fail");
+        let find_keys_by_prefix = register_histogram_vec(&find_keys1, &find_keys2, &[], None);
 
         let find_key_values1 = format!("{}_find_key_values_by_prefix_latency", var_name);
         let find_key_values2 = format!("{} find key values by prefix latency", title_name);
         let find_key_values_by_prefix =
-            register_histogram_vec(&find_key_values1, &find_key_values2, &[], None)
-                .expect("Counter creation should not fail");
+            register_histogram_vec(&find_key_values1, &find_key_values2, &[], None);
 
         let write_batch1 = format!("{}_write_batch_latency", var_name);
         let write_batch2 = format!("{} write batch latency", title_name);
-        let write_batch = register_histogram_vec(&write_batch1, &write_batch2, &[], None)
-            .expect("Counter creation should not fail");
+        let write_batch = register_histogram_vec(&write_batch1, &write_batch2, &[], None);
 
         let clear_journal1 = format!("{}_clear_journal_latency", var_name);
         let clear_journal2 = format!("{} clear journal latency", title_name);
-        let clear_journal = register_histogram_vec(&clear_journal1, &clear_journal2, &[], None)
-            .expect("Counter creation should not fail");
+        let clear_journal = register_histogram_vec(&clear_journal1, &clear_journal2, &[], None);
 
         let read_value_none_cases1 = format!("{}_read_value_number_none_cases", var_name);
         let read_value_none_cases2 = format!("{} read value number none cases", title_name);
         let read_value_none_cases =
-            register_int_counter_vec(&read_value_none_cases1, &read_value_none_cases2, &[])
-                .expect("Counter creation should not fail");
+            register_int_counter_vec(&read_value_none_cases1, &read_value_none_cases2, &[]);
 
         let read_value_key_size1 = format!("{}_read_value_key_size", var_name);
         let read_value_key_size2 = format!("{} read value key size", title_name);
         let read_value_key_size =
-            register_histogram_vec(&read_value_key_size1, &read_value_key_size2, &[], None)
-                .expect("Counter creation should not fail");
+            register_histogram_vec(&read_value_key_size1, &read_value_key_size2, &[], None);
 
         let read_value_value_size1 = format!("{}_read_value_value_size", var_name);
         let read_value_value_size2 = format!("{} read value value size", title_name);
         let read_value_value_size =
-            register_histogram_vec(&read_value_value_size1, &read_value_value_size2, &[], None)
-                .expect("Counter creation should not fail");
+            register_histogram_vec(&read_value_value_size1, &read_value_value_size2, &[], None);
 
         let read_multi_values_num_entries1 = format!("{}_read_multi_values_num_entries", var_name);
         let read_multi_values_num_entries2 =
@@ -148,8 +137,7 @@ impl KeyValueStoreMetrics {
             &read_multi_values_num_entries2,
             &[],
             None,
-        )
-        .expect("Counter creation should not fail");
+        );
 
         let read_multi_values_key_sizes1 = format!("{}_read_multi_values_key_sizes", var_name);
         let read_multi_values_key_sizes2 = format!("{} read multi values key sizes", title_name);
@@ -158,8 +146,7 @@ impl KeyValueStoreMetrics {
             &read_multi_values_key_sizes2,
             &[],
             None,
-        )
-        .expect("Counter creation should not fail");
+        );
 
         let contains_keys_num_entries1 = format!("{}_contains_keys_num_entries", var_name);
         let contains_keys_num_entries2 = format!("{} contains keys num entries", title_name);
@@ -168,8 +155,7 @@ impl KeyValueStoreMetrics {
             &contains_keys_num_entries2,
             &[],
             None,
-        )
-        .expect("Counter creation should not fail");
+        );
 
         let contains_keys_key_sizes1 = format!("{}_contains_keys_key_sizes", var_name);
         let contains_keys_key_sizes2 = format!("{} contains keys key sizes", title_name);
@@ -178,14 +164,12 @@ impl KeyValueStoreMetrics {
             &contains_keys_key_sizes2,
             &[],
             None,
-        )
-        .expect("Counter creation should not fail");
+        );
 
         let contains_key_key_size1 = format!("{}_contains_key_key_size", var_name);
         let contains_key_key_size2 = format!("{} contains key key size", title_name);
         let contains_key_key_size =
-            register_histogram_vec(&contains_key_key_size1, &contains_key_key_size2, &[], None)
-                .expect("Counter creation should not fail");
+            register_histogram_vec(&contains_key_key_size1, &contains_key_key_size2, &[], None);
 
         let find_keys_by_prefix_prefix_size1 =
             format!("{}_find_keys_by_prefix_prefix_size", var_name);
@@ -196,8 +180,7 @@ impl KeyValueStoreMetrics {
             &find_keys_by_prefix_prefix_size2,
             &[],
             None,
-        )
-        .expect("Counter creation should not fail");
+        );
 
         let find_keys_by_prefix_num_keys1 = format!("{}_find_keys_by_prefix_num_keys", var_name);
         let find_keys_by_prefix_num_keys2 = format!("{} find keys by prefix num keys", title_name);
@@ -206,8 +189,7 @@ impl KeyValueStoreMetrics {
             &find_keys_by_prefix_num_keys2,
             &[],
             None,
-        )
-        .expect("Counter creation should not fail");
+        );
 
         let find_keys_by_prefix_keys_size1 = format!("{}_find_keys_by_prefix_keys_size", var_name);
         let find_keys_by_prefix_keys_size2 =
@@ -217,8 +199,7 @@ impl KeyValueStoreMetrics {
             &find_keys_by_prefix_keys_size2,
             &[],
             None,
-        )
-        .expect("Counter creation should not fail");
+        );
 
         let find_key_values_by_prefix_prefix_size1 =
             format!("{}_find_key_values_by_prefix_prefix_size", var_name);
@@ -229,8 +210,7 @@ impl KeyValueStoreMetrics {
             &find_key_values_by_prefix_prefix_size2,
             &[],
             None,
-        )
-        .expect("Counter creation should not fail");
+        );
 
         let find_key_values_by_prefix_num_keys1 =
             format!("{}_find_key_values_by_prefix_num_keys", var_name);
@@ -241,8 +221,7 @@ impl KeyValueStoreMetrics {
             &find_key_values_by_prefix_num_keys2,
             &[],
             None,
-        )
-        .expect("Counter creation should not fail");
+        );
 
         let find_key_values_by_prefix_key_values_size1 =
             format!("{}_find_key_values_by_prefix_key_values_size", var_name);
@@ -253,14 +232,12 @@ impl KeyValueStoreMetrics {
             &find_key_values_by_prefix_key_values_size2,
             &[],
             None,
-        )
-        .expect("Counter creation should not fail");
+        );
 
         let write_batch_size1 = format!("{}_write_batch_size", var_name);
         let write_batch_size2 = format!("{} write batch size", title_name);
         let write_batch_size =
-            register_histogram_vec(&write_batch_size1, &write_batch_size2, &[], None)
-                .expect("Counter creation should not fail");
+            register_histogram_vec(&write_batch_size1, &write_batch_size2, &[], None);
 
         KeyValueStoreMetrics {
             read_value_bytes,

--- a/linera-views/src/metrics.rs
+++ b/linera-views/src/metrics.rs
@@ -26,7 +26,6 @@ pub static LOAD_VIEW_LATENCY: LazyLock<prometheus::HistogramVec> = LazyLock::new
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Load view latency should not fail")
 });
 
 /// The metric counting how often a view is read from storage.
@@ -37,7 +36,6 @@ pub static LOAD_VIEW_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "The metric counting how often a view is read from storage",
         &["type", "base_key"],
     )
-    .expect("Counter creation should not fail")
 });
 /// The metric counting how often a view is written from storage.
 #[doc(hidden)]
@@ -47,5 +45,4 @@ pub static SAVE_VIEW_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "The metric counting how often a view is written from storage",
         &["type", "base_key"],
     )
-    .expect("Counter creation should not fail")
 });

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -35,7 +35,6 @@ static BUCKET_QUEUE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(||
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Histogram can be created")
 });
 
 /// Key tags to create the sub-keys of a [`BucketQueueView`] on top of the base key.

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -41,7 +41,6 @@ static COLLECTION_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Histogram can be created")
 });
 
 /// A view that supports accessing a collection of views of the same kind, indexed by a

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -37,7 +37,6 @@ static KEY_VALUE_STORE_VIEW_HASH_LATENCY: LazyLock<HistogramVec> = LazyLock::new
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Histogram can be created")
 });
 
 #[cfg(with_metrics)]
@@ -51,7 +50,6 @@ static KEY_VALUE_STORE_VIEW_GET_LATENCY: LazyLock<HistogramVec> = LazyLock::new(
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Histogram can be created")
 });
 
 #[cfg(with_metrics)]
@@ -65,7 +63,6 @@ static KEY_VALUE_STORE_VIEW_MULTI_GET_LATENCY: LazyLock<HistogramVec> = LazyLock
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Histogram can be created")
 });
 
 #[cfg(with_metrics)]
@@ -79,7 +76,6 @@ static KEY_VALUE_STORE_VIEW_CONTAINS_KEY_LATENCY: LazyLock<HistogramVec> = LazyL
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Histogram can be created")
 });
 
 #[cfg(with_metrics)]
@@ -93,7 +89,6 @@ static KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_LATENCY: LazyLock<HistogramVec> = Lazy
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Histogram can be created")
 });
 
 #[cfg(with_metrics)]
@@ -108,7 +103,6 @@ static KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_LATENCY: LazyLock<HistogramVec> 
                 0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
             ]),
         )
-        .expect("Histogram can be created")
     });
 
 #[cfg(with_metrics)]
@@ -123,7 +117,6 @@ static KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_LATENCY: LazyLock<Histogra
                 0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
             ]),
         )
-        .expect("Histogram can be created")
     });
 
 #[cfg(with_metrics)]
@@ -137,7 +130,6 @@ static KEY_VALUE_STORE_VIEW_WRITE_BATCH_LATENCY: LazyLock<HistogramVec> = LazyLo
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Histogram can be created")
 });
 
 #[cfg(with_testing)]

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -35,7 +35,6 @@ static LOG_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Histogram can be created")
 });
 
 /// Key tags to create the sub-keys of a LogView on top of the base key.

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -36,7 +36,6 @@ static MAP_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Histogram can be created")
 });
 
 use std::{

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -36,7 +36,6 @@ static QUEUE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Histogram can be created")
 });
 
 /// Key tags to create the sub-keys of a QueueView on top of the base key.

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -42,7 +42,6 @@ static REENTRANT_COLLECTION_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Histogram can be created")
 });
 
 /// A read-only accessor for a particular subview in a [`ReentrantCollectionView`].

--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -32,7 +32,6 @@ static REGISTER_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Histogram can be created")
 });
 
 /// A view that supports modifying a single value of type `T`.

--- a/linera-views/src/views/set_view.rs
+++ b/linera-views/src/views/set_view.rs
@@ -33,7 +33,6 @@ static SET_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
         ]),
     )
-    .expect("Histogram can be created")
 });
 
 /// A [`View`] that supports inserting and removing values indexed by a key.


### PR DESCRIPTION
## Motivation

The creation of metrics is done via the use of metrics created by `LazyLock`. The error cases are never handled and instead the `expect` statement is used to unwrap.

## Proposal

Move the statements where they matter. This partially addresses issue #2795.

## Test Plan

Not relevant. We probably should have some metrics being tested in the CI.

## Release Plan

This should not change the use scenario for TestNet / DevNet.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
