### PR TITLE
Pass proper shard id on docker compose

### DIFF
--- a/docker/compose-server-entrypoint.sh
+++ b/docker/compose-server-entrypoint.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 
+# Check if the ordinal number is provided
+if [ -z "$1" ]; then
+  echo "Error: No ordinal number provided."
+  echo "Usage: $0 <ordinal_number>"
+  exit 1
+fi
+
 exec ./linera-server run \
   --storage scylladb:tcp:scylla:9042 \
   --server /config/server.json \
-  --shard 0 \
+  --shard $1 \
   --genesis /config/genesis.json

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,11 +22,33 @@ services:
     depends_on:
       shard-init:
         condition: service_completed_successfully
-  shard:
+  shard-0:
     image: "${LINERA_IMAGE:-linera}"
-    deploy:
-      replicas: 4
-    command: [ "./compose-server-entrypoint.sh" ]
+    command: [ "./compose-server-entrypoint.sh", "0" ]
+    volumes:
+      - .:/config
+    depends_on:
+      shard-init:
+        condition: service_completed_successfully
+  shard-1:
+    image: "${LINERA_IMAGE:-linera}"
+    command: [ "./compose-server-entrypoint.sh", "1" ]
+    volumes:
+      - .:/config
+    depends_on:
+      shard-init:
+        condition: service_completed_successfully
+  shard-2:
+    image: "${LINERA_IMAGE:-linera}"
+    command: [ "./compose-server-entrypoint.sh", "2" ]
+    volumes:
+      - .:/config
+    depends_on:
+      shard-init:
+        condition: service_completed_successfully
+  shard-3:
+    image: "${LINERA_IMAGE:-linera}"
+    command: [ "./compose-server-entrypoint.sh", "3" ]
     volumes:
       - .:/config
     depends_on:


### PR DESCRIPTION
## Motivation

Stumbled upon this while randomly reading this code. Right now instead of 4 shards, we have 4 instances that are being passed shard 0. This seems to affect just logging, but could be confusing.

## Proposal

`$HOSTNAME` under docker compose is actually set to a container ID, which is a hash. We might eventually replace the shard ID with some ID other than a number, but that's a much bigger change, and not necessary atm.

So for now, doing different services per shard.

## Test Plan

Docker compose CI should make sure this works

## Release Plan

Maybe we should backport this? Only logs are affected, but that can be confusing for validators trying to look at logs to debug things.

- These changes should be backported to the latest `devnet` branch
- These changes should be backported to the latest `testnet` branch

