### PR TITLE
Fix test code generated by `linera project new`

### DIFF
--- a/linera-service/src/project.rs
+++ b/linera-service/src/project.rs
@@ -160,7 +160,6 @@ impl Project {
             contract_binary_name = contract_binary_name,
             service_binary_name = service_binary_name,
             linera_sdk_dep = linera_sdk_dep,
-            linera_sdk_testing_dep = linera_sdk_dev_dep,
             linera_sdk_dev_dep = linera_sdk_dev_dep,
         );
         Self::write_string_to_file(&toml_path, &toml_contents)
@@ -250,7 +249,7 @@ impl Project {
             linera_sdk_path.display()
         );
         let linera_sdk_dev_dep = format!(
-            "linera-sdk = {{ path = \"{}\", features = [\"test\"] }}",
+            "linera-sdk = {{ path = \"{}\", features = [\"test\", \"wasmer\"] }}",
             linera_sdk_path.display()
         );
         (linera_sdk_dep, linera_sdk_dev_dep)

--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -10,12 +10,9 @@ futures = {{ version = "0.3 "}}
 serde = {{ version = "1.0", features = ["derive"] }}
 serde_json = {{ version = "1.0" }}
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-{linera_sdk_testing_dep}
-tokio = {{ version = "1.40", features = ["rt", "sync"] }}
-
 [dev-dependencies]
 {linera_sdk_dev_dep}
+tokio = {{ version = "1.40", features = ["rt", "sync"] }}
 
 [[bin]]
 name = "{contract_binary_name}"

--- a/linera-service/template/service.rs.template
+++ b/linera-service/template/service.rs.template
@@ -64,13 +64,13 @@ mod tests {{
     use linera_sdk::{{util::BlockingWait, views::View, Service, ServiceRuntime}};
     use serde_json::json;
 
-    use super::{{{project_name}, {project_name}Service}};
+    use super::{{{project_name}Service, {project_name}State}};
 
     #[test]
     fn query() {{
         let value = 60u64;
         let runtime = ServiceRuntime::<{project_name}Service>::new();
-        let mut state = {project_name}::load(runtime.root_view_storage_context())
+        let mut state = {project_name}State::load(runtime.root_view_storage_context())
             .blocking_wait()
             .expect("Failed to read from mock key value store");
         state.value.set(value);

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -666,6 +666,12 @@ async fn test_project_new() -> Result<()> {
         .spawn()?;
     assert!(child.wait()?.success());
 
+    let mut child = Command::new("cargo")
+        .arg("test")
+        .current_dir(project_dir.as_path())
+        .spawn()?;
+    assert!(child.wait()?.success());
+
     Ok(())
 }
 


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
The unit test code generated by `linera project new` was broken because the state type was missing the newly added `State` suffix (#2987).

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Fix the generated unit test code, and update the `Cargo.toml` file to use the more up-to-date version that doesn't require a separate section of dependencies based on the target architecture.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
The `test_project_new` test was updated to also run `cargo test` on the generated code, to prevent these bugs from happening again.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do, because this just fixes a bug that isn't present in any released version.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
