### PR TITLE
Await for a chain worker to be available for eviction

### DIFF
--- a/linera-core/src/chain_worker/cache.rs
+++ b/linera-core/src/chain_worker/cache.rs
@@ -1,0 +1,176 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types to handle a set of running chain workers.
+//!
+//! The [`ChainWorkers`] type contains a set of running [`ChainWorkerActor`]s. It will
+//! limit itself to a maximum number of active tasks, and will evict the least-recently
+//! used chain worker when it is full and a new chain worker actor needs to be created.
+
+use std::{
+    collections::{HashMap, HashSet},
+    num::NonZeroUsize,
+    sync::{Arc, Mutex, RwLock},
+};
+
+use linera_base::{crypto::CryptoHash, identifiers::ChainId};
+use linera_chain::{data_types::ExecutedBlock, types::Hashed};
+use linera_storage::Storage;
+use lru::LruCache;
+use tokio::sync::mpsc;
+use tracing::Instrument as _;
+
+use crate::{
+    chain_worker::{ChainWorkerActor, ChainWorkerConfig, ChainWorkerRequest, DeliveryNotifier},
+    join_set_ext::{JoinSet, JoinSetExt},
+    value_cache::ValueCache,
+    worker::WorkerError,
+};
+
+/// A cache of running [`ChainWorkerActor`]s.
+#[derive(Clone)]
+pub struct ChainWorkers<StorageClient>
+where
+    StorageClient: Storage,
+{
+    /// One-shot channels to notify callers when messages of a particular chain have been
+    /// delivered.
+    delivery_notifiers: Arc<Mutex<DeliveryNotifiers>>,
+    /// The set of spawned [`ChainWorkerActor`] tasks.
+    tasks: Arc<Mutex<JoinSet>>,
+    /// The cache of running [`ChainWorkerActor`]s.
+    cache: Arc<Mutex<LruCache<ChainId, ChainActorEndpoint<StorageClient>>>>,
+}
+
+/// The map of [`DeliveryNotifier`]s for each chain.
+pub(crate) type DeliveryNotifiers = HashMap<ChainId, DeliveryNotifier>;
+
+/// The sender endpoint for [`ChainWorkerRequest`]s.
+pub type ChainActorEndpoint<StorageClient> =
+    mpsc::UnboundedSender<ChainWorkerRequest<<StorageClient as Storage>::Context>>;
+
+impl<StorageClient> ChainWorkers<StorageClient>
+where
+    StorageClient: Storage,
+{
+    /// Creates a new [`ChainWorkers`] that stores at most `limit` workers.
+    pub fn new(limit: NonZeroUsize) -> Self {
+        ChainWorkers {
+            delivery_notifiers: Arc::default(),
+            tasks: Arc::default(),
+            cache: Arc::new(Mutex::new(LruCache::new(limit))),
+        }
+    }
+
+    /// Obtains a [`ChainActorEndpoint`] to a [`ChainWorkerActor`] for a specific [`ChainId`], or
+    /// creates a new one if it doesn't yet exist.
+    pub async fn get_endpoint(
+        &self,
+        chain_id: ChainId,
+    ) -> Option<Result<ChainActorEndpoint<StorageClient>, NewChainActorEndpoint<StorageClient>>>
+    {
+        let mut cache = self.cache.lock().unwrap();
+
+        if let Some(endpoint) = cache.get(&chain_id) {
+            Some(Ok(endpoint.clone()))
+        } else {
+            if cache.len() >= usize::from(cache.cap()) {
+                let (chain_to_evict, _) = cache
+                    .iter()
+                    .rev()
+                    .find(|(_, candidate_endpoint)| candidate_endpoint.strong_count() <= 1)?;
+                let chain_to_evict = *chain_to_evict;
+
+                cache.pop(&chain_to_evict);
+
+                self.clean_up_finished_chain_workers(&*cache);
+            }
+
+            let (sender, receiver) = mpsc::unbounded_channel();
+            cache.push(chain_id, sender.clone());
+
+            let delivery_notifier = self
+                .delivery_notifiers
+                .lock()
+                .unwrap()
+                .entry(chain_id)
+                .or_default()
+                .clone();
+
+            Some(Err(NewChainActorEndpoint {
+                chain_id,
+                delivery_notifier,
+                tasks: self.tasks.clone(),
+                sender,
+                receiver,
+            }))
+        }
+    }
+
+    /// Cleans up any delivery notifiers for any chain workers that have stopped.
+    fn clean_up_finished_chain_workers(
+        &self,
+        active_chain_workers: &LruCache<ChainId, ChainActorEndpoint<StorageClient>>,
+    ) {
+        self.tasks.lock().unwrap().reap_finished_tasks();
+
+        self.delivery_notifiers
+            .lock()
+            .unwrap()
+            .retain(|chain_id, notifier| {
+                !notifier.is_empty() || active_chain_workers.contains(chain_id)
+            });
+    }
+
+    /// Clears the set, forcing all running [`ChainWorkerActor`]s to stop.
+    #[cfg(test)]
+    pub(crate) fn stop_all(&self) {
+        self.cache.lock().unwrap().clear();
+    }
+}
+
+/// A [`ChainActorEndpoint`] for an actor that has not started yet.
+pub struct NewChainActorEndpoint<StorageClient>
+where
+    StorageClient: Storage,
+{
+    chain_id: ChainId,
+    delivery_notifier: DeliveryNotifier,
+    tasks: Arc<Mutex<JoinSet>>,
+    sender: ChainActorEndpoint<StorageClient>,
+    receiver: mpsc::UnboundedReceiver<ChainWorkerRequest<StorageClient::Context>>,
+}
+
+impl<StorageClient> NewChainActorEndpoint<StorageClient>
+where
+    StorageClient: Storage + Clone + Send + Sync + 'static,
+{
+    /// Consumes this [`NewChainActorEndpoint`] in order to start its [`ChainWorkerActor`]
+    /// task.
+    ///
+    /// Returns the [`ChainActorEndpoint`] for the new [`ChainWorkerActor`].
+    pub async fn start_actor(
+        self,
+        chain_worker_config: ChainWorkerConfig,
+        storage: StorageClient,
+        executed_block_cache: Arc<ValueCache<CryptoHash, Hashed<ExecutedBlock>>>,
+        tracked_chains: Option<Arc<RwLock<HashSet<ChainId>>>>,
+    ) -> Result<ChainActorEndpoint<StorageClient>, WorkerError> {
+        let actor = ChainWorkerActor::load(
+            chain_worker_config,
+            storage,
+            executed_block_cache,
+            tracked_chains,
+            self.delivery_notifier,
+            self.chain_id,
+        )
+        .await?;
+
+        self.tasks
+            .lock()
+            .unwrap()
+            .spawn_task(actor.run(self.receiver).in_current_span());
+
+        Ok(self.sender)
+    }
+}

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -4,6 +4,7 @@
 //! A worker to handle a single chain.
 
 mod actor;
