### PR TITLE
Add `BlockHeight` and `ChainId` to `BlobState`.

### DIFF
--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -313,6 +313,8 @@ where
         // Update the blob state with last used certificate hash.
         let blob_state = BlobState {
             last_used_by: certificate_hash,
+            chain_id: block.chain_id,
+            block_height,
             epoch: block.epoch,
         };
         self.state

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -292,7 +292,7 @@ where
                     let mut chain_heights = BTreeMap::new();
                     for blob_state in blob_states {
                         let block_chain_id = blob_state.chain_id;
-                        let block_height = blob_state.block_height;
+                        let block_height = blob_state.block_height.try_add_one()?;
                         chain_heights
                             .entry(block_chain_id)
                             .and_modify(|h| *h = block_height.max(*h))

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -289,14 +289,10 @@ where
                         .await;
                     let local_storage = self.local_node.storage_client();
                     let blob_states = local_storage.read_blob_states(&missing_blob_ids).await?;
-                    let certificates = local_storage
-                        .read_certificates(blob_states.into_iter().map(|x| x.last_used_by))
-                        .await?;
                     let mut chain_heights = BTreeMap::new();
-                    for certificate in certificates {
-                        let block_chain_id = certificate.executed_block().block.chain_id;
-                        let block_height =
-                            certificate.executed_block().block.height.try_add_one()?;
+                    for blob_state in blob_states {
+                        let block_chain_id = blob_state.chain_id;
+                        let block_height = blob_state.block_height;
                         chain_heights
                             .entry(block_chain_id)
                             .and_modify(|h| *h = block_height.max(*h))

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1174,6 +1174,10 @@ impl From<Vec<u8>> for Response {
 pub struct BlobState {
     /// Hash of the last `Certificate` that published or used this blob.
     pub last_used_by: CryptoHash,
+    /// The `ChainId` of the chain that published the change
+    pub chain_id: ChainId,
+    /// The `BlockHeight` of the chain that published the change
+    pub block_height: BlockHeight,
     /// Epoch of the `last_used_by` certificate.
     pub epoch: Epoch,
 }


### PR DESCRIPTION
## Motivation

The code in updater.rs does a fairly expensive things. It download first the blob states and then
for each blob_state it downloads the certificates but then only reads the chain_id and the block_height
which seems wasteful.

## Proposal

The following changes:
* Add the `block_height` and `chain_id` to the blob_state. We cannot remove the `last_used_by` since it is used by the `download_certificate` function. The addition is not expensive as the `block_height` and `chain_id` are small data types.
* Update the `attempted_change.rs` by adding this information as this is the only place where blob_state is created.
* Correspondingly change the `updater.rs`.

## Test Plan

The CI.

## Release Plan

This changes the `BlobState`, so it is not a matter of recompiling and running again the validators. It does break the storage state. If an update is needed, then specific code can be created for upgrading the storage.

## Links

None.