### PR TITLE
Increase ScyllaDB test timeout.

### DIFF
--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -35,7 +35,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest-8-cores
-    timeout-minutes: 40
+    timeout-minutes: 50
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Motivation

As of https://github.com/linera-io/linera-protocol/pull/2925 the ScyllaDB tests are timing out, even though that PR didn't significantly slow down any other tests.

## Proposal

Try if it passes with a slightly increased timeout.

## Test Plan

If CI passes, we could merge that, so that the tests are green again, and investigate the performance regression later.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- PR that maybe caused this: https://github.com/linera-io/linera-protocol/pull/2925
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
