### PR TITLE
Run Docker Compose CI in all docker changes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,10 +7,7 @@ on:
     branches:
       - "**"
     paths:
-      - 'docker/Dockerfile'
-      - 'docker/docker-compose.yml'
-      - 'docker/compose.sh'
-      - 'docker/docker-compose.yml'
+      - 'docker/**'
       - 'Cargo.toml'
       - '.github/workflows/docker.yml'
   workflow_dispatch:


### PR DESCRIPTION
## Motivation

Some of the stuff on `docker/` is not really used by the docker compose workflow, but we might as well have the whole directory as it's most files (we would have to add most of the files manually otherwise).
Then PRs like https://github.com/linera-io/linera-protocol/pull/3021 can trigger CI and have some sanity tests run before merging.

## Proposal

Trigger docker compose CI on all changes in the `docker` directory

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
