### PR TITLE
Persist the received certificate trackers; avoid redundant requests.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -535,19 +535,24 @@ where
         Ok(new_outbox_entries)
     }
 
-    /// Updates the `received_log` tracker for the given validator.
-    pub fn update_received_certificate_tracker(&mut self, name: ValidatorName, tracker: u64) {
-        self.received_certificate_trackers
-            .get_mut()
-            .entry(name)
-            .and_modify(|t| {
-                // Because several synchronizations could happen in parallel, we need to make
-                // sure to never go backward.
-                if tracker > *t {
-                    *t = tracker;
-                }
-            })
-            .or_insert(tracker);
+    /// Updates the `received_log` trackers.
+    pub fn update_received_certificate_trackers(
+        &mut self,
+        new_trackers: BTreeMap<ValidatorName, u64>,
+    ) {
+        for (name, tracker) in new_trackers {
+            self.received_certificate_trackers
+                .get_mut()
+                .entry(name)
+                .and_modify(|t| {
+                    // Because several synchronizations could happen in parallel, we need to make
+                    // sure to never go backward.
+                    if tracker > *t {
+                        *t = tracker;
+                    }
+                })
+                .or_insert(tracker);
+        }
     }
 
     pub async fn execute_init_message(

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -512,11 +512,9 @@ where
         &mut self,
         new_trackers: BTreeMap<ValidatorName, u64>,
     ) -> Result<(), WorkerError> {
-        for (name, tracker) in new_trackers {
-            self.state
-                .chain
-                .update_received_certificate_tracker(name, tracker);
-        }
+        self.state
+            .chain
+            .update_received_certificate_trackers(new_trackers);
         self.save().await?;
         Ok(())
     }

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -17,7 +17,7 @@ use linera_chain::{
     ChainStateView,
 };
 use linera_execution::{
-    committee::{Committee, Epoch},
+    committee::{Committee, Epoch, ValidatorName},
     BlobState,
 };
 use linera_storage::{Clock as _, Storage};
@@ -505,6 +505,19 @@ where
             .delivery_notifier
             .notify(height_with_fully_delivered_messages);
 
+        Ok(())
+    }
+
+    pub async fn update_received_certificate_trackers(
+        &mut self,
+        new_trackers: BTreeMap<ValidatorName, u64>,
+    ) -> Result<(), WorkerError> {
+        for (name, tracker) in new_trackers {
+            self.state
+                .chain
+                .update_received_certificate_tracker(name, tracker);
+        }
+        self.save().await?;
         Ok(())
     }
 

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -26,7 +26,8 @@ use linera_chain::{
     ChainError, ChainStateView,
 };
 use linera_execution::{
-    committee::Epoch, Message, Query, QueryContext, Response, ServiceRuntimeEndpoint, SystemMessage,
+    committee::{Epoch, ValidatorName},
+    Message, Query, QueryContext, Response, ServiceRuntimeEndpoint, SystemMessage,
 };
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::{ClonableView, ViewError};
@@ -539,6 +540,17 @@ where
             }
         }
         Ok(true)
+    }
+
+    /// Updates the received certificate trackers to at least the given values.
+    pub async fn update_received_certificate_trackers(
+        &mut self,
+        new_trackers: BTreeMap<ValidatorName, u64>,
+    ) -> Result<(), WorkerError> {
+        ChainWorkerStateWithAttemptedChanges::new(self)
+            .await
+            .update_received_certificate_trackers(new_trackers)
+            .await
     }
 }
 

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -17,7 +17,7 @@ use linera_chain::{
     types::{Certificate, ConfirmedBlockCertificate, LiteCertificate},
     ChainStateView,
 };
-use linera_execution::{Query, Response};
+use linera_execution::{committee::ValidatorName, Query, Response};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
 use thiserror::Error;
@@ -331,5 +331,17 @@ where
             .buffer_unordered(chain_worker_limit)
             .try_collect()
             .await
+    }
+
+    pub async fn update_received_certificate_trackers(
+        &self,
+        chain_id: ChainId,
+        new_trackers: BTreeMap<ValidatorName, u64>,
+    ) -> Result<(), LocalNodeError> {
+        self.node
+            .state
+            .update_received_certificate_trackers(chain_id, new_trackers)
+            .await?;
+        Ok(())
     }
 }

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -273,6 +273,17 @@ impl<N: ValidatorNode> RemoteNode<N> {
         Ok(hashes)
     }
 
+    #[instrument(level = "trace")]
+    pub async fn download_certificates(
+        &self,
+        hashes: Vec<CryptoHash>,
+    ) -> Result<Vec<Certificate>, NodeError> {
+        if hashes.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.node.download_certificates(hashes).await
+    }
+
     #[instrument(level = "trace", skip(validators))]
     async fn download_blob(validators: &[Self], blob_id: BlobId) -> Option<Blob> {
         // Sequentially try each validator in random order.

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -530,7 +530,7 @@ where
             .certificate_for(&sub_message_id)
             .await
             .unwrap(),
-        certificate.clone()
+        certificate
     );
 
     assert_eq!(sender.next_block_height(), BlockHeight::from(1));

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     num::NonZeroUsize,
     sync::{Arc, Mutex, RwLock},
     time::Duration,
@@ -30,7 +30,10 @@ use linera_chain::{
     },
     ChainError, ChainStateView,
 };
-use linera_execution::{committee::Epoch, ExecutionError, Query, Response};
+use linera_execution::{
+    committee::{Epoch, ValidatorName},
+    ExecutionError, Query, Response,
+};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
 use lru::LruCache;
@@ -924,6 +927,21 @@ where
                 Ok(NetworkActions::default())
             }
         }
+    }
+
+    /// Updates the received certificate trackers to at least the given values.
+    pub async fn update_received_certificate_trackers(
+        &self,
+        chain_id: ChainId,
+        new_trackers: BTreeMap<ValidatorName, u64>,
+    ) -> Result<(), WorkerError> {
+        self.query_chain_worker(chain_id, move |callback| {
+            ChainWorkerRequest::UpdateReceivedCertificateTrackers {
+                new_trackers,
+                callback,
+            }
+        })
+        .await
     }
 }
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -203,6 +203,10 @@ type ChainStateExtendedView {
 	"""
 	receivedLog: LogView_ChainAndHeight_7af83576!
 	"""
+	The number of `received_log` entries we have synchronized, for each validator.
+	"""
+	receivedCertificateTrackers: JSONObject!
+	"""
 	Mailboxes used to receive messages indexed by their origin.
 	"""
 	inboxes: ReentrantCollectionView_Origin_InboxStateView_3699835794!


### PR DESCRIPTION
## Motivation

The received certificate trackers are not persisted, so we download the complete `received_log` from each validator every time the `linera` binary starts.

Even if the log is up to date, we always call `synchronize_chain_state(admin_id)`, even if the chain being synchronized anyway is already the admin chain. We also make an actual gRPC request to download certificates, even if the number of certificate hashes is zero.

## Proposal

Persist the trackers as part of the chain state. (Used in the client only.)

Don't make a request if `download_certificates` is called with zero hashes.

Synchronize the admin chain first, and only if it is different from the current client's chain. Then call `prepare_chain` (so that even if it _is_ the admin chain it is now up to date), and finally call `find_received_certificates`.

## Test Plan

CI should catch regressions.

I also backported it to testnet_archimedes and tried it out. It reduced the time of the second `sync` command from 996 ms to 528 ms.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
## Links

- Closes https://github.com/linera-io/linera-protocol/issues/2798
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
