### PR TITLE
Add `State` suffix to template's state type

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3688,7 +3688,6 @@ dependencies = [
  "linera-sdk",
  "log",
  "rand",
- "serde",
  "sha3",
  "tokenizers",
  "tokio",

--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -15,10 +15,10 @@ use linera_sdk::{
 use num_bigint::BigUint;
 use num_traits::{cast::FromPrimitive, ToPrimitive};
 
-use self::state::Amm;
+use self::state::AmmState;
 
 pub struct AmmContract {
-    state: Amm,
+    state: AmmState,
     runtime: ContractRuntime<Self>,
 }
 
@@ -34,7 +34,7 @@ impl Contract for AmmContract {
     type Parameters = Parameters;
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {
-        let state = Amm::load(runtime.root_view_storage_context())
+        let state = AmmState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         AmmContract { state, runtime }

--- a/examples/amm/src/service.rs
+++ b/examples/amm/src/service.rs
@@ -13,10 +13,10 @@ use linera_sdk::{
     base::WithServiceAbi, graphql::GraphQLMutationRoot, views::View, Service, ServiceRuntime,
 };
 
-use self::state::Amm;
+use self::state::AmmState;
 
 pub struct AmmService {
-    state: Arc<Amm>,
+    state: Arc<AmmState>,
 }
 
 linera_sdk::service!(AmmService);
@@ -29,7 +29,7 @@ impl Service for AmmService {
     type Parameters = Parameters;
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {
-        let state = Amm::load(runtime.root_view_storage_context())
+        let state = AmmState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         AmmService {

--- a/examples/amm/src/state.rs
+++ b/examples/amm/src/state.rs
@@ -9,7 +9,7 @@ use linera_sdk::{
 
 #[derive(RootView, async_graphql::SimpleObject)]
 #[view(context = "ViewStorageContext")]
-pub struct Amm {
+pub struct AmmState {
     pub shares: MapView<Account, Amount>,
     pub total_shares_supply: RegisterView<Amount>,
 }

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -12,10 +12,10 @@ use linera_sdk::{
     Contract, ContractRuntime,
 };
 
-use self::state::Counter;
+use self::state::CounterState;
 
 pub struct CounterContract {
-    state: Counter,
+    state: CounterState,
     runtime: ContractRuntime<Self>,
 }
 
@@ -31,7 +31,7 @@ impl Contract for CounterContract {
     type Parameters = ();
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {
-        let state = Counter::load(runtime.root_view_storage_context())
+        let state = CounterState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         CounterContract { state, runtime }
@@ -64,7 +64,7 @@ mod tests {
     use futures::FutureExt as _;
     use linera_sdk::{util::BlockingWait, views::View, Contract, ContractRuntime};
 
-    use super::{Counter, CounterContract};
+    use super::{CounterContract, CounterState};
 
     #[test]
     fn operation() {
@@ -117,7 +117,7 @@ mod tests {
     fn create_and_instantiate_counter(initial_value: u64) -> CounterContract {
         let runtime = ContractRuntime::new().with_application_parameters(());
         let mut contract = CounterContract {
-            state: Counter::load(runtime.root_view_storage_context())
+            state: CounterState::load(runtime.root_view_storage_context())
                 .blocking_wait()
                 .expect("Failed to read from mock key value store"),
             runtime,

--- a/examples/counter/src/service.rs
+++ b/examples/counter/src/service.rs
@@ -8,10 +8,10 @@ mod state;
 use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
 use linera_sdk::{base::WithServiceAbi, views::View, Service, ServiceRuntime};
 
-use self::state::Counter;
+use self::state::CounterState;
 
 pub struct CounterService {
-    state: Counter,
+    state: CounterState,
 }
 
 linera_sdk::service!(CounterService);
@@ -24,7 +24,7 @@ impl Service for CounterService {
     type Parameters = ();
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {
-        let state = Counter::load(runtime.root_view_storage_context())
+        let state = CounterState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         CounterService { state }
@@ -70,13 +70,13 @@ mod tests {
     use linera_sdk::{util::BlockingWait, views::View, Service, ServiceRuntime};
     use serde_json::json;
 
-    use super::{Counter, CounterService};
+    use super::{CounterService, CounterState};
 
     #[test]
     fn query() {
         let value = 61_098_721_u64;
         let runtime = ServiceRuntime::<CounterService>::new();
-        let mut state = Counter::load(runtime.root_view_storage_context())
+        let mut state = CounterState::load(runtime.root_view_storage_context())
             .blocking_wait()
             .expect("Failed to read from mock key value store");
         state.value.set(value);

--- a/examples/counter/src/state.rs
+++ b/examples/counter/src/state.rs
@@ -6,6 +6,6 @@ use linera_sdk::views::{linera_views, RegisterView, RootView, ViewStorageContext
 /// The application state.
 #[derive(RootView)]
 #[view(context = "ViewStorageContext")]
-pub struct Counter {
+pub struct CounterState {
     pub value: RegisterView<u64>,
 }

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -12,10 +12,10 @@ use linera_sdk::{
     views::{RootView, View},
     Contract, ContractRuntime,
 };
-use state::{CrowdFunding, Status};
+use state::{CrowdFundingState, Status};
 
 pub struct CrowdFundingContract {
-    state: CrowdFunding,
+    state: CrowdFundingState,
     runtime: ContractRuntime<Self>,
 }
 
@@ -31,7 +31,7 @@ impl Contract for CrowdFundingContract {
     type Parameters = ApplicationId<fungible::FungibleTokenAbi>;
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {
-        let state = CrowdFunding::load(runtime.root_view_storage_context())
+        let state = CrowdFundingState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         CrowdFundingContract { state, runtime }

--- a/examples/crowd-funding/src/service.rs
+++ b/examples/crowd-funding/src/service.rs
@@ -15,10 +15,10 @@ use linera_sdk::{
     views::View,
     Service, ServiceRuntime,
 };
-use state::CrowdFunding;
+use state::CrowdFundingState;
 
 pub struct CrowdFundingService {
-    state: Arc<CrowdFunding>,
+    state: Arc<CrowdFundingState>,
 }
 
 linera_sdk::service!(CrowdFundingService);
@@ -31,7 +31,7 @@ impl Service for CrowdFundingService {
     type Parameters = ApplicationId<fungible::FungibleTokenAbi>;
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {
-        let state = CrowdFunding::load(runtime.root_view_storage_context())
+        let state = CrowdFundingState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         CrowdFundingService {

--- a/examples/crowd-funding/src/state.rs
+++ b/examples/crowd-funding/src/state.rs
@@ -26,7 +26,7 @@ scalar!(Status);
 /// The crowd-funding campaign's state.
 #[derive(RootView, async_graphql::SimpleObject)]
 #[view(context = "ViewStorageContext")]
-pub struct CrowdFunding {
+pub struct CrowdFundingState {
     /// The status of the campaign.
     pub status: RegisterView<Status>,
     /// The map of pledges that will be collected if the campaign succeeds.

--- a/examples/ethereum-tracker/src/contract.rs
+++ b/examples/ethereum-tracker/src/contract.rs
@@ -13,10 +13,10 @@ use linera_sdk::{
     Contract, ContractRuntime,
 };
 
-use self::state::EthereumTracker;
+use self::state::EthereumTrackerState;
 
 pub struct EthereumTrackerContract {
-    state: EthereumTracker,
+    state: EthereumTrackerState,
     runtime: ContractRuntime<Self>,
 }
 
@@ -32,7 +32,7 @@ impl Contract for EthereumTrackerContract {
     type Parameters = ();
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {
-        let state = EthereumTracker::load(runtime.root_view_storage_context())
+        let state = EthereumTrackerState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         EthereumTrackerContract { state, runtime }

--- a/examples/ethereum-tracker/src/service.rs
+++ b/examples/ethereum-tracker/src/service.rs
@@ -13,11 +13,11 @@ use linera_sdk::{
     base::WithServiceAbi, graphql::GraphQLMutationRoot, views::View, Service, ServiceRuntime,
 };
 
-use self::state::EthereumTracker;
+use self::state::EthereumTrackerState;
 
 #[derive(Clone)]
 pub struct EthereumTrackerService {
-    state: Arc<EthereumTracker>,
+    state: Arc<EthereumTrackerState>,
 }
 
 linera_sdk::service!(EthereumTrackerService);
@@ -30,7 +30,7 @@ impl Service for EthereumTrackerService {
     type Parameters = ();
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {
-        let state = EthereumTracker::load(runtime.root_view_storage_context())
+        let state = EthereumTrackerState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         EthereumTrackerService {

--- a/examples/ethereum-tracker/src/state.rs
+++ b/examples/ethereum-tracker/src/state.rs
@@ -7,7 +7,7 @@ use linera_sdk::views::{linera_views, MapView, RegisterView, RootView, ViewStora
 /// The application state.
 #[derive(RootView, async_graphql::SimpleObject)]
 #[view(context = "ViewStorageContext")]
-pub struct EthereumTracker {
+pub struct EthereumTrackerState {
     pub ethereum_endpoint: RegisterView<String>,
     pub contract_address: RegisterView<String>,
     pub start_block: RegisterView<u64>,

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -16,10 +16,10 @@ use linera_sdk::{
     Contract, ContractRuntime,
 };
 
-use self::state::FungibleToken;
+use self::state::FungibleTokenState;
 
 pub struct FungibleTokenContract {
-    state: FungibleToken,
+    state: FungibleTokenState,
     runtime: ContractRuntime<Self>,
 }
 
@@ -35,7 +35,7 @@ impl Contract for FungibleTokenContract {
     type InstantiationArgument = InitialState;
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {
-        let state = FungibleToken::load(runtime.root_view_storage_context())
+        let state = FungibleTokenState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         FungibleTokenContract { state, runtime }

--- a/examples/fungible/src/service.rs
+++ b/examples/fungible/src/service.rs
@@ -16,11 +16,11 @@ use linera_sdk::{
     Service, ServiceRuntime,
 };
 
-use self::state::FungibleToken;
+use self::state::FungibleTokenState;
 
 #[derive(Clone)]
 pub struct FungibleTokenService {
-    state: Arc<FungibleToken>,
+    state: Arc<FungibleTokenState>,
     runtime: Arc<Mutex<ServiceRuntime<Self>>>,
 }
 
@@ -34,7 +34,7 @@ impl Service for FungibleTokenService {
     type Parameters = Parameters;
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {
-        let state = FungibleToken::load(runtime.root_view_storage_context())
+        let state = FungibleTokenState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         FungibleTokenService {

--- a/examples/fungible/src/state.rs
+++ b/examples/fungible/src/state.rs
@@ -10,12 +10,12 @@ use linera_sdk::{
 /// The application state.
 #[derive(RootView)]
 #[view(context = "ViewStorageContext")]
-pub struct FungibleToken {
+pub struct FungibleTokenState {
     pub accounts: MapView<AccountOwner, Amount>,
 }
 
 #[allow(dead_code)]
-impl FungibleToken {
+impl FungibleTokenState {
     /// Initializes the application state with some accounts with initial balances.
     pub(crate) async fn initialize_accounts(&mut self, state: InitialState) {
         for (k, v) in state.accounts {

--- a/examples/gen-nft/src/contract.rs
+++ b/examples/gen-nft/src/contract.rs
@@ -15,10 +15,10 @@ use linera_sdk::{
     Contract, ContractRuntime,
 };
 
-use self::state::GenNft;
+use self::state::GenNftState;
 
 pub struct GenNftContract {
-    state: GenNft,
+    state: GenNftState,
     runtime: ContractRuntime<Self>,
 }
 
@@ -34,7 +34,7 @@ impl Contract for GenNftContract {
     type Parameters = ();
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {
-        let state = GenNft::load(runtime.root_view_storage_context())
+        let state = GenNftState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         GenNftContract { state, runtime }

--- a/examples/gen-nft/src/service.rs
+++ b/examples/gen-nft/src/service.rs
@@ -24,11 +24,11 @@ use linera_sdk::{
 };
 use log::info;
 
-use self::state::GenNft;
+use self::state::GenNftState;
 use crate::model::ModelContext;
 
 pub struct GenNftService {
-    state: Arc<GenNft>,
+    state: Arc<GenNftState>,
     runtime: Arc<Mutex<ServiceRuntime<Self>>>,
 }
 
@@ -42,7 +42,7 @@ impl Service for GenNftService {
     type Parameters = ();
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {
-        let state = GenNft::load(runtime.root_view_storage_context())
+        let state = GenNftState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         GenNftService {
@@ -67,7 +67,7 @@ impl Service for GenNftService {
 }
 
 struct QueryRoot {
-    non_fungible_token: Arc<GenNft>,
+    non_fungible_token: Arc<GenNftState>,
 }
 
 #[Object]

--- a/examples/gen-nft/src/state.rs
+++ b/examples/gen-nft/src/state.rs
@@ -13,7 +13,7 @@ use linera_sdk::{
 /// The application state.
 #[derive(RootView, SimpleObject)]
 #[view(context = "ViewStorageContext")]
-pub struct GenNft {
+pub struct GenNftState {
     // Map from token ID to the NFT data
     pub nfts: MapView<TokenId, Nft>,
     // Map from owners to the set of NFT token IDs they own

--- a/examples/llm/Cargo.toml
+++ b/examples/llm/Cargo.toml
@@ -11,7 +11,6 @@ getrandom.workspace = true
 linera-sdk.workspace = true
 log.workspace = true
 rand.workspace = true
-serde.workspace = true
 sha3.workspace = true
 tokenizers.workspace = true
 

--- a/examples/llm/src/contract.rs
+++ b/examples/llm/src/contract.rs
@@ -3,8 +3,6 @@
 
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
-mod state;
-
 use linera_sdk::{base::WithContractAbi, Contract, ContractRuntime};
 
 pub struct LlmContract;

--- a/examples/llm/src/service.rs
+++ b/examples/llm/src/service.rs
@@ -4,7 +4,6 @@
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
 mod random;
-mod state;
 mod token;
 
 use std::{

--- a/examples/llm/src/state.rs
+++ b/examples/llm/src/state.rs
@@ -1,7 +1,0 @@
-// Copyright (c) Zefchain Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
-use serde::{Deserialize, Serialize};
-
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
-pub struct Llm {}

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -16,12 +16,12 @@ use matching_engine::{
     product_price_amount, MatchingEngineAbi, Message, Operation, Order, OrderId, OrderNature,
     Parameters, Price, PriceAsk, PriceBid,
 };
-use state::{LevelView, MatchingEngine};
+use state::{LevelView, MatchingEngineState};
 
 use crate::state::{KeyBook, OrderEntry};
 
 pub struct MatchingEngineContract {
-    state: MatchingEngine,
+    state: MatchingEngineState,
     runtime: ContractRuntime<Self>,
 }
 
@@ -57,7 +57,7 @@ impl Contract for MatchingEngineContract {
     type Parameters = Parameters;
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {
-        let state = MatchingEngine::load(runtime.root_view_storage_context())
+        let state = MatchingEngineState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         MatchingEngineContract { state, runtime }

--- a/examples/matching-engine/src/service.rs
+++ b/examples/matching-engine/src/service.rs
@@ -13,10 +13,10 @@ use linera_sdk::{
 };
 use matching_engine::{Operation, Parameters};
 
-use crate::state::MatchingEngine;
+use crate::state::MatchingEngineState;
 
 pub struct MatchingEngineService {
-    state: Arc<MatchingEngine>,
+    state: Arc<MatchingEngineState>,
 }
 
 linera_sdk::service!(MatchingEngineService);
@@ -29,7 +29,7 @@ impl Service for MatchingEngineService {
     type Parameters = Parameters;
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {
-        let state = MatchingEngine::load(runtime.root_view_storage_context())
+        let state = MatchingEngineState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         MatchingEngineService {

--- a/examples/matching-engine/src/state.rs
+++ b/examples/matching-engine/src/state.rs
@@ -60,7 +60,7 @@ pub struct LevelView {
 /// The matching engine containing the information.
 #[derive(RootView, SimpleObject)]
 #[view(context = "ViewStorageContext")]
-pub struct MatchingEngine {
+pub struct MatchingEngineState {
     ///The next_order_number contains the order_id so that
     ///the order_id gets created from 0, to infinity.
     pub next_order_number: RegisterView<OrderId>,

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -15,10 +15,10 @@ use linera_sdk::{
 };
 use non_fungible::{Message, Nft, NonFungibleTokenAbi, Operation, TokenId};
 
-use self::state::NonFungibleToken;
+use self::state::NonFungibleTokenState;
 
 pub struct NonFungibleTokenContract {
-    state: NonFungibleToken,
+    state: NonFungibleTokenState,
     runtime: ContractRuntime<Self>,
 }
 
@@ -34,7 +34,7 @@ impl Contract for NonFungibleTokenContract {
     type Parameters = ();
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {
-        let state = NonFungibleToken::load(runtime.root_view_storage_context())
+        let state = NonFungibleTokenState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         NonFungibleTokenContract { state, runtime }

--- a/examples/non-fungible/src/service.rs
+++ b/examples/non-fungible/src/service.rs
@@ -20,10 +20,10 @@ use linera_sdk::{
 };
 use non_fungible::{NftOutput, Operation, TokenId};
 
-use self::state::NonFungibleToken;
+use self::state::NonFungibleTokenState;
 
 pub struct NonFungibleTokenService {
-    state: Arc<NonFungibleToken>,
+    state: Arc<NonFungibleTokenState>,
     runtime: Arc<Mutex<ServiceRuntime<Self>>>,
 }
 
@@ -37,7 +37,7 @@ impl Service for NonFungibleTokenService {
     type Parameters = ();
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {
-        let state = NonFungibleToken::load(runtime.root_view_storage_context())
+        let state = NonFungibleTokenState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         NonFungibleTokenService {
@@ -61,7 +61,7 @@ impl Service for NonFungibleTokenService {
 }
 
 struct QueryRoot {
-    non_fungible_token: Arc<NonFungibleToken>,
+    non_fungible_token: Arc<NonFungibleTokenState>,
     runtime: Arc<Mutex<ServiceRuntime<NonFungibleTokenService>>>,
 }
 

--- a/examples/non-fungible/src/state.rs
+++ b/examples/non-fungible/src/state.rs
@@ -13,7 +13,7 @@ use non_fungible::{Nft, TokenId};
 /// The application state.
 #[derive(RootView, SimpleObject)]
 #[view(context = "ViewStorageContext")]
-pub struct NonFungibleToken {
+pub struct NonFungibleTokenState {
     // Map from token ID to the NFT data
     pub nfts: MapView<TokenId, Nft>,
     // Map from owners to the set of NFT token IDs they own

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -11,13 +11,13 @@ use linera_sdk::{
     Contract, ContractRuntime,
 };
 use social::{Comment, Key, Message, Operation, OwnPost, Post, SocialAbi};
-use state::Social;
+use state::SocialState;
 
 /// The channel name the application uses for cross-chain messages about new posts.
 const POSTS_CHANNEL_NAME: &[u8] = b"posts";
 
 pub struct SocialContract {
-    state: Social,
+    state: SocialState,
     runtime: ContractRuntime<Self>,
 }
 
@@ -33,7 +33,7 @@ impl Contract for SocialContract {
     type Parameters = ();
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {
-        let state = Social::load(runtime.root_view_storage_context())
+        let state = SocialState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         SocialContract { state, runtime }

--- a/examples/social/src/service.rs
+++ b/examples/social/src/service.rs
@@ -12,10 +12,10 @@ use linera_sdk::{
     base::WithServiceAbi, graphql::GraphQLMutationRoot, views::View, Service, ServiceRuntime,
 };
 use social::Operation;
-use state::Social;
+use state::SocialState;
 
 pub struct SocialService {
-    state: Arc<Social>,
+    state: Arc<SocialState>,
 }
 
 linera_sdk::service!(SocialService);
@@ -28,7 +28,7 @@ impl Service for SocialService {
     type Parameters = ();
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {
-        let state = Social::load(runtime.root_view_storage_context())
+        let state = SocialState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         SocialService {

--- a/examples/social/src/state.rs
+++ b/examples/social/src/state.rs
@@ -7,7 +7,7 @@ use social::{Key, OwnPost, Post};
 /// The application state.
 #[derive(RootView, async_graphql::SimpleObject)]
 #[view(context = "ViewStorageContext")]
-pub struct Social {
+pub struct SocialState {
     /// Our posts.
     pub own_posts: LogView<OwnPost>,
     /// Posts we received from authors we subscribed to.

--- a/linera-service/template/contract.rs.template
+++ b/linera-service/template/contract.rs.template
@@ -10,10 +10,10 @@ use linera_sdk::{{
 
 use {module_name}::Operation;
 
-use self::state::{project_name};
+use self::state::{project_name}State;
 
 pub struct {project_name}Contract {{
-    state: {project_name},
+    state: {project_name}State,
     runtime: ContractRuntime<Self>,
 }}
 
@@ -29,7 +29,7 @@ impl Contract for {project_name}Contract {{
     type InstantiationArgument = u64;
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {{
-        let state = {project_name}::load(runtime.root_view_storage_context())
+        let state = {project_name}State::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         {project_name}Contract {{ state, runtime }}
@@ -63,7 +63,7 @@ mod tests {{
 
     use linera_sdk::{{util::BlockingWait, views::View, Contract, ContractRuntime}};
 
-    use super::{{{project_name}, {project_name}Contract}};
+    use super::{{{project_name}State, {project_name}Contract}};
 
     #[test]
     fn operation() {{
@@ -83,7 +83,7 @@ mod tests {{
     fn create_and_instantiate_app(initial_value: u64) -> {project_name}Contract {{
         let runtime = ContractRuntime::new().with_application_parameters(());
         let mut contract = {project_name}Contract {{
-            state: {project_name}::load(runtime.root_view_storage_context())
+            state: {project_name}State::load(runtime.root_view_storage_context())
                 .blocking_wait()
                 .expect("Failed to read from mock key value store"),
             runtime,

--- a/linera-service/template/service.rs.template
+++ b/linera-service/template/service.rs.template
@@ -2,7 +2,7 @@
 
 mod state;
 
-use self::state::{project_name};
+use self::state::{project_name}State;
 use linera_sdk::{{
     base::WithServiceAbi,
     views::{{View, ViewStorageContext}},
@@ -14,7 +14,7 @@ use {module_name}::Operation;
 use async_graphql::{{EmptySubscription, Object, Schema}};
 
 pub struct {project_name}Service {{
-    state: {project_name},
+    state: {project_name}State,
     runtime: ServiceRuntime<Self>,
 }}
 
@@ -28,7 +28,7 @@ impl Service for {project_name}Service {{
     type Parameters = ();
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {{
-        let state = {project_name}::load(runtime.root_view_storage_context())
+        let state = {project_name}State::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         {project_name}Service {{ state, runtime }}

--- a/linera-service/template/state.rs.template
+++ b/linera-service/template/state.rs.template
@@ -2,7 +2,7 @@ use linera_sdk::views::{{linera_views, RegisterView, RootView, ViewStorageContex
 
 #[derive(RootView, async_graphql::SimpleObject)]
 #[view(context = "ViewStorageContext")]
-pub struct {project_name} {{
+pub struct {project_name}State {{
     pub value: RegisterView<u64>,
     // Add fields here.
 }}


### PR DESCRIPTION
The `Contract` and `Service` traits are no longer implemented for that type, so the type no longer represents the application itself. Make it clearer that the type just holds the application's persisted state.

## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
The state type originally represented the application, and implemented the `Contract` and `Service` traits. However, that is no longer the case, as there are now separate contract and service types. That means that the name used for the state type can be confusing.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Add a `State` suffix to the state type in the template for new applications.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
CI should catch if the changes to the template are valid.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do, these only affect new projects created with `linera project new` after a new version of the SDK is released.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
