### PR TITLE
Remove some serializations in `MapView`.

### DIFF
--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -640,7 +640,7 @@ where
     /// assert_eq!(part_keys.len(), 2);
     /// # })
     /// ```
-    pub(crate) async fn for_each_key_value_or_bytes_while<'a, F>(
+    pub async fn for_each_key_value_or_bytes_while<'a, F>(
         &'a self,
         mut f: F,
         prefix: Vec<u8>,
@@ -776,7 +776,7 @@ where
     /// assert_eq!(count, 1);
     /// # })
     /// ```
-    pub(crate) async fn for_each_key_value_or_bytes<'a, F>(
+    pub async fn for_each_key_value_or_bytes<'a, F>(
         &'a self,
         mut f: F,
         prefix: Vec<u8>,
@@ -807,7 +807,7 @@ where
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// let mut count = 0;
     /// let prefix = Vec::new();
-    /// map.for_each_key_value_or_bytes(
+    /// map.for_each_key_value(
     ///     |_key, _value| {
     ///         count += 1;
     ///         Ok(())

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -96,11 +96,10 @@ where
     pub fn to_bytes(self) -> Result<Vec<u8>, ViewError> {
         match self {
             ValueOrBytes::Value(value) => Ok(bcs::to_bytes(value)?),
-            ValueOrBytes::Bytes(bytes) => Ok(bytes)
+            ValueOrBytes::Bytes(bytes) => Ok(bytes),
         }
     }
 }
-
 
 #[async_trait]
 impl<C, V> View<C> for ByteMapView<C, V>

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -661,12 +661,12 @@ where
                 .context
                 .find_key_values_by_prefix(&base)
                 .await?
