### PR TITLE
Implement the `index_values` and `count` functions.

### DIFF
--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -112,14 +112,7 @@ where
             }
 
             OwnerBalances { callback } => {
-                let mut balances = Vec::new();
-                self.system
-                    .balances
-                    .for_each_index_value(|owner, balance| {
-                        balances.push((owner, balance));
-                        Ok(())
-                    })
-                    .await?;
+                let balances = self.system.balances.index_values().await?;
                 callback.respond(balances.into_iter().collect());
             }
 

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -173,17 +173,7 @@ where
     }
 
     async fn registered_application_count(&self) -> anyhow::Result<usize> {
-        let mut count = 0;
-
-        self.registry
-            .known_applications
-            .for_each_index(|_| {
-                count += 1;
-                Ok(())
-            })
-            .await?;
-
-        Ok(count)
+        Ok(self.registry.known_applications.count().await?)
     }
 
     async fn register_mock_application_with(

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -800,15 +800,7 @@ impl TransferTestEndpoint {
             Some(account_owner) => (Amount::ZERO, vec![(account_owner, amount)]),
         };
 
-        let mut balances = Vec::new();
-
-        system
-            .balances
-            .for_each_index_value(|owner, balance| {
-                balances.push((owner, balance));
-                Ok(())
-            })
-            .await?;
+        let balances = system.balances.index_values().await?;
 
         assert_eq!(*system.balance.get(), expected_chain_balance);
         assert_eq!(balances, expected_balances);

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -586,6 +586,31 @@ where
         .await?;
         Ok(keys)
     }
+
+    /// Returns the number of entries in the collection.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::collection_view::ByteCollectionView;
+    /// # use linera_views::register_view::RegisterView;
+    /// # use linera_views::views::View;
+    /// # let context = create_test_memory_context();
+    /// let mut view: ByteCollectionView<_, RegisterView<_, String>> =
+    ///     ByteCollectionView::load(context).await.unwrap();
+    /// view.load_entry_mut(&[0, 1]).await.unwrap();
+    /// view.load_entry_mut(&[0, 2]).await.unwrap();
+    /// assert_eq!(view.count().await.unwrap(), 2);
+    /// # })
+    /// ```
+    pub async fn count(&self) -> Result<usize, ViewError> {
+        let mut count = 0;
+        self.for_each_key(|_key| {
+            count += 1;
+            Ok(())
+        })
+        .await?;
+        Ok(count)
+    }
 }
 
 #[async_trait]
