### PR TITLE
Optimize CI costs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,8 +11,8 @@ env:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,8 +37,8 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -10,8 +10,8 @@ permissions:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,6 +33,7 @@ jobs:
 
   publish-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     # We only publish docs for the main branch.
     if: github.ref == 'refs/heads/main'
@@ -57,6 +58,7 @@ jobs:
 
   test-crates-and-docrs:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -34,7 +34,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest-8-cores
-    timeout-minutes: 30
+    timeout-minutes: 40
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -33,7 +33,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   long-faucet-chain-test:
     runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 60
+    timeout-minutes: 40
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   remote-net-test:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 40
 
     steps:
@@ -97,8 +97,8 @@ jobs:
         cargo test --locked
 
   default-features-and-witty-integration-test:
-    runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v3
@@ -191,7 +191,7 @@ jobs:
   
   storage-service-tests:
     runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 50
+    timeout-minutes: 40
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -420,7 +420,7 @@ jobs:
 
   lint-check-all-features:
     runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 50
+    timeout-minutes: 40
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Motivation

Inspired by https://github.com/linera-io/linera-protocol/pull/2898, there's still some optimizations we can make to CI.

## Proposal

Based on the data here https://github.com/linera-io/linera-protocol/actions/metrics/performance?tab=jobs, adjust the runner size for some jobs and adjust the timeouts for others (so we can fail earlier in case of an issue).
There was also some jobs without a timeout, which is pretty dangerous because Github's default timeout is 6 hours 😅
So added timeouts for those based on the data.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
