### PR TITLE
Fix benchmarks compilation

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -488,7 +488,7 @@ pub struct LiteVote {
 
 impl LiteVote {
     /// Returns the full vote, with the value, if it matches.
-    #[cfg(with_testing)]
+    #[cfg(any(feature = "benchmark", with_testing))]
     pub fn with_value<T>(self, value: Hashed<T>) -> Option<Vote<T>> {
         if self.value.value_hash != value.hash() {
             return None;


### PR DESCRIPTION
## Motivation

`--features benchmark` is failing due to missing `LiteVote::with_value` method - this method is feature-gated but only for `with_testing` on `main`.

## Proposal

Fix it by compiling `with_value` method for `feature = "benchmark"` as well.

## Test Plan

CI.

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.
## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
