### PR TITLE
No oracles in fast blocks; automatically propose a regular block if oracles.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -761,13 +761,6 @@ pub enum OracleResponse {
     Assert,
 }
 
-impl OracleResponse {
-    /// Wether an `OracleResponse` is permitted in fast blocks or not.
-    pub fn is_permitted_in_fast_blocks(&self) -> bool {
-        matches!(self, OracleResponse::Blob(_))
-    }
-}
-
 impl Display for OracleResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -728,6 +728,12 @@ impl BlockExecutionOutcome {
 
         required_blob_ids
     }
+
+    pub fn has_oracle_responses(&self) -> bool {
+        self.oracle_responses
+            .iter()
+            .any(|responses| !responses.is_empty())
+    }
 }
 
 /// The data a block proposer signs.

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -240,16 +240,10 @@ where
                 .with_value(value)
                 .ok_or_else(|| WorkerError::InvalidLiteCertificate)?;
         }
-        if round.is_fast() {
-            ensure!(
-                outcome
-                    .oracle_responses
-                    .iter()
-                    .flatten()
-                    .all(|response| response.is_permitted_in_fast_blocks()),
-                WorkerError::FastBlockUsingOracles
-            );
-        }
+        ensure!(
+            !round.is_fast() || !outcome.has_oracle_responses(),
+            WorkerError::FastBlockUsingOracles
+        );
         // Check if the counters of tip_state would be valid.
         self.0
             .chain

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2458,7 +2458,7 @@ where
         } else if let Some(round) = manager
             .ownership
             .next_round(manager.current_round)
-            .filter(|_| manager.current_round.is_multi_leader())
+            .filter(|_| manager.current_round.is_multi_leader() || manager.current_round.is_fast())
         {
             round
         } else if let Some(timeout) = info.round_timeout() {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2432,7 +2432,7 @@ where
     let client2 = builder.add_initial_chain(description2, Amount::ONE).await?;
     let client3 = builder.add_initial_chain(description3, Amount::ONE).await?;
 
-    // Use fast blocks by default on all chains.
+    // Configure the clients as super owners, so they make fast blocks by default.
     for client in [&client1, &client2, &client3] {
         let pub_key = client.public_key().await?;
         let owner_change_op = Operation::System(SystemOperation::ChangeOwnership {


### PR DESCRIPTION
## Motivation

Fast blocks must be deterministic, so no oracle calls are allowed. This goes for reading blobs (for the first time on this chain), too.

## Proposal

Remove the exception for reading blobs.

Automatically propose a regular block if we are super owner but the block uses oracles.

## Test Plan

The `test_propose_block_with_messages_and_blobs` test has been extended to assert the new behavior.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/2654
- Closes https://github.com/linera-io/linera-protocol/issues/2965
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
