### PR TITLE
Simplify ValidatorNode API.

### DIFF
--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -10,7 +10,7 @@ use super::{
     HashedCertificateValue,
 };
 use crate::{
-    block::{ConfirmedBlock, ValidatedBlock},
+    block::{ConfirmedBlock, ConversionError, ValidatedBlock},
     data_types::{ExecutedBlock, Medium, MessageBundle},
 };
 
@@ -57,7 +57,7 @@ impl GenericCertificate<ConfirmedBlock> {
 }
 
 impl TryFrom<Certificate> for GenericCertificate<ConfirmedBlock> {
-    type Error = &'static str;
+    type Error = ConversionError;
 
     fn try_from(cert: Certificate) -> Result<Self, Self::Error> {
         let hash = cert.hash();
@@ -68,7 +68,7 @@ impl TryFrom<Certificate> for GenericCertificate<ConfirmedBlock> {
                 round,
                 signatures,
             )),
-            _ => Err("Expected a confirmed block certificate"),
+            _ => Err(ConversionError::ConfirmedBlock),
         }
     }
 }

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -14,7 +14,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{BlockProposal, Origin},
-    types::{Certificate, ConfirmedBlock, GenericCertificate, Hashed, LiteCertificate},
+    types::{Certificate, GenericCertificate, LiteCertificate},
     ChainError,
 };
 use linera_execution::{
@@ -90,11 +90,6 @@ pub trait ValidatorNode {
     async fn subscribe(&self, chains: Vec<ChainId>) -> Result<Self::NotificationStream, NodeError>;
 
     async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError>;
-
-    async fn download_certificate_value(
-        &self,
-        hash: CryptoHash,
-    ) -> Result<Hashed<ConfirmedBlock>, NodeError>;
 
     async fn download_certificate(&self, hash: CryptoHash) -> Result<Certificate, NodeError>;
 

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -14,7 +14,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{BlockProposal, Origin},
-    types::{Certificate, GenericCertificate, LiteCertificate},
+    types::{Certificate, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
     ChainError,
 };
 use linera_execution::{
@@ -91,7 +91,10 @@ pub trait ValidatorNode {
 
     async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError>;
 
-    async fn download_certificate(&self, hash: CryptoHash) -> Result<Certificate, NodeError>;
+    async fn download_certificate(
+        &self,
+        hash: CryptoHash,
+    ) -> Result<ConfirmedBlockCertificate, NodeError>;
 
     /// Requests a batch of certificates from the validator.
     async fn download_certificates(

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -176,9 +176,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
             );
             return Err(NodeError::InvalidCertificateForBlob(blob_id));
         }
-        certificate.try_into().map_err(|_| NodeError::ChainError {
-            error: "Expected ConfirmedBlock certificate".to_string(),
-        })
+        Ok(certificate)
     }
 
     /// Tries to download the given blobs from this node. Returns `None` if not all could be found.

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -21,10 +21,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::BlockProposal,
-    types::{
-        Certificate, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate, Hashed,
-        LiteCertificate,
-    },
+    types::{Certificate, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
 };
 use linera_execution::{
     committee::{Committee, ValidatorName},
@@ -161,16 +158,6 @@ where
     async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
         self.spawn_and_receive(move |validator, sender| {
             validator.do_download_blob_content(blob_id, sender)
-        })
-        .await
-    }
-
-    async fn download_certificate_value(
-        &self,
-        hash: CryptoHash,
-    ) -> Result<Hashed<ConfirmedBlock>, NodeError> {
-        self.spawn_and_receive(move |validator, sender| {
-            validator.do_download_certificate_value(hash, sender)
         })
         .await
     }
@@ -456,21 +443,6 @@ where
             .await
             .map_err(Into::into);
         sender.send(blob.map(|blob| blob.into_inner_content()))
-    }
-
-    async fn do_download_certificate_value(
-        self,
-        hash: CryptoHash,
-        sender: oneshot::Sender<Result<Hashed<ConfirmedBlock>, NodeError>>,
-    ) -> Result<(), Result<Hashed<ConfirmedBlock>, NodeError>> {
-        let validator = self.client.lock().await;
-        let certificate_value = validator
-            .state
-            .storage_client()
-            .read_hashed_confirmed_block(hash)
-            .await
-            .map_err(Into::into);
-        sender.send(certificate_value)
     }
 
     async fn do_download_certificate(

--- a/linera-explorer/rust-toolchain.toml
+++ b/linera-explorer/rust-toolchain.toml
@@ -1,0 +1,1 @@
+toolchains/stable/rust-toolchain.toml

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -168,10 +168,10 @@ message ChainInfoQuery {
   bool request_leader_timeout = 8;
 
   // Query the balance of a given owner.
-  optional Owner request_owner_balance = 10;
+  optional Owner request_owner_balance = 9;
 
   // Request a signed vote for fallback mode.
-  bool request_fallback = 11;
+  bool request_fallback = 10;
 }
 
 // An authenticated proposal for a new block.
@@ -222,13 +222,13 @@ message HandleCertificateRequest {
 
   // Wait until all outgoing cross-chain messages from this certificate have
   // been received by the target chains.
-  bool wait_for_outgoing_messages = 6;
+  bool wait_for_outgoing_messages = 2;
 
   // Blobs required by this certificate
-  bytes blobs = 7;
+  bytes blobs = 3;
 
   // A certified statement from the committee.
-  Certificate certificate = 8;
+  Certificate certificate = 4;
 }
 
 // A certified statement from the committee.

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -58,9 +58,6 @@ service ValidatorNode {
   // Downloads a blob content.
   rpc DownloadBlobContent(BlobId) returns (BlobContent);
 
-  // Downloads a certificate value.
-  rpc DownloadCertificateValue(CryptoHash) returns (CertificateValue);
-
   // Downloads a certificate.
   rpc DownloadCertificate(CryptoHash) returns (Certificate);
 
@@ -244,10 +241,6 @@ message Certificate {
 
   // Signatures on the value hash and round
   bytes signatures = 3;
-}
-
-message CertificateValue {
-  bytes bytes = 1;
 }
 
 message ChainId {

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -8,7 +8,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::BlockProposal,
-    types::{Certificate, GenericCertificate, LiteCertificate},
+    types::{Certificate, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
 };
 use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
@@ -149,7 +149,10 @@ impl ValidatorNode for Client {
         })
     }
 
-    async fn download_certificate(&self, hash: CryptoHash) -> Result<Certificate, NodeError> {
+    async fn download_certificate(
+        &self,
+        hash: CryptoHash,
+    ) -> Result<ConfirmedBlockCertificate, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => grpc_client.download_certificate(hash).await?,
 

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -8,7 +8,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::BlockProposal,
-    types::{Certificate, ConfirmedBlock, GenericCertificate, Hashed, LiteCertificate},
+    types::{Certificate, GenericCertificate, LiteCertificate},
 };
 use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
@@ -146,18 +146,6 @@ impl ValidatorNode for Client {
 
             #[cfg(with_simple_network)]
             Client::Simple(simple_client) => simple_client.download_blob_content(blob_id).await?,
-        })
-    }
-
-    async fn download_certificate_value(
-        &self,
-        hash: CryptoHash,
-    ) -> Result<Hashed<ConfirmedBlock>, NodeError> {
-        Ok(match self {
-            Client::Grpc(grpc_client) => grpc_client.download_certificate_value(hash).await?,
-
-            #[cfg(with_simple_network)]
-            Client::Simple(simple_client) => simple_client.download_certificate_value(hash).await?,
         })
     }
 

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -12,7 +12,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{self},
-    types::{self, Certificate, ConfirmedBlock, GenericCertificate, Hashed},
+    types::{self, Certificate, GenericCertificate},
 };
 use linera_core::{
     node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
@@ -320,16 +320,6 @@ impl ValidatorNode for GrpcClient {
     async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
         let req = api::BlobId::try_from(blob_id)?;
         Ok(client_delegate!(self, download_blob_content, req)?.try_into()?)
-    }
-
-    #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
-    async fn download_certificate_value(
-        &self,
-        hash: CryptoHash,
-    ) -> Result<Hashed<ConfirmedBlock>, NodeError> {
-        let value = client_delegate!(self, download_certificate_value, hash)?;
-        let confirmed_block = ConfirmedBlock::try_from(value).unwrap();
-        Ok(confirmed_block.with_hash_checked(hash)?)
     }
 
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -12,7 +12,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{self},
-    types::{self, Certificate, GenericCertificate},
+    types::{self, Certificate, ConfirmedBlockCertificate, GenericCertificate},
 };
 use linera_core::{
     node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
@@ -323,8 +323,16 @@ impl ValidatorNode for GrpcClient {
     }
 
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
-    async fn download_certificate(&self, hash: CryptoHash) -> Result<Certificate, NodeError> {
-        Ok(client_delegate!(self, download_certificate, hash)?.try_into()?)
+    async fn download_certificate(
+        &self,
+        hash: CryptoHash,
+    ) -> Result<ConfirmedBlockCertificate, NodeError> {
+        ConfirmedBlockCertificate::try_from(Certificate::try_from(client_delegate!(
+            self,
+            download_certificate,
+            hash
+        )?)?)
+        .map_err(|_| NodeError::UnexpectedCertificateValue)
     }
 
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -9,7 +9,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{BlockProposal, LiteValue, ProposalContent},
-    types::{Certificate, ConfirmedBlock, Hashed, HashedCertificateValue, LiteCertificate},
+    types::{Certificate, HashedCertificateValue, LiteCertificate},
 };
 use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
@@ -608,32 +608,6 @@ impl TryFrom<api::BlobContent> for BlobContent {
 
     fn try_from(blob: api::BlobContent) -> Result<Self, Self::Error> {
         Ok(bincode::deserialize(blob.bytes.as_slice())?)
-    }
-}
-
-impl TryFrom<api::CertificateValue> for ConfirmedBlock {
-    type Error = GrpcProtoConversionError;
-
-    fn try_from(certificate: api::CertificateValue) -> Result<Self, Self::Error> {
-        Ok(bincode::deserialize(certificate.bytes.as_slice())?)
-    }
-}
-
-impl TryFrom<ConfirmedBlock> for api::CertificateValue {
-    type Error = GrpcProtoConversionError;
-
-    fn try_from(block: ConfirmedBlock) -> Result<Self, Self::Error> {
-        Ok(Self {
-            bytes: bincode::serialize(&block)?,
-        })
-    }
-}
-
-impl TryFrom<Hashed<ConfirmedBlock>> for api::CertificateValue {
-    type Error = GrpcProtoConversionError;
-
-    fn try_from(value: Hashed<ConfirmedBlock>) -> Result<Self, Self::Error> {
-        value.into_inner().try_into()
     }
 }
 

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -14,7 +14,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::BlockProposal,
-    types::{Certificate, GenericCertificate, LiteCertificate},
+    types::{Certificate, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
 };
 use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
@@ -145,9 +145,14 @@ impl ValidatorNode for SimpleClient {
             .await
     }
 
-    async fn download_certificate(&self, hash: CryptoHash) -> Result<Certificate, NodeError> {
-        self.query(RpcMessage::DownloadCertificate(Box::new(hash)))
-            .await
+    async fn download_certificate(
+        &self,
+        hash: CryptoHash,
+    ) -> Result<ConfirmedBlockCertificate, NodeError> {
+        self.query::<Certificate>(RpcMessage::DownloadCertificate(Box::new(hash)))
+            .await?
+            .try_into()
+            .map_err(|_| NodeError::UnexpectedCertificateValue)
     }
 
     async fn download_certificates(

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -14,7 +14,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::BlockProposal,
-    types::{Certificate, ConfirmedBlock, GenericCertificate, Hashed, LiteCertificate},
+    types::{Certificate, GenericCertificate, LiteCertificate},
 };
 use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
@@ -143,16 +143,6 @@ impl ValidatorNode for SimpleClient {
     async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
         self.query(RpcMessage::DownloadBlobContent(Box::new(blob_id)))
             .await
-    }
-
-    async fn download_certificate_value(
-        &self,
-        hash: CryptoHash,
-    ) -> Result<Hashed<ConfirmedBlock>, NodeError> {
-        let confirmed_block: ConfirmedBlock = self
-            .query(RpcMessage::DownloadConfirmedBlock(Box::new(hash)))
-            .await?;
-        Ok(confirmed_block.with_hash_checked(hash)?)
     }
 
     async fn download_certificate(&self, hash: CryptoHash) -> Result<Certificate, NodeError> {

--- a/linera-rpc/tests/format.rs
+++ b/linera-rpc/tests/format.rs
@@ -10,7 +10,7 @@ use linera_base::{
 use linera_chain::{
     data_types::{Medium, MessageAction},
     manager::ChainManagerInfo,
-    types::{CertificateValue, HashedCertificateValue},
+    types::{CertificateValue, ConfirmedBlock, Hashed, HashedCertificateValue},
 };
 use linera_core::{data_types::CrossChainRequest, node::NodeError};
 use linera_execution::{
@@ -41,7 +41,9 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<MessageAction>(&samples)?;
     tracer.trace_type::<MessageKind>(&samples)?;
     tracer.trace_type::<HashedCertificateValue>(&samples)?;
+    tracer.trace_type::<Hashed<ConfirmedBlock>>(&samples)?;
     tracer.trace_type::<CertificateValue>(&samples)?;
+    tracer.trace_type::<ConfirmedBlock>(&samples)?;
     tracer.trace_type::<Medium>(&samples)?;
     tracer.trace_type::<Destination>(&samples)?;
     tracer.trace_type::<ChainDescription>(&samples)?;

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -31,10 +31,10 @@ use linera_rpc::{
             notifier_service_server::{NotifierService, NotifierServiceServer},
             validator_node_server::{ValidatorNode, ValidatorNodeServer},
             validator_worker_client::ValidatorWorkerClient,
-            BlobContent, BlobId, BlobIds, BlockProposal, Certificate, CertificateValue,
-            CertificatesBatchRequest, CertificatesBatchResponse, ChainInfoQuery, ChainInfoResult,
-            CryptoHash, HandleCertificateRequest, LiteCertificate, Notification,
-            SubscriptionRequest, VersionInfo,
+            BlobContent, BlobId, BlobIds, BlockProposal, Certificate, CertificatesBatchRequest,
+            CertificatesBatchResponse, ChainInfoQuery, ChainInfoResult, CryptoHash,
+            HandleCertificateRequest, LiteCertificate, Notification, SubscriptionRequest,
+            VersionInfo,
         },
         pool::GrpcConnectionPool,
         GrpcProtoConversionError, GrpcProxyable, GRPC_CHUNKED_MESSAGE_FILL_LIMIT,
@@ -439,21 +439,6 @@ where
             .await
             .map_err(|err| Status::from_error(Box::new(err)))?;
         Ok(Response::new(blob.into_inner_content().try_into()?))
-    }
-
-    #[instrument(skip_all, err(Display))]
-    async fn download_certificate_value(
-        &self,
-        request: Request<CryptoHash>,
-    ) -> Result<Response<CertificateValue>, Status> {
-        let hash = request.into_inner().try_into()?;
-        let confirmed_block = self
-            .0
-            .storage
-            .read_hashed_confirmed_block(hash)
-            .await
-            .map_err(|err| Status::from_error(Box::new(err)))?;
-        Ok(Response::new(confirmed_block.into_inner().try_into()?))
     }
 
     #[instrument(skip_all, err(Display))]

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -9,7 +9,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::BlockProposal,
-    types::{Certificate, GenericCertificate, LiteCertificate},
+    types::{Certificate, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
 };
 use linera_client::{
     chain_listener::{ChainListenerConfig, ClientContext},
@@ -83,7 +83,10 @@ impl ValidatorNode for DummyValidatorNode {
         Err(NodeError::UnexpectedMessage)
     }
 
-    async fn download_certificate(&self, _: CryptoHash) -> Result<Certificate, NodeError> {
+    async fn download_certificate(
+        &self,
+        _: CryptoHash,
+    ) -> Result<ConfirmedBlockCertificate, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -9,7 +9,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::BlockProposal,
-    types::{Certificate, ConfirmedBlock, GenericCertificate, Hashed, LiteCertificate},
+    types::{Certificate, GenericCertificate, LiteCertificate},
 };
 use linera_client::{
     chain_listener::{ChainListenerConfig, ClientContext},
@@ -80,13 +80,6 @@ impl ValidatorNode for DummyValidatorNode {
     }
 
     async fn download_blob_content(&self, _: BlobId) -> Result<BlobContent, NodeError> {
-        Err(NodeError::UnexpectedMessage)
-    }
-
-    async fn download_certificate_value(
-        &self,
-        _: CryptoHash,
-    ) -> Result<Hashed<ConfirmedBlock>, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 


### PR DESCRIPTION
## Motivation

On the road to removal of `Certificate` and replacing it with more type-safe|specific API.

## Proposal

Here we do two things mainly:
- remove `download_certificate_value` (it was unused)
- change `download_certificate` from returning (old) `Certificate` type to `ConfirmedBlockCertificate`

## Test Plan

CI should catch any regressions.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.
- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- Backporting is not possible but we may want to deploy a new `devnet` and release a new
      SDK soon.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
