### PR TITLE
Simplify the Prometheus stuff

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
 #[cfg(with_metrics)]
-use crate::prometheus_util::{self, MeasureLatency};
+use crate::prometheus_util::{self, bucket_latencies, MeasureLatency};
 use crate::{
     crypto::BcsHashable,
     doc_scalar, hex_debug,
@@ -1216,10 +1216,7 @@ static BYTECODE_COMPRESSION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "bytecode_compression_latency",
         "Bytecode compression latency",
         &[],
-        Some(vec![
-            0.000_1, 0.000_25, 0.000_5, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
-            1.0, 2.5, 5.0, 10.0,
-        ]),
+        bucket_latencies(10.0),
     )
 });
 
@@ -1230,10 +1227,7 @@ static BYTECODE_DECOMPRESSION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(||
         "bytecode_decompression_latency",
         "Bytecode decompression latency",
         &[],
-        Some(vec![
-            0.000_1, 0.000_25, 0.000_5, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
-            1.0, 2.5, 5.0, 10.0,
-        ]),
+        bucket_latencies(10.0),
     )
 });
 

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
 #[cfg(with_metrics)]
-use crate::prometheus_util::{self, bucket_latencies, MeasureLatency};
+use crate::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency};
 use crate::{
     crypto::BcsHashable,
     doc_scalar, hex_debug,
@@ -1212,7 +1212,7 @@ doc_scalar!(
 /// The time it takes to compress a bytecode.
 #[cfg(with_metrics)]
 static BYTECODE_COMPRESSION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "bytecode_compression_latency",
         "Bytecode compression latency",
         &[],
@@ -1223,7 +1223,7 @@ static BYTECODE_COMPRESSION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
 /// The time it takes to decompress a bytecode.
 #[cfg(with_metrics)]
 static BYTECODE_DECOMPRESSION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "bytecode_decompression_latency",
         "Bytecode decompression latency",
         &[],

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -44,7 +44,7 @@ pub fn bucket_interval(start_value: f64, end_value: f64) -> Option<Vec<f64>> {
     let factor = 3.0_f64;
     let count_approx = quot.ln() / factor.ln();
     let count = count_approx.round() as usize;
-    Some(exponential_buckets(start_value, factor, count).expect("An exponential buckets"))
+    Some(exponential_buckets(start_value, factor, count).expect("Exponential buckets creation should not fail!"))
 }
 
 /// Construct the latencies starting from 0.0001 and ending at the maximum latency

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -74,8 +74,6 @@ pub fn bucket_interval(start_value: f64, end_value: f64) -> Option<Vec<f64>> {
     }
 }
 
-
-
 /// A guard for an active latency measurement.
 ///
 /// Finishes the measurement when dropped, and then updates the `Metric`.

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -56,6 +56,26 @@ pub fn bucket_latencies(max_latency: f64) -> Option<Vec<f64>> {
     }
 }
 
+/// Construct the bucket interval starting from a value and an ending value.
+pub fn bucket_interval(start_value: f64, end_value: f64) -> Option<Vec<f64>> {
+    let mut values = Vec::new();
+    let mut value = start_value;
+    let max_delta = 0.01;
+    loop {
+        for mult in [1.0_f64, 2.5_f64, 5.0_f64] {
+            let target_value = value * mult;
+            values.push(target_value);
+            let delta = (target_value - end_value).abs() / end_value;
+            if delta < max_delta {
+                return Some(values);
+            }
+        }
+        value *= 10_f64;
+    }
+}
+
+
+
 /// A guard for an active latency measurement.
 ///
 /// Finishes the measurement when dropped, and then updates the `Metric`.

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -38,6 +38,24 @@ pub fn register_histogram_vec(
     register_histogram_vec!(histogram_opts, label_names).expect("Histogram can be created")
 }
 
+/// Construct the latencies starting from 0.0001 and ending at the maximum latency
+pub fn bucket_latencies(max_latency: f64) -> Option<Vec<f64>> {
+    let mut latencies = Vec::new();
+    let mut latency = 0.0001_f64;
+    let max_delta = 0.01;
+    loop {
+        for mult in [1.0_f64, 2.5_f64, 5.0_f64] {
+            let target_latency = latency * mult;
+            latencies.push(target_latency);
+            let delta = (target_latency - max_latency).abs() / max_latency;
+            if delta < max_delta {
+                return Some(latencies);
+            }
+        }
+        latency *= 10_f64;
+    }
+}
+
 /// A guard for an active latency measurement.
 ///
 /// Finishes the measurement when dropped, and then updates the `Metric`.

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -44,7 +44,10 @@ pub fn bucket_interval(start_value: f64, end_value: f64) -> Option<Vec<f64>> {
     let factor = 3.0_f64;
     let count_approx = quot.ln() / factor.ln();
     let count = count_approx.round() as usize;
-    Some(exponential_buckets(start_value, factor, count).expect("Exponential buckets creation should not fail!"))
+    Some(
+        exponential_buckets(start_value, factor, count)
+            .expect("Exponential buckets creation should not fail!"),
+    )
 }
 
 /// Construct the latencies starting from 0.0001 and ending at the maximum latency

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -4,8 +4,8 @@
 //! This module defines util functions for interacting with Prometheus (logging metrics, etc)
 
 use prometheus::{
-    histogram_opts, register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounterVec,
-    Opts,
+    exponential_buckets, histogram_opts, register_histogram_vec, register_int_counter_vec,
+    HistogramVec, IntCounterVec, Opts,
 };
 
 use crate::time::Instant;
