### PR TITLE
Avoid cloning blob content.

### DIFF
--- a/linera-base/src/crypto.rs
+++ b/linera-base/src/crypto.rs
@@ -424,6 +424,15 @@ impl CryptoHash {
         CryptoHash(hasher.finalize())
     }
 
+    /// Computes the hash of the given bytes.
+    pub fn new_from_bytes(bytes: &[u8]) -> Self {
+        use sha3::digest::Digest;
+
+        let mut hasher = sha3::Sha3_256::default();
+        bytes.write(&mut hasher);
+        CryptoHash(hasher.finalize())
+    }
+
     /// Reads the bytes of the hash value.
     pub fn as_bytes(&self) -> &HasherOutput {
         &self.0

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -206,7 +206,7 @@ impl BlobId {
     /// Creates a new `BlobId` from a `BlobContent`
     pub fn from_content(content: &BlobContent) -> Self {
         Self {
-            hash: CryptoHash::new(&content.blob_bytes()),
+            hash: CryptoHash::new_from_bytes(content.inner_bytes()),
             blob_type: content.into(),
         }
     }

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -54,11 +54,7 @@ use {
 };
 #[cfg(feature = "fs")]
 use {
-    linera_base::{
-        crypto::CryptoHash,
-        data_types::{BlobBytes, Bytecode},
-        identifiers::BytecodeId,
-    },
+    linera_base::{crypto::CryptoHash, data_types::Bytecode, identifiers::BytecodeId},
     linera_core::client::create_bytecode_blobs,
     std::{fs, path::PathBuf},
 };
@@ -542,7 +538,7 @@ where
         .await?;
 
         info!("{}", "Data blob published successfully!");
-        Ok(CryptoHash::new(&BlobBytes(blob_bytes)))
+        Ok(CryptoHash::new_from_bytes(&blob_bytes))
     }
 
     // TODO(#2490): Consider removing or renaming this.

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1292,10 +1292,7 @@ where
         .await?;
 
     let blob0_bytes = b"blob0".to_vec();
-    let blob0_id = BlobId::new(
-        CryptoHash::new(&BlobBytes(blob0_bytes.clone())),
-        BlobType::Data,
-    );
+    let blob0_id = BlobId::new(CryptoHash::new_from_bytes(&blob0_bytes), BlobType::Data);
 
     // Try to read a blob without publishing it first, should fail
     let result = client1_a
@@ -1467,10 +1464,7 @@ where
     builder.set_fault_type([3], FaultType::Offline).await;
 
     let blob0_bytes = b"blob0".to_vec();
-    let blob0_id = BlobId::new(
-        CryptoHash::new(&BlobBytes(blob0_bytes.clone())),
-        BlobType::Data,
-    );
+    let blob0_id = BlobId::new(CryptoHash::new_from_bytes(&blob0_bytes), BlobType::Data);
 
     // Publish blob on chain 1
     let publish_certificate = client1
@@ -1611,10 +1605,7 @@ where
     builder.set_fault_type([3], FaultType::Offline).await;
 
     let blob0_bytes = b"blob0".to_vec();
-    let blob0_id = BlobId::new(
-        CryptoHash::new(&BlobBytes(blob0_bytes.clone())),
-        BlobType::Data,
-    );
+    let blob0_id = BlobId::new(CryptoHash::new_from_bytes(&blob0_bytes), BlobType::Data);
 
     client1.synchronize_from_validators().await.unwrap();
     // Publish blob0 on chain 1
@@ -1628,10 +1619,7 @@ where
         .requires_blob(&blob0_id));
 
     let blob2_bytes = b"blob2".to_vec();
-    let blob2_id = BlobId::new(
-        CryptoHash::new(&BlobBytes(blob2_bytes.clone())),
-        BlobType::Data,
-    );
+    let blob2_id = BlobId::new(CryptoHash::new_from_bytes(&blob2_bytes), BlobType::Data);
 
     client2.synchronize_from_validators().await.unwrap();
     // Publish blob2 on chain 2
@@ -2266,10 +2254,7 @@ where
     builder.set_fault_type([3], FaultType::Offline).await;
 
     // Publish a blob on chain 1.
-    let blob_id = BlobId::new(
-        CryptoHash::new(&BlobBytes(blob_bytes.clone())),
-        BlobType::Data,
-    );
+    let blob_id = BlobId::new(CryptoHash::new_from_bytes(&blob_bytes), BlobType::Data);
     let certificate = client1
         .publish_data_blob(blob_bytes)
         .await

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1032,7 +1032,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
             self.transaction_tracker
                 .replay_oracle_response(OracleResponse::Blob(blob_id))?;
         }
-        Ok(blob_content.inner_bytes())
+        Ok(blob_content.into_inner_bytes())
     }
 
     fn assert_data_blob_exists(&mut self, hash: &CryptoHash) -> Result<(), ExecutionError> {

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -15,9 +15,7 @@ use axum::{extract::Path, http::StatusCode, response, response::IntoResponse, Ex
 use futures::{lock::Mutex, Future};
 use linera_base::{
     crypto::{CryptoError, CryptoHash, PublicKey},
-    data_types::{
-        Amount, ApplicationPermissions, BlobBytes, Bytecode, TimeDelta, UserApplicationDescription,
-    },
+    data_types::{Amount, ApplicationPermissions, Bytecode, TimeDelta, UserApplicationDescription},
     identifiers::{ApplicationId, BytecodeId, ChainId, Owner, UserApplicationId},
     ownership::{ChainOwnership, TimeoutConfig},
     BcsHexParseError,
@@ -583,7 +581,7 @@ where
         chain_id: ChainId,
         bytes: Vec<u8>,
     ) -> Result<CryptoHash, Error> {
-        let hash = CryptoHash::new(&BlobBytes(bytes.clone()));
+        let hash = CryptoHash::new_from_bytes(&bytes);
         self.apply_client_command(&chain_id, move |client| {
             let bytes = bytes.clone();
             async move {

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -28,7 +28,7 @@ use futures::{
 use linera_base::{
     command::resolve_binary,
     crypto::CryptoHash,
-    data_types::{Amount, BlobBytes},
+    data_types::Amount,
     identifiers::{Account, AccountOwner, ApplicationId, ChainId},
 };
 use linera_chain::data_types::{Medium, Origin};
@@ -1015,7 +1015,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     let nft1_minter = account_owner1;
 
     let nft1_blob_bytes = b"nft1_data".to_vec();
-    let nft1_blob_hash = CryptoHash::new(&BlobBytes(nft1_blob_bytes.clone()));
+    let nft1_blob_hash = CryptoHash::new_from_bytes(&nft1_blob_bytes);
     let blob_hash = node_service1
         .publish_data_blob(&chain1, nft1_blob_bytes.clone())
         .await?;
@@ -1145,7 +1145,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     let nft2_name = "nft2".to_string();
     let nft2_minter = account_owner2;
     let nft2_blob_bytes = b"nft2_data".to_vec();
-    let nft2_blob_hash = CryptoHash::new(&BlobBytes(nft2_blob_bytes.clone()));
+    let nft2_blob_hash = CryptoHash::new_from_bytes(&nft2_blob_bytes);
     let blob_hash = node_service2
         .publish_data_blob(&chain2, nft2_blob_bytes.clone())
         .await?;


### PR DESCRIPTION
## Motivation

It's not necessary to clone the blob content just to hash it.

## Proposal

Add a `CryptoHash::new_from_bytes` that doesn't need a `BcsHashable` value. Use it to hash the borrowed blob bytes.

## Test Plan

CI should catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
