### PR TITLE
Fix `has_message` implementation.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -747,12 +747,7 @@ impl CertificateValue {
         let Some(executed_block) = self.executed_block() else {
             return false;
         };
-        let Ok(index) = usize::try_from(message_id.index) else {
-            return false;
-        };
-        self.height() == message_id.height
-            && self.chain_id() == message_id.chain_id
-            && executed_block.messages().len() > index
+        executed_block.message_by_id(message_id).is_some()
     }
 
     pub fn is_confirmed(&self) -> bool {


### PR DESCRIPTION
## Motivation

`has_message` returns `true` if the message index is less than the length of `messages()`, which is a `Vec<Vec<_>>`.

This is used when assigning and synchronizing a new chain in the wallet, in the `wallet init` and `assign` commands.

## Proposal

Fix the implementation.

## Test Plan

We will add a regression test later.

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