@@ -38,40 +38,18 @@ pub fn register_histogram_vec(
     register_histogram_vec!(histogram_opts, label_names).expect("Histogram can be created")
 }
 
-/// Construct the latencies starting from 0.0001 and ending at the maximum latency
-pub fn bucket_latencies(max_latency: f64) -> Option<Vec<f64>> {
-    let mut latencies = Vec::new();
-    let mut latency = 0.0001_f64;
-    let max_delta = 0.01;
-    loop {
-        for mult in [1.0_f64, 2.5_f64, 5.0_f64] {
-            let target_latency = latency * mult;
-            latencies.push(target_latency);
-            let delta = (target_latency - max_latency).abs() / max_latency;
-            if delta < max_delta {
-                return Some(latencies);
-            }
-        }
-        latency *= 10_f64;
-    }
-}
-
 /// Construct the bucket interval starting from a value and an ending value.
 pub fn bucket_interval(start_value: f64, end_value: f64) -> Option<Vec<f64>> {
-    let mut values = Vec::new();
-    let mut value = start_value;
-    let max_delta = 0.01;
-    loop {
-        for mult in [1.0_f64, 2.5_f64, 5.0_f64] {
-            let target_value = value * mult;
-            values.push(target_value);
-            let delta = (target_value - end_value).abs() / end_value;
-            if delta < max_delta {
-                return Some(values);
-            }
-        }
-        value *= 10_f64;
-    }
+    let quot = end_value / start_value;
+    let factor = 3.0_f64;
+    let count_approx = quot.ln() / factor.ln();
+    let count = count_approx.round() as usize;
+    Some(exponential_buckets(start_value, factor, count).expect("An exponential buckets"))
+}
+
+/// Construct the latencies starting from 0.0001 and ending at the maximum latency
+pub fn bucket_latencies(max_latency: f64) -> Option<Vec<f64>> {
+    bucket_interval(0.0001_f64, max_latency)
 }
 
 /// A guard for an active latency measurement.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -55,13 +55,13 @@ mod chain_tests;
 
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{self, bucket_latencies, MeasureLatency},
+    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, register_int_counter_vec, MeasureLatency},
     prometheus::{HistogramVec, IntCounterVec},
 };
 
 #[cfg(with_metrics)]
 static NUM_BLOCKS_EXECUTED: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "num_blocks_executed",
         "Number of blocks executed",
         &[],
@@ -70,7 +70,7 @@ static NUM_BLOCKS_EXECUTED: LazyLock<IntCounterVec> = LazyLock::new(|| {
 
 #[cfg(with_metrics)]
 static BLOCK_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "block_execution_latency",
         "Block execution latency",
         &[],
@@ -80,7 +80,7 @@ static BLOCK_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
 
 #[cfg(with_metrics)]
 static MESSAGE_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "message_execution_latency",
         "Message execution latency",
         &[],
@@ -90,7 +90,7 @@ static MESSAGE_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
 
 #[cfg(with_metrics)]
 static OPERATION_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "operation_execution_latency",
         "Operation execution latency",
         &[],
@@ -100,7 +100,7 @@ static OPERATION_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
 
 #[cfg(with_metrics)]
 static WASM_FUEL_USED_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "wasm_fuel_used_per_block",
         "Wasm fuel used per block",
         &[],
@@ -113,7 +113,7 @@ static WASM_FUEL_USED_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
 
 #[cfg(with_metrics)]
 static WASM_NUM_READS_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "wasm_num_reads_per_block",
         "Wasm number of reads per block",
         &[],
@@ -123,7 +123,7 @@ static WASM_NUM_READS_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
 
 #[cfg(with_metrics)]
 static WASM_BYTES_READ_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "wasm_bytes_read_per_block",
         "Wasm number of bytes read per block",
         &[],
@@ -149,7 +149,7 @@ static WASM_BYTES_READ_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
 
 #[cfg(with_metrics)]
 static WASM_BYTES_WRITTEN_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "wasm_bytes_written_per_block",
         "Wasm number of bytes written per block",
         &[],
@@ -175,7 +175,7 @@ static WASM_BYTES_WRITTEN_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
 
 #[cfg(with_metrics)]
 static STATE_HASH_COMPUTATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "state_hash_computation_latency",
         "Time to recompute the state hash",
         &[],

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -55,7 +55,7 @@ mod chain_tests;
 
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, register_int_counter_vec, MeasureLatency},
+    linera_base::prometheus_util::{bucket_latencies, bucket_interval, register_histogram_vec, register_int_counter_vec, MeasureLatency},
     prometheus::{HistogramVec, IntCounterVec},
 };
 
@@ -104,10 +104,7 @@ static WASM_FUEL_USED_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
         "wasm_fuel_used_per_block",
         "Wasm fuel used per block",
         &[],
