### PR TITLE
Require that BlockProposal contains exactly the published blobs.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -2,7 +2,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, fmt};
+use std::{
+    collections::{BTreeSet, HashSet},
+    fmt,
+};
 
 use async_graphql::SimpleObject;
 use custom_debug_derive::Debug;
@@ -74,8 +77,8 @@ pub struct Block {
 
 impl Block {
     /// Returns all the published blob IDs in this block's operations.
-    pub fn published_blob_ids(&self) -> HashSet<BlobId> {
-        let mut blob_ids = HashSet::new();
+    pub fn published_blob_ids(&self) -> BTreeSet<BlobId> {
+        let mut blob_ids = BTreeSet::new();
         for operation in &self.operations {
             if let Operation::System(SystemOperation::PublishDataBlob { blob_hash }) = operation {
                 blob_ids.insert(BlobId::new(*blob_hash, BlobType::Data));

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -201,6 +201,8 @@ pub enum WorkerError {
     UnneededValue { value_hash: CryptoHash },
     #[error("An additional blob was provided that is not required: {blob_id}.")]
     UnneededBlob { blob_id: BlobId },
+    #[error("The blobs provided in the proposal were not the published ones, in order.")]
+    WrongBlobsInProposal,
     #[error("The certificate in the block proposal is not a ValidatedBlock")]
     MissingExecutedBlockInProposal,
     #[error("Fast blocks cannot query oracles")]


### PR DESCRIPTION
## Motivation

A validator that has signed a block proposal must be able to provide everything so that a client is able to execute that proposal, too. So we need to store all published blobs in the chain manager.

## Proposal

Since we store the whole `BlockProposal` there, it is easiest to require that it always contains exactly the published blobs, and in the right order.

## Test Plan

The added check is very short and the block proposals we produce in the client already pass it. Existing tests should catch any regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/2963.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
