### PR TITLE
Use `change_ownership` in some tests, instead of `execute_operation`.

### DIFF
--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1850,7 +1850,7 @@ where
     let pub_key1 = KeyPair::generate().public();
 
     let owners = [(pub_key0, 100), (pub_key1, 100)];
-    let ownership = ChainOwnership::multiple(owners, 10, TimeoutConfig::default());
+    let ownership = ChainOwnership::multiple(owners, 0, TimeoutConfig::default());
     client.change_ownership(ownership).await.unwrap();
 
     let manager = client.chain_info().await.unwrap().manager;


### PR DESCRIPTION
## Motivation

In some client tests we use `execute_operation` and put together a `SystemOperation::ChangeOwnership` manually, when there is the `change_ownership` method that does exactly that.

## Proposal

Use `change_ownership` instead.

## Test Plan

This code should be equivalent, just with less repetition.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