-        Some(vec![
-            50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10_000.0, 25_000.0, 50_000.0,
-            100_000.0, 250_000.0, 500_000.0,
-        ]),
+        bucket_interval(10.0, 500_000.0),
     )
 });
 
@@ -117,7 +114,7 @@ static WASM_NUM_READS_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
         "wasm_num_reads_per_block",
         "Wasm number of reads per block",
         &[],
-        Some(vec![0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0, 50.0, 100.0]),
+        bucket_interval(0.1, 100.0),
     )
 });
 
@@ -127,23 +124,7 @@ static WASM_BYTES_READ_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
         "wasm_bytes_read_per_block",
         "Wasm number of bytes read per block",
         &[],
-        Some(vec![
-            0.5,
-            1.0,
-            10.0,
-            100.0,
-            256.0,
-            512.0,
-            1024.0,
-            2048.0,
-            4096.0,
-            8192.0,
-            16384.0,
-            65_536.0,
-            524_288.0,
-            1_048_576.0,
-            8_388_608.0,
-        ]),
+        bucket_interval(0.1, 10_000_000.0),
     )
 });
 
@@ -153,23 +134,7 @@ static WASM_BYTES_WRITTEN_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
         "wasm_bytes_written_per_block",
         "Wasm number of bytes written per block",
         &[],
-        Some(vec![
-            0.5,
-            1.0,
-            10.0,
-            100.0,
-            256.0,
-            512.0,
-            1024.0,
-            2048.0,
-            4096.0,
-            8192.0,
-            16384.0,
-            65_536.0,
-            524_288.0,
-            1_048_576.0,
-            8_388_608.0,
-        ]),
+        bucket_interval(0.1, 10_000_000.0),
     )
 });
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -55,7 +55,7 @@ mod chain_tests;
 
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{self, MeasureLatency},
+    linera_base::prometheus_util::{self, bucket_latencies, MeasureLatency},
     prometheus::{HistogramVec, IntCounterVec},
 };
 
@@ -74,10 +74,7 @@ static BLOCK_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "block_execution_latency",
         "Block execution latency",
         &[],
-        Some(vec![
-            0.000_1, 0.000_25, 0.000_5, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
-            1.0, 2.5, 5.0, 10.0, 25.0, 50.0,
-        ]),
+        bucket_latencies(50.0),
     )
 });
 
@@ -87,10 +84,7 @@ static MESSAGE_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "message_execution_latency",
         "Message execution latency",
         &[],
-        Some(vec![
-            0.000_1, 0.000_25, 0.000_5, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
-            1.0, 2.5,
-        ]),
+        bucket_latencies(2.5),
     )
 });
 
@@ -100,10 +94,7 @@ static OPERATION_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "operation_execution_latency",
         "Operation execution latency",
         &[],
-        Some(vec![
-            0.000_1, 0.000_25, 0.000_5, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
-            1.0, 2.5,
-        ]),
+        bucket_latencies(2.5),
     )
 });
 
@@ -188,9 +179,7 @@ static STATE_HASH_COMPUTATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(||
         "state_hash_computation_latency",
         "Time to recompute the state hash",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -55,17 +55,16 @@ mod chain_tests;
 
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_latencies, bucket_interval, register_histogram_vec, register_int_counter_vec, MeasureLatency},
+    linera_base::prometheus_util::{
+        bucket_interval, bucket_latencies, register_histogram_vec, register_int_counter_vec,
+        MeasureLatency,
+    },
     prometheus::{HistogramVec, IntCounterVec},
 };
 
 #[cfg(with_metrics)]
 static NUM_BLOCKS_EXECUTED: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    register_int_counter_vec(
-        "num_blocks_executed",
-        "Number of blocks executed",
-        &[],
-    )
+    register_int_counter_vec("num_blocks_executed", "Number of blocks executed", &[])
 });
 
 #[cfg(with_metrics)]

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -88,67 +88,52 @@ mod client_tests;
 mod metrics {
     use std::sync::LazyLock;
 
-    use linera_base::prometheus_util;
+    use linera_base::prometheus_util::{bucket_latencies, register_histogram_vec};
     use prometheus::HistogramVec;
 
     pub static PROCESS_INBOX_WITHOUT_PREPARE_LATENCY: LazyLock<HistogramVec> =
         LazyLock::new(|| {
-            prometheus_util::register_histogram_vec(
+            register_histogram_vec(
                 "process_inbox_latency",
                 "process_inbox latency",
                 &[],
-                Some(vec![
-                    0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
-                    25.0, 50.0, 100.0, 250.0, 500.0,
-                ]),
+                bucket_latencies(500.0),
             )
         });
 
     pub static PREPARE_CHAIN_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        prometheus_util::register_histogram_vec(
+        register_histogram_vec(
             "prepare_chain_latency",
             "prepare_chain latency",
             &[],
-            Some(vec![
-                0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
-                25.0, 50.0, 100.0, 250.0, 500.0,
-            ]),
+            bucket_latencies(500.0),
         )
     });
 
     pub static SYNCHRONIZE_CHAIN_STATE_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        prometheus_util::register_histogram_vec(
+        register_histogram_vec(
             "synchronize_chain_state_latency",
             "synchronize_chain_state latency",
             &[],
-            Some(vec![
-                0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
-                25.0, 50.0, 100.0, 250.0, 500.0,
-            ]),
+            bucket_latencies(500.0),
         )
     });
 
     pub static EXECUTE_BLOCK_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        prometheus_util::register_histogram_vec(
+        register_histogram_vec(
             "execute_block_latency",
             "execute_block latency",
             &[],
-            Some(vec![
-                0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
-                25.0, 50.0, 100.0, 250.0, 500.0,
-            ]),
+            bucket_latencies(500.0),
         )
     });
 
     pub static FIND_RECEIVED_CERTIFICATES_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        prometheus_util::register_histogram_vec(
+        register_histogram_vec(
             "find_received_certificates_latency",
             "find_received_certificates latency",
             &[],
-            Some(vec![
-                0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
-                25.0, 50.0, 100.0, 250.0, 500.0,
-            ]),
+            bucket_latencies(500.0),
         )
     });
 }

