### PR TITLE
Move more functions to the right module in linera-core.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -20,7 +20,6 @@ use dashmap::{
 use futures::{
     future::{self, try_join_all, FusedFuture, Future},
     stream::{self, AbortHandle, FusedStream, FuturesUnordered, StreamExt},
-    TryStreamExt as _,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use linera_base::data_types::Bytecode;
@@ -305,7 +304,7 @@ where
         let mut validators = validators.iter().collect::<Vec<_>>();
         validators.shuffle(&mut rand::thread_rng());
         for remote_node in validators {
-            let info = self.local_node.local_chain_info(chain_id).await?;
+            let info = self.local_node.chain_info(chain_id).await?;
             if target_next_block_height <= info.next_block_height {
                 return Ok(info);
             }
@@ -317,7 +316,7 @@ where
             )
             .await?;
         }
-        let info = self.local_node.local_chain_info(chain_id).await?;
+        let info = self.local_node.chain_info(chain_id).await?;
         if target_next_block_height <= info.next_block_height {
             Ok(info)
         } else {
@@ -1304,8 +1303,13 @@ where
 
         // Obtain the next block height we need in the local node, for each chain.
         let local_next_heights = self
-            .local_next_block_heights(remote_max_heights.keys(), chain_worker_limit)
-            .await?;
+            .client
+            .local_node
+            .next_block_heights(remote_max_heights.keys(), chain_worker_limit)
+            .await
+            .map_err(|error| NodeError::LocalError {
+                error: error.to_string(),
+            })?;
 
         // We keep track of the height we've successfully downloaded and checked, per chain.
         let mut downloaded_heights = BTreeMap::new();
@@ -1706,7 +1710,7 @@ where
 
         self.client
             .local_node
-            .local_chain_info(chain_id)
+            .chain_info(chain_id)
             .await
             .map_err(Into::into)
     }
@@ -1719,7 +1723,7 @@ where
         remote_node: &RemoteNode<P::Node>,
         chain_id: ChainId,
     ) -> Result<(), ChainClientError> {
-        let local_info = self.client.local_node.local_chain_info(chain_id).await?;
+        let local_info = self.client.local_node.chain_info(chain_id).await?;
         let range = BlockHeightRange {
             start: local_info.next_block_height,
             limit: None,
@@ -1797,8 +1801,8 @@ where
         Ok(())
     }
 
-    /// Downloads and processes from the specified validator a confirmed block certificate that
-    /// uses the given blob. If this succeeds, the blob will be in our storage.
+    /// Downloads and processes from the specified validator a confirmed block certificates that
+    /// use the given blobs. If this succeeds, the blob will be in our storage.
     async fn update_local_node_with_blobs_from(
         &self,
         blob_ids: Vec<BlobId>,
@@ -3071,7 +3075,7 @@ where
         chain_id: ChainId,
         local_node: &mut LocalNodeClient<S>,
     ) -> Option<Box<ChainInfo>> {
-        let Ok(info) = local_node.local_chain_info(chain_id).await else {
+        let Ok(info) = local_node.chain_info(chain_id).await else {
             error!("Fail to read local chain info for {chain_id}");
             return None;
         };
@@ -3329,31 +3333,6 @@ where
         self.receive_certificates_from_validators(vec![received_certificates])
             .await;
         Ok(())
-    }
-
-    /// Given a list of chain IDs, returns a map that assigns to each of them the next block
-    /// height, i.e. the lowest block height that we have not processed in the local node yet.
-    ///
-    /// It makes at most `chain_worker_limit` requests to the local node in parallel.
-    async fn local_next_block_heights(
-        &self,
-        chain_ids: impl IntoIterator<Item = &ChainId>,
-        chain_worker_limit: usize,
-    ) -> Result<BTreeMap<ChainId, BlockHeight>, NodeError> {
-        let futures = chain_ids
-            .into_iter()
-            .map(|chain_id| async move {
-                let local_info = self.client.local_node.local_chain_info(*chain_id).await?;
-                Ok::<_, LocalNodeError>((*chain_id, local_info.next_block_height))
-            })
-            .collect::<Vec<_>>();
-        stream::iter(futures)
-            .buffer_unordered(chain_worker_limit)
-            .try_collect()
-            .await
-            .map_err(|error| NodeError::LocalNodeQuery {
-                error: error.to_string(),
-            })
     }
 
     /// Given a set of chain ID-block height pairs, returns a map that assigns to each chain ID

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -222,6 +222,10 @@ pub enum NodeError {
 
     #[error("Node failed to provide a 'last used by' certificate for the blob")]
     InvalidCertificateForBlob(BlobId),
+    #[error("Node returned a BlobsNotFound error with duplicates")]
+    DuplicatesInBlobsNotFound,
+    #[error("Node returned a BlobsNotFound error with unexpected blob IDs")]
+    UnexpectedEntriesInBlobsNotFound,
     #[error("Local error handling validator response")]
     LocalError { error: String },
 }

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -304,7 +304,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
 
     /// Checks that requesting these blobs when trying to handle this certificate is legitimate,
     /// i.e. that there are no duplicates and the blobs are actually required.
-    pub fn check_blobs_not_found_error(
+    pub fn check_blobs_not_found(
         &self,
         certificate: &Certificate,
         blob_ids: &[BlobId],

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use custom_debug_derive::Debug;
 use futures::{stream::FuturesUnordered, StreamExt};
@@ -13,7 +13,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::BlockProposal,
-    types::{Certificate, ConfirmedBlockCertificate, LiteCertificate},
+    types::{Certificate, CertificateValue, ConfirmedBlockCertificate, LiteCertificate},
 };
 use linera_execution::committee::ValidatorName;
 use rand::seq::SliceRandom as _;
@@ -277,5 +277,38 @@ impl<N: ValidatorNode> RemoteNode<N> {
             blobs.push(maybe_blob?);
         }
         Some(blobs)
+    }
+
+    /// Checks that requesting these blobs when trying to handle this certificate is legitimate,
+    /// i.e. that there are no duplicates and the blobs are actually required.
+    pub fn check_blobs_not_found_error(
+        &self,
+        certificate: &Certificate,
+        blob_ids: &[BlobId],
+    ) -> Result<(), NodeError> {
+        // Find the missing blobs locally and retry.
+        let required = match certificate.inner() {
+            CertificateValue::ConfirmedBlock(confirmed) => confirmed.inner().required_blob_ids(),
+            CertificateValue::ValidatedBlock(validated) => validated.inner().required_blob_ids(),
+            CertificateValue::Timeout(_) => HashSet::new(),
+        };
+        for blob_id in blob_ids {
+            if !required.contains(blob_id) {
+                warn!(
+                    "validator {} requested blob {blob_id:?} but it is not required",
+                    self.name
+                );
+                return Err(NodeError::UnexpectedEntriesInBlobsNotFound);
+            }
+        }
+        let unique_missing_blob_ids = blob_ids.iter().cloned().collect::<HashSet<_>>();
+        if blob_ids.len() > unique_missing_blob_ids.len() {
+            warn!(
+                "blobs requested by validator {} contain duplicates",
+                self.name
+            );
+            return Err(NodeError::DuplicatesInBlobsNotFound);
+        }
+        Ok(())
     }
 }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -238,9 +238,12 @@ where
 
         match &result {
             Err(original_err @ NodeError::BlobsNotFound(blob_ids)) => {
+                self.remote_node
+                    .check_blobs_not_found_error(&certificate, blob_ids)?;
+
                 let blobs = self
                     .local_node
-                    .find_missing_blobs(&certificate, blob_ids, certificate.inner().chain_id())
+                    .find_missing_blobs(blob_ids.clone(), certificate.inner().chain_id())
                     .await?
                     .ok_or_else(|| original_err.clone())?;
                 self.remote_node

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -82,7 +82,9 @@ where
 pub enum CommunicationError<E: fmt::Debug> {
     /// No consensus is possible since validators returned different possibilities
     /// for the next block
-    #[error("No error but failed to find a consensus block. Consensus threshold: {}, Proposals: {:?}", .0, .1)]
+    #[error(
+        "No error but failed to find a consensus block. Consensus threshold: {0}, Proposals: {1:?}"
+    )]
     NoConsensus(u64, Vec<(u64, usize)>),
     /// A single error that was returned by a sufficient number of nodes to be trusted as
     /// valid.

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -215,7 +215,7 @@ where
         match &result {
             Err(original_err @ NodeError::BlobsNotFound(blob_ids)) => {
                 self.remote_node
-                    .check_blobs_not_found_error(&certificate, blob_ids)?;
+                    .check_blobs_not_found(&certificate, blob_ids)?;
 
                 let blobs = self
                     .local_node

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -23,7 +23,7 @@ use linera_chain::{
 use linera_execution::committee::Committee;
 use linera_storage::Storage;
 use thiserror::Error;
-use tracing::{error, warn};
+use tracing::error;
 
 use crate::{
     data_types::{ChainInfo, ChainInfoQuery},
@@ -200,40 +200,14 @@ where
     A: ValidatorNode + Clone + 'static,
     S: Storage + Clone + Send + Sync + 'static,
 {
-    async fn send_optimized_certificate(
-        &mut self,
-        certificate: &Certificate,
-        delivery: CrossChainMessageDelivery,
-    ) -> Result<Box<ChainInfo>, NodeError> {
-        if certificate.is_signed_by(&self.remote_node.name) {
-            let result = self
-                .remote_node
-                .handle_lite_certificate(certificate.lite_certificate(), delivery)
-                .await;
-            match result {
-                Err(NodeError::MissingCertificateValue) => {
-                    warn!(
-                        "Validator {} forgot a certificate value that they signed before",
-                        self.remote_node.name
-                    );
-                }
-                _ => {
-                    return result;
-                }
-            }
-        }
-        self.remote_node
-            .handle_certificate(certificate.clone(), vec![], delivery)
-            .await
-    }
-
     async fn send_certificate(
         &mut self,
         certificate: Certificate,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, NodeError> {
         let result = self
-            .send_optimized_certificate(&certificate, delivery)
+            .remote_node
+            .handle_optimized_certificate(&certificate, delivery)
             .await;
 
         match &result {

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -596,6 +596,10 @@ NodeError:
         NEWTYPE:
           TYPENAME: BlobId
     21:
+      DuplicatesInBlobsNotFound: UNIT
+    22:
+      UnexpectedEntriesInBlobsNotFound: UNIT
+    23:
       LocalError:
         STRUCT:
           - error: STR

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -100,7 +100,7 @@ pub trait Contract: WithContractAbi + ContractAbi + Sized {
     /// instead.
     type InstantiationArgument: Serialize + DeserializeOwned + Debug;
 
-    /// Creates a in-memory instance of the contract handler.
+    /// Creates an in-memory instance of the contract handler.
     async fn load(runtime: ContractRuntime<Self>) -> Self;
 
     /// Instantiates the application on the chain that created it.
@@ -148,7 +148,7 @@ pub trait Service: WithServiceAbi + ServiceAbi + Sized {
     /// Immutable parameters specific to this application.
     type Parameters: Serialize + DeserializeOwned + Send + Sync + Clone + Debug + 'static;
 
-    /// Creates a in-memory instance of the service handler.
+    /// Creates an in-memory instance of the service handler.
     async fn new(runtime: ServiceRuntime<Self>) -> Self;
 
     /// Executes a read-only query on the state of this application.


### PR DESCRIPTION
## Motivation

`next_block_heights` uses only the `LocalNode`, `send_optimized_certificate` only the `RemoteNode`. The checks in `LocalNode::find_missing_blobs` are really checking whether the _remote_ node is faulty.

This and other minor cleanups is making https://github.com/linera-io/linera-protocol/pull/2871 hard to review.

## Proposal

Move the logic to the module it belongs in, in this separate PR, so https://github.com/linera-io/linera-protocol/pull/2871 can be about https://github.com/linera-io/linera-protocol/issues/2857 only.

## Test Plan

Apart from two new errors and a bit more information in the log messages, this is only a refactoring without new logic.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- This is preparation for https://github.com/linera-io/linera-protocol/issues/2857
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
