### PR TITLE
Correct the termination of the end-to-end tests.

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -406,7 +406,7 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
     };
 
     // Setting up the validators
-    let (_net, client) = config.instantiate().await?;
+    let (net, client) = config.instantiate().await?;
     let chain = client.load_wallet()?.default_chain().unwrap();
 
     // Change the ownership so that the blocks inserted are not
@@ -465,6 +465,11 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
         (address1.clone(), U256::from(10)),
     ])
     .await;
+
+    node_service.ensure_is_running()?;
+
+    net.ensure_is_running().await?;
+    net.terminate().await?;
     Ok(())
 }
 

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -406,7 +406,7 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
     };
 
     // Setting up the validators
-    let (net, client) = config.instantiate().await?;
+    let (mut net, client) = config.instantiate().await?;
     let chain = client.load_wallet()?.default_chain().unwrap();
 
     // Change the ownership so that the blocks inserted are not
@@ -433,7 +433,7 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
         )
         .await?;
     let port = get_node_port().await;
-    let node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
+    let mut node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
 
     let app = EthereumTrackerApp(
         node_service
@@ -470,6 +470,7 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
 
     net.ensure_is_running().await?;
     net.terminate().await?;
+
     Ok(())
 }
 

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -194,7 +194,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
         )
         .await?;
 
-    if let Some(node_service_2) = node_service_2 {
+    if let Some(mut node_service_2) = node_service_2 {
         node_service_2.process_inbox(&chain_2).await?;
         let query = format!(
             "query {{ chain(chainId:\"{chain_2}\") {{
@@ -216,6 +216,8 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
         let committees = &response["chain"]["executionState"]["system"]["committees"];
         let epochs = committees.as_object().unwrap().keys().collect::<Vec<_>>();
         assert_eq!(&epochs, &["7"]);
+
+        node_service_2.ensure_is_running()?;
     } else {
         client_2.sync(chain_2).await?;
         client_2.process_inbox(chain_2).await?;
@@ -586,12 +588,14 @@ async fn test_project_publish(database: Database, network: Network) -> Result<()
     let chain = client.load_wallet()?.default_chain().unwrap();
 
     let port = get_node_port().await;
-    let node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
+    let mut node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
 
     assert_eq!(
         node_service.try_get_applications_uri(&chain).await?.len(),
         1
     );
+
+    node_service.ensure_is_running()?;
 
     net.ensure_is_running().await?;
     net.terminate().await?;
@@ -621,12 +625,14 @@ async fn test_example_publish(database: Database, network: Network) -> Result<()
     let chain = client.load_wallet()?.default_chain().unwrap();
 
     let port = get_node_port().await;
-    let node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
+    let mut node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
 
     assert_eq!(
         node_service.try_get_applications_uri(&chain).await?.len(),
         1
     );
+
+    node_service.ensure_is_running()?;
 
     net.ensure_is_running().await?;
     net.terminate().await?;
@@ -688,7 +694,7 @@ async fn test_storage_service_wallet_lock() -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
-    let (_net, client) = config.instantiate().await?;
+    let (mut net, client) = config.instantiate().await?;
 
     let wallet_state = WalletState::read_from_file(client.wallet_path().as_path())?;
     let chain_id = wallet_state.default_chain().unwrap();
@@ -698,6 +704,9 @@ async fn test_storage_service_wallet_lock() -> Result<()> {
 
     drop(lock);
     assert!(client.process_inbox(chain_id).await.is_ok());
+
+    net.ensure_is_running().await?;
+    net.terminate().await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

The end-to-end tests should end with the termination of the `net`. This was missing for one test of `linera_net_tests`.

## Proposal

The following was done to the tests in `linera_net_tests` and `local_net_tests`:
* If the test spawn a `node_service` then before the end of the test we have a `node_service.ensure_is_running()?`.
* If a `net` is spawned then at the end of the test we have a `net.ensure_is_running().await` and a `net.terminate`.

## Test Plan

The CI. The corrections should make the behavior of the tests more predictable.

## Release Plan

No impact.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