--- a/linera-core/src/value_cache.rs
+++ b/linera-core/src/value_cache.rs
@@ -16,7 +16,7 @@ use linera_chain::data_types::{Certificate, HashedCertificateValue, LiteCertific
 use lru::LruCache;
 use tokio::sync::Mutex;
 #[cfg(with_metrics)]
-use {linera_base::prometheus_util, prometheus::IntCounterVec};
+use {linera_base::prometheus_util::register_int_counter_vec, prometheus::IntCounterVec};
 
 use crate::worker::WorkerError;
 
@@ -26,7 +26,7 @@ pub const DEFAULT_VALUE_CACHE_SIZE: usize = 1000;
 /// A counter metric for the number of cache hits in the [`ValueCache`].
 #[cfg(with_metrics)]
 static CACHE_HIT_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "value_cache_hit",
         "Cache hits in `ValueCache`",
         &["key_type", "value_type"],
@@ -36,7 +36,7 @@ static CACHE_HIT_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
 /// A counter metric for the number of cache misses in the [`ValueCache`].
 #[cfg(with_metrics)]
 static CACHE_MISS_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "value_cache_miss",
         "Cache misses in `ValueCache`",
         &["key_type", "value_type"],

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -37,7 +37,7 @@ use tokio::sync::{mpsc, oneshot, OwnedRwLockReadGuard};
 use tracing::{error, instrument, trace, warn, Instrument as _};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util,
+    linera_base::prometheus_util::{register_histogram_vec, register_int_counter_vec},
     prometheus::{HistogramVec, IntCounterVec},
     std::sync::LazyLock,
 };
@@ -56,7 +56,7 @@ mod worker_tests;
 
 #[cfg(with_metrics)]
 static NUM_ROUNDS_IN_CERTIFICATE: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "num_rounds_in_certificate",
         "Number of rounds in certificate",
         &["certificate_value", "round_type"],
@@ -68,7 +68,7 @@ static NUM_ROUNDS_IN_CERTIFICATE: LazyLock<HistogramVec> = LazyLock::new(|| {
 
 #[cfg(with_metrics)]
 static NUM_ROUNDS_IN_BLOCK_PROPOSAL: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "num_rounds_in_block_proposal",
         "Number of rounds in block proposal",
         &["round_type"],
@@ -80,12 +80,12 @@ static NUM_ROUNDS_IN_BLOCK_PROPOSAL: LazyLock<HistogramVec> = LazyLock::new(|| {
 
 #[cfg(with_metrics)]
 static TRANSACTION_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec("transaction_count", "Transaction count", &[])
+    register_int_counter_vec("transaction_count", "Transaction count", &[])
 });
 
 #[cfg(with_metrics)]
 static NUM_BLOCKS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec("num_blocks", "Number of blocks added to chains", &[])
+    register_int_counter_vec("num_blocks", "Number of blocks added to chains", &[])
 });
 
 /// Instruct the networking layer to send cross-chain requests and/or push notifications.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -37,7 +37,7 @@ use tokio::sync::{mpsc, oneshot, OwnedRwLockReadGuard};
 use tracing::{error, instrument, trace, warn, Instrument as _};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{register_histogram_vec, register_int_counter_vec},
+    linera_base::prometheus_util::{bucket_interval, register_histogram_vec, register_int_counter_vec},
     prometheus::{HistogramVec, IntCounterVec},
     std::sync::LazyLock,
 };
@@ -60,9 +60,7 @@ static NUM_ROUNDS_IN_CERTIFICATE: LazyLock<HistogramVec> = LazyLock::new(|| {
         "num_rounds_in_certificate",
         "Number of rounds in certificate",
         &["certificate_value", "round_type"],
-        Some(vec![
-            0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 10.0, 15.0, 25.0, 50.0,
-        ]),
+        bucket_interval(0.1, 50.0),
     )
 });
 
