### PR TITLE
Include the outcome in a re-proposal instead of re-executing.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -743,10 +743,9 @@ pub struct ProposalContent {
     pub block: Block,
     /// The consensus round in which this proposal is made.
     pub round: Round,
-    /// If this is a retry from an earlier round, the oracle responses from when the block was
-    /// first validated. These are reused so the execution outcome remains the same.
+    /// If this is a retry from an earlier round, the execution outcome.
     #[debug(skip_if = Option::is_none)]
-    pub forced_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
+    pub outcome: Option<BlockExecutionOutcome>,
 }
 
 impl BlockProposal {
@@ -754,7 +753,7 @@ impl BlockProposal {
         let content = ProposalContent {
             round,
             block,
-            forced_oracle_responses: None,
+            outcome: None,
         };
         let signature = Signature::new(&content, secret);
         Self {
@@ -777,7 +776,7 @@ impl BlockProposal {
         let content = ProposalContent {
             block: executed_block.block,
             round,
-            forced_oracle_responses: Some(executed_block.outcome.oracle_responses),
+            outcome: Some(executed_block.outcome),
         };
         let signature = Signature::new(&content, secret);
         Self {

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -1104,14 +1104,12 @@ pub mod tests {
     #[test]
     pub fn test_block_proposal() {
         let key_pair = KeyPair::generate();
+        let outcome = BlockExecutionOutcome {
+            state_hash: CryptoHash::new(&Foo("validated".into())),
+            ..BlockExecutionOutcome::default()
+        };
         let cert = ValidatedBlockCertificate::new(
-            Hashed::new(ValidatedBlock::new(
-                BlockExecutionOutcome {
-                    state_hash: CryptoHash::new(&Foo("validated".into())),
-                    ..BlockExecutionOutcome::default()
-                }
-                .with(get_block()),
-            )),
+            Hashed::new(ValidatedBlock::new(outcome.clone().with(get_block()))),
             Round::SingleLeader(2),
             vec![(
                 ValidatorName::from(key_pair.public()),
@@ -1124,7 +1122,7 @@ pub mod tests {
             content: ProposalContent {
                 block: get_block(),
                 round: Round::SingleLeader(4),
-                forced_oracle_responses: Some(Vec::new()),
+                outcome: Some(outcome),
             },
             owner: Owner::from(KeyPair::generate().public()),
             signature: Signature::new(&Foo("test".into()), &KeyPair::generate()),

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -719,11 +719,9 @@ ProposalContent:
         TYPENAME: Block
     - round:
         TYPENAME: Round
-    - forced_oracle_responses:
+    - outcome:
         OPTION:
-          SEQ:
-            SEQ:
-              TYPENAME: OracleResponse
+          TYPENAME: BlockExecutionOutcome
 PublicKey:
   NEWTYPESTRUCT:
     TUPLEARRAY:


### PR DESCRIPTION
## Motivation

It must always be possible to re-propose the locked block, even if the committee that certified a blob which the new block reads has been deprecated in the meantime. This would currently fail, in theory, because the validator tries to execute the proposal even if it includes a validated block certificate, and during execution it doesn't have access to the included blobs.

## Proposal

Include the whole execution outcome in the proposal and don't re-execute it.

## Test Plan

CI should catch any regressions.

The bug itself can't actually be triggered due to https://github.com/linera-io/linera-protocol/issues/2351: The validator would wrongly accept the deprecated blob.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Fixes https://github.com/linera-io/linera-protocol/issues/2993.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
