### PR TITLE
Block proposal size limits

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -430,6 +430,7 @@ View or update the resource control policy
 * `--maximum-executed-block-size <MAXIMUM_EXECUTED_BLOCK_SIZE>` — Set the maximum size of an executed block, in bytes
 * `--maximum-blob-size <MAXIMUM_BLOB_SIZE>` — Set the maximum size of data blobs, compressed bytecode and other binary blobs, in bytes
 * `--maximum-bytecode-size <MAXIMUM_BYTECODE_SIZE>` — Set the maximum size of decompressed contract or service bytecode, in bytes
+* `--maximum-block-proposal-size <MAXIMUM_BLOCK_PROPOSAL_SIZE>` — Set the maximum size of a block proposal, in bytes
 * `--maximum-bytes-read-per-block <MAXIMUM_BYTES_READ_PER_BLOCK>` — Set the maximum read data per block
 * `--maximum-bytes-written-per-block <MAXIMUM_BYTES_WRITTEN_PER_BLOCK>` — Set the maximum write data per block
 
@@ -493,6 +494,7 @@ Create genesis configuration for a Linera deployment. Create initial user chains
 * `--maximum-executed-block-size <MAXIMUM_EXECUTED_BLOCK_SIZE>` — Set the maximum size of an executed block
 * `--maximum-bytecode-size <MAXIMUM_BYTECODE_SIZE>` — Set the maximum size of decompressed contract or service bytecode, in bytes
 * `--maximum-blob-size <MAXIMUM_BLOB_SIZE>` — Set the maximum size of data blobs, compressed bytecode and other binary blobs, in bytes
