### PR TITLE
Simplify some code related to certificates and the chain manager.

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -83,15 +83,6 @@ impl ConfirmedBlock {
         Self { executed_block }
     }
 
-    /// Creates a new `ConfirmedBlock` from a `ValidatedBlock`.
-    /// Note: There's no `new` method for `ConfirmedBlock` because it's
-    /// only created from a `ValidatedBlock`.
-    pub fn from_validated(validated: ValidatedBlock) -> Self {
-        Self {
-            executed_block: validated.executed_block,
-        }
-    }
-
     /// Returns a reference to the `ExecutedBlock` contained in this `ConfirmedBlock`.
     pub fn executed_block(&self) -> &ExecutedBlock {
         &self.executed_block

--- a/linera-chain/src/certificate/mod.rs
+++ b/linera-chain/src/certificate/mod.rs
@@ -88,6 +88,8 @@ impl Certificate {
 }
 
 pub trait CertificateValueT: Clone {
+    const IS_VALIDATED: bool;
+
     fn chain_id(&self) -> ChainId;
 
     fn epoch(&self) -> Epoch;
@@ -95,14 +97,11 @@ pub trait CertificateValueT: Clone {
     fn height(&self) -> BlockHeight;
 
     fn required_blob_ids(&self) -> HashSet<BlobId>;
-
-    #[cfg(with_testing)]
-    fn is_validated(&self) -> bool {
-        false
-    }
 }
 
 impl CertificateValueT for Timeout {
+    const IS_VALIDATED: bool = false;
+
     fn chain_id(&self) -> ChainId {
         self.chain_id
     }
@@ -121,6 +120,8 @@ impl CertificateValueT for Timeout {
 }
 
 impl CertificateValueT for ValidatedBlock {
+    const IS_VALIDATED: bool = true;
+
     fn chain_id(&self) -> ChainId {
         self.executed_block().block.chain_id
     }
@@ -136,14 +137,11 @@ impl CertificateValueT for ValidatedBlock {
     fn required_blob_ids(&self) -> HashSet<BlobId> {
         self.executed_block().required_blob_ids().clone()
     }
-
-    #[cfg(with_testing)]
-    fn is_validated(&self) -> bool {
-        true
-    }
 }
 
 impl CertificateValueT for ConfirmedBlock {
+    const IS_VALIDATED: bool = false;
+
     fn chain_id(&self) -> ChainId {
         self.executed_block().block.chain_id
     }

--- a/linera-chain/src/certificate/mod.rs
+++ b/linera-chain/src/certificate/mod.rs
@@ -135,7 +135,7 @@ impl CertificateValueT for ValidatedBlock {
     }
 
     fn required_blob_ids(&self) -> HashSet<BlobId> {
-        self.executed_block().required_blob_ids().clone()
+        self.executed_block().required_blob_ids()
     }
 }
 
@@ -155,6 +155,6 @@ impl CertificateValueT for ConfirmedBlock {
     }
 
     fn required_blob_ids(&self) -> HashSet<BlobId> {
-        self.executed_block().required_blob_ids().clone()
+        self.executed_block().required_blob_ids()
     }
 }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1032,7 +1032,7 @@ where
         // Remember what we are trying to do before sending the proposal to the validators.
         self.state_mut()
             .set_pending_block(proposal.content.block.clone());
-        let required_blob_ids: HashSet<BlobId> = value.inner().required_blob_ids();
+        let required_blob_ids = value.inner().required_blob_ids();
         let proposed_blobs = proposal.blobs.clone();
         let submit_action = CommunicateAction::SubmitBlock {
             proposal,

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -309,7 +309,7 @@ where
         blobs: Vec<Blob>,
     ) -> Option<Result<ChainInfoResponse, NodeError>> {
         match validator.fault_type {
-            FaultType::DontProcessValidated if certificate.inner().is_validated() => None,
+            FaultType::DontProcessValidated if T::IS_VALIDATED => None,
             FaultType::Honest
             | FaultType::DontSendConfirmVote
             | FaultType::Malicious
@@ -358,7 +358,6 @@ where
         validator: &mut MutexGuard<'_, LocalValidator<S>>,
         blobs: Vec<Blob>,
     ) -> Result<ChainInfoResponse, NodeError> {
-        let is_validated = certificate.inner().is_validated();
         let handle_certificate_result =
             Self::handle_certificate(certificate, validator, blobs).await;
         match handle_certificate_result {
@@ -367,7 +366,7 @@ where
             }
             _ => match validator.fault_type {
                 FaultType::DontSendConfirmVote | FaultType::DontProcessValidated
-                    if is_validated =>
+                    if T::IS_VALIDATED =>
                 {
                     Err(NodeError::ClientIoError {
                         error: "refusing to confirm".to_string(),


### PR DESCRIPTION
## Motivation

* `ConfirmedBlock::from_validated` is unused.
* `CertificateValueT::is_validated` doesn't actually use `&self`. Also, I will soon need it in non-test code.
* `ChainManager::create_vote` returns either a validated or confirmed block vote. There is currently a panic in the unreachable case that it returns both.

## Proposal

* Remove the unused function, as well as some unused `clone` calls and a redundant type annotation.
* Replace `is_validated` with a `const IS_VALIDATED`.
* Use `Either` and remove the panic.

## Test Plan

No logic was changed.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