@@ -72,9 +70,7 @@ static NUM_ROUNDS_IN_BLOCK_PROPOSAL: LazyLock<HistogramVec> = LazyLock::new(|| {
         "num_rounds_in_block_proposal",
         "Number of rounds in block proposal",
         &["round_type"],
-        Some(vec![
-            0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 10.0, 15.0, 25.0, 50.0,
-        ]),
+        bucket_interval(0.1, 50.0),
     )
 });
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -37,7 +37,9 @@ use tokio::sync::{mpsc, oneshot, OwnedRwLockReadGuard};
 use tracing::{error, instrument, trace, warn, Instrument as _};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_interval, register_histogram_vec, register_int_counter_vec},
+    linera_base::prometheus_util::{
+        bucket_interval, register_histogram_vec, register_int_counter_vec,
+    },
     prometheus::{HistogramVec, IntCounterVec},
     std::sync::LazyLock,
 };
@@ -75,9 +77,8 @@ static NUM_ROUNDS_IN_BLOCK_PROPOSAL: LazyLock<HistogramVec> = LazyLock::new(|| {
 });
 
 #[cfg(with_metrics)]
-static TRANSACTION_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    register_int_counter_vec("transaction_count", "Transaction count", &[])
-});
+static TRANSACTION_COUNT: LazyLock<IntCounterVec> =
+    LazyLock::new(|| register_int_counter_vec("transaction_count", "Transaction count", &[]));
 
 #[cfg(with_metrics)]
 static NUM_BLOCKS: LazyLock<IntCounterVec> = LazyLock::new(|| {

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -9,7 +9,7 @@ use std::sync::LazyLock;
 
 use futures::channel::mpsc;
 #[cfg(with_metrics)]
-use linera_base::prometheus_util::{self, MeasureLatency as _};
+use linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency as _};
 use linera_base::{
     data_types::{Amount, ApplicationPermissions, BlobContent, Timestamp},
     identifiers::{Account, BlobId, MessageId, Owner},
@@ -32,28 +32,22 @@ use crate::{
 #[cfg(with_metrics)]
 /// Histogram of the latency to load a contract bytecode.
 static LOAD_CONTRACT_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "load_contract_latency",
         "Load contract latency",
         &[],
-        Some(vec![
-            0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0,
-            100.0, 250.0,
-        ]),
+        bucket_latencies(250.0),
     )
 });
 
 #[cfg(with_metrics)]
 /// Histogram of the latency to load a service bytecode.
 static LOAD_SERVICE_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "load_service_latency",
         "Load service latency",
         &[],
-        Some(vec![
-            0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0,
-            100.0, 250.0,
-        ]),
+        bucket_latencies(250.0),
     )
 });
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -33,7 +33,7 @@ use linera_views::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 #[cfg(with_metrics)]
-use {linera_base::prometheus_util, prometheus::IntCounterVec};
+use {linera_base::prometheus_util::register_int_counter_vec, prometheus::IntCounterVec};
 
 #[cfg(test)]
 use crate::test_utils::SystemExecutionState;
@@ -54,7 +54,7 @@ pub static CREATE_APPLICATION_MESSAGE_INDEX: u32 = 0;
 /// The number of times the [`SystemOperation::OpenChain`] was executed.
 #[cfg(with_metrics)]
 static OPEN_CHAIN_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "open_chain_count",
         "The number of times the `OpenChain` operation was executed",
         &[],

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -28,7 +28,7 @@ use wasmer::{WasmerContractInstance, WasmerServiceInstance};
 use wasmtime::{WasmtimeContractInstance, WasmtimeServiceInstance};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{self, MeasureLatency},
+    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
     prometheus::HistogramVec,
     std::sync::LazyLock,
 };
@@ -45,25 +45,21 @@ use crate::{
 
 #[cfg(with_metrics)]
 static CONTRACT_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "contract_instantiation_latency",
         "Contract instantiation latency",
         &[],
-        Some(vec![
-            0.000_1, 0.000_3, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
-        ]),
+        bucket_latencies(1.0),
     )
 });
 
 #[cfg(with_metrics)]
 static SERVICE_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "service_instantiation_latency",
         "Service instantiation latency",
         &[],
-        Some(vec![
-            0.000_1, 0.000_3, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
-        ]),
+        bucket_latencies(1.0),
     )
 });
 

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -30,7 +30,7 @@ use tower::{builder::ServiceBuilder, Layer, Service};
 use tracing::{debug, error, info, instrument, trace, warn};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util,
+    linera_base::prometheus_util::{register_histogram_vec, register_int_counter_vec},
     prometheus::{HistogramVec, IntCounterVec},
 };
 
@@ -55,7 +55,7 @@ type NotificationSender = mpsc::Sender<Notification>;
 
 #[cfg(with_metrics)]
 static SERVER_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "server_request_latency",
         "Server request latency",
         &[],
@@ -65,12 +65,12 @@ static SERVER_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
 
 #[cfg(with_metrics)]
 static SERVER_REQUEST_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec("server_request_count", "Server request count", &[])
+    register_int_counter_vec("server_request_count", "Server request count", &[])
 });
 
 #[cfg(with_metrics)]
 static SERVER_REQUEST_SUCCESS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "server_request_success",
         "Server request success",
         &["method_name"],
