### PR TITLE
ValidatorNode::download_certificates returns ConfirmedBlockCertificates

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1311,13 +1311,11 @@ where
 
         // Check the signatures and keep only the ones that are valid.
         let mut certificates = Vec::new();
-        for certificate in remote_certificates {
-            let sender_chain_id = certificate.inner().chain_id();
-            let height = certificate.inner().height();
-            let epoch = certificate.inner().epoch();
-            let confirmed_block_certificate = certificate
-                .try_into()
-                .map_err(|_| NodeError::UnexpectedCertificateValue)?;
+        for confirmed_block_certificate in remote_certificates {
+            let block = &confirmed_block_certificate.inner().executed_block().block;
+            let sender_chain_id = block.chain_id;
+            let height = block.height;
+            let epoch = block.epoch;
             match self.check_certificate(max_epoch, &committees, &confirmed_block_certificate)? {
                 CheckCertificateResult::FutureEpoch => {
                     warn!(

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -100,7 +100,7 @@ pub trait ValidatorNode {
     async fn download_certificates(
         &self,
         hashes: Vec<CryptoHash>,
-    ) -> Result<Vec<Certificate>, NodeError>;
+    ) -> Result<Vec<ConfirmedBlockCertificate>, NodeError>;
 
     /// Returns the hash of the `Certificate` that last used a blob.
     async fn blob_last_used_by(&self, blob_id: BlobId) -> Result<CryptoHash, NodeError>;

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -284,7 +284,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
     pub async fn download_certificates(
         &self,
         hashes: Vec<CryptoHash>,
-    ) -> Result<Vec<Certificate>, NodeError> {
+    ) -> Result<Vec<ConfirmedBlockCertificate>, NodeError> {
         if hashes.is_empty() {
             return Ok(Vec::new());
         }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -21,7 +21,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::BlockProposal,
-    types::{Certificate, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
+    types::{ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
 };
 use linera_execution::{
     committee::{Committee, ValidatorName},
@@ -176,12 +176,11 @@ where
     async fn download_certificates(
         &self,
         hashes: Vec<CryptoHash>,
-    ) -> Result<Vec<Certificate>, NodeError> {
+    ) -> Result<Vec<ConfirmedBlockCertificate>, NodeError> {
         self.spawn_and_receive(move |validator, sender| {
             validator.do_download_certificates(hashes, sender)
         })
         .await
-        .map(|certs| certs.into_iter().map(Certificate::from).collect())
     }
 
     async fn blob_last_used_by(&self, blob_id: BlobId) -> Result<CryptoHash, NodeError> {

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -164,7 +164,7 @@ impl ValidatorNode for Client {
     async fn download_certificates(
         &self,
         hashes: Vec<CryptoHash>,
-    ) -> Result<Vec<Certificate>, NodeError> {
+    ) -> Result<Vec<ConfirmedBlockCertificate>, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => grpc_client.download_certificates(hashes).await?,
 

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -9,7 +9,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::BlockProposal,
-    types::{Certificate, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
+    types::{ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
 };
 use linera_client::{
     chain_listener::{ChainListenerConfig, ClientContext},
@@ -93,7 +93,7 @@ impl ValidatorNode for DummyValidatorNode {
     async fn download_certificates(
         &self,
         _: Vec<CryptoHash>,
-    ) -> Result<Vec<Certificate>, NodeError> {
+    ) -> Result<Vec<ConfirmedBlockCertificate>, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 


### PR DESCRIPTION
## Motivation

On the mission to removal of `Certificate` type.

## Proposal

We already fixed `download_certificate` (singular) to return `ConfirmedBlockCertificate` in the previous PR, this one went unnoticed.

## Test Plan

CI.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.

## Links

Closes https://github.com/linera-io/linera-protocol/issues/2974
<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
