### PR TITLE
Use `serde_bytes` for binary data in `EventRecord` and `OracleResponse`.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -744,9 +744,17 @@ impl ApplicationPermissions {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub enum OracleResponse {
     /// The response from a service query.
-    Service(#[debug(with = "hex_debug")] Vec<u8>),
+    Service(
+        #[debug(with = "hex_debug")]
+        #[serde(with = "serde_bytes")]
+        Vec<u8>,
+    ),
     /// The response from an HTTP POST request.
-    Post(#[debug(with = "hex_debug")] Vec<u8>),
+    Post(
+        #[debug(with = "hex_debug")]
+        #[serde(with = "serde_bytes")]
+        Vec<u8>,
+    ),
     /// A successful read or write of a blob.
     Blob(BlobId),
     /// An assertion oracle that passed.

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -404,9 +404,11 @@ pub struct EventRecord {
     pub stream_id: StreamId,
     /// The event key.
     #[debug(with = "hex_debug")]
+    #[serde(with = "serde_bytes")]
     pub key: Vec<u8>,
     /// The payload data.
     #[debug(with = "hex_debug")]
+    #[serde(with = "serde_bytes")]
     pub value: Vec<u8>,
 }
 

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -394,10 +394,8 @@ EventRecord:
   STRUCT:
     - stream_id:
         TYPENAME: StreamId
-    - key:
-        SEQ: U8
-    - value:
-        SEQ: U8
+    - key: BYTES
+    - value: BYTES
 ExecutedBlock:
   STRUCT:
     - block:
@@ -635,12 +633,10 @@ OracleResponse:
   ENUM:
     0:
       Service:
-        NEWTYPE:
-          SEQ: U8
+        NEWTYPE: BYTES
     1:
       Post:
-        NEWTYPE:
-          SEQ: U8
+        NEWTYPE: BYTES
     2:
       Blob:
         NEWTYPE:


### PR DESCRIPTION
## Motivation

We generally use `serde_bytes` to better serialize binary data. We (or I, probably) forgot to do this for `EventRecord` and `OracleResponse`.

## Proposal

Use `serde_bytes` where appropriate.

## Test Plan

This does not change any logic, only the serialization format.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
