### PR TITLE
Fix the build error: queries overflow the depth limit!

### DIFF
--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -168,7 +168,7 @@ where
     let result = publisher
         .publish_bytecode(small_bytecode, large_bytecode)
         .await;
-    assert_matches!(result, Err(ChainClientError::LocalNodeError(_)));
+    assert_matches!(result.unwrap_err(), ChainClientError::LocalNodeError(_));
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

`cargo test -p linera-core` fails with:

```
error: queries overflow the depth limit!
  |
  = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`linera_core`)
  = note: query depth increased by 130 when computing layout of `{async fn body of client::client_tests::wasm::test_memory_create_application()}`

error: could not compile `linera-core` (lib test) due to 1 previous error
```

## Proposal

The compiler seems to have difficulty inferring a `T` in the `Result<T, _>` in a test. Use `unwrap_err` instead, so it only has to match the error, not the result.

## Test Plan

No logic was changed.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