@@ -79,7 +79,7 @@ static SERVER_REQUEST_SUCCESS: LazyLock<IntCounterVec> = LazyLock::new(|| {
 
 #[cfg(with_metrics)]
 static SERVER_REQUEST_ERROR: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "server_request_error",
         "Server request error",
         &["method_name"],
@@ -88,7 +88,7 @@ static SERVER_REQUEST_ERROR: LazyLock<IntCounterVec> = LazyLock::new(|| {
 
 #[cfg(with_metrics)]
 static SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "server_request_latency_per_request_type",
         "Server request latency per request type",
         &["method_name"],

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -30,7 +30,7 @@ use tower::{builder::ServiceBuilder, Layer, Service};
 use tracing::{debug, error, info, instrument, trace, warn};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{register_histogram_vec, register_int_counter_vec},
+    linera_base::prometheus_util::{bucket_interval, register_histogram_vec, register_int_counter_vec},
     prometheus::{HistogramVec, IntCounterVec},
 };
 
@@ -59,7 +59,7 @@ static SERVER_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "server_request_latency",
         "Server request latency",
         &[],
-        Some(vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0]),
+        bucket_interval(0.1, 50.0),
     )
 });
 
@@ -92,7 +92,7 @@ static SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE: LazyLock<HistogramVec> = LazyLoc
         "server_request_latency_per_request_type",
         "Server request latency per request type",
         &["method_name"],
-        Some(vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0]),
+        bucket_interval(0.1, 50.0),
     )
 });
 

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -30,7 +30,9 @@ use tower::{builder::ServiceBuilder, Layer, Service};
 use tracing::{debug, error, info, instrument, trace, warn};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_interval, register_histogram_vec, register_int_counter_vec},
+    linera_base::prometheus_util::{
+        bucket_interval, register_histogram_vec, register_int_counter_vec,
+    },
     prometheus::{HistogramVec, IntCounterVec},
 };
 
@@ -64,9 +66,8 @@ static SERVER_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
 });
 
 #[cfg(with_metrics)]
-static SERVER_REQUEST_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    register_int_counter_vec("server_request_count", "Server request count", &[])
-});
+static SERVER_REQUEST_COUNT: LazyLock<IntCounterVec> =
+    LazyLock::new(|| register_int_counter_vec("server_request_count", "Server request count", &[]));
 
 #[cfg(with_metrics)]
 static SERVER_REQUEST_SUCCESS: LazyLock<IntCounterVec> = LazyLock::new(|| {

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -37,7 +37,9 @@ use {
 };
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{self, MeasureLatency},
+    linera_base::prometheus_util::{
+        bucket_latencies, register_histogram_vec, register_int_counter_vec, MeasureLatency,
+    },
     prometheus::{HistogramVec, IntCounterVec},
 };
 
@@ -46,7 +48,7 @@ use crate::{ChainRuntimeContext, Clock, Storage};
 /// The metric counting how often a blob is tested for existence from storage
 #[cfg(with_metrics)]
 static CONTAINS_BLOB_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "contains_blob",
         "The metric counting how often a blob is tested for existence from storage",
         &[],
@@ -56,7 +58,7 @@ static CONTAINS_BLOB_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
 /// The metric counting how often multiple blobs are tested for existence from storage
 #[cfg(with_metrics)]
 static CONTAINS_BLOBS_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "contains_blobs",
         "The metric counting how often multiple blobs are tested for existence from storage",
         &[],
@@ -66,7 +68,7 @@ static CONTAINS_BLOBS_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
 /// The metric counting how often a blob state is tested for existence from storage
 #[cfg(with_metrics)]
 static CONTAINS_BLOB_STATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "contains_blob_state",
         "The metric counting how often a blob state is tested for existence from storage",
         &[],
@@ -76,7 +78,7 @@ static CONTAINS_BLOB_STATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
 /// The metric counting how often a certificate is tested for existence from storage.
 #[cfg(with_metrics)]
 static CONTAINS_CERTIFICATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "contains_certificate",
         "The metric counting how often a certificate is tested for existence from storage",
         &[],
@@ -87,7 +89,7 @@ static CONTAINS_CERTIFICATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| 
 #[cfg(with_metrics)]
 #[doc(hidden)]
 pub static READ_HASHED_CERTIFICATE_VALUE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "read_hashed_certificate_value",
         "The metric counting how often a hashed certificate value is read from storage",
         &[],
@@ -98,7 +100,7 @@ pub static READ_HASHED_CERTIFICATE_VALUE_COUNTER: LazyLock<IntCounterVec> = Lazy
 #[cfg(with_metrics)]
 #[doc(hidden)]
 pub static READ_BLOB_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "read_blob",
         "The metric counting how often a blob is read from storage",
         &[],
@@ -109,7 +111,7 @@ pub static READ_BLOB_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
 #[cfg(with_metrics)]
 #[doc(hidden)]
 pub static READ_BLOB_STATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "read_blob_state",
         "The metric counting how often a blob state is read from storage",
         &[],
@@ -120,7 +122,7 @@ pub static READ_BLOB_STATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
 #[cfg(with_metrics)]
 #[doc(hidden)]
 pub static READ_BLOB_STATES_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "read_blob_states",
         "The metric counting how often blob states are read from storage",
         &[],
@@ -131,7 +133,7 @@ pub static READ_BLOB_STATES_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| 
 #[cfg(with_metrics)]
 #[doc(hidden)]
 pub static WRITE_BLOB_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "write_blob",
         "The metric counting how often a blob is written to storage",
         &[],
@@ -142,7 +144,7 @@ pub static WRITE_BLOB_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
 #[cfg(with_metrics)]
 #[doc(hidden)]
 pub static READ_CERTIFICATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "read_certificate",
         "The metric counting how often a certificate is read from storage",
         &[],
@@ -153,7 +155,7 @@ pub static READ_CERTIFICATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| 
 #[cfg(with_metrics)]
 #[doc(hidden)]
 pub static READ_CERTIFICATES_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "read_certificates",
         "The metric counting how often certificate are read from storage",
         &[],
@@ -164,7 +166,7 @@ pub static READ_CERTIFICATES_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(||
 #[cfg(with_metrics)]
 #[doc(hidden)]
 pub static WRITE_CERTIFICATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
+    register_int_counter_vec(
         "write_certificate",
         "The metric counting how often a certificate is written to storage",
         &[],
@@ -175,13 +177,11 @@ pub static WRITE_CERTIFICATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(||
 #[cfg(with_metrics)]
 #[doc(hidden)]
 pub static LOAD_CHAIN_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "load_chain_latency",
         "The latency to load a chain state",
         &[],
-        Some(vec![
-            0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
-        ]),
+        bucket_latencies(1.0),
     )
 });
 

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -15,7 +15,7 @@ use std::{
 
 use linked_hash_map::LinkedHashMap;
 #[cfg(with_metrics)]
-use {linera_base::prometheus_util, prometheus::IntCounterVec};
+use {linera_base::prometheus_util::register_int_counter_vec, prometheus::IntCounterVec};
 
 use crate::{
     batch::{Batch, WriteOperation},
@@ -28,13 +28,13 @@ use crate::{memory::MemoryStore, store::TestKeyValueStore};
 #[cfg(with_metrics)]
 /// The total number of cache faults
 static NUM_CACHE_FAULT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec("num_cache_fault", "Number of cache faults", &[])
+    register_int_counter_vec("num_cache_fault", "Number of cache faults", &[])
 });
 
 #[cfg(with_metrics)]
 /// The total number of cache successes
 static NUM_CACHE_SUCCESS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec("num_cache_success", "Number of cache success", &[])
+    register_int_counter_vec("num_cache_success", "Number of cache success", &[])
 });
 
 /// The `LruPrefixCache` stores the data for simple `read_values` queries

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -27,15 +27,13 @@ use crate::{memory::MemoryStore, store::TestKeyValueStore};
 
 #[cfg(with_metrics)]
 /// The total number of cache faults
