### PR TITLE
Add a regression test for #2869.

### DIFF
--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -511,6 +511,26 @@ where
         .await
         .unwrap()
         .unwrap();
+
+    // Regression test for #2869.
+    let sub_message_id = MessageId {
+        index: message_id.index + 1,
+        ..message_id
+    };
+    assert_matches!(
+        certificate.executed_block().messages()[0][sub_message_id.index as usize].message,
+        Message::System(SystemMessage::Subscribe { .. })
+    );
+    assert_eq!(
+        sender
+            .client
+            .local_node()
+            .certificate_for(&sub_message_id)
+            .await
+            .unwrap(),
+        certificate.clone().into()
+    );
+
     assert_eq!(sender.next_block_height(), BlockHeight::from(1));
     assert!(sender.pending_block().is_none());
     assert!(sender.key_pair().await.is_ok());


### PR DESCRIPTION
## Motivation

In #2869 we fixed `has_message` and thus `certificate_for`: It checked the index of the _transaction_ rather than the _message_.

## Proposal

An assertion was added to an existing test that sends two messages in a single transaction: Thus it does have a message with index 1, even though it doesn't have a transaction with index 1.

## Test Plan

I verified that this failed before #2869.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- This is a regression test for: #2869 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
