### PR TITLE
Add watchtower service to automatically upgrade the shard and proxy.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "0"
       - "--overprovisioned"
       - "1"
+
   proxy:
     image: "${LINERA_IMAGE:-linera}"
     container_name: proxy
@@ -19,9 +20,12 @@ services:
     command: [ "./compose-proxy-entrypoint.sh" ]
     volumes:
       - .:/config
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     depends_on:
       shard-init:
         condition: service_completed_successfully
+
   shard:
     image: "${LINERA_IMAGE:-linera}"
     deploy:
@@ -29,9 +33,12 @@ services:
     command: [ "./compose-server-entrypoint.sh" ]
     volumes:
       - .:/config
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     depends_on:
       shard-init:
         condition: service_completed_successfully
+
   shard-init:
     image: "${LINERA_IMAGE:-linera}"
     container_name: shard-init
@@ -60,6 +67,13 @@ services:
       - grafana-storage:/var/lib/grafana
       - ./provisioning/dashboards:/etc/grafana/provisioning/dashboards
       - ./dashboards:/var/lib/grafana/dashboards
+
+  watchtower:
+    image: containrrr/watchtower:latest
+    container_name: watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: [ "--interval", "30"]
 
 volumes:
   linera-scylla-data:


### PR DESCRIPTION
## Motivation

During testnet we would like validators to be updated automatically.

## Proposal

Add watch-tower to `docker-compose.yml` monitoring only the proxy and shards.

### Caveats
1. Kubernetes is going to require a different approach and is in general going to require more work + refactoring.
2. The validators _must_ use the external image tagged with the network name, for example:

```bash
./deploy-validator.sh my-domain.com --remote-image  us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:testnet-archimedes
```

If a local image is used, automatic updating won't work since provenance is not shared with remote images.

This is a feature not a bug, if validators want they _can_ build everything from scratch and opt-out from "forced" updates. However I see no reason why they might choose to.

## Test Plan

Manual testing. CI will catch functional regressions.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

https://containrrr.dev/watchtower/
