### PR TITLE
Switch to thin for lto.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,7 +231,7 @@ social = { path = "./examples/social" }
 amm = { path = "./examples/amm" }
 
 [profile.release]
-lto = "fat"
+lto = "thin"
 debug = true
 
 [profile.bench]


### PR DESCRIPTION
## Motivation

The compilation with `lto="fat"` and `debug = true` causes out-of-memory problems.

## Proposal

The switch to thin alleviates the memory problem.

## Test Plan

Running locally, we now have less problems with OOM. More work is needed to have 

## Release Plan

That is relevant to the TestNet / DevNet.

## Links

None.