### PR TITLE
[summary] Set Job Summary to be the markdown results

### DIFF
--- a/.github/workflows/performance_summary.yml
+++ b/.github/workflows/performance_summary.yml
@@ -35,4 +35,4 @@ jobs:
           GITHUB_PR_COMMIT_HASH: ${{ github.event.workflow_run.pull_requests[0].head.sha }}
         # The list of workflows that trigger this need to be hardcoded above.
         # Make sure you have the same comma separated list of workflows here.
-        run: cargo run -p linera-summary -- --workflows "Rust" ci
+        run: cargo run -p linera-summary -- --workflows "Rust" ci >> $GITHUB_STEP_SUMMARY

--- a/linera-summary/src/github.rs
+++ b/linera-summary/src/github.rs
@@ -176,7 +176,7 @@ impl Github {
                     self.context.repository.owner.clone(),
                     self.context.repository.name.clone(),
                 )
-                .create_comment(self.context.pr_number, body.clone())
+                .create_comment(self.context.pr_number, body)
                 .await?;
         }
         Ok(())

--- a/linera-summary/src/github.rs
+++ b/linera-summary/src/github.rs
@@ -165,17 +165,18 @@ impl Github {
     }
 
     pub async fn comment_on_pr(&self, body: String) -> Result<()> {
-        if self.is_local {
-            info!("Printing summary to stdout:");
-            println!("{}", body);
-        } else {
+        // Always print the summary to stdout, as we'll use it to set the job summary in CI.
+        info!("Printing summary to stdout...");
+        println!("{}", body);
+
+        if !self.is_local {
             info!("Commenting on PR {}", self.context.pr_number);
             self.octocrab
                 .issues(
                     self.context.repository.owner.clone(),
                     self.context.repository.name.clone(),
                 )
-                .create_comment(self.context.pr_number, body)
+                .create_comment(self.context.pr_number, body.clone())
                 .await?;
         }
         Ok(())


### PR DESCRIPTION
## Motivation

There also exists a feature that allows us to add a job summary to a github job, as markdown: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-job-summary

## Proposal

Add job summary to the Performance Summary CI job, so that we can have access to historical results of runs.

## Test Plan

Tested it in the same way as the base PR. You can see it properly set the job summary in this job https://github.com/linera-io/linera-protocol/actions/runs/11983964611 for example

## Release Plan
- Nothing to do / These changes follow the usual release cycle.
