### PR TITLE
Clear the pending block if the local node rejected the proposal

### DIFF
--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2474,8 +2474,6 @@ where
             LocalNodeError::WorkerError(WorkerError::ChainError(chain_error))
         )) if matches!(*chain_error, ChainError::BlockProposalTooLarge)
     );
-    // TODO(#2906): Remove this once the client properly clears the pending block.
-    client1.clear_pending_block();
 
     let result = client1.publish_data_blob(large_blob_bytes).await;
     assert_matches!(


### PR DESCRIPTION
## Motivation

If a block fails locally before being sent to the validators (for whatever reason), we currently don't clear the pending block. That means that we'll basically "brick" that chain client, as every block that we try to propose using it, will try (and fail) to propose the pending block again.

## Proposal

If we fail locally, clear the pending block. Fixes #2906

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