-                .iterator()
+                .into_iterator_owned()
             {
                 let (index, bytes) = entry?;
                 loop {
                     match update {
-                        Some((key, value)) if &key[prefix_len..] <= index => {
+                        Some((key, value)) if key[prefix_len..] <= *index => {
                             if let Update::Set(value) = value {
                                 let value = ValueOrBytes::Value(value);
                                 if !f(&key[prefix_len..], value)? {
@@ -674,14 +674,14 @@ where
                                 }
                             }
                             update = updates.next();
-                            if &key[prefix_len..] == index {
+                            if key[prefix_len..] == index {
                                 break;
                             }
                         }
                         _ => {
-                            if !suffix_closed_set.find_key(index) {
-                                let value = ValueOrBytes::Bytes(bytes.to_vec());
-                                if !f(index, value)? {
+                            if !suffix_closed_set.find_key(&index) {
+                                let value = ValueOrBytes::Bytes(bytes);
+                                if !f(&index, value)? {
                                     return Ok(());
                                 }
                             }

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -616,31 +616,7 @@ where
     /// deserialize something that was serialized. The key/value are send to the
     /// function f. If it returns false the the loop ends prematurely. Keys and values
     /// are visited in the lexicographic order.
-    /// ```rust
-    /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
-    /// # use linera_views::map_view::ByteMapView;
-    /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
-    /// let mut map = ByteMapView::load(context).await.unwrap();
-    /// map.insert(vec![0, 1], String::from("Hello"));
-    /// map.insert(vec![1, 2], String::from("Bonjour"));
-    /// map.insert(vec![1, 3], String::from("Hallo"));
-    /// let mut part_keys = Vec::new();
-    /// let prefix = vec![1];
-    /// map.for_each_key_value_or_bytes_while(
-    ///     |key, _value| {
-    ///         part_keys.push(key.to_vec());
-    ///         Ok(part_keys.len() < 2)
-    ///     },
-    ///     prefix,
-    /// )
-    /// .await
-    /// .unwrap();
-    /// assert_eq!(part_keys.len(), 2);
-    /// # })
-    /// ```
-    pub async fn for_each_key_value_or_bytes_while<'a, F>(
+    pub(crate) async fn for_each_key_value_or_bytes_while<'a, F>(
         &'a self,
         mut f: F,
         prefix: Vec<u8>,
@@ -754,29 +730,7 @@ where
     /// or its serialization. This is needed in order to avoid a scenario where we
     /// deserialize something that was serialized. The key/value are send to the
     /// function f. Keys and values are visited in the lexicographic order.
-    /// ```rust
-    /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
-    /// # use linera_views::map_view::ByteMapView;
-    /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
-    /// let mut map = ByteMapView::load(context).await.unwrap();
-    /// map.insert(vec![0, 1], String::from("Hello"));
-    /// let mut count = 0;
-    /// let prefix = Vec::new();
-    /// map.for_each_key_value_or_bytes(
-    ///     |_key, _value| {
-    ///         count += 1;
-    ///         Ok(())
-    ///     },
-    ///     prefix,
-    /// )
-    /// .await
-    /// .unwrap();
-    /// assert_eq!(count, 1);
-    /// # })
-    /// ```
-    pub async fn for_each_key_value_or_bytes<'a, F>(
+    pub(crate) async fn for_each_key_value_or_bytes<'a, F>(
         &'a self,
         mut f: F,
         prefix: Vec<u8>,

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -616,7 +616,7 @@ where
     /// deserialize something that was serialized. The key/value are send to the
     /// function f. If it returns false the the loop ends prematurely. Keys and values
     /// are visited in the lexicographic order.
-    pub(crate) async fn for_each_key_value_or_bytes_while<'a, F>(
+    async fn for_each_key_value_or_bytes_while<'a, F>(
         &'a self,
         mut f: F,
         prefix: Vec<u8>,
@@ -730,7 +730,7 @@ where
     /// or its serialization. This is needed in order to avoid a scenario where we
     /// deserialize something that was serialized. The key/value are send to the
     /// function f. Keys and values are visited in the lexicographic order.
-    pub(crate) async fn for_each_key_value_or_bytes<'a, F>(
+    async fn for_each_key_value_or_bytes<'a, F>(
         &'a self,
         mut f: F,
         prefix: Vec<u8>,

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -863,9 +863,8 @@ where
     ) -> Result<Vec<(Vec<u8>, V)>, ViewError> {
         let mut key_values = Vec::new();
         let prefix_copy = prefix.clone();
-        self.for_each_key_value_or_bytes(
+        self.for_each_key_value(
             |key, value| {
-                let value = value.to_value()?;
                 let mut big_key = prefix.clone();
                 big_key.extend(key);
                 key_values.push((big_key, value));
@@ -1329,10 +1328,9 @@ where
     {
         let prefix = Vec::new();
         self.map
-            .for_each_key_value_or_bytes_while(
+            .for_each_key_value_while(
                 |key, value| {
                     let index = C::deserialize_value(key)?;
-                    let value = value.to_value()?;
                     f(index, value)
                 },
                 prefix,
@@ -1367,10 +1365,9 @@ where
     {
         let prefix = Vec::new();
         self.map
-            .for_each_key_value_or_bytes(
+            .for_each_key_value(
                 |key, value| {
                     let index = C::deserialize_value(key)?;
-                    let value = value.to_value()?;
                     f(index, value)
                 },
                 prefix,
@@ -1827,10 +1824,9 @@ where
     {
         let prefix = Vec::new();
         self.map
-            .for_each_key_value_or_bytes_while(
+            .for_each_key_value_while(
                 |key, value| {
                     let index = I::from_custom_bytes(key)?;
-                    let value = value.to_value()?;
                     f(index, value)
                 },
                 prefix,
@@ -1866,10 +1862,9 @@ where
     {
         let prefix = Vec::new();
         self.map
-            .for_each_key_value_or_bytes(
+            .for_each_key_value(
                 |key, value| {
                     let index = I::from_custom_bytes(key)?;
-                    let value = value.to_value()?;
                     f(index, value)
                 },
                 prefix,


### PR DESCRIPTION
## Motivation

The performance of the `MapView` has recently emerged as a subject of concern. While the use of async Iterators is under discussion, it is clear that there are other issues.

## Proposal

The following was done:
* The enum type `ValueOrBytes` was introduced to represent the fact that in some cases we have the values and in some other cases its serialization.
* The function `for_each_key_value_while` no longer serializes the values; it just creates a `ValueOrBytes::Value`.
* The use of `iterator()` is replaced by a `into_iterator_owned()` since this avoids a `.to_vec()` in the construction of the `ValueOrBytes::Bytes`. Note that we cannot have a `Bytes(&`a [u8])` since indeed the scope of `f` is larger than the one in which the key values are created.
* Some `Clone` traits have to be added. But this should be viewed as a gain since before we were serializing and then deserializing, i.e. a very expensive clone.
* The recently introduced functions `index_values` were needlessly complex. They are replaced by simpler code.

Possible criticism:
* The functions `for_each_key_value` and `for_each_key_value_while` are kept even if their use is complex. This is not an issue as those functions are not used outside of the `linera-views` code. They could be made private.
* Lack of benchmark. But I consider the elimination of serialization/deserialization sufficient as a win so as to not need additional justifications.

## Test Plan

The CI should do the job.

## Release Plan

The PR could be deployed on TestNet / DevNet as desired.

## Links

None.