### PR TITLE
Certificate is a type alias for GenericCertificate

### DIFF
--- a/examples/hex-game/tests/hex_game.rs
+++ b/examples/hex-game/tests/hex_game.rs
@@ -31,7 +31,7 @@ async fn hex_game() {
         })
         .await;
 
-    let executed_block = certificate.value().executed_block().unwrap();
+    let executed_block = certificate.inner().executed_block().unwrap();
     let message_id = executed_block.message_id_for_operation(0, 0).unwrap();
     let description = ChainDescription::Child(message_id);
     let mut chain = ActiveChain::new(key_pair1.copy(), description, validator);
@@ -105,7 +105,7 @@ async fn hex_game_clock() {
         })
         .await;
 
-    let executed_block = certificate.value().executed_block().unwrap();
+    let executed_block = certificate.inner().executed_block().unwrap();
     let message_id = executed_block.message_id_for_operation(0, 0).unwrap();
     let description = ChainDescription::Child(message_id);
     let mut chain = ActiveChain::new(key_pair1.copy(), description, validator.clone());

--- a/linera-chain/src/certificate.rs
+++ b/linera-chain/src/certificate.rs
@@ -167,7 +167,7 @@ impl From<ConfirmedBlockCertificate> for Certificate {
             round,
             signatures,
         } = cert;
