### PR TITLE
Pin scylla db docker container

### DIFF
--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -53,7 +53,7 @@ jobs:
         cargo build --locked --features scylladb
     - name: Setup local ScyllaDB instance
       run: |
-        docker run --name my_scylla_container -d -p 9042:9042 scylladb/scylla
+        docker run --name my_scylla_container -d -p 9042:9042 scylladb/scylla:6.2
     - name: Run ScyllaDB tests
       run: |
         RUST_LOG=linera=info cargo test --locked --features scylladb -- scylla --nocapture

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -53,7 +53,7 @@ jobs:
         cargo build --locked --features scylladb
     - name: Setup local ScyllaDB instance
       run: |
-        docker run --name my_scylla_container -d -p 9042:9042 scylladb/scylla:6.2
+        docker run --name my_scylla_container -d -p 9042:9042 scylladb/scylla:6.1
     - name: Run ScyllaDB tests
       run: |
         RUST_LOG=linera=info cargo test --locked --features scylladb -- scylla --nocapture

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   scylla:
-    image: scylladb/scylla:latest
+    image: scylladb/scylla:6.1
     container_name: scylla
     volumes:
       - linera-scylla-data:/var/lib/scylla


### PR DESCRIPTION
## Motivation

We want ScyllaDB pinned in GitHub workflows and for validators to avoid unwanted changes.

## Proposal

Pin ScyllaDB to the latest provably working version (6.2).

## Test Plan

CI will catch regressions.