### PR TITLE
Use standalone structs in CertificateValue enum

### DIFF
--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -15,6 +15,7 @@ version.workspace = true
 test = ["tokio/macros", "linera-base/test", "linera-execution/test"]
 metrics = ["prometheus", "linera-views/metrics", "linera-execution/metrics"]
 web = ["linera-base/web", "linera-views/web", "linera-execution/web"]
+benchmark = ["linera-base/test"]
 
 [dependencies]
 async-graphql.workspace = true

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -57,7 +57,13 @@ impl From<ConfirmedBlock> for HashedCertificateValue {
 impl BcsHashable for ConfirmedBlock {}
 
 impl ConfirmedBlock {
+    #[cfg(not(feature = "benchmark"))]
     pub(super) fn new(executed_block: ExecutedBlock) -> Self {
+        Self { executed_block }
+    }
+
+    #[cfg(feature = "benchmark")]
+    pub fn new(executed_block: ExecutedBlock) -> Self {
         Self { executed_block }
     }
 

--- a/linera-chain/src/certificate.rs
+++ b/linera-chain/src/certificate.rs
@@ -346,8 +346,8 @@ impl From<Certificate> for ValidatedBlockCertificate {
         let signatures = cert.signatures().clone();
         let hash = cert.value.hash();
         match cert.value.into_inner() {
-            CertificateValue::ValidatedBlock { executed_block } => Self {
-                value: Hashed::unchecked_new(ValidatedBlock::new(executed_block), hash),
+            CertificateValue::ValidatedBlock(validated) => Self {
+                value: Hashed::unchecked_new(validated, hash),
                 round: cert.round,
                 signatures,
             },
@@ -409,8 +409,8 @@ impl TryFrom<Certificate> for ConfirmedBlockCertificate {
         let signatures = cert.signatures().clone();
         let hash = cert.value.hash();
         match cert.value.into_inner() {
-            CertificateValue::ConfirmedBlock { executed_block } => Ok(Self {
-                value: Hashed::unchecked_new(ConfirmedBlock::new(executed_block), hash),
+            CertificateValue::ConfirmedBlock(confirmed) => Ok(Self {
+                value: Hashed::unchecked_new(confirmed, hash),
                 round: cert.round,
                 signatures,
             }),
@@ -424,12 +424,8 @@ impl From<Certificate> for TimeoutCertificate {
         let signatures = cert.signatures().clone();
         let hash = cert.value.hash();
         match cert.value.into_inner() {
-            CertificateValue::Timeout {
-                chain_id,
-                epoch,
-                height,
-            } => Self {
-                value: Hashed::unchecked_new(Timeout::new(chain_id, height, epoch), hash),
+            CertificateValue::Timeout(timeout) => Self {
+                value: Hashed::unchecked_new(timeout, hash),
                 round: cert.round,
                 signatures,
             },

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -342,15 +342,15 @@ impl ChainManager {
         let new_round = certificate.round;
         if let Some(Vote { value, round, .. }) = &self.pending {
             match value.inner() {
-                CertificateValue::ConfirmedBlock { executed_block } => {
-                    if &executed_block.block == new_block && *round == new_round {
+                CertificateValue::ConfirmedBlock(confirmed) => {
+                    if &confirmed.inner().block == new_block && *round == new_round {
                         return Ok(Outcome::Skip); // We already voted to confirm this block.
                     }
                 }
-                CertificateValue::ValidatedBlock { .. } => {
+                CertificateValue::ValidatedBlock(_) => {
                     ensure!(new_round >= *round, ChainError::InsufficientRound(*round))
                 }
-                CertificateValue::Timeout { .. } => {
+                CertificateValue::Timeout(_) => {
                     // Unreachable: We only put validated or confirmed blocks in pending.
                     return Err(ChainError::InternalError(
                         "pending can only be validated or confirmed block".to_string(),

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -205,11 +205,9 @@ where
 
         // Find the missing blobs locally and retry.
         let required = match certificate.value() {
-            CertificateValue::ConfirmedBlock { executed_block, .. }
-            | CertificateValue::ValidatedBlock { executed_block, .. } => {
-                executed_block.required_blob_ids()
-            }
-            CertificateValue::Timeout { .. } => HashSet::new(),
+            CertificateValue::ConfirmedBlock(confirmed) => confirmed.inner().required_blob_ids(),
+            CertificateValue::ValidatedBlock(validated) => validated.inner().required_blob_ids(),
+            CertificateValue::Timeout(_) => HashSet::new(),
         };
         for blob_id in missing_blob_ids {
             if !required.contains(blob_id) {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -15,6 +15,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{CertificateValue, IncomingBundle, Medium, MessageBundle, Origin, PostedMessage},
+    types::Timeout,
     ChainError, ChainExecutionContext,
 };
 use linera_execution::{
@@ -2012,11 +2013,7 @@ where
     let certificate = client.request_leader_timeout().await.unwrap();
     assert_eq!(
         *certificate.value(),
-        CertificateValue::Timeout {
-            chain_id,
-            height: BlockHeight::from(1),
-            epoch: Epoch::ZERO
-        }
+        CertificateValue::Timeout(Timeout::new(chain_id, BlockHeight::from(1), Epoch::ZERO))
     );
     assert_eq!(certificate.round, Round::SingleLeader(0));
 

--- a/linera-core/src/unit_tests/value_cache_tests.rs
+++ b/linera-core/src/unit_tests/value_cache_tests.rs
@@ -8,8 +8,11 @@ use linera_base::{
     data_types::{Blob, BlockHeight, Timestamp},
     identifiers::{BlobId, ChainId},
 };
-use linera_chain::data_types::{
-    Block, BlockExecutionOutcome, CertificateValue, ExecutedBlock, HashedCertificateValue,
+use linera_chain::{
+    data_types::{
+        Block, BlockExecutionOutcome, CertificateValue, ExecutedBlock, HashedCertificateValue,
+    },
+    types::{Timeout, ValidatedBlock},
 };
 use linera_execution::committee::Epoch;
 
@@ -518,11 +521,11 @@ fn create_dummy_blobs() -> Vec<Blob> {
 
 /// Creates a new dummy [`HashedCertificateValue`] to use in the tests.
 fn create_dummy_certificate_value(height: impl Into<BlockHeight>) -> HashedCertificateValue {
-    CertificateValue::Timeout {
-        chain_id: ChainId(CryptoHash::test_hash("Fake chain ID")),
-        height: height.into(),
-        epoch: Epoch(0),
-    }
+    CertificateValue::Timeout(Timeout::new(
+        ChainId(CryptoHash::test_hash("Fake chain ID")),
+        height.into(),
+        Epoch(0),
+    ))
     .into()
 }
 
@@ -533,20 +536,18 @@ fn create_dummy_blob(id: usize) -> Blob {
 
 /// Creates a dummy [`HashedCertificateValue::ValidatedBlock`] to use in the tests.
 fn create_dummy_validated_block_value() -> HashedCertificateValue {
-    CertificateValue::ValidatedBlock {
-        executed_block: ExecutedBlock {
-            block: Block {
-                chain_id: ChainId(CryptoHash::test_hash("Fake chain ID")),
-                epoch: Epoch::ZERO,
-                incoming_bundles: vec![],
-                operations: vec![],
-                height: BlockHeight::ZERO,
-                timestamp: Timestamp::from(0),
-                authenticated_signer: None,
-                previous_block_hash: None,
-            },
-            outcome: BlockExecutionOutcome::default(),
+    CertificateValue::ValidatedBlock(ValidatedBlock::new(ExecutedBlock {
+        block: Block {
+            chain_id: ChainId(CryptoHash::test_hash("Fake chain ID")),
+            epoch: Epoch::ZERO,
+            incoming_bundles: vec![],
+            operations: vec![],
+            height: BlockHeight::ZERO,
+            timestamp: Timestamp::from(0),
+            authenticated_signer: None,
+            previous_block_hash: None,
         },
-    }
+        outcome: BlockExecutionOutcome::default(),
+    }))
     .into()
 }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -765,13 +765,11 @@ where
                 let (info, actions, _) = validation_outcomes;
                 (info, actions)
             }
-            CertificateValue::ConfirmedBlock {
-                executed_block: _executed_block,
-            } => {
+            CertificateValue::ConfirmedBlock(_confirmed) => {
                 #[cfg(with_metrics)]
                 {
-                    confirmed_transactions = (_executed_block.block.incoming_bundles.len()
-                        + _executed_block.block.operations.len())
+                    confirmed_transactions = (_confirmed.inner().block.incoming_bundles.len()
+                        + _confirmed.inner().block.operations.len())
                         as u64;
                 }
                 let confirmed_block_certificate: ConfirmedBlockCertificate =

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -151,23 +151,16 @@ CertificateValue:
   ENUM:
     0:
       ValidatedBlock:
-        STRUCT:
-          - executed_block:
-              TYPENAME: ExecutedBlock
+        NEWTYPE:
+          TYPENAME: ValidatedBlock
     1:
       ConfirmedBlock:
-        STRUCT:
-          - executed_block:
-              TYPENAME: ExecutedBlock
+        NEWTYPE:
+          TYPENAME: ConfirmedBlock
     2:
       Timeout:
-        STRUCT:
-          - chain_id:
-              TYPENAME: ChainId
-          - height:
-              TYPENAME: BlockHeight
-          - epoch:
-              TYPENAME: Epoch
+        NEWTYPE:
+          TYPENAME: Timeout
 ChainAndHeight:
   STRUCT:
     - chain_id:
@@ -342,6 +335,10 @@ Committee:
 CompressedBytecode:
   STRUCT:
     - compressed_bytes: BYTES
+ConfirmedBlock:
+  STRUCT:
+    - executed_block:
+        TYPENAME: ExecutedBlock
 CrateVersion:
   STRUCT:
     - major: U32

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -20,7 +20,12 @@ test = [
     "linera-execution/test",
     "dep:stdext",
 ]
-benchmark = ["linera-base/test", "linera-client/benchmark", "linera-chain/benchmark", "dep:linera-sdk"]
+benchmark = [
+    "linera-base/test",
+    "linera-client/benchmark",
+    "linera-chain/benchmark",
+    "dep:linera-sdk",
+]
 wasmer = ["linera-client/wasmer", "linera-execution/wasmer", "linera-storage/wasmer"]
 wasmtime = [
     "linera-client/wasmtime",

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -20,7 +20,7 @@ test = [
     "linera-execution/test",
     "dep:stdext",
 ]
-benchmark = ["linera-base/test", "linera-client/benchmark", "dep:linera-sdk"]
+benchmark = ["linera-base/test", "linera-client/benchmark", "linera-chain/benchmark", "dep:linera-sdk"]
 wasmer = ["linera-client/wasmer", "linera-execution/wasmer", "linera-storage/wasmer"]
 wasmtime = [
     "linera-client/wasmtime",

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -21,7 +21,10 @@ use linera_base::{
     ownership::ChainOwnership,
 };
 #[cfg(feature = "benchmark")]
-use linera_chain::data_types::CertificateValue;
+use linera_chain::{
+    data_types::CertificateValue,
+    types::ConfirmedBlock,
+};
 use linera_client::{
     chain_listener::ClientContext as _,
     client_context::ClientContext,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -720,10 +720,9 @@ impl Runnable for Job {
                         let executed_block = context
                             .stage_block_execution(proposal.content.block.clone())
                             .await?;
-                        let value =
-                            HashedCertificateValue::from(CertificateValue::ConfirmedBlock {
-                                executed_block,
-                            });
+                        let value = HashedCertificateValue::from(CertificateValue::ConfirmedBlock(
+                            ConfirmedBlock::new(executed_block),
+                        ));
                         values.insert(value.hash(), value);
                     }
                 }

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -21,10 +21,7 @@ use linera_base::{
     ownership::ChainOwnership,
 };
 #[cfg(feature = "benchmark")]
-use linera_chain::{
-    data_types::CertificateValue,
-    types::ConfirmedBlock,
-};
+use linera_chain::{data_types::CertificateValue, types::ConfirmedBlock};
 use linera_client::{
     chain_listener::ClientContext as _,
     client_context::ClientContext,


### PR DESCRIPTION
## Motivation

With more and more places adjusted to work with standalone-types, it turned out we can remove some repetition between `CertificateValue` variants and new types. 

<!--
Briefly describe the goal(s) of this PR.
-->

## Proposal

Make the new types be part of the `CertificateValue` enum variants.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.
## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
