### PR TITLE
Map view error to appropriate status; don't retry if `NotFound`/`AlreadyExists`.

### DIFF
--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -73,15 +73,13 @@ impl GrpcClient {
                 info!("gRPC request interrupted: {}; retrying", status);
                 true
             }
-            Code::Ok
-            | Code::Cancelled
-            | Code::NotFound
-            | Code::AlreadyExists
-            | Code::ResourceExhausted => {
+            Code::Ok | Code::Cancelled | Code::ResourceExhausted => {
                 error!("Unexpected gRPC status: {}; retrying", status);
                 true
             }
             Code::InvalidArgument
+            | Code::NotFound
+            | Code::AlreadyExists
             | Code::PermissionDenied
             | Code::FailedPrecondition
             | Code::OutOfRange

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -20,7 +20,7 @@ test = [
     "linera-execution/test",
     "dep:stdext",
 ]
-benchmark = ["linera-base/test", "linera-client/benchmark", "dep:linera-sdk"]
+benchmark = ["linera-base/test", "linera-client/benchmark"]
 wasmer = ["linera-client/wasmer", "linera-execution/wasmer", "linera-storage/wasmer"]
 wasmtime = [
     "linera-client/wasmtime",
@@ -84,7 +84,7 @@ linera-client = { workspace = true, features = ["fs"] }
 linera-core.workspace = true
 linera-execution = { workspace = true, features = ["fs"] }
 linera-rpc = { workspace = true, features = ["server", "simple-network"] }
-linera-sdk = { workspace = true, optional = true }
+linera-sdk = { workspace = true }
 linera-storage.workspace = true
 linera-storage-service = { workspace = true, optional = true }
 linera-version.workspace = true


### PR DESCRIPTION
## Motivation

The proxy returns a gRPC status with code `Unknown` for any `ViewError`, which causes the client to retry the request. For most errors, this doesn't make sense.

## Proposal

Map the errors to appropriate status codes. Don't retry on "not found" or "already exists" errors.

## Test Plan

This brings down the 53 seconds from the scenario in https://github.com/linera-io/linera-protocol/issues/3029 to less than 9 seconds.

## Release Plan

- These changes should
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be ported to the `main` branch.
    - They might be superseded by https://github.com/linera-io/linera-protocol/issues/3033, but that will take much longer to implement and possibly needs some discussion.

## Links

- Related to https://github.com/linera-io/linera-protocol/issues/3029.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
