### PR TITLE
Accept `ChainClientError`s in `communicate_with_quorum`.

### DIFF
--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -26,7 +26,6 @@ use tracing::{instrument, warn};
 
 use crate::{
     data_types::{BlockHeightRange, ChainInfo, ChainInfoQuery, ChainInfoResponse},
-    node::NodeError,
     notifier::Notifier,
     worker::{WorkerError, WorkerState},
 };
@@ -190,7 +189,7 @@ where
         &self,
         mut missing_blob_ids: Vec<BlobId>,
         chain_id: ChainId,
-    ) -> Result<Option<Vec<Blob>>, NodeError> {
+    ) -> Result<Option<Vec<Blob>>, LocalNodeError> {
         if missing_blob_ids.is_empty() {
             return Ok(Some(Vec::new()));
         }
@@ -234,8 +233,8 @@ where
     pub async fn chain_state_view(
         &self,
         chain_id: ChainId,
-    ) -> Result<OwnedRwLockReadGuard<ChainStateView<S::Context>>, WorkerError> {
-        self.node.state.chain_state_view(chain_id).await
+    ) -> Result<OwnedRwLockReadGuard<ChainStateView<S::Context>>, LocalNodeError> {
+        Ok(self.node.state.chain_state_view(chain_id).await?)
     }
 
     #[instrument(level = "trace", skip(self))]

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -218,9 +218,6 @@ pub enum NodeError {
     #[error("Failed to subscribe; tonic status: {status}")]
     SubscriptionFailed { status: String },
 
-    #[error("Failed to make a chain info query on the local node: {error}")]
-    LocalNodeQuery { error: String },
-
     #[error("Node failed to provide a 'last used by' certificate for the blob")]
     InvalidCertificateForBlob(BlobId),
     #[error("Node returned a BlobsNotFound error with duplicates")]
@@ -228,7 +225,7 @@ pub enum NodeError {
     #[error("Node returned a BlobsNotFound error with unexpected blob IDs")]
     UnexpectedEntriesInBlobsNotFound,
     #[error("Local error handling validator response")]
-    LocalError { error: String },
+    ResponseHandlingError { error: String },
 }
 
 impl From<tonic::Status> for NodeError {

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -198,6 +198,8 @@ pub enum NodeError {
 
     #[error("The received chain info response is invalid")]
     InvalidChainInfoResponse,
+    #[error("Unexpected certificate value")]
+    UnexpectedCertificateValue,
 
     // Networking errors.
     // TODO(#258): These errors should be defined in linera-rpc.

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -155,7 +155,7 @@ where
                 // TODO(#2857): Handle non-remote errors properly.
                 let err = match err {
                     ChainClientError::RemoteNodeError(err) => err,
-                    err => NodeError::LocalError {
+                    err => NodeError::ResponseHandlingError {
                         error: err.to_string(),
                     },
                 };

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -567,42 +567,44 @@ NodeError:
     11:
       InvalidChainInfoResponse: UNIT
     12:
-      InvalidDecoding: UNIT
+      UnexpectedCertificateValue: UNIT
     13:
-      UnexpectedMessage: UNIT
+      InvalidDecoding: UNIT
     14:
+      UnexpectedMessage: UNIT
+    15:
       GrpcError:
         STRUCT:
           - error: STR
-    15:
+    16:
       ClientIoError:
         STRUCT:
           - error: STR
-    16:
+    17:
       CannotResolveValidatorAddress:
         STRUCT:
           - address: STR
-    17:
+    18:
       SubscriptionError:
         STRUCT:
           - transport: STR
-    18:
+    19:
       SubscriptionFailed:
         STRUCT:
           - status: STR
-    19:
+    20:
       LocalNodeQuery:
         STRUCT:
           - error: STR
-    20:
+    21:
       InvalidCertificateForBlob:
         NEWTYPE:
           TYPENAME: BlobId
-    21:
-      DuplicatesInBlobsNotFound: UNIT
     22:
-      UnexpectedEntriesInBlobsNotFound: UNIT
+      DuplicatesInBlobsNotFound: UNIT
     23:
+      UnexpectedEntriesInBlobsNotFound: UNIT
+    24:
       LocalError:
         STRUCT:
           - error: STR

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -593,19 +593,15 @@ NodeError:
         STRUCT:
           - status: STR
     20:
-      LocalNodeQuery:
-        STRUCT:
-          - error: STR
-    21:
       InvalidCertificateForBlob:
         NEWTYPE:
           TYPENAME: BlobId
-    22:
+    21:
       DuplicatesInBlobsNotFound: UNIT
-    23:
+    22:
       UnexpectedEntriesInBlobsNotFound: UNIT
-    24:
-      LocalError:
+    23:
+      ResponseHandlingError:
         STRUCT:
           - error: STR
 OpenChainConfig:


### PR DESCRIPTION
## Motivation

We are currently converting lots of errors to `NodeError`s and treating them as if they were the validator's fault in `communicate_with_quorum`. In the long run we will want to properly distinguish these (https://github.com/linera-io/linera-protocol/issues/2857): A _local_ error should make us cancel all the tasks and return that error immediately. However, we need to carefully go through all the code that runs inside tasks passed into `communicate_with_quorum` and make sure that no local error can be triggered by a remote node.

## Proposal

As a step towards addressing https://github.com/linera-io/linera-protocol/issues/2857, accept `ChainClientError`s from the tasks passed into `communicate_with_quorum`, but convert them all to `NodeError`s. That way we can be sure we are not opening up a new vulnerability for a remote node to cause us to cancel `communicate_with_quorum`, while also moving the rest of the code into the right direction: Several methods can now return `ChainClientError`s rather than `NodeError`s, as appropriate.

## Test Plan

This PR does not change the behavior yet: We are not canceling `communicate_with_quorum` yet.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Preparation for https://github.com/linera-io/linera-protocol/issues/2857.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
