### PR TITLE
Avoid build on linera net up --kubernetes

### DIFF
--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -1004,6 +1004,16 @@ pub enum NetCommand {
         #[arg(long, num_args=0..=1)]
         binaries: Option<Option<PathBuf>>,
 
+        /// Don't build docker image. This assumes that the image is already built.
+        #[cfg(feature = "kubernetes")]
+        #[arg(long, default_value = "false")]
+        no_build: bool,
+
+        /// The name of the docker image to use.
+        #[cfg(feature = "kubernetes")]
+        #[arg(long, default_value = "linera:latest")]
+        docker_image_name: String,
+
         /// Run with a specific path where the wallet and validator input files are.
         /// If none, then a temporary directory is created.
         #[arg(long)]

--- a/linera-service/src/cli_wrappers/docker.rs
+++ b/linera-service/src/cli_wrappers/docker.rs
@@ -17,7 +17,7 @@ impl DockerImage {
         &self.name
     }
 
-    pub async fn build(name: String, binaries: &BuildArg, github_root: &PathBuf) -> Result<Self> {
+    pub async fn build(name: &String, binaries: &BuildArg, github_root: &PathBuf) -> Result<Self> {
         let build_arg = match binaries {
             BuildArg::Directory(bin_path) => {
                 // Get the binaries from the specified path
@@ -73,12 +73,7 @@ impl DockerImage {
                 ),
             ]);
 
-        command
-            .arg(".")
-            .args(["-t", &name])
-            .spawn_and_wait()
-            .await?;
-
+        command.arg(".").args(["-t", name]).spawn_and_wait().await?;
         Ok(docker_image)
     }
 }

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1592,6 +1592,8 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                 policy_config,
                 kubernetes: true,
                 binaries,
+                no_build,
+                docker_image_name,
                 path: _,
                 storage: _,
                 external_protocol: _,
@@ -1604,6 +1606,8 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                     *shards,
                     *testing_prng_seed,
                     binaries,
+                    *no_build,
+                    docker_image_name.clone(),
                     policy_config.into_policy(),
                 )
                 .boxed()

--- a/linera-service/src/linera/net_up_utils.rs
+++ b/linera-service/src/linera/net_up_utils.rs
@@ -110,6 +110,8 @@ pub async fn handle_net_up_kubernetes(
     num_shards: usize,
     testing_prng_seed: Option<u64>,
     binaries: &Option<Option<PathBuf>>,
+    no_build: bool,
+    docker_image_name: String,
     policy: ResourceControlPolicy,
 ) -> anyhow::Result<()> {
     if num_initial_validators < 1 {
@@ -130,6 +132,8 @@ pub async fn handle_net_up_kubernetes(
         num_initial_validators,
         num_shards,
         binaries: binaries.clone().into(),
+        no_build,
+        docker_image_name,
         policy,
     };
     let (mut net, client1) = config.instantiate().await?;


### PR DESCRIPTION
## Motivation

When testing kubernetes related config changes locally with `linera net up --kubernetes`, there's no way to just use an existing docker image (if you're not testing something on the linera binaries, there's no need to rebuild the docker image every time)

## Proposal

Add options to skip building the image and just use an existing one. The name of the image to use also became a configurable option

## Test Plan

Ran `linera net up --kubernetes` locally with these new arguments

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
