### PR TITLE
Update the storage service reading.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4930,6 +4930,7 @@ dependencies = [
  "cfg_aliases",
  "clap",
  "criterion",
+ "futures",
  "linera-base",
  "linera-storage-service",
  "linera-version",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3697,6 +3697,7 @@ dependencies = [
  "bcs",
  "cfg_aliases",
  "clap",
+ "futures",
  "linera-base",
  "linera-version",
  "linera-views",

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -26,6 +26,7 @@ anyhow.workspace = true
 async-lock.workspace = true
 bcs.workspace = true
 clap.workspace = true
+futures.workspace = true
 linera-base.workspace = true
 linera-version.workspace = true
 linera-views.workspace = true

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -381,11 +381,11 @@ impl ServiceStoreClientInternal {
             let handle = self.read_single_entry(message_index, index);
             handles.push(handle);
         }
-        let values: Vec<Vec<u8>> = join_all(handles)
-            .await
-            .into_iter()
-            .collect::<Result<_, _>>()?;
-        let value = values.into_iter().flatten().collect::<Vec<_>>();
+        let mut value = Vec::new();
+        for chunk in join_all(handles).await {
+            let chunk = chunk?;
+            value.extend(chunk);
+        }
         Ok(bcs::from_bytes(&value)?)
     }
 }

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -376,7 +376,6 @@ impl ServiceStoreClientInternal {
         num_chunks: i32,
     ) -> Result<S, ServiceStoreError> {
         let mut handles = Vec::new();
-        println!("read_entries: message_index={message_index} num_chunks={num_chunks}");
         for index in 0..num_chunks {
             let handle = self.read_single_entry(message_index, index);
             handles.push(handle);

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -46,9 +46,15 @@ enum ServiceStoreServerInternal {
 }
 
 #[derive(Default)]
+struct BigRead {
+    num_read: usize,
+    chunks: Vec<Vec<u8>>,
+}
+
+#[derive(Default)]
 struct PendingBigReads {
     index: i64,
-    chunks_by_index: BTreeMap<i64, Vec<Vec<u8>>>,
+    big_reads: BTreeMap<i64, BigRead>,
 }
 
 struct ServiceStoreServer {
@@ -219,9 +225,11 @@ impl ServiceStoreServer {
         let mut pending_big_reads = self.pending_big_reads.write().await;
         let message_index = pending_big_reads.index;
         pending_big_reads.index += 1;
-        pending_big_reads
-            .chunks_by_index
-            .insert(message_index, chunks);
+        let big_read = BigRead {
+            num_read: 0,
+            chunks,
+        };
+        pending_big_reads.big_reads.insert(message_index, big_read);
         (message_index, num_chunks)
     }
 }
@@ -457,13 +465,14 @@ impl StoreProcessor for ServiceStoreServer {
             index,
         } = request;
         let mut pending_big_reads = self.pending_big_reads.write().await;
-        let Some(entry) = pending_big_reads.chunks_by_index.get(&message_index) else {
+        let Some(entry) = pending_big_reads.big_reads.get_mut(&message_index) else {
             return Err(Status::not_found("process_specific_chunk"));
         };
         let index = index as usize;
-        let chunk = entry[index].clone();
-        if entry.len() == index + 1 {
-            pending_big_reads.chunks_by_index.remove(&message_index);
+        let chunk = entry.chunks[index].clone();
+        entry.num_read += 1;
+        if entry.chunks.len() == entry.num_read {
+            pending_big_reads.big_reads.remove(&message_index);
         }
         let response = ReplySpecificChunk { chunk };
         Ok(Response::new(response))

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -47,7 +47,7 @@ enum ServiceStoreServerInternal {
 
 #[derive(Default)]
 struct BigRead {
-    num_read: usize,
+    num_processed_chunks: usize,
     chunks: Vec<Vec<u8>>,
 }
 
@@ -226,7 +226,7 @@ impl ServiceStoreServer {
         let message_index = pending_big_reads.index;
         pending_big_reads.index += 1;
         let big_read = BigRead {
-            num_read: 0,
+            num_processed_chunks: 0,
             chunks,
         };
         pending_big_reads.big_reads.insert(message_index, big_read);
@@ -470,8 +470,8 @@ impl StoreProcessor for ServiceStoreServer {
         };
         let index = index as usize;
         let chunk = entry.chunks[index].clone();
-        entry.num_read += 1;
-        if entry.chunks.len() == entry.num_read {
+        entry.num_processed_chunks += 1;
+        if entry.chunks.len() == entry.num_processed_chunks {
             pending_big_reads.big_reads.remove(&message_index);
         }
         let response = ReplySpecificChunk { chunk };


### PR DESCRIPTION
## Motivation

The `read_entries` code of the storage-service is doing a blocking loop. That is inefficient from the viewpoint of concurrency.

## Proposal

The following was done:
* A vector of handles is created.
* The handles are processed and then merged.
* On the server side, the code is changed so that it is no longer assumed that the request arrive in order.

## Test Plan

The CI proved adequate. The `test_storage_service_big_raw_write` did catch the problem with the ordering of the requests.

## Release Plan

Not relevant as we do not use so far the `storage-service` in TestNet / DevNet.

## Links

None.