### PR TITLE
Fixed broken symlink in linera-explorer/rust-toolchain.toml.

### DIFF
--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -39,6 +39,10 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: Check toolchain symlinks
+      run: |
+        cd linera-explorer
+        cat rust-toolchain.toml
     - name: Build
       run: |
         cd linera-explorer

--- a/linera-explorer/rust-toolchain.toml
+++ b/linera-explorer/rust-toolchain.toml
@@ -1,1 +1,1 @@
-toolchains/stable/rust-toolchain.toml
+../toolchains/stable/rust-toolchain.toml


### PR DESCRIPTION
## Motivation

Broken symlink in `linera-explorer/rust-toolchain.toml`.

## Proposal

Point it to the correct file.

## Test Plan

CI will catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.