### PR TITLE
Small cleanup

### DIFF
--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -220,10 +220,10 @@ where
             missing_published_blob_ids.is_empty(),
             WorkerError::BlobsNotFound(missing_published_blob_ids)
         );
+        block.check_proposal_size(policy.maximum_block_proposal_size, blobs)?;
         for blob in blobs {
             Self::check_blob_size(blob.content(), &policy)?;
         }
-        block.check_proposal_size(policy.maximum_block_proposal_size, blobs)?;
 
         let local_time = self.0.storage.clock().current_time();
         ensure!(


### PR DESCRIPTION
## Motivation

`round_for_new_proposal` can just take the block reference now, instead of an option, as we don't have a `None` case for that in the codebase anymore.
Also, we can invert the order of the size limit checks for blobs and block proposal: it's more likely for the block proposal size to fail than the blobs, if the blobs fail the block proposal is likely to fail too.
That way we save potentially decompressing and checking the size of several blobs before actually failing on the block proposal size limit.

## Proposal

Do the changes

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
