### PR TITLE
Remove accounts with zero balance from storage

### DIFF
--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -269,7 +269,7 @@ where
                     balance,
                     application_permissions,
                 };
-                let messages = self.system.open_chain(config, next_message_id)?;
+                let messages = self.system.open_chain(config, next_message_id).await?;
                 callback.respond(messages)
             }
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -2,6 +2,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(test)]
+#[path = "./unit_tests/system_tests.rs"]
+mod tests;
+
 #[cfg(with_metrics)]
 use std::sync::LazyLock;
 use std::{
@@ -1057,119 +1061,5 @@ where
         } else {
             Err(SystemExecutionError::BlobsNotFound(missing_blobs))
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use linera_base::{
-        data_types::{Blob, BlockHeight, Bytecode},
-        identifiers::ApplicationId,
-    };
-    use linera_views::context::MemoryContext;
-
-    use super::*;
-    use crate::{ExecutionOutcome, ExecutionStateView, TestExecutionRuntimeContext};
-
-    /// Returns an execution state view and a matching operation context, for epoch 1, with root
-    /// chain 0 as the admin ID and one empty committee.
-    async fn new_view_and_context() -> (
-        ExecutionStateView<MemoryContext<TestExecutionRuntimeContext>>,
-        OperationContext,
-    ) {
-        let description = ChainDescription::Root(5);
-        let context = OperationContext {
-            chain_id: ChainId::from(description),
-            authenticated_signer: None,
-            authenticated_caller_id: None,
-            height: BlockHeight::from(7),
-            index: Some(2),
-        };
-        let state = SystemExecutionState {
-            description: Some(description),
-            epoch: Some(Epoch(1)),
-            admin_id: Some(ChainId::root(0)),
-            committees: BTreeMap::new(),
-            ..SystemExecutionState::default()
-        };
-        let view = state.into_view().await;
-        (view, context)
-    }
-
-    #[tokio::test]
-    async fn application_message_index() -> anyhow::Result<()> {
-        let (mut view, context) = new_view_and_context().await;
-        let contract = Bytecode::new(b"contract".into());
-        let service = Bytecode::new(b"service".into());
-        let contract_blob = Blob::new_contract_bytecode(contract.compress());
-        let service_blob = Blob::new_service_bytecode(service.compress());
-        let bytecode_id = BytecodeId::new(contract_blob.id().hash, service_blob.id().hash);
-
-        let operation = SystemOperation::CreateApplication {
-            bytecode_id,
-            parameters: vec![],
-            instantiation_argument: vec![],
-            required_application_ids: vec![],
-        };
-        let mut txn_tracker = TransactionTracker::default();
-        view.context()
-            .extra()
-            .add_blobs([contract_blob, service_blob])
-            .await?;
-        let new_application = view
-            .system
-            .execute_operation(context, operation, &mut txn_tracker)
-            .await?;
-        let [ExecutionOutcome::System(result)] = &txn_tracker.destructure()?.0[..] else {
-            panic!("Unexpected outcome");
-        };
-        assert_eq!(
-            result.messages[CREATE_APPLICATION_MESSAGE_INDEX as usize].message,
-            SystemMessage::ApplicationCreated
-        );
-        let creation = MessageId {
-            chain_id: context.chain_id,
-            height: context.height,
-            index: CREATE_APPLICATION_MESSAGE_INDEX,
-        };
-        let id = ApplicationId {
-            bytecode_id,
-            creation,
-        };
-        assert_eq!(new_application, Some((id, vec![])));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn open_chain_message_index() {
-        let (mut view, context) = new_view_and_context().await;
-        let epoch = view.system.epoch.get().unwrap();
-        let admin_id = view.system.admin_id.get().unwrap();
-        let committees = view.system.committees.get().clone();
-        let ownership = ChainOwnership::single(PublicKey::test_key(0));
-        let config = OpenChainConfig {
-            ownership,
-            committees,
-            epoch,
-            admin_id,
-            balance: Amount::ZERO,
-            application_permissions: Default::default(),
-        };
-        let mut txn_tracker = TransactionTracker::default();
-        let operation = SystemOperation::OpenChain(config.clone());
-        let new_application = view
-            .system
-            .execute_operation(context, operation, &mut txn_tracker)
-            .await
-            .unwrap();
-        assert_eq!(new_application, None);
-        let [ExecutionOutcome::System(result)] = &txn_tracker.destructure().unwrap().0[..] else {
-            panic!("Unexpected outcome");
-        };
-        assert_eq!(
-            result.messages[OPEN_CHAIN_MESSAGE_INDEX as usize].message,
-            SystemMessage::OpenChain(config)
-        );
     }
 }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -449,7 +449,7 @@ where
         match operation {
             OpenChain(config) => {
                 let next_message_id = context.next_message_id(txn_tracker.next_message_index());
-                let messages = self.open_chain(config, next_message_id)?;
+                let messages = self.open_chain(config, next_message_id).await?;
                 outcome.messages.extend(messages);
                 #[cfg(with_metrics)]
                 OPEN_CHAIN_COUNT.with_label_values(&[]).inc();
@@ -911,7 +911,7 @@ where
 
     /// Returns the messages to open a new chain, and subtracts the new chain's balance
     /// from this chain's.
-    pub fn open_chain(
+    pub async fn open_chain(
         &mut self,
         config: OpenChainConfig,
         next_message_id: MessageId,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -768,6 +768,12 @@ where
             .try_sub_assign(amount)
             .map_err(|_| SystemExecutionError::InsufficientFunding { balance: *balance })?;
 
+        if let Some(owner) = account {
+            if balance.is_zero() {
+                self.balances.remove(owner)?;
+            }
+        }
+
         Ok(())
     }
 

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -1,0 +1,113 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use linera_base::{
+    data_types::{Blob, BlockHeight, Bytecode},
+    identifiers::ApplicationId,
+};
+use linera_views::context::MemoryContext;
+
+use super::*;
+use crate::{ExecutionOutcome, ExecutionStateView, TestExecutionRuntimeContext};
+
+/// Returns an execution state view and a matching operation context, for epoch 1, with root
+/// chain 0 as the admin ID and one empty committee.
+async fn new_view_and_context() -> (
+    ExecutionStateView<MemoryContext<TestExecutionRuntimeContext>>,
+    OperationContext,
+) {
+    let description = ChainDescription::Root(5);
+    let context = OperationContext {
+        chain_id: ChainId::from(description),
+        authenticated_signer: None,
+        authenticated_caller_id: None,
+        height: BlockHeight::from(7),
+        index: Some(2),
+    };
+    let state = SystemExecutionState {
+        description: Some(description),
+        epoch: Some(Epoch(1)),
+        admin_id: Some(ChainId::root(0)),
+        committees: BTreeMap::new(),
+        ..SystemExecutionState::default()
+    };
+    let view = state.into_view().await;
+    (view, context)
+}
+
+#[tokio::test]
+async fn application_message_index() -> anyhow::Result<()> {
+    let (mut view, context) = new_view_and_context().await;
+    let contract = Bytecode::new(b"contract".into());
+    let service = Bytecode::new(b"service".into());
+    let contract_blob = Blob::new_contract_bytecode(contract.compress());
+    let service_blob = Blob::new_service_bytecode(service.compress());
+    let bytecode_id = BytecodeId::new(contract_blob.id().hash, service_blob.id().hash);
+
+    let operation = SystemOperation::CreateApplication {
+        bytecode_id,
+        parameters: vec![],
+        instantiation_argument: vec![],
+        required_application_ids: vec![],
+    };
+    let mut txn_tracker = TransactionTracker::default();
+    view.context()
+        .extra()
+        .add_blobs([contract_blob, service_blob])
+        .await?;
+    let new_application = view
+        .system
+        .execute_operation(context, operation, &mut txn_tracker)
+        .await?;
+    let [ExecutionOutcome::System(result)] = &txn_tracker.destructure()?.0[..] else {
+        panic!("Unexpected outcome");
+    };
+    assert_eq!(
+        result.messages[CREATE_APPLICATION_MESSAGE_INDEX as usize].message,
+        SystemMessage::ApplicationCreated
+    );
+    let creation = MessageId {
+        chain_id: context.chain_id,
+        height: context.height,
+        index: CREATE_APPLICATION_MESSAGE_INDEX,
+    };
+    let id = ApplicationId {
+        bytecode_id,
+        creation,
+    };
+    assert_eq!(new_application, Some((id, vec![])));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn open_chain_message_index() {
+    let (mut view, context) = new_view_and_context().await;
+    let epoch = view.system.epoch.get().unwrap();
+    let admin_id = view.system.admin_id.get().unwrap();
+    let committees = view.system.committees.get().clone();
+    let ownership = ChainOwnership::single(PublicKey::test_key(0));
+    let config = OpenChainConfig {
+        ownership,
+        committees,
+        epoch,
+        admin_id,
+        balance: Amount::ZERO,
+        application_permissions: Default::default(),
+    };
+    let mut txn_tracker = TransactionTracker::default();
+    let operation = SystemOperation::OpenChain(config.clone());
+    let new_application = view
+        .system
+        .execute_operation(context, operation, &mut txn_tracker)
+        .await
+        .unwrap();
+    assert_eq!(new_application, None);
+    let [ExecutionOutcome::System(result)] = &txn_tracker.destructure().unwrap().0[..] else {
+        panic!("Unexpected outcome");
+    };
+    assert_eq!(
+        result.messages[OPEN_CHAIN_MESSAGE_INDEX as usize].message,
+        SystemMessage::OpenChain(config)
+    );
+}

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -111,3 +111,24 @@ async fn open_chain_message_index() {
         SystemMessage::OpenChain(config)
     );
 }
+
+/// Tests if an account is removed from storage if it is drained.
+#[tokio::test]
+async fn empty_accounts_are_removed() -> anyhow::Result<()> {
+    let owner = Owner(CryptoHash::test_hash("account owner"));
+    let amount = Amount::from_tokens(99);
+
+    let mut view = SystemExecutionState {
+        description: Some(ChainDescription::Root(0)),
+        balances: BTreeMap::from([(owner, amount)]),
+        ..SystemExecutionState::default()
+    }
+    .into_view()
+    .await;
+
+    view.system.debit(Some(&owner), amount).await?;
+
+    assert!(view.system.balances.indices().await?.is_empty());
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
Account balances that are zero are currently stored in the chain state view, and end up using persistent storage space unnecessarily.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Remove entries from `balances` when they are depleted after having some tokens debited from them.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
A unit test was added to reproduce the scenario.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- These are breaking changes, because they change the system execution state view contents, and therefore the execution hash of the block.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
