### PR TITLE
fix: Fix improper array syntax to handle lines with spaces or special…

### DIFF
--- a/scripts/yank.sh
+++ b/scripts/yank.sh
@@ -8,10 +8,11 @@ set -e
 
 # Yank the given packages.
 grep -v '^#' "$2" | while read LINE; do
-    LINE=($LINE)
+    read -a LINE <<< "$LINE"
     NAME="${LINE[0]}"
     (
         set -x;
         cargo yank "$NAME"@"$1"
     )
 done
+


### PR DESCRIPTION
**Description:**  
This update resolves an issue where the script improperly uses array syntax without explicitly defining `LINE` as an array.  

Previously, the command `LINE=($LINE)` attempted to split a line into parts but could fail when `LINE` contained spaces or special characters. For example, a line like `crate-name 1.0.0` would lead to errors because `$LINE` was not properly treated as an array.  

The fix replaces the problematic line with:  
```bash
read -a LINE <<< "$LINE"
```  
This ensures that the input is correctly parsed into an array, allowing the script to handle multi-part lines reliably.  

This change improves the script's robustness and prevents runtime errors when processing package lists with complex formatting.