### PR TITLE
[summary] Update existing comment

### DIFF
--- a/linera-summary/src/github.rs
+++ b/linera-summary/src/github.rs
@@ -166,52 +166,35 @@ impl Github {
         &self.context
     }
 
+    // Updates an existing comment or creates a new one in the PR.
     pub async fn upsert_pr_comment(&self, body: String) -> Result<()> {
         let issue_handler = self.octocrab.issues(
             self.context.repository.owner.clone(),
             self.context.repository.name.clone(),
         );
-        let comments = issue_handler
+        let existing_comment_id = issue_handler
             .list_comments(self.context.pr_number)
             .send()
-            .await?;
-        let existing_comments = comments
+            .await?
             .items
             .into_iter()
-            .filter(|comment| {
-                comment.user.login == "github-actions[bot]"
+            .find_map(|comment| {
+                if comment.user.login == "github-actions[bot]"
                     && comment
                         .body
-                        .as_ref()
                         .is_some_and(|body| body.starts_with(PR_COMMENT_HEADER))
-            })
-            .collect::<Vec<_>>();
+                {
+                    Some(comment.id)
+                } else {
+                    None
+                }
+            });
 
         // Always print the summary to stdout, as we'll use it to set the job summary in CI.
         info!("Printing summary to stdout...");
         println!("{}", body);
 
-        let issue_handler = self.octocrab.issues(
-            self.context.repository.owner.clone(),
-            self.context.repository.name.clone(),
-        );
-        if existing_comments.is_empty() {
-            if self.is_local {
-                info!(
-                    "Would have commented on PR {}, but is local",
-                    self.context.pr_number
-                );
-            } else {
-                info!("Commenting on PR {}", self.context.pr_number);
-                issue_handler
-                    .create_comment(self.context.pr_number, body)
-                    .await?;
-            }
-        } else {
-            let existing_comment_id = existing_comments
-                .first()
-                .expect("Should have at least one comment!")
-                .id;
+        if let Some(existing_comment_id) = existing_comment_id {
             if self.is_local {
                 info!(
                     "Would have updated comment {} on PR {}, but is local",
@@ -226,6 +209,16 @@ impl Github {
                     .update_comment(existing_comment_id, body)
                     .await?;
             }
+        } else if self.is_local {
+            info!(
+                "Would have commented on PR {}, but is local",
+                self.context.pr_number
+            );
+        } else {
+            info!("Commenting on PR {}", self.context.pr_number);
+            issue_handler
+                .create_comment(self.context.pr_number, body)
+                .await?;
         }
         Ok(())
     }

--- a/linera-summary/src/main.rs
+++ b/linera-summary/src/main.rs
@@ -13,7 +13,7 @@ async fn run(options: SummaryOptions) -> Result<()> {
     let tracked_workflows = options.workflows();
     let github = Github::new(options.is_local(), options.pr_number())?;
     let summary = PerformanceSummary::init(github, tracked_workflows).await?;
-    summary.comment_on_pr().await?;
+    summary.upsert_pr_comment().await?;
     Ok(())
 }
 

--- a/linera-summary/src/performance_summary.rs
+++ b/linera-summary/src/performance_summary.rs
@@ -9,6 +9,8 @@ use serde::Serialize;
 
 use crate::{ci_runtime_comparison::CiRuntimeComparison, github::Github};
 
+pub const PR_COMMENT_HEADER: &str = "## Performance Summary for commit";
+
 #[derive(Serialize)]
 pub struct PerformanceSummary {
     #[serde(skip_serializing)]
@@ -65,8 +67,8 @@ impl PerformanceSummary {
         );
 
         let mut markdown_content = format!(
-            "## Performance Summary for commit [{}]({})\n\n",
-            short_commit_hash, commit_url
+            "{} [{}]({})\n\n",
+            PR_COMMENT_HEADER, short_commit_hash, commit_url
         );
 
         markdown_content.push_str("### CI Runtime Comparison\n\n");
@@ -97,10 +99,9 @@ impl PerformanceSummary {
         markdown_content
     }
 
-    pub async fn comment_on_pr(&self) -> Result<()> {
+    pub async fn upsert_pr_comment(&self) -> Result<()> {
         self.github
-            .comment_on_pr(self.format_comment_body())
-            .await?;
-        Ok(())
+            .upsert_pr_comment(self.format_comment_body())
+            .await
     }
 }

--- a/linera-summary/src/performance_summary.rs
+++ b/linera-summary/src/performance_summary.rs
@@ -99,6 +99,7 @@ impl PerformanceSummary {
         markdown_content
     }
 
+    // Updates an existing comment or creates a new one in the PR.
     pub async fn upsert_pr_comment(&self) -> Result<()> {
         self.github
             .upsert_pr_comment(self.format_comment_body())


### PR DESCRIPTION
## Motivation

Right now the performance summary always "spams" the PR with comments, one for everytime the `Rust` workflow finishes successfully in CI.

## Proposal

Now that we have the summary attached to the performance summary CI job, we have a way of accessing the historical values for these things. So now we can just edit an existing comment instead of always creating a new one.

## Test Plan

Will be tested with workflow dispatch, like in previous PRs. You can see that there's only one comment, and it's edited (instead of just commenting again)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
