### PR TITLE
Implement `WitType`, `WitLoad` and `WitStore` for pointer types

### DIFF
--- a/linera-witty/src/type_traits/implementations/std/box.rs
+++ b/linera-witty/src/type_traits/implementations/std/box.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementations of the custom traits for the [`Box`] type.
+
+impl_for_wrapper_type!(Box);

--- a/linera-witty/src/type_traits/implementations/std/mod.rs
+++ b/linera-witty/src/type_traits/implementations/std/mod.rs
@@ -3,6 +3,90 @@
 
 //! Implementations of the custom traits for types from the standard library.
 
+/// A macro to implement [`WitType`][super::WitType], [`WitLoad`][super::WitLoad] and
+/// [`WitStore`][super::WitStore] for a simple wrapper type.
+///
+/// This assumes that:
+/// - The type is `$wrapper<T>`
+/// - It can be constructed with `$wrapper::new(instance_to_wrap)`
+/// - The type implements `Deref<Target = T>`
+macro_rules! impl_for_wrapper_type {
+    ($wrapper:ident) => {
+        impl<T> crate::WitType for $wrapper<T>
+        where
+            T: crate::WitType,
+        {
+            const SIZE: u32 = T::SIZE;
+
+            type Layout = T::Layout;
+            type Dependencies = T::Dependencies;
+
+            fn wit_type_name() -> ::std::borrow::Cow<'static, str> {
+                T::wit_type_name()
+            }
+
+            fn wit_type_declaration() -> ::std::borrow::Cow<'static, str> {
+                T::wit_type_declaration()
+            }
+        }
+
+        impl<T> crate::WitLoad for $wrapper<T>
+        where
+            T: crate::WitLoad,
+        {
+            fn load<Instance>(
+                memory: &crate::Memory<'_, Instance>,
+                location: crate::GuestPointer,
+            ) -> Result<Self, crate::RuntimeError>
+            where
+                Instance: crate::InstanceWithMemory,
+                <Instance::Runtime as crate::Runtime>::Memory: crate::RuntimeMemory<Instance>,
+            {
+                T::load(memory, location).map($wrapper::new)
+            }
+
+            fn lift_from<Instance>(
+                flat_layout: <Self::Layout as crate::Layout>::Flat,
+                memory: &crate::Memory<'_, Instance>,
+            ) -> Result<Self, crate::RuntimeError>
+            where
+                Instance: crate::InstanceWithMemory,
+                <Instance::Runtime as crate::Runtime>::Memory: crate::RuntimeMemory<Instance>,
+            {
+                T::lift_from(flat_layout, memory).map($wrapper::new)
+            }
+        }
+
+        impl<T> crate::WitStore for $wrapper<T>
+        where
+            T: crate::WitStore,
+        {
+            fn store<Instance>(
+                &self,
+                memory: &mut crate::Memory<'_, Instance>,
+                location: crate::GuestPointer,
+            ) -> Result<(), crate::RuntimeError>
+            where
+                Instance: crate::InstanceWithMemory,
+                <Instance::Runtime as crate::Runtime>::Memory: crate::RuntimeMemory<Instance>,
+            {
+                <$wrapper<T> as ::std::ops::Deref>::deref(self).store(memory, location)
+            }
+
+            fn lower<Instance>(
+                &self,
+                memory: &mut crate::Memory<'_, Instance>,
+            ) -> Result<<Self::Layout as crate::Layout>::Flat, crate::RuntimeError>
+            where
+                Instance: crate::InstanceWithMemory,
+                <Instance::Runtime as crate::Runtime>::Memory: crate::RuntimeMemory<Instance>,
+            {
+                <$wrapper<T> as ::std::ops::Deref>::deref(self).lower(memory)
+            }
+        }
+    };
+}
+
 mod collections;
 mod floats;
 mod integers;

--- a/linera-witty/src/type_traits/implementations/std/mod.rs
+++ b/linera-witty/src/type_traits/implementations/std/mod.rs
@@ -97,6 +97,7 @@ mod primitives;
 mod rc;
 mod result;
 mod string;
+mod sync;
 mod time;
 mod tuples;
 mod vec;

--- a/linera-witty/src/type_traits/implementations/std/mod.rs
+++ b/linera-witty/src/type_traits/implementations/std/mod.rs
@@ -94,6 +94,7 @@ mod integers;
 mod option;
 mod phantom_data;
 mod primitives;
+mod rc;
 mod result;
 mod string;
 mod time;

--- a/linera-witty/src/type_traits/implementations/std/mod.rs
+++ b/linera-witty/src/type_traits/implementations/std/mod.rs
@@ -87,6 +87,7 @@ macro_rules! impl_for_wrapper_type {
     };
 }
 
+mod r#box;
 mod collections;
 mod floats;
 mod integers;

--- a/linera-witty/src/type_traits/implementations/std/rc.rs
+++ b/linera-witty/src/type_traits/implementations/std/rc.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementations of the custom traits for the [`Rc`] type.
+
+use std::rc::Rc;
+
+impl_for_wrapper_type!(Rc);

--- a/linera-witty/src/type_traits/implementations/std/sync.rs
+++ b/linera-witty/src/type_traits/implementations/std/sync.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementations of the custom traits for types from [`std::sync`].
+
+use std::sync::Arc;
+
+impl_for_wrapper_type!(Arc);

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -68,3 +68,9 @@ pub enum SpecializedGenericEnum<A, B> {
     First(A),
     MaybeSecond { maybe: Option<B> },
 }
+
+/// A struct that contains fields that are wrapped in smart pointer types.
+#[derive(Clone, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
+pub struct StructWithHeapFields {
+    pub boxed: Box<SimpleWrapper>,
+}

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -60,7 +60,7 @@ pub struct SpecializedGenericStruct<A, B> {
 }
 
 /// A generic enum with some specialized fields.