@@ -907,12 +932,31 @@ where
     /// ```
     pub async fn indices(&self) -> Result<Vec<I>, ViewError> {
         let mut indices = Vec::new();
-        self.for_each_index(|index: I| {
+        self.for_each_index(|index| {
             indices.push(index);
             Ok(())
         })
         .await?;
         Ok(indices)
+    }
+
+    /// Returns the number of entries in the collection.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::collection_view::CollectionView;
+    /// # use linera_views::register_view::RegisterView;
+    /// # use linera_views::views::View;
+    /// # let context = create_test_memory_context();
+    /// let mut view: CollectionView<_, u64, RegisterView<_, String>> =
+    ///     CollectionView::load(context).await.unwrap();
+    /// view.load_entry_mut(&23).await.unwrap();
+    /// view.load_entry_mut(&25).await.unwrap();
+    /// assert_eq!(view.count().await.unwrap(), 2);
+    /// # })
+    /// ```
+    pub async fn count(&self) -> Result<usize, ViewError> {
+        self.collection.count().await
     }
 }
 
@@ -1267,12 +1311,31 @@ where
     /// ```
     pub async fn indices(&self) -> Result<Vec<I>, ViewError> {
         let mut indices = Vec::new();
-        self.for_each_index(|index: I| {
+        self.for_each_index(|index| {
             indices.push(index);
             Ok(())
         })
         .await?;
         Ok(indices)
+    }
+
+    /// Returns the number of entries in the collection.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::collection_view::CollectionView;
+    /// # use linera_views::register_view::RegisterView;
+    /// # use linera_views::views::View;
+    /// # let context = create_test_memory_context();
+    /// let mut view: CollectionView<_, u64, RegisterView<_, String>> =
+    ///     CollectionView::load(context).await.unwrap();
+    /// view.load_entry_mut(&23).await.unwrap();
+    /// view.load_entry_mut(&25).await.unwrap();
+    /// assert_eq!(view.count().await.unwrap(), 2);
+    /// # })
+    /// ```
+    pub async fn count(&self) -> Result<usize, ViewError> {
+        self.collection.count().await
     }
 }
 

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -1267,11 +1267,13 @@ where
     /// let mut map: MapView<_, String, _> = MapView::load(context).await.unwrap();
     /// map.insert("Italian", String::from("Ciao"));
     /// let index_values = map.index_values().await.unwrap();
-    /// assert_eq!(index_values, vec![("Italian".to_string(), "Ciao".to_string())]);
+    /// assert_eq!(
+    ///     index_values,
+    ///     vec![("Italian".to_string(), "Ciao".to_string())]
+    /// );
     /// # })
     /// ```
-    pub async fn index_values(&self) -> Result<Vec<(I,V)>, ViewError>
-    {
+    pub async fn index_values(&self) -> Result<Vec<(I, V)>, ViewError> {
         let prefix = Vec::new();
         let mut key_values = Vec::new();
         self.map
@@ -1771,11 +1773,13 @@ where
     /// let mut map: MapView<_, String, _> = MapView::load(context).await.unwrap();
     /// map.insert("Italian", String::from("Ciao"));
     /// let index_values = map.index_values().await.unwrap();
-    /// assert_eq!(index_values, vec![("Italian".to_string(), "Ciao".to_string())]);
+    /// assert_eq!(
+    ///     index_values,
+    ///     vec![("Italian".to_string(), "Ciao".to_string())]
+    /// );
     /// # })
     /// ```
-    pub async fn index_values(&self) -> Result<Vec<(I,V)>, ViewError>
-    {
+    pub async fn index_values(&self) -> Result<Vec<(I, V)>, ViewError> {
         let prefix = Vec::new();
         let mut key_values = Vec::new();
         self.map

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -365,7 +365,7 @@ impl<C, V> ByteMapView<C, V>
 where
     C: Context,
     ViewError: From<C::Error>,
-    V: Sync + Serialize + DeserializeOwned + 'static,
+    V: Serialize + 'static,
 {
     /// Applies the function f on each index (aka key) which has the assigned prefix.
     /// Keys are visited in the lexicographic order. The shortened key is send to the
@@ -709,7 +709,7 @@ impl<C, V> ByteMapView<C, V>
 where
     C: Context,
     ViewError: From<C::Error>,
-    V: Sync + Send + Serialize + DeserializeOwned + 'static,
+    V: Send + Serialize + DeserializeOwned + 'static,
 {
     /// Returns the list of keys and values of the map matching a prefix
     /// in lexicographic order.
@@ -824,7 +824,7 @@ impl<C, V> HashableView<C> for ByteMapView<C, V>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    V: Clone + Send + Sync + Serialize + DeserializeOwned + 'static,
+    V: Send + Sync + Serialize + 'static,
 {
     type Hasher = sha3::Sha3_256;
 
@@ -866,7 +866,7 @@ impl<C, I, V> View<C> for MapView<C, I, V>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    I: Send + Sync + Serialize,
+    I: Sync,
     V: Send + Sync + Serialize,
 {
     const NUM_INIT_KEYS: usize = ByteMapView::<C, V>::NUM_INIT_KEYS;
@@ -912,7 +912,7 @@ impl<C, I, V> ClonableView<C> for MapView<C, I, V>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    I: Send + Sync + Serialize,
+    I: Sync,
     V: Clone + Send + Sync + Serialize,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
@@ -1068,7 +1068,7 @@ impl<C, I, V> MapView<C, I, V>
 where
     C: Context + Sync,
     ViewError: From<C::Error>,
-    I: Sync + Send + Serialize + DeserializeOwned,
+    I: Send + DeserializeOwned,
     V: Sync + Serialize + DeserializeOwned + 'static,
 {
     /// Returns the list of indices in the map. The order is determined by serialization.
@@ -1247,6 +1247,45 @@ where
             )
             .await?;
         Ok(())
+    }
+}
+
+impl<C, I, V> MapView<C, I, V>
+where
+    C: Context + Sync,
+    ViewError: From<C::Error>,
+    I: Send + DeserializeOwned,
+    V: Sync + Send + Serialize + DeserializeOwned + 'static,
+{
+    /// Obtains all the `(index,value)` pairs.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::map_view::MapView;
+    /// # use linera_views::views::View;
+    /// # let context = create_test_memory_context();
+    /// let mut map: MapView<_, String, _> = MapView::load(context).await.unwrap();
+    /// map.insert("Italian", String::from("Ciao"));
+    /// let index_values = map.index_values().await.unwrap();
+    /// assert_eq!(index_values, vec![("Italian".to_string(), "Ciao".to_string())]);
+    /// # })
+    /// ```
+    pub async fn index_values(&self) -> Result<Vec<(I,V)>, ViewError>
+    {
+        let prefix = Vec::new();
+        let mut key_values = Vec::new();
+        self.map
+            .for_each_key_value(
+                |key, bytes| {
+                    let index = C::deserialize_value(key)?;
+                    let value = C::deserialize_value(bytes)?;
+                    key_values.push((index, value));
+                    Ok(())
+                },
+                prefix,
+            )
+            .await?;
+        Ok(key_values)
     }
 }
 
@@ -1512,8 +1551,8 @@ impl<C, I, V> CustomMapView<C, I, V>
 where
     C: Context + Sync,
     ViewError: From<C::Error>,
-    I: Sync + Send + CustomSerialize,
-    V: Sync + Serialize + DeserializeOwned + 'static,
+    I: Send + CustomSerialize,
+    V: Serialize + DeserializeOwned + 'static,
 {
     /// Returns the list of indices in the map. The order is determined
     /// by the custom serialization.
@@ -1702,6 +1741,74 @@ impl<C, I, V> CustomMapView<C, I, V>
 where
     C: Context + Sync,
     ViewError: From<C::Error>,
+    I: Send + CustomSerialize,
+    V: Sync + Send + Serialize + DeserializeOwned + 'static,
+{
+    /// Obtains all the `(index,value)` pairs.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::map_view::MapView;
+    /// # use linera_views::views::View;
+    /// # let context = create_test_memory_context();
+    /// let mut map: MapView<_, String, _> = MapView::load(context).await.unwrap();
+    /// map.insert("Italian", String::from("Ciao"));
+    /// let index_values = map.index_values().await.unwrap();
+    /// assert_eq!(index_values, vec![("Italian".to_string(), "Ciao".to_string())]);
+    /// # })
+    /// ```
+    pub async fn index_values(&self) -> Result<Vec<(I,V)>, ViewError>
+    {
+        let prefix = Vec::new();
+        let mut key_values = Vec::new();
+        self.map
+            .for_each_key_value(
+                |key, bytes| {
+                    let index = I::from_custom_bytes(key)?;
+                    let value = C::deserialize_value(bytes)?;
+                    key_values.push((index, value));
+                    Ok(())
+                },
+                prefix,
+            )
+            .await?;
+        Ok(key_values)
+    }
+
+    /// Obtains the number of entries in the map
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::map_view::MapView;
+    /// # use linera_views::views::View;
+    /// # let context = create_test_memory_context();
+    /// let mut map: MapView<_, String, _> = MapView::load(context).await.unwrap();
+    /// map.insert("Italian", String::from("Ciao"));
+    /// map.insert("French", String::from("Bonjour"));
+    /// assert_eq!(map.count().await.unwrap(), 2);
+    /// # })
+    /// ```
+    pub async fn count(&self) -> Result<usize, ViewError>
+    {
+        let prefix = Vec::new();
+        let mut count = 0;
+        self.map
+            .for_each_key_value(
+                |_key, _bytes| {
+                    count += 1;
+                    Ok(())
+                },
+                prefix,
+            )
+            .await?;
+        Ok(count)
+    }
+}
+
+impl<C, I, V> CustomMapView<C, I, V>
+where
+    C: Context + Sync,
+    ViewError: From<C::Error>,
     I: CustomSerialize,
     V: Default + DeserializeOwned + 'static,
 {
@@ -1723,7 +1830,7 @@ where
     pub async fn get_mut_or_default<Q>(&mut self, index: &Q) -> Result<&mut V, ViewError>
     where
         I: Borrow<Q>,
-        Q: Sync + Send + Serialize + CustomSerialize,
+        Q: Send + CustomSerialize,
     {
         let short_key = index.to_custom_bytes()?;
         self.map.get_mut_or_default(&short_key).await

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -1287,6 +1287,23 @@ where
             .await?;
         Ok(key_values)
     }
+
+    /// Obtains the number of entries in the map
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::map_view::MapView;
+    /// # use linera_views::views::View;
+    /// # let context = create_test_memory_context();
+    /// let mut map: MapView<_, String, _> = MapView::load(context).await.unwrap();
+    /// map.insert("Italian", String::from("Ciao"));
+    /// map.insert("French", String::from("Bonjour"));
+    /// assert_eq!(map.count().await.unwrap(), 2);
+    /// # })
+    /// ```
+    pub async fn count(&self) -> Result<usize, ViewError> {
+        self.map.count().await
+    }
 }
 
 impl<C, I, V> MapView<C, I, V>
@@ -1788,20 +1805,8 @@ where
     /// assert_eq!(map.count().await.unwrap(), 2);
     /// # })
     /// ```
-    pub async fn count(&self) -> Result<usize, ViewError>
-    {
-        let prefix = Vec::new();
-        let mut count = 0;
-        self.map
-            .for_each_key_value(
-                |_key, _bytes| {
-                    count += 1;
-                    Ok(())
-                },
-                prefix,
-            )
-            .await?;
-        Ok(count)
+    pub async fn count(&self) -> Result<usize, ViewError> {
+        self.map.count().await
     }
 }
 

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -842,6 +842,31 @@ where
         Ok(keys)
     }
 
+    /// Returns the number of indices of the collection.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
+    /// # use linera_views::register_view::RegisterView;
+    /// # use linera_views::views::View;
+    /// # let context = create_test_memory_context();
+    /// let mut view: ReentrantByteCollectionView<_, RegisterView<_, String>> =
+    ///     ReentrantByteCollectionView::load(context).await.unwrap();
+    /// view.try_load_entry_mut(&[0, 1]).await.unwrap();
+    /// view.try_load_entry_mut(&[0, 2]).await.unwrap();
+    /// assert_eq!(view.count().await.unwrap(), 2);
+    /// # })
+    /// ```
+    pub async fn count(&self) -> Result<usize, ViewError> {
+        let mut count = 0;
+        self.for_each_key(|_key| {
+            count += 1;
+            Ok(())
+        })
+        .await?;
+        Ok(count)
+    }
+
     /// Applies a function f on each index (aka key). Keys are visited in a
     /// lexicographic order. If the function returns false then the loop
     /// ends prematurely.
@@ -1426,12 +1451,31 @@ where
     /// ```
     pub async fn indices(&self) -> Result<Vec<I>, ViewError> {
         let mut indices = Vec::new();
-        self.for_each_index(|index: I| {
+        self.for_each_index(|index| {
             indices.push(index);
             Ok(())
         })
         .await?;
         Ok(indices)
+    }
+
+    /// Returns the number of indices in the collection.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
+    /// # use linera_views::register_view::RegisterView;
+    /// # use linera_views::views::View;
+    /// # let context = create_test_memory_context();
+    /// let mut view: ReentrantCollectionView<_, u64, RegisterView<_, String>> =
+    ///     ReentrantCollectionView::load(context).await.unwrap();
+    /// view.try_load_entry_mut(&23).await.unwrap();
+    /// view.try_load_entry_mut(&25).await.unwrap();
+    /// assert_eq!(view.count().await.unwrap(), 2);
+    /// # })
+    /// ```
+    pub async fn count(&self) -> Result<usize, ViewError> {
+        self.collection.count().await
     }
 
     /// Applies a function f on each index. Indices are visited in an order
@@ -1925,12 +1969,31 @@ where
     /// ```
     pub async fn indices(&self) -> Result<Vec<I>, ViewError> {
         let mut indices = Vec::new();
-        self.for_each_index(|index: I| {
+        self.for_each_index(|index| {
             indices.push(index);
             Ok(())
         })
         .await?;
         Ok(indices)
+    }
+
+    /// Returns the number of entries in the collection.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
+    /// # use linera_views::register_view::RegisterView;
+    /// # use linera_views::views::View;
+    /// # let context = create_test_memory_context();
+    /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
+    ///     ReentrantCustomCollectionView::load(context).await.unwrap();
+    /// view.try_load_entry_mut(&23).await.unwrap();
+    /// view.try_load_entry_mut(&25).await.unwrap();
+    /// assert_eq!(view.count().await.unwrap(), 2);
+    /// # })
+    /// ```
+    pub async fn count(&self) -> Result<usize, ViewError> {
+        self.collection.count().await
     }
 
     /// Applies a function f on each index. Indices are visited in an order

--- a/linera-views/src/views/set_view.rs
+++ b/linera-views/src/views/set_view.rs
@@ -232,6 +232,28 @@ where
         Ok(keys)
     }
 
+    /// Returns the number of entries in the set.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::{context::create_test_memory_context, set_view::ByteSetView};
+    /// # use linera_views::views::View;
+    /// # let context = create_test_memory_context();
+    /// let mut set = ByteSetView::load(context).await.unwrap();
+    /// set.insert(vec![0, 1]);
+    /// set.insert(vec![0, 2]);
+    /// assert_eq!(set.keys().await.unwrap(), vec![vec![0, 1], vec![0, 2]]);
+    /// # })
+    /// ```
+    pub async fn count(&self) -> Result<usize, ViewError> {
+        let mut count = 0;
+        self.for_each_key(|_key| {
+            count += 1;
+            Ok(())
+        })
+        .await?;
+        Ok(count)
+    }
+
     /// Applies a function f on each index (aka key). Keys are visited in a
     /// lexicographic order. If the function returns false, then the loop ends
     /// prematurely.
@@ -527,13 +549,28 @@ where
     /// # })
     /// ```
     pub async fn indices(&self) -> Result<Vec<I>, ViewError> {
-        let mut indices = Vec::<I>::new();
-        self.for_each_index(|index: I| {
+        let mut indices = Vec::new();
+        self.for_each_index(|index| {
             indices.push(index);
             Ok(())
         })
         .await?;
         Ok(indices)
+    }
+
+    /// Returns the number of entries in the set.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::{context::create_test_memory_context, set_view::SetView};
+    /// # use linera_views::views::View;
+    /// # let context = create_test_memory_context();
+    /// let mut set: SetView<_, u32> = SetView::load(context).await.unwrap();
+    /// set.insert(&(34 as u32));
+    /// assert_eq!(set.count().await.unwrap(), 1);
+    /// # })
+    /// ```
+    pub async fn count(&self) -> Result<usize, ViewError> {
+        self.set.count().await
     }
 
     /// Applies a function f on each index. Indices are visited in an order
@@ -800,13 +837,30 @@ where
     /// # })
     /// ```
     pub async fn indices(&self) -> Result<Vec<I>, ViewError> {
-        let mut indices = Vec::<I>::new();
-        self.for_each_index(|index: I| {
+        let mut indices = Vec::new();
+        self.for_each_index(|index| {
             indices.push(index);
             Ok(())
         })
         .await?;
         Ok(indices)
+    }
+
+    /// Returns the number of entries of the set.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::set_view::CustomSetView;
+    /// # use linera_views::views::View;
+    /// # let context = create_test_memory_context();
+    /// let mut set = CustomSetView::<_, u128>::load(context).await.unwrap();
+    /// set.insert(&(34 as u128));
+    /// set.insert(&(37 as u128));
+    /// assert_eq!(set.count().await.unwrap(), 2);
+    /// # })
+    /// ```
+    pub async fn count(&self) -> Result<usize, ViewError> {
+        self.set.count().await
     }
 
     /// Applies a function f on each index. Indices are visited in an order


### PR DESCRIPTION
## Motivation

In several applications, we only need the number of entries and the set of pairs `(I, V)`.

Fixes https://github.com/linera-io/linera-protocol/issues/2952

## Proposal

The following was done:
* The `fn count` was added to all the containers.
* The `index_values` functions are added to the `MapView` and `CustomMapView`.
* The code is correspondingly simplified.
* The trait requirements are simplified.

## Test Plan

The added functions have their own tests. The change in other parts of the code should be handled by the existing code.

## Release Plan

This change is a relatively minor one and does not change the TestNet / DevNet.

## Links

None.