-static NUM_CACHE_FAULT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    register_int_counter_vec("num_cache_fault", "Number of cache faults", &[])
-});
+static NUM_CACHE_FAULT: LazyLock<IntCounterVec> =
+    LazyLock::new(|| register_int_counter_vec("num_cache_fault", "Number of cache faults", &[]));
 
 #[cfg(with_metrics)]
 /// The total number of cache successes
-static NUM_CACHE_SUCCESS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    register_int_counter_vec("num_cache_success", "Number of cache success", &[])
-});
+static NUM_CACHE_SUCCESS: LazyLock<IntCounterVec> =
+    LazyLock::new(|| register_int_counter_vec("num_cache_success", "Number of cache success", &[]));
 
 /// The `LruPrefixCache` stores the data for simple `read_values` queries
 /// It is inspired by the crate `lru-cache`.

--- a/linera-views/src/metrics.rs
+++ b/linera-views/src/metrics.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 
 // Re-export for macros.
 #[doc(hidden)]
-pub use linera_base::prometheus_util;
+pub use linera_base::prometheus_util::{self, bucket_latencies};
 use prometheus::IntCounterVec;
 
 /// Increments the metrics counter with the given name, with the struct and base key as labels.
@@ -22,9 +22,7 @@ pub static LOAD_VIEW_LATENCY: LazyLock<prometheus::HistogramVec> = LazyLock::new
         "load_view_latency",
         "Load view latency",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{self, MeasureLatency},
+    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
     prometheus::HistogramVec,
 };
 
@@ -27,13 +27,11 @@ use crate::{
 #[cfg(with_metrics)]
 /// The runtime of hash computation
 static BUCKET_QUEUE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "bucket_queue_view_hash_runtime",
         "BucketQueueView hash runtime",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{self, MeasureLatency},
+    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
     prometheus::HistogramVec,
 };
 
