### PR TITLE
Fix resource control policy GraphQL serialization

### DIFF
--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -20,7 +20,8 @@ use linera_execution::{
     system::{OpenChainConfig, Recipient},
     test_utils::{ExpectedCall, MockApplication},
     ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message, MessageKind,
-    Operation, ResourceControlPolicy, SystemMessage, SystemOperation, TestExecutionRuntimeContext,
+    Operation, ResourceControlPolicy, ResourceLimit, SystemMessage, SystemOperation,
+    TestExecutionRuntimeContext,
 };
 use linera_views::{
     context::{Context as _, MemoryContext},
@@ -110,7 +111,7 @@ async fn test_block_size_limit() {
     let mut chain = ChainStateView::new(chain_id).await;
 
     // The size of the executed valid block below.
-    let maximum_executed_block_size = 691;
+    let maximum_executed_block_size = ResourceLimit(691);
 
     // Initialize the chain.
     let mut config = make_open_chain_config();
@@ -174,7 +175,7 @@ async fn test_block_size_limit() {
     // ...because its size is exactly at the allowed limit.
     assert_eq!(
         bcs::serialized_size(&executed_block).unwrap(),
-        maximum_executed_block_size as usize
+        maximum_executed_block_size.0 as usize
     );
 }
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -20,7 +20,8 @@ use linera_base::{
 };
 use linera_core::client::BlanketMessagePolicy;
 use linera_execution::{
-    committee::ValidatorName, ResourceControlPolicy, WasmRuntime, WithWasmDefault as _,
+    committee::ValidatorName, ResourceControlPolicy, ResourceLimit, WasmRuntime,
+    WithWasmDefault as _,
 };
 use linera_views::store::CommonStoreConfig;
 
@@ -531,28 +532,28 @@ pub enum ClientCommand {
 
         /// Set the maximum amount of fuel per block.
         #[arg(long)]
-        maximum_fuel_per_block: Option<u64>,
+        maximum_fuel_per_block: Option<ResourceLimit>,
 
         /// Set the maximum size of an executed block, in bytes.
         #[arg(long)]
-        maximum_executed_block_size: Option<u64>,
+        maximum_executed_block_size: Option<ResourceLimit>,
 
         /// Set the maximum size of data blobs, compressed bytecode and other binary blobs,
         /// in bytes.
         #[arg(long)]
-        maximum_blob_size: Option<u64>,
+        maximum_blob_size: Option<ResourceLimit>,
 
         /// Set the maximum size of decompressed contract or service bytecode, in bytes.
         #[arg(long)]
-        maximum_bytecode_size: Option<u64>,
+        maximum_bytecode_size: Option<ResourceLimit>,
 
         /// Set the maximum read data per block.
         #[arg(long)]
-        maximum_bytes_read_per_block: Option<u64>,
+        maximum_bytes_read_per_block: Option<ResourceLimit>,
 
         /// Set the maximum write data per block.
         #[arg(long)]
-        maximum_bytes_written_per_block: Option<u64>,
+        maximum_bytes_written_per_block: Option<ResourceLimit>,
     },
 
     /// Send one transfer per chain in bulk mode
@@ -654,28 +655,28 @@ pub enum ClientCommand {
 
         /// Set the maximum amount of fuel per block.
         #[arg(long)]
-        maximum_fuel_per_block: Option<u64>,
+        maximum_fuel_per_block: ResourceLimit,
 
         /// Set the maximum size of an executed block.
         #[arg(long)]
-        maximum_executed_block_size: Option<u64>,
+        maximum_executed_block_size: ResourceLimit,
 
         /// Set the maximum size of decompressed contract or service bytecode, in bytes.
         #[arg(long)]
-        maximum_bytecode_size: Option<u64>,
+        maximum_bytecode_size: ResourceLimit,
 
         /// Set the maximum size of data blobs, compressed bytecode and other binary blobs,
         /// in bytes.
         #[arg(long)]
-        maximum_blob_size: Option<u64>,
+        maximum_blob_size: ResourceLimit,
 
         /// Set the maximum read data per block.
         #[arg(long)]
-        maximum_bytes_read_per_block: Option<u64>,
+        maximum_bytes_read_per_block: ResourceLimit,
 
         /// Set the maximum write data per block.
         #[arg(long)]
-        maximum_bytes_written_per_block: Option<u64>,
+        maximum_bytes_written_per_block: ResourceLimit,
 
         /// Force this wallet to generate keys using a PRNG and a given seed. USE FOR
         /// TESTING ONLY.

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -357,7 +357,7 @@ where
             BlobContent::ContractBytecode(compressed_bytecode)
             | BlobContent::ServiceBytecode(compressed_bytecode) => {
                 ensure!(
-                    compressed_bytecode.decompressed_size_at_most(policy.maximum_bytecode_size)?,
+                    compressed_bytecode.decompressed_size_at_most(*policy.maximum_bytecode_size)?,
                     WorkerError::BytecodeTooLarge
                 );
             }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -21,8 +21,8 @@ use linera_chain::{
 use linera_execution::{
     committee::{Committee, Epoch},
     system::{Recipient, SystemOperation},
-    ExecutionError, Message, MessageKind, Operation, ResourceControlPolicy, SystemExecutionError,
-    SystemMessage, SystemQuery, SystemResponse,
+    ExecutionError, Message, MessageKind, Operation, ResourceControlPolicy, ResourceLimit,
+    SystemExecutionError, SystemMessage, SystemQuery, SystemResponse,
 };
 use linera_storage::{DbStorage, TestClock};
 use linera_views::memory::MemoryStore;
@@ -2407,7 +2407,7 @@ where
     let blob_bytes = b"blob".to_vec();
     let large_blob_bytes = b"blob+".to_vec();
     let policy = ResourceControlPolicy {
-        maximum_blob_size: blob_bytes.len() as u64,
+        maximum_blob_size: ResourceLimit(blob_bytes.len() as u64),
         ..ResourceControlPolicy::default()
     };
     let mut builder = TestBuilder::new(storage_builder, 4, 0)

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -66,7 +66,7 @@ pub use crate::{
     applications::ApplicationRegistryView,
     execution::{ExecutionStateView, ServiceRuntimeEndpoint},
     execution_state_actor::ExecutionRequest,
-    policy::ResourceControlPolicy,
+    policy::{ResourceControlPolicy, ResourceLimit},
     resources::{ResourceController, ResourceTracker},
     runtime::{
         ContractSyncRuntimeHandle, ServiceRuntimeRequest, ServiceSyncRuntime,

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -3,7 +3,7 @@
 
 //! This module contains types related to fees and pricing.
 
-use std::fmt;
+use std::fmt::{self, Display, Formatter};
 
 use async_graphql::InputObject;
 use linera_base::data_types::{Amount, ArithmeticError, Resources};
@@ -53,8 +53,8 @@ pub struct ResourceControlPolicy {
     pub maximum_bytes_written_per_block: u64,
 }
 
-impl fmt::Display for ResourceControlPolicy {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Display for ResourceControlPolicy {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let ResourceControlPolicy {
             block,
             fuel_unit,

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -3,6 +3,10 @@
 
 //! This module contains types related to fees and pricing.
 
+#[cfg(test)]
+#[path = "unit_tests/policy_tests.rs"]
+mod tests;
+
 use std::{
     cmp,
     fmt::{self, Display, Formatter},

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -18,7 +18,7 @@ use linera_base::{
 use serde::{Deserialize, Serialize};
 
 /// A collection of prices and limits associated with block execution.
-#[derive(Eq, PartialEq, Hash, Clone, Debug, Serialize, Deserialize, InputObject)]
+#[derive(Eq, PartialEq, Hash, Clone, Debug, Default, Serialize, Deserialize, InputObject)]
 pub struct ResourceControlPolicy {
     /// The base price for creating a new block.
     pub block: Amount,
@@ -47,18 +47,18 @@ pub struct ResourceControlPolicy {
     // TODO(#1538): Cap the number of transactions per block and the total size of their
     // arguments.
     /// The maximum amount of fuel a block can consume.
-    pub maximum_fuel_per_block: u64,
+    pub maximum_fuel_per_block: ResourceLimit,
     /// The maximum size of an executed block. This includes the block proposal itself as well as
     /// the execution outcome.
-    pub maximum_executed_block_size: u64,
+    pub maximum_executed_block_size: ResourceLimit,
     /// The maximum size of decompressed contract or service bytecode, in bytes.
-    pub maximum_bytecode_size: u64,
+    pub maximum_bytecode_size: ResourceLimit,
     /// The maximum size of a blob.
-    pub maximum_blob_size: u64,
+    pub maximum_blob_size: ResourceLimit,
     /// The maximum data to read per block
-    pub maximum_bytes_read_per_block: u64,
+    pub maximum_bytes_read_per_block: ResourceLimit,
     /// The maximum data to write per block
-    pub maximum_bytes_written_per_block: u64,
+    pub maximum_bytes_written_per_block: ResourceLimit,
 }
 
 impl Display for ResourceControlPolicy {
@@ -103,30 +103,6 @@ impl Display for ResourceControlPolicy {
             {maximum_bytes_read_per_block} maximum number bytes read per block\n\
             {maximum_bytes_written_per_block} maximum number bytes written per block",
         )
-    }
-}
-
-impl Default for ResourceControlPolicy {
-    fn default() -> Self {
-        Self {
-            block: Amount::default(),
-            fuel_unit: Amount::default(),
-            read_operation: Amount::default(),
-            write_operation: Amount::default(),
-            byte_read: Amount::default(),
-            byte_written: Amount::default(),
-            byte_stored: Amount::default(),
-            operation: Amount::default(),
-            operation_byte: Amount::default(),
-            message: Amount::default(),
-            message_byte: Amount::default(),
-            maximum_fuel_per_block: u64::MAX,
-            maximum_executed_block_size: u64::MAX,
-            maximum_blob_size: u64::MAX,
-            maximum_bytecode_size: u64::MAX,
-            maximum_bytes_read_per_block: u64::MAX,
-            maximum_bytes_written_per_block: u64::MAX,
-        }
     }
 }
 
@@ -241,12 +217,12 @@ impl ResourceControlPolicy {
             operation_byte: Amount::from_nanos(10),
             operation: Amount::from_micros(10),
             message: Amount::from_micros(10),
-            maximum_fuel_per_block: 100_000_000,
-            maximum_executed_block_size: 1_000_000,
-            maximum_blob_size: 1_000_000,
-            maximum_bytecode_size: 10_000_000,
-            maximum_bytes_read_per_block: 100_000_000,
-            maximum_bytes_written_per_block: 10_000_000,
+            maximum_fuel_per_block: ResourceLimit(100_000_000),
+            maximum_executed_block_size: ResourceLimit(1_000_000),
+            maximum_blob_size: ResourceLimit(1_000_000),
+            maximum_bytecode_size: ResourceLimit(10_000_000),
+            maximum_bytes_read_per_block: ResourceLimit(100_000_000),
+            maximum_bytes_written_per_block: ResourceLimit(10_000_000),
         }
     }
 }

--- a/linera-execution/src/unit_tests/policy_tests.rs
+++ b/linera-execution/src/unit_tests/policy_tests.rs
@@ -10,3 +10,19 @@ use super::ResourceLimit;
 fn default_resource_limit() {
     assert_eq!(ResourceLimit::default(), ResourceLimit(u64::MAX));
 }
+
+/// Test the JSON serialization round-trip of the [`ResourceLimit`].
+///
+/// Checks if a large value is serialized as a string, instead of being serialized as a
+/// floating-point number which would lose precision.
+#[test]
+fn resource_limit_json_roundtrip() -> anyhow::Result<()> {
+    let initial_value = ResourceLimit::default();
+    let json = serde_json::to_string(&initial_value)?;
+    let recovered_value = serde_json::from_str::<ResourceLimit>(&json)?;
+
+    assert_eq!(json, format!("\"{}\"", u64::MAX));
+    assert_eq!(recovered_value, initial_value);
+
+    Ok(())
+}

--- a/linera-execution/src/unit_tests/policy_tests.rs
+++ b/linera-execution/src/unit_tests/policy_tests.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for the `policy` module types.
+
+use super::ResourceLimit;
+
+/// Check that the default [`ResourceLimit`] is the maximal value.
+#[test]
+fn default_resource_limit() {
+    assert_eq!(ResourceLimit::default(), ResourceLimit(u64::MAX));
+}

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -15,7 +15,8 @@ use linera_base::{
 use linera_execution::{
     test_utils::{register_mock_applications, ExpectedCall, SystemExecutionState},
     ContractRuntime, ExecutionError, ExecutionOutcome, Message, MessageContext,
-    RawExecutionOutcome, ResourceControlPolicy, ResourceController, TransactionTracker,
+    RawExecutionOutcome, ResourceControlPolicy, ResourceController, ResourceLimit,
+    TransactionTracker,
 };
 use test_case::test_case;
 
@@ -146,12 +147,12 @@ async fn test_fee_consumption(
         operation_byte: Amount::from_tokens(23),
         message: Amount::from_tokens(29),
         message_byte: Amount::from_tokens(31),
-        maximum_fuel_per_block: 4_868_145_137,
-        maximum_executed_block_size: 37,
-        maximum_blob_size: 41,
-        maximum_bytecode_size: 43,
-        maximum_bytes_read_per_block: 47,
-        maximum_bytes_written_per_block: 53,
+        maximum_fuel_per_block: ResourceLimit(4_868_145_137),
+        maximum_executed_block_size: ResourceLimit(37),
+        maximum_blob_size: ResourceLimit(41),
+        maximum_bytecode_size: ResourceLimit(43),
+        maximum_bytes_read_per_block: ResourceLimit(47),
+        maximum_bytes_written_per_block: ResourceLimit(53),
     };
 
     let consumed_fees = spends

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -609,31 +609,31 @@ impl Runnable for Job {
                                         policy.message_byte = message_byte;
                                     }
                                     if let Some(maximum_fuel_per_block) = maximum_fuel_per_block {
-                                        policy.maximum_fuel_per_block = maximum_fuel_per_block;
+                                        policy.maximum_fuel_per_block = *maximum_fuel_per_block;
                                     }
                                     if let Some(maximum_executed_block_size) =
                                         maximum_executed_block_size
                                     {
                                         policy.maximum_executed_block_size =
-                                            maximum_executed_block_size;
+                                            *maximum_executed_block_size;
                                     }
                                     if let Some(maximum_bytecode_size) = maximum_bytecode_size {
-                                        policy.maximum_bytecode_size = maximum_bytecode_size;
+                                        policy.maximum_bytecode_size = *maximum_bytecode_size;
                                     }
                                     if let Some(maximum_blob_size) = maximum_blob_size {
-                                        policy.maximum_blob_size = maximum_blob_size;
+                                        policy.maximum_blob_size = *maximum_blob_size;
                                     }
                                     if let Some(maximum_bytes_read_per_block) =
                                         maximum_bytes_read_per_block
                                     {
                                         policy.maximum_bytes_read_per_block =
-                                            maximum_bytes_read_per_block;
+                                            *maximum_bytes_read_per_block;
                                     }
                                     if let Some(maximum_bytes_written_per_block) =
                                         maximum_bytes_written_per_block
                                     {
                                         policy.maximum_bytes_written_per_block =
-                                            maximum_bytes_written_per_block;
+                                            *maximum_bytes_written_per_block;
                                     }
                                     info!("{policy}");
                                     if committee.policy() == &policy {
@@ -1394,13 +1394,6 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
         } => {
             let committee_config: CommitteeConfig = util::read_json(committee_config_path)
                 .expect("Unable to read committee config file");
-            let maximum_fuel_per_block = maximum_fuel_per_block.unwrap_or(u64::MAX);
-            let maximum_bytes_read_per_block = maximum_bytes_read_per_block.unwrap_or(u64::MAX);
-            let maximum_bytes_written_per_block =
-                maximum_bytes_written_per_block.unwrap_or(u64::MAX);
-            let maximum_executed_block_size = maximum_executed_block_size.unwrap_or(u64::MAX);
-            let maximum_blob_size = maximum_blob_size.unwrap_or(u64::MAX);
-            let maximum_bytecode_size = maximum_bytecode_size.unwrap_or(u64::MAX);
             let policy = ResourceControlPolicy {
                 block: *block_price,
                 fuel_unit: *fuel_unit_price,
@@ -1413,12 +1406,12 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                 operation: *operation_price,
                 message_byte: *message_byte_price,
                 message: *message_price,
-                maximum_fuel_per_block,
-                maximum_executed_block_size,
-                maximum_blob_size,
-                maximum_bytecode_size,
-                maximum_bytes_read_per_block,
-                maximum_bytes_written_per_block,
+                maximum_fuel_per_block: maximum_fuel_per_block.0,
+                maximum_executed_block_size: maximum_executed_block_size.0,
+                maximum_blob_size: maximum_blob_size.0,
+                maximum_bytecode_size: maximum_bytecode_size.0,
+                maximum_bytes_read_per_block: maximum_bytes_read_per_block.0,
+                maximum_bytes_written_per_block: maximum_bytes_written_per_block.0,
             };
             let timestamp = start_timestamp
                 .map(|st| {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -609,31 +609,31 @@ impl Runnable for Job {
                                         policy.message_byte = message_byte;
                                     }
                                     if let Some(maximum_fuel_per_block) = maximum_fuel_per_block {
-                                        policy.maximum_fuel_per_block = *maximum_fuel_per_block;
+                                        policy.maximum_fuel_per_block = maximum_fuel_per_block;
                                     }
                                     if let Some(maximum_executed_block_size) =
                                         maximum_executed_block_size
                                     {
                                         policy.maximum_executed_block_size =
-                                            *maximum_executed_block_size;
+                                            maximum_executed_block_size;
                                     }
                                     if let Some(maximum_bytecode_size) = maximum_bytecode_size {
-                                        policy.maximum_bytecode_size = *maximum_bytecode_size;
+                                        policy.maximum_bytecode_size = maximum_bytecode_size;
                                     }
                                     if let Some(maximum_blob_size) = maximum_blob_size {
-                                        policy.maximum_blob_size = *maximum_blob_size;
+                                        policy.maximum_blob_size = maximum_blob_size;
                                     }
                                     if let Some(maximum_bytes_read_per_block) =
                                         maximum_bytes_read_per_block
                                     {
                                         policy.maximum_bytes_read_per_block =
-                                            *maximum_bytes_read_per_block;
+                                            maximum_bytes_read_per_block;
                                     }
                                     if let Some(maximum_bytes_written_per_block) =
                                         maximum_bytes_written_per_block
                                     {
                                         policy.maximum_bytes_written_per_block =
-                                            *maximum_bytes_written_per_block;
+                                            maximum_bytes_written_per_block;
                                     }
                                     info!("{policy}");
                                     if committee.policy() == &policy {
@@ -1406,12 +1406,12 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                 operation: *operation_price,
                 message_byte: *message_byte_price,
                 message: *message_price,
-                maximum_fuel_per_block: maximum_fuel_per_block.0,
-                maximum_executed_block_size: maximum_executed_block_size.0,
-                maximum_blob_size: maximum_blob_size.0,
-                maximum_bytecode_size: maximum_bytecode_size.0,
-                maximum_bytes_read_per_block: maximum_bytes_read_per_block.0,
-                maximum_bytes_written_per_block: maximum_bytes_written_per_block.0,
+                maximum_fuel_per_block: *maximum_fuel_per_block,
+                maximum_executed_block_size: *maximum_executed_block_size,
+                maximum_blob_size: *maximum_blob_size,
+                maximum_bytecode_size: *maximum_bytecode_size,
+                maximum_bytes_read_per_block: *maximum_bytes_read_per_block,
+                maximum_bytes_written_per_block: *maximum_bytes_written_per_block,
             };
             let timestamp = start_timestamp
                 .map(|st| {


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
JSON does not distinguish between floating-point numbers and integers. Therefore, some fields in `ResourceControlPolicy` fail to be deserialized into integers when they are received through GraphQL (issue #2743).

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Create a new `ResourceLimit` wrapper type that uses a string to represent its value when serialized to a human-readable serialization format (like JSON). The type also allows specifying a default value that's the maximal value.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
Some trivial unit tests were added to ensure that precision isn't lost when serializing and deserializing a `ResourceLimit` value.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Closes #2743
