### PR TITLE
Inline `propose_block` and simplify `process_pending_block_without_prepare`.

### DIFF
--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -85,7 +85,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     block::{ConfirmedBlock, Timeout, ValidatedBlock},
-    data_types::{BlockExecutionOutcome, BlockProposal, LiteVote, ProposalContent, Vote},
+    data_types::{Block, BlockExecutionOutcome, BlockProposal, LiteVote, ProposalContent, Vote},
     types::{
         ConfirmedBlockCertificate, Hashed, HashedCertificateValue, TimeoutCertificate,
         ValidatedBlockCertificate,
@@ -692,5 +692,12 @@ impl ChainManagerInfo {
             Round::MultiLeader(_) => true,
             Round::SingleLeader(_) | Round::Validator(_) => self.leader.as_ref() == Some(identity),
         }
+    }
+
+    /// Returns whether a proposal with this content was already handled.
+    pub fn already_handled_proposal(&self, round: Round, block: &Block) -> bool {
+        self.requested_proposed.as_ref().is_some_and(|proposal| {
+            proposal.content.round == round && proposal.content.block == *block
+        })
     }
 }

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -85,7 +85,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     block::{ConfirmedBlock, Timeout, ValidatedBlock},
-    data_types::{Block, BlockExecutionOutcome, BlockProposal, LiteVote, ProposalContent, Vote},
+    data_types::{BlockExecutionOutcome, BlockProposal, LiteVote, ProposalContent, Vote},
     types::{
         ConfirmedBlockCertificate, Hashed, HashedCertificateValue, TimeoutCertificate,
         ValidatedBlockCertificate,
@@ -682,21 +682,6 @@ impl ChainManagerInfo {
             .as_ref()
             .map(|vote| Box::new(vote.value.clone()));
         self.pending_blobs = manager.pending_blobs.clone();
-    }
-
-    /// Gets the highest validated block.
-    pub fn highest_validated_block(&self) -> Option<&Block> {
-        if let Some(certificate) = &self.requested_locked {
-            return Some(&certificate.executed_block().block);
-        }
-
-        if let Some(proposal) = &self.requested_proposed {
-            if proposal.content.round.is_fast() {
-                return Some(&proposal.content.block);
-            }
-        }
-
-        None
     }
 
     /// Returns whether the `identity` is allowed to propose a block in `round`.

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -700,4 +700,11 @@ impl ChainManagerInfo {
             proposal.content.round == round && proposal.content.block == *block
         })
     }
+
+    /// Returns whether there is a locked block in the current round.
+    pub fn has_locked_block_in_current_round(&self) -> bool {
+        self.requested_locked
+            .as_ref()
+            .is_some_and(|certificate| certificate.round == self.current_round)
+    }
 }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -740,6 +740,7 @@ where
             .local_node
             .handle_chain_info_query(query)
             .await?;
+        self.update_from_info(&response.info);
         Ok(response.info)
     }
 
@@ -752,6 +753,7 @@ where
             .local_node
             .handle_chain_info_query(query)
             .await?;
+        self.update_from_info(&response.info);
         Ok(response.info)
     }
 
@@ -2378,7 +2380,6 @@ where
                 info = self.chain_info_with_manager_values().await?;
             }
         }
-        self.update_from_info(&info);
 
         // If there is a validated block in the current round, finalize it.
         if let Some(certificate) = &info.manager.requested_locked {

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -199,6 +199,19 @@ pub struct ChainInfo {
     pub requested_received_log: Vec<ChainAndHeight>,
 }
 
+impl ChainInfo {
+    /// Returns the `RoundTimeout` value for the current round, or `None` if the current round
+    /// does not time out.
+    pub fn round_timeout(&self) -> Option<RoundTimeout> {
+        // TODO(#1424): The local timeout might not match the validators' exactly.
+        Some(RoundTimeout {
+            timestamp: self.manager.round_timeout?,
+            current_round: self.manager.current_round,
+            next_block_height: self.next_block_height,
+        })
+    }
+}
+
 /// The response to an `ChainInfoQuery`
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]


### PR DESCRIPTION
## Motivation

As discussed in https://github.com/linera-io/linera-protocol/pull/2925, this code is unnecessarily convoluted, and some of the checks are redundant.

## Proposal

Simplify the code.

## Test Plan

The logic hasn't changed. CI should catch any regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