@@ -33,13 +33,11 @@ use crate::{
 #[cfg(with_metrics)]
 /// The runtime of hash computation
 static COLLECTION_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "collection_view_hash_runtime",
         "CollectionView hash runtime",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -10,7 +10,7 @@ use linera_base::{data_types::ArithmeticError, ensure};
 use serde::{Deserialize, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{self, MeasureLatency},
+    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
     prometheus::HistogramVec,
 };
 
@@ -29,65 +29,55 @@ use crate::{
 #[cfg(with_metrics)]
 /// The latency of hash computation
 static KEY_VALUE_STORE_VIEW_HASH_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "key_value_store_view_hash_latency",
         "KeyValueStoreView hash latency",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 
 #[cfg(with_metrics)]
 /// The latency of get operation
 static KEY_VALUE_STORE_VIEW_GET_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "key_value_store_view_get_latency",
         "KeyValueStoreView get latency",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 
 #[cfg(with_metrics)]
 /// The latency of multi get
 static KEY_VALUE_STORE_VIEW_MULTI_GET_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "key_value_store_view_multi_get_latency",
         "KeyValueStoreView multi get latency",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 
 #[cfg(with_metrics)]
 /// The latency of contains key
 static KEY_VALUE_STORE_VIEW_CONTAINS_KEY_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "key_value_store_view_contains_key_latency",
         "KeyValueStoreView contains key latency",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 
 #[cfg(with_metrics)]
 /// The latency of contains keys
 static KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "key_value_store_view_contains_keys_latency",
         "KeyValueStoreView contains keys latency",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 
@@ -95,13 +85,11 @@ static KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_LATENCY: LazyLock<HistogramVec> = Lazy
 /// The latency of find keys by prefix operation
 static KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_LATENCY: LazyLock<HistogramVec> =
     LazyLock::new(|| {
-        prometheus_util::register_histogram_vec(
+        register_histogram_vec(
             "key_value_store_view_find_keys_by_prefix_latency",
             "KeyValueStoreView find keys by prefix latency",
             &[],
-            Some(vec![
-                0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-            ]),
+            bucket_latencies(5.0),
         )
     });
 
@@ -109,26 +97,22 @@ static KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_LATENCY: LazyLock<HistogramVec> 
 /// The latency of find key values by prefix operation
 static KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_LATENCY: LazyLock<HistogramVec> =
     LazyLock::new(|| {
-        prometheus_util::register_histogram_vec(
+        register_histogram_vec(
             "key_value_store_view_find_key_values_by_prefix_latency",
             "KeyValueStoreView find key values by prefix latency",
             &[],
-            Some(vec![
-                0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-            ]),
+            bucket_latencies(5.0),
         )
     });
 
 #[cfg(with_metrics)]
 /// The latency of write batch operation
 static KEY_VALUE_STORE_VIEW_WRITE_BATCH_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "key_value_store_view_write_batch_latency",
         "KeyValueStoreView write batch latency",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{self, MeasureLatency},
+    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
     prometheus::HistogramVec,
 };
 
@@ -27,13 +27,11 @@ use crate::{
 #[cfg(with_metrics)]
 /// The runtime of hash computation
 static LOG_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "log_view_hash_runtime",
         "LogView hash runtime",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -21,20 +21,18 @@ use std::sync::LazyLock;
 
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{self, MeasureLatency},
+    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
     prometheus::HistogramVec,
 };
 
 #[cfg(with_metrics)]
 /// The runtime of hash computation
 static MAP_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "map_view_hash_runtime",
         "MapView hash runtime",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{self, MeasureLatency},
+    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
     prometheus::HistogramVec,
 };
 
@@ -28,13 +28,11 @@ use crate::{
 #[cfg(with_metrics)]
 /// The runtime of hash computation
 static QUEUE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "queue_view_hash_runtime",
         "QueueView hash runtime",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{self, MeasureLatency},
+    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
     prometheus::HistogramVec,
 };
 
@@ -34,13 +34,11 @@ use crate::{
 #[cfg(with_metrics)]
 /// The runtime of hash computation
 static REENTRANT_COLLECTION_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "reentrant_collection_view_hash_runtime",
         "ReentrantCollectionView hash runtime",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{self, MeasureLatency},
+    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
     prometheus::HistogramVec,
 };
 
@@ -24,13 +24,11 @@ use crate::{
 #[cfg(with_metrics)]
 /// The runtime of hash computation
 static REGISTER_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "register_view_hash_runtime",
         "RegisterView hash runtime",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/set_view.rs
+++ b/linera-views/src/views/set_view.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{self, MeasureLatency},
+    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
     prometheus::HistogramVec,
 };
 
@@ -25,13 +25,11 @@ use crate::{
 #[cfg(with_metrics)]
 /// The runtime of hash computation
 static SET_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
+    register_histogram_vec(
         "set_view_hash_runtime",
         "SetView hash runtime",
         &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
+        bucket_latencies(5.0),
     )
 });
 


### PR DESCRIPTION
## Motivation

The Prometheus entries is creating a lot of copy-pasted code which is bad taste. 

## Proposal

This PR does two things:
* Change the use statements which lead to smaller code.
* Introduce functions `bucket_latencies` and `bucket_interval` for creating the bucket of values in a more organized way.

## Test Plan

The CI

## Release Plan

The intervals have changed a bit. So, if the operation code strictly depends on the exact values of the buckets then
something else would have to be done.

## Links

None.