+* `--maximum-block-proposal-size <MAXIMUM_BLOCK_PROPOSAL_SIZE>` — Set the maximum size of a block proposal, in bytes
 * `--maximum-bytes-read-per-block <MAXIMUM_BYTES_READ_PER_BLOCK>` — Set the maximum read data per block
 * `--maximum-bytes-written-per-block <MAXIMUM_BYTES_WRITTEN_PER_BLOCK>` — Set the maximum write data per block
 * `--testing-prng-seed <TESTING_PRNG_SEED>` — Force this wallet to generate keys using a PRNG and a given seed. USE FOR TESTING ONLY

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -7,6 +7,7 @@ use std::{collections::HashSet, fmt};
 use async_graphql::SimpleObject;
 use custom_debug_derive::Debug;
 use linera_base::{
+    bcs,
     crypto::{BcsHashable, BcsSignable, CryptoError, CryptoHash, KeyPair, PublicKey, Signature},
     data_types::{Amount, Blob, BlockHeight, OracleResponse, Round, Timestamp},
     doc_scalar, ensure, hex_debug,
@@ -773,6 +774,15 @@ impl BlockProposal {
             blobs,
             validated_block_certificate: Some(lite_cert),
         }
+    }
+
+    pub fn check_size(&self, maximum_block_proposal_size: u64) -> Result<(), ChainError> {
+        let size = bcs::serialized_size(&self)?;
+        ensure!(
+            size <= usize::try_from(maximum_block_proposal_size).unwrap_or(usize::MAX),
+            ChainError::BlockProposalTooLarge
+        );
+        Ok(())
     }
 
     pub fn check_signature(&self, public_key: PublicKey) -> Result<(), CryptoError> {

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -23,6 +23,7 @@ pub mod test;
 pub use chain::ChainStateView;
 use data_types::{MessageBundle, Origin, PostedMessage};
 use linera_base::{
+    bcs,
     crypto::{CryptoError, CryptoHash},
     data_types::{ArithmeticError, BlockHeight, Round, Timestamp},
     identifiers::{ApplicationId, BlobId, ChainId},
@@ -138,6 +139,10 @@ pub enum ChainError {
     CertificateSignatureVerificationFailed { error: String },
     #[error("Internal error {0}")]
     InternalError(String),
+    #[error("Block proposal is too large")]
+    BlockProposalTooLarge,
+    #[error(transparent)]
+    BcsError(#[from] bcs::Error),
     #[error("Insufficient balance to pay the fees")]
     InsufficientBalance,
     #[error("Invalid owner weights: {0}")]

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -111,7 +111,7 @@ async fn test_block_size_limit() {
     let mut chain = ChainStateView::new(chain_id).await;
 
     // The size of the executed valid block below.
-    let maximum_executed_block_size = 691;
+    let maximum_executed_block_size = 699;
 
     // Initialize the chain.
     let mut config = make_open_chain_config();

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -546,6 +546,10 @@ pub enum ClientCommand {
         #[arg(long)]
         maximum_bytecode_size: Option<u64>,
 
+        /// Set the maximum size of a block proposal, in bytes.
+        #[arg(long)]
+        maximum_block_proposal_size: Option<u64>,
+
         /// Set the maximum read data per block.
         #[arg(long)]
         maximum_bytes_read_per_block: Option<u64>,
@@ -668,6 +672,10 @@ pub enum ClientCommand {
         /// in bytes.
         #[arg(long)]
         maximum_blob_size: Option<u64>,
+
+        /// Set the maximum size of a block proposal, in bytes.
+        #[arg(long)]
+        maximum_block_proposal_size: Option<u64>,
 
         /// Set the maximum read data per block.
         #[arg(long)]

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -180,8 +180,9 @@ where
             .system
             .current_committee()
             .expect("chain is active");
-        let policy = committee.policy().clone();
         check_block_epoch(epoch, block)?;
+        let policy = committee.policy().clone();
+        proposal.check_size(policy.maximum_block_proposal_size)?;
         // Check the authentication of the block.
         let public_key = self
             .0

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -47,6 +47,8 @@ pub struct ResourceControlPolicy {
     pub maximum_bytecode_size: u64,
     /// The maximum size of a blob.
     pub maximum_blob_size: u64,
+    /// The maximum size of a block proposal.
+    pub maximum_block_proposal_size: u64,
     /// The maximum data to read per block
     pub maximum_bytes_read_per_block: u64,
     /// The maximum data to write per block
@@ -71,6 +73,7 @@ impl fmt::Display for ResourceControlPolicy {
             maximum_executed_block_size,
             maximum_blob_size,
             maximum_bytecode_size,
+            maximum_block_proposal_size,
             maximum_bytes_read_per_block,
             maximum_bytes_written_per_block,
         } = self;
@@ -92,6 +95,7 @@ impl fmt::Display for ResourceControlPolicy {
             {maximum_executed_block_size} maximum size of an executed block\n\
             {maximum_blob_size} maximum size of a data blob, bytecode or other binary blob\n\
             {maximum_bytecode_size} maximum size of service and contract bytecode\n\
+            {maximum_block_proposal_size} maximum size of a block proposal\n\
             {maximum_bytes_read_per_block} maximum number bytes read per block\n\
             {maximum_bytes_written_per_block} maximum number bytes written per block",
         )
@@ -116,6 +120,7 @@ impl Default for ResourceControlPolicy {
             maximum_executed_block_size: u64::MAX,
             maximum_blob_size: u64::MAX,
             maximum_bytecode_size: u64::MAX,
+            maximum_block_proposal_size: u64::MAX,
             maximum_bytes_read_per_block: u64::MAX,
             maximum_bytes_written_per_block: u64::MAX,
         }
@@ -237,6 +242,7 @@ impl ResourceControlPolicy {
             maximum_executed_block_size: 1_000_000,
             maximum_blob_size: 1_000_000,
             maximum_bytecode_size: 10_000_000,
+            maximum_block_proposal_size: 13_000_000,
             maximum_bytes_read_per_block: 100_000_000,
             maximum_bytes_written_per_block: 10_000_000,
         }

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -150,8 +150,9 @@ async fn test_fee_consumption(
         maximum_executed_block_size: 37,
         maximum_blob_size: 41,
         maximum_bytecode_size: 43,
-        maximum_bytes_read_per_block: 47,
-        maximum_bytes_written_per_block: 53,
+        maximum_block_proposal_size: 47,
+        maximum_bytes_read_per_block: 53,
+        maximum_bytes_written_per_block: 59,
     };
 
     let consumed_fees = spends

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -739,6 +739,7 @@ ResourceControlPolicy:
     - maximum_executed_block_size: U64
     - maximum_bytecode_size: U64
     - maximum_blob_size: U64
+    - maximum_block_proposal_size: U64
     - maximum_bytes_read_per_block: U64
     - maximum_bytes_written_per_block: U64
 Round:

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -919,6 +919,10 @@ input ResourceControlPolicy {
 	"""
 	maximumBlobSize: Int!
 	"""
+	The maximum size of a block proposal.
+	"""
+	maximumBlockProposalSize: Int!
+	"""
 	The maximum data to read per block
 	"""
 	maximumBytesReadPerBlock: Int!

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -250,6 +250,7 @@ impl ClientWrapper {
             maximum_executed_block_size,
             maximum_blob_size,
             maximum_bytecode_size,
+            maximum_block_proposal_size,
             maximum_bytes_read_per_block,
             maximum_bytes_written_per_block,
         } = policy;
@@ -285,6 +286,10 @@ impl ClientWrapper {
             .args([
                 "--maximum-bytecode-size",
                 &maximum_bytecode_size.to_string(),
+            ])
+            .args([
+                "--maximum-block-proposal-size",
+                &maximum_block_proposal_size.to_string(),
             ])
             .args([
                 "--maximum-bytes-read-per-block",

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -570,6 +570,7 @@ impl Runnable for Job {
                                     maximum_executed_block_size,
                                     maximum_blob_size,
                                     maximum_bytecode_size,
+                                    maximum_block_proposal_size,
                                     maximum_bytes_read_per_block,
                                     maximum_bytes_written_per_block,
                                 } => {
@@ -620,6 +621,12 @@ impl Runnable for Job {
                                     }
                                     if let Some(maximum_blob_size) = maximum_blob_size {
                                         policy.maximum_blob_size = maximum_blob_size;
+                                    }
+                                    if let Some(maximum_block_proposal_size) =
+                                        maximum_block_proposal_size
+                                    {
+                                        policy.maximum_block_proposal_size =
+                                            maximum_block_proposal_size;
                                     }
                                     if let Some(maximum_bytes_read_per_block) =
                                         maximum_bytes_read_per_block
@@ -1385,6 +1392,7 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
             maximum_executed_block_size,
             maximum_blob_size,
             maximum_bytecode_size,
+            maximum_block_proposal_size,
             maximum_bytes_read_per_block,
             maximum_bytes_written_per_block,
             testing_prng_seed,
@@ -1399,6 +1407,7 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
             let maximum_executed_block_size = maximum_executed_block_size.unwrap_or(u64::MAX);
             let maximum_blob_size = maximum_blob_size.unwrap_or(u64::MAX);
             let maximum_bytecode_size = maximum_bytecode_size.unwrap_or(u64::MAX);
+            let maximum_block_proposal_size = maximum_block_proposal_size.unwrap_or(u64::MAX);
             let policy = ResourceControlPolicy {
                 block: *block_price,
                 fuel_unit: *fuel_unit_price,
@@ -1415,6 +1424,7 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                 maximum_executed_block_size,
                 maximum_blob_size,
                 maximum_bytecode_size,
+                maximum_block_proposal_size,
                 maximum_bytes_read_per_block,
                 maximum_bytes_written_per_block,
             };


### PR DESCRIPTION
## Motivation

Large block proposals can make messages containing them exceed the gRPC message limit, and require a lot of storage and bandwidth, as they may contain several blobs.

## Proposal

Add configurable block proposal size limits. This is part of #2199

## Test Plan

CI, incremented one of the tests

## Release Plan

- These changes should be backported to the latest `devnet` branch
- These changes should be backported to the latest `testnet` branch
