### PR TITLE
Remove `linera-execution`'s dependency on `counter`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4247,7 +4247,6 @@ dependencies = [
  "js-sys",
  "linera-base",
  "linera-execution",
- "linera-storage",
  "linera-views",
  "linera-views-derive",
  "linera-wasmer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4239,7 +4239,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "clap",
- "counter",
  "custom_debug_derive",
  "dashmap 5.5.3",
  "derive_more 1.0.0",

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -78,7 +78,6 @@ assert_matches.workspace = true
 bcs.workspace = true
 linera-base = { workspace = true, features = ["test"] }
 linera-execution = { path = ".", default-features = false, features = ["test"] }
-linera-storage = { workspace = true, features = ["test"] }
 linera-witty = { workspace = true, features = ["log", "macros", "test"] }
 test-case.workspace = true
 test-log = { workspace = true, features = ["trace"] }

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -76,7 +76,6 @@ wasmer = { workspace = true, optional = true, features = ["js-default"] }
 anyhow.workspace = true
 assert_matches.workspace = true
 bcs.workspace = true
-counter.workspace = true
 linera-base = { workspace = true, features = ["test"] }
 linera-execution = { path = ".", default-features = false, features = ["test"] }
 linera-storage = { workspace = true, features = ["test"] }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1088,15 +1088,23 @@ impl Operation {
         Operation::System(operation)
     }
 
+    /// Creates a new user application operation following the `application_id`'s [`Abi`].
     pub fn user<A: Abi>(
         application_id: UserApplicationId<A>,
         operation: &A::Operation,
     ) -> Result<Self, bcs::Error> {
-        let application_id = application_id.forget_abi();
-        let bytes = bcs::to_bytes(&operation)?;
+        Self::user_without_abi(application_id.forget_abi(), operation)
+    }
+
+    /// Creates a new user application operation assuming that the `operation` is valid for the
+    /// `application_id`.
+    pub fn user_without_abi(
+        application_id: UserApplicationId<()>,
+        operation: &impl Serialize,
+    ) -> Result<Self, bcs::Error> {
         Ok(Operation::User {
             application_id,
-            bytes,
+            bytes: bcs::to_bytes(&operation)?,
         })
     }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1193,15 +1193,23 @@ impl Query {
         Query::System(query)
     }
 
+    /// Creates a new user application query following the `application_id`'s [`Abi`].
     pub fn user<A: Abi>(
         application_id: UserApplicationId<A>,
         query: &A::Query,
     ) -> Result<Self, serde_json::Error> {
-        let application_id = application_id.forget_abi();
-        let bytes = serde_json::to_vec(&query)?;
+        Self::user_without_abi(application_id.forget_abi(), query)
+    }
+
+    /// Creates a new user application query assuming that the `query` is valid for the
+    /// `application_id`.
+    pub fn user_without_abi(
+        application_id: UserApplicationId<()>,
+        query: &impl Serialize,
+    ) -> Result<Self, serde_json::Error> {
         Ok(Query::User {
             application_id,
-            bytes,
+            bytes: serde_json::to_vec(&query)?,
         })
     }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1127,7 +1127,9 @@ impl Message {
         Message::System(message)
     }
 
-    pub fn user<A: Abi, M: Serialize>(
+    /// Creates a new user application message assuming that the `message` is valid for the
+    /// `application_id`.
+    pub fn user<A, M: Serialize>(
         application_id: UserApplicationId<A>,
         message: &M,
     ) -> Result<Self, bcs::Error> {

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -5,7 +5,6 @@
 
 use std::sync::Arc;
 
-use counter::CounterAbi;
 use linera_base::{
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, ChainDescription, ChainId},
@@ -67,8 +66,6 @@ async fn test_fuel_for_counter_wasm_application(
         .add_blobs([contract_blob, service_blob])
         .await?;
 
-    let app_id = app_id.with_abi::<CounterAbi>();
-
     let context = OperationContext {
         chain_id: ChainId::root(0),
         height: BlockHeight(0),
@@ -98,7 +95,7 @@ async fn test_fuel_for_counter_wasm_application(
         view.execute_operation(
             context,
             Timestamp::from(0),
-            Operation::user(app_id, increment).unwrap(),
+            Operation::user_without_abi(app_id, increment).unwrap(),
             &mut txn_tracker,
             &mut controller,
         )
@@ -140,7 +137,7 @@ async fn test_fuel_for_counter_wasm_application(
     let Response::User(serialized_value) = view
         .query_application(
             context,
-            Query::user(app_id, &request).unwrap(),
+            Query::user_without_abi(app_id, &request).unwrap(),
             Some(&mut service_runtime_endpoint),
         )
         .await?


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
The CI is failing when building the documentation for the crates. This appears to be caused by a cyclic dependency where (for tests) `linera-execution` depends on `counter`, which in turn depends on `linera-sdk` and eventually `linera-execution` again.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Rewrite the test that used the counter ABI to not use the ABI, so that the dependency can be removed.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
The CI job that previously failed should be started manually to ensure that the issue is solved.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do, because this is an internal refactor to fix CI.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
