### PR TITLE
Increase compilation recursion limit if linera-core

### DIFF
--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -4,6 +4,7 @@
 
 //! This module defines the core Linera protocol.
 
+#![recursion_limit = "256"]
 #![deny(clippy::large_futures)]
 
 pub mod chain_worker;


### PR DESCRIPTION
## Motivation

Running `cargo test -p linera-core` fails because we exceed the default compilation recursion limit of 128.

## Proposal

Increase recursion limit to 256.

## Test Plan

CI + ran `cargo test -p linera-core` locally, and it succeeds.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
