### PR TITLE
Two corrections

### DIFF
--- a/examples/gen-nft/README.md
+++ b/examples/gen-nft/README.md
@@ -40,7 +40,7 @@ linera_spawn_and_read_wallet_variables linera net up --testing-prng-seed 37
 Compile the `non-fungible` application WebAssembly binaries, and publish them as an application bytecode:
 
 ```bash
-(cd examples/gen-nft && cargo build --release)
+(cd examples/gen-nft && cargo build --release --target wasm32-unknown-unknown)
 
 BYTECODE_ID=$(linera publish-bytecode \
     examples/target/wasm32-unknown-unknown/release/gen_nft_{contract,service}.wasm)

--- a/examples/gen-nft/src/lib.rs
+++ b/examples/gen-nft/src/lib.rs
@@ -44,7 +44,7 @@ linera_spawn_and_read_wallet_variables linera net up --testing-prng-seed 37
 Compile the `non-fungible` application WebAssembly binaries, and publish them as an application bytecode:
 
 ```bash
-(cd examples/gen-nft && cargo build --release)
+(cd examples/gen-nft && cargo build --release --target wasm32-unknown-unknown)
 
 BYTECODE_ID=$(linera publish-bytecode \
     examples/target/wasm32-unknown-unknown/release/gen_nft_{contract,service}.wasm)

--- a/linera-views/src/backends/dual.rs
+++ b/linera-views/src/backends/dual.rs
@@ -16,7 +16,6 @@ use crate::{
 };
 
 /// The initial configuration of the system.
