### PR TITLE
Add `RegisterMockApplication` test helper extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4248,6 +4248,7 @@ dependencies = [
  "js-sys",
  "linera-base",
  "linera-execution",
+ "linera-storage",
  "linera-views",
  "linera-views-derive",
  "linera-wasmer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4077,6 +4077,7 @@ dependencies = [
 name = "linera-chain"
 version = "0.14.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "async-graphql",
  "async-trait",

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -36,6 +36,7 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+anyhow.workspace = true
 assert_matches.workspace = true
 bcs.workspace = true
 linera-chain = { path = ".", default-features = false, features = ["test"] }

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -194,7 +194,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     extra
         .user_contracts()
         .insert(application_id, application.clone().into());
-    extra.add_blobs(vec![contract_blob, service_blob]).await?;
+    extra.add_blobs([contract_blob, service_blob]).await?;
 
     // Initialize the chain, with a chain application.
     let config = OpenChainConfig {

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -180,7 +180,7 @@ async fn test_block_size_limit() {
 }
 
 #[tokio::test]
-async fn test_application_permissions() {
+async fn test_application_permissions() -> anyhow::Result<()> {
     let time = Timestamp::from(0);
     let message_id = make_admin_message_id(BlockHeight(3));
     let chain_id = ChainId::child(message_id);
@@ -203,8 +203,7 @@ async fn test_application_permissions() {
     };
     chain
         .execute_init_message(message_id, &config, time, time)
-        .await
-        .unwrap();
+        .await?;
     let open_chain_message = Message::System(SystemMessage::OpenChain(config));
 
     let register_app_message = SystemMessage::RegisterApplications {
@@ -246,11 +245,11 @@ async fn test_application_permissions() {
     let valid_block = make_first_block(chain_id)
         .with_incoming_bundle(bundle)
         .with_operation(app_operation.clone());
-    let outcome = chain.execute_block(&valid_block, time, None).await.unwrap();
+    let outcome = chain.execute_block(&valid_block, time, None).await?;
     let value = HashedCertificateValue::new_confirmed(outcome.with(valid_block));
 
     // In the second block, other operations are still not allowed.
-    let invalid_block = make_child_block(&value.clone().try_into().unwrap())
+    let invalid_block = make_child_block(&value.clone().try_into()?)
         .with_simple_transfer(chain_id, Amount::ONE)
         .with_operation(app_operation.clone());
     let result = chain.execute_block(&invalid_block, time, None).await;
@@ -259,7 +258,7 @@ async fn test_application_permissions() {
     );
 
     // Also, blocks without an application operation or incoming message are forbidden.
-    let invalid_block = make_child_block(&value.clone().try_into().unwrap());
+    let invalid_block = make_child_block(&value.clone().try_into()?);
     let result = chain.execute_block(&invalid_block, time, None).await;
     assert_matches!(result, Err(ChainError::MissingMandatoryApplications(app_ids))
         if app_ids == vec![application_id]
@@ -268,6 +267,8 @@ async fn test_application_permissions() {
     // But app operations continue to work.
     application.expect_call(ExpectedCall::execute_operation(|_, _, _| Ok(vec![])));
     application.expect_call(ExpectedCall::default_finalize());
-    let valid_block = make_child_block(&value.try_into().unwrap()).with_operation(app_operation);
-    chain.execute_block(&valid_block, time, None).await.unwrap();
+    let valid_block = make_child_block(&value.try_into()?).with_operation(app_operation);
+    chain.execute_block(&valid_block, time, None).await?;
+
+    Ok(())
 }

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -194,7 +194,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     extra
         .user_contracts()
         .insert(application_id, application.clone().into());
-    extra.add_blobs(vec![contract_blob, service_blob]);
+    extra.add_blobs(vec![contract_blob, service_blob]).await?;
 
     // Initialize the chain, with a chain application.
     let config = OpenChainConfig {

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -40,13 +40,12 @@ use linera_execution::{
     system::{
         AdminOperation, OpenChainConfig, Recipient, SystemChannel, SystemMessage, SystemOperation,
     },
-    test_utils::{register_mock_applications, ExpectedCall, SystemExecutionState},
+    test_utils::{ExpectedCall, RegisterMockApplication, SystemExecutionState},
     ChannelSubscription, ExecutionError, Message, MessageKind, Query, QueryContext, Response,
-    SystemExecutionError, SystemQuery, SystemResponse, TestExecutionRuntimeContext,
+    SystemExecutionError, SystemQuery, SystemResponse,
 };
 use linera_storage::{DbStorage, Storage, TestClock};
 use linera_views::{
-    context::MemoryContext,
     memory::MemoryStore,
     random::generate_test_namespace,
     store::TestKeyValueStore as _,
@@ -3918,7 +3917,7 @@ where
     }
     .into_view()
     .await;
-    register_mock_applications::<MemoryContext<TestExecutionRuntimeContext>>(&mut state, 1).await?;
+    let _ = state.register_mock_application().await?;
 
     let value = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3735,18 +3735,12 @@ where
         .await
         .unwrap();
 
-    let mut applications;
+    let (application_id, application);
     {
         let mut chain = storage.load_chain(chain_id).await?;
-        applications =
-            crate::test_utils::register_mock_applications(&mut chain.execution_state, 1, storage)
-                .await?;
+        (application_id, application) = chain.execution_state.register_mock_application().await?;
         chain.save().await?;
     }
-
-    let (application_id, application, _, _) = applications
-        .next()
-        .expect("Mock application should be registered");
 
     let query_times = (0..NUM_QUERIES as u64).map(Timestamp::from);
     let query_contexts = query_times.clone().map(|local_time| QueryContext {
@@ -3827,18 +3821,12 @@ where
         .await
         .unwrap();
 
-    let mut applications;
+    let (application_id, application);
     {
         let mut chain = storage.load_chain(chain_id).await?;
-        applications =
-            crate::test_utils::register_mock_applications(&mut chain.execution_state, 1, storage)
-                .await?;
+        (application_id, application) = chain.execution_state.register_mock_application().await?;
         chain.save().await?;
     }
-
-    let (application_id, application, _, _) = applications
-        .next()
-        .expect("Mock application should be registered");
 
     let queries_before_proposal = (0..NUM_QUERIES as u64).map(Timestamp::from);
     let queries_before_confirmation =

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-test = ["tokio/macros", "linera-views/test"]
+test = ["tokio/macros", "linera-base/test", "linera-views/test"]
 fs = ["tokio/fs"]
 metrics = ["prometheus", "linera-views/metrics"]
 unstable-oracles = []

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -79,6 +79,7 @@ bcs.workspace = true
 counter.workspace = true
 linera-base = { workspace = true, features = ["test"] }
 linera-execution = { path = ".", default-features = false, features = ["test"] }
+linera-storage = { workspace = true, features = ["test"] }
 linera-witty = { workspace = true, features = ["log", "macros", "test"] }
 test-case.workspace = true
 test-log = { workspace = true, features = ["trace"] }

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -94,7 +94,8 @@ where
 
         self.context()
             .extra()
-            .add_blobs(vec![contract_blob, service_blob]);
+            .add_blobs(vec![contract_blob, service_blob])
+            .await?;
 
         let tracker = ResourceTracker::default();
         let policy = ResourceControlPolicy::default();

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -94,7 +94,7 @@ where
 
         self.context()
             .extra()
-            .add_blobs(vec![contract_blob, service_blob])
+            .add_blobs([contract_blob, service_blob])
             .await?;
 
         let tracker = ResourceTracker::default();

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -377,6 +377,12 @@ pub trait ExecutionRuntimeContext {
     async fn get_blob(&self, blob_id: BlobId) -> Result<Blob, ViewError>;
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError>;
+
+    #[cfg(with_testing)]
+    async fn add_blobs(
+        &self,
+        blobs: impl IntoIterator<Item = Blob> + Send,
+    ) -> Result<(), ViewError>;
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -996,13 +1002,6 @@ impl TestExecutionRuntimeContext {
             blobs: Arc::default(),
         }
     }
-
-    pub async fn add_blobs(&self, blobs: Vec<Blob>) -> Result<(), ViewError> {
-        for blob in blobs {
-            self.blobs.insert(blob.id(), blob);
-        }
-        Ok(())
-    }
 }
 
 #[cfg(with_testing)]
@@ -1063,6 +1062,18 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {
         Ok(self.blobs.contains_key(&blob_id))
+    }
+
+    #[cfg(with_testing)]
+    async fn add_blobs(
+        &self,
+        blobs: impl IntoIterator<Item = Blob> + Send,
+    ) -> Result<(), ViewError> {
+        for blob in blobs {
+            self.blobs.insert(blob.id(), blob);
+        }
+
+        Ok(())
     }
 }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -997,10 +997,11 @@ impl TestExecutionRuntimeContext {
         }
     }
 
-    pub fn add_blobs(&self, blobs: Vec<Blob>) {
+    pub async fn add_blobs(&self, blobs: Vec<Blob>) -> Result<(), ViewError> {
         for blob in blobs {
             self.blobs.insert(blob.id(), blob);
         }
+        Ok(())
     }
 }
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -1097,7 +1097,7 @@ mod tests {
         let mut txn_tracker = TransactionTracker::default();
         view.context()
             .extra()
-            .add_blobs(vec![contract_blob, service_blob])
+            .add_blobs([contract_blob, service_blob])
             .await?;
         let new_application = view
             .system

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -1080,7 +1080,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn application_message_index() {
+    async fn application_message_index() -> anyhow::Result<()> {
         let (mut view, context) = new_view_and_context().await;
         let contract = Bytecode::new(b"contract".into());
         let service = Bytecode::new(b"service".into());
@@ -1101,9 +1101,8 @@ mod tests {
         let new_application = view
             .system
             .execute_operation(context, operation, &mut txn_tracker)
-            .await
-            .unwrap();
-        let [ExecutionOutcome::System(result)] = &txn_tracker.destructure().unwrap().0[..] else {
+            .await?;
+        let [ExecutionOutcome::System(result)] = &txn_tracker.destructure()?.0[..] else {
             panic!("Unexpected outcome");
         };
         assert_eq!(
@@ -1120,6 +1119,8 @@ mod tests {
             creation,
         };
         assert_eq!(new_application, Some((id, vec![])));
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -1097,7 +1097,8 @@ mod tests {
         let mut txn_tracker = TransactionTracker::default();
         view.context()
             .extra()
-            .add_blobs(vec![contract_blob, service_blob]);
+            .add_blobs(vec![contract_blob, service_blob])
+            .await?;
         let new_application = view
             .system
             .execute_operation(context, operation, &mut txn_tracker)

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -86,6 +86,15 @@ impl MockApplication {
     }
 }
 
+impl PartialEq for MockApplication {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.expected_calls, &other.expected_calls)
+            && Arc::ptr_eq(&self.active_instances, &other.active_instances)
+    }
+}
+
+impl Eq for MockApplication {}
+
 impl<Runtime> Drop for MockApplicationInstance<Runtime> {
     fn drop(&mut self) {
         if self.expected_calls.is_empty() {

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -7,7 +7,7 @@
 
 use std::{
     collections::VecDeque,
-    fmt::{self, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     mem,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -86,6 +86,24 @@ impl MockApplication {
     }
 }
 
+impl Debug for MockApplication {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        let mut struct_formatter = formatter.debug_struct("MockApplication");
+
+        match self.expected_calls.lock() {
+            Ok(expected_calls) => struct_formatter.field("expected_calls", &*expected_calls),
+            Err(_) => struct_formatter.field("expected_calls", &"[POISONED]"),
+        };
+
+        struct_formatter
+            .field(
+                "active_instances",
+                &self.active_instances.load(Ordering::Acquire),
+            )
+            .finish()
+    }
+}
+
 impl PartialEq for MockApplication {
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.expected_calls, &other.expected_calls)
@@ -146,17 +164,18 @@ type HandleQueryHandler = Box<
 >;
 
 /// An expected call to a [`MockApplicationInstance`].
+#[derive(custom_debug_derive::Debug)]
 pub enum ExpectedCall {
     /// An expected call to [`UserContract::instantiate`].
-    Instantiate(InstantiateHandler),
+    Instantiate(#[debug(skip)] InstantiateHandler),
     /// An expected call to [`UserContract::execute_operation`].
-    ExecuteOperation(ExecuteOperationHandler),
+    ExecuteOperation(#[debug(skip)] ExecuteOperationHandler),
     /// An expected call to [`UserContract::execute_message`].
-    ExecuteMessage(ExecuteMessageHandler),
+    ExecuteMessage(#[debug(skip)] ExecuteMessageHandler),
     /// An expected call to [`UserContract::finalize`].
-    Finalize(FinalizeHandler),
+    Finalize(#[debug(skip)] FinalizeHandler),
     /// An expected call to [`UserService::handle_query`].
-    HandleQuery(HandleQueryHandler),
+    HandleQuery(#[debug(skip)] HandleQueryHandler),
 }
 
 impl Display for ExpectedCall {

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -59,11 +59,6 @@ pub fn create_dummy_user_application_description(
     )
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct FakeBlob(String);
-
-impl BcsSignable for FakeBlob {}
-
 /// Creates `count` [`MockApplication`]s and registers them in the provided [`ExecutionStateView`].
 ///
 /// Returns an iterator over pairs of [`UserApplicationId`]s and their respective

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -36,10 +36,10 @@ pub fn create_dummy_user_application_description(
 ) -> (UserApplicationDescription, Blob, Blob) {
     let chain_id = ChainId::root(1);
     let contract_blob = Blob::new_contract_bytecode(CompressedBytecode {
-        compressed_bytes: String::from("contract").as_bytes().to_vec(),
+        compressed_bytes: b"contract".to_vec(),
     });
     let service_blob = Blob::new_service_bytecode(CompressedBytecode {
-        compressed_bytes: String::from("service").as_bytes().to_vec(),
+        compressed_bytes: b"service".to_vec(),
     });
 
     (

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -162,7 +162,7 @@ where
         extra
             .user_services()
             .insert(id, mock_application.clone().into());
-        extra.add_blobs(vec![contract, service]);
+        extra.add_blobs(vec![contract, service]).await?;
 
         Ok((id, mock_application))
     }
@@ -183,7 +183,9 @@ where
     let mock_applications = register_mock_applications_internal(state, count).await?;
     let extra = state.context().extra();
     for (_id, _mock_application, contract_blob, service_blob) in &mock_applications {
-        extra.add_blobs(vec![contract_blob.clone(), service_blob.clone()]);
+        extra
+            .add_blobs(vec![contract_blob.clone(), service_blob.clone()])
+            .await?;
     }
 
     Ok(mock_applications.into_iter())

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -98,7 +98,7 @@ pub trait RegisterMockApplication {
 
 impl<C> RegisterMockApplication for ExecutionStateView<C>
 where
-    C: Context<Extra = TestExecutionRuntimeContext> + Clone + Send + Sync + 'static,
+    C: Context + Clone + Send + Sync + 'static,
     C::Extra: ExecutionRuntimeContext,
 {
     fn creator_chain_id(&self) -> ChainId {
@@ -123,7 +123,7 @@ where
 
 impl<C> RegisterMockApplication for SystemExecutionStateView<C>
 where
-    C: Context<Extra = TestExecutionRuntimeContext> + Clone + Send + Sync + 'static,
+    C: Context + Clone + Send + Sync + 'static,
     C::Extra: ExecutionRuntimeContext,
 {
     fn creator_chain_id(&self) -> ChainId {

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -162,7 +162,7 @@ where
         extra
             .user_services()
             .insert(id, mock_application.clone().into());
-        extra.add_blobs(vec![contract, service]).await?;
+        extra.add_blobs([contract, service]).await?;
 
         Ok((id, mock_application))
     }

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -31,6 +31,7 @@ use crate::{
     TestExecutionRuntimeContext, UserApplicationDescription, UserApplicationId,
 };
 
+/// Creates a dummy [`UserApplicationDescription`] for use in tests.
 pub fn create_dummy_user_application_description(
     index: u64,
 ) -> (UserApplicationDescription, Blob, Blob) {

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -59,6 +59,42 @@ pub fn create_dummy_user_application_description(
     )
 }
 
+/// Registration of [`MockApplication`]s to use in tests.
+#[allow(async_fn_in_trait)]
+pub trait RegisterMockApplication {
+    /// Returns the chain to use for the creation of the application.
+    ///
+    /// This is included in the mocked [`ApplicationId`].
+    fn creator_chain_id(&self) -> ChainId;
+
+    /// Returns the amount of known registrated applications.
+    ///
+    /// Used to avoid duplicate registrations.
+    async fn registered_application_count(&self) -> anyhow::Result<usize>;
+
+    /// Registers a new [`MockApplication`] and returns it with the [`UserApplicationId`] that was
+    /// used for it.
+    async fn register_mock_application(
+        &mut self,
+    ) -> anyhow::Result<(UserApplicationId, MockApplication)> {
+        let (description, contract, service) = create_dummy_user_application_description(
+            self.registered_application_count().await? as u64,
+        );
+
+        self.register_mock_application_with(description, contract, service)
+            .await
+    }
+
+    /// Registers a new [`MockApplication`] associated with a [`UserApplicationDescription`] and
+    /// its bytecode [`Blob`]s.
+    async fn register_mock_application_with(
+        &mut self,
+        description: UserApplicationDescription,
+        contract: Blob,
+        service: Blob,
+    ) -> anyhow::Result<(UserApplicationId, MockApplication)>;
+}
+
 /// Creates `count` [`MockApplication`]s and registers them in the provided [`ExecutionStateView`].
 ///
 /// Returns an iterator over pairs of [`UserApplicationId`]s and their respective

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -68,7 +68,7 @@ pub trait RegisterMockApplication {
     /// This is included in the mocked [`ApplicationId`].
     fn creator_chain_id(&self) -> ChainId;
 
-    /// Returns the amount of known registrated applications.
+    /// Returns the amount of known registered applications.
     ///
     /// Used to avoid duplicate registrations.
     async fn registered_application_count(&self) -> anyhow::Result<usize>;

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -96,6 +96,31 @@ pub trait RegisterMockApplication {
     ) -> anyhow::Result<(UserApplicationId, MockApplication)>;
 }
 
+impl<C> RegisterMockApplication for ExecutionStateView<C>
+where
+    C: Context<Extra = TestExecutionRuntimeContext> + Clone + Send + Sync + 'static,
+    C::Extra: ExecutionRuntimeContext,
+{
+    fn creator_chain_id(&self) -> ChainId {
+        self.system.creator_chain_id()
+    }
+
+    async fn registered_application_count(&self) -> anyhow::Result<usize> {
+        self.system.registered_application_count().await
+    }
+
+    async fn register_mock_application_with(
+        &mut self,
+        description: UserApplicationDescription,
+        contract: Blob,
+        service: Blob,
+    ) -> anyhow::Result<(UserApplicationId, MockApplication)> {
+        self.system
+            .register_mock_application_with(description, contract, service)
+            .await
+    }
+}
+
 impl<C> RegisterMockApplication for SystemExecutionStateView<C>
 where
     C: Context<Extra = TestExecutionRuntimeContext> + Clone + Send + Sync + 'static,

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -115,7 +115,10 @@ impl SystemExecutionState {
         } = self;
 
         let extra = TestExecutionRuntimeContext::new(chain_id, execution_runtime_config);
-        extra.add_blobs(extra_blobs);
+        extra
+            .add_blobs(extra_blobs)
+            .await
+            .expect("Adding blobs to the `TestExecutionRuntimeContext` should not fail");
         for (id, mock_application) in mock_applications {
             extra
                 .user_contracts()

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -23,10 +23,10 @@ use linera_execution::{
         create_dummy_user_application_registrations, ExpectedCall, RegisterMockApplication,
         SystemExecutionState,
     },
-    BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome, Message, MessageContext,
-    MessageKind, Operation, OperationContext, Query, QueryContext, RawExecutionOutcome,
-    RawOutgoingMessage, ResourceControlPolicy, ResourceController, Response, SystemExecutionError,
-    SystemOperation, TransactionTracker,
+    BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome, ExecutionRuntimeContext,
+    Message, MessageContext, MessageKind, Operation, OperationContext, Query, QueryContext,
+    RawExecutionOutcome, RawOutgoingMessage, ResourceControlPolicy, ResourceController, Response,
+    SystemExecutionError, SystemOperation, TransactionTracker,
 };
 use linera_views::{batch::Batch, context::Context, views::View};
 use test_case::test_case;

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -41,7 +41,8 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
         &create_dummy_user_application_registrations(&mut view.system.registry, 1).await?[0];
     view.context()
         .extra()
-        .add_blobs(vec![contract_blob.clone(), service_blob.clone()]);
+        .add_blobs(vec![contract_blob.clone(), service_blob.clone()])
+        .await?;
 
     let context = make_operation_context();
     let mut controller = ResourceController::default();

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -5,7 +5,7 @@
 
 use std::{collections::BTreeMap, vec};
 
-use anyhow::anyhow;
+use anyhow::Context as _;
 use assert_matches::assert_matches;
 use futures::{stream, StreamExt, TryStreamExt};
 use linera_base::{
@@ -1471,7 +1471,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
             ExecutionOutcome::User(_, _) => panic!("Unexpected message"),
         })
         .nth((index - first_message_index) as usize)
-        .ok_or_else(|| anyhow!("Message index out of bounds"))?;
+        .context("Message index out of bounds")?;
     let RawOutgoingMessage {
         message: SystemMessage::OpenChain(config),
         destination: Destination::Recipient(recipient_id),

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -41,7 +41,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
         &create_dummy_user_application_registrations(&mut view.system.registry, 1).await?[0];
     view.context()
         .extra()
-        .add_blobs(vec![contract_blob.clone(), service_blob.clone()])
+        .add_blobs([contract_blob.clone(), service_blob.clone()])
         .await?;
 
     let context = make_operation_context();

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -64,7 +64,7 @@ async fn test_fuel_for_counter_wasm_application(
 
     view.context()
         .extra()
-        .add_blobs(vec![contract_blob, service_blob])
+        .add_blobs([contract_blob, service_blob])
         .await?;
 
     let app_id = app_id.with_abi::<CounterAbi>();

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -64,7 +64,8 @@ async fn test_fuel_for_counter_wasm_application(
 
     view.context()
         .extra()
-        .add_blobs(vec![contract_blob, service_blob]);
+        .add_blobs(vec![contract_blob, service_blob])
+        .await?;
 
     let app_id = app_id.with_abi::<CounterAbi>();
 

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -16,8 +16,9 @@ ethereum = []
 default = ["wasmer", "rocksdb", "storage-service"]
 test = [
     "linera-base/test",
-    "linera-views/test",
     "linera-execution/test",
+    "linera-storage/test",
+    "linera-views/test",
     "dep:stdext",
 ]
 benchmark = [

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -401,6 +401,15 @@ where
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {
         self.storage.contains_blob(blob_id).await
     }
+
+    #[cfg(with_testing)]
+    async fn add_blobs(
+        &self,
+        blobs: impl IntoIterator<Item = Blob> + Send,
+    ) -> Result<(), ViewError> {
+        let blobs = Vec::from_iter(blobs);
+        self.storage.write_blobs(&blobs).await
+    }
 }
 
 /// A clock that can be used to get the current `Timestamp`.


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
While writing some tests, I had a need to create a `MockApplication` with a specific `ApplicationId`. The current `register_mock_applications` test helper function did not support that, and that function was already scheduled to be replaced with a better alternative (issue #2851) that is more ergonomic.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Create a `RegisterMockApplication` trait that allows some tests to create and register `MockApplication`s. Refactor the tests to use them instead of `register_mock_applications`, and remove the old API.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
CI should catch any regressions to the refactors made to the tests.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do, because this only affects tests.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Closes #2851 
