### PR TITLE
Handle `ChainClientError`s in `communicate_with_quorum`.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1752,6 +1752,7 @@ where
                         .update_local_node_with_blobs_from(blob_ids.clone(), remote_node)
                         .await
                     {
+                        // TODO(#2875): Distinguish local and remote errors properly.
                         warn!("Error updating local node with blobs: {error}");
                     } else {
                         continue; // We found the missing blobs: retry.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1542,13 +1542,15 @@ where
         .await;
         let received_certificate_batches = match result {
             Ok(((), received_certificate_batches)) => received_certificate_batches,
-            Err(CommunicationError::Trusted(NodeError::InactiveChain(id))) if id == chain_id => {
+            Err(ChainClientError::CommunicationError(CommunicationError::Trusted(
+                NodeError::InactiveChain(id),
+            ))) if id == chain_id => {
                 // The chain is visibly not active (yet or any more) so there is no need
                 // to synchronize received certificates.
                 return Ok(());
             }
             Err(error) => {
-                return Err(error.into());
+                return Err(error);
             }
         };
         self.receive_certificates_from_validators(received_certificate_batches)

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, HashSet, VecDeque},
+    collections::{BTreeMap, VecDeque},
     sync::Arc,
 };
 
@@ -187,7 +187,7 @@ where
     /// - Returns `None` if not all blobs could be found.
     pub async fn find_missing_blobs(
         &self,
-        mut missing_blob_ids: HashSet<BlobId>,
+        mut missing_blob_ids: Vec<BlobId>,
         chain_id: ChainId,
     ) -> Result<Option<Vec<Blob>>, LocalNodeError> {
         if missing_blob_ids.is_empty() {
@@ -213,7 +213,7 @@ where
 
         let storage = self.storage_client();
         let Some(read_blobs) = storage
-            .read_blobs(&missing_blob_ids.into_iter().collect::<Vec<_>>())
+            .read_blobs(&missing_blob_ids)
             .await?
             .into_iter()
             .collect::<Option<Vec<_>>>()

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -222,8 +222,10 @@ pub enum NodeError {
 
     #[error("Node failed to provide a 'last used by' certificate for the blob")]
     InvalidCertificateForBlob(BlobId),
-    #[error("Local error handling validator response")]
-    LocalError { error: String },
+    #[error("Node returned a BlobsNotFound error with duplicates")]
+    DuplicatesInBlobsNotFound,
+    #[error("Node returned a BlobsNotFound error with unexpected blob IDs")]
+    UnexpectedEntriesInBlobsNotFound,
 }
 
 impl From<tonic::Status> for NodeError {

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use custom_debug_derive::Debug;
 use futures::{stream::FuturesUnordered, StreamExt};
@@ -13,7 +13,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::BlockProposal,
-    types::{Certificate, ConfirmedBlockCertificate, LiteCertificate},
+    types::{Certificate, CertificateValue, ConfirmedBlockCertificate, LiteCertificate},
 };
 use linera_execution::committee::ValidatorName;
 use rand::seq::SliceRandom as _;
@@ -300,5 +300,38 @@ impl<N: ValidatorNode> RemoteNode<N> {
             blobs.push(maybe_blob?);
         }
         Some(blobs)
+    }
+
+    /// Checks that requesting these blobs when trying to handle this certificate is legitimate,
+    /// i.e. that there are no duplicates and the blobs are actually required.
+    pub fn check_blobs_not_found_error(
+        &self,
+        certificate: &Certificate,
+        blob_ids: &[BlobId],
+    ) -> Result<(), NodeError> {
+        // Find the missing blobs locally and retry.
+        let required = match certificate.inner() {
+            CertificateValue::ConfirmedBlock(confirmed) => confirmed.inner().required_blob_ids(),
+            CertificateValue::ValidatedBlock(validated) => validated.inner().required_blob_ids(),
+            CertificateValue::Timeout(_) => HashSet::new(),
+        };
+        for blob_id in blob_ids {
+            if !required.contains(blob_id) {
+                warn!(
+                    "validator {} requested blob {blob_id:?} but it is not required",
+                    self.name
+                );
+                return Err(NodeError::UnexpectedEntriesInBlobsNotFound);
+            }
+        }
+        let unique_missing_blob_ids = blob_ids.iter().cloned().collect::<HashSet<_>>();
+        if blob_ids.len() > unique_missing_blob_ids.len() {
+            warn!(
+                "blobs requested by validator {} contain duplicates",
+                self.name
+            );
+            return Err(NodeError::DuplicatesInBlobsNotFound);
+        }
+        Ok(())
     }
 }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -596,9 +596,9 @@ NodeError:
         NEWTYPE:
           TYPENAME: BlobId
     21:
-      LocalError:
-        STRUCT:
-          - error: STR
+      DuplicatesInBlobsNotFound: UNIT
+    22:
+      UnexpectedEntriesInBlobsNotFound: UNIT
 OpenChainConfig:
   STRUCT:
     - ownership:


### PR DESCRIPTION
## Motivation

`communicate_with_quorum` currently takes a call operator that returns a `Result<_, NodeError>` (async). However, we pass in tasks that use the local node, too, so not all potential errors are `NodeErrors`.

## Proposal

Make `communicate_with_quorum` deal with `ChainClientError`s instead. Internally, only `NodeError`s are counted by vote weight; other errors cause the call to fail immediately.

Also don't convert every `ChainClientError` into a `NodeError` anymore. Instead, distinguish whether this could possibly be the fault of the remote node (then it _must_ be a `NodeError`) or not.

Finally, I'm moving `handle_optimized_certificate` to `RemoteNode` and `next_block_heights` to `LocalNode`, because they only use that, respectively. And the checks for the remote node's blob errors are moved out of `LocalNode::find_missing_blobs`.

## Test Plan

CI should catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/2857
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