-#[derive(Debug)]
 pub struct DualStoreConfig<C1, C2> {
     /// The first config.
     pub first_config: C1,
@@ -25,7 +24,7 @@ pub struct DualStoreConfig<C1, C2> {
 }
 
 /// The store in use.
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub enum StoreInUse {
     /// The first store.
     First,

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -314,7 +314,7 @@ impl TransactionBuilder {
 }
 
 /// A DynamoDB client.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct DynamoDbStoreInternal {
     client: Client,
     namespace: String,
@@ -324,7 +324,6 @@ pub struct DynamoDbStoreInternal {
 }
 
 /// The initial configuration of the system
-#[derive(Debug)]
 pub struct DynamoDbStoreInternalConfig {
     /// The AWS configuration
     config: aws_sdk_dynamodb::Config,

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -3,7 +3,7 @@
 
 //! Implements [`crate::store::KeyValueStore`] for the IndexedDB Web database.
 
-use std::{fmt::Debug, rc::Rc};
+use std::rc::Rc;
 
 use futures::future;
 use indexed_db_futures::{js_sys, prelude::*, web_sys};
@@ -19,7 +19,6 @@ use crate::{
 };
 
 /// The initial configuration of the system
-#[derive(Debug)]
 pub struct IndexedDbStoreConfig {
     /// The common configuration of the key value store
     pub common_config: CommonStoreConfig,

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -19,8 +19,6 @@
 //! time the data in a block are written, the journal header is updated in the same
 //! transaction to mark the block as processed.
 
-use std::fmt::Debug;
-
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use static_assertions as sa;
@@ -94,7 +92,7 @@ impl<T> DirectKeyValueStore for T where
 }
 
 /// The header that contains the current state of the journal.
-#[derive(Serialize, Deserialize, Default, Debug)]
+#[derive(Serialize, Deserialize, Default)]
 struct JournalHeader {
     block_count: u32,
 }

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -5,7 +5,6 @@
 
 use std::{
     collections::BTreeMap,
-    fmt::Debug,
     sync::{Arc, LazyLock, Mutex, RwLock},
 };
 
@@ -25,7 +24,6 @@ use crate::{
 };
 
 /// The initial configuration of the system
-#[derive(Debug)]
 pub struct MemoryStoreConfig {
     /// The common configuration of the key value store
     pub common_config: CommonStoreInternalConfig,

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -257,7 +257,7 @@ pub struct RocksDbStoreInternal {
 }
 
 /// The initial configuration of the system
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct RocksDbStoreInternalConfig {
     /// The path to the storage containing the namespaces
     path_with_guard: PathWithGuard,
@@ -559,7 +559,7 @@ pub enum RocksDbStoreInternalError {
 }
 
 /// A path and the guard for the temporary directory if needed
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct PathWithGuard {
     /// The path to the data
     pub path_buf: PathBuf,

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -595,7 +595,6 @@ fn get_big_root_key(root_key: &[u8]) -> Vec<u8> {
 }
 
 /// The type for building a new ScyllaDB Key Value Store
-#[derive(Debug)]
 pub struct ScyllaDbStoreInternalConfig {
     /// The url to which the requests have to be sent
     pub uri: String,

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -5,7 +5,6 @@
 
 use std::{
     collections::BTreeSet,
-    fmt::Debug,
     ops::{
         Bound,
         Bound::{Excluded, Included, Unbounded},

--- a/linera-views/src/context.rs
+++ b/linera-views/src/context.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::Debug;
-
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -1,12 +1,9 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::{vec_deque::IterMut, VecDeque};
 #[cfg(with_metrics)]
 use std::sync::LazyLock;
-use std::{
-    collections::{vec_deque::IterMut, VecDeque},
-    fmt::Debug,
-};
 
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -50,7 +47,7 @@ enum KeyTag {
 }
 
 /// The `StoredIndices` contains the description of the stored buckets.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Default, Serialize, Deserialize)]
 struct StoredIndices {
     /// The stored buckets with the first index being the size (at most N) and the
     /// second one is the index in the storage. If the index is 0 then it corresponds
@@ -72,7 +69,7 @@ impl StoredIndices {
 /// and the new_back_values are the ones accessed by the front operation.
 /// If position is not trivial, then the first index is the relevant
 /// bucket for the front and the second index is the position in the index.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct Cursor {
     position: Option<(usize, usize)>,
 }

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -6,7 +6,6 @@ use std::sync::LazyLock;
 use std::{
     borrow::Borrow,
     collections::{btree_map, BTreeMap},
-    fmt::Debug,
     io::Write,
     marker::PhantomData,
     mem,
@@ -692,7 +691,7 @@ impl<C, I, W> View<C> for CollectionView<C, I, W>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    I: Send + Sync + Debug + Serialize + DeserializeOwned,
+    I: Send + Sync + Serialize + DeserializeOwned,
     W: View<C> + Send + Sync,
 {
     const NUM_INIT_KEYS: usize = ByteCollectionView::<C, W>::NUM_INIT_KEYS;
@@ -738,7 +737,7 @@ impl<C, I, W> ClonableView<C> for CollectionView<C, I, W>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    I: Send + Sync + Debug + Serialize + DeserializeOwned,
+    I: Send + Sync + Serialize + DeserializeOwned,
     W: ClonableView<C> + Send + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
@@ -910,7 +909,7 @@ impl<C, I, W> CollectionView<C, I, W>
 where
     C: Context + Send,
     ViewError: From<C::Error>,
-    I: Sync + Clone + Send + Debug + Serialize + DeserializeOwned,
+    I: Sync + Clone + Send + Serialize + DeserializeOwned,
     W: View<C> + Sync,
 {
     /// Returns the list of indices in the collection in the order determined by
@@ -964,7 +963,7 @@ impl<C, I, W> CollectionView<C, I, W>
 where
     C: Context + Send,
     ViewError: From<C::Error>,
-    I: Debug + DeserializeOwned,
+    I: DeserializeOwned,
     W: View<C> + Sync,
 {
     /// Applies a function f on each index. Indices are visited in an order
@@ -1046,7 +1045,7 @@ impl<C, I, W> HashableView<C> for CollectionView<C, I, W>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    I: Clone + Debug + Send + Sync + Serialize + DeserializeOwned,
+    I: Clone + Send + Sync + Serialize + DeserializeOwned,
     W: HashableView<C> + Send + Sync + 'static,
 {
     type Hasher = sha3::Sha3_256;
@@ -1072,7 +1071,7 @@ impl<C, I, W> View<C> for CustomCollectionView<C, I, W>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    I: Send + Sync + Debug,
+    I: Send + Sync,
     W: View<C> + Send + Sync,
 {
     const NUM_INIT_KEYS: usize = ByteCollectionView::<C, W>::NUM_INIT_KEYS;
@@ -1118,7 +1117,7 @@ impl<C, I, W> ClonableView<C> for CustomCollectionView<C, I, W>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    I: Send + Sync + Debug,
+    I: Send + Sync,
     W: ClonableView<C> + Send + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
@@ -1290,7 +1289,7 @@ impl<C, I, W> CustomCollectionView<C, I, W>
 where
     C: Context + Send,
     ViewError: From<C::Error>,
-    I: Send + Debug + CustomSerialize,
+    I: Send + CustomSerialize,
     W: View<C> + Sync,
 {
     /// Returns the list of indices in the collection in the order determined by the custom serialization.
@@ -1343,7 +1342,7 @@ impl<C, I, W> CustomCollectionView<C, I, W>
 where
     C: Context + Send,
     ViewError: From<C::Error>,
-    I: Debug + CustomSerialize,
+    I: CustomSerialize,
     W: View<C> + Sync,
 {
     /// Applies a function f on each index. Indices are visited in an order
@@ -1427,7 +1426,7 @@ impl<C, I, W> HashableView<C> for CustomCollectionView<C, I, W>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    I: Clone + Debug + Send + Sync + CustomSerialize,
+    I: Clone + Send + Sync + CustomSerialize,
     W: HashableView<C> + Send + Sync + 'static,
 {
     type Hasher = sha3::Sha3_256;

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -1,12 +1,9 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::{Bound, Range, RangeBounds};
 #[cfg(with_metrics)]
 use std::sync::LazyLock;
-use std::{
-    fmt::Debug,
-    ops::{Bound, Range, RangeBounds},
-};
 
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -39,7 +39,6 @@ static MAP_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
 use std::{
     borrow::Borrow,
     collections::{btree_map::Entry, BTreeMap},
-    fmt::Debug,
     marker::PhantomData,
     mem,
 };

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -5,7 +5,6 @@
 use std::sync::LazyLock;
 use std::{
     collections::{vec_deque::IterMut, VecDeque},
-    fmt::Debug,
     ops::Range,
 };
 

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -6,7 +6,6 @@ use std::sync::LazyLock;
 use std::{
     borrow::Borrow,
     collections::{btree_map, BTreeMap},
-    fmt::Debug,
     io::Write,
     marker::PhantomData,
     mem,
@@ -1065,7 +1064,7 @@ impl<C, I, W> View<C> for ReentrantCollectionView<C, I, W>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    I: Send + Sync + Debug + Serialize + DeserializeOwned,
+    I: Send + Sync + Serialize + DeserializeOwned,
     W: View<C> + Send + Sync,
 {
     const NUM_INIT_KEYS: usize = ReentrantByteCollectionView::<C, W>::NUM_INIT_KEYS;
@@ -1111,7 +1110,7 @@ impl<C, I, W> ClonableView<C> for ReentrantCollectionView<C, I, W>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    I: Send + Sync + Debug + Serialize + DeserializeOwned,
+    I: Send + Sync + Serialize + DeserializeOwned,
     W: ClonableView<C> + Send + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
@@ -1126,7 +1125,7 @@ impl<C, I, W> ReentrantCollectionView<C, I, W>
 where
     C: Context + Send,
     ViewError: From<C::Error>,
-    I: Sync + Clone + Send + Debug + Serialize + DeserializeOwned,
+    I: Sync + Clone + Send + Serialize + DeserializeOwned,
     W: View<C> + Send + Sync,
 {
     /// Loads a subview for the data at the given index in the collection. If an entry
@@ -1281,7 +1280,7 @@ impl<C, I, W> ReentrantCollectionView<C, I, W>
 where
     C: Context + Send + Clone + 'static,
     ViewError: From<C::Error>,
-    I: Sync + Clone + Send + Debug + Serialize + DeserializeOwned,
+    I: Sync + Clone + Send + Serialize + DeserializeOwned,
     W: View<C> + Send + Sync + 'static,
 {
     /// Load multiple entries for writing at once.
@@ -1429,7 +1428,7 @@ impl<C, I, W> ReentrantCollectionView<C, I, W>
 where
     C: Context + Send,
     ViewError: From<C::Error>,
-    I: Sync + Clone + Send + Debug + Serialize + DeserializeOwned,
+    I: Sync + Clone + Send + Serialize + DeserializeOwned,
     W: View<C> + Send + Sync,
 {
     /// Returns the list of indices in the collection in an order determined
@@ -1557,7 +1556,7 @@ impl<C, I, W> HashableView<C> for ReentrantCollectionView<C, I, W>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    I: Debug + Send + Sync + Serialize + DeserializeOwned,
+    I: Send + Sync + Serialize + DeserializeOwned,
     W: HashableView<C> + Send + Sync + 'static,
 {
     type Hasher = sha3::Sha3_256;
@@ -1584,7 +1583,7 @@ impl<C, I, W> View<C> for ReentrantCustomCollectionView<C, I, W>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    I: Send + Sync + Debug + CustomSerialize,
+    I: Send + Sync + CustomSerialize,
     W: View<C> + Send + Sync,
 {
     const NUM_INIT_KEYS: usize = ReentrantByteCollectionView::<C, W>::NUM_INIT_KEYS;
@@ -1630,7 +1629,7 @@ impl<C, I, W> ClonableView<C> for ReentrantCustomCollectionView<C, I, W>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    I: Send + Sync + Debug + CustomSerialize,
+    I: Send + Sync + CustomSerialize,
     W: ClonableView<C> + Send + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
@@ -1645,7 +1644,7 @@ impl<C, I, W> ReentrantCustomCollectionView<C, I, W>
 where
     C: Context + Send,
     ViewError: From<C::Error>,
-    I: Sync + Clone + Send + Debug + CustomSerialize,
+    I: Sync + Clone + Send + CustomSerialize,
     W: View<C> + Send + Sync,
 {
     /// Loads a subview for the data at the given index in the collection. If an entry
@@ -1801,7 +1800,7 @@ impl<C, I, W> ReentrantCustomCollectionView<C, I, W>
 where
     C: Context + Send + Clone + 'static,
     ViewError: From<C::Error>,
-    I: Sync + Clone + Send + Debug + CustomSerialize,
+    I: Sync + Clone + Send + CustomSerialize,
     W: View<C> + Send + Sync + 'static,
 {
     /// Load multiple entries for writing at once.
@@ -1947,7 +1946,7 @@ impl<C, I, W> ReentrantCustomCollectionView<C, I, W>
 where
     C: Context + Send,
     ViewError: From<C::Error>,
-    I: Sync + Clone + Send + Debug + CustomSerialize,
+    I: Sync + Clone + Send + CustomSerialize,
     W: View<C> + Send + Sync,
 {
     /// Returns the list of indices in the collection. The order is determined by
@@ -2077,7 +2076,7 @@ impl<C, I, W> HashableView<C> for ReentrantCustomCollectionView<C, I, W>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    I: Debug + Send + Sync + CustomSerialize,
+    I: Send + Sync + CustomSerialize,
     W: HashableView<C> + Send + Sync + 'static,
 {
     type Hasher = sha3::Sha3_256;

--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::Debug;
 #[cfg(with_metrics)]
 use std::sync::LazyLock;
 

--- a/linera-views/src/views/set_view.rs
+++ b/linera-views/src/views/set_view.rs
@@ -3,7 +3,7 @@
 
 #[cfg(with_metrics)]
 use std::sync::LazyLock;
-use std::{borrow::Borrow, collections::BTreeMap, fmt::Debug, marker::PhantomData, mem};
+use std::{borrow::Borrow, collections::BTreeMap, marker::PhantomData, mem};
 
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -235,6 +235,7 @@ impl StateStorage for DynamoDbTestStorage {
     }
 }
 
+#[derive(Debug)]
 pub struct TestConfig {
     with_x1: bool,
     with_x2: bool,

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -235,7 +235,6 @@ impl StateStorage for DynamoDbTestStorage {
     }
 }
 
-#[derive(Debug)]
 pub struct TestConfig {
     with_x1: bool,
     with_x2: bool,


### PR DESCRIPTION
## Motivation

Two independent corrections. One for the `gen-nft/README.md` and another for the elimination of `Debug` trait requirements.

## Proposal

It was mentioned in previous PR that maybe we have too much requirements of `Debug` trait.
The unnecessary `Debug` have been removed.

We need to have `Debug` for the following types:
* The views need to have `Debug` since the corresponding code in the protocol code is `Debug`.
* The error types need to be `Debug`.
* The async_graphql need to be `Debug`as well.


## Test Plan

The CI.

## Release Plan

Not of importance to the TestNet / DevNet.

## Links

None.