### PR TITLE
Split APIs into per-certificate type endpoints

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -40,6 +40,18 @@ impl ValidatedBlock {
     pub fn to_log_str(&self) -> &'static str {
         "validated_block"
     }
+
+    pub fn chain_id(&self) -> ChainId {
+        self.executed_block.block.chain_id
+    }
+
+    pub fn height(&self) -> BlockHeight {
+        self.executed_block.block.height
+    }
+
+    pub fn epoch(&self) -> Epoch {
+        self.executed_block.block.epoch
+    }
 }
 
 impl BcsHashable for ValidatedBlock {}
@@ -156,6 +168,18 @@ impl Timeout {
 
     pub fn to_log_str(&self) -> &'static str {
         "timeout"
+    }
+
+    pub fn chain_id(&self) -> ChainId {
+        self.chain_id
+    }
+
+    pub fn height(&self) -> BlockHeight {
+        self.height
+    }
+
+    pub fn epoch(&self) -> Epoch {
+        self.epoch
     }
 }
 

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -67,7 +67,7 @@ pub trait ValidatorNode {
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError>;
 
-    /// Processes a certificate.
+    /// Processes a confirmed certificate.
     async fn handle_confirmed_certificate(
         &self,
         certificate: GenericCertificate<ConfirmedBlock>,
@@ -75,14 +75,14 @@ pub trait ValidatorNode {
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError>;
 
-    /// Processes a certificate.
+    /// Processes a validated certificate.
     async fn handle_validated_certificate(
         &self,
         certificate: GenericCertificate<ValidatedBlock>,
         blobs: Vec<Blob>,
     ) -> Result<ChainInfoResponse, NodeError>;
 
-    /// Processes a certificate.
+    /// Processes a timeout certificate.
     async fn handle_timeout_certificate(
         &self,
         certificate: GenericCertificate<Timeout>,

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -14,7 +14,10 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{BlockProposal, Origin},
-    types::{Certificate, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
+    types::{
+        ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate, Timeout,
+        ValidatedBlock,
+    },
     ChainError,
 };
 use linera_execution::{
@@ -28,7 +31,7 @@ use thiserror::Error;
 
 use crate::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
-    worker::{Notification, ProcessableCertificate, WorkerError},
+    worker::{Notification, WorkerError},
 };
 
 /// A pinned [`Stream`] of Notifications.
@@ -65,14 +68,25 @@ pub trait ValidatorNode {
     ) -> Result<ChainInfoResponse, NodeError>;
 
     /// Processes a certificate.
-    async fn handle_certificate<T: ProcessableCertificate>(
+    async fn handle_confirmed_certificate(
         &self,
-        certificate: GenericCertificate<T>,
+        certificate: GenericCertificate<ConfirmedBlock>,
         blobs: Vec<Blob>,
         delivery: CrossChainMessageDelivery,
-    ) -> Result<ChainInfoResponse, NodeError>
-    where
-        Certificate: From<GenericCertificate<T>>;
+    ) -> Result<ChainInfoResponse, NodeError>;
+
+    /// Processes a certificate.
+    async fn handle_validated_certificate(
+        &self,
+        certificate: GenericCertificate<ValidatedBlock>,
+        blobs: Vec<Blob>,
+    ) -> Result<ChainInfoResponse, NodeError>;
+
+    /// Processes a certificate.
+    async fn handle_timeout_certificate(
+        &self,
+        certificate: GenericCertificate<Timeout>,
+    ) -> Result<ChainInfoResponse, NodeError>;
 
     /// Handles information queries for this chain.
     async fn handle_chain_info_query(

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -107,7 +107,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
     }
 
     pub(crate) async fn handle_optimized_validated_certificate(
-        &self,
+        &mut self,
         certificate: &ValidatedBlockCertificate,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, NodeError> {
@@ -130,7 +130,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
     }
 
     pub(crate) async fn handle_optimized_confirmed_certificate(
-        &self,
+        &mut self,
         certificate: &ConfirmedBlockCertificate,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, NodeError> {

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -107,7 +107,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
     }
 
     pub(crate) async fn handle_optimized_validated_certificate(
-        &mut self,
+        &self,
         certificate: &ValidatedBlockCertificate,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, NodeError> {
@@ -130,7 +130,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
     }
 
     pub(crate) async fn handle_optimized_confirmed_certificate(
-        &mut self,
+        &self,
         certificate: &ConfirmedBlockCertificate,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, NodeError> {

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -106,28 +106,6 @@ impl<N: ValidatorNode> RemoteNode<N> {
         self.check_and_return_info(response, chain_id)
     }
 
-    pub(crate) async fn handle_optimized_timeout_certificate(
-        &mut self,
-        certificate: &TimeoutCertificate,
-        delivery: CrossChainMessageDelivery,
-    ) -> Result<Box<ChainInfo>, NodeError> {
-        if certificate.is_signed_by(&self.name) {
-            let result = self
-                .handle_lite_certificate(certificate.lite_certificate(), delivery)
-                .await;
-            match result {
-                Err(NodeError::MissingCertificateValue) => {
-                    warn!(
-                        "Validator {} forgot a certificate value that they signed before",
-                        self.name
-                    );
-                }
-                _ => return result,
-            }
-        }
-        self.handle_timeout_certificate(certificate.clone()).await
-    }
-
     pub(crate) async fn handle_optimized_validated_certificate(
         &mut self,
         certificate: &ValidatedBlockCertificate,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1823,11 +1823,7 @@ where
     let validated_block_certificate = *manager.requested_locked.unwrap();
     let resubmission_result = builder
         .node(2)
-        .handle_certificate(
-            validated_block_certificate,
-            Vec::new(),
-            CrossChainMessageDelivery::Blocking,
-        )
+        .handle_validated_certificate(validated_block_certificate, Vec::new())
         .await;
     assert!(resubmission_result.is_err());
 
@@ -1895,11 +1891,7 @@ where
     let validated_block_certificate = *manager.requested_locked.unwrap();
     let resubmission_result = builder
         .node(3)
-        .handle_certificate(
-            validated_block_certificate,
-            Vec::new(),
-            CrossChainMessageDelivery::Blocking,
-        )
+        .handle_validated_certificate(validated_block_certificate, Vec::new())
         .await;
     assert!(resubmission_result.is_err());
 
@@ -2299,11 +2291,7 @@ where
     let validated_block_certificate = *manager.requested_locked.unwrap();
     builder
         .node(0)
-        .handle_certificate(
-            validated_block_certificate,
-            Vec::new(),
-            CrossChainMessageDelivery::Blocking,
-        )
+        .handle_validated_certificate(validated_block_certificate, Vec::new())
         .await
         .unwrap();
 

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -153,9 +153,10 @@ where
     let publish_certificate = make_certificate(&committee, &worker, publish_block_proposal);
 
     let info = worker
-        .fully_handle_certificate(
+        .fully_handle_certificate_with_notifications(
             publish_certificate.clone(),
             vec![contract_blob.clone(), service_blob.clone()],
+            &(),
         )
         .await
         .unwrap()
@@ -239,7 +240,7 @@ where
     let create_certificate = make_certificate(&committee, &worker, create_block_proposal);
 
     let info = worker
-        .fully_handle_certificate(create_certificate.clone(), vec![])
+        .fully_handle_certificate_with_notifications(create_certificate.clone(), vec![], &())
         .await
         .unwrap()
         .info;
@@ -292,7 +293,7 @@ where
     let run_certificate = make_certificate(&committee, &worker, run_block_proposal);
 
     let info = worker
-        .fully_handle_certificate(run_certificate.clone(), vec![])
+        .fully_handle_certificate_with_notifications(run_certificate.clone(), vec![], &())
         .await
         .unwrap()
         .info;

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -562,7 +562,7 @@ where
         make_certificate(&committee, &worker, value)
     };
     worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
         .await?;
 
     {
@@ -1303,7 +1303,7 @@ where
     .await;
     assert_matches!(
         worker
-            .fully_handle_certificate(certificate, vec![])
+            .fully_handle_certificate_with_notifications(certificate, vec![], &())
             .await,
         Err(WorkerError::ChainError(error)) if matches!(*error, ChainError::InactiveChain {..})
     );
@@ -1381,7 +1381,7 @@ where
     ));
     let certificate = make_certificate(&committee, &worker, value);
     let info = worker
-        .fully_handle_certificate(certificate, vec![])
+        .fully_handle_certificate_with_notifications(certificate, vec![], &())
         .await?
         .info;
     assert_eq!(info.next_block_height, BlockHeight::from(1));
@@ -1427,7 +1427,9 @@ where
     // This fails because `make_simple_transfer_certificate` uses `sender_key_pair.public()` to
     // compute the hash of the execution state.
     assert_matches!(
-        worker.fully_handle_certificate(certificate, vec![]).await,
+        worker
+            .fully_handle_certificate_with_notifications(certificate, vec![], &())
+            .await,
         Err(WorkerError::IncorrectOutcome { .. })
     );
     Ok(())
@@ -1473,9 +1475,11 @@ where
     .await;
     // Replays are ignored.
     worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
         .await?;
-    worker.fully_handle_certificate(certificate, vec![]).await?;
+    worker
+        .fully_handle_certificate_with_notifications(certificate, vec![], &())
+        .await?;
     Ok(())
 }
 
@@ -1532,7 +1536,7 @@ where
     )
     .await;
     worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
         .await?;
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
@@ -1622,7 +1626,7 @@ where
     )
     .await;
     worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
         .await?;
     let new_sender_chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(new_sender_chain.is_active());
@@ -1678,7 +1682,7 @@ where
     )
     .await;
     worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
         .await?;
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
@@ -1949,7 +1953,7 @@ where
     .await;
 
     let info = worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
         .await?
         .info;
     assert_eq!(ChainId::root(1), info.chain_id);
@@ -1992,7 +1996,7 @@ where
     )
     .await;
     worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
         .await?;
 
     assert_eq!(
@@ -2075,7 +2079,7 @@ where
     .await;
 
     let info = worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
         .await?
         .info;
     assert_eq!(ChainId::root(1), info.chain_id);
@@ -2146,7 +2150,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate(certificate00.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate00.clone(), vec![], &())
         .await?;
 
     let certificate01 = make_transfer_certificate(
@@ -2180,7 +2184,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate(certificate01.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate01.clone(), vec![], &())
         .await?;
 
     {
@@ -2206,7 +2210,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate(certificate1.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate1.clone(), vec![], &())
         .await?;
 
     let certificate2 = make_transfer_certificate(
@@ -2225,7 +2229,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate(certificate2.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate2.clone(), vec![], &())
         .await?;
 
     // Reject the first transfer and try to use the money of the second one.
@@ -2278,7 +2282,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
         .await?;
 
     {
@@ -2319,7 +2323,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate(certificate3.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate3.clone(), vec![], &())
         .await?;
 
     {
@@ -2423,7 +2427,7 @@ where
         )),
     );
     worker
-        .fully_handle_certificate(certificate0.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate0.clone(), vec![], &())
         .await?;
     {
         let admin_chain = worker.chain_state_view(admin_id).await?;
@@ -2485,7 +2489,7 @@ where
         )),
     );
     worker
-        .fully_handle_certificate(certificate1.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate1.clone(), vec![], &())
         .await?;
 
     {
@@ -2637,7 +2641,7 @@ where
         )),
     );
     worker
-        .fully_handle_certificate(certificate3, vec![])
+        .fully_handle_certificate_with_notifications(certificate3, vec![], &())
         .await?;
     {
         let user_chain = worker.chain_state_view(user_id).await?;
@@ -2776,12 +2780,12 @@ where
         )),
     );
     worker
-        .fully_handle_certificate(certificate1.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate1.clone(), vec![], &())
         .await?;
 
     // Try to execute the transfer.
     worker
-        .fully_handle_certificate(certificate0.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate0.clone(), vec![], &())
         .await?;
 
     // The transfer was started..
@@ -2913,12 +2917,12 @@ where
         )),
     );
     worker
