### PR TITLE
Increasing resources for the tests.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,6 +3,16 @@ name: Benchmarks
 on:
   push:
     branches: [ main, 'devnet_*', 'testnet_*' ]
+  pull_request:
+    branches:
+      - "**"
+    paths-ignore:
+      - 'CONTRIBUTING.md'
+      - 'INSTALL.md'
+      - 'docker/**'
+      - 'docker_scylla/**'
+      - 'configuration/**'
+      - 'kubernetes/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   long-faucet-chain-test:
     runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 40
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Motivation

The recent switch to the LTO introduced some problems with the CI.

## Proposal

Following proposals:
* Increasing the runtime to 60 minutes for the long_faucet. It already uses a beefy machine.
* Switch to a beefier machine for the `benchmark.yml`.

## Test Plan

The CI reliability is the issue here.

## Release Plan

Not relevant to TestNet nor DevNet.

## Links

None.
