### PR TITLE
Don't handle proposal before setting the pending block.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -139,6 +139,19 @@ impl Block {
         let config = posted_message.message.matches_open_chain()?;
         Some((in_bundle, posted_message, config))
     }
+
+    pub fn check_proposal_size(
+        &self,
+        maximum_block_proposal_size: u64,
+        blobs: &[Blob],
+    ) -> Result<(), ChainError> {
+        let size = bcs::serialized_size(&(self, blobs))?;
+        ensure!(
+            size <= usize::try_from(maximum_block_proposal_size).unwrap_or(usize::MAX),
+            ChainError::BlockProposalTooLarge
+        );
+        Ok(())
+    }
 }
 
 /// A transaction in a block: incoming messages or an operation.
@@ -774,15 +787,6 @@ impl BlockProposal {
             blobs,
             validated_block_certificate: Some(lite_cert),
         }
-    }
-
-    pub fn check_size(&self, maximum_block_proposal_size: u64) -> Result<(), ChainError> {
-        let size = bcs::serialized_size(&self)?;
-        ensure!(
-            size <= usize::try_from(maximum_block_proposal_size).unwrap_or(usize::MAX),
-            ChainError::BlockProposalTooLarge
-        );
-        Ok(())
     }
 
     pub fn check_signature(&self, public_key: PublicKey) -> Result<(), CryptoError> {

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -182,7 +182,6 @@ where
             .expect("chain is active");
         check_block_epoch(epoch, block)?;
         let policy = committee.policy().clone();
-        proposal.check_size(policy.maximum_block_proposal_size)?;
         // Check the authentication of the block.
         let public_key = self
             .0
@@ -224,6 +223,7 @@ where
         for blob in blobs {
             Self::check_blob_size(blob.content(), &policy)?;
         }
+        block.check_proposal_size(policy.maximum_block_proposal_size, blobs)?;
 
         let local_time = self.0.storage.clock().current_time();
         ensure!(

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2470,9 +2470,9 @@ where
     let result = client1.publish_data_blobs(blob_bytes).await;
     assert_matches!(
         result,
-        Err(ChainClientError::LocalNodeError(
-            LocalNodeError::WorkerError(WorkerError::ChainError(chain_error))
-        )) if matches!(*chain_error, ChainError::BlockProposalTooLarge)
+        Err(ChainClientError::ChainError(
+            ChainError::BlockProposalTooLarge
+        ))
     );
 
     let result = client1.publish_data_blob(large_blob_bytes).await;


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/2925 made the `test_end_to_end_listen_for_new_rounds::scylladb_grpc` test fail: If we only set the pending block after locally handling the block proposal then we don't set the block at all if we fail to find a suitable round number to propose in, which is what happens if we are not the leader in the current single-leader round, and the round has not timed out yet.

This change was originally made necessary by the introduction of the proposal size limit, which is applied to the whole `BlockProposal`. To make sure a block can always be re-proposed, it must only be applied to the block itself and its blobs. (https://github.com/linera-io/linera-protocol/issues/2924)

## Proposal

Don't handle the block proposal locally when setting the pending block.

Instead, only check the size of the block plus its published blobs.

## Test Plan

I reproduced the issue locally and `test_end_to_end_listen_for_new_rounds::scylladb_grpc` passes again with this change.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Fixes https://github.com/linera-io/linera-protocol/issues/2924.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
