### PR TITLE
Fix variable usage in cargo publish Update publish.sh

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -8,5 +8,5 @@ set -x -e
 
 # Publish the given packages.
 grep -v '^#' "$1" | while read LINE; do
-    cargo publish -p $LINE
+    cargo publish -p "$LINE"
 done


### PR DESCRIPTION
### Problem:
In the script, the variable `$LINE` is used without quotes in the following command:

```bash
cargo publish -p $LINE
```

This can lead to security risks or errors if the variable contains spaces or special characters. For example, if `$LINE` contains a name with spaces, it will be treated as multiple arguments, which could cause the command to fail or behave unexpectedly.

---

### Solution:
To address this, we have enclosed the variable `$LINE` in double quotes, ensuring it is treated as a single argument even if it contains spaces or special characters:

```bash
cargo publish -p "$LINE"
```

---

### Importance:
This fix is important for the following reasons:
- **Security**: It prevents potential command injection or unexpected behavior if `$LINE` contains malicious input.
- **Reliability**: It ensures the command executes correctly even when the variable contains spaces or special characters.
- **Good practice**: Enclosing variables in quotes is a standard and recommended approach to prevent issues in shell scripts.

This change improves the robustness and security of the script.