### PR TITLE
Avoid cloning blob content.

### DIFF
--- a/linera-base/src/crypto.rs
+++ b/linera-base/src/crypto.rs
@@ -374,18 +374,18 @@ pub trait HasTypeName {
 /// Activate the blanket implementation of `Hashable` based on serde and BCS.
 /// * We use `serde_name` to extract a seed from the name of structs and enums.
 /// * We use `BCS` to generate canonical bytes suitable for hashing.
-pub trait BcsHashable: Serialize + serde::de::DeserializeOwned {}
+pub trait BcsHashable<'de>: Serialize + Deserialize<'de> {}
 
 /// Activate the blanket implementation of `Signable` based on serde and BCS.
 /// * We use `serde_name` to extract a seed from the name of structs and enums.
 /// * We use `BCS` to generate canonical bytes suitable for signing.
-pub trait BcsSignable: Serialize + serde::de::DeserializeOwned {}
+pub trait BcsSignable<'de>: Serialize + Deserialize<'de> {}
 
-impl<T: BcsSignable> BcsHashable for T {}
+impl<'de, T: BcsSignable<'de>> BcsHashable<'de> for T {}
 
-impl<T, Hasher> Hashable<Hasher> for T
+impl<'de, T, Hasher> Hashable<Hasher> for T
 where
-    T: BcsHashable,
+    T: BcsHashable<'de>,
     Hasher: io::Write,
 {
     fn write(&self, hasher: &mut Hasher) {
@@ -405,9 +405,9 @@ where
     }
 }
 
-impl<T> HasTypeName for T
+impl<'de, T> HasTypeName for T
 where
-    T: BcsHashable,
+    T: BcsHashable<'de>,
 {
     fn type_name() -> &'static str {
         serde_name::trace_name::<Self>().expect("Self must be a struct or an enum")
@@ -416,7 +416,7 @@ where
 
 impl CryptoHash {
     /// Computes a hash.
-    pub fn new<T: BcsHashable>(value: &T) -> Self {
+    pub fn new<'de, T: BcsHashable<'de>>(value: &T) -> Self {
         use sha3::digest::Digest;
 
         let mut hasher = sha3::Sha3_256::default();
@@ -438,9 +438,9 @@ impl CryptoHash {
 
 impl Signature {
     /// Computes a signature.
-    pub fn new<T>(value: &T, secret: &KeyPair) -> Self
+    pub fn new<'de, T>(value: &T, secret: &KeyPair) -> Self
     where
-        T: BcsSignable,
+        T: BcsSignable<'de>,
     {
         let mut message = Vec::new();
         value.write(&mut message);
@@ -448,9 +448,13 @@ impl Signature {
         Signature(signature)
     }
 
-    fn check_internal<T>(&self, value: &T, author: PublicKey) -> Result<(), dalek::SignatureError>
+    fn check_internal<'de, T>(
+        &self,
+        value: &T,
+        author: PublicKey,
+    ) -> Result<(), dalek::SignatureError>
     where
-        T: BcsSignable,
+        T: BcsSignable<'de>,
     {
         let mut message = Vec::new();
         value.write(&mut message);
@@ -459,9 +463,9 @@ impl Signature {
     }
 
     /// Checks a signature.
-    pub fn check<T>(&self, value: &T, author: PublicKey) -> Result<(), CryptoError>
+    pub fn check<'de, T>(&self, value: &T, author: PublicKey) -> Result<(), CryptoError>
     where
-        T: BcsSignable + fmt::Debug,
+        T: BcsSignable<'de> + fmt::Debug,
     {
         self.check_internal(value, author)
             .map_err(|error| CryptoError::InvalidSignature {
@@ -471,13 +475,13 @@ impl Signature {
     }
 
     /// Checks an optional signature.
-    pub fn check_optional_signature<T>(
+    pub fn check_optional_signature<'de, T>(
         signature: Option<&Self>,
         value: &T,
         author: &PublicKey,
     ) -> Result<(), CryptoError>
     where
-        T: BcsSignable + fmt::Debug,
+        T: BcsSignable<'de> + fmt::Debug,
     {
         match signature {
             Some(sig) => sig.check(value, *author),
@@ -487,9 +491,12 @@ impl Signature {
         }
     }
 
-    fn verify_batch_internal<'a, T, I>(value: &'a T, votes: I) -> Result<(), dalek::SignatureError>
+    fn verify_batch_internal<'a, 'de, T, I>(
+        value: &'a T,
+        votes: I,
+    ) -> Result<(), dalek::SignatureError>
     where
-        T: BcsSignable,
+        T: BcsSignable<'de>,
         I: IntoIterator<Item = (&'a PublicKey, &'a Signature)>,
     {
         let mut msg = Vec::new();
@@ -506,9 +513,9 @@ impl Signature {
     }
 
     /// Verifies a batch of signatures.
-    pub fn verify_batch<'a, T, I>(value: &'a T, votes: I) -> Result<(), CryptoError>
+    pub fn verify_batch<'a, 'de, T, I>(value: &'a T, votes: I) -> Result<(), CryptoError>
     where
-        T: BcsSignable,
+        T: BcsSignable<'de>,
         I: IntoIterator<Item = (&'a PublicKey, &'a Signature)>,
     {
         Signature::verify_batch_internal(value, votes).map_err(|error| {
@@ -682,7 +689,7 @@ impl Arbitrary for CryptoHash {
     }
 }
 
-impl BcsHashable for PublicKey {}
+impl<'de> BcsHashable<'de> for PublicKey {}
 
 doc_scalar!(CryptoHash, "A Sha3-256 value");
 doc_scalar!(PublicKey, "A signature public key");
@@ -702,7 +709,7 @@ impl TestString {
 }
 
 #[cfg(with_testing)]
-impl BcsSignable for TestString {}
+impl<'de> BcsSignable<'de> for TestString {}
 
 #[cfg(with_getrandom)]
 #[test]
@@ -710,7 +717,7 @@ fn test_signatures() {
     #[derive(Debug, Serialize, Deserialize)]
     struct Foo(String);
 
-    impl BcsSignable for Foo {}
+    impl<'de> BcsSignable<'de> for Foo {}
 
     let key1 = KeyPair::generate();
     let addr1 = key1.public();

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -11,7 +11,7 @@ use std::sync::LazyLock;
 use std::{
     fmt::{self, Display},
     fs,
-    hash::{Hash, Hasher},
+    hash::Hash,
     io, iter,
     num::ParseIntError,
     path::Path,
@@ -953,18 +953,12 @@ impl CompressedBytecode {
 }
 
 /// Internal bytes of a blob.
-#[derive(Clone, Serialize, Deserialize, WitType, WitStore)]
+#[derive(Clone, Hash, Serialize, Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 #[repr(transparent)]
 pub struct BlobBytes(#[serde(with = "serde_bytes")] pub Vec<u8>);
 
 impl BcsHashable for BlobBytes {}
-
-impl Hash for BlobBytes {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.hash(state);
-    }
-}
 
 /// A blob of binary data.
 #[derive(Hash, Clone, Debug, Serialize, Deserialize, WitType, WitStore)]
@@ -1021,14 +1015,10 @@ impl BlobContent {
 
     /// Creates a `Blob` checking that this is the correct `BlobId`.
     pub fn with_blob_id_checked(self, blob_id: BlobId) -> Option<Blob> {
-        match blob_id.blob_type {
-            BlobType::Data if matches!(&self, BlobContent::Data(_)) => Some(()),
-            BlobType::ContractBytecode if matches!(&self, BlobContent::ContractBytecode(_)) => {
-                Some(())
-            }
-            BlobType::ServiceBytecode if matches!(&self, BlobContent::ServiceBytecode(_)) => {
-                Some(())
-            }
+        match (blob_id.blob_type, &self) {
+            (BlobType::Data, BlobContent::Data(_)) => Some(()),
+            (BlobType::ContractBytecode, BlobContent::ContractBytecode(_)) => Some(()),
+            (BlobType::ServiceBytecode, BlobContent::ServiceBytecode(_)) => Some(()),
             _ => None,
         }?;
 
@@ -1041,8 +1031,8 @@ impl BlobContent {
         }
     }
 
-    /// Gets the inner blob's bytes.
-    pub fn inner_bytes(&self) -> Vec<u8> {
+    /// Gets a reference to the inner blob's bytes.
+    pub fn inner_bytes(&self) -> &[u8] {
         match self {
             BlobContent::Data(bytes) => bytes,
             BlobContent::ContractBytecode(compressed_bytecode) => {
@@ -1052,12 +1042,24 @@ impl BlobContent {
                 &compressed_bytecode.compressed_bytes
             }
         }
-        .clone()
+    }
+
+    /// Gets the inner blob's bytes, consuming the blob.
+    pub fn into_inner_bytes(self) -> Vec<u8> {
+        match self {
+            BlobContent::Data(bytes) => bytes,
+            BlobContent::ContractBytecode(compressed_bytecode) => {
+                compressed_bytecode.compressed_bytes
+            }
+            BlobContent::ServiceBytecode(compressed_bytecode) => {
+                compressed_bytecode.compressed_bytes
+            }
+        }
     }
 
     /// Gets the `BlobBytes` for this `BlobContent`.
     pub fn blob_bytes(&self) -> BlobBytes {
-        BlobBytes(self.inner_bytes())
+        BlobBytes(self.inner_bytes().to_vec())
     }
 
     /// Returns the size of the blob content in bytes.
@@ -1133,9 +1135,14 @@ impl Blob {
         self.content
     }
 
-    /// Gets the inner blob's bytes.
-    pub fn inner_bytes(&self) -> Vec<u8> {
+    /// Gets a reference to the inner blob's bytes.
+    pub fn inner_bytes(&self) -> &[u8] {
         self.content.inner_bytes()
+    }
+
+    /// Gets the inner blob's bytes.
+    pub fn into_inner_bytes(self) -> Vec<u8> {
+        self.content.into_inner_bytes()
     }
 
     /// Loads data blob content from a file.

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -956,9 +956,9 @@ impl CompressedBytecode {
 #[derive(Clone, Hash, Serialize, Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 #[repr(transparent)]
-pub struct BlobBytes(#[serde(with = "serde_bytes")] pub Vec<u8>);
+pub struct BlobBytes<'a>(#[serde(with = "serde_bytes")] pub &'a [u8]);
 
-impl BcsHashable for BlobBytes {}
+impl<'a> BcsHashable<'a> for BlobBytes<'a> {}
 
 /// A blob of binary data.
 #[derive(Hash, Clone, Debug, Serialize, Deserialize, WitType, WitStore)]
@@ -1059,7 +1059,7 @@ impl BlobContent {
 
     /// Gets the `BlobBytes` for this `BlobContent`.
     pub fn blob_bytes(&self) -> BlobBytes {
-        BlobBytes(self.inner_bytes().to_vec())
+        BlobBytes(self.inner_bytes())
     }
 
     /// Returns the size of the blob content in bytes.

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -998,7 +998,7 @@ impl ChainId {
     }
 }
 
-impl BcsHashable for ChainDescription {}
+impl<'de> BcsHashable<'de> for ChainDescription {}
 
 bcs_scalar!(ApplicationId, "A unique identifier for a user application");
 doc_scalar!(

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -64,7 +64,7 @@ impl ValidatedBlock {
     }
 }
 
-impl BcsHashable for ValidatedBlock {}
+impl<'de> BcsHashable<'de> for ValidatedBlock {}
 
 /// Wrapper around an `ExecutedBlock` that has been confirmed.
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
@@ -98,7 +98,7 @@ impl Hashed<ConfirmedBlock> {
     }
 }
 
-impl BcsHashable for ConfirmedBlock {}
+impl<'de> BcsHashable<'de> for ConfirmedBlock {}
 
 impl ConfirmedBlock {
     pub fn new(executed_block: ExecutedBlock) -> Self {
@@ -194,7 +194,7 @@ impl Timeout {
     }
 }
 
-impl BcsHashable for Timeout {}
+impl<'de> BcsHashable<'de> for Timeout {}
 
 /// Failure to convert a `Certificate` into one of the expected certificate types.
 #[derive(Clone, Copy, Debug, Error)]

--- a/linera-chain/src/certificate/hashed.rs
+++ b/linera-chain/src/certificate/hashed.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 
 use custom_debug_derive::Debug;
 use linera_base::crypto::{BcsHashable, CryptoHash};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::CertificateValueT;
 use crate::data_types::LiteValue;
@@ -33,9 +33,9 @@ impl<T> Hashed<T> {
     ///
     /// Note: Contrary to its `unchecked_new` counterpart, this method is safe because it
     /// calculates the hash from the value.
-    pub fn new(value: T) -> Self
+    pub fn new<'de>(value: T) -> Self
     where
-        T: BcsHashable,
+        T: BcsHashable<'de>,
     {
         let hash = CryptoHash::new(&value);
         Self { value, hash }
@@ -74,7 +74,7 @@ impl<T: Serialize> Serialize for Hashed<T> {
     }
 }
 
-impl<'de, T: DeserializeOwned + BcsHashable> Deserialize<'de> for Hashed<T> {
+impl<'de, T: BcsHashable<'de>> Deserialize<'de> for Hashed<T> {
     fn deserialize<D>(deserializer: D) -> Result<Hashed<T>, D::Error>
     where
         D: serde::Deserializer<'de>,

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -24,7 +24,7 @@ use linera_execution::{
     system::OpenChainConfig,
     Message, MessageKind, Operation, SystemMessage, SystemOperation,
 };
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     types::{
@@ -400,7 +400,7 @@ pub struct ExecutedBlock {
     pub outcome: BlockExecutionOutcome,
 }
 
-impl BcsHashable for ExecutedBlock {}
+impl<'de> BcsHashable<'de> for ExecutedBlock {}
 
 /// The messages and the state hash resulting from a [`Block`]'s execution.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
@@ -444,7 +444,7 @@ struct VoteValue(CryptoHash, Round, CertificateKind);
 
 /// A vote on a statement from a validator.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(bound(deserialize = "T: DeserializeOwned + BcsHashable"))]
+#[serde(bound(deserialize = "T: BcsHashable<'de>"))]
 pub struct Vote<T> {
     pub value: Hashed<T>,
     pub round: Round,
@@ -916,9 +916,9 @@ pub(crate) fn check_signatures(
     Ok(())
 }
 
-impl BcsSignable for ProposalContent {}
+impl<'de> BcsSignable<'de> for ProposalContent {}
 
-impl BcsSignable for VoteValue {}
+impl<'de> BcsSignable<'de> for VoteValue {}
 
 doc_scalar!(
     MessageAction,

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -542,7 +542,7 @@ where
         .await?;
 
         info!("{}", "Data blob published successfully!");
-        Ok(CryptoHash::new(&BlobBytes(blob_bytes)))
+        Ok(CryptoHash::new(&BlobBytes(&blob_bytes)))
     }
 
     // TODO(#2490): Consider removing or renaming this.

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -189,7 +189,7 @@ pub struct GenesisConfig {
     pub network_name: String,
 }
 
-impl BcsSignable for GenesisConfig {}
+impl<'de> BcsSignable<'de> for GenesisConfig {}
 
 impl GenesisConfig {
     pub fn new(

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -315,7 +315,7 @@ impl ChainInfoResponse {
     }
 }
 
-impl BcsSignable for ChainInfo {}
+impl<'de> BcsSignable<'de> for ChainInfo {}
 
 /// The outcome of trying to commit a list of operations to the chain.
 #[derive(Debug)]

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1292,10 +1292,7 @@ where
         .await?;
 
     let blob0_bytes = b"blob0".to_vec();
-    let blob0_id = BlobId::new(
-        CryptoHash::new(&BlobBytes(blob0_bytes.clone())),
-        BlobType::Data,
-    );
+    let blob0_id = BlobId::new(CryptoHash::new(&BlobBytes(&blob0_bytes)), BlobType::Data);
 
     // Try to read a blob without publishing it first, should fail
     let result = client1_a
@@ -1467,10 +1464,7 @@ where
     builder.set_fault_type([3], FaultType::Offline).await;
 
     let blob0_bytes = b"blob0".to_vec();
-    let blob0_id = BlobId::new(
-        CryptoHash::new(&BlobBytes(blob0_bytes.clone())),
-        BlobType::Data,
-    );
+    let blob0_id = BlobId::new(CryptoHash::new(&BlobBytes(&blob0_bytes)), BlobType::Data);
 
     // Publish blob on chain 1
     let publish_certificate = client1
@@ -1611,10 +1605,7 @@ where
     builder.set_fault_type([3], FaultType::Offline).await;
 
     let blob0_bytes = b"blob0".to_vec();
-    let blob0_id = BlobId::new(
-        CryptoHash::new(&BlobBytes(blob0_bytes.clone())),
-        BlobType::Data,
-    );
+    let blob0_id = BlobId::new(CryptoHash::new(&BlobBytes(&blob0_bytes)), BlobType::Data);
 
     client1.synchronize_from_validators().await.unwrap();
     // Publish blob0 on chain 1
@@ -1628,10 +1619,7 @@ where
         .requires_blob(&blob0_id));
 
     let blob2_bytes = b"blob2".to_vec();
-    let blob2_id = BlobId::new(
-        CryptoHash::new(&BlobBytes(blob2_bytes.clone())),
-        BlobType::Data,
-    );
+    let blob2_id = BlobId::new(CryptoHash::new(&BlobBytes(&blob2_bytes)), BlobType::Data);
 
     client2.synchronize_from_validators().await.unwrap();
     // Publish blob2 on chain 2
@@ -2266,10 +2254,7 @@ where
     builder.set_fault_type([3], FaultType::Offline).await;
 
     // Publish a blob on chain 1.
-    let blob_id = BlobId::new(
-        CryptoHash::new(&BlobBytes(blob_bytes.clone())),
-        BlobType::Data,
-    );
+    let blob_id = BlobId::new(CryptoHash::new(&BlobBytes(&blob_bytes)), BlobType::Data);
     let certificate = client1
         .publish_data_blob(blob_bytes)
         .await

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1032,7 +1032,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
             self.transaction_tracker
                 .replay_oracle_response(OracleResponse::Blob(blob_id))?;
         }
-        Ok(blob_content.inner_bytes())
+        Ok(blob_content.into_inner_bytes())
     }
 
     fn assert_data_blob_exists(&mut self, hash: &CryptoHash) -> Result<(), ExecutionError> {

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -925,7 +925,7 @@ pub mod tests {
     #[derive(Debug, Serialize, Deserialize)]
     struct Foo(String);
 
-    impl BcsSignable for Foo {}
+    impl<'de> BcsSignable<'de> for Foo {}
 
     fn get_block() -> Block {
         make_first_block(ChainId::root(0))

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -583,7 +583,7 @@ where
         chain_id: ChainId,
         bytes: Vec<u8>,
     ) -> Result<CryptoHash, Error> {
-        let hash = CryptoHash::new(&BlobBytes(bytes.clone()));
+        let hash = CryptoHash::new(&BlobBytes(&bytes));
         self.apply_client_command(&chain_id, move |client| {
             let bytes = bytes.clone();
             async move {

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -1015,7 +1015,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     let nft1_minter = account_owner1;
 
     let nft1_blob_bytes = b"nft1_data".to_vec();
-    let nft1_blob_hash = CryptoHash::new(&BlobBytes(nft1_blob_bytes.clone()));
+    let nft1_blob_hash = CryptoHash::new(&BlobBytes(&nft1_blob_bytes));
     let blob_hash = node_service1
         .publish_data_blob(&chain1, nft1_blob_bytes.clone())
         .await?;
@@ -1145,7 +1145,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     let nft2_name = "nft2".to_string();
     let nft2_minter = account_owner2;
     let nft2_blob_bytes = b"nft2_data".to_vec();
-    let nft2_blob_hash = CryptoHash::new(&BlobBytes(nft2_blob_bytes.clone()));
+    let nft2_blob_hash = CryptoHash::new(&BlobBytes(&nft2_blob_bytes));
     let blob_hash = node_service2
         .publish_data_blob(&chain2, nft2_blob_bytes.clone())
         .await?;

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -265,7 +265,7 @@ pub trait Storage: Sized {
         );
         let contract_blob = self.read_blob(contract_bytecode_blob_id).await?;
         let compressed_contract_bytecode = CompressedBytecode {
-            compressed_bytes: contract_blob.inner_bytes(),
+            compressed_bytes: contract_blob.into_inner_bytes(),
         };
         let contract_bytecode =
             linera_base::task::Blocking::<linera_base::task::NoInput, _>::spawn(
@@ -308,7 +308,7 @@ pub trait Storage: Sized {
         );
         let service_blob = self.read_blob(service_bytecode_blob_id).await?;
         let compressed_service_bytecode = CompressedBytecode {
-            compressed_bytes: service_blob.inner_bytes(),
+            compressed_bytes: service_blob.into_inner_bytes(),
         };
         let service_bytecode = linera_base::task::Blocking::<linera_base::task::NoInput, _>::spawn(
             move |_| async move { compressed_service_bytecode.decompress() },

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -356,7 +356,7 @@ fn generate_crypto_hash_code(input: ItemStruct) -> TokenStream2 {
                 use serde::{Serialize, Deserialize};
                 #[derive(Serialize, Deserialize)]
                 struct #hash_type(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-                impl BcsHashable for #hash_type {}
+                impl<'de> BcsHashable<'de> for #hash_type {}
                 let hash = self.hash().await?;
                 Ok(CryptoHash::new(&#hash_type(hash)))
             }
@@ -372,7 +372,7 @@ fn generate_crypto_hash_code(input: ItemStruct) -> TokenStream2 {
                 use serde::{Serialize, Deserialize};
                 #[derive(Serialize, Deserialize)]
                 struct #hash_type(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-                impl BcsHashable for #hash_type {}
+                impl<'de> BcsHashable<'de> for #hash_type {}
                 let hash = self.hash_mut().await?;
                 Ok(CryptoHash::new(&#hash_type(hash)))
             }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-2.snap
@@ -20,7 +20,7 @@ where
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }
@@ -36,7 +36,7 @@ where
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash_mut().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-3.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-3.snap
@@ -16,7 +16,7 @@ impl linera_views::views::CryptoHashView<CustomContext> for TestView {
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }
@@ -32,7 +32,7 @@ impl linera_views::views::CryptoHashView<CustomContext> for TestView {
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash_mut().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-4.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-4.snap
@@ -19,7 +19,7 @@ where
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }
@@ -35,7 +35,7 @@ where
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash_mut().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-5.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-5.snap
@@ -16,7 +16,7 @@ impl linera_views::views::CryptoHashView<custom::path::to::ContextType> for Test
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }
@@ -32,7 +32,7 @@ impl linera_views::views::CryptoHashView<custom::path::to::ContextType> for Test
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash_mut().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-6.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-6.snap
@@ -20,7 +20,7 @@ where
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }
@@ -36,7 +36,7 @@ where
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash_mut().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-7.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-7.snap
@@ -16,7 +16,7 @@ impl linera_views::views::CryptoHashView<custom::GenericContext<T>> for TestView
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }
@@ -32,7 +32,7 @@ impl linera_views::views::CryptoHashView<custom::GenericContext<T>> for TestView
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash_mut().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-8.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-8.snap
@@ -20,7 +20,7 @@ where
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }
@@ -36,7 +36,7 @@ where
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash_mut().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code.snap
@@ -19,7 +19,7 @@ where
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }
@@ -35,7 +35,7 @@ where
         use serde::{Serialize, Deserialize};
         #[derive(Serialize, Deserialize)]
         struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-        impl BcsHashable for TestViewHash {}
+        impl<'de> BcsHashable<'de> for TestViewHash {}
         let hash = self.hash_mut().await?;
         Ok(CryptoHash::new(&TestViewHash(hash)))
     }


### PR DESCRIPTION
## Motivation

It's not necessary to clone the blob content just to hash it.

## Proposal

Change `BcsHashable` to not require `DeserializeOwned`, so that `BlobBytes` can borrow the bytes.

There were also a few other places where they were unnecessarily cloned.

## Test Plan

CI should catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Supersedes https://github.com/linera-io/linera-protocol/pull/3049.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
