### PR TITLE
Blob use is only an oracle the first time per chain.

### DIFF
--- a/linera-chain/src/certificate/mod.rs
+++ b/linera-chain/src/certificate/mod.rs
@@ -175,7 +175,7 @@ impl CertificateValueT for ValidatedBlock {
     }
 
     fn required_blob_ids(&self) -> HashSet<BlobId> {
-        self.inner().outcome.required_blob_ids().clone()
+        self.inner().required_blob_ids()
     }
 
     #[cfg(with_testing)]
@@ -198,7 +198,7 @@ impl CertificateValueT for ConfirmedBlock {
     }
 
     fn required_blob_ids(&self) -> HashSet<BlobId> {
-        self.executed_block().outcome.required_blob_ids().clone()
+        self.executed_block().required_blob_ids()
     }
 }
 

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -697,11 +697,14 @@ impl ExecutedBlock {
     }
 
     pub fn required_blob_ids(&self) -> HashSet<BlobId> {
-        self.outcome.required_blob_ids()
+        let mut blob_ids = self.outcome.oracle_blob_ids();
+        blob_ids.extend(self.block.published_blob_ids());
+        blob_ids
     }
 
     pub fn requires_blob(&self, blob_id: &BlobId) -> bool {
-        self.required_blob_ids().contains(blob_id)
+        self.outcome.oracle_blob_ids().contains(blob_id)
+            || self.block.published_blob_ids().contains(blob_id)
     }
 }
 
@@ -713,7 +716,7 @@ impl BlockExecutionOutcome {
         }
     }
 
