### PR TITLE
Cleanup ChainClientError::BlobsNotFound

### DIFF
--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1431,7 +1431,7 @@ where
         .await;
     assert_matches!(
         result,
-        Err(ChainClientError::BlobsNotFound(not_found_blob_ids)) if not_found_blob_ids == [blob0_id]
+        Err(ChainClientError::RemoteNodeError(NodeError::BlobsNotFound(not_found_blob_ids))) if not_found_blob_ids == [blob0_id]
     );
 
     // Take one validator down


### PR DESCRIPTION
## Motivation

Now that we're not propagating any `BlobsNotFound` errors to `ChainClientError`, this variant can be removed

## Proposal

Remove `ChainClientError::BlobsNotFound`. There was also one place where we were using `ChainClientError` when we should be using `NodeError`.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
