### PR TITLE
Scylla improvement

### DIFF
--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -232,6 +232,16 @@ fn build_key_value(
     .into()
 }
 
+/// Checks that a key is of the correct size
+fn check_key_size(key: &[u8]) -> Result<(), DynamoDbStoreInternalError> {
+    ensure!(!key.is_empty(), DynamoDbStoreInternalError::ZeroLengthKey);
+    ensure!(
+        key.len() <= MAX_KEY_SIZE,
+        DynamoDbStoreInternalError::KeyTooLong
+    );
+    Ok(())
+}
+
 /// Extracts the key attribute from an item.
 fn extract_key(
     prefix_len: usize,
@@ -554,11 +564,7 @@ impl DynamoDbStoreInternal {
         root_key: &[u8],
         key: Vec<u8>,
     ) -> Result<TransactWriteItem, DynamoDbStoreInternalError> {
-        ensure!(!key.is_empty(), DynamoDbStoreInternalError::ZeroLengthKey);
-        ensure!(
-            key.len() <= MAX_KEY_SIZE,
-            DynamoDbStoreInternalError::KeyTooLong
-        );
+        check_key_size(&key)?;
         let request = Delete::builder()
             .table_name(&self.namespace)
             .set_key(Some(build_key(root_key, key)))
@@ -572,11 +578,7 @@ impl DynamoDbStoreInternal {
         key: Vec<u8>,
         value: Vec<u8>,
     ) -> Result<TransactWriteItem, DynamoDbStoreInternalError> {
-        ensure!(!key.is_empty(), DynamoDbStoreInternalError::ZeroLengthKey);
-        ensure!(
-            key.len() <= MAX_KEY_SIZE,
-            DynamoDbStoreInternalError::KeyTooLong
-        );
+        check_key_size(&key)?;
         ensure!(
             value.len() <= RAW_MAX_VALUE_SIZE,
             DynamoDbStoreInternalError::ValueLengthTooLarge
@@ -669,14 +671,7 @@ impl DynamoDbStoreInternal {
         root_key: &[u8],
         key_prefix: &[u8],
     ) -> Result<QueryResponses, DynamoDbStoreInternalError> {
-        ensure!(
-            !key_prefix.is_empty(),
-            DynamoDbStoreInternalError::ZeroLengthKeyPrefix
-        );
-        ensure!(
-            key_prefix.len() <= MAX_KEY_SIZE,
-            DynamoDbStoreInternalError::KeyPrefixTooLong
-        );
+        check_key_size(&key_prefix)?;
         let mut responses = Vec::new();
         let mut start_key = None;
         loop {
@@ -887,19 +882,13 @@ impl ReadableKeyValueStore for DynamoDbStoreInternal {
         &self,
         key: &[u8],
     ) -> Result<Option<Vec<u8>>, DynamoDbStoreInternalError> {
-        ensure!(
-            key.len() <= MAX_KEY_SIZE,
-            DynamoDbStoreInternalError::KeyTooLong
-        );
+        check_key_size(&key)?;
         let key_db = build_key(&self.root_key, key.to_vec());
         self.read_value_bytes_general(key_db).await
     }
 
     async fn contains_key(&self, key: &[u8]) -> Result<bool, DynamoDbStoreInternalError> {
-        ensure!(
-            key.len() <= MAX_KEY_SIZE,
-            DynamoDbStoreInternalError::KeyTooLong
-        );
+        check_key_size(&key)?;
         let key_db = build_key(&self.root_key, key.to_vec());
         self.contains_key_general(key_db).await
     }
@@ -910,10 +899,7 @@ impl ReadableKeyValueStore for DynamoDbStoreInternal {
     ) -> Result<Vec<bool>, DynamoDbStoreInternalError> {
         let mut handles = Vec::new();
         for key in keys {
-            ensure!(
-                key.len() <= MAX_KEY_SIZE,
-                DynamoDbStoreInternalError::KeyTooLong
-            );
+            check_key_size(&key)?;
             let key_db = build_key(&self.root_key, key);
             let handle = self.contains_key_general(key_db);
             handles.push(handle);
@@ -930,10 +916,7 @@ impl ReadableKeyValueStore for DynamoDbStoreInternal {
     ) -> Result<Vec<Option<Vec<u8>>>, DynamoDbStoreInternalError> {
         let mut handles = Vec::new();
         for key in keys {
-            ensure!(
-                key.len() <= MAX_KEY_SIZE,
-                DynamoDbStoreInternalError::KeyTooLong
-            );
+            check_key_size(&key)?;
             let key_db = build_key(&self.root_key, key);
             let handle = self.read_value_bytes_general(key_db);
             handles.push(handle);

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -671,7 +671,7 @@ impl DynamoDbStoreInternal {
         root_key: &[u8],
         key_prefix: &[u8],
     ) -> Result<QueryResponses, DynamoDbStoreInternalError> {
-        check_key_size(&key_prefix)?;
+        check_key_size(key_prefix)?;
         let mut responses = Vec::new();
         let mut start_key = None;
         loop {
@@ -882,13 +882,13 @@ impl ReadableKeyValueStore for DynamoDbStoreInternal {
         &self,
         key: &[u8],
     ) -> Result<Option<Vec<u8>>, DynamoDbStoreInternalError> {
-        check_key_size(&key)?;
+        check_key_size(key)?;
         let key_db = build_key(&self.root_key, key.to_vec());
         self.read_value_bytes_general(key_db).await
     }
 
     async fn contains_key(&self, key: &[u8]) -> Result<bool, DynamoDbStoreInternalError> {
-        check_key_size(&key)?;
+        check_key_size(key)?;
         let key_db = build_key(&self.root_key, key.to_vec());
         self.contains_key_general(key_db).await
     }

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -93,7 +93,6 @@ fn check_key_size(key: &[u8]) -> Result<(), RocksDbStoreInternalError> {
     Ok(())
 }
 
-
 #[derive(Clone)]
 struct RocksDbStoreExecutor {
     db: Arc<DB>,
@@ -130,7 +129,7 @@ impl RocksDbStoreExecutor {
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, RocksDbStoreInternalError> {
         for key in &keys {
-            check_key_size(&key)?;
+            check_key_size(key)?;
         }
         let full_keys = keys
             .into_iter()
@@ -323,7 +322,7 @@ impl ReadableKeyValueStore for RocksDbStoreInternal {
         &self,
         key: &[u8],
     ) -> Result<Option<Vec<u8>>, RocksDbStoreInternalError> {
-        check_key_size(&key)?;
+        check_key_size(key)?;
         let db = self.executor.db.clone();
         let mut full_key = self.executor.root_key.to_vec();
         full_key.extend(key);
@@ -333,7 +332,7 @@ impl ReadableKeyValueStore for RocksDbStoreInternal {
     }
 
     async fn contains_key(&self, key: &[u8]) -> Result<bool, RocksDbStoreInternalError> {
-        check_key_size(&key)?;
+        check_key_size(key)?;
         let db = self.executor.db.clone();
         let mut full_key = self.executor.root_key.to_vec();
         full_key.extend(key);

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -165,7 +165,10 @@ impl ScyllaDbClient {
         root_key: &[u8],
         key: Vec<u8>,
     ) -> Result<Option<Vec<u8>>, ScyllaDbStoreInternalError> {
-        ensure!(key.len() <= MAX_KEY_SIZE, ScyllaDbStoreInternalError::KeyTooLong);
+        ensure!(
+            key.len() <= MAX_KEY_SIZE,
+            ScyllaDbStoreInternalError::KeyTooLong
+        );
         let session = &self.session;
         // Read the value of a key
         let values = (root_key.to_vec(), key);
@@ -191,7 +194,10 @@ impl ScyllaDbClient {
         let mut inputs = Vec::new();
         inputs.push(root_key.to_vec());
         for (i_key, key) in keys.into_iter().enumerate() {
-            ensure!(key.len() <= MAX_KEY_SIZE, ScyllaDbStoreInternalError::KeyTooLong);
+            ensure!(
+                key.len() <= MAX_KEY_SIZE,
+                ScyllaDbStoreInternalError::KeyTooLong
+            );
             match map.entry(key.clone()) {
                 Entry::Occupied(entry) => {
                     let entry = entry.into_mut();
@@ -237,7 +243,10 @@ impl ScyllaDbClient {
         let mut inputs = Vec::new();
         inputs.push(root_key.to_vec());
         for (i_key, key) in keys.into_iter().enumerate() {
-            ensure!(key.len() <= MAX_KEY_SIZE, ScyllaDbStoreInternalError::KeyTooLong);
+            ensure!(
+                key.len() <= MAX_KEY_SIZE,
+                ScyllaDbStoreInternalError::KeyTooLong
+            );
             match map.entry(key.clone()) {
                 Entry::Occupied(entry) => {
                     let entry = entry.into_mut();
@@ -273,7 +282,10 @@ impl ScyllaDbClient {
         root_key: &[u8],
         key: Vec<u8>,
     ) -> Result<bool, ScyllaDbStoreInternalError> {
-        ensure!(key.len() <= MAX_KEY_SIZE, ScyllaDbStoreInternalError::KeyTooLong);
+        ensure!(
+            key.len() <= MAX_KEY_SIZE,
+            ScyllaDbStoreInternalError::KeyTooLong
+        );
         let session = &self.session;
         // Read the value of a key
         let values = (root_key.to_vec(), key);
@@ -293,8 +305,14 @@ impl ScyllaDbClient {
         let query1 = &self.write_batch_delete_prefix_unbounded;
         let query2 = &self.write_batch_delete_prefix_bounded;
         println!("|batch|={}", batch.len());
-        ensure!(batch.len() <= MAX_BATCH_SIZE, ScyllaDbStoreInternalError::TooLargeBatch);
-        println!("|key_prefix_deletions|={}", batch.key_prefix_deletions.len());
+        ensure!(
+            batch.len() <= MAX_BATCH_SIZE,
+            ScyllaDbStoreInternalError::TooLargeBatch
+        );
+        println!(
+            "|key_prefix_deletions|={}",
+            batch.key_prefix_deletions.len()
+        );
         for key_prefix in batch.key_prefix_deletions {
             ensure!(
                 key_prefix.len() <= MAX_KEY_SIZE,
@@ -314,7 +332,10 @@ impl ScyllaDbClient {
             }
         }
         let query3 = &self.write_batch_deletion;
-        println!("|deletions|={}", batch.simple_unordered_batch.deletions.len());
+        println!(
+            "|deletions|={}",
+            batch.simple_unordered_batch.deletions.len()
+        );
         for key in batch.simple_unordered_batch.deletions {
             ensure!(
                 key.len() <= MAX_KEY_SIZE,
@@ -325,12 +346,18 @@ impl ScyllaDbClient {
             batch_query.append_statement(query3.clone());
         }
         let query4 = &self.write_batch_insertion;
-        println!("|insertions|={}", batch.simple_unordered_batch.insertions.len());
+        println!(
+            "|insertions|={}",
+            batch.simple_unordered_batch.insertions.len()
+        );
         let mut total_size = 0;
         for (key, value) in batch.simple_unordered_batch.insertions {
             println!("|key|={} |value|={}", key.len(), value.len());
             total_size += key.len() + value.len();
-            ensure!(key.len() <= MAX_KEY_SIZE, ScyllaDbStoreInternalError::KeyTooLong);
+            ensure!(
+                key.len() <= MAX_KEY_SIZE,
+                ScyllaDbStoreInternalError::KeyTooLong
+            );
             ensure!(
                 value.len() <= RAW_MAX_VALUE_SIZE,
                 ScyllaDbStoreInternalError::ValueTooLong
@@ -485,7 +512,10 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
         self.max_stream_queries
     }
 
-    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, ScyllaDbStoreInternalError> {
+    async fn read_value_bytes(
+        &self,
+        key: &[u8],
+    ) -> Result<Option<Vec<u8>>, ScyllaDbStoreInternalError> {
         let store = self.store.deref();
         let _guard = self.acquire().await;
         store
@@ -501,7 +531,10 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
             .await
     }
 
-    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ScyllaDbStoreInternalError> {
+    async fn contains_keys(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<bool>, ScyllaDbStoreInternalError> {
         if keys.is_empty() {
             return Ok(Vec::new());
         }
@@ -702,7 +735,10 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
         Ok(())
     }
 
-    async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, ScyllaDbStoreInternalError> {
+    async fn exists(
+        config: &Self::Config,
+        namespace: &str,
+    ) -> Result<bool, ScyllaDbStoreInternalError> {
         Self::check_namespace(namespace)?;
         let session = SessionBuilder::new()
             .known_node(config.uri.as_str())
@@ -746,7 +782,10 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
         }
     }
 
-    async fn create(config: &Self::Config, namespace: &str) -> Result<(), ScyllaDbStoreInternalError> {
+    async fn create(
+        config: &Self::Config,
+        namespace: &str,
+    ) -> Result<(), ScyllaDbStoreInternalError> {
         Self::check_namespace(namespace)?;
         let session = SessionBuilder::new()
             .known_node(config.uri.as_str())
@@ -771,7 +810,10 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
         Ok(())
     }
 
-    async fn delete(config: &Self::Config, namespace: &str) -> Result<(), ScyllaDbStoreInternalError> {
+    async fn delete(
+        config: &Self::Config,
+        namespace: &str,
+    ) -> Result<(), ScyllaDbStoreInternalError> {
         Self::check_namespace(namespace)?;
         let session = SessionBuilder::new()
             .known_node(config.uri.as_str())
@@ -828,12 +870,18 @@ impl TestKeyValueStore for JournalingKeyValueStore<ScyllaDbStoreInternal> {
 
 /// The `ScyllaDbStore` composed type with metrics
 #[cfg(with_metrics)]
-pub type ScyllaDbStore =
-    MeteredStore<LruCachingStore<MeteredStore<ValueSplittingStore<MeteredStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>>>>>;
+pub type ScyllaDbStore = MeteredStore<
+    LruCachingStore<
+        MeteredStore<
+            ValueSplittingStore<MeteredStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>>,
+        >,
+    >,
+>;
 
 /// The `ScyllaDbStore` composed type
 #[cfg(not(with_metrics))]
-pub type ScyllaDbStore = LruCachingStore<ValueSplittingStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>>;
+pub type ScyllaDbStore =
+    LruCachingStore<ValueSplittingStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>>;
 
 /// The `ScyllaDbStoreConfig` input type
 pub type ScyllaDbStoreConfig = LruSplittingConfig<ScyllaDbStoreInternalConfig>;

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -437,12 +437,12 @@ pub enum ScyllaDbStoreInternalError {
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
 
-    /// The key must have at most 100K bytes
-    #[error("The key must have at most 100K")]
+    /// The key must have at most MAX_KEY_SIZE bytes
+    #[error("The key must have at most MAX_KEY_SIZE")]
     KeyTooLong,
 
-    /// The value must have at most 16M
-    #[error("The value must have at most 16M")]
+    /// The value must have at most MAX_VALUE_SIZE bytes
+    #[error("The value must have at most MAX_VALUE_SIZE")]
     ValueTooLong,
 
     /// A row error in ScyllaDB

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -16,9 +16,11 @@ const MAX_MULTI_KEYS: usize = 99;
 /// "There is a hard limit at 16MB, and nothing bigger than that can arrive at once
 ///  at the database at any particular time"
 /// So, we set up the maximal size of 16M - 10K for the values and 10K for the keys
-const RAW_MAX_VALUE_SIZE: usize = 16766976;
+/// We also arbitrarily decrease the size by 4000 bytes because an amount of size is
+/// taken internally by the database.
+const RAW_MAX_VALUE_SIZE: usize = 16762976;
 const MAX_KEY_SIZE: usize = 10240;
-const MAX_BATCH_TOTAL_SIZE: usize = 16777216;
+const MAX_BATCH_TOTAL_SIZE: usize = 16773216;
 
 /// The RAW_MAX_VALUE_SIZE is the maximum size on the ScyllaDb storage.
 /// However, the value being written can also be the serialization of a SimpleUnorderedBatch
@@ -29,7 +31,7 @@ const MAX_BATCH_TOTAL_SIZE: usize = 16777216;
 /// and so this simplifies to 1 + 1 + (2 + 10240) + (4 + x) <= RAW_MAX_VALUE_SIZE
 /// (we write 4 because get_uleb128_size(RAW_MAX_VALUE_SIZE) = 4)
 /// and so to a maximal value of 408569;
-const VISIBLE_MAX_VALUE_SIZE: usize = 16756728;
+const VISIBLE_MAX_VALUE_SIZE: usize = 16754728;
 
 /// The constant 14000 is an empirical constant that was found to be necessary
 /// to make the ScyllaDb system work. We have not been able to find this or

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -306,7 +306,7 @@ impl ScyllaDbClient {
         let query2 = &self.write_batch_delete_prefix_bounded;
         ensure!(
             batch.len() <= MAX_BATCH_SIZE,
-            ScyllaDbStoreInternalError::TooLargeBatch
+            ScyllaDbStoreInternalError::BatchTooLong
         );
         for key_prefix in batch.key_prefix_deletions {
             ensure!(
@@ -473,9 +473,9 @@ pub enum ScyllaDbStoreInternalError {
     #[error(transparent)]
     JournalConsistencyError(#[from] JournalConsistencyError),
 
-    /// Too large batch
-    #[error("Too large batch")]
-    TooLargeBatch,
+    /// The batch is too long to be written
+    #[error("The batch is too long to be written")]
+    BatchTooLong,
 }
 
 impl KeyValueStoreError for ScyllaDbStoreInternalError {

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -304,14 +304,9 @@ impl ScyllaDbClient {
         let mut batch_values = Vec::new();
         let query1 = &self.write_batch_delete_prefix_unbounded;
         let query2 = &self.write_batch_delete_prefix_bounded;
-        println!("|batch|={}", batch.len());
         ensure!(
             batch.len() <= MAX_BATCH_SIZE,
             ScyllaDbStoreInternalError::TooLargeBatch
-        );
-        println!(
-            "|key_prefix_deletions|={}",
-            batch.key_prefix_deletions.len()
         );
         for key_prefix in batch.key_prefix_deletions {
             ensure!(
@@ -332,10 +327,6 @@ impl ScyllaDbClient {
             }
         }
         let query3 = &self.write_batch_deletion;
-        println!(
-            "|deletions|={}",
-            batch.simple_unordered_batch.deletions.len()
-        );
         for key in batch.simple_unordered_batch.deletions {
             ensure!(
                 key.len() <= MAX_KEY_SIZE,
@@ -346,14 +337,7 @@ impl ScyllaDbClient {
             batch_query.append_statement(query3.clone());
         }
         let query4 = &self.write_batch_insertion;
-        println!(
-            "|insertions|={}",
-            batch.simple_unordered_batch.insertions.len()
-        );
-        let mut total_size = 0;
         for (key, value) in batch.simple_unordered_batch.insertions {
-            println!("|key|={} |value|={}", key.len(), value.len());
-            total_size += key.len() + value.len();
             ensure!(
                 key.len() <= MAX_KEY_SIZE,
                 ScyllaDbStoreInternalError::KeyTooLong
@@ -366,7 +350,6 @@ impl ScyllaDbClient {
             batch_values.push(values);
             batch_query.append_statement(query4.clone());
         }
-        println!("total_size={}", total_size);
         session.batch(&batch_query, batch_values).await?;
         Ok(())
     }

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -153,6 +153,11 @@ impl UnorderedBatch {
     pub fn len(&self) -> usize {
         self.key_prefix_deletions.len() + self.simple_unordered_batch.len()
     }
+
+    /// Tests whether the batch is empty or not
+    pub fn is_empty(&self) -> bool {
+        self.key_prefix_deletions.len() == 0 && self.simple_unordered_batch.len() == 0
+    }
 }
 
 /// Checks if `key` is matched by any prefix in `key_prefix_set`.

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -156,7 +156,7 @@ impl UnorderedBatch {
 
     /// Tests whether the batch is empty or not
     pub fn is_empty(&self) -> bool {
-        self.key_prefix_deletions.len() == 0 && self.simple_unordered_batch.len() == 0
+        self.key_prefix_deletions.is_empty() && self.simple_unordered_batch.is_empty()
     }
 }
 

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -148,6 +148,11 @@ impl UnorderedBatch {
         self.key_prefix_deletions = key_prefix_deletions;
         Ok(())
     }
+
+    /// The total number of entries of the batch.
+    pub fn len(&self) -> usize {
+        self.key_prefix_deletions.len() + self.simple_unordered_batch.len()
+    }
 }
 
 /// Checks if `key` is matched by any prefix in `key_prefix_set`.

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -310,7 +310,7 @@ impl CustomSerialize for u128 {
 /// The formula that should be satisfied is
 /// serialized_size(vec![v_1, ...., v_n]) = get_uleb128_size(n)
 ///  + serialized_size(v_1)? + .... serialized_size(v_n)?
-pub(crate) fn get_uleb128_size(len: usize) -> usize {
+pub(crate) const fn get_uleb128_size(len: usize) -> usize {
     let mut power = 128;
     let mut expo = 1;
     while len >= power {

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -418,7 +418,7 @@ pub async fn run_writes_from_blank<C: LocalRestrictedKeyValueStore>(key_value_st
     }
 }
 
-/// Doing a big read of many keys could trigger some error. That need to be tested.
+/// Reading many keys at a time could trigger an error. This needs to be tested.
 pub async fn big_read_multi_values<C: LocalKeyValueStore>(
     config: C::Config,
     value_size: usize,
@@ -503,10 +503,6 @@ pub async fn run_big_write_read<C: LocalRestrictedKeyValueStore>(
     let mut rng = make_deterministic_rng();
     for (pos, value_size) in value_sizes.into_iter().enumerate() {
         let n_entry: usize = target_size / value_size;
-        println!(
-            "n_entry={} target_size={} value_size={}",
-            n_entry, target_size, value_size
-        );
         let mut batch = Batch::new();
         let key_prefix = vec![0, pos as u8];
         for i in 0..n_entry {

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -418,6 +418,32 @@ pub async fn run_writes_from_blank<C: LocalRestrictedKeyValueStore>(key_value_st
     }
 }
 
+/// Doing a big read of many keys could trigger some error. That need to be tested.
+pub async fn big_read_multi_values<C: LocalKeyValueStore>(config: C::Config, value_size: usize, n_entries: usize) {
+    let mut rng = make_deterministic_rng();
+    let namespace = generate_test_namespace();
+    let root_key = &[];
+    //
+    let store = C::recreate_and_connect(&config, &namespace, root_key).await.unwrap();
+    let key_prefix = vec![42, 54];
+    let mut batch = Batch::new();
+    let mut keys = Vec::new();
+    let mut values = Vec::new();
+    for i in 0..n_entries {
+        let mut key = key_prefix.clone();
+        bcs::serialize_into(&mut key, &i).unwrap();
+        let value = get_random_byte_vector(&mut rng, &[], value_size);
+        batch.put_key_value_bytes(key.clone(), value.clone());
+        keys.push(key);
+        values.push(Some(value));
+    }
+    store.write_batch(batch).await.unwrap();
+    // We reconnect so that the read is not using the cache.
+    let store = C::connect(&config, &namespace, root_key).await.unwrap();
+    let values_read = store.read_multi_values_bytes(keys).await.unwrap();
+    assert_eq!(values, values_read);
+}
+
 /// That test is especially challenging for ScyllaDB.
 /// In its default settings, Scylla has a limitation to 10000 tombstones.
 /// A tombstone is an indication that the data has been deleted. That
@@ -471,6 +497,7 @@ pub async fn run_big_write_read<C: LocalRestrictedKeyValueStore>(
     let mut rng = make_deterministic_rng();
     for (pos, value_size) in value_sizes.into_iter().enumerate() {
         let n_entry: usize = target_size / value_size;
+        println!("n_entry={} target_size={} value_size={}", n_entry, target_size, value_size);
         let mut batch = Batch::new();
         let key_prefix = vec![0, pos as u8];
         for i in 0..n_entry {

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -419,12 +419,18 @@ pub async fn run_writes_from_blank<C: LocalRestrictedKeyValueStore>(key_value_st
 }
 
 /// Doing a big read of many keys could trigger some error. That need to be tested.
-pub async fn big_read_multi_values<C: LocalKeyValueStore>(config: C::Config, value_size: usize, n_entries: usize) {
+pub async fn big_read_multi_values<C: LocalKeyValueStore>(
+    config: C::Config,
+    value_size: usize,
+    n_entries: usize,
+) {
     let mut rng = make_deterministic_rng();
     let namespace = generate_test_namespace();
     let root_key = &[];
     //
-    let store = C::recreate_and_connect(&config, &namespace, root_key).await.unwrap();
+    let store = C::recreate_and_connect(&config, &namespace, root_key)
+        .await
+        .unwrap();
     let key_prefix = vec![42, 54];
     let mut batch = Batch::new();
     let mut keys = Vec::new();
@@ -497,7 +503,10 @@ pub async fn run_big_write_read<C: LocalRestrictedKeyValueStore>(
     let mut rng = make_deterministic_rng();
     for (pos, value_size) in value_sizes.into_iter().enumerate() {
         let n_entry: usize = target_size / value_size;
-        println!("n_entry={} target_size={} value_size={}", n_entry, target_size, value_size);
+        println!(
+            "n_entry={} target_size={} value_size={}",
+            n_entry, target_size, value_size
+        );
         let mut batch = Batch::new();
         let key_prefix = vec![0, pos as u8];
         for i in 0..n_entry {

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -9,8 +9,8 @@ use linera_views::{
     random::make_deterministic_rng,
     store::TestKeyValueStore as _,
     test_utils::{
-        get_random_test_scenarios, run_big_write_read, run_reads, run_writes_from_blank,
-        run_writes_from_state,
+        big_read_multi_values, get_random_test_scenarios, run_big_write_read, run_reads,
+        run_writes_from_blank, run_writes_from_state,
     },
     value_splitting::create_value_splitting_memory_store,
 };
@@ -19,6 +19,35 @@ use wasm_bindgen_test::wasm_bindgen_test;
 
 #[cfg(web)]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+#[ignore]
+#[tokio::test]
+async fn test_read_multi_values_memory() {
+    let config = MemoryStore::new_test_config().await.unwrap();
+    big_read_multi_values::<MemoryStore>(config, 2200000, 1000).await;
+}
+
+#[ignore]
+#[cfg(with_dynamodb)]
+#[tokio::test]
+async fn test_read_multi_values_dynamo_db() {
+    use linera_views::dynamo_db::DynamoDbStore;
+    let config = DynamoDbStore::new_test_config()
+        .await
+        .unwrap();
+    big_read_multi_values::<DynamoDbStore>(config, 22000000, 1000).await;
+}
+
+#[ignore]
+#[cfg(with_scylladb)]
+#[tokio::test]
+async fn test_read_multi_values_scylla_db() {
+    use linera_views::scylla_db::ScyllaDbStore;
+    let config = ScyllaDbStore::new_test_config()
+        .await
+        .unwrap();
+    big_read_multi_values::<ScyllaDbStore>(config, 22200000, 200).await;
+}
 
 #[tokio::test]
 async fn test_reads_test_memory() {

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -32,9 +32,7 @@ async fn test_read_multi_values_memory() {
 #[tokio::test]
 async fn test_read_multi_values_dynamo_db() {
     use linera_views::dynamo_db::DynamoDbStore;
-    let config = DynamoDbStore::new_test_config()
-        .await
-        .unwrap();
+    let config = DynamoDbStore::new_test_config().await.unwrap();
     big_read_multi_values::<DynamoDbStore>(config, 22000000, 1000).await;
 }
 
@@ -43,9 +41,7 @@ async fn test_read_multi_values_dynamo_db() {
 #[tokio::test]
 async fn test_read_multi_values_scylla_db() {
     use linera_views::scylla_db::ScyllaDbStore;
-    let config = ScyllaDbStore::new_test_config()
-        .await
-        .unwrap();
+    let config = ScyllaDbStore::new_test_config().await.unwrap();
     big_read_multi_values::<ScyllaDbStore>(config, 22200000, 200).await;
 }
 


### PR DESCRIPTION
## Motivation

The `ScyllaDb` is our main storage system. So, we need to remove limitations from it.

## Proposal

The following was done:
* A generic test for writing very big entries and doing a corresponding `multi_read_values` was introduced.
* The test was proven to be correct for ScyllaDb, but still matched as ignored as it takes too long to run.
* Tests show that a `read_multi_values` of 1.6G passes correctly even if slow. This is the maximum possible size (about 99 * 16M). So, no limitation problem here.
* The `ValueSplitting` is used for the ScyllaDb in order to have values larger than 16M.
* The constants are changed to more realistic values.
* Clean up the ensure statements for key sizes.

## Test Plan

The CI + additional offline tests.

## Release Plan

This changes the storage, 

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