-    pub fn required_blob_ids(&self) -> HashSet<BlobId> {
+    pub fn oracle_blob_ids(&self) -> HashSet<BlobId> {
         let mut required_blob_ids = HashSet::new();
         for responses in &self.oracle_responses {
             for response in responses {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1033,7 +1033,12 @@ where
         self.state_mut()
             .set_pending_block(proposal.content.block.clone());
         let required_blob_ids: HashSet<BlobId> = value.inner().required_blob_ids();
-        let proposed_blobs = proposal.blobs.clone();
+        let required_blobs = proposal
+            .blobs
+            .iter()
+            .filter(|blob| required_blob_ids.contains(&blob.id()))
+            .cloned()
+            .collect();
         let submit_action = CommunicateAction::SubmitBlock {
             proposal,
             blob_ids: required_blob_ids,
@@ -1041,7 +1046,7 @@ where
         let certificate = self
             .communicate_chain_action(committee, submit_action, value)
             .await?;
-        self.process_certificate(certificate.clone(), proposed_blobs)
+        self.process_certificate(certificate.clone(), required_blobs)
             .await?;
         Ok(certificate)
     }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1033,12 +1033,7 @@ where
         self.state_mut()
             .set_pending_block(proposal.content.block.clone());
         let required_blob_ids: HashSet<BlobId> = value.inner().required_blob_ids();
-        let required_blobs = proposal
-            .blobs
-            .iter()
-            .filter(|blob| required_blob_ids.contains(&blob.id()))
-            .cloned()
-            .collect();
+        let proposed_blobs = proposal.blobs.clone();
         let submit_action = CommunicateAction::SubmitBlock {
             proposal,
             blob_ids: required_blob_ids,
@@ -1046,7 +1041,7 @@ where
         let certificate = self
             .communicate_chain_action(committee, submit_action, value)
             .await?;
-        self.process_certificate(certificate.clone(), required_blobs)
+        self.process_certificate(certificate.clone(), proposed_blobs)
             .await?;
         Ok(certificate)
     }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1435,7 +1435,8 @@ where
         .await;
     assert_matches!(
         result,
-        Err(ChainClientError::RemoteNodeError(NodeError::BlobsNotFound(not_found_blob_ids))) if not_found_blob_ids == [blob0_id]
+        Err(ChainClientError::RemoteNodeError(NodeError::BlobsNotFound(not_found_blob_ids)))
+            if not_found_blob_ids == [blob0_id]
     );
 
     // Take one validator down
@@ -1456,15 +1457,16 @@ where
     // But another one goes down
     builder.set_fault_type([3], FaultType::Offline).await;
 
-    // Try to read the blob. This is a different client but on the same chain, so when we synchronize this with the validators
-    // before executing the block, we'll actually download and cache locally the blobs that were published by `client_a`.
-    // So this will succeed.
+    // Try to read the blob. This is a different client but on the same chain, so when we
+    // synchronize this with the validators before executing the block, we'll actually download
+    // and cache locally the blobs that were published by `client_a`. So this will succeed.
     let certificate = client1_b
         .execute_operation(SystemOperation::ReadBlob { blob_id: blob0_id }.into())
         .await?
         .unwrap();
     assert_eq!(certificate.round, Round::MultiLeader(0));
-    assert!(certificate.executed_block().requires_blob(&blob0_id));
+    // The blob is not new on this chain, so it is not required.
+    assert!(!certificate.executed_block().requires_blob(&blob0_id));
 
     builder
         .set_fault_type([0, 1, 2], FaultType::DontSendConfirmVote)

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -146,10 +146,7 @@ where
             messages: vec![Vec::new()],
             events: vec![Vec::new()],
             state_hash: publisher_state_hash,
-            oracle_responses: vec![vec![
-                OracleResponse::Blob(contract_blob_id),
-                OracleResponse::Blob(service_blob_id),
-            ]],
+            oracle_responses: vec![vec![]],
         }
         .with(publish_block),
     );

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -10,6 +10,8 @@
 #![allow(clippy::large_futures)]
 #![cfg(any(feature = "wasmer", feature = "wasmtime"))]
 
+use std::collections::BTreeSet;
+
 use linera_base::{
     crypto::KeyPair,
     data_types::{
@@ -135,6 +137,7 @@ where
         committees: [(Epoch::ZERO, committee.clone())].into_iter().collect(),
         ownership: ChainOwnership::single(publisher_key_pair.public()),
         timestamp: Timestamp::from(1),
+        used_blobs: BTreeSet::from([contract_blob_id, service_blob_id]),
         ..SystemExecutionState::new(Epoch::ZERO, publisher_chain, admin_id)
     };
     let publisher_state_hash = publisher_system_state.clone().into_hash().await;

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -199,8 +199,6 @@ pub enum WorkerError {
     MissingCertificateValue,
     #[error("The hash certificate doesn't match its value.")]
     InvalidLiteCertificate,
-    #[error("An additional value was provided that is not required: {value_hash}.")]
-    UnneededValue { value_hash: CryptoHash },
     #[error("An additional blob was provided that is not required: {blob_id}.")]
     UnneededBlob { blob_id: BlobId },
     #[error("The blobs provided in the proposal were not the published ones, in order.")]

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -87,6 +87,9 @@ where
             .register_application(application_description)
             .await?;
 
+        self.system.used_blobs.insert(&contract_blob.id())?;
+        self.system.used_blobs.insert(&service_blob.id())?;
+
         self.context()
             .extra()
             .user_contracts()

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -311,20 +311,13 @@ where
 
             ReadBlobContent { blob_id, callback } => {
                 let blob = self.system.read_blob_content(blob_id).await?;
-                let is_new = !self.system.used_blobs.contains(&blob_id).await?;
-                if is_new {
-                    self.system.used_blobs.insert(&blob_id)?;
-                }
-                callback.respond((blob, is_new));
+                let is_new = self.system.blob_used(None, blob_id).await?;
+                callback.respond((blob, is_new))
             }
 
             AssertBlobExists { blob_id, callback } => {
                 self.system.assert_blob_exists(blob_id).await?;
-                let is_new = !self.system.used_blobs.contains(&blob_id).await?;
-                if is_new {
-                    self.system.used_blobs.insert(&blob_id)?;
-                }
-                callback.respond(is_new)
+                callback.respond(self.system.blob_used(None, blob_id).await?)
             }
         }
 

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -11,7 +11,7 @@ use custom_debug_derive::Debug;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, ApplicationPermissions, Blob, Timestamp},
-    identifiers::{ApplicationId, ChainDescription, ChainId, Owner},
+    identifiers::{ApplicationId, BlobId, ChainDescription, ChainId, Owner},
     ownership::ChainOwnership,
 };
 use linera_views::{
@@ -46,6 +46,7 @@ pub struct SystemExecutionState {
     pub balances: BTreeMap<Owner, Amount>,
     pub timestamp: Timestamp,
     pub registry: ApplicationRegistry,
+    pub used_blobs: BTreeSet<BlobId>,
     #[debug(skip_if = Not::not)]
     pub closed: bool,
     pub application_permissions: ApplicationPermissions,
@@ -108,6 +109,7 @@ impl SystemExecutionState {
             balances,
             timestamp,
             registry,
+            used_blobs,
             closed,
             application_permissions,
             extra_blobs,
@@ -160,6 +162,12 @@ impl SystemExecutionState {
             .registry
             .import(registry)
             .expect("serialization of registry components should not fail");
+        for blob_id in used_blobs {
+            view.system
+                .used_blobs
+                .insert(&blob_id)
+                .expect("inserting blob IDs should not fail");
+        }
         view.system.closed.set(closed);
         view.system
             .application_permissions


### PR DESCRIPTION
## Motivation

Reading a blob that has already been used (published or read) on the same chain before is guaranteed to succeed, so it does not need an oracle response entry in the execution outcome.

## Proposal

Add a `used_blobs` field to the system execution state to keep track of all blobs that have been used on this chain so far. Only make oracle entries for blobs that have not been used before.

## Test Plan

Tests have been updated to assert the new behavior.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/2964.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