+mod cache;
 mod config;
 mod delivery_notifier;
 mod state;
@@ -13,6 +14,7 @@ pub(super) use self::delivery_notifier::DeliveryNotifier;
 pub(crate) use self::state::CrossChainUpdateHelper;
 pub use self::{
     actor::{ChainWorkerActor, ChainWorkerRequest},
+    cache::{ChainActorEndpoint, ChainWorkers},
     config::ChainWorkerConfig,
     state::ChainWorkerState,
 };

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -662,7 +662,7 @@ where
         &self,
         chain_id: ChainId,
     ) -> Result<ChainActorEndpoint<StorageClient>, WorkerError> {
-        match self.chain_workers.get_endpoint(chain_id).await? {
+        match self.chain_workers.get_endpoint(chain_id).await {
             Ok(endpoint) => Ok(endpoint),
             Err(new_endpoint) => {
                 new_endpoint


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
The `WorkerState` [contains](https://github.com/linera-io/linera-protocol/blob/adef7e0c8cb1b3c81fe199f45dc7dca31d1712be/linera-core/src/worker.rs#L273) an LRU cache of chain workers (more specifically, it keeps open channels to the `ChainWorkerActor`s so that they keep running). Once the cache becomes full, requests for new chain workers randomly [attempt](https://github.com/linera-io/linera-protocol/blob/adef7e0c8cb1b3c81fe199f45dc7dca31d1712be/linera-core/src/worker.rs#L681-L691) to evict an idle chain worker.

Eviction was done by looking for an idle chain worker, in the order of least-recently used endpoints. This means that we iterate through the endpoints, starting with the one that was last used the earliest, and checked if it had a strong count of one or less. If it did, it meant that the endpoint that sent the request had already been dropped, and that only [happens after the response is received](https://github.com/linera-io/linera-protocol/blob/adef7e0c8cb1b3c81fe199f45dc7dca31d1712be/linera-core/src/worker.rs#L662-L671).

If no idle worker is found, that means that there is no worker that's a candidate for eviction, because they all seem to be handling a request. If we evict a chain worker before it finishes handling the request and later on start another chain worker for the same chain while the request is still executing, a race condition is formed which could corrupt the chain state data. Therefore, if there's no eviction candidate the code would [wait 250 milliseconds](https://github.com/linera-io/linera-protocol/blob/adef7e0c8cb1b3c81fe199f45dc7dca31d1712be/linera-core/src/worker.rs#L685) and try again repeatedly [for up to three seconds](https://github.com/linera-io/linera-protocol/blob/adef7e0c8cb1b3c81fe199f45dc7dca31d1712be/linera-core/src/worker.rs#L681) before giving up with an error.

This whole eviction process may run concurrently between many requesters. This leads to possible unfairness, as there's no guarantee which one will succeed. It also introduces undesirable delays between retries.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Use a `Semaphore` to establish a queue among the chain worker requests. This way there's certainty that once the permit is acquired, there will be at least one idle chain worker ready to be evicted.

In order to implement this change, a new `ChainWorkers` type was created to manage the cache. The `ChainActorEndpoint` also became a new type, in order to hold the semaphore permit.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
CI should catch any regressions to the happy path, and #3052 should add a new test for the extreme load case.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do, because this is a just a refactor that should follow the normal release cycle.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
