### PR TITLE
Set pending block only after making sure it is valid.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2096,7 +2096,7 @@ where
             Either::Right(timeout) => return Ok(ExecuteBlockOutcome::WaitForTimeout(timeout)),
         };
         let confirmed_value = self
-            .set_pending_block(round, incoming_bundles, operations, identity)
+            .new_pending_block(round, incoming_bundles, operations, identity)
             .await?;
 
         match self.process_pending_block_without_prepare().await? {
@@ -2118,10 +2118,11 @@ where
         }
     }
 
-    /// Sets the pending block, so that next time `process_pending_block_without_prepare` is
-    /// called, it will be proposed to the validators.
+    /// Creates a new pending block and handles the proposal in the local node.
+    /// Next time `process_pending_block_without_prepare` is called, this block will be proposed
+    /// to the validators.
     #[instrument(level = "trace", skip(incoming_bundles, operations))]
-    async fn set_pending_block(
+    async fn new_pending_block(
         &self,
         round: Round,
         incoming_bundles: Vec<IncomingBundle>,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2474,8 +2474,6 @@ where
             LocalNodeError::WorkerError(WorkerError::ChainError(chain_error))
         )) if matches!(*chain_error, ChainError::BlockProposalTooLarge)
     );
-    // TODO(#2906): Remove this once the client properly clears the pending block.
-    client1.clear_pending_block();
 
     let result = client1.publish_data_blob(large_blob_bytes).await;
     assert_matches!(


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/2904 introduced block proposal size limits that are only enforced when the proposal was handled in the worker, not when staging block execution. This could result in the pending block getting set to an invalid proposal.

## Proposal

Handle the proposal in the local node before setting the pending block.

## Test Plan

The explicit `clear_pending_block` call was removed from the test.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Fixes https://github.com/linera-io/linera-protocol/issues/2906.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
