### PR TITLE
Remove redundant prepare_chain calls.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -417,6 +417,7 @@ where
         Fut: Future<Output = Result<ClientOutcome<T>, E>>,
         Error: From<E>,
     {
+        client.prepare_chain().await?;
         // Try applying f optimistically without validator notifications. Return if committed.
         let result = f(client).await;
         self.update_and_save_wallet(client).await?;
@@ -635,7 +636,7 @@ where
                 .take(num_new_chains)
                 .collect();
             let certificate = chain_client
-                .execute_without_prepare(operations)
+                .execute_operations(operations)
                 .await?
                 .expect("should execute block with OpenChain operations");
             let executed_block = certificate.executed_block();
@@ -704,7 +705,7 @@ where
         // Put at most 1000 fungible token operations in each block.
         for operations in operations.chunks(1000) {
             chain_client
-                .execute_without_prepare(operations.to_vec())
+                .execute_operations(operations.to_vec())
                 .await?
                 .expect("should execute block with OpenChain operations");
         }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1459,6 +1459,7 @@ where
     // Try to read the blob. This is a different client but on the same chain, so when we synchronize this with the validators
     // before executing the block, we'll actually download and cache locally the blobs that were published by `client_a`.
     // So this will succeed.
+    client1_b.prepare_chain().await?;
     let certificate = client1_b
         .execute_operation(SystemOperation::ReadBlob { blob_id: blob0_id }.into())
         .await?
@@ -1651,6 +1652,7 @@ where
     builder.set_fault_type([2], FaultType::Offline).await;
     builder.set_fault_type([0, 1, 3], FaultType::Honest).await;
 
+    client2_b.prepare_chain().await.unwrap();
     let bt_certificate = client2_b
         .burn(None, Amount::from_tokens(1))
         .await
@@ -2178,6 +2180,7 @@ where
     assert!(client0.pending_block().is_none());
 
     // Burn another token so Client 1 sees that the blob is already published
+    client1.prepare_chain().await.unwrap();
     client1.burn(None, Amount::from_tokens(1)).await.unwrap();
     client1.synchronize_from_validators().await.unwrap();
     client1.process_inbox().await.unwrap();


### PR DESCRIPTION
## Motivation

It is redundant in some situations to call `prepare_chain` inside `execute_operations`: Whenever we are in connected mode, i.e. the client listener is running, we should not need to call `prepare_chain` or `synchronize_from_validators`, and instead rely on the notifications.

## Proposal

Remove the `prepare_chain` call, and instead call it explicitly if we are executing a CLI command, i.e. are not in connected mode.

## Test Plan

Since this call is redundant, the logic should not have changed. Only in some client tests I had to add explicit `prepare_chain` calls, which is expected.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
