### PR TITLE
Generalize Vote and SignatureAggregator over type of value they hold.

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -113,12 +113,13 @@ impl From<Timeout> for HashedCertificateValue {
     }
 }
 
-impl From<HashedCertificateValue> for Hashed<Timeout> {
-    fn from(hv: HashedCertificateValue) -> Hashed<Timeout> {
-        let hash = hv.hash();
-        match hv.into_inner() {
-            CertificateValue::Timeout(timeout) => Hashed::unchecked_new(timeout, hash),
-            _ => panic!("Expected a Timeout value"),
+impl TryFrom<HashedCertificateValue> for Hashed<Timeout> {
+    type Error = &'static str;
+    fn try_from(value: HashedCertificateValue) -> Result<Hashed<Timeout>, Self::Error> {
+        let hash = value.hash();
+        match value.into_inner() {
+            CertificateValue::Timeout(timeout) => Ok(Hashed::unchecked_new(timeout, hash)),
+            _ => Err("Expected a Timeout value"),
         }
     }
 }

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     data_types::ExecutedBlock,
-    types::{CertificateValue, Hashed, HashedCertificateValue},
+    types::{CertificateValue, Has, Hashed, HashedCertificateValue},
 };
 
 /// Wrapper around an `ExecutedBlock` that has been validated.
@@ -124,3 +124,9 @@ impl From<HashedCertificateValue> for Hashed<Timeout> {
 }
 
 impl BcsHashable for Timeout {}
+
+impl Has<ChainId> for Timeout {
+    fn get(&self) -> &ChainId {
+        &self.chain_id
+    }
+}

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -8,7 +8,10 @@ use linera_base::{crypto::BcsHashable, data_types::BlockHeight, identifiers::Cha
 use linera_execution::committee::Epoch;
 use serde::{Deserialize, Serialize};
 
-use crate::{data_types::ExecutedBlock, types::HashedCertificateValue};
+use crate::{
+    data_types::ExecutedBlock,
+    types::{CertificateValue, Hashed, HashedCertificateValue},
+};
 
 /// Wrapper around an `ExecutedBlock` that has been validated.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Deserialize, Serialize)]
@@ -109,3 +112,15 @@ impl From<Timeout> for HashedCertificateValue {
         HashedCertificateValue::new_timeout(value.chain_id, value.height, value.epoch)
     }
 }
+
+impl From<HashedCertificateValue> for Hashed<Timeout> {
+    fn from(hv: HashedCertificateValue) -> Hashed<Timeout> {
+        let hash = hv.hash();
+        match hv.into_inner() {
+            CertificateValue::Timeout(timeout) => Hashed::unchecked_new(timeout, hash),
+            _ => panic!("Expected a Timeout value"),
+        }
+    }
+}
+
+impl BcsHashable for Timeout {}

--- a/linera-chain/src/certificate/hashed.rs
+++ b/linera-chain/src/certificate/hashed.rs
@@ -59,7 +59,7 @@ impl<T> Hashed<T> {
     {
         LiteValue {
             value_hash: self.hash,
-            chain_id: *Has::<ChainId>::get(&self.value),
+            chain_id: *self.value.get(),
         }
     }
 }

--- a/linera-chain/src/certificate/hashed.rs
+++ b/linera-chain/src/certificate/hashed.rs
@@ -101,7 +101,7 @@ impl<T> PartialEq for Hashed<T> {
 #[cfg(with_testing)]
 impl<T> Eq for Hashed<T> {}
 
-//TODO: Move
+/// A constraint summing a value of type `T`.
 pub trait Has<T> {
     fn get(&self) -> &T;
 }

--- a/linera-chain/src/certificate/mod.rs
+++ b/linera-chain/src/certificate/mod.rs
@@ -13,7 +13,7 @@ mod value;
 use std::borrow::Cow;
 
 pub use generic::GenericCertificate;
-pub use hashed::Hashed;
+pub use hashed::{Has, Hashed};
 use linera_base::{
     crypto::Signature,
     data_types::Round,

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -20,7 +20,7 @@ use linera_execution::{
     system::OpenChainConfig,
     Message, MessageKind, Operation, SystemMessage, SystemOperation,
 };
-use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
     block::Timeout,
@@ -422,41 +422,13 @@ pub struct LiteValue {
 struct ValueHashAndRound(CryptoHash, Round);
 
 /// A vote on a statement from a validator.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound(deserialize = "T: DeserializeOwned + BcsHashable"))]
 pub struct Vote<T> {
     pub value: Hashed<T>,
     pub round: Round,
     pub validator: ValidatorName,
     pub signature: Signature,
-}
-
-impl<'de, T: DeserializeOwned + BcsHashable> Deserialize<'de> for Vote<T> {
-    fn deserialize<D>(deserializer: D) -> Result<Vote<T>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Debug, Deserialize)]
-        struct VoteHelper<T> {
-            value: T,
-            round: Round,
-            validator: ValidatorName,
-            signature: Signature,
-        }
-
-        let VoteHelper {
-            value,
-            round,
-            validator,
-            signature,
-        } = VoteHelper::deserialize(deserializer)?;
-
-        Ok(Vote {
-            value: Hashed::new(value),
-            round,
-            validator,
-            signature,
-        })
-    }
 }
 
 impl Has<ChainId> for CertificateValue {

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -125,13 +125,13 @@ pub struct ChainManager {
     pub timeout: Option<TimeoutCertificate>,
     /// Latest vote we have cast, to validate or confirm.
     #[debug(skip_if = Option::is_none)]
-    pub pending: Option<Vote>,
+    pub pending: Option<Vote<CertificateValue>>,
     /// Latest timeout vote we cast.
     #[debug(skip_if = Option::is_none)]
-    pub timeout_vote: Option<Vote>,
+    pub timeout_vote: Option<Vote<CertificateValue>>,
     /// Fallback vote we cast.
     #[debug(skip_if = Option::is_none)]
-    pub fallback_vote: Option<Vote>,
+    pub fallback_vote: Option<Vote<CertificateValue>>,
     /// The time after which we are ready to sign a timeout certificate for the current round.
     #[debug(skip_if = Option::is_none)]
     pub round_timeout: Option<Timestamp>,
@@ -221,7 +221,7 @@ impl ChainManager {
     }
 
     /// Returns the most recent vote we cast.
-    pub fn pending(&self) -> Option<&Vote> {
+    pub fn pending(&self) -> Option<&Vote<CertificateValue>> {
         self.pending.as_ref()
     }
 

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -319,7 +319,11 @@ impl ChainManager {
             }
         }
         let value = HashedCertificateValue::new_timeout(chain_id, height, epoch);
-        self.timeout_vote = Some(Vote::new(value.into(), current_round, key_pair));
+        self.timeout_vote = Some(Vote::new(
+            value.try_into().expect("Timeout certificate"),
+            current_round,
+            key_pair,
+        ));
         true
     }
 
@@ -342,7 +346,11 @@ impl ChainManager {
         }
         let value = HashedCertificateValue::new_timeout(chain_id, height, epoch);
         let last_regular_round = Round::SingleLeader(u32::MAX);
-        self.fallback_vote = Some(Vote::new(value.into(), last_regular_round, key_pair));
+        self.fallback_vote = Some(Vote::new(
+            value.try_into().expect("Timeout certificate"),
+            last_regular_round,
+            key_pair,
+        ));
         true
     }
 

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -84,6 +84,7 @@ use rand_distr::{Distribution, WeightedAliasIndex};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    block::Timeout,
     data_types::{Block, BlockExecutionOutcome, BlockProposal, LiteVote, ProposalContent, Vote},
     types::{
         CertificateValue, ConfirmedBlockCertificate, HashedCertificateValue, TimeoutCertificate,
@@ -128,10 +129,10 @@ pub struct ChainManager {
     pub pending: Option<Vote<CertificateValue>>,
     /// Latest timeout vote we cast.
     #[debug(skip_if = Option::is_none)]
-    pub timeout_vote: Option<Vote<CertificateValue>>,
+    pub timeout_vote: Option<Vote<Timeout>>,
     /// Fallback vote we cast.
     #[debug(skip_if = Option::is_none)]
-    pub fallback_vote: Option<Vote<CertificateValue>>,
+    pub fallback_vote: Option<Vote<Timeout>>,
     /// The time after which we are ready to sign a timeout certificate for the current round.
     #[debug(skip_if = Option::is_none)]
     pub round_timeout: Option<Timestamp>,
@@ -318,7 +319,7 @@ impl ChainManager {
             }
         }
         let value = HashedCertificateValue::new_timeout(chain_id, height, epoch);
-        self.timeout_vote = Some(Vote::new(value, current_round, key_pair));
+        self.timeout_vote = Some(Vote::new(value.into(), current_round, key_pair));
         true
     }
 
@@ -341,7 +342,7 @@ impl ChainManager {
         }
         let value = HashedCertificateValue::new_timeout(chain_id, height, epoch);
         let last_regular_round = Round::SingleLeader(u32::MAX);
-        self.fallback_vote = Some(Vote::new(value, last_regular_round, key_pair));
+        self.fallback_vote = Some(Vote::new(value.into(), last_regular_round, key_pair));
         true
     }
 

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -16,7 +16,7 @@ use linera_execution::{
 
 use crate::{
     data_types::{Block, BlockProposal, IncomingBundle, PostedMessage, SignatureAggregator, Vote},
-    types::{Certificate, HashedCertificateValue},
+    types::{GenericCertificate, HashedCertificateValue},
 };
 
 /// Creates a new child of the given block, with the same timestamp.
@@ -124,13 +124,13 @@ impl BlockTestExt for Block {
     }
 }
 
-pub trait VoteTestExt: Sized {
+pub trait VoteTestExt<T>: Sized {
     /// Returns a certificate for a committee consisting only of this validator.
-    fn into_certificate(self) -> Certificate;
+    fn into_certificate(self) -> GenericCertificate<T>;
 }
 
-impl VoteTestExt for Vote {
-    fn into_certificate(self) -> Certificate {
+impl<T: Clone> VoteTestExt<T> for Vote<T> {
+    fn into_certificate(self) -> GenericCertificate<T> {
         let state = ValidatorState {
             network_address: "".to_string(),
             votes: 100,

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -5,7 +5,10 @@
 use linera_base::data_types::Amount;
 
 use super::*;
-use crate::test::{make_first_block, BlockTestExt};
+use crate::{
+    test::{make_first_block, BlockTestExt},
+    types::HashedCertificateValue,
+};
 
 #[test]
 fn test_signed_values() {


### PR DESCRIPTION
## Motivation

`Vote` and `SignatureAggregator` both work with hardcoded types (`Certificate` and `HashedCertificateValue` respectively) which is an obstacle to full removal of `Certificate` from the codebase.

## Proposal

Make both generic over type they work with. 

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

CI should catch regressions.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.

## Links

Closes https://github.com/linera-io/linera-protocol/issues/2885
<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