-        .fully_handle_certificate(certificate1.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate1.clone(), vec![], &())
         .await?;
 
     // Try to execute the transfer from the user chain to the admin chain.
     worker
-        .fully_handle_certificate(certificate0.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate0.clone(), vec![], &())
         .await?;
 
     {
@@ -2981,7 +2985,7 @@ where
         )),
     );
     worker
-        .fully_handle_certificate(certificate2.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate2.clone(), vec![], &())
         .await?;
 
     {
@@ -2997,7 +3001,7 @@ where
     // Try again to execute the transfer from the user chain to the admin chain.
     // This time, the epoch verification should be overruled.
     worker
-        .fully_handle_certificate(certificate0.clone(), vec![])
+        .fully_handle_certificate_with_notifications(certificate0.clone(), vec![], &())
         .await?;
 
     {
@@ -3261,7 +3265,7 @@ where
     let value0 = Hashed::new(ConfirmedBlock::new(executed_block0));
     let certificate0 = make_certificate(&committee, &worker, value0.clone());
     let response = worker
-        .fully_handle_certificate(certificate0, vec![])
+        .fully_handle_certificate_with_notifications(certificate0, vec![], &())
         .await?;
 
     // The leader sequence is pseudorandom but deterministic. The first leader is owner 1.
@@ -3467,7 +3471,7 @@ where
     let value0 = Hashed::new(ConfirmedBlock::new(executed_block0));
     let certificate0 = make_certificate(&committee, &worker, value0.clone());
     let response = worker
-        .fully_handle_certificate(certificate0, vec![])
+        .fully_handle_certificate_with_notifications(certificate0, vec![], &())
         .await?;
 
     // The first round is the fast-block round, and owner 0 is a super owner.
@@ -3555,7 +3559,7 @@ where
     let value0 = Hashed::new(ConfirmedBlock::new(executed_block0));
     let certificate0 = make_certificate(&committee, &worker, value0.clone());
     let response = worker
-        .fully_handle_certificate(certificate0, vec![])
+        .fully_handle_certificate_with_notifications(certificate0, vec![], &())
         .await?;
 
     // The first round is the fast-block round, and owner 0 is a super owner.
@@ -3665,7 +3669,9 @@ where
     let (executed_block, _) = worker.stage_block_execution(block).await?;
     let value = Hashed::new(ConfirmedBlock::new(executed_block));
     let certificate = make_certificate(&committee, &worker, value);
-    worker.fully_handle_certificate(certificate, vec![]).await?;
+    worker
+        .fully_handle_certificate_with_notifications(certificate, vec![], &())
+        .await?;
 
     // The message only just arrived: No fallback mode.
     let (response, _) = worker.handle_chain_info_query(query.clone()).await?;
@@ -3680,7 +3686,7 @@ where
     assert_eq!(vote.value.value_hash, value.hash());
     assert_eq!(vote.round, round);
     let certificate = make_certificate_with_round(&committee, &worker, value, round);
-    worker.fully_handle_certificate(certificate, vec![]).await?;
+    worker.handle_timeout_certificate(certificate).await?;
 
     // Now we are in fallback mode, and the validator is the leader.
     let (response, _) = worker.handle_chain_info_query(query.clone()).await?;

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -7,6 +7,7 @@ use std::{
     fmt,
     hash::Hash,
     ops::Range,
+    sync::Arc,
 };
 
 use futures::{stream, stream::TryStreamExt, Future, StreamExt};
@@ -17,12 +18,14 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{BlockProposal, LiteVote},
-    types::{ConfirmedBlockCertificate, TimeoutCertificate, ValidatedBlockCertificate},
+    types::{
+        ConfirmedBlockCertificate, GenericCertificate, TimeoutCertificate,
+        ValidatedBlockCertificate,
+    },
 };
 use linera_execution::committee::Committee;
 use linera_storage::Storage;
 use thiserror::Error;
-use tracing::warn;
 
 use crate::{
     client::ChainClientError,
@@ -30,6 +33,7 @@ use crate::{
     local_node::LocalNodeClient,
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
     remote_node::RemoteNode,
+    worker::ProcessableCertificate,
 };
 
 /// The amount of time we wait for additional validators to contribute to the result, as a fraction
@@ -206,56 +210,38 @@ where
 
 impl<A, S> ValidatorUpdater<A, S>
 where
-    A: ValidatorNode + Clone + 'static,
+    A: ValidatorNode + Clone + 'static + Sync,
     S: Storage + Clone + Send + Sync + 'static,
 {
+    async fn send_certificate<T: ProcessableCertificate>(
+        &mut self,
+        certificate: GenericCertificate<T>,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<Box<ChainInfo>, ChainClientError> {
+        ProcessableCertificate::dispatch_certificate(
+            Arc::new(self.remote_node.clone()),
+            self.local_node.clone(),
+            certificate,
+            delivery,
+        )
+        .await
+        .map_err(Into::into)
+    }
+
     async fn send_confirmed_certificate(
         &mut self,
         certificate: ConfirmedBlockCertificate,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, ChainClientError> {
-        let result = self
-            .remote_node
-            .handle_optimized_confirmed_certificate(&certificate, delivery)
-            .await;
-
-        Ok(match &result {
-            Err(original_err @ NodeError::BlobsNotFound(blob_ids)) => {
-                self.remote_node
-                    .check_blobs_not_found(&certificate, blob_ids)?;
-
-                let blobs = self
-                    .local_node
-                    .find_missing_blobs(blob_ids.clone(), certificate.inner().chain_id())
-                    .await?
-                    .ok_or_else(|| original_err.clone())?;
-                self.remote_node
-                    .handle_confirmed_certificate(certificate, blobs, delivery)
-                    .await
-            }
-            _ => result,
-        }?)
+        self.send_certificate(certificate, delivery).await
     }
 
     async fn send_timeout_certificate(
         &mut self,
         certificate: TimeoutCertificate,
     ) -> Result<Box<ChainInfo>, ChainClientError> {
-        let result = self
-            .remote_node
-            .handle_timeout_certificate(certificate)
-            .await;
-
-        match &result {
-            Err(original_err @ NodeError::BlobsNotFound(blob_ids)) => {
-                warn!(
-                    "BlobsNotFound error while handling a timeout certificate: {:?}",
-                    blob_ids
-                );
-                Err(ChainClientError::RemoteNodeError(original_err.clone()))
-            }
-            _ => Ok(result?),
-        }
+        self.send_certificate(certificate, CrossChainMessageDelivery::default())
+            .await
     }
 
     async fn send_validated_certificate(
@@ -263,27 +249,7 @@ where
         certificate: ValidatedBlockCertificate,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, ChainClientError> {
-        let result = self
-            .remote_node
-            .handle_optimized_validated_certificate(&certificate, delivery)
-            .await;
-
-        Ok(match &result {
-            Err(original_err @ NodeError::BlobsNotFound(blob_ids)) => {
-                self.remote_node
-                    .check_blobs_not_found(&certificate, blob_ids)?;
-
-                let blobs = self
-                    .local_node
-                    .find_missing_blobs(blob_ids.clone(), certificate.inner().chain_id())
-                    .await?
-                    .ok_or_else(|| original_err.clone())?;
-                self.remote_node
-                    .handle_validated_certificate(certificate, blobs)
-                    .await
-            }
-            _ => result,
-        }?)
+        self.send_certificate(certificate, delivery).await
     }
 
     async fn send_block_proposal(

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -22,7 +22,7 @@ use linera_chain::{
 use linera_execution::committee::Committee;
 use linera_storage::Storage;
 use thiserror::Error;
-use tracing::{error, warn};
+use tracing::warn;
 
 use crate::{
     client::ChainClientError,
@@ -240,11 +240,10 @@ where
     async fn send_timeout_certificate(
         &mut self,
         certificate: TimeoutCertificate,
-        delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, ChainClientError> {
         let result = self
             .remote_node
-            .handle_optimized_timeout_certificate(&certificate, delivery)
+            .handle_timeout_certificate(certificate)
             .await;
 
         match &result {
@@ -374,8 +373,7 @@ where
         }
         if let Some(cert) = manager.timeout {
             if cert.inner().chain_id == chain_id {
-                self.send_timeout_certificate(cert, CrossChainMessageDelivery::NonBlocking)
-                    .await?;
+                self.send_timeout_certificate(cert).await?;
             }
         }
         Ok(())

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -462,24 +462,9 @@ impl<StorageClient> WorkerState<StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
 {
-    // NOTE: This only works for non-sharded workers!
-    #[instrument(level = "trace", skip(self, certificate, blobs))]
-    #[cfg(with_testing)]
-    pub async fn fully_handle_certificate<T>(
-        &self,
-        certificate: GenericCertificate<T>,
-        blobs: Vec<Blob>,
-    ) -> Result<ChainInfoResponse, WorkerError>
-    where
-        T: ProcessableCertificate,
-    {
-        self.fully_handle_certificate_with_notifications(certificate, blobs, &())
-            .await
-    }
-
     #[instrument(level = "trace", skip(self, certificate, notifier))]
     #[inline]
-    pub(crate) async fn fully_handle_certificate_with_notifications<T>(
+    pub async fn fully_handle_certificate_with_notifications<T>(
         &self,
         certificate: GenericCertificate<T>,
         blobs: Vec<Blob>,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -53,9 +53,13 @@ use {
 
 use crate::{
     chain_worker::{ChainWorkerActor, ChainWorkerConfig, ChainWorkerRequest, DeliveryNotifier},
-    data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
+    client::ChainClientError,
+    data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     join_set_ext::{JoinSet, JoinSetExt},
+    local_node::LocalNodeClient,
+    node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
     notifier::Notifier,
+    remote_node::RemoteNode,
     value_cache::ValueCache,
 };
 
@@ -422,6 +426,16 @@ pub trait ProcessableCertificate: CertificateValueT + Sized + 'static {
         certificate: GenericCertificate<Self>,
         blobs: Vec<Blob>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError>;
+
+    async fn dispatch_certificate<
+        A: ValidatorNode + Clone + 'static + Sync,
+        S: Storage + Clone + Send + Sync + 'static,
+    >(
+        remote_node: Arc<RemoteNode<A>>,
+        local_node: LocalNodeClient<S>,
+        certificate: GenericCertificate<Self>,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<Box<ChainInfo>, ChainClientError>;
 }
 
 impl ProcessableCertificate for ConfirmedBlock {
@@ -433,6 +447,35 @@ impl ProcessableCertificate for ConfirmedBlock {
         worker
             .handle_confirmed_certificate(certificate, blobs, None)
             .await
+    }
+
+    async fn dispatch_certificate<
+        A: ValidatorNode + Clone + 'static + Sync,
+        S: Storage + Clone + Send + Sync + 'static,
+    >(
+        remote_node: Arc<RemoteNode<A>>,
+        local_node: LocalNodeClient<S>,
+        certificate: ConfirmedBlockCertificate,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<Box<ChainInfo>, ChainClientError> {
+        let result = remote_node
+            .handle_optimized_confirmed_certificate(&certificate, delivery)
+            .await;
+
+        Ok(match &result {
+            Err(original_err @ NodeError::BlobsNotFound(blob_ids)) => {
+                remote_node.check_blobs_not_found(&certificate, blob_ids)?;
+
+                let blobs = local_node
+                    .find_missing_blobs(blob_ids.clone(), certificate.inner().chain_id())
+                    .await?
+                    .ok_or_else(|| original_err.clone())?;
+                remote_node
+                    .handle_confirmed_certificate(certificate, blobs, delivery)
+                    .await
+            }
+            _ => result,
+        }?)
     }
 }
 
@@ -446,6 +489,35 @@ impl ProcessableCertificate for ValidatedBlock {
             .handle_validated_certificate(certificate, blobs)
             .await
     }
+
+    async fn dispatch_certificate<
+        A: ValidatorNode + Clone + 'static + Sync + Send,
+        S: Storage + Clone + Send + Sync + 'static,
+    >(
+        remote_node: Arc<RemoteNode<A>>,
+        local_node: LocalNodeClient<S>,
+        certificate: ValidatedBlockCertificate,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<Box<ChainInfo>, ChainClientError> {
+        let result = remote_node
+            .handle_optimized_validated_certificate(&certificate, delivery)
+            .await;
+
+        Ok(match &result {
+            Err(original_err @ NodeError::BlobsNotFound(blob_ids)) => {
+                remote_node.check_blobs_not_found(&certificate, blob_ids)?;
+
+                let blobs = local_node
+                    .find_missing_blobs(blob_ids.clone(), certificate.inner().chain_id())
+                    .await?
+                    .ok_or_else(|| original_err.clone())?;
+                remote_node
+                    .handle_validated_certificate(certificate, blobs)
+                    .await
+            }
+            _ => result,
+        }?)
+    }
 }
 
 impl ProcessableCertificate for Timeout {
@@ -455,6 +527,29 @@ impl ProcessableCertificate for Timeout {
         _blobs: Vec<Blob>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         worker.handle_timeout_certificate(certificate).await
+    }
+
+    async fn dispatch_certificate<
+        A: ValidatorNode + Clone + 'static + Sync + Send,
+        S: Storage + Clone + Send + Sync + 'static,
+    >(
+        remote_node: Arc<RemoteNode<A>>,
+        _local_node: LocalNodeClient<S>,
+        certificate: TimeoutCertificate,
+        _delivery: CrossChainMessageDelivery,
+    ) -> Result<Box<ChainInfo>, ChainClientError> {
+        let result = remote_node.handle_timeout_certificate(certificate).await;
+
+        match &result {
+            Err(original_err @ NodeError::BlobsNotFound(blob_ids)) => {
+                warn!(
+                    "BlobsNotFound error while handling a timeout certificate: {:?}",
+                    blob_ids
+                );
+                Err(ChainClientError::RemoteNodeError(original_err.clone()))
+            }
+            _ => Ok(result?),
+        }
     }
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -26,9 +26,8 @@ use linera_chain::{
         Block, BlockExecutionOutcome, BlockProposal, ExecutedBlock, MessageBundle, Origin, Target,
     },
     types::{
-        Certificate, CertificateValueT, ConfirmedBlock, ConfirmedBlockCertificate,
-        GenericCertificate, Hashed, LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock,
-        ValidatedBlockCertificate,
+        CertificateValueT, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate, Hashed,
+        LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock, ValidatedBlockCertificate,
     },
     ChainError, ChainStateView,
 };
@@ -629,7 +628,7 @@ where
         .await
     }
 
-    /// Returns a stored [`Certificate`] for a chain's block.
+    /// Returns a stored [`ConfirmedBlockCertificate`] for a chain's block.
     #[instrument(level = "trace", skip(self, chain_id, height))]
     #[cfg(with_testing)]
     pub async fn read_certificate(
@@ -824,34 +823,6 @@ where
                 .await
             }
             Either::Right(validated) => self.handle_validated_certificate(validated, vec![]).await,
-        }
-    }
-
-    /// Processes a certificate.
-    #[instrument(skip_all, fields(
-        nick = self.nickname,
-        chain_id = format!("{:.8}", certificate.chain_id()),
-        height = %certificate.height(),
-    ))]
-    pub async fn handle_certificate(
-        &self,
-        certificate: Certificate,
-        blobs: Vec<Blob>,
-        notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
-    ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
-        match certificate {
-            Certificate::Confirmed(confirmed) => {
-                self.handle_confirmed_certificate(
-                    confirmed,
-                    blobs,
-                    notify_when_messages_are_delivered,
-                )
-                .await
-            }
-            Certificate::Validated(validated) => {
-                self.handle_validated_certificate(validated, blobs).await
-            }
-            Certificate::Timeout(timeout) => self.handle_timeout_certificate(timeout).await,
         }
     }
 

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -236,11 +236,11 @@ message HandleValidatedCertificateRequest {
   // The ID of the chain (used for routing).
   ChainId chain_id = 1;
 
+  // A certified statement from the committee.
+  Certificate certificate = 2;
+
   // Blobs required by this certificate
   bytes blobs = 3;
-
-  // A certified statement from the committee.
-  Certificate certificate = 4;
 }
 
 // A certified statement from the committee, together with other certificates
@@ -249,15 +249,15 @@ message HandleConfirmedCertificateRequest {
   // The ID of the chain (used for routing).
   ChainId chain_id = 1;
 
+  // A certified statement from the committee.
+  Certificate certificate = 2;
+
   // Wait until all outgoing cross-chain messages from this certificate have
   // been received by the target chains.
-  bool wait_for_outgoing_messages = 2;
+  bool wait_for_outgoing_messages = 3;
 
   // Blobs required by this certificate
-  bytes blobs = 3;
-
-  // A certified statement from the committee.
-  Certificate certificate = 4;
+  bytes blobs = 4;
 }
 
 // A certified statement from the committee.
@@ -271,12 +271,16 @@ message Certificate {
   // Signatures on the value hash and round
   bytes signatures = 3;
 
+  // The kind of certificate serialized in `value` field.
   CertificateKind kind = 4;
 }
 
 enum CertificateKind {
+  // Certificate for a timeout vote.
   Timeout = 0;
+  // Certificate for a validated block.
   Validated = 1;
+  // Certificate for a confirmed block.
   Confirmed = 2;
 }
 

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -22,8 +22,11 @@ service ValidatorWorker {
   // Process a certificate without value.
   rpc HandleLiteCertificate(LiteCertificate) returns (ChainInfoResult);
 
-  // Process a certificate.
-  rpc HandleCertificate(HandleCertificateRequest) returns (ChainInfoResult);
+  rpc HandleConfirmedCertificate(HandleConfirmedCertificateRequest) returns (ChainInfoResult);
+
+  rpc HandleValidatedCertificate(HandleValidatedCertificateRequest) returns (ChainInfoResult);
+
+  rpc HandleTimeoutCertificate(HandleTimeoutCertificateRequest) returns (ChainInfoResult);
 
   // Handle information queries for this chain.
   rpc HandleChainInfoQuery(ChainInfoQuery) returns (ChainInfoResult);
@@ -40,8 +43,11 @@ service ValidatorNode {
   // Process a certificate without value.
   rpc HandleLiteCertificate(LiteCertificate) returns (ChainInfoResult);
 
-  // Process a certificate.
-  rpc HandleCertificate(HandleCertificateRequest) returns (ChainInfoResult);
+  rpc HandleConfirmedCertificate(HandleConfirmedCertificateRequest) returns (ChainInfoResult);
+
+  rpc HandleValidatedCertificate(HandleValidatedCertificateRequest) returns (ChainInfoResult);
+
+  rpc HandleTimeoutCertificate(HandleTimeoutCertificateRequest) returns (ChainInfoResult);
 
   // Handle information queries for this chain.
   rpc HandleChainInfoQuery(ChainInfoQuery) returns (ChainInfoResult);
@@ -216,7 +222,30 @@ message LiteCertificate {
 
 // A certified statement from the committee, together with other certificates
 // required for execution.
-message HandleCertificateRequest {
+message HandleTimeoutCertificateRequest {
+  // The ID of the chain (used for routing).
+  ChainId chain_id = 1;
+
+  // A certified statement from the committee.
+  Certificate certificate = 4;
+}
+
+// A certified statement from the committee, together with other certificates
+// required for execution.
+message HandleValidatedCertificateRequest {
+  // The ID of the chain (used for routing).
+  ChainId chain_id = 1;
+
+  // Blobs required by this certificate
+  bytes blobs = 3;
+
+  // A certified statement from the committee.
+  Certificate certificate = 4;
+}
+
+// A certified statement from the committee, together with other certificates
+// required for execution.
+message HandleConfirmedCertificateRequest {
   // The ID of the chain (used for routing).
   ChainId chain_id = 1;
 
@@ -242,20 +271,13 @@ message Certificate {
   // Signatures on the value hash and round
   bytes signatures = 3;
 
-  // The type of the `value` field.
-  CertificateType kind = 4;
+  CertificateKind kind = 4;
 }
 
-// Type of the value within the certificate.
-enum CertificateType {
-  // A value for validated block.
-  ValidatedBlock = 0;
-
-  // A value for confirmed block.
-  ConfirmedBlock = 1;
-
-  // A value for a timeout message.
-  Timeout = 2;
+enum CertificateKind {
+  Timeout = 0;
+  Validated = 1;
+  Confirmed = 2;
 }
 
 message ChainId {

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -538,7 +538,7 @@ where
                 #[cfg(with_metrics)]
                 {
                     SERVER_REQUEST_ERROR
-                        .with_label_values(&["handle_certificate"])
+                        .with_label_values(&["handle_confirmed_certificate"])
                         .inc();
                 }
                 error!(nickname = self.state.nickname(), %error, "Failed to handle confirmed certificate");
@@ -563,7 +563,7 @@ where
             .await
         {
             Ok((info, actions)) => {
-                Self::log_request_success_and_latency(start, "handle_certificate");
+                Self::log_request_success_and_latency(start, "handle_validated_certificate");
                 self.handle_network_actions(actions);
                 Ok(Response::new(info.try_into()?))
             }

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -431,7 +431,15 @@ impl<S> ValidatorWorkerRpc for GrpcServer<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    #[instrument(target = "grpc_server", skip_all, err, fields(nickname = self.state.nickname(), chain_id = ?request.get_ref().chain_id()))]
+    #[instrument(
+        target = "grpc_server",
+        skip_all,
+        err,
+        fields(
+            nickname = self.state.nickname(),
+            chain_id = ?request.get_ref().chain_id()
+        )
+    )]
     async fn handle_block_proposal(
         &self,
         request: Request<BlockProposal>,
@@ -460,7 +468,15 @@ where
         ))
     }
 
-    #[instrument(target = "grpc_server", skip_all, err, fields(nickname = self.state.nickname(), chain_id = ?request.get_ref().chain_id()))]
+    #[instrument(
+        target = "grpc_server",
+        skip_all,
+        err,
+        fields(
+            nickname = self.state.nickname(),
+            chain_id = ?request.get_ref().chain_id()
+        )
+    )]
     async fn handle_lite_certificate(
         &self,
         request: Request<LiteCertificate>,
@@ -505,7 +521,15 @@ where
         }
     }
 
-    #[instrument(target = "grpc_server", skip_all, err, fields(nickname = self.state.nickname(), chain_id = ?request.get_ref().chain_id()))]
+    #[instrument(
+        target = "grpc_server",
+        skip_all,
+        err,
+        fields(
+            nickname = self.state.nickname(),
+            chain_id = ?request.get_ref().chain_id()
+        )
+    )]
     async fn handle_confirmed_certificate(
         &self,
         request: Request<api::HandleConfirmedCertificateRequest>,
@@ -547,7 +571,15 @@ where
         }
     }
 
-    #[instrument(target = "grpc_server", skip_all, err, fields(nickname = self.state.nickname(), chain_id = ?request.get_ref().chain_id()))]
+    #[instrument(
+        target = "grpc_server",
+        skip_all,
+        err,
+        fields(
+            nickname = self.state.nickname(),
+            chain_id = ?request.get_ref().chain_id()
+        )
+    )]
     async fn handle_validated_certificate(
         &self,
         request: Request<api::HandleValidatedCertificateRequest>,
@@ -580,7 +612,15 @@ where
         }
     }
 
-    #[instrument(target = "grpc_server", skip_all, err, fields(nickname = self.state.nickname(), chain_id = ?request.get_ref().chain_id()))]
+    #[instrument(
+        target = "grpc_server",
+        skip_all,
+        err,
+        fields(
+            nickname = self.state.nickname(),
+            chain_id = ?request.get_ref().chain_id()
+        )
+    )]
     async fn handle_timeout_certificate(
         &self,
         request: Request<api::HandleTimeoutCertificateRequest>,
@@ -611,7 +651,15 @@ where
         }
     }
 
-    #[instrument(target = "grpc_server", skip_all, err, fields(nickname = self.state.nickname(), chain_id = ?request.get_ref().chain_id()))]
+    #[instrument(
+        target = "grpc_server",
+        skip_all,
+        err,
+        fields(
+            nickname = self.state.nickname(),
+            chain_id = ?request.get_ref().chain_id()
+        )
+    )]
     async fn handle_chain_info_query(
         &self,
         request: Request<ChainInfoQuery>,
@@ -638,7 +686,15 @@ where
         }
     }
 
