### PR TITLE
Remove `&static str` usage as error type

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -52,7 +52,7 @@ impl From<ValidatedBlock> for HashedCertificateValue {
 }
 
 impl TryFrom<HashedCertificateValue> for Hashed<ValidatedBlock> {
-    type Error = &'static str;
+    type Error = ConversionError;
 
     fn try_from(value: HashedCertificateValue) -> Result<Self, Self::Error> {
         let hash = value.hash();
@@ -60,7 +60,7 @@ impl TryFrom<HashedCertificateValue> for Hashed<ValidatedBlock> {
             CertificateValue::ValidatedBlock(validated) => {
                 Ok(Hashed::unchecked_new(validated, hash))
             }
-            _ => Err("Expected a ValidatedBlock value"),
+            _ => Err(ConversionError::ValidatedBlock),
         }
     }
 }

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -79,7 +79,7 @@ impl From<ConfirmedBlock> for HashedCertificateValue {
 }
 
 impl TryFrom<HashedCertificateValue> for Hashed<ConfirmedBlock> {
-    type Error = &'static str;
+    type Error = ConversionError;
 
     fn try_from(value: HashedCertificateValue) -> Result<Self, Self::Error> {
         let hash = value.hash();
@@ -87,7 +87,7 @@ impl TryFrom<HashedCertificateValue> for Hashed<ConfirmedBlock> {
             CertificateValue::ConfirmedBlock(confirmed) => {
                 Ok(Hashed::unchecked_new(confirmed, hash))
             }
-            _ => Err("Expected a ConfirmedBlock value"),
+            _ => Err(ConversionError::ConfirmedBlock),
         }
     }
 }

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -7,6 +7,7 @@ use std::fmt::Debug;
 use linera_base::{crypto::BcsHashable, data_types::BlockHeight, identifiers::ChainId};
 use linera_execution::committee::Epoch;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::{
     data_types::ExecutedBlock,
@@ -170,4 +171,16 @@ impl Has<ChainId> for Timeout {
     fn get(&self) -> &ChainId {
         &self.chain_id
     }
+}
+
+/// Failure to convert a [`HashedCertificateValue`] into one of the block types.
+#[derive(Clone, Copy, Debug, Error)]
+pub enum ConversionError {
+    /// Failure to convert to [`ConfirmedBlock`].
+    #[error("Expected a `ConfirmedBlock` value")]
+    ConfirmedBlock,
+
+    /// Failure to convert to [`ValidatedBlock`].
+    #[error("Expected a `ValidatedBlock` value")]
+    ValidatedBlock,
 }


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
Some implementations of `TryFrom` return a `&static str` as an error. However, `&static str` does not implement `std::error::Error`. This prevents `.try_into()?` from being used in tests that return `anyhow::Result<()>`.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Create a `ConversionError` error type, and use it instead of `&static str` in the relevant `TryFrom` implementations.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
CI should catch any regressions, because this only affects types.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do, because this is just an internal refactor.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