-#[derive(Clone, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
 #[witty_specialize_with(A = Option<bool>)]
 #[witty_specialize_with(B = u32)]
 pub enum SpecializedGenericEnum<A, B> {

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -3,6 +3,8 @@
 
 //! Dummy types used in tests.
 
+use std::rc::Rc;
+
 use linera_witty::{WitLoad, WitStore, WitType};
 
 /// A type that wraps a simple type.
@@ -73,4 +75,5 @@ pub enum SpecializedGenericEnum<A, B> {
 #[derive(Clone, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
 pub struct StructWithHeapFields {
     pub boxed: Box<SimpleWrapper>,
+    pub rced: Rc<Leaf>,
 }

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -3,7 +3,7 @@
 
 //! Dummy types used in tests.
 
-use std::rc::Rc;
+use std::{rc::Rc, sync::Arc};
 
 use linera_witty::{WitLoad, WitStore, WitType};
 
@@ -76,4 +76,5 @@ pub enum SpecializedGenericEnum<A, B> {
 pub struct StructWithHeapFields {
     pub boxed: Box<SimpleWrapper>,
     pub rced: Rc<Leaf>,
+    pub arced: Arc<Enum>,
 }

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -317,12 +317,16 @@ fn test_heap_allocated_fields() {
             first: false,
             second: 0x201f_1e1d_1c1b_1a19_1817_1615_1413_1211_u128,
         }),
+        arced: Arc::new(Enum::SmallerVariantWithStrictAlignment {
+            inner: 0x2f2e_2d2c_2b2a_2928,
+        }),
     };
 
     test_load_from_memory(
         &[
             1, 2, 3, 4, 5, 6, 7, 8, 0, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26, 27, 28, 29, 30, 31, 32,
+            25, 26, 27, 28, 29, 30, 31, 32, 2, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+            46, 47, 48,
         ],
         expected.clone(),
     );
@@ -332,6 +336,17 @@ fn test_heap_allocated_fields() {
             0_i32,
             0x1817_1615_1413_1211_i64,
             0x201f_1e1d_1c1b_1a19_i64,
+            2_i32,
+            0x2f2e_2d2c_2b2a_2928_i64,
+            0_i32,
+            0_i32,
+            0_i32,
+            0_i32,
+            0_i32,
+            0_i32,
+            0_i32,
+            0_i32,
+            0_i32,
         ],
         expected,
         &[],

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -6,7 +6,7 @@
 #[path = "common/types.rs"]
 mod types;
 
-use std::{fmt::Debug, rc::Rc};
+use std::{fmt::Debug, rc::Rc, sync::Arc};
 
 use assert_matches::assert_matches;
 use linera_witty::{hlist, InstanceWithMemory, Layout, MockInstance, RuntimeError, WitLoad};
@@ -346,7 +346,8 @@ where
 {
     test_single_load_from_memory(input, &expected);
     test_single_load_from_memory(input, &Box::new(expected.clone()));
-    test_single_load_from_memory(input, &Rc::new(expected));
+    test_single_load_from_memory(input, &Rc::new(expected.clone()));
+    test_single_load_from_memory(input, &Arc::new(expected));
 }
 
 /// Tests that the type `T` can be loaded from an `input` sequence of bytes in memory and that it
@@ -377,7 +378,8 @@ fn test_lift_from_flat_layout<T>(
 {
     test_single_lift_from_flat_layout(input, &expected, initial_memory);
     test_single_lift_from_flat_layout(input, &Box::new(expected.clone()), initial_memory);
-    test_single_lift_from_flat_layout(input, &Rc::new(expected), initial_memory);
+    test_single_lift_from_flat_layout(input, &Rc::new(expected.clone()), initial_memory);
+    test_single_lift_from_flat_layout(input, &Arc::new(expected), initial_memory);
 }
 
 /// Tests that the type `T` can be lifted from an `input` flat layout and that they match the

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -6,7 +6,7 @@
 #[path = "common/types.rs"]
 mod types;
 
-use std::fmt::Debug;
+use std::{fmt::Debug, rc::Rc};
 
 use assert_matches::assert_matches;
 use linera_witty::{hlist, InstanceWithMemory, Layout, MockInstance, RuntimeError, WitLoad};
@@ -323,10 +323,11 @@ fn test_heap_allocated_fields() {
 /// bytes in memory and that it matches the `expected` value.
 fn test_load_from_memory<T>(input: &[u8], expected: T)
 where
-    T: Debug + Eq + WitLoad,
+    T: Clone + Debug + Eq + WitLoad,
 {
     test_single_load_from_memory(input, &expected);
-    test_single_load_from_memory(input, &Box::new(expected));
+    test_single_load_from_memory(input, &Box::new(expected.clone()));
+    test_single_load_from_memory(input, &Rc::new(expected));
 }
 
 /// Tests that the type `T` can be loaded from an `input` sequence of bytes in memory and that it
@@ -352,11 +353,12 @@ fn test_lift_from_flat_layout<T>(
     expected: T,
     initial_memory: &[u8],
 ) where
-    T: Debug + Eq + WitLoad,
+    T: Clone + Debug + Eq + WitLoad,
     <T::Layout as Layout>::Flat: Copy,
 {
     test_single_lift_from_flat_layout(input, &expected, initial_memory);
-    test_single_lift_from_flat_layout(input, &Box::new(expected), initial_memory);
+    test_single_lift_from_flat_layout(input, &Box::new(expected.clone()), initial_memory);
+    test_single_lift_from_flat_layout(input, &Rc::new(expected), initial_memory);
 }
 
 /// Tests that the type `T` can be lifted from an `input` flat layout and that they match the

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -13,7 +13,7 @@ use linera_witty::{hlist, InstanceWithMemory, Layout, MockInstance, RuntimeError
 
 use self::types::{
     Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, SpecializedGenericEnum,
-    SpecializedGenericStruct, TupleWithPadding, TupleWithoutPadding,
+    SpecializedGenericStruct, StructWithHeapFields, TupleWithPadding, TupleWithoutPadding,
 };
 
 /// Check that a wrapper type is properly loaded from memory and lifted from its flat layout.
@@ -305,6 +305,18 @@ fn test_invalid_discriminant() {
             discriminant,
         }) if *discriminant == invalid_discriminant as i64
     );
+}
+
+/// Check that a type with fields stored in the heap is properly loaded from memory and lifted from
+/// its flat layout.
+#[test]
+fn test_heap_allocated_fields() {
+    let expected = StructWithHeapFields {
+        boxed: Box::new(SimpleWrapper(true)),
+    };
+
+    test_load_from_memory(&[1], expected.clone());
+    test_lift_from_flat_layout(hlist![1], expected, &[]);
 }
 
 /// Tests that the type `T` and wrapped versions of it can be loaded from an `input` sequence of

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -19,11 +19,11 @@ use self::types::{
 /// Check that a wrapper type is properly loaded from memory and lifted from its flat layout.
 #[test]
 fn test_simple_bool_wrapper() {
-    test_load_from_memory(&[1], &SimpleWrapper(true));
-    test_load_from_memory(&[0], &SimpleWrapper(false));
+    test_load_from_memory(&[1], SimpleWrapper(true));
+    test_load_from_memory(&[0], SimpleWrapper(false));
 
-    test_lift_from_flat_layout(hlist![1], &SimpleWrapper(true), &[]);
-    test_lift_from_flat_layout(hlist![0], &SimpleWrapper(false), &[]);
+    test_lift_from_flat_layout(hlist![1], SimpleWrapper(true), &[]);
+    test_lift_from_flat_layout(hlist![0], SimpleWrapper(false), &[]);
 }
 
 /// Check that a type with multiple fields ordered in a way that doesn't require any padding is
@@ -34,11 +34,11 @@ fn test_tuple_struct_without_padding() {
 
     test_load_from_memory(
         &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-        &expected,
+        expected,
     );
     test_lift_from_flat_layout(
         hlist![0x0807_0605_0403_0201_i64, 0x0c0b_0a09_i32, 0x0000_0e0d_i32],
-        &expected,
+        expected,
         &[],
     );
 }
@@ -51,11 +51,11 @@ fn test_tuple_struct_with_padding() {
 
     test_load_from_memory(
         &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-        &expected,
+        expected,
     );
     test_lift_from_flat_layout(
         hlist![0x0000_0201_i32, 0x0807_0605_i32, 0x100f_0e0d_0c0b_0a09_i64],
-        &expected,
+        expected,
         &[],
     );
 }
@@ -75,7 +75,7 @@ fn test_named_struct_with_double_padding() {
         &[
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
         ],
-        &expected,
+        expected,
     );
     test_lift_from_flat_layout(
         hlist![
@@ -84,7 +84,7 @@ fn test_named_struct_with_double_padding() {
             0x0000_0009_i32,
             0x1817_1615_1413_1211_i64,
         ],
-        &expected,
+        expected,
         &[],
     );
 }
@@ -111,7 +111,7 @@ fn test_nested_types() {
             25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
             47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
         ],
-        &expected,
+        expected,
     );
     test_lift_from_flat_layout(
         hlist![
@@ -123,7 +123,7 @@ fn test_nested_types() {
             0x302f_2e2d_2c2b_2a29_i64,
             0x3837_3635_3433_3231_i64,
         ],
-        &expected,
+        expected,
         &[],
     );
 }
@@ -136,11 +136,11 @@ fn test_enum_type() {
 
     test_load_from_memory(
         &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
-        &expected,
+        expected,
     );
     test_lift_from_flat_layout(
         hlist![0_i32, 0_i64, 0_i32, 0_i32, 0_i32, 0_i32, 0_i32, 0_i32, 0_i32, 0_i32, 0_i32],
-        &expected,
+        expected,
         &[],
     );
 
@@ -148,11 +148,11 @@ fn test_enum_type() {
 
     test_load_from_memory(
         &[1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-        &expected,
+        expected,
     );
     test_lift_from_flat_layout(
         hlist![1_i32, 7_i64, 8_i32, 9_i32, 10_i32, 11_i32, 12_i32, 13_i32, 14_i32, 15_i32, 16_i32],
-        &expected,
+        expected,
         &[],
     );
 
@@ -162,7 +162,7 @@ fn test_enum_type() {
 
     test_load_from_memory(
         &[2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-        &expected,
+        expected,
     );
     test_lift_from_flat_layout(
         hlist![
@@ -178,7 +178,7 @@ fn test_enum_type() {
             0_i32,
             0_i32
         ],
-        &expected,
+        expected,
         &[],
     );
 }
@@ -197,11 +197,11 @@ fn test_specialized_generic_struct() {
         &[
             254, 0, 246, 255, 12, 0, 0, 0, 2, 0, 0, 0, 1, 0, 255, 255, 2, 0, 254, 255,
         ],
-        &expected,
+        expected.clone(),
     );
     test_lift_from_flat_layout(
         hlist![0x0000_00fe_i32, -10_i32, 0_i32, 2_i32,],
-        &expected,
+        expected,
         &[1, 0, 255, 255, 2, 0, 254, 255],
     );
 }
@@ -212,35 +212,35 @@ fn test_specialized_generic_struct() {
 fn test_specialized_generic_enum_type() {
     let expected = SpecializedGenericEnum::None;
 
-    test_load_from_memory(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &expected);
-    test_lift_from_flat_layout(hlist![0_i32, 0_i32, 0_i32], &expected, &[]);
+    test_load_from_memory(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], expected);
+    test_lift_from_flat_layout(hlist![0_i32, 0_i32, 0_i32], expected, &[]);
 
     let expected = SpecializedGenericEnum::First(None);
 
-    test_load_from_memory(&[1, 2, 3, 4, 0, 5, 6, 7, 8, 9, 10, 11], &expected);
-    test_lift_from_flat_layout(hlist![1_i32, 0_i32, 0_i32], &expected, &[]);
+    test_load_from_memory(&[1, 2, 3, 4, 0, 5, 6, 7, 8, 9, 10, 11], expected);
+    test_lift_from_flat_layout(hlist![1_i32, 0_i32, 0_i32], expected, &[]);
 
     let expected = SpecializedGenericEnum::First(Some(false));
 
-    test_load_from_memory(&[1, 2, 3, 4, 1, 0, 6, 7, 8, 9, 10, 11], &expected);
-    test_lift_from_flat_layout(hlist![1_i32, 1_i32, 0_i32], &expected, &[]);
+    test_load_from_memory(&[1, 2, 3, 4, 1, 0, 6, 7, 8, 9, 10, 11], expected);
+    test_lift_from_flat_layout(hlist![1_i32, 1_i32, 0_i32], expected, &[]);
 
     let expected = SpecializedGenericEnum::First(Some(true));
 
-    test_load_from_memory(&[1, 2, 3, 4, 1, 1, 6, 7, 8, 9, 10, 11], &expected);
-    test_lift_from_flat_layout(hlist![1_i32, 1_i32, 1_i32], &expected, &[]);
+    test_load_from_memory(&[1, 2, 3, 4, 1, 1, 6, 7, 8, 9, 10, 11], expected);
+    test_lift_from_flat_layout(hlist![1_i32, 1_i32, 1_i32], expected, &[]);
 
     let expected = SpecializedGenericEnum::MaybeSecond { maybe: None };
 
-    test_load_from_memory(&[2, 3, 4, 5, 0, 6, 7, 8, 9, 10, 11, 12], &expected);
-    test_lift_from_flat_layout(hlist![2_i32, 0_i32, 0_i32], &expected, &[]);
+    test_load_from_memory(&[2, 3, 4, 5, 0, 6, 7, 8, 9, 10, 11, 12], expected);
+    test_lift_from_flat_layout(hlist![2_i32, 0_i32, 0_i32], expected, &[]);
 
     let expected = SpecializedGenericEnum::MaybeSecond {
         maybe: Some(0x0c0b_0a09),
     };
 
-    test_load_from_memory(&[2, 3, 4, 5, 1, 6, 7, 8, 9, 10, 11, 12], &expected);
-    test_lift_from_flat_layout(hlist![2_i32, 1_i32, 0x0c0b_0a09_i32], &expected, &[]);
+    test_load_from_memory(&[2, 3, 4, 5, 1, 6, 7, 8, 9, 10, 11, 12], expected);
+    test_lift_from_flat_layout(hlist![2_i32, 1_i32, 0x0c0b_0a09_i32], expected, &[]);
 }
 
 /// Check that an invalid discriminant reports a useful error.
@@ -307,9 +307,19 @@ fn test_invalid_discriminant() {
     );
 }
 
+/// Tests that the type `T` and wrapped versions of it can be loaded from an `input` sequence of
+/// bytes in memory and that it matches the `expected` value.
+fn test_load_from_memory<T>(input: &[u8], expected: T)
+where
+    T: Debug + Eq + WitLoad,
+{
+    test_single_load_from_memory(input, &expected);
+    test_single_load_from_memory(input, &Box::new(expected));
+}
+
 /// Tests that the type `T` can be loaded from an `input` sequence of bytes in memory and that it
 /// matches the `expected` value.
-fn test_load_from_memory<T>(input: &[u8], expected: &T)
+fn test_single_load_from_memory<T>(input: &[u8], expected: &T)
 where
     T: Debug + Eq + WitLoad,
 {
@@ -323,9 +333,23 @@ where
     assert_eq!(&T::load(&memory, address).unwrap(), expected);
 }
 
-/// Tests that the type `T` can be lifted from an `input` flat layout and that it matches the
-/// `expected` value.
+/// Tests that the type `T` and wrapped versions of it can be lifted from an `input` flat layout and
+/// that they match the `expected` value.
 fn test_lift_from_flat_layout<T>(
+    input: <T::Layout as Layout>::Flat,
+    expected: T,
+    initial_memory: &[u8],
+) where
+    T: Debug + Eq + WitLoad,
+    <T::Layout as Layout>::Flat: Copy,
+{
+    test_single_lift_from_flat_layout(input, &expected, initial_memory);
+    test_single_lift_from_flat_layout(input, &Box::new(expected), initial_memory);
+}
+
+/// Tests that the type `T` can be lifted from an `input` flat layout and that they match the
+/// `expected` value.
+fn test_single_lift_from_flat_layout<T>(
     input: <T::Layout as Layout>::Flat,
     expected: &T,
     initial_memory: &[u8],

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -313,10 +313,29 @@ fn test_invalid_discriminant() {
 fn test_heap_allocated_fields() {
     let expected = StructWithHeapFields {
         boxed: Box::new(SimpleWrapper(true)),
+        rced: Rc::new(Leaf {
+            first: false,
+            second: 0x201f_1e1d_1c1b_1a19_1817_1615_1413_1211_u128,
+        }),
     };
 
-    test_load_from_memory(&[1], expected.clone());
-    test_lift_from_flat_layout(hlist![1], expected, &[]);
+    test_load_from_memory(
+        &[
+            1, 2, 3, 4, 5, 6, 7, 8, 0, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 32,
+        ],
+        expected.clone(),
+    );
+    test_lift_from_flat_layout(
+        hlist![
+            1_i32,
+            0_i32,
+            0x1817_1615_1413_1211_i64,
+            0x201f_1e1d_1c1b_1a19_i64,
+        ],
+        expected,
+        &[],
+    );
 }
 
 /// Tests that the type `T` and wrapped versions of it can be loaded from an `input` sequence of

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -363,13 +363,17 @@ fn test_heap_allocated_fields() {
             first: true,
             second: 0x7071_7273_7475_7677_7879_7a7b_7c7d_7e7f_u128,
         }),
+        arced: Arc::new(Enum::SmallerVariantWithStrictAlignment {
+            inner: 0x4041_4243_4445_4647_u64,
+        }),
     };
 
     test_store_in_memory(
         data.clone(),
         &[
             0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0x7f, 0x7e, 0x7d, 0x7c, 0x7b, 0x7a,
-            0x79, 0x78, 0x77, 0x76, 0x75, 0x74, 0x73, 0x72, 0x71, 0x70,
+            0x79, 0x78, 0x77, 0x76, 0x75, 0x74, 0x73, 0x72, 0x71, 0x70, 2, 0, 0, 0, 0, 0, 0, 0,
+            0x47, 0x46, 0x45, 0x44, 0x43, 0x42, 0x41, 0x40, 0, 0, 0, 0, 0, 0, 0, 0,
         ],
         &[],
     );
@@ -380,6 +384,17 @@ fn test_heap_allocated_fields() {
             1_i32,
             0x7879_7a7b_7c7d_7e7f_i64,
             0x7071_7273_7475_7677_i64,
+            2_i32,
+            0x4041_4243_4445_4647_i64,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
         ],
         &[],
     );

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -12,7 +12,7 @@ use linera_witty::{hlist, InstanceWithMemory, Layout, MockInstance, WitStore};
 
 use self::types::{
     Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, SpecializedGenericEnum,
-    SpecializedGenericStruct, TupleWithPadding, TupleWithoutPadding,
+    SpecializedGenericStruct, StructWithHeapFields, TupleWithPadding, TupleWithoutPadding,
 };
 
 /// Check that a wrapper type is properly stored in memory and lowered into its flat layout.
@@ -351,6 +351,18 @@ fn test_specialized_generic_enum_type() {
         hlist![0x0000_0002_i32, 0x0000_0001_i32, 0x0000_0009_i32],
         &[],
     );
+}
+
+/// Check that a type with fields stored in the heap is properly stored in memory and lowered into
+/// its flat layout.
+#[test]
+fn test_heap_allocated_fields() {
+    let data = StructWithHeapFields {
+        boxed: Box::new(SimpleWrapper(true)),
+    };
+
+    test_store_in_memory(data.clone(), &[1], &[]);
+    test_lower_to_flat_layout(data, hlist![1], &[]);
 }
 
 /// Tests that the `data` of type `T` and wrapped versions of it can be stored as a sequence of

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -18,11 +18,11 @@ use self::types::{
 /// Check that a wrapper type is properly stored in memory and lowered into its flat layout.
 #[test]
 fn test_simple_bool_wrapper() {
-    test_store_in_memory(&SimpleWrapper(true), &[1], &[]);
-    test_store_in_memory(&SimpleWrapper(false), &[0], &[]);
+    test_store_in_memory(SimpleWrapper(true), &[1], &[]);
+    test_store_in_memory(SimpleWrapper(false), &[0], &[]);
 
-    test_lower_to_flat_layout(&SimpleWrapper(true), hlist![1], &[]);
-    test_lower_to_flat_layout(&SimpleWrapper(false), hlist![0], &[]);
+    test_lower_to_flat_layout(SimpleWrapper(true), hlist![1], &[]);
+    test_lower_to_flat_layout(SimpleWrapper(false), hlist![0], &[]);
 }
 
 /// Check that a type with multiple fields ordered in a way that doesn't require any padding is
@@ -32,7 +32,7 @@ fn test_tuple_struct_without_padding() {
     let data = TupleWithoutPadding(0x0123_4567_89ab_cdef_u64, 0x0011_2233_i32, 0x4455_i16);
 
     test_store_in_memory(
-        &data,
+        data,
         &[
             0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, 0x33, 0x22, 0x11, 0x00, 0x55, 0x44, 0,
             0,
@@ -40,7 +40,7 @@ fn test_tuple_struct_without_padding() {
         &[],
     );
     test_lower_to_flat_layout(
-        &data,
+        data,
         hlist![0x0123_4567_89ab_cdef_i64, 0x0011_2233_i32, 0x0000_4455_i32],
         &[],
     );
@@ -53,7 +53,7 @@ fn test_tuple_struct_with_padding() {
     let data = TupleWithPadding(0x0123_u16, 0x4567_89ab_u32, 0x0011_2233_4455_6677_i64);
 
     test_store_in_memory(
-        &data,
+        data,
         &[
             0x23, 0x01, 0, 0, 0xab, 0x89, 0x67, 0x45, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11,
             0x00,
@@ -61,7 +61,7 @@ fn test_tuple_struct_with_padding() {
         &[],
     );
     test_lower_to_flat_layout(
-        &data,
+        data,
         hlist![0x0000_0123_i32, 0x4567_89ab_i32, 0x0011_2233_4455_6677_i64],
         &[],
     );
@@ -79,7 +79,7 @@ fn test_named_struct_with_double_padding() {
     };
 
     test_store_in_memory(
-        &data,
+        data,
         &[
             0x23, 0x01, 0, 0, 0x33, 0x22, 0x11, 0x00, 0x45, 0, 0, 0, 0, 0, 0, 0, 0x66, 0x55, 0x44,
             0xef, 0xcd, 0xab, 0x89, 0x67,
@@ -87,7 +87,7 @@ fn test_named_struct_with_double_padding() {
         &[],
     );
     test_lower_to_flat_layout(
-        &data,
+        data,
         hlist![
             0x0000_0123_i32,
             0x0011_2233_i32,
@@ -115,7 +115,7 @@ fn test_nested_types() {
     };
 
     test_store_in_memory(
-        &data,
+        data,
         &[
             0x23, 0x01, 0, 0, 0, 0, 0, 0, 0x00, 0, 0, 0, 0, 0, 0, 0, 0x99, 0x88, 0x77, 0x66, 0x55,
             0x44, 0x33, 0x22, 0x11, 0x00, 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x01, 0, 0, 0, 0, 0,
@@ -125,7 +125,7 @@ fn test_nested_types() {
         &[],
     );
     test_lower_to_flat_layout(
-        &data,
+        data,
         hlist![
             0x0000_0123_i32,
             0x0000_0000_i32,
@@ -146,7 +146,7 @@ fn test_enum_type() {
     let data = Enum::Empty;
 
     test_store_in_memory(
-        &data,
+        data,
         &[
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0, 0, 0, 0, 0, 0,
@@ -154,7 +154,7 @@ fn test_enum_type() {
         &[],
     );
     test_lower_to_flat_layout(
-        &data,
+        data,
         hlist![
             0x0000_0000_i32,
             0x0000_0000_0000_0000_i64,
@@ -174,7 +174,7 @@ fn test_enum_type() {
     let data = Enum::LargeVariantWithLooseAlignment(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
     test_store_in_memory(
-        &data,
+        data,
         &[
             0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
             0x06, 0x07, 0x08, 0x09, 0, 0, 0, 0, 0, 0,
@@ -182,7 +182,7 @@ fn test_enum_type() {
         &[],
     );
     test_lower_to_flat_layout(
-        &data,
+        data,
         hlist![
             0x0000_0001_i32,
             0x0000_0000_0000_0000_i64,
@@ -204,7 +204,7 @@ fn test_enum_type() {
     };
 
     test_store_in_memory(
-        &data,
+        data,
         &[
             0x02, 0, 0, 0, 0, 0, 0, 0, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0, 0, 0, 0,
             0, 0, 0, 0,
@@ -212,7 +212,7 @@ fn test_enum_type() {
         &[],
     );
     test_lower_to_flat_layout(
-        &data,
+        data,
         hlist![
             0x0000_0002_i32,
             0x0102_0304_0506_0708_i64,
@@ -245,14 +245,14 @@ fn test_specialized_generic_struct() {
     ];
 
     test_store_in_memory(
-        &data,
+        data.clone(),
         &[
             0xc8, 0, 0x38, 0xff, 0x0c, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
         ],
         &expected_heap,
     );
     test_lower_to_flat_layout(
-        &data,
+        data,
         hlist![0x0000_00c8_i32, -200_i32, 0x0000_0000_i32, 0x0000_0004_i32],
         &expected_heap,
     );
@@ -265,14 +265,14 @@ fn test_specialized_generic_enum_type() {
     let data = SpecializedGenericEnum::None;
 
     test_store_in_memory(
-        &data,
+        data,
         &[
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ],
         &[],
     );
     test_lower_to_flat_layout(
-        &data,
+        data,
         hlist![0x0000_0000_i32, 0x0000_0000_i32, 0x0000_0000_i32],
         &[],
     );
@@ -280,14 +280,14 @@ fn test_specialized_generic_enum_type() {
     let data = SpecializedGenericEnum::First(None);
 
     test_store_in_memory(
-        &data,
+        data,
         &[
             0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ],
         &[],
     );
     test_lower_to_flat_layout(
-        &data,
+        data,
         hlist![0x0000_0001_i32, 0x0000_0000_i32, 0x0000_0000_i32],
         &[],
     );
@@ -295,14 +295,14 @@ fn test_specialized_generic_enum_type() {
     let data = SpecializedGenericEnum::First(Some(false));
 
     test_store_in_memory(
-        &data,
+        data,
         &[
             0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ],
         &[],
     );
     test_lower_to_flat_layout(
-        &data,
+        data,
         hlist![0x0000_0001_i32, 0x0000_0001_i32, 0x0000_0000_i32],
         &[],
     );
@@ -310,14 +310,14 @@ fn test_specialized_generic_enum_type() {
     let data = SpecializedGenericEnum::First(Some(true));
 
     test_store_in_memory(
-        &data,
+        data,
         &[
             0x01, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ],
         &[],
     );
     test_lower_to_flat_layout(
-        &data,
+        data,
         hlist![0x0000_0001_i32, 0x0000_0001_i32, 0x0000_0001_i32],
         &[],
     );
@@ -325,14 +325,14 @@ fn test_specialized_generic_enum_type() {
     let data = SpecializedGenericEnum::MaybeSecond { maybe: None };
 
     test_store_in_memory(
-        &data,
+        data,
         &[
             0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ],
         &[],
     );
     test_lower_to_flat_layout(
-        &data,
+        data,
         hlist![0x0000_0002_i32, 0x0000_0000_i32, 0x0000_0000_i32],
         &[],
     );
@@ -340,22 +340,43 @@ fn test_specialized_generic_enum_type() {
     let data = SpecializedGenericEnum::MaybeSecond { maybe: Some(9) };
 
     test_store_in_memory(
-        &data,
+        data,
         &[
             0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00,
         ],
         &[],
     );
     test_lower_to_flat_layout(
-        &data,
+        data,
         hlist![0x0000_0002_i32, 0x0000_0001_i32, 0x0000_0009_i32],
         &[],
     );
 }
 
+/// Tests that the `data` of type `T` and wrapped versions of it can be stored as a sequence of
+/// bytes in memory and that they match the `expected` bytes.
+fn test_store_in_memory<T>(
+    data: T,
+    expected_without_allocation: &[u8],
+    expected_additionally_allocated: &[u8],
+) where
+    T: WitStore,
+{
+    test_single_store_in_memory(
+        &data,
+        expected_without_allocation,
+        expected_additionally_allocated,
+    );
+    test_single_store_in_memory(
+        &Box::new(data),
+        expected_without_allocation,
+        expected_additionally_allocated,
+    );
+}
+
 /// Tests that the `data` of type `T` can be stored as a sequence of bytes in memory and that it
 /// matches the `expected` bytes.
-fn test_store_in_memory<T>(
+fn test_single_store_in_memory<T>(
     data: &T,
     expected_without_allocation: &[u8],
     expected_additionally_allocated: &[u8],
@@ -388,9 +409,23 @@ fn test_store_in_memory<T>(
     );
 }
 
+/// Tests that the `data` of type `T` and wrapped versions of it can be lowered to their flat layout
+/// and that they match the `expected` value.
+fn test_lower_to_flat_layout<T>(
+    data: T,
+    expected: <T::Layout as Layout>::Flat,
+    expected_memory: &[u8],
+) where
+    T: WitStore,
+    <T::Layout as Layout>::Flat: Copy + Debug + Eq,
+{
+    test_single_lower_to_flat_layout(&data, expected, expected_memory);
+    test_single_lower_to_flat_layout(&Box::new(data), expected, expected_memory);
+}
+
 /// Tests that the `data` of type `T` can be lowered to its flat layout and that it matches the
 /// `expected` value.
-fn test_lower_to_flat_layout<T>(
+fn test_single_lower_to_flat_layout<T>(
     data: &T,
     expected: <T::Layout as Layout>::Flat,
     expected_memory: &[u8],

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -358,11 +358,31 @@ fn test_specialized_generic_enum_type() {
 #[test]
 fn test_heap_allocated_fields() {
     let data = StructWithHeapFields {
-        boxed: Box::new(SimpleWrapper(true)),
+        boxed: Box::new(SimpleWrapper(false)),
+        rced: Rc::new(Leaf {
+            first: true,
+            second: 0x7071_7273_7475_7677_7879_7a7b_7c7d_7e7f_u128,
+        }),
     };
 
-    test_store_in_memory(data.clone(), &[1], &[]);
-    test_lower_to_flat_layout(data, hlist![1], &[]);
+    test_store_in_memory(
+        data.clone(),
+        &[
+            0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0x7f, 0x7e, 0x7d, 0x7c, 0x7b, 0x7a,
+            0x79, 0x78, 0x77, 0x76, 0x75, 0x74, 0x73, 0x72, 0x71, 0x70,
+        ],
+        &[],
+    );
+    test_lower_to_flat_layout(
+        data,
+        hlist![
+            0_i32,
+            1_i32,
+            0x7879_7a7b_7c7d_7e7f_i64,
+            0x7071_7273_7475_7677_i64,
+        ],
+        &[],
+    );
 }
 
 /// Tests that the `data` of type `T` and wrapped versions of it can be stored as a sequence of

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -6,7 +6,7 @@
 #[path = "common/types.rs"]
 mod types;
 
-use std::fmt::Debug;
+use std::{fmt::Debug, rc::Rc};
 
 use linera_witty::{hlist, InstanceWithMemory, Layout, MockInstance, WitStore};
 
@@ -372,7 +372,7 @@ fn test_store_in_memory<T>(
     expected_without_allocation: &[u8],
     expected_additionally_allocated: &[u8],
 ) where
-    T: WitStore,
+    T: Clone + WitStore,
 {
     test_single_store_in_memory(
         &data,
@@ -380,7 +380,12 @@ fn test_store_in_memory<T>(
         expected_additionally_allocated,
     );
     test_single_store_in_memory(
-        &Box::new(data),
+        &Box::new(data.clone()),
+        expected_without_allocation,
+        expected_additionally_allocated,
+    );
+    test_single_store_in_memory(
+        &Rc::new(data),
         expected_without_allocation,
         expected_additionally_allocated,
     );
@@ -428,11 +433,12 @@ fn test_lower_to_flat_layout<T>(
     expected: <T::Layout as Layout>::Flat,
     expected_memory: &[u8],
 ) where
-    T: WitStore,
+    T: Clone + WitStore,
     <T::Layout as Layout>::Flat: Copy + Debug + Eq,
 {
     test_single_lower_to_flat_layout(&data, expected, expected_memory);
-    test_single_lower_to_flat_layout(&Box::new(data), expected, expected_memory);
+    test_single_lower_to_flat_layout(&Box::new(data.clone()), expected, expected_memory);
+    test_single_lower_to_flat_layout(&Rc::new(data), expected, expected_memory);
 }
 
 /// Tests that the `data` of type `T` can be lowered to its flat layout and that it matches the

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -6,7 +6,7 @@
 #[path = "common/types.rs"]
 mod types;
 
-use std::{fmt::Debug, rc::Rc};
+use std::{fmt::Debug, rc::Rc, sync::Arc};
 
 use linera_witty::{hlist, InstanceWithMemory, Layout, MockInstance, WitStore};
 
@@ -458,7 +458,8 @@ fn test_lower_to_flat_layout<T>(
 {
     test_single_lower_to_flat_layout(&data, expected, expected_memory);
     test_single_lower_to_flat_layout(&Box::new(data.clone()), expected, expected_memory);
-    test_single_lower_to_flat_layout(&Rc::new(data), expected, expected_memory);
+    test_single_lower_to_flat_layout(&Rc::new(data.clone()), expected, expected_memory);
+    test_single_lower_to_flat_layout(&Arc::new(data), expected, expected_memory);
 }
 
 /// Tests that the `data` of type `T` can be lowered to its flat layout and that it matches the

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -353,7 +353,7 @@ fn test_specialized_generic_enum_type() {
     );
 }
 
-/// Check that a type with fields stored in the heap is properly stored in memory and lowered into
+/// Checks that a type with fields stored in the heap is properly stored in memory and lowered into
 /// its flat layout.
 #[test]
 fn test_heap_allocated_fields() {

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -6,7 +6,7 @@
 #[path = "common/types.rs"]
 mod types;
 
-use std::{collections::BTreeMap, rc::Rc};
+use std::{collections::BTreeMap, rc::Rc, sync::Arc};
 
 use linera_witty::{HList, Layout, RegisterWitTypes, WitType};
 
@@ -219,6 +219,7 @@ where
     test_single_wit_type_implementation::<T>(expected);
     test_single_wit_type_implementation::<Box<T>>(expected);
     test_single_wit_type_implementation::<Rc<T>>(expected);
+    test_single_wit_type_implementation::<Arc<T>>(expected);
 }
 
 /// Tests that a type `T` has the `expected` [`WitType`] metadata in its implementation.

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -181,10 +181,17 @@ fn test_specialized_generic_enum_type() {
 #[test]
 fn test_heap_allocated_fields() {
     test_wit_type_implementation::<StructWithHeapFields>(ExpectedMetadata {
-        size: 32,
+        size: 56,
         alignment: 8,
-        flat_layout_length: 4,
+        flat_layout_length: 15,
         declaration: concat!(
+            "    variant enum {\n",
+            "        empty,\n",
+            "        large-variant-with-loose-alignment(\
+                        tuple<s8, s8, s8, s8, s8, s8, s8, s8, s8, s8>\
+                     ),\n",
+            "        smaller-variant-with-strict-alignment(u64),\n",
+            "    }\n\n",
             "    record leaf {\n",
             "        first: bool,\n",
             "        second: u128,\n",
@@ -195,6 +202,7 @@ fn test_heap_allocated_fields() {
             "    record struct-with-heap-fields {\n",
             "        boxed: simple-wrapper,\n",
             "        rced: leaf,\n",
+            "        arced: enum,\n",
             "    }\n\n",
             "    type u128 = tuple<u64, u64>;\n",
         ),

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -18,106 +18,95 @@ use self::types::{
 /// Check the memory size, layout and WIT type declaration derived for a wrapper type.
 #[test]
 fn test_simple_bool_wrapper() {
-    assert_eq!(SimpleWrapper::SIZE, 1);
-    assert_eq!(<SimpleWrapper as WitType>::Layout::ALIGNMENT, 1);
-    assert_eq!(<<SimpleWrapper as WitType>::Layout as Layout>::Flat::LEN, 1);
-    assert_eq!(
-        wit_type_declaration_of::<SimpleWrapper>(),
-        "    record simple-wrapper {\n        inner0: bool,\n    }\n"
-    );
+    test_wit_type_implementation::<SimpleWrapper>(ExpectedMetadata {
+        size: 1,
+        alignment: 1,
+        flat_layout_length: 1,
+        declaration: concat!(
+            "    record simple-wrapper {\n",
+            "        inner0: bool,\n",
+            "    }\n"
+        ),
+    });
 }
 
 /// Check the memory size, layout and WIT type declaration derived for a type with multiple fields
 /// ordered in a way that doesn't require any padding.
 #[test]
 fn test_tuple_struct_without_padding() {
-    assert_eq!(TupleWithoutPadding::SIZE, 16);
-    assert_eq!(<TupleWithoutPadding as WitType>::Layout::ALIGNMENT, 8);
-    assert_eq!(
-        <<TupleWithoutPadding as WitType>::Layout as Layout>::Flat::LEN,
-        3
-    );
-    assert_eq!(
-        wit_type_declaration_of::<TupleWithoutPadding>(),
-        concat!(
+    test_wit_type_implementation::<TupleWithoutPadding>(ExpectedMetadata {
+        size: 16,
+        alignment: 8,
+        flat_layout_length: 3,
+        declaration: concat!(
             "    record tuple-without-padding {\n",
             "        inner0: u64,\n",
             "        inner1: s32,\n",
             "        inner2: s16,\n",
             "    }\n"
-        )
-    );
+        ),
+    });
 }
 
 /// Check the memory size, layout and WIT type declaration derived for a type with multiple fields
 /// ordered in a way that requires padding between all fields.
 #[test]
 fn test_tuple_struct_with_padding() {
-    assert_eq!(TupleWithPadding::SIZE, 16);
-    assert_eq!(<TupleWithPadding as WitType>::Layout::ALIGNMENT, 8);
-    assert_eq!(
-        <<TupleWithPadding as WitType>::Layout as Layout>::Flat::LEN,
-        3
-    );
-    assert_eq!(
-        wit_type_declaration_of::<TupleWithPadding>(),
-        concat!(
+    test_wit_type_implementation::<TupleWithPadding>(ExpectedMetadata {
+        size: 16,
+        alignment: 8,
+        flat_layout_length: 3,
+        declaration: concat!(
             "    record tuple-with-padding {\n",
             "        inner0: u16,\n",
             "        inner1: u32,\n",
             "        inner2: s64,\n",
             "    }\n"
-        )
-    );
+        ),
+    });
 }
 
 /// Check the memory size, layout and WIT type declaration derived for a type with multiple named
 /// fields ordered in a way that requires padding before two fields.
 #[test]
 fn test_named_struct_with_double_padding() {
-    assert_eq!(RecordWithDoublePadding::SIZE, 24);
-    assert_eq!(<RecordWithDoublePadding as WitType>::Layout::ALIGNMENT, 8);
-    assert_eq!(
-        <<RecordWithDoublePadding as WitType>::Layout as Layout>::Flat::LEN,
-        4
-    );
-    assert_eq!(
-        wit_type_declaration_of::<RecordWithDoublePadding>(),
-        concat!(
+    test_wit_type_implementation::<RecordWithDoublePadding>(ExpectedMetadata {
+        size: 24,
+        alignment: 8,
+        flat_layout_length: 4,
+        declaration: concat!(
             "    record record-with-double-padding {\n",
             "        first: u16,\n",
             "        second: u32,\n",
             "        third: s8,\n",
             "        fourth: s64,\n",
             "    }\n"
-        )
-    );
+        ),
+    });
 }
 
 /// Check the memory size, layout and WIT type declarations derived for a type that contains a
 /// field with a type that also has `WitType` derived for it.
 #[test]
 fn test_nested_types() {
-    assert_eq!(Leaf::SIZE, 24);
-    assert_eq!(<Leaf as WitType>::Layout::ALIGNMENT, 8);
-    assert_eq!(<<Leaf as WitType>::Layout as Layout>::Flat::LEN, 3);
-    assert_eq!(
-        wit_type_declaration_of::<Leaf>(),
-        concat!(
+    test_wit_type_implementation::<Leaf>(ExpectedMetadata {
+        size: 24,
+        alignment: 8,
+        flat_layout_length: 3,
+        declaration: concat!(
             "    record leaf {\n",
             "        first: bool,\n",
             "        second: u128,\n",
             "    }\n\n",
             "    type u128 = tuple<u64, u64>;\n"
-        )
-    );
+        ),
+    });
 
-    assert_eq!(Branch::SIZE, 56);
-    assert_eq!(<Branch as WitType>::Layout::ALIGNMENT, 8);
-    assert_eq!(<<Branch as WitType>::Layout as Layout>::Flat::LEN, 7);
-    assert_eq!(
-        wit_type_declaration_of::<Branch>(),
-        concat!(
+    test_wit_type_implementation::<Branch>(ExpectedMetadata {
+        size: 56,
+        alignment: 8,
+        flat_layout_length: 7,
+        declaration: concat!(
             "    record branch {\n",
             "        tag: u16,\n",
             "        first-leaf: leaf,\n",
@@ -128,19 +117,18 @@ fn test_nested_types() {
             "        second: u128,\n",
             "    }\n\n",
             "    type u128 = tuple<u64, u64>;\n"
-        )
-    );
+        ),
+    });
 }
 
 /// Check the memory size, layout and WIT type declaration derived for an `enum` type.
 #[test]
 fn test_enum_type() {
-    assert_eq!(Enum::SIZE, 24);
-    assert_eq!(<Enum as WitType>::Layout::ALIGNMENT, 8);
-    assert_eq!(<<Enum as WitType>::Layout as Layout>::Flat::LEN, 11);
-    assert_eq!(
-        wit_type_declaration_of::<Enum>(),
-        concat!(
+    test_wit_type_implementation::<Enum>(ExpectedMetadata {
+        size: 24,
+        alignment: 8,
+        flat_layout_length: 11,
+        declaration: concat!(
             "    variant enum {\n",
             "        empty,\n",
             "        large-variant-with-loose-alignment(\
@@ -148,58 +136,66 @@ fn test_enum_type() {
                      ),\n",
             "        smaller-variant-with-strict-alignment(u64),\n",
             "    }\n",
-        )
-    );
+        ),
+    });
 }
 
 /// Check the memory size, layout and WIT type declaration derived for a specialized generic
 /// `struct` type.
 #[test]
 fn test_specialized_generic_struct() {
-    assert_eq!(SpecializedGenericStruct::SIZE, 12);
-    assert_eq!(
-        <SpecializedGenericStruct<u8, i16> as WitType>::Layout::ALIGNMENT,
-        4
-    );
-    assert_eq!(
-        <<SpecializedGenericStruct<u8, i16> as WitType>::Layout as Layout>::Flat::LEN,
-        4
-    );
-    assert_eq!(
-        wit_type_declaration_of::<SpecializedGenericStruct<u8, i16>>(),
-        concat!(
+    test_wit_type_implementation::<SpecializedGenericStruct<u8, i16>>(ExpectedMetadata {
+        size: 12,
+        alignment: 4,
+        flat_layout_length: 4,
+        declaration: concat!(
             "    record specialized-generic-struct {\n",
             "        first: u8,\n",
             "        second: s16,\n",
             "        both: list<tuple<u8, s16>>,\n",
             "    }\n",
-        )
-    );
+        ),
+    });
 }
 
 /// Check the memory size, layout and WIT type declaration derived for a specialized generic `enum`
 /// type.
 #[test]
 fn test_specialized_generic_enum_type() {
-    assert_eq!(SpecializedGenericEnum::SIZE, 12);
-    assert_eq!(
-        <SpecializedGenericEnum<Option<bool>, u32> as WitType>::Layout::ALIGNMENT,
-        4
-    );
-    assert_eq!(
-        <<SpecializedGenericEnum<Option<bool>, u32> as WitType>::Layout as Layout>::Flat::LEN,
-        3
-    );
-    assert_eq!(
-        wit_type_declaration_of::<SpecializedGenericEnum<Option<bool>, u32>>(),
-        concat!(
+    test_wit_type_implementation::<SpecializedGenericEnum<Option<bool>, u32>>(ExpectedMetadata {
+        size: 12,
+        alignment: 4,
+        flat_layout_length: 3,
+        declaration: concat!(
             "    variant specialized-generic-enum {\n",
             "        none,\n",
             "        first(option<bool>),\n",
             "        maybe-second(option<u32>),\n",
             "    }\n",
-        )
+        ),
+    });
+}
+
+/// Helper type to make visible what each metadata value is.
+struct ExpectedMetadata {
+    size: u32,
+    alignment: u32,
+    flat_layout_length: usize,
+    declaration: &'static str,
+}
+
+/// Tests that a type `T` has the `expected` [`WitType`] metadata in its implementation.
+fn test_wit_type_implementation<T>(expected: ExpectedMetadata)
+where
+    T: WitType,
+{
+    assert_eq!(T::SIZE, expected.size);
+    assert_eq!(<T as WitType>::Layout::ALIGNMENT, expected.alignment);
+    assert_eq!(
+        <<T as WitType>::Layout as Layout>::Flat::LEN,
+        expected.flat_layout_length
     );
+    assert_eq!(wit_type_declaration_of::<T>(), expected.declaration);
 }
 
 /// Returns the WIT snippet with the type declarations for `T`.

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -177,6 +177,7 @@ fn test_specialized_generic_enum_type() {
 }
 
 /// Helper type to make visible what each metadata value is.
+#[derive(Clone, Copy, Debug)]
 struct ExpectedMetadata {
     size: u32,
     alignment: u32,
@@ -184,8 +185,23 @@ struct ExpectedMetadata {
     declaration: &'static str,
 }
 
-/// Tests that a type `T` has the `expected` [`WitType`] metadata in its implementation.
+/// Tests that a type `T` and wrapped versions of it have the `expected` [`WitType`] metadata in
+/// their implementations.
 fn test_wit_type_implementation<T>(expected: ExpectedMetadata)
+where
+    T: WitType,
+{
+    let expected_when_wrapped = ExpectedMetadata {
+        declaration: "",
+        ..expected
+    };
+
+    test_single_wit_type_implementation::<T>(expected);
+    test_single_wit_type_implementation::<Box<T>>(expected_when_wrapped);
+}
+
+/// Tests that a type `T` has the `expected` [`WitType`] metadata in its implementation.
+fn test_single_wit_type_implementation<T>(expected: ExpectedMetadata)
 where
     T: WitType,
 {

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -6,7 +6,7 @@
 #[path = "common/types.rs"]
 mod types;
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, rc::Rc};
 
 use linera_witty::{HList, Layout, RegisterWitTypes, WitType};
 
@@ -212,6 +212,7 @@ where
 {
     test_single_wit_type_implementation::<T>(expected);
     test_single_wit_type_implementation::<Box<T>>(expected);
+    test_single_wit_type_implementation::<Rc<T>>(expected);
 }
 
 /// Tests that a type `T` has the `expected` [`WitType`] metadata in its implementation.

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -12,7 +12,7 @@ use linera_witty::{HList, Layout, RegisterWitTypes, WitType};
 
 use self::types::{
     Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, SpecializedGenericEnum,
-    SpecializedGenericStruct, TupleWithPadding, TupleWithoutPadding,
+    SpecializedGenericStruct, StructWithHeapFields, TupleWithPadding, TupleWithoutPadding,
 };
 
 /// Check the memory size, layout and WIT type declaration derived for a wrapper type.
@@ -176,6 +176,25 @@ fn test_specialized_generic_enum_type() {
     });
 }
 
+/// Check the memory size, layout and WIT declaration derived for a complex type that has heap
+/// allocated fields.
+#[test]
+fn test_heap_allocated_fields() {
+    test_wit_type_implementation::<StructWithHeapFields>(ExpectedMetadata {
+        size: 1,
+        alignment: 1,
+        flat_layout_length: 1,
+        declaration: concat!(
+            "    record simple-wrapper {\n",
+            "        inner0: bool,\n",
+            "    }\n\n",
+            "    record struct-with-heap-fields {\n",
+            "        boxed: simple-wrapper,\n",
+            "    }\n",
+        ),
+    });
+}
+
 /// Helper type to make visible what each metadata value is.
 #[derive(Clone, Copy, Debug)]
 struct ExpectedMetadata {
@@ -191,13 +210,8 @@ fn test_wit_type_implementation<T>(expected: ExpectedMetadata)
 where
     T: WitType,
 {
-    let expected_when_wrapped = ExpectedMetadata {
-        declaration: "",
-        ..expected
-    };
-
     test_single_wit_type_implementation::<T>(expected);
-    test_single_wit_type_implementation::<Box<T>>(expected_when_wrapped);
+    test_single_wit_type_implementation::<Box<T>>(expected);
 }
 
 /// Tests that a type `T` has the `expected` [`WitType`] metadata in its implementation.

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -181,16 +181,22 @@ fn test_specialized_generic_enum_type() {
 #[test]
 fn test_heap_allocated_fields() {
     test_wit_type_implementation::<StructWithHeapFields>(ExpectedMetadata {
-        size: 1,
-        alignment: 1,
-        flat_layout_length: 1,
+        size: 32,
+        alignment: 8,
+        flat_layout_length: 4,
         declaration: concat!(
+            "    record leaf {\n",
+            "        first: bool,\n",
+            "        second: u128,\n",
+            "    }\n\n",
             "    record simple-wrapper {\n",
             "        inner0: bool,\n",
             "    }\n\n",
             "    record struct-with-heap-fields {\n",
             "        boxed: simple-wrapper,\n",
-            "    }\n",
+            "        rced: leaf,\n",
+            "    }\n\n",
+            "    type u128 = tuple<u64, u64>;\n",
         ),
     });
 }

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -176,7 +176,7 @@ fn test_specialized_generic_enum_type() {
     });
 }
 
-/// Check the memory size, layout and WIT declaration derived for a complex type that has heap
+/// Checks the memory size, layout and WIT declaration derived for a complex type that has heap
 /// allocated fields.
 #[test]
 fn test_heap_allocated_fields() {


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
It's not uncommon to want to store some values in the heap, but still be able to copy them to and from guest Wasm modules. For that to work, heap smart pointer types should implement the `WitType`, `WitLoad` and `WitStore` traits.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Create a new macro with the code to delegate implement the traits by delegating the items to the wrapped type, and use the macro to implement the traits for `Box`, `Rc`, and `Arc`.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
Unit tests were modified to wrap all tested types in `Arc`, `Rc` and `Box` containers and check that it doesn't affect the loading and storing of the types.
Unit tests were added to check derived `WitType`, `WitLoad` and `WitStore` implementations for types that have `Arc`, `Rc` and `Box` fields.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- These changes introduce a backwards compatible feature, so they follow the usual release cycle.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
