### PR TITLE
fix: Ensure status variable is properly quoted in conditional checks …

### DIFF
--- a/docker/proxy-init.sh
+++ b/docker/proxy-init.sh
@@ -4,12 +4,12 @@ while true; do
   ./linera storage check_existence --storage "scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042"
   status=$?
 
-  if [ $status -eq 0 ]; then
+  if [ "$status" -eq 0 ]; then
     echo "Database already exists, no need to initialize."
     exit 0
   else
     # We rely on the shards to initialize the database, so just wait here
-    if [ $status -eq 1 ]; then
+    if [ "$status" -eq 1 ]; then
         echo "Database does not exist, retrying in 5 seconds..."
     else
         echo "An unexpected error occurred (status: $status), retrying in 5 seconds..."


### PR DESCRIPTION
**Description:**  
This change addresses a potential issue in the script where the `status` variable was not enclosed in quotes during conditional checks.  

Unquoted variables can lead to unexpected behavior if the variable is empty or contains characters that disrupt the shell syntax. For instance, if the `status` variable is empty, the conditional checks like `[ $status -eq 0 ]` will throw an error and cause the script to fail. By adding quotes around `$status`, we ensure robust handling and prevent such runtime errors.  

This fix enhances the script's reliability and prevents unexpected termination in edge cases.