### PR TITLE
Remove some code duplication

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -574,7 +574,7 @@ where
     W: Persist<Target = Wallet>,
 {
     pub async fn process_inboxes_and_force_validator_updates(&mut self) {
-        for chain_id in self.wallet.own_chain_ids() {
+        for chain_id in self.wallet.owned_chain_ids() {
             let chain_client = self
                 .make_chain_client(chain_id)
                 .expect("chains in the wallet must exist");
@@ -592,7 +592,7 @@ where
         balance: Amount,
     ) -> Result<HashMap<ChainId, KeyPair>, Error> {
         let mut key_pairs = HashMap::new();
-        for chain_id in self.wallet.own_chain_ids() {
+        for chain_id in self.wallet.owned_chain_ids() {
             if key_pairs.len() == num_chains {
                 break;
             }

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -91,15 +91,8 @@ impl Wallet {
         self.chains.keys().copied().collect()
     }
 
-    pub fn owned_chain_ids(&self) -> Vec<ChainId> {
-        self.chains
-            .iter()
-            .filter_map(|(chain_id, chain)| chain.key_pair.is_some().then_some(*chain_id))
-            .collect()
-    }
-
     /// Returns the list of all chain IDs for which we have a secret key.
-    pub fn own_chain_ids(&self) -> Vec<ChainId> {
+    pub fn owned_chain_ids(&self) -> Vec<ChainId> {
         self.chains
             .iter()
             .filter_map(|(chain_id, chain)| chain.key_pair.is_some().then_some(*chain_id))


### PR DESCRIPTION
## Motivation

`owned_chain_ids` and `own_chain_ids` do the same thing

## Proposal

Keep `owned_chain_ids`, as that name seems better

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
