### PR TITLE
Fix `close_chain` errors.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -730,6 +730,7 @@ Show the contents of the wallet
 ###### **Options:**
 
 * `--short` — Only print a non-formatted list of the wallet's chain IDs
+* `--owned` — Print only the chains that we have a key pair for
 
 
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -1068,6 +1068,9 @@ pub enum WalletCommand {
         /// Only print a non-formatted list of the wallet's chain IDs.
         #[arg(long)]
         short: bool,
+        /// Print only the chains that we have a key pair for.
+        #[arg(long)]
+        owned: bool,
     },
 
     /// Change the wallet default chain.

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -91,6 +91,13 @@ impl Wallet {
         self.chains.keys().copied().collect()
     }
 
+    pub fn owned_chain_ids(&self) -> Vec<ChainId> {
+        self.chains
+            .iter()
+            .filter_map(|(chain_id, chain)| chain.key_pair.is_some().then_some(*chain_id))
+            .collect()
+    }
+
     /// Returns the list of all chain IDs for which we have a secret key.
     pub fn own_chain_ids(&self) -> Vec<ChainId> {
         self.chains

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2685,12 +2685,21 @@ where
     }
 
     /// Closes the chain (and loses everything in it!!).
+    /// Returns `None` if the chain was already closed.
     #[instrument(level = "trace")]
     pub async fn close_chain(
         &self,
-    ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
-        self.execute_operation(Operation::System(SystemOperation::CloseChain))
-            .await
+    ) -> Result<ClientOutcome<Option<ConfirmedBlockCertificate>>, ChainClientError> {
+        let operation = Operation::System(SystemOperation::CloseChain);
+        match self.execute_operation(operation).await {
+            Ok(outcome) => Ok(outcome.map(Some)),
+            Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(
+                WorkerError::ChainError(chain_error),
+            ))) if matches!(*chain_error, ChainError::ClosedChain) => {
+                Ok(ClientOutcome::Committed(None)) // Chain is already closed.
+            }
+            Err(error) => Err(error),
+        }
     }
 
     /// Publishes some bytecode.

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -815,7 +815,7 @@ where
         .add_initial_chain(ChainDescription::Root(2), Amount::from_tokens(4))
         .await?;
 
-    let certificate = client1.close_chain().await.unwrap().unwrap();
+    let certificate = client1.close_chain().await.unwrap().unwrap().unwrap();
     assert_matches!(
         certificate.executed_block().block.operations[..],
         [Operation::System(SystemOperation::CloseChain)],
@@ -890,6 +890,10 @@ where
             LocalNodeError::WorkerError(WorkerError::ChainError(error))
         )) if matches!(*error, ChainError::ClosedChain)
     );
+
+    // Trying to close the chain again returns None.
+    let maybe_certificate = client1.close_chain().await.unwrap().unwrap();
+    assert_matches!(maybe_certificate, None);
     Ok(())
 }
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -628,9 +628,9 @@ type MutationRoot {
 		fallbackDurationMs: Int! = 86400000
 	): ChainId!
 	"""
-	Closes the chain.
+	Closes the chain. Returns `None` if it was already closed.
 	"""
-	closeChain(chainId: ChainId!): CryptoHash!
+	closeChain(chainId: ChainId!): CryptoHash
 	"""
 	Changes the authentication key of the chain.
 	"""

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -986,7 +986,7 @@ impl Drop for ClientWrapper {
 
         let Ok(wallet_show_output) = wallet_show_command
             .current_dir(working_directory)
-            .args(["wallet", "show", "--short"])
+            .args(["wallet", "show", "--short", "--owned"])
             .output()
         else {
             warn!("Failed to execute `wallet show --short` to list chains to close");

--- a/linera-service/src/wallet.rs
+++ b/linera-service/src/wallet.rs
@@ -8,7 +8,7 @@ use comfy_table::{
 use linera_base::identifiers::{ChainId, Owner};
 pub use linera_client::wallet::*;
 
-pub fn pretty_print(wallet: &Wallet, chain_id: Option<ChainId>) {
+pub fn pretty_print(wallet: &Wallet, chain_ids: impl IntoIterator<Item = ChainId>) {
     let mut table = Table::new();
     table
         .load_preset(UTF8_FULL)
@@ -18,26 +18,16 @@ pub fn pretty_print(wallet: &Wallet, chain_id: Option<ChainId>) {
             Cell::new("Chain ID").add_attribute(Attribute::Bold),
             Cell::new("Latest Block").add_attribute(Attribute::Bold),
         ]);
-    if let Some(chain_id) = chain_id {
-        if let Some(user_chain) = wallet.chains.get(&chain_id) {
-            update_table_with_chain(
-                &mut table,
-                chain_id,
-                user_chain,
-                Some(chain_id) == wallet.default,
-            );
-        } else {
+    for chain_id in chain_ids {
+        let Some(user_chain) = wallet.chains.get(&chain_id) else {
             panic!("Chain {} not found.", chain_id);
-        }
-    } else {
-        for (chain_id, user_chain) in &wallet.chains {
-            update_table_with_chain(
-                &mut table,
-                *chain_id,
-                user_chain,
-                Some(chain_id) == wallet.default.as_ref(),
-            );
-        }
+        };
+        update_table_with_chain(
+            &mut table,
+            chain_id,
+            user_chain,
+            Some(chain_id) == wallet.default,
+        );
     }
     println!("{}", table);
 }


### PR DESCRIPTION
## Motivation

The end-to-end tests close their chains at the end. Sometimes that results in error messages because:
* the chain is not actually owned by that client, or
* the chain was already closed by another client.

## Proposal

Add an option to list only the _owned_ chains, and use that in the tests.

Return `None` from `ChainClient` if the chain was already closed, instead of an error.

## Test Plan

A test was extended to verify that `None` is returned if the chain is already closed.

Listing only the owned chains is now used in the end-to-end tests.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Fixes https://github.com/linera-io/linera-protocol/issues/2954.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
