### PR TITLE
Cleanup of some errors.

### DIFF
--- a/linera-base/src/crypto.rs
+++ b/linera-base/src/crypto.rs
@@ -53,7 +53,7 @@ pub enum CryptoError {
     InvalidSignature { error: String, type_name: String },
     #[error("Signature for object {type_name} is missing")]
     MissingSignature { type_name: String },
-    #[error("String contains non-hexadecimal digits")]
+    #[error(transparent)]
     NonHexDigits(#[from] hex::FromHexError),
     #[error(
         "Byte slice has length {0} but a `CryptoHash` requires exactly {expected} bytes",
@@ -65,7 +65,7 @@ pub enum CryptoError {
         expected = dalek::PUBLIC_KEY_LENGTH,
     )]
     IncorrectPublicKeySize(usize),
-    #[error("Could not parse integer")]
+    #[error("Could not parse integer: {0}")]
     ParseIntError(#[from] ParseIntError),
 }
 

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -948,7 +948,7 @@ impl CompressedBytecode {
         while !decoder.get_ref().is_empty() {
             decoder
                 .read_to_end(&mut bytes)
-                .expect("Reading from a slice in memory should not result in IO errors");
+                .expect("Reading from a slice in memory should not result in I/O errors");
         }
 
         Ok(Bytecode { bytes })

--- a/linera-base/src/graphql.rs
+++ b/linera-base/src/graphql.rs
@@ -21,7 +21,7 @@ macro_rules! doc_scalar {
 #[allow(missing_docs)]
 pub enum BcsHexParseError {
     #[error(transparent)]
-    Bcs(#[from] bcs::Error),
+    BcsError(#[from] bcs::Error),
     #[error("Invalid hexadecimal: {0}")]
     Hex(#[from] hex::FromHexError),
 }

--- a/linera-base/src/graphql.rs
+++ b/linera-base/src/graphql.rs
@@ -20,7 +20,7 @@ macro_rules! doc_scalar {
 #[derive(thiserror::Error, Debug)]
 #[allow(missing_docs)]
 pub enum BcsHexParseError {
-    #[error("Invalid BCS: {0}")]
+    #[error(transparent)]
     Bcs(#[from] bcs::Error),
     #[error("Invalid hexadecimal: {0}")]
     Hex(#[from] hex::FromHexError),

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -37,9 +37,9 @@ use thiserror::Error;
 pub enum ChainError {
     #[error("Cryptographic error: {0}")]
     CryptoError(#[from] CryptoError),
-    #[error("Arithmetic error: {0}")]
+    #[error(transparent)]
     ArithmeticError(#[from] ArithmeticError),
-    #[error("Error in view operation: {0}")]
+    #[error(transparent)]
     ViewError(ViewError),
     #[error("Execution error: {0} during {1:?}")]
     ExecutionError(Box<ExecutionError>, ChainExecutionContext),
@@ -142,7 +142,7 @@ pub enum ChainError {
     #[error("Block proposal is too large")]
     BlockProposalTooLarge,
     #[error(transparent)]
-    BcsError(#[from] bcs::Error),
+    Bcs(#[from] bcs::Error),
     #[error("Insufficient balance to pay the fees")]
     InsufficientBalance,
     #[error("Invalid owner weights: {0}")]

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -142,7 +142,7 @@ pub enum ChainError {
     #[error("Block proposal is too large")]
     BlockProposalTooLarge,
     #[error(transparent)]
-    Bcs(#[from] bcs::Error),
+    BcsError(#[from] bcs::Error),
     #[error("Insufficient balance to pay the fees")]
     InsufficientBalance,
     #[error("Invalid owner weights: {0}")]

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -38,7 +38,7 @@ use crate::{
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("I/O error: {0}")]
-    Io(#[from] std::io::Error),
+    IoError(#[from] std::io::Error),
     #[error("a storage option must be provided")]
     NoStorageOption,
     #[error("wallet already exists at {0}")]

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("I/O error: {0}")]
-    Io(#[from] std::io::Error),
+    IoError(#[from] std::io::Error),
     #[error("chain error: {0}")]
     Chain(#[from] linera_chain::ChainError),
     #[error("persistence error: {0}")]

--- a/linera-client/src/persistent/file.rs
+++ b/linera-client/src/persistent/file.rs
@@ -17,9 +17,9 @@ struct Lock(fs_err::File);
 #[derive(Debug, thiserror::Error)]
 enum ErrorInner {
     #[error("I/O error: {0}")]
-    Io(#[from] std::io::Error),
+    IoError(#[from] std::io::Error),
     #[error("JSON error: {0}")]
-    Serde(#[from] serde_json::Error),
+    JsonError(#[from] serde_json::Error),
 }
 
 thiserror_context::impl_context!(Error(ErrorInner));

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -155,7 +155,7 @@ pub enum WorkerError {
     #[error("Block was not signed by an authorized owner")]
     InvalidOwner,
 
-    #[error("Operations in the block are not authenticated by the proper signer")]
+    #[error("Operations in the block are not authenticated by the proper signer: {0}")]
     InvalidSigner(Owner),
 
     // Chaining

--- a/linera-ethereum/src/common.rs
+++ b/linera-ethereum/src/common.rs
@@ -38,9 +38,6 @@ pub enum EthereumServiceError {
     #[error("Failed to deploy the smart contract")]
     DeployError,
 
-    #[error("Json error occurred")]
-    JsonError,
-
     #[error("Unsupported Ethereum type")]
     UnsupportedEthereumTypeError,
 
@@ -65,7 +62,7 @@ pub enum EthereumServiceError {
 
     /// `serde_json` error
     #[error(transparent)]
-    SerdeJsonError(#[from] serde_json::Error),
+    JsonError(#[from] serde_json::Error),
 
     /// RPC error
     #[error(transparent)]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -238,13 +238,13 @@ pub enum ExecutionError {
     OwnerIsNone,
     #[error("Application is not authorized to perform system operations on this chain: {0:}")]
     UnauthorizedApplication(UserApplicationId),
-    #[error("Failed to make network reqwest")]
+    #[error("Failed to make network reqwest: {0}")]
     ReqwestError(#[from] reqwest::Error),
-    #[error("Encountered IO error")]
+    #[error("Encountered IO error: {0}")]
     IoError(#[from] std::io::Error),
     #[error("More recorded oracle responses than expected")]
     UnexpectedOracleResponse,
-    #[error("Invalid JSON: {}", .0)]
+    #[error("Invalid JSON: {0}")]
     Json(#[from] serde_json::Error),
     #[error(transparent)]
     Bcs(#[from] bcs::Error),

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -240,7 +240,7 @@ pub enum ExecutionError {
     UnauthorizedApplication(UserApplicationId),
     #[error("Failed to make network reqwest: {0}")]
     ReqwestError(#[from] reqwest::Error),
-    #[error("Encountered IO error: {0}")]
+    #[error("Encountered I/O error: {0}")]
     IoError(#[from] std::io::Error),
     #[error("More recorded oracle responses than expected")]
     UnexpectedOracleResponse,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -245,9 +245,9 @@ pub enum ExecutionError {
     #[error("More recorded oracle responses than expected")]
     UnexpectedOracleResponse,
     #[error("Invalid JSON: {0}")]
-    Json(#[from] serde_json::Error),
+    JsonError(#[from] serde_json::Error),
     #[error(transparent)]
-    Bcs(#[from] bcs::Error),
+    BcsError(#[from] bcs::Error),
     #[error("Recorded response for oracle query has the wrong type")]
     OracleResponseMismatch,
     #[error("Assertion failed: local time {local_time} is not earlier than {timestamp}")]

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -284,7 +284,7 @@ pub enum WasmExecutionError {
     #[error("Failed to instantiate Wasm module: {_0}")]
     InstantiateModuleWithWasmer(#[from] Box<::wasmer::InstantiationError>),
     #[cfg(with_wasmtime)]
-    #[error("Failed to create and configure Wasmtime runtime")]
+    #[error("Failed to create and configure Wasmtime runtime: {_0}")]
     CreateWasmtimeEngine(#[source] anyhow::Error),
     #[cfg(with_wasmer)]
     #[error(

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -27,7 +27,7 @@ pub enum GrpcError {
     #[error("failed to communicate cross-chain queries: {0}")]
     CrossChain(#[from] tonic::Status),
 
-    #[error("failed to execute task to completion")]
+    #[error("failed to execute task to completion: {0}")]
     Join(#[from] futures::channel::oneshot::Canceled),
 
     #[error("failed to parse socket address: {0}")]

--- a/linera-rpc/src/mass_client.rs
+++ b/linera-rpc/src/mass_client.rs
@@ -9,7 +9,7 @@ use crate::RpcMessage;
 #[derive(Error, Debug)]
 pub enum MassClientError {
     #[error("io error: {0}")]
-    Io(#[from] std::io::Error),
+    IoError(#[from] std::io::Error),
     #[error("tonic transport: {0}")]
     TonicTransport(#[from] crate::grpc::transport::Error),
     #[error("conversion error: {0}")]

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -54,13 +54,13 @@ impl SimpleClient {
         // Send message
         timer::timeout(self.send_timeout, stream.send(message))
             .await
-            .map_err(|timeout| codec::Error::Io(timeout.into()))??;
+            .map_err(|timeout| codec::Error::IoError(timeout.into()))??;
         // Wait for reply
         timer::timeout(self.recv_timeout, stream.next())
             .await
-            .map_err(|timeout| codec::Error::Io(timeout.into()))?
+            .map_err(|timeout| codec::Error::IoError(timeout.into()))?
             .transpose()?
-            .ok_or_else(|| codec::Error::Io(std::io::ErrorKind::UnexpectedEof.into()))
+            .ok_or_else(|| codec::Error::IoError(std::io::ErrorKind::UnexpectedEof.into()))
     }
 
     async fn query<Response>(&self, query: RpcMessage) -> Result<Response, Response::Error>

--- a/linera-rpc/src/simple/codec.rs
+++ b/linera-rpc/src/simple/codec.rs
@@ -104,7 +104,7 @@ pub enum Error {
 impl From<Error> for NodeError {
     fn from(error: Error) -> NodeError {
         match error {
-            Error::Io(io_error) => NodeError::ClientIoError {
+            Error::IoError(io_error) => NodeError::ClientIoError {
                 error: format!("{}", io_error),
             },
             err => {

--- a/linera-rpc/src/simple/codec.rs
+++ b/linera-rpc/src/simple/codec.rs
@@ -86,13 +86,13 @@ impl Decoder for Codec {
 /// Errors that can arise during transmission or reception of [`RpcMessage`]s.
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("IO error in the underlying transport")]
+    #[error("I/O error in the underlying transport: {0}")]
     Io(#[from] io::Error),
 
-    #[error("Failed to deserialize an incoming message")]
+    #[error("Failed to deserialize an incoming message: {0}")]
     Deserialization(#[source] bincode::ErrorKind),
 
-    #[error("Failed to serialize outgoing message")]
+    #[error("Failed to serialize outgoing message: {0}")]
     Serialization(#[source] bincode::ErrorKind),
 
     #[error("RpcMessage is too big to fit in a protocol frame: \

--- a/linera-rpc/src/simple/codec.rs
+++ b/linera-rpc/src/simple/codec.rs
@@ -87,7 +87,7 @@ impl Decoder for Codec {
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("I/O error in the underlying transport: {0}")]
-    Io(#[from] io::Error),
+    IoError(#[from] io::Error),
 
     #[error("Failed to deserialize an incoming message: {0}")]
     Deserialization(#[source] bincode::ErrorKind),

--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -288,8 +288,8 @@ where
     /// Handles an error while receiving a message.
     async fn handle_error(&mut self, error: codec::Error) -> Result<(), std::io::Error> {
         match error {
-            codec::Error::Io(io_error) => {
-                error!("IO error in UDP server: {io_error}");
+            codec::Error::IoError(io_error) => {
+                error!("I/O error in UDP server: {io_error}");
                 self.shutdown().await;
                 Err(io_error)
             }
@@ -485,7 +485,7 @@ where
     fn handle_error(&self, error: codec::Error) {
         if !matches!(
             &error,
-            codec::Error::Io(error)
+            codec::Error::IoError(error)
                 if error.kind() == io::ErrorKind::UnexpectedEof
                 || error.kind() == io::ErrorKind::ConnectionReset
         ) {

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -91,7 +91,7 @@ pub enum KeyValueStoreError {
     KeyTooLong,
 
     /// BCS serialization error.
-    #[error("BCS error: {0}")]
+    #[error(transparent)]
     Bcs(#[from] bcs::Error),
 }
 

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -92,7 +92,7 @@ pub enum KeyValueStoreError {
 
     /// BCS serialization error.
     #[error(transparent)]
-    Bcs(#[from] bcs::Error),
+    BcsError(#[from] bcs::Error),
 }
 
 impl linera_views::store::KeyValueStoreError for KeyValueStoreError {

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -83,7 +83,7 @@ enum NodeServiceError {
     #[error("could not decode query string: {0}")]
     QueryStringError(#[from] hex::FromHexError),
     #[error(transparent)]
-    Bcs(#[from] bcs::Error),
+    BcsError(#[from] bcs::Error),
     #[error(transparent)]
     JsonError(#[from] serde_json::Error),
     #[error("missing GraphQL operation")]

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -120,7 +120,9 @@ impl IntoResponse for NodeServiceError {
             NodeServiceError::ChainClientError(e) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, vec![e.to_string()])
             }
-            NodeServiceError::Bcs(e) => (StatusCode::INTERNAL_SERVER_ERROR, vec![e.to_string()]),
+            NodeServiceError::BcsError(e) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, vec![e.to_string()])
+            }
             NodeServiceError::JsonError(e) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, vec![e.to_string()])
             }

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -80,10 +80,10 @@ enum NodeServiceError {
     ChainClientError(#[from] ChainClientError),
     #[error(transparent)]
     BcsHexError(#[from] BcsHexParseError),
-    #[error("could not decode query string")]
+    #[error("could not decode query string: {0}")]
     QueryStringError(#[from] hex::FromHexError),
     #[error(transparent)]
-    BcsError(#[from] bcs::Error),
+    Bcs(#[from] bcs::Error),
     #[error(transparent)]
     JsonError(#[from] serde_json::Error),
     #[error("missing GraphQL operation")]
@@ -96,11 +96,11 @@ enum NodeServiceError {
     GraphQLParseError { error: String },
     #[error("malformed application response")]
     MalformedApplicationResponse,
-    #[error("application service error")]
+    #[error("application service error: {errors:?}")]
     ApplicationServiceError { errors: Vec<String> },
-    #[error("chain ID not found")]
+    #[error("chain ID not found: {chain_id}")]
     UnknownChainId { chain_id: String },
-    #[error("malformed chain ID")]
+    #[error("malformed chain ID: {0}")]
     InvalidChainId(CryptoError),
 }
 
@@ -120,7 +120,7 @@ impl IntoResponse for NodeServiceError {
             NodeServiceError::ChainClientError(e) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, vec![e.to_string()])
             }
-            NodeServiceError::BcsError(e) => {
+            NodeServiceError::Bcs(e) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, vec![e.to_string()])
             }
             NodeServiceError::JsonError(e) => {

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -120,9 +120,7 @@ impl IntoResponse for NodeServiceError {
             NodeServiceError::ChainClientError(e) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, vec![e.to_string()])
             }
-            NodeServiceError::Bcs(e) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, vec![e.to_string()])
-            }
+            NodeServiceError::Bcs(e) => (StatusCode::INTERNAL_SERVER_ERROR, vec![e.to_string()]),
             NodeServiceError::JsonError(e) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, vec![e.to_string()])
             }

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -57,8 +57,8 @@ pub enum ServiceStoreError {
     VarError(#[from] std::env::VarError),
 
     /// An error occurred during BCS serialization
-    #[error("An error occurred during BCS serialization")]
-    Serialization(#[from] bcs::Error),
+    #[error(transparent)]
+    Bcs(#[from] bcs::Error),
 }
 
 impl KeyValueStoreError for ServiceStoreError {

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -58,7 +58,7 @@ pub enum ServiceStoreError {
 
     /// An error occurred during BCS serialization
     #[error(transparent)]
-    Bcs(#[from] bcs::Error),
+    BcsError(#[from] bcs::Error),
 }
 
 impl KeyValueStoreError for ServiceStoreError {

--- a/linera-version/src/version_info/type.rs
+++ b/linera-version/src/version_info/type.rs
@@ -73,13 +73,13 @@ pub enum Error {
     #[error("no such package: {0}")]
     NoSuchPackage(String),
     #[error("I/O error: {0}")]
-    Io(#[from] std::io::Error),
+    IoError(#[from] std::io::Error),
     #[error("glob error: {0}")]
     Glob(#[from] glob::GlobError),
     #[error("pattern error: {0}")]
     Pattern(#[from] glob::PatternError),
     #[error("JSON error: {0}")]
-    Json(#[from] serde_json::Error),
+    JsonError(#[from] serde_json::Error),
 }
 
 struct Outcome {

--- a/linera-views/src/backends/dual.rs
+++ b/linera-views/src/backends/dual.rs
@@ -353,7 +353,7 @@ where
 pub enum DualStoreError<E1, E2> {
     /// Serialization error with BCS.
     #[error(transparent)]
-    Bcs(#[from] bcs::Error),
+    BcsError(#[from] bcs::Error),
 
     /// First store.
     #[error("Error in first store: {0}")]

--- a/linera-views/src/backends/dual.rs
+++ b/linera-views/src/backends/dual.rs
@@ -352,7 +352,7 @@ where
 #[derive(Error, Debug)]
 pub enum DualStoreError<E1, E2> {
     /// Serialization error with BCS.
-    #[error("BCS error: {0}")]
+    #[error(transparent)]
     Bcs(#[from] bcs::Error),
 
     /// First store.

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -1096,7 +1096,7 @@ pub enum DynamoDbStoreInternalError {
 
     /// A BCS error occurred.
     #[error(transparent)]
-    Bcs(#[from] bcs::Error),
+    BcsError(#[from] bcs::Error),
 
     /// A wrong table name error occurred
     #[error(transparent)]

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -1067,7 +1067,7 @@ pub enum DynamoDbStoreInternalError {
     JournalConsistencyError(#[from] JournalConsistencyError),
 
     /// Missing database
-    #[error("Missing database")]
+    #[error("Missing database: {0}")]
     MissingDatabase(String),
 
     /// Already existing database
@@ -1096,7 +1096,7 @@ pub enum DynamoDbStoreInternalError {
 
     /// A BCS error occurred.
     #[error(transparent)]
-    BcsError(#[from] bcs::Error),
+    Bcs(#[from] bcs::Error),
 
     /// A wrong table name error occurred
     #[error(transparent)]

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -341,7 +341,7 @@ pub use testing::*;
 #[derive(Error, Debug)]
 pub enum IndexedDbStoreError {
     /// Serialization error with BCS.
-    #[error("BCS error: {0}")]
+    #[error(transparent)]
     Bcs(#[from] bcs::Error),
 
     /// The value is too large for the IndexedDbStore

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -342,7 +342,7 @@ pub use testing::*;
 pub enum IndexedDbStoreError {
     /// Serialization error with BCS.
     #[error(transparent)]
-    Bcs(#[from] bcs::Error),
+    BcsError(#[from] bcs::Error),
 
     /// The value is too large for the IndexedDbStore
     #[error("The value is too large for the IndexedDbStore")]

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -391,7 +391,7 @@ pub fn create_test_memory_store() -> MemoryStore {
 #[derive(Error, Debug)]
 pub enum MemoryStoreError {
     /// Serialization error with BCS.
-    #[error("BCS error: {0}")]
+    #[error(transparent)]
     Bcs(#[from] bcs::Error),
 
     /// The value is too large for the MemoryStore

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -392,7 +392,7 @@ pub fn create_test_memory_store() -> MemoryStore {
 pub enum MemoryStoreError {
     /// Serialization error with BCS.
     #[error(transparent)]
-    Bcs(#[from] bcs::Error),
+    BcsError(#[from] bcs::Error),
 
     /// The value is too large for the MemoryStore
     #[error("The value is too large for the MemoryStore")]

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -582,7 +582,7 @@ pub enum RocksDbStoreInternalError {
 
     /// BCS serialization error.
     #[error(transparent)]
-    Bcs(#[from] bcs::Error),
+    BcsError(#[from] bcs::Error),
 }
 
 /// A path and the guard for the temporary directory if needed

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -557,7 +557,7 @@ pub enum RocksDbStoreInternalError {
     NonDirectoryNamespace,
 
     /// Error converting `OsString` to `String`
-    #[error("error in the conversion from OsString")]
+    #[error("error in the conversion from OsString: {0:?}")]
     IntoStringError(OsString),
 
     /// The key must have at most 8M
@@ -565,7 +565,7 @@ pub enum RocksDbStoreInternalError {
     KeyTooLong,
 
     /// Missing database
-    #[error("Missing database")]
+    #[error("Missing database: {0}")]
     MissingDatabase(String),
 
     /// Invalid namespace
@@ -581,7 +581,7 @@ pub enum RocksDbStoreInternalError {
     FsError(#[from] std::io::Error),
 
     /// BCS serialization error.
-    #[error("BCS error: {0}")]
+    #[error(transparent)]
     Bcs(#[from] bcs::Error),
 }
 

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -386,7 +386,7 @@ pub struct ScyllaDbStoreInternal {
 pub enum ScyllaDbStoreError {
     /// BCS serialization error.
     #[error(transparent)]
-    Bcs(#[from] bcs::Error),
+    BcsError(#[from] bcs::Error),
 
     /// The key must have at most 1M bytes
     #[error("The key must have at most 1M")]

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -385,7 +385,7 @@ pub struct ScyllaDbStoreInternal {
 #[derive(Error, Debug)]
 pub enum ScyllaDbStoreError {
     /// BCS serialization error.
-    #[error("BCS error: {0}")]
+    #[error(transparent)]
     Bcs(#[from] bcs::Error),
 
     /// The key must have at most 1M bytes
@@ -409,7 +409,7 @@ pub enum ScyllaDbStoreError {
     InvalidTableName,
 
     /// Missing database
-    #[error("Missing database")]
+    #[error("Missing database: {0}")]
     MissingDatabase(String),
 
     /// Already existing database

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -1211,7 +1211,7 @@ pub enum ViewContainerError {
 
     /// BCS serialization error.
     #[error(transparent)]
-    Bcs(#[from] bcs::Error),
+    BcsError(#[from] bcs::Error),
 }
 
 #[cfg(with_testing)]

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -1210,7 +1210,7 @@ pub enum ViewContainerError {
     ViewError(#[from] ViewError),
 
     /// BCS serialization error.
-    #[error("BCS error: {0}")]
+    #[error(transparent)]
     Bcs(#[from] bcs::Error),
 }
 

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -107,7 +107,7 @@ pub enum ViewError {
     CannotAcquireCollectionEntry,
 
     /// Input output error.
-    #[error("IO error")]
+    #[error("I/O error")]
     IoError(#[from] std::io::Error),
 
     /// Arithmetic error

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -98,9 +98,9 @@ pub trait View<C>: Sized {
 /// Main error type for the crate.
 #[derive(Error, Debug)]
 pub enum ViewError {
-    /// An error occurred during BCS serialization.
-    #[error("failed to serialize value to calculate its hash")]
-    Serialization(#[from] bcs::Error),
+    /// BCS serialization error.
+    #[error(transparent)]
+    Bcs(#[from] bcs::Error),
 
     /// We failed to acquire an entry in a CollectionView or a ReentrantCollectionView.
     #[error("trying to access a collection view or reentrant collection view while some entries are still being accessed")]
@@ -111,7 +111,7 @@ pub enum ViewError {
     Io(#[from] std::io::Error),
 
     /// Arithmetic error
-    #[error("Arithmetic error")]
+    #[error(transparent)]
     ArithmeticError(#[from] ArithmeticError),
 
     /// An error happened while trying to lock.

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -100,7 +100,7 @@ pub trait View<C>: Sized {
 pub enum ViewError {
     /// BCS serialization error.
     #[error(transparent)]
-    Bcs(#[from] bcs::Error),
+    BcsError(#[from] bcs::Error),
 
     /// We failed to acquire an entry in a CollectionView or a ReentrantCollectionView.
     #[error("trying to access a collection view or reentrant collection view while some entries are still being accessed")]
@@ -108,7 +108,7 @@ pub enum ViewError {
 
     /// Input output error.
     #[error("IO error")]
-    Io(#[from] std::io::Error),
+    IoError(#[from] std::io::Error),
 
     /// Arithmetic error
     #[error(transparent)]

--- a/linera-witty/src/runtime/error.rs
+++ b/linera-witty/src/runtime/error.rs
@@ -39,11 +39,11 @@ pub enum RuntimeError {
     NotMemory,
 
     /// Attempt to load a string from a sequence of bytes that doesn't contain a UTF-8 string.
-    #[error("Failed to load string from non-UTF-8 bytes")]
+    #[error("Failed to load string from non-UTF-8 bytes: {0}")]
     InvalidString(#[from] FromUtf8Error),
 
     /// Attempt to create a `GuestPointer` from an invalid address representation.
-    #[error("Invalid address read")]
+    #[error("Invalid address read: {0}")]
     InvalidNumber(#[from] TryFromIntError),
 
     /// Attempt to load an `enum` type but the discriminant doesn't match any of the variants.


### PR DESCRIPTION
## Motivation

The way we do errors is a little bit disorganized. We need to cleanup.

## Proposal

The following is done:
* The `ArithmeticError` and `ViewError` are handled as `transparent`. The exception is `NodeError` because we want to have `PartialEq`, `Eq`, `Serialize` and other traits.
* For the error statements, if some entries are present, then they are printed if an error occurs.

## Test Plan

The CI.

## Release Plan

It should help operators of TestNet / DevNet.

## Links

None.