-        Certificate::unchecked_new(
+        Certificate::new(
             HashedCertificateValue::new_confirmed(value.into_inner().into_inner()),
             round,
             signatures,
@@ -182,7 +182,7 @@ impl From<ValidatedBlockCertificate> for Certificate {
             round,
             signatures,
         } = cert;
-        Certificate::unchecked_new(
+        Certificate::new(
             HashedCertificateValue::new_validated(value.into_inner().into_inner()),
             round,
             signatures,
@@ -198,7 +198,7 @@ impl From<TimeoutCertificate> for Certificate {
             signatures,
         } = cert;
         let timeout = value.into_inner();
-        Certificate::unchecked_new(
+        Certificate::new(
             HashedCertificateValue::new_timeout(timeout.chain_id, timeout.height, timeout.epoch),
             round,
             signatures,
@@ -267,25 +267,17 @@ impl<T: Clone> Clone for Hashed<T> {
 }
 
 impl<T> GenericCertificate<T> {
-    pub fn unchecked_new(
+    pub fn new(
         value: Hashed<T>,
         round: Round,
-        signatures: Vec<(ValidatorName, Signature)>,
-    ) -> Self {
-        Self {
-            value,
-            round,
-            signatures,
-        }
-    }
-
-    pub fn new(value: T, round: Round, mut signatures: Vec<(ValidatorName, Signature)>) -> Self
+        mut signatures: Vec<(ValidatorName, Signature)>,
+    ) -> Self
     where
         T: BcsHashable,
     {
         signatures.sort_by_key(|&(validator_name, _)| validator_name);
         Self {
-            value: Hashed::new(value),
+            value,
             round,
             signatures,
         }
@@ -295,6 +287,7 @@ impl<T> GenericCertificate<T> {
         &self.signatures
     }
 
+    #[cfg(with_testing)]
     pub fn signatures_mut(&mut self) -> &mut Vec<(ValidatorName, Signature)> {
         &mut self.signatures
     }

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -23,7 +23,7 @@ use serde::{de::Deserializer, Deserialize, Serialize};
 
 use crate::{
     block::{ConfirmedBlock, Timeout, ValidatedBlock},
-    types::{Hashed, ValidatedBlockCertificate},
+    types::{GenericCertificate, Hashed, ValidatedBlockCertificate},
     ChainError,
 };
 
@@ -582,11 +582,11 @@ impl<'a> LiteCertificate<'a> {
         {
             return None;
         }
-        Some(Certificate {
+        Some(Certificate::unchecked_new(
             value,
-            round: self.round,
-            signatures: self.signatures.into_owned(),
-        })
+            self.round,
+            self.signatures.into_owned(),
+        ))
     }
 
     /// Returns a `LiteCertificate` that owns the list of signatures.
@@ -600,15 +600,29 @@ impl<'a> LiteCertificate<'a> {
 }
 
 /// A certified statement from the committee.
-#[derive(Clone, Debug, Serialize)]
-#[cfg_attr(with_testing, derive(Eq, PartialEq))]
-pub struct Certificate {
-    /// The certified value.
-    pub value: HashedCertificateValue,
-    /// The round in which the value was certified.
-    pub round: Round,
-    /// Signatures on the value.
-    signatures: Vec<(ValidatorName, Signature)>,
+pub type Certificate = GenericCertificate<CertificateValue>;
+
+impl Serialize for Certificate {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Debug, Serialize)]
+        #[serde(rename = "Certificate")]
+        struct CertificateHelper {
+            value: CertificateValue,
+            round: Round,
+            signatures: Vec<(ValidatorName, Signature)>,
+        }
+
+        let helper = CertificateHelper {
+            value: self.inner().clone(),
+            round: self.round,
+            signatures: self.signatures().clone(),
+        };
+
+        helper.serialize(serializer)
+    }
 }
 
 impl fmt::Display for Origin {
@@ -1079,11 +1093,7 @@ impl<'a> SignatureAggregator<'a> {
             committee,
             weight: 0,
             used_validators: HashSet::new(),
-            partial: Certificate {
-                value,
-                round,
-                signatures: Vec::new(),
-            },
+            partial: Certificate::unchecked_new(value, round, Vec::new()),
         }
     }
 
@@ -1142,68 +1152,22 @@ impl<'de> Deserialize<'de> for Certificate {
         if !is_strictly_ordered(&helper.signatures) {
             Err(serde::de::Error::custom("Vector is not strictly sorted"))
         } else {
-            Ok(Self {
-                value: helper.value,
-                round: helper.round,
-                signatures: helper.signatures,
-            })
+            Ok(Self::unchecked_new(
+                helper.value,
+                helper.round,
+                helper.signatures,
+            ))
         }
     }
 }
 
 impl Certificate {
-    pub fn new(
-        value: HashedCertificateValue,
-        round: Round,
-        mut signatures: Vec<(ValidatorName, Signature)>,
-    ) -> Self {
-        signatures.sort_by_key(|&(validator_name, _)| validator_name);
-
-        Self {
-            value,
-            round,
-            signatures,
-        }
-    }
-
-    pub fn signatures(&self) -> &Vec<(ValidatorName, Signature)> {
-        &self.signatures
-    }
-
-    // Adds a signature to the certificate's list of signatures
-    // It's the responsibility of the caller to not insert duplicates
-    pub fn add_signature(
-        &mut self,
-        signature: (ValidatorName, Signature),
-    ) -> &Vec<(ValidatorName, Signature)> {
-        let index = self
-            .signatures
-            .binary_search_by(|(name, _)| name.cmp(&signature.0))
-            .unwrap_or_else(std::convert::identity);
-        self.signatures.insert(index, signature);
-        &self.signatures
-    }
-
-    /// Verifies the certificate.
-    pub fn check<'a>(
-        &'a self,
-        committee: &Committee,
-    ) -> Result<&'a HashedCertificateValue, ChainError> {
-        check_signatures(
-            self.lite_value().value_hash,
-            self.round,
-            &self.signatures,
-            committee,
-        )?;
-        Ok(&self.value)
-    }
-
     /// Returns the certificate without the full value.
     pub fn lite_certificate(&self) -> LiteCertificate<'_> {
         LiteCertificate {
             value: self.lite_value(),
             round: self.round,
-            signatures: Cow::Borrowed(&self.signatures),
+            signatures: Cow::Borrowed(self.signatures()),
         }
     }
 
@@ -1211,25 +1175,8 @@ impl Certificate {
     pub fn lite_value(&self) -> LiteValue {
         LiteValue {
             value_hash: self.hash(),
-            chain_id: self.value().chain_id(),
+            chain_id: self.inner().chain_id(),
         }
-    }
-
-    /// Returns the certified value.
-    pub fn value(&self) -> &CertificateValue {
-        self.value.inner()
-    }
-
-    /// Returns the certified value's hash.
-    pub fn hash(&self) -> CryptoHash {
-        self.value.hash()
-    }
-
-    /// Returns whether the validator is among the signatories of this certificate.
-    pub fn is_signed_by(&self, validator_name: &ValidatorName) -> bool {
-        self.signatures
-            .binary_search_by(|(name, _)| name.cmp(validator_name))
-            .is_ok()
     }
 
     /// Returns the bundles of messages sent via the given medium to the specified
@@ -1242,7 +1189,7 @@ impl Certificate {
         recipient: ChainId,
     ) -> impl Iterator<Item = (Epoch, MessageBundle)> + 'a {
         let certificate_hash = self.hash();
-        self.value()
+        self.inner()
             .executed_block()
             .into_iter()
             .flat_map(move |executed_block| {
@@ -1251,14 +1198,14 @@ impl Certificate {
     }
 
     pub fn requires_blob(&self, blob_id: &BlobId) -> bool {
-        self.value()
+        self.inner()
             .executed_block()
             .is_some_and(|executed_block| executed_block.requires_blob(blob_id))
     }
 
     #[cfg(with_testing)]
     pub fn outgoing_message_count(&self) -> usize {
-        let Some(executed_block) = self.value().executed_block() else {
+        let Some(executed_block) = self.inner().executed_block() else {
             return 0;
         };
         executed_block.messages().iter().map(Vec::len).sum()

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -582,7 +582,7 @@ impl<'a> LiteCertificate<'a> {
         {
             return None;
         }
-        Some(Certificate::unchecked_new(
+        Some(Certificate::new(
             value,
             self.round,
             self.signatures.into_owned(),
@@ -609,16 +609,16 @@ impl Serialize for Certificate {
     {
         #[derive(Debug, Serialize)]
         #[serde(rename = "Certificate")]
-        struct CertificateHelper {
-            value: CertificateValue,
+        struct CertificateHelper<'a> {
+            value: &'a CertificateValue,
             round: Round,
-            signatures: Vec<(ValidatorName, Signature)>,
+            signatures: &'a Vec<(ValidatorName, Signature)>,
         }
 
         let helper = CertificateHelper {
-            value: self.inner().clone(),
+            value: self.inner(),
             round: self.round,
-            signatures: self.signatures().clone(),
+            signatures: self.signatures(),
         };
 
         helper.serialize(serializer)
@@ -1093,7 +1093,7 @@ impl<'a> SignatureAggregator<'a> {
             committee,
             weight: 0,
             used_validators: HashSet::new(),
-            partial: Certificate::unchecked_new(value, round, Vec::new()),
+            partial: Certificate::new(value, round, Vec::new()),
         }
     }
 
@@ -1152,11 +1152,7 @@ impl<'de> Deserialize<'de> for Certificate {
         if !is_strictly_ordered(&helper.signatures) {
             Err(serde::de::Error::custom("Vector is not strictly sorted"))
         } else {
-            Ok(Self::unchecked_new(
-                helper.value,
-                helper.round,
-                helper.signatures,
-            ))
+            Ok(Self::new(helper.value, helper.round, helper.signatures))
         }
     }
 }

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -64,7 +64,7 @@ fn test_certificates() {
         .is_none());
     let mut c = builder.append(v2.validator, v2.signature).unwrap().unwrap();
     assert!(c.check(&committee).is_ok());
-    c.signatures.pop();
+    c.signatures_mut().pop();
     assert!(c.check(&committee).is_err());
 
     let mut builder = SignatureAggregator::new(value, Round::Fast, &committee);

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -196,7 +196,7 @@ where
         let cert = Certificate::from(certificate.clone());
         self.state
             .recent_hashed_certificate_values
-            .insert(Cow::Borrowed(&cert.value))
+            .insert(Cow::Borrowed(cert.value()))
             .await;
         let required_blob_ids = executed_block.required_blob_ids();
         // Verify that no unrelated blobs were provided.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1079,7 +1079,7 @@ where
             .await?;
         self.process_certificate(certificate.clone(), proposed_blobs)
             .await?;
-        if certificate.value().is_confirmed() {
+        if certificate.inner().is_confirmed() {
             Ok(certificate.try_into().unwrap()) // shouldn't panic, we just checked.
         } else {
             self.finalize_block(committee, certificate.into()).await
@@ -1319,9 +1319,9 @@ where
         // Check the signatures and keep only the ones that are valid.
         let mut certificates = Vec::new();
         for certificate in remote_certificates {
-            let sender_chain_id = certificate.value().chain_id();
-            let height = certificate.value().height();
-            let epoch = certificate.value().epoch();
+            let sender_chain_id = certificate.inner().chain_id();
+            let height = certificate.inner().height();
+            let epoch = certificate.inner().epoch();
             let confirmed_block_certificate = certificate
                 .try_into()
                 .map_err(|_| NodeError::InvalidChainInfoResponse)?;

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -204,7 +204,7 @@ where
         }
 
         // Find the missing blobs locally and retry.
-        let required = match certificate.value() {
+        let required = match certificate.inner() {
             CertificateValue::ConfirmedBlock(confirmed) => confirmed.inner().required_blob_ids(),
             CertificateValue::ValidatedBlock(validated) => validated.inner().required_blob_ids(),
             CertificateValue::Timeout(_) => HashSet::new(),

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -66,7 +66,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
         blobs: Vec<Blob>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, NodeError> {
-        let chain_id = certificate.value().chain_id();
+        let chain_id = certificate.inner().chain_id();
         let response = self
             .node
             .handle_certificate(certificate, blobs, delivery)

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2012,7 +2012,7 @@ where
     // After the timeout they will.
     let certificate = client.request_leader_timeout().await.unwrap();
     assert_eq!(
-        *certificate.value(),
+        *certificate.inner(),
         CertificateValue::Timeout(Timeout::new(chain_id, BlockHeight::from(1), Epoch::ZERO))
     );
     assert_eq!(certificate.round, Round::SingleLeader(0));

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -321,7 +321,7 @@ where
         blobs: Vec<Blob>,
     ) -> Option<Result<ChainInfoResponse, NodeError>> {
         match validator.fault_type {
-            FaultType::DontProcessValidated if certificate.value().is_validated() => None,
+            FaultType::DontProcessValidated if certificate.inner().is_validated() => None,
             FaultType::Honest
             | FaultType::DontSendConfirmVote
             | FaultType::Malicious
@@ -363,7 +363,7 @@ where
         validator: &mut MutexGuard<'_, LocalValidator<S>>,
         blobs: Vec<Blob>,
     ) -> Result<ChainInfoResponse, NodeError> {
-        let is_validated = certificate.value().is_validated();
+        let is_validated = certificate.inner().is_validated();
         let handle_certificate_result =
             Self::handle_certificate(certificate, validator, blobs).await;
         match handle_certificate_result {
@@ -873,9 +873,9 @@ where
                     debug_assert!(requested_sent_certificate_hashes.len() <= 1);
                     if let Some(cert_hash) = requested_sent_certificate_hashes.pop() {
                         if let Ok(cert) = validator.download_certificate(cert_hash).await {
-                            if cert.value().is_confirmed()
-                                && cert.value().chain_id() == chain_id
-                                && cert.value().height() == block_height
+                            if cert.inner().is_confirmed()
+                                && cert.inner().chain_id() == chain_id
+                                && cert.inner().height() == block_height
                             {
                                 cert.check(&self.initial_committee).unwrap();
                                 count += 1;

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -252,7 +252,7 @@ where
     // Execute an application operation
     let increment = 5_u64;
     let user_operation = bcs::to_bytes(&increment)?;
-    let run_block = make_child_block(&create_certificate.value)
+    let run_block = make_child_block(create_certificate.value())
         .with_timestamp(3)
         .with_operation(Operation::User {
             application_id,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -267,7 +267,7 @@ where
     };
     let block_template = match &previous_confirmed_block {
         None => make_first_block(chain_id),
-        Some(cert) => make_child_block(&cert.value),
+        Some(cert) => make_child_block(cert.value()),
     };
 
     let mut messages = incoming_bundles
@@ -395,7 +395,7 @@ fn generate_key_pairs(count: usize) -> Vec<KeyPair> {
 
 /// Creates a `CrossChainRequest` with the messages sent by the certificate to the recipient.
 fn update_recipient_direct(recipient: ChainId, certificate: &Certificate) -> CrossChainRequest {
-    let sender = certificate.value().chain_id();
+    let sender = certificate.inner().chain_id();
     let bundles = certificate.message_bundles_for(&Medium::Direct, recipient);
     CrossChainRequest::UpdateRecipient {
         sender,
@@ -556,7 +556,7 @@ where
         .await?;
 
     {
-        let block_proposal = make_child_block(&certificate.value)
+        let block_proposal = make_child_block(certificate.value())
             .with_timestamp(block_0_time.saturating_sub_micros(1))
             .into_fast_proposal(&key_pair);
         // Timestamp older than previous one
@@ -645,7 +645,7 @@ where
         None,
     )
     .await;
-    let block_proposal1 = make_child_block(&certificate0.value)
+    let block_proposal1 = make_child_block(certificate0.value())
         .with_simple_transfer(ChainId::root(2), Amount::from_tokens(2))
         .into_fast_proposal(&sender_key_pair);
 
@@ -764,7 +764,7 @@ where
                 oracle_responses: vec![Vec::new()],
             }
             .with(
-                make_child_block(&certificate0.value)
+                make_child_block(certificate0.value())
                     .with_simple_transfer(ChainId::root(2), Amount::from_tokens(3))
                     .with_authenticated_signer(Some(sender_key_pair.public().into())),
             ),
@@ -842,7 +842,7 @@ where
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
-                    certificate_hash: certificate0.value.hash(),
+                    certificate_hash: certificate0.hash(),
                     height: BlockHeight::ZERO,
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
@@ -855,7 +855,7 @@ where
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
-                    certificate_hash: certificate0.value.hash(),
+                    certificate_hash: certificate0.hash(),
                     height: BlockHeight::ZERO,
                     timestamp: Timestamp::from(0),
                     transaction_index: 1,
@@ -867,7 +867,7 @@ where
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
-                    certificate_hash: certificate1.value.hash(),
+                    certificate_hash: certificate1.hash(),
                     height: BlockHeight::from(1),
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
@@ -893,7 +893,7 @@ where
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
-                    certificate_hash: certificate0.value.hash(),
+                    certificate_hash: certificate0.hash(),
                     height: BlockHeight::ZERO,
                     timestamp: Timestamp::from(0),
                     transaction_index: 1,
@@ -917,7 +917,7 @@ where
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
-                    certificate_hash: certificate1.value.hash(),
+                    certificate_hash: certificate1.hash(),
                     height: BlockHeight::from(1),
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
@@ -929,7 +929,7 @@ where
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
-                    certificate_hash: certificate0.value.hash(),
+                    certificate_hash: certificate0.hash(),
                     height: BlockHeight::ZERO,
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
@@ -942,7 +942,7 @@ where
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
-                    certificate_hash: certificate0.value.hash(),
+                    certificate_hash: certificate0.hash(),
                     height: BlockHeight::ZERO,
                     timestamp: Timestamp::from(0),
                     transaction_index: 1,
@@ -966,7 +966,7 @@ where
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
-                    certificate_hash: certificate0.value.hash(),
+                    certificate_hash: certificate0.hash(),
                     height: BlockHeight::ZERO,
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
@@ -1007,12 +1007,12 @@ where
             .await?;
 
         // Then receive the next two messages.
-        let block_proposal = make_child_block(&certificate.value)
+        let block_proposal = make_child_block(certificate.value())
             .with_simple_transfer(ChainId::root(3), Amount::from_tokens(3))
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
-                    certificate_hash: certificate0.value.hash(),
+                    certificate_hash: certificate0.hash(),
                     height: BlockHeight::from(0),
                     timestamp: Timestamp::from(0),
                     transaction_index: 1,
@@ -1024,7 +1024,7 @@ where
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
-                    certificate_hash: certificate1.value.hash(),
+                    certificate_hash: certificate1.hash(),
                     height: BlockHeight::from(1),
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
@@ -2365,7 +2365,7 @@ where
                 oracle_responses: vec![Vec::new(); 2],
             }
             .with(
-                make_child_block(&certificate0.value)
+                make_child_block(certificate0.value())
                     .with_operation(SystemOperation::Admin(AdminOperation::CreateCommittee {
                         epoch: Epoch::from(1),
                         committee: committee.clone(),
@@ -2478,7 +2478,7 @@ where
                     .with_incoming_bundle(IncomingBundle {
                         origin: Origin::chain(admin_id),
                         bundle: MessageBundle {
-                            certificate_hash: certificate0.value.hash(),
+                            certificate_hash: certificate0.hash(),
                             height: BlockHeight::from(0),
                             timestamp: Timestamp::from(0),
                             transaction_index: 0,
@@ -2499,7 +2499,7 @@ where
                     .with_incoming_bundle(IncomingBundle {
                         origin: admin_channel_origin.clone(),
                         bundle: MessageBundle {
-                            certificate_hash: certificate1.value.hash(),
+                            certificate_hash: certificate1.hash(),
                             height: BlockHeight::from(1),
                             timestamp: Timestamp::from(0),
                             transaction_index: 0,
@@ -2514,7 +2514,7 @@ where
                     .with_incoming_bundle(IncomingBundle {
                         origin: Origin::chain(admin_id),
                         bundle: MessageBundle {
-                            certificate_hash: certificate1.value.hash(),
+                            certificate_hash: certificate1.hash(),
                             height: BlockHeight::from(1),
                             timestamp: Timestamp::from(0),
                             transaction_index: 1,
@@ -2853,12 +2853,12 @@ where
                 oracle_responses: vec![Vec::new()],
             }
             .with(
-                make_child_block(&certificate1.value)
+                make_child_block(certificate1.value())
                     .with_epoch(1)
                     .with_incoming_bundle(IncomingBundle {
                         origin: Origin::chain(user_id),
                         bundle: MessageBundle {
-                            certificate_hash: certificate0.value.hash(),
+                            certificate_hash: certificate0.hash(),
                             height: BlockHeight::ZERO,
                             timestamp: Timestamp::from(0),
                             transaction_index: 0,

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -237,7 +237,7 @@ where
             Err(original_err @ NodeError::BlobsNotFound(blob_ids)) => {
                 let blobs = self
                     .local_node
-                    .find_missing_blobs(&certificate, blob_ids, certificate.value().chain_id())
+                    .find_missing_blobs(&certificate, blob_ids, certificate.inner().chain_id())
                     .await?
                     .ok_or_else(|| original_err.clone())?;
                 self.remote_node
@@ -411,7 +411,7 @@ where
                 (block.height, block.chain_id)
             }
             CommunicateAction::FinalizeBlock { certificate, .. } => {
-                let value = certificate.value();
+                let value = certificate.inner();
                 (value.height(), value.chain_id())
             }
             CommunicateAction::RequestTimeout {

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -731,8 +731,8 @@ where
     /// Processes a certificate.
     #[instrument(skip_all, fields(
         nick = self.nickname,
-        chain_id = format!("{:.8}", certificate.value().chain_id()),
-        height = %certificate.value().height(),
+        chain_id = format!("{:.8}", certificate.inner().chain_id()),
+        height = %certificate.inner().height(),
     ))]
     pub async fn handle_certificate(
         &self,
@@ -745,12 +745,12 @@ where
         #[cfg(with_metrics)]
         let (round, log_str, mut confirmed_transactions, mut duplicated) = (
             certificate.round,
-            certificate.value().to_log_str(),
+            certificate.inner().to_log_str(),
             0u64,
             false,
         );
 
-        let (info, actions) = match certificate.value() {
+        let (info, actions) = match certificate.inner() {
             CertificateValue::ValidatedBlock { .. } => {
                 // Confirm the validated block.
                 // Note: This conversion panics if `certificate` is not a validated block certificate.

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -864,7 +864,7 @@ pub mod tests {
     #[test]
     pub fn test_certificate() {
         let key_pair = KeyPair::generate();
-        let certificate = Certificate::unchecked_new(
+        let certificate = Certificate::new(
             HashedCertificateValue::new_validated(
                 BlockExecutionOutcome {
                     state_hash: CryptoHash::new(&Foo("test".into())),
@@ -913,7 +913,7 @@ pub mod tests {
     #[test]
     pub fn test_block_proposal() {
         let key_pair = KeyPair::generate();
-        let cert = Certificate::unchecked_new(
+        let cert = Certificate::new(
             HashedCertificateValue::new_validated(
                 BlockExecutionOutcome {
                     state_hash: CryptoHash::new(&Foo("validated".into())),

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -340,7 +340,7 @@ impl TryFrom<HandleCertificateRequest> for api::HandleCertificateRequest {
 
     fn try_from(request: HandleCertificateRequest) -> Result<Self, Self::Error> {
         Ok(Self {
-            chain_id: Some(request.certificate.value().chain_id().into()),
+            chain_id: Some(request.certificate.inner().chain_id().into()),
             certificate: Some(request.certificate.try_into()?),
             blobs: bincode::serialize(&request.blobs)?,
             wait_for_outgoing_messages: request.wait_for_outgoing_messages,
@@ -365,7 +365,7 @@ impl TryFrom<Certificate> for api::Certificate {
 
     fn try_from(certificate: Certificate) -> Result<Self, Self::Error> {
         Ok(Self {
-            value: bincode::serialize(&certificate.value)?,
+            value: bincode::serialize(certificate.inner())?,
             round: bincode::serialize(&certificate.round)?,
             signatures: bincode::serialize(certificate.signatures())?,
         })
@@ -864,7 +864,7 @@ pub mod tests {
     #[test]
     pub fn test_certificate() {
         let key_pair = KeyPair::generate();
-        let certificate = Certificate::new(
+        let certificate = Certificate::unchecked_new(
             HashedCertificateValue::new_validated(
                 BlockExecutionOutcome {
                     state_hash: CryptoHash::new(&Foo("test".into())),
@@ -913,7 +913,7 @@ pub mod tests {
     #[test]
     pub fn test_block_proposal() {
         let key_pair = KeyPair::generate();
-        let cert = Certificate::new(
+        let cert = Certificate::unchecked_new(
             HashedCertificateValue::new_validated(
                 BlockExecutionOutcome {
                     state_hash: CryptoHash::new(&Foo("validated".into())),

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -64,7 +64,7 @@ impl RpcMessage {
         let chain_id = match self {
             BlockProposal(proposal) => proposal.content.block.chain_id,
             LiteCertificate(request) => request.certificate.value.chain_id,
-            Certificate(request) => request.certificate.value().chain_id(),
+            Certificate(request) => request.certificate.inner().chain_id(),
             ChainInfoQuery(query) => query.chain_id,
             CrossChainRequest(request) => request.target_chain_id(),
             Vote(_)

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -52,7 +52,7 @@ impl BlockBuilder {
         let height = previous_block
             .map(|certificate| {
                 certificate
-                    .value()
+                    .inner()
                     .height()
                     .try_add_one()
                     .expect("Block height limit reached")
@@ -191,7 +191,7 @@ impl BlockBuilder {
         action: MessageAction,
     ) -> &mut Self {
         let origin = Origin {
-            sender: certificate.value().chain_id(),
+            sender: certificate.inner().chain_id(),
             medium: medium.clone(),
         };
         let bundles = certificate

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -209,7 +209,7 @@ impl ActiveChain {
             .await;
 
         let executed_block = certificate
-            .value()
+            .inner()
             .executed_block()
             .expect("Failed to obtain executed block from certificate");
         assert_eq!(executed_block.messages().len(), 1);
@@ -319,7 +319,7 @@ impl ActiveChain {
             .await
             .as_ref()
             .expect("Block was not successfully added")
-            .value()
+            .inner()
             .height()
     }
 
@@ -364,7 +364,7 @@ impl ActiveChain {
             .await;
 
         let executed_block = creation_certificate
-            .value()
+            .inner()
             .executed_block()
             .expect("Failed to obtain executed block from certificate");
         assert_eq!(executed_block.messages().len(), 1);

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -201,7 +201,7 @@ impl TestValidator {
             })
             .await;
         let executed_block = certificate
-            .value()
+            .inner()
             .executed_block()
             .expect("Failed to obtain executed block from certificate");
 

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -620,7 +620,7 @@ mod proto_message_cap {
             outcome: BlockExecutionOutcome::default(),
         };
         let signatures = vec![(validator, signature)];
-        Certificate::new(
+        Certificate::unchecked_new(
             HashedCertificateValue::new_confirmed(executed_block),
             Default::default(),
             signatures,

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -620,7 +620,7 @@ mod proto_message_cap {
             outcome: BlockExecutionOutcome::default(),
         };
         let signatures = vec![(validator, signature)];
-        Certificate::unchecked_new(
+        Certificate::new(
             HashedCertificateValue::new_confirmed(executed_block),
             Default::default(),
             signatures,

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -704,7 +704,7 @@ where
         let value_key = bcs::to_bytes(&BaseKey::CertificateValue(hash))?;
         let old_certificate: Certificate = certificate.clone().into();
         batch.put_key_value(cert_key.to_vec(), &old_certificate.lite_certificate())?;
-        batch.put_key_value(value_key.to_vec(), &old_certificate.value)?;
+        batch.put_key_value(value_key.to_vec(), old_certificate.value())?;
         Ok(())
     }
 


### PR DESCRIPTION
## Motivation

During an ongoing refactor it turned out that the `Certificate` type could become an alias of `GenericCertificate<CertificateValue>`.

## Proposal

Unify the types.

## Test Plan

None. CI will catch any regressions.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.

## Links

Closes https://github.com/linera-io/linera-protocol/issues/2872

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
