### PR TITLE
Corrections to `MapView` after the introduction of `ValueOrBytes`.

### DIFF
--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -175,6 +175,7 @@ impl CrowdFundingContract {
         self.state
             .pledges
             .for_each_index_value(|pledger, amount| {
+                let amount = amount.into_owned();
                 pledges.push((pledger, amount));
                 Ok(())
             })

--- a/examples/gen-nft/src/service.rs
+++ b/examples/gen-nft/src/service.rs
@@ -94,6 +94,7 @@ impl QueryRoot {
         self.non_fungible_token
             .nfts
             .for_each_index_value(|_token_id, nft| {
+                let nft = nft.into_owned();
                 let nft_output = NftOutput::new(nft);
                 nfts.insert(nft_output.token_id.clone(), nft_output);
                 Ok(())
@@ -121,6 +122,7 @@ impl QueryRoot {
         self.non_fungible_token
             .owned_token_ids
             .for_each_index_value(|owner, token_ids| {
+                let token_ids = token_ids.into_owned();
                 let new_token_ids = token_ids
                     .into_iter()
                     .map(|token_id| STANDARD_NO_PAD.encode(token_id.id))

--- a/examples/non-fungible/src/service.rs
+++ b/examples/non-fungible/src/service.rs
@@ -96,6 +96,7 @@ impl QueryRoot {
         self.non_fungible_token
             .nfts
             .for_each_index_value(|_token_id, nft| {
+                let nft = nft.into_owned();
                 let payload = {
                     let mut runtime = self
                         .runtime
@@ -130,6 +131,7 @@ impl QueryRoot {
         self.non_fungible_token
             .owned_token_ids
             .for_each_index_value(|owner, token_ids| {
+                let token_ids = token_ids.into_owned();
                 let new_token_ids = token_ids
                     .into_iter()
                     .map(|token_id| STANDARD_NO_PAD.encode(token_id.id))

--- a/linera-views/src/test_utils/test_views.rs
+++ b/linera-views/src/test_utils/test_views.rs
@@ -226,6 +226,7 @@ impl TestView for TestMapView<MemoryContext<()>> {
         let mut state = HashMap::new();
         self.map
             .for_each_index_value(|key, value| {
+                let value = value.into_owned();
                 state.insert(key, value);
                 Ok(())
             })

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -627,7 +627,7 @@ where
         let mut hasher = sha3::Sha3_256::default();
         let keys = self.keys().await?;
         let count = keys.len() as u32;
-        hasher.update_with_bcs_bytes(&count);
+        hasher.update_with_bcs_bytes(&count)?;
         let updates = self.updates.get_mut();
         for key in keys {
             hasher.update_with_bytes(&key)?;

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -655,7 +655,8 @@ where
         let _hash_latency = COLLECTION_VIEW_HASH_RUNTIME.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
         let keys = self.keys().await?;
-        hasher.update_with_bcs_bytes(&keys.len())?;
+        let count = keys.len() as u32;
+        hasher.update_with_bcs_bytes(&count)?;
         let updates = self.updates.read().await;
         for key in keys {
             hasher.update_with_bytes(&key)?;

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -626,7 +626,8 @@ where
         let _hash_latency = COLLECTION_VIEW_HASH_RUNTIME.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
         let keys = self.keys().await?;
-        hasher.update_with_bcs_bytes(&keys.len())?;
+        let count = keys.len() as u32;
+        hasher.update_with_bcs_bytes(&count);
         let updates = self.updates.get_mut();
         for key in keys {
             hasher.update_with_bytes(&key)?;

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -1125,7 +1125,7 @@ where
         #[cfg(with_metrics)]
         let _hash_latency = KEY_VALUE_STORE_VIEW_HASH_LATENCY.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
-        let mut count = 0;
+        let mut count = 0u32;
         self.for_each_index_value(|index, value| -> Result<(), ViewError> {
             count += 1;
             hasher.update_with_bytes(index)?;

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -79,7 +79,7 @@ where
     T: Clone + DeserializeOwned,
 {
     /// Convert to a Cow.
-    fn to_cow(&self) -> Result<Cow<'a, T>, ViewError> {
+    fn to_value(&self) -> Result<Cow<'a, T>, ViewError> {
         match self {
             ValueOrBytes::Value(value) => Ok(Cow::Borrowed(value)),
             ValueOrBytes::Bytes(bytes) => Ok(Cow::Owned(bcs::from_bytes(bytes)?)),
@@ -92,7 +92,7 @@ where
     T: Serialize,
 {
     /// Convert to bytes.
-    pub fn bytes(self) -> Result<Vec<u8>, ViewError> {
+    pub fn into_bytes(self) -> Result<Vec<u8>, ViewError> {
         match self {
             ValueOrBytes::Value(value) => Ok(bcs::to_bytes(value)?),
             ValueOrBytes::Bytes(bytes) => Ok(bytes),
@@ -716,7 +716,7 @@ where
     {
         self.for_each_key_value_or_bytes_while(
             |key, value| {
-                let value = value.to_cow()?;
+                let value = value.to_value()?;
                 f(key, value)
             },
             prefix,
@@ -928,7 +928,7 @@ where
             |index, value| {
                 count += 1;
                 hasher.update_with_bytes(index)?;
-                let bytes = value.bytes()?;
+                let bytes = value.into_bytes()?;
                 hasher.update_with_bytes(&bytes)?;
                 Ok(())
             },

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -67,7 +67,7 @@ pub struct ByteMapView<C, V> {
 }
 
 /// Whether we have a value or its serialization.
-pub enum ValueOrBytes<'a, T> {
+enum ValueOrBytes<'a, T> {
     /// The value itself.
     Value(&'a T),
     /// The serialization.
@@ -917,7 +917,7 @@ where
         #[cfg(with_metrics)]
         let _hash_latency = MAP_VIEW_HASH_RUNTIME.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
-        let mut count = 0;
+        let mut count = 0u32;
         let prefix = Vec::new();
         self.for_each_key_value_or_bytes(
             |index, value| {

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -79,7 +79,7 @@ where
     T: Clone + DeserializeOwned,
 {
     /// Convert to a Cow.
-    pub fn to_cow(&self) -> Result<Cow<'a, T>, ViewError> {
+    fn to_cow(&self) -> Result<Cow<'a, T>, ViewError> {
         match self {
             ValueOrBytes::Value(value) => Ok(Cow::Borrowed(value)),
             ValueOrBytes::Bytes(bytes) => Ok(Cow::Owned(bcs::from_bytes(bytes)?)),

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -983,7 +983,8 @@ where
         let _hash_latency = REENTRANT_COLLECTION_VIEW_HASH_RUNTIME.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
         let keys = self.keys().await?;
-        hasher.update_with_bcs_bytes(&keys.len())?;
+        let count = keys.len() as u32;
+        hasher.update_with_bcs_bytes(&count)?;
         let cached_entries = self.cached_entries.get_mut().unwrap();
         for key in keys {
             hasher.update_with_bytes(&key)?;

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -1017,7 +1017,8 @@ where
         let _hash_latency = REENTRANT_COLLECTION_VIEW_HASH_RUNTIME.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
         let keys = self.keys().await?;
-        hasher.update_with_bcs_bytes(&keys.len())?;
+        let count = keys.len() as u32;
+        hasher.update_with_bcs_bytes(&count)?;
         let mut cached_entries_result = Vec::new();
         {
             let cached_entries = self.cached_entries.lock().unwrap();

--- a/linera-views/src/views/set_view.rs
+++ b/linera-views/src/views/set_view.rs
@@ -369,7 +369,7 @@ where
         #[cfg(with_metrics)]
         let _hash_latency = SET_VIEW_HASH_RUNTIME.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
-        let mut count = 0;
+        let mut count = 0u32;
         self.for_each_key(|key| {
             count += 1;
             hasher.update_with_bytes(key)?;


### PR DESCRIPTION
## Motivation

Several additional suggestions were forgotten in the PR https://github.com/linera-io/linera-protocol/pull/3036 

## Proposal

The following corrections were made:
* The `ValueOrBytes` is marked as private.
* The `count` used for `SetView`, `CollectionView`, `ReentrantCollectionView`, `MapView` and `KeyvalueStoreView` are `usize` which makes them architecture dependent. We switch to u32.
* The `FnMut(I, V)` forces a clone which is not always needed. So, it was replaced by `FnMut(I, Cow<'a, V>)`. Actually, the clone still occurs, but if someone were to want to just access the reference, it would be possible.

Unfortunately, the use of the Cow complexifies the call to the `for_each_key_value`. 

## Test Plan

The CI.

## Release Plan

This is a breaking change with TestNEt / DevNet as it changes the hashes values.

## Links

None.