-    #[instrument(target = "grpc_server", skip_all, err, fields(nickname = self.state.nickname(), chain_id= ?request.get_ref().chain_id()))]
+    #[instrument(
+        target = "grpc_server",
+        skip_all,
+        err,
+        fields(
+            nickname = self.state.nickname(),
+            chain_id = ?request.get_ref().chain_id()
+        )
+    )]
     async fn handle_cross_chain_request(
         &self,
         request: Request<CrossChainRequest>,

--- a/linera-rpc/src/lib.rs
+++ b/linera-rpc/src/lib.rs
@@ -33,10 +33,23 @@ pub struct HandleLiteCertRequest<'a> {
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
-pub struct HandleCertificateRequest {
-    pub certificate: linera_chain::types::Certificate,
+pub struct HandleConfirmedCertificateRequest {
+    pub certificate: linera_chain::types::ConfirmedBlockCertificate,
     pub wait_for_outgoing_messages: bool,
     pub blobs: Vec<linera_base::data_types::Blob>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(with_testing, derive(Eq, PartialEq))]
+pub struct HandleValidatedCertificateRequest {
+    pub certificate: linera_chain::types::ValidatedBlockCertificate,
+    pub blobs: Vec<linera_base::data_types::Blob>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(with_testing, derive(Eq, PartialEq))]
+pub struct HandleTimeoutCertificateRequest {
+    pub certificate: linera_chain::types::TimeoutCertificate,
 }
 
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("file_descriptor_set");

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -14,7 +14,9 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::BlockProposal,
-    types::{Certificate, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
+    types::{
+        ConfirmedBlockCertificate, LiteCertificate, TimeoutCertificate, ValidatedBlockCertificate,
+    },
 };
 use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
@@ -24,8 +26,9 @@ use linera_version::VersionInfo;
 
 use super::{codec, transport::TransportProtocol};
 use crate::{
-    config::ValidatorPublicNetworkPreConfig, mass_client, HandleCertificateRequest,
-    HandleLiteCertRequest, RpcMessage,
+    config::ValidatorPublicNetworkPreConfig, mass_client, HandleConfirmedCertificateRequest,
+    HandleLiteCertRequest, HandleTimeoutCertificateRequest, HandleValidatedCertificateRequest,
+    RpcMessage,
 };
 
 #[derive(Clone)]
@@ -98,21 +101,37 @@ impl ValidatorNode for SimpleClient {
     }
 
     /// Processes a certificate.
-    async fn handle_certificate<T>(
+    async fn handle_validated_certificate(
         &self,
-        certificate: GenericCertificate<T>,
+        certificate: ValidatedBlockCertificate,
+        blobs: Vec<Blob>,
+    ) -> Result<ChainInfoResponse, NodeError> {
+        let request = HandleValidatedCertificateRequest { certificate, blobs };
+        self.query(request.into()).await
+    }
+
+    /// Processes a certificate.
+    async fn handle_confirmed_certificate(
+        &self,
+        certificate: ConfirmedBlockCertificate,
         blobs: Vec<Blob>,
         delivery: CrossChainMessageDelivery,
-    ) -> Result<ChainInfoResponse, NodeError>
-    where
-        Certificate: From<GenericCertificate<T>>,
-    {
+    ) -> Result<ChainInfoResponse, NodeError> {
         let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
-        let request = HandleCertificateRequest {
-            certificate: certificate.into(),
+        let request = HandleConfirmedCertificateRequest {
+            certificate,
             blobs,
             wait_for_outgoing_messages,
         };
+        self.query(request.into()).await
+    }
+
+    /// Processes a certificate.
+    async fn handle_timeout_certificate(
+        &self,
+        certificate: TimeoutCertificate,
+    ) -> Result<ChainInfoResponse, NodeError> {
+        let request = HandleTimeoutCertificateRequest { certificate };
         self.query(request.into()).await
     }
 

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -100,7 +100,7 @@ impl ValidatorNode for SimpleClient {
         self.query(request.into()).await
     }
 
-    /// Processes a certificate.
+    /// Processes a validated certificate.
     async fn handle_validated_certificate(
         &self,
         certificate: ValidatedBlockCertificate,
@@ -110,7 +110,7 @@ impl ValidatorNode for SimpleClient {
         self.query(request.into()).await
     }
 
-    /// Processes a certificate.
+    /// Processes a confirmed certificate.
     async fn handle_confirmed_certificate(
         &self,
         certificate: ConfirmedBlockCertificate,
@@ -126,7 +126,7 @@ impl ValidatorNode for SimpleClient {
         self.query(request.into()).await
     }
 
-    /// Processes a certificate.
+    /// Processes a timeout certificate.
     async fn handle_timeout_certificate(
         &self,
         certificate: TimeoutCertificate,

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -253,7 +253,7 @@ where
                         Ok(Some(info.into()))
                     }
                     Err(error) => {
-                        error!(nickname = self.server.state.nickname(), %error, "Failed to handle certificate");
+                        error!(nickname = self.server.state.nickname(), %error, "Failed to handle timeout certificate");
                         Err(error.into())
                     }
                 }
@@ -272,7 +272,7 @@ where
                         Ok(Some(info.into()))
                     }
                     Err(error) => {
-                        error!(nickname = self.server.state.nickname(), %error, "Failed to handle certificate");
+                        error!(nickname = self.server.state.nickname(), %error, "Failed to handle validated certificate");
                         Err(error.into())
                     }
                 }
@@ -300,7 +300,7 @@ where
                         Ok(Some(info.into()))
                     }
                     Err(error) => {
-                        error!(nickname = self.server.state.nickname(), %error, "Failed to handle certificate");
+                        error!(nickname = self.server.state.nickname(), %error, "Failed to handle confirmed certificate");
                         Err(error.into())
                     }
                 }

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -190,7 +190,14 @@ impl<S> MessageHandler for RunningServerState<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    #[instrument(target = "simple_server", skip_all, fields(nickname = self.server.state.nickname(), chain_id = ?message.target_chain_id()))]
+    #[instrument(
+        target = "simple_server",
+        skip_all,
+        fields(
+            nickname = self.server.state.nickname(),
+            chain_id = ?message.target_chain_id()
+        )
+    )]
     async fn handle_message(&mut self, message: RpcMessage) -> Option<RpcMessage> {
         let reply = match message {
             RpcMessage::BlockProposal(message) => {

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -1,7 +1,6 @@
 ---
 source: linera-rpc/tests/format.rs
 expression: get_registry().unwrap()
-snapshot_kind: text
 ---
 Account:
   STRUCT:
@@ -424,10 +423,10 @@ GenericApplicationId:
       User:
         NEWTYPE:
           TYPENAME: ApplicationId
-HandleCertificateRequest:
+HandleConfirmedCertificateRequest:
   STRUCT:
     - certificate:
-        TYPENAME: Certificate
+        TYPENAME: ConfirmedBlockCertificate
     - wait_for_outgoing_messages: BOOL
     - blobs:
         SEQ:
@@ -437,6 +436,17 @@ HandleLiteCertRequest:
     - certificate:
         TYPENAME: LiteCertificate
     - wait_for_outgoing_messages: BOOL
+HandleTimeoutCertificateRequest:
+  STRUCT:
+    - certificate:
+        TYPENAME: TimeoutCertificate
+HandleValidatedCertificateRequest:
+  STRUCT:
+    - certificate:
+        TYPENAME: ValidatedBlockCertificate
+    - blobs:
+        SEQ:
+          TYPENAME: BlobContent
 IncomingBundle:
   STRUCT:
     - origin:
@@ -779,86 +789,94 @@ RpcMessage:
         NEWTYPE:
           TYPENAME: BlockProposal
     1:
-      Certificate:
+      TimeoutCertificate:
         NEWTYPE:
-          TYPENAME: HandleCertificateRequest
+          TYPENAME: HandleTimeoutCertificateRequest
     2:
+      ValidatedCertificate:
+        NEWTYPE:
+          TYPENAME: HandleValidatedCertificateRequest
+    3:
+      ConfirmedCertificate:
+        NEWTYPE:
+          TYPENAME: HandleConfirmedCertificateRequest
+    4:
       LiteCertificate:
         NEWTYPE:
           TYPENAME: HandleLiteCertRequest
-    3:
+    5:
       ChainInfoQuery:
         NEWTYPE:
           TYPENAME: ChainInfoQuery
-    4:
+    6:
       DownloadBlobContent:
         NEWTYPE:
           TYPENAME: BlobId
-    5:
+    7:
       DownloadConfirmedBlock:
         NEWTYPE:
           TYPENAME: CryptoHash
-    6:
+    8:
       DownloadCertificates:
         NEWTYPE:
           SEQ:
             TYPENAME: CryptoHash
-    7:
+    9:
       BlobLastUsedBy:
         NEWTYPE:
           TYPENAME: BlobId
-    8:
+    10:
       MissingBlobIds:
         NEWTYPE:
           SEQ:
             TYPENAME: BlobId
-    9:
-      VersionInfoQuery: UNIT
-    10:
-      GenesisConfigHashQuery: UNIT
     11:
+      VersionInfoQuery: UNIT
+    12:
+      GenesisConfigHashQuery: UNIT
+    13:
       Vote:
         NEWTYPE:
           TYPENAME: LiteVote
-    12:
+    14:
       ChainInfoResponse:
         NEWTYPE:
           TYPENAME: ChainInfoResponse
-    13:
+    15:
       Error:
         NEWTYPE:
           TYPENAME: NodeError
-    14:
+    16:
       VersionInfoResponse:
         NEWTYPE:
           TYPENAME: VersionInfo
-    15:
+    17:
       GenesisConfigHashResponse:
         NEWTYPE:
           TYPENAME: CryptoHash
-    16:
+    18:
       DownloadBlobContentResponse:
         NEWTYPE:
           TYPENAME: BlobContent
-    17:
+    19:
       DownloadConfirmedBlockResponse:
         NEWTYPE:
           TYPENAME: ConfirmedBlock
-    18:
+    20:
       DownloadCertificatesResponse:
         NEWTYPE:
           SEQ:
             TYPENAME: ConfirmedBlockCertificate
-    19:
+    21:
       BlobLastUsedByResponse:
         NEWTYPE:
           TYPENAME: CryptoHash
-    20:
+    22:
       MissingBlobIdsResponse:
         NEWTYPE:
           SEQ:
             TYPENAME: BlobId
-    21:
+    23:
       CrossChainRequest:
         NEWTYPE:
           TYPENAME: CrossChainRequest

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -141,7 +141,7 @@ impl ActiveChain {
 
         self.validator
             .worker()
-            .fully_handle_certificate(certificate.clone(), blobs)
+            .fully_handle_certificate_with_notifications(certificate.clone(), blobs, &())
             .await
             .expect("Rejected certificate");
 

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -64,7 +64,7 @@ mod net_up_utils;
 use {
     linera_chain::types::{ConfirmedBlock, Hashed},
     linera_core::data_types::ChainInfoResponse,
-    linera_rpc::{HandleCertificateRequest, RpcMessage},
+    linera_rpc::{HandleConfirmedCertificateRequest, RpcMessage},
     std::collections::HashSet,
 };
 
@@ -787,8 +787,8 @@ impl Runnable for Job {
                 let messages = certificates
                     .iter()
                     .map(|certificate| {
-                        HandleCertificateRequest {
-                            certificate: certificate.clone().into(),
+                        HandleConfirmedCertificateRequest {
+                            certificate: certificate.clone(),
                             blobs: vec![],
                             wait_for_outgoing_messages: true,
                         }

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -28,13 +28,13 @@ use linera_rpc::{
     },
     grpc::{
         api::{
+            self,
             notifier_service_server::{NotifierService, NotifierServiceServer},
             validator_node_server::{ValidatorNode, ValidatorNodeServer},
             validator_worker_client::ValidatorWorkerClient,
             BlobContent, BlobId, BlobIds, BlockProposal, Certificate, CertificatesBatchRequest,
             CertificatesBatchResponse, ChainInfoQuery, ChainInfoResult, CryptoHash,
-            HandleCertificateRequest, LiteCertificate, Notification, SubscriptionRequest,
-            VersionInfo,
+            LiteCertificate, Notification, SubscriptionRequest, VersionInfo,
         },
         pool::GrpcConnectionPool,
         GrpcProtoConversionError, GrpcProxyable, GRPC_CHUNKED_MESSAGE_FILL_LIMIT,
@@ -366,14 +366,38 @@ where
     }
 
     #[instrument(skip_all, err(Display))]
-    async fn handle_certificate(
+    async fn handle_confirmed_certificate(
         &self,
-        request: Request<HandleCertificateRequest>,
+        request: Request<api::HandleConfirmedCertificateRequest>,
     ) -> Result<Response<ChainInfoResult>, Status> {
         let (mut client, inner) = self.worker_client(request).await?;
         Self::log_and_return_proxy_request_outcome(
-            client.handle_certificate(inner).await,
-            "handle_certificate",
+            client.handle_confirmed_certificate(inner).await,
+            "handle_confirmed_certificate",
+        )
+    }
+
+    #[instrument(skip_all, err(Display))]
+    async fn handle_validated_certificate(
+        &self,
+        request: Request<api::HandleValidatedCertificateRequest>,
+    ) -> Result<Response<ChainInfoResult>, Status> {
+        let (mut client, inner) = self.worker_client(request).await?;
+        Self::log_and_return_proxy_request_outcome(
+            client.handle_validated_certificate(inner).await,
+            "handle_validated_certificate",
+        )
+    }
+
+    #[instrument(skip_all, err(Display))]
+    async fn handle_timeout_certificate(
+        &self,
+        request: Request<api::HandleTimeoutCertificateRequest>,
+    ) -> Result<Response<ChainInfoResult>, Status> {
+        let (mut client, inner) = self.worker_client(request).await?;
+        Self::log_and_return_proxy_request_outcome(
+            client.handle_timeout_certificate(inner).await,
+            "handle_timeout_certificate",
         )
     }
 

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -323,7 +323,9 @@ where
             )))),
             BlockProposal(_)
             | LiteCertificate(_)
-            | Certificate(_)
+            | TimeoutCertificate(_)
+            | ConfirmedCertificate(_)
+            | ValidatedCertificate(_)
             | ChainInfoQuery(_)
             | CrossChainRequest(_)
             | Vote(_)

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -9,7 +9,10 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::BlockProposal,
-    types::{ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
+    types::{
+        ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate, Timeout,
+        ValidatedBlock,
+    },
 };
 use linera_client::{
     chain_listener::{ChainListenerConfig, ClientContext},
@@ -51,11 +54,26 @@ impl ValidatorNode for DummyValidatorNode {
         Err(NodeError::UnexpectedMessage)
     }
 
-    async fn handle_certificate<T>(
+    async fn handle_timeout_certificate(
         &self,
-        _: GenericCertificate<T>,
+        _: GenericCertificate<Timeout>,
+    ) -> Result<ChainInfoResponse, NodeError> {
+        Err(NodeError::UnexpectedMessage)
+    }
+
+    async fn handle_confirmed_certificate(
+        &self,
+        _: GenericCertificate<ConfirmedBlock>,
         _: Vec<Blob>,
         _delivery: CrossChainMessageDelivery,
+    ) -> Result<ChainInfoResponse, NodeError> {
+        Err(NodeError::UnexpectedMessage)
+    }
+
+    async fn handle_validated_certificate(
+        &self,
+        _: GenericCertificate<ValidatedBlock>,
+        _: Vec<Blob>,
     ) -> Result<ChainInfoResponse, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }


### PR DESCRIPTION
## Motivation

Before this PR there are generic API endpoints (messages) that operate on a `Certificate` type, without differentiating between certificate types explicitly in the API.

## Proposal

This PR follows through and makes the differentiations at the API level in the following ways:
1. In `rpc.proto`:
  - replace `HandleCertificateRequest` message with `HandleConfirmedCertificateRequest`, `HandleValidatedCertificateRequest` and `HandleTimeoutCertificateRequest`.
  - replace `HandleCertificate` endpoint in `service ValidatorWorker` and `service ValidatorNode`  with `HandleConfirmedCertificate`, `HandleValidatedCertificate` and `HandleTimeoutCertificate`.
2. In `remote_node.rs` (and similar), replace `handle_certificate<T>` with per-certificate type methods.

Everything else follows from these two changes to appease compiler and simplify code when it makes sense.

## Test Plan

CI should catch any regressions.

## Release Plan

Follows regular release process.

## Links

N/A