### PR TITLE
Add tests of triviality

### DIFF
--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -576,7 +576,7 @@ where
     }
 
     async fn write_blobs(&self, blobs: &[Blob]) -> Result<(), ViewError> {
-        if !blobs.is_empty() {
+        if blobs.is_empty() {
             return Ok(());
         }
         let mut batch = Batch::new();

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -576,14 +576,14 @@ where
     }
 
     async fn write_blobs(&self, blobs: &[Blob]) -> Result<(), ViewError> {
+        if !blobs.is_empty() {
+            return Ok(());
+        }
         let mut batch = Batch::new();
         for blob in blobs {
             Self::add_blob_to_batch(blob, &mut batch)?;
         }
-        if !batch.is_empty() {
-            self.write_batch(batch).await?;
-        }
-        Ok(())
+        self.write_batch(batch).await
     }
 
     async fn write_blobs_and_certificate(

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -571,7 +571,10 @@ where
         for blob in blobs {
             Self::add_blob_to_batch(blob, &mut batch)?;
         }
-        self.write_batch(batch).await
+        if !batch.is_empty() {
+            self.write_batch(batch).await?;
+        }
+        Ok(())
     }
 
     async fn write_blobs_and_certificate(

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -422,6 +422,9 @@ where
     }
 
     async fn read_blobs(&self, blob_ids: &[BlobId]) -> Result<Vec<Option<Blob>>, ViewError> {
+        if blob_ids.is_empty() {
+            return Ok(Vec::new());
+        }
         let blob_keys = blob_ids
             .iter()
             .map(|blob_id| bcs::to_bytes(&BaseKey::Blob(*blob_id)))
@@ -452,6 +455,9 @@ where
     }
 
     async fn read_blob_states(&self, blob_ids: &[BlobId]) -> Result<Vec<BlobState>, ViewError> {
+        if blob_ids.is_empty() {
+            return Ok(Vec::new());
+        }
         let blob_state_keys = blob_ids
             .iter()
             .map(|blob_id| bcs::to_bytes(&BaseKey::BlobState(*blob_id)))
@@ -524,6 +530,9 @@ where
         blob_ids: &[BlobId],
         blob_state: BlobState,
     ) -> Result<Vec<Epoch>, ViewError> {
+        if blob_ids.is_empty() {
+            return Ok(Vec::new());
+        }
         let blob_state_keys = blob_ids
             .iter()
             .map(|blob_id| bcs::to_bytes(&BaseKey::BlobState(*blob_id)))
@@ -617,6 +626,9 @@ where
         hashes: I,
     ) -> Result<Vec<ConfirmedBlockCertificate>, ViewError> {
         let hashes = hashes.into_iter().collect::<Vec<_>>();
+        if hashes.is_empty() {
+            return Ok(Vec::new());
+        }
         let keys = Self::get_keys_for_certificates(&hashes)?;
         let values = self.store.read_multi_values_bytes(keys).await;
         if values.is_ok() {

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -190,9 +190,13 @@ fn generate_view_code(input: ItemStruct, root: bool) -> TokenStream2 {
             async fn load(context: #context) -> Result<Self, linera_views::views::ViewError> {
                 use linera_views::context::Context as _;
                 #load_metrics
-                let keys = Self::pre_load(&context)?;
-                let values = context.read_multi_values_bytes(keys).await?;
-                Self::post_load(context, &values)
+                if Self::NUM_INIT_KEYS == 0 {
+                    Self::post_load(context, &[])
+                } else {
+                    let keys = Self::pre_load(&context)?;
+                    let values = context.read_multi_values_bytes(keys).await?;
+                    Self::post_load(context, &values)
+                }
             }
 
 

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
@@ -64,9 +64,13 @@ where
     }
     async fn load(context: C) -> Result<Self, linera_views::views::ViewError> {
         use linera_views::context::Context as _;
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
@@ -65,9 +65,13 @@ where
     }
     async fn load(context: C) -> Result<Self, linera_views::views::ViewError> {
         use linera_views::context::Context as _;
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
@@ -76,9 +76,13 @@ impl linera_views::views::View<CustomContext> for TestView {
         context: CustomContext,
     ) -> Result<Self, linera_views::views::ViewError> {
         use linera_views::context::Context as _;
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
@@ -79,9 +79,13 @@ where
         context: CustomContext,
     ) -> Result<Self, linera_views::views::ViewError> {
         use linera_views::context::Context as _;
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
@@ -80,9 +80,13 @@ impl linera_views::views::View<custom::GenericContext<T>> for TestView {
         context: custom::GenericContext<T>,
     ) -> Result<Self, linera_views::views::ViewError> {
         use linera_views::context::Context as _;
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
@@ -83,9 +83,13 @@ where
         context: custom::GenericContext<T>,
     ) -> Result<Self, linera_views::views::ViewError> {
         use linera_views::context::Context as _;
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
@@ -80,9 +80,13 @@ impl linera_views::views::View<custom::path::to::ContextType> for TestView {
         context: custom::path::to::ContextType,
     ) -> Result<Self, linera_views::views::ViewError> {
         use linera_views::context::Context as _;
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
@@ -84,9 +84,13 @@ where
         context: custom::path::to::ContextType,
     ) -> Result<Self, linera_views::views::ViewError> {
         use linera_views::context::Context as _;
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
@@ -73,9 +73,13 @@ where
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
@@ -74,9 +74,13 @@ where
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
@@ -85,9 +85,13 @@ impl linera_views::views::View<CustomContext> for TestView {
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
@@ -88,9 +88,13 @@ where
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
@@ -89,9 +89,13 @@ impl linera_views::views::View<custom::GenericContext<T>> for TestView {
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
@@ -92,9 +92,13 @@ where
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
@@ -89,9 +89,13 @@ impl linera_views::views::View<custom::path::to::ContextType> for TestView {
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
@@ -93,9 +93,13 @@ where
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
-        let keys = Self::pre_load(&context)?;
-        let values = context.read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
+        if Self::NUM_INIT_KEYS == 0 {
+            Self::post_load(context, &[])
+        } else {
+            let keys = Self::pre_load(&context)?;
+            let values = context.read_multi_values_bytes(keys).await?;
+            Self::post_load(context, &values)
+        }
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -216,9 +216,6 @@ impl ScyllaDbClient {
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, ScyllaDbStoreInternalError> {
         let num_keys = keys.len();
-        if num_keys == 0 {
-            return Ok(Vec::new());
-        }
         let session = &self.session;
         let mut map = HashMap::<Vec<u8>, Vec<usize>>::new();
         let mut inputs = Vec::new();
@@ -262,9 +259,6 @@ impl ScyllaDbClient {
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<bool>, ScyllaDbStoreInternalError> {
         let num_keys = keys.len();
-        if num_keys == 0 {
-            return Ok(Vec::new());
-        }
         let session = &self.session;
         let mut map = HashMap::<Vec<u8>, Vec<usize>>::new();
         let mut inputs = Vec::new();

--- a/linera-views/src/context.rs
+++ b/linera-views/src/context.rs
@@ -230,14 +230,22 @@ where
     }
 
     async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Self::Error> {
-        self.store.contains_keys(keys).await
+        if keys.is_empty() {
+            Ok(Vec::new())
+        } else {
+            self.store.contains_keys(keys).await
+        }
     }
 
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
-        self.store.read_multi_values_bytes(keys).await
+        if keys.is_empty() {
+            Ok(Vec::new())
+        } else {
+            self.store.read_multi_values_bytes(keys).await
+        }
     }
 
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error> {


### PR DESCRIPTION
## Motivation

The `write_batch`, `contains_keys`, and `read_multi_values_bytes` functions can return trivially in some cases.
This leads to some potential optimization.

## Proposal

It has emerged from https://github.com/linera-io/linera-protocol/pull/3010 that the preferred way to handle this is to handle it as early as possible.

Therefore the following was done:
* Add the tests in the `db_storage.rs` as we use the storage directly.
* Add the tests in the `LruCachingStore` since a non-trivial call can become a trivial call if the cache catches it.
* Remove the ScyllaDb tests as they should have been caught before.
* Add the tests in the `context.rs` since this is the go-to point for the views calls.
* Change the code for the `linera-views-derive`. This is needed since many of the `NUM_INIT_KEYS` are 0 (CollectionView, SetView, etc.) and so a test is needed. The compiler should simplify the if test away.

## Test Plan

The CI should do the job.

## Release Plan

This PR increases the speed a little and could be considered for the TestNEt / DevNet.

## Links

None.