### PR TITLE
Move `Hashed` to linera-base.

### DIFF
--- a/linera-base/src/hashed.rs
+++ b/linera-base/src/hashed.rs
@@ -2,11 +2,14 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! A wrapper for hashable types to memoize the hash.
+
 use std::borrow::Cow;
 
 use custom_debug_derive::Debug;
-use linera_base::crypto::{BcsHashable, CryptoHash};
 use serde::{Deserialize, Serialize};
+
+use crate::crypto::{BcsHashable, CryptoHash};
 
 /// Wrapper type around hashed instance of `T` type.
 #[derive(Debug)]
@@ -38,14 +41,17 @@ impl<T> Hashed<T> {
         Self { value, hash }
     }
 
+    /// Returns the hash.
     pub fn hash(&self) -> CryptoHash {
         self.hash
     }
 
+    /// Returns a reference to the value, without the hash.
     pub fn inner(&self) -> &T {
         &self.value
     }
 
+    /// Consumes the hashed value and returns the value without the hash.
     pub fn into_inner(self) -> T {
         self.value
     }
@@ -81,6 +87,19 @@ impl<T: Clone> Clone for Hashed<T> {
 impl<T: async_graphql::OutputType> async_graphql::TypeName for Hashed<T> {
     fn type_name() -> Cow<'static, str> {
         format!("Hashed{}", T::type_name(),).into()
+    }
+}
+
+#[async_graphql::Object(cache_control(no_cache), name_type)]
+impl<T: async_graphql::OutputType + Clone> Hashed<T> {
+    #[graphql(derived(name = "hash"))]
+    async fn _hash(&self) -> CryptoHash {
+        self.hash()
+    }
+
+    #[graphql(derived(name = "value"))]
+    async fn _value(&self) -> T {
+        self.inner().clone()
     }
 }
 

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -20,6 +20,7 @@ pub mod crypto;
 pub mod data_types;
 pub mod dyn_convert;
 mod graphql;
+pub mod hashed;
 pub mod identifiers;
 mod limited_writer;
 pub mod ownership;

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -7,13 +7,14 @@ use std::fmt::Debug;
 use linera_base::{
     crypto::{BcsHashable, CryptoHash},
     data_types::BlockHeight,
+    hashed::Hashed,
     identifiers::ChainId,
 };
 use linera_execution::committee::Epoch;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{data_types::ExecutedBlock, types::Hashed, ChainError};
+use crate::{data_types::ExecutedBlock, ChainError};
 
 /// Wrapper around an `ExecutedBlock` that has been validated.
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
@@ -82,19 +83,6 @@ impl ConfirmedBlock {
 
     async fn status(&self) -> String {
         "confirmed".to_string()
-    }
-}
-
-#[async_graphql::Object(cache_control(no_cache), name_type)]
-impl Hashed<ConfirmedBlock> {
-    #[graphql(derived(name = "hash"))]
-    async fn _hash(&self) -> CryptoHash {
-        self.hash()
-    }
-
-    #[graphql(derived(name = "value"))]
-    async fn _value(&self) -> ConfirmedBlock {
-        self.inner().clone()
     }
 }
 

--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -5,12 +5,13 @@
 use linera_base::{
     crypto::Signature,
     data_types::Round,
+    hashed::Hashed,
     identifiers::{BlobId, ChainId, MessageId},
 };
 use linera_execution::committee::{Epoch, ValidatorName};
 use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize};
 
-use super::{generic::GenericCertificate, hashed::Hashed, Certificate};
+use super::{generic::GenericCertificate, Certificate};
 use crate::{
     block::{ConfirmedBlock, ConversionError},
     data_types::{ExecutedBlock, Medium, MessageBundle},

--- a/linera-chain/src/certificate/generic.rs
+++ b/linera-chain/src/certificate/generic.rs
@@ -10,7 +10,7 @@ use linera_base::{
 use linera_execution::committee::{Committee, ValidatorName};
 
 use super::{hashed::Hashed, CertificateValueT};
-use crate::ChainError;
+use crate::{data_types::LiteValue, ChainError};
 
 /// Generic type representing a certificate for `value` of type `T`.
 #[derive(Debug)]
@@ -113,9 +113,8 @@ impl<T> GenericCertificate<T> {
     where
         T: CertificateValueT,
     {
-        let value = self.value.lite();
         crate::certificate::LiteCertificate {
-            value,
+            value: LiteValue::new(&self.value),
             round: self.round,
             signatures: std::borrow::Cow::Borrowed(&self.signatures),
         }

--- a/linera-chain/src/certificate/generic.rs
+++ b/linera-chain/src/certificate/generic.rs
@@ -10,7 +10,7 @@ use linera_base::{
 };
 use linera_execution::committee::{Committee, ValidatorName};
 
-use super::CertificateValueT;
+use super::CertificateValue;
 use crate::{data_types::LiteValue, ChainError};
 
 /// Generic type representing a certificate for `value` of type `T`.
@@ -98,7 +98,7 @@ impl<T> GenericCertificate<T> {
     /// Verifies the certificate.
     pub fn check(&self, committee: &Committee) -> Result<(), ChainError>
     where
-        T: CertificateValueT,
+        T: CertificateValue,
     {
         crate::data_types::check_signatures(
             self.hash(),
@@ -112,7 +112,7 @@ impl<T> GenericCertificate<T> {
 
     pub fn lite_certificate(&self) -> crate::certificate::LiteCertificate<'_>
     where
-        T: CertificateValueT,
+        T: CertificateValue,
     {
         crate::certificate::LiteCertificate {
             value: LiteValue::new(&self.value),

--- a/linera-chain/src/certificate/generic.rs
+++ b/linera-chain/src/certificate/generic.rs
@@ -6,10 +6,11 @@ use custom_debug_derive::Debug;
 use linera_base::{
     crypto::{CryptoHash, Signature},
     data_types::Round,
+    hashed::Hashed,
 };
 use linera_execution::committee::{Committee, ValidatorName};
 
-use super::{hashed::Hashed, CertificateValueT};
+use super::CertificateValueT;
 use crate::{data_types::LiteValue, ChainError};
 
 /// Generic type representing a certificate for `value` of type `T`.

--- a/linera-chain/src/certificate/hashed.rs
+++ b/linera-chain/src/certificate/hashed.rs
@@ -8,9 +8,6 @@ use custom_debug_derive::Debug;
 use linera_base::crypto::{BcsHashable, CryptoHash};
 use serde::{Deserialize, Serialize};
 
-use super::CertificateValueT;
-use crate::data_types::LiteValue;
-
 /// Wrapper type around hashed instance of `T` type.
 #[derive(Debug)]
 pub struct Hashed<T> {
@@ -51,17 +48,6 @@ impl<T> Hashed<T> {
 
     pub fn into_inner(self) -> T {
         self.value
-    }
-
-    pub fn lite(&self) -> LiteValue
-    where
-        T: CertificateValueT,
-    {
-        LiteValue {
-            value_hash: self.hash,
-            chain_id: self.value.chain_id(),
-            kind: T::KIND,
-        }
     }
 }
 

--- a/linera-chain/src/certificate/lite.rs
+++ b/linera-chain/src/certificate/lite.rs
@@ -4,11 +4,11 @@
 
 use std::borrow::Cow;
 
-use linera_base::{crypto::Signature, data_types::Round};
+use linera_base::{crypto::Signature, data_types::Round, hashed::Hashed};
 use linera_execution::committee::{Committee, ValidatorName};
 use serde::{Deserialize, Serialize};
 
-use super::{CertificateValueT, GenericCertificate, Hashed};
+use super::{CertificateValueT, GenericCertificate};
 use crate::{
     data_types::{check_signatures, LiteValue, LiteVote},
     ChainError,

--- a/linera-chain/src/certificate/lite.rs
+++ b/linera-chain/src/certificate/lite.rs
@@ -8,7 +8,7 @@ use linera_base::{crypto::Signature, data_types::Round, hashed::Hashed};
 use linera_execution::committee::{Committee, ValidatorName};
 use serde::{Deserialize, Serialize};
 
-use super::{CertificateValueT, GenericCertificate};
+use super::{CertificateValue, GenericCertificate};
 use crate::{
     data_types::{check_signatures, LiteValue, LiteVote},
     ChainError,
@@ -75,7 +75,7 @@ impl<'a> LiteCertificate<'a> {
     }
 
     /// Returns the [`GenericCertificate`] with the specified value, if it matches.
-    pub fn with_value<T: CertificateValueT>(
+    pub fn with_value<T: CertificateValue>(
         self,
         value: Hashed<T>,
     ) -> Option<GenericCertificate<T>> {

--- a/linera-chain/src/certificate/mod.rs
+++ b/linera-chain/src/certificate/mod.rs
@@ -4,7 +4,6 @@
 
 mod confirmed;
 mod generic;
-mod hashed;
 mod lite;
 mod timeout;
 mod validated;
@@ -12,7 +11,6 @@ mod validated;
 use std::collections::HashSet;
 
 pub use generic::GenericCertificate;
-pub use hashed::Hashed;
 use linera_base::{
     crypto::Signature,
     data_types::{BlockHeight, Round},

--- a/linera-chain/src/certificate/mod.rs
+++ b/linera-chain/src/certificate/mod.rs
@@ -93,7 +93,7 @@ pub enum CertificateKind {
     Confirmed = 2,
 }
 
-pub trait CertificateValueT: Clone {
+pub trait CertificateValue: Clone {
     const KIND: CertificateKind;
 
     fn chain_id(&self) -> ChainId;
@@ -105,7 +105,7 @@ pub trait CertificateValueT: Clone {
     fn required_blob_ids(&self) -> HashSet<BlobId>;
 }
 
-impl CertificateValueT for Timeout {
+impl CertificateValue for Timeout {
     const KIND: CertificateKind = CertificateKind::Timeout;
 
     fn chain_id(&self) -> ChainId {
@@ -125,7 +125,7 @@ impl CertificateValueT for Timeout {
     }
 }
 
-impl CertificateValueT for ValidatedBlock {
+impl CertificateValue for ValidatedBlock {
     const KIND: CertificateKind = CertificateKind::Validated;
 
     fn chain_id(&self) -> ChainId {
@@ -145,7 +145,7 @@ impl CertificateValueT for ValidatedBlock {
     }
 }
 
-impl CertificateValueT for ConfirmedBlock {
+impl CertificateValue for ConfirmedBlock {
     const KIND: CertificateKind = CertificateKind::Confirmed;
 
     fn chain_id(&self) -> ChainId {

--- a/linera-chain/src/certificate/timeout.rs
+++ b/linera-chain/src/certificate/timeout.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_base::{crypto::Signature, data_types::Round};
+use linera_base::{crypto::Signature, data_types::Round, hashed::Hashed};
 use linera_execution::committee::ValidatorName;
 use serde::{
     ser::{Serialize, SerializeStruct, Serializer},
@@ -10,10 +10,7 @@ use serde::{
 };
 
 use super::{generic::GenericCertificate, Certificate};
-use crate::{
-    block::{ConversionError, Timeout},
-    types::Hashed,
-};
+use crate::block::{ConversionError, Timeout};
 
 impl TryFrom<Certificate> for GenericCertificate<Timeout> {
     type Error = ConversionError;

--- a/linera-chain/src/certificate/validated.rs
+++ b/linera-chain/src/certificate/validated.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_base::{crypto::Signature, data_types::Round, identifiers::BlobId};
+use linera_base::{crypto::Signature, data_types::Round, hashed::Hashed, identifiers::BlobId};
 use linera_execution::committee::ValidatorName;
 use serde::{
     ser::{Serialize, SerializeStruct, Serializer},
@@ -13,7 +13,6 @@ use super::{generic::GenericCertificate, Certificate};
 use crate::{
     block::{ConversionError, ValidatedBlock},
     data_types::ExecutedBlock,
-    types::Hashed,
 };
 
 impl GenericCertificate<ValidatedBlock> {

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     types::{
-        CertificateKind, CertificateValueT, GenericCertificate, LiteCertificate,
+        CertificateKind, CertificateValue, GenericCertificate, LiteCertificate,
         ValidatedBlockCertificate,
     },
     ChainError,
@@ -442,7 +442,7 @@ pub struct LiteValue {
 }
 
 impl LiteValue {
-    pub fn new<T: CertificateValueT>(value: &Hashed<T>) -> Self {
+    pub fn new<T: CertificateValue>(value: &Hashed<T>) -> Self {
         LiteValue {
             value_hash: value.hash(),
             chain_id: value.inner().chain_id(),
@@ -468,7 +468,7 @@ impl<T> Vote<T> {
     /// Use signing key to create a signed object.
     pub fn new(value: Hashed<T>, round: Round, key_pair: &KeyPair) -> Self
     where
-        T: CertificateValueT,
+        T: CertificateValue,
     {
         let hash_and_round = VoteValue(value.hash(), round, T::KIND);
         let signature = Signature::new(&hash_and_round, key_pair);
@@ -483,7 +483,7 @@ impl<T> Vote<T> {
     /// Returns the vote, with a `LiteValue` instead of the full value.
     pub fn lite(&self) -> LiteVote
     where
-        T: CertificateValueT,
+        T: CertificateValue,
     {
         LiteVote {
             value: LiteValue::new(&self.value),
@@ -863,7 +863,7 @@ impl<'a, T> SignatureAggregator<'a, T> {
         signature: Signature,
     ) -> Result<Option<GenericCertificate<T>>, ChainError>
     where
-        T: CertificateValueT,
+        T: CertificateValue,
     {
         let hash_and_round = VoteValue(self.partial.hash(), self.partial.round, T::KIND);
         signature.check(&hash_and_round, validator.0)?;

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -13,7 +13,9 @@ use linera_base::{
     bcs,
     crypto::{BcsHashable, BcsSignable, CryptoError, CryptoHash, KeyPair, PublicKey, Signature},
     data_types::{Amount, Blob, BlockHeight, OracleResponse, Round, Timestamp},
-    doc_scalar, ensure, hex_debug,
+    doc_scalar, ensure,
+    hashed::Hashed,
+    hex_debug,
     identifiers::{
         Account, BlobId, BlobType, ChainId, ChannelName, Destination, GenericApplicationId,
         MessageId, Owner, StreamId,
@@ -28,7 +30,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     types::{
-        CertificateKind, CertificateValueT, GenericCertificate, Hashed, LiteCertificate,
+        CertificateKind, CertificateValueT, GenericCertificate, LiteCertificate,
         ValidatedBlockCertificate,
     },
     ChainError,

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -439,6 +439,16 @@ pub struct LiteValue {
     pub kind: CertificateKind,
 }
 
+impl LiteValue {
+    pub fn new<T: CertificateValueT>(value: &Hashed<T>) -> Self {
+        LiteValue {
+            value_hash: value.hash(),
+            chain_id: value.inner().chain_id(),
+            kind: T::KIND,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 struct VoteValue(CryptoHash, Round, CertificateKind);
 
@@ -474,7 +484,7 @@ impl<T> Vote<T> {
         T: CertificateValueT,
     {
         LiteVote {
-            value: self.value.lite(),
+            value: LiteValue::new(&self.value),
             round: self.round,
             validator: self.validator,
             signature: self.signature,

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -76,6 +76,7 @@ use linera_base::{
     crypto::{KeyPair, PublicKey},
     data_types::{ArithmeticError, Blob, BlockHeight, Round, Timestamp},
     doc_scalar, ensure,
+    hashed::Hashed,
     identifiers::{BlobId, ChainId, Owner},
     ownership::ChainOwnership,
 };
@@ -87,7 +88,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     block::{ConfirmedBlock, Timeout, ValidatedBlock},
     data_types::{Block, BlockProposal, ExecutedBlock, LiteVote, Vote},
-    types::{Hashed, TimeoutCertificate, ValidatedBlockCertificate},
+    types::{TimeoutCertificate, ValidatedBlockCertificate},
     ChainError,
 };
 

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -6,6 +6,7 @@
 use linera_base::{
     crypto::KeyPair,
     data_types::{Amount, BlockHeight, Round, Timestamp},
+    hashed::Hashed,
     identifiers::{ChainId, Owner},
 };
 use linera_execution::{
@@ -17,7 +18,7 @@ use linera_execution::{
 use crate::{
     block::ConfirmedBlock,
     data_types::{Block, BlockProposal, IncomingBundle, PostedMessage, SignatureAggregator, Vote},
-    types::{CertificateValueT, GenericCertificate, Hashed},
+    types::{CertificateValueT, GenericCertificate},
 };
 
 /// Creates a new child of the given block, with the same timestamp.

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -18,7 +18,7 @@ use linera_execution::{
 use crate::{
     block::ConfirmedBlock,
     data_types::{Block, BlockProposal, IncomingBundle, PostedMessage, SignatureAggregator, Vote},
-    types::{CertificateValueT, GenericCertificate},
+    types::{CertificateValue, GenericCertificate},
 };
 
 /// Creates a new child of the given block, with the same timestamp.
@@ -132,7 +132,7 @@ pub trait VoteTestExt<T>: Sized {
     fn into_certificate(self) -> GenericCertificate<T>;
 }
 
-impl<T: CertificateValueT> VoteTestExt<T> for Vote<T> {
+impl<T: CertificateValue> VoteTestExt<T> for Vote<T> {
     fn into_certificate(self) -> GenericCertificate<T> {
         let state = ValidatorState {
             network_address: "".to_string(),

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -12,6 +12,7 @@ use linera_base::{
         Amount, ApplicationPermissions, Blob, BlockHeight, Bytecode, Timestamp,
         UserApplicationDescription,
     },
+    hashed::Hashed,
     identifiers::{ApplicationId, BytecodeId, ChainId, MessageId},
     ownership::ChainOwnership,
 };
@@ -33,7 +34,6 @@ use crate::{
     block::ConfirmedBlock,
     data_types::{IncomingBundle, MessageAction, MessageBundle, Origin},
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt},
-    types::Hashed,
     ChainError, ChainExecutionContext, ChainStateView,
 };
 

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -27,18 +27,18 @@ fn test_signed_values() {
     .with(block);
     let confirmed_value = Hashed::new(ConfirmedBlock::new(executed_block.clone()));
 
-    let confirmed_vote = LiteVote::new(confirmed_value.lite(), Round::Fast, &key1);
+    let confirmed_vote = LiteVote::new(LiteValue::new(&confirmed_value), Round::Fast, &key1);
     assert!(confirmed_vote.check().is_ok());
 
     let validated_value = Hashed::new(ValidatedBlock::new(executed_block));
-    let validated_vote = LiteVote::new(validated_value.lite(), Round::Fast, &key1);
+    let validated_vote = LiteVote::new(LiteValue::new(&validated_value), Round::Fast, &key1);
     assert!(validated_vote.check().is_ok());
     assert_ne!(
         confirmed_vote.value, validated_vote.value,
         "Confirmed and validated votes should be different, even if for the same executed block"
     );
 
-    let mut v = LiteVote::new(confirmed_value.lite(), Round::Fast, &key2);
+    let mut v = LiteVote::new(LiteValue::new(&confirmed_value), Round::Fast, &key2);
     v.validator = name1;
     assert!(v.check().is_err());
 }
@@ -83,9 +83,9 @@ fn test_certificates() {
     .with(block);
     let value = Hashed::new(ConfirmedBlock::new(executed_block));
 
-    let v1 = LiteVote::new(value.lite(), Round::Fast, &key1);
-    let v2 = LiteVote::new(value.lite(), Round::Fast, &key2);
-    let v3 = LiteVote::new(value.lite(), Round::Fast, &key3);
+    let v1 = LiteVote::new(LiteValue::new(&value), Round::Fast, &key1);
+    let v2 = LiteVote::new(LiteValue::new(&value), Round::Fast, &key2);
+    let v3 = LiteVote::new(LiteValue::new(&value), Round::Fast, &key3);
 
     let mut builder = SignatureAggregator::new(value.clone(), Round::Fast, &committee);
     assert!(builder

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -37,7 +37,7 @@ use {
         identifiers::{AccountOwner, ApplicationId, Owner},
     },
     linera_chain::data_types::{Block, BlockProposal, ExecutedBlock, SignatureAggregator, Vote},
-    linera_chain::types::{CertificateValueT, GenericCertificate},
+    linera_chain::types::{CertificateValue, GenericCertificate},
     linera_core::data_types::ChainInfoQuery,
     linera_execution::{
         committee::Epoch,
@@ -808,7 +808,7 @@ where
         votes: Vec<Vote<T>>,
     ) -> Vec<GenericCertificate<T>>
     where
-        T: std::fmt::Debug + CertificateValueT,
+        T: std::fmt::Debug + CertificateValue,
     {
         let committee = self.wallet.genesis_config().create_committee();
         let mut aggregators = HashMap::new();

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -13,11 +13,12 @@ use custom_debug_derive::Debug;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Blob, BlockHeight, Timestamp, UserApplicationDescription},
+    hashed::Hashed,
     identifiers::{ChainId, UserApplicationId},
 };
 use linera_chain::{
     data_types::{Block, BlockProposal, ExecutedBlock, MessageBundle, Origin, Target},
-    types::{ConfirmedBlockCertificate, Hashed, TimeoutCertificate, ValidatedBlockCertificate},
+    types::{ConfirmedBlockCertificate, TimeoutCertificate, ValidatedBlockCertificate},
     ChainStateView,
 };
 use linera_execution::{

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -15,11 +15,12 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Blob, BlockHeight, UserApplicationDescription},
     ensure,
+    hashed::Hashed,
     identifiers::{BlobId, ChainId, UserApplicationId},
 };
 use linera_chain::{
     data_types::{Block, BlockProposal, ExecutedBlock, Medium, MessageBundle, Origin, Target},
-    types::{ConfirmedBlockCertificate, Hashed, TimeoutCertificate, ValidatedBlockCertificate},
+    types::{ConfirmedBlockCertificate, TimeoutCertificate, ValidatedBlockCertificate},
     ChainError, ChainStateView,
 };
 use linera_execution::{

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -9,6 +9,7 @@ use linera_base::{
         UserApplicationDescription,
     },
     ensure,
+    hashed::Hashed,
     identifiers::{AccountOwner, BlobType, GenericApplicationId, UserApplicationId},
 };
 use linera_chain::{
@@ -17,7 +18,7 @@ use linera_chain::{
         IncomingBundle, Medium, MessageAction, ProposalContent,
     },
     manager,
-    types::{Hashed, ValidatedBlock},
+    types::ValidatedBlock,
 };
 use linera_execution::{ChannelSubscription, Query, ResourceControlPolicy, Response};
 use linera_storage::{Clock as _, Storage};

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -32,6 +32,7 @@ use linera_base::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Round, Timestamp,
     },
     ensure,
+    hashed::Hashed,
     identifiers::{
         Account, AccountOwner, ApplicationId, BlobId, BlobType, BytecodeId, ChainId, MessageId,
         Owner, UserApplicationId,
@@ -44,7 +45,7 @@ use linera_chain::{
         MessageAction,
     },
     types::{
-        CertificateValueT, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate, Hashed,
+        CertificateValueT, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate,
         LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock, ValidatedBlockCertificate,
     },
     ChainError, ChainExecutionContext, ChainStateView,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -45,7 +45,7 @@ use linera_chain::{
         MessageAction,
     },
     types::{
-        CertificateValueT, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate,
+        CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate,
         LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock, ValidatedBlockCertificate,
     },
     ChainError, ChainExecutionContext, ChainStateView,
@@ -1122,7 +1122,7 @@ where
     /// In that case, it verifies that the validator votes are for the provided value,
     /// and returns a certificate.
     #[instrument(level = "trace", skip(committee, action, value))]
-    async fn communicate_chain_action<T: CertificateValueT>(
+    async fn communicate_chain_action<T: CertificateValue>(
         &self,
         committee: &Committee,
         action: CommunicateAction,

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -14,7 +14,7 @@ use linera_base::{
 use linera_chain::{
     data_types::BlockProposal,
     types::{
-        CertificateValueT, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate,
+        CertificateValue, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate,
         TimeoutCertificate, ValidatedBlockCertificate,
     },
 };
@@ -322,7 +322,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
 
     /// Checks that requesting these blobs when trying to handle this certificate is legitimate,
     /// i.e. that there are no duplicates and the blobs are actually required.
-    pub fn check_blobs_not_found<T: CertificateValueT>(
+    pub fn check_blobs_not_found<T: CertificateValue>(
         &self,
         certificate: &GenericCertificate<T>,
         blob_ids: &[BlobId],

--- a/linera-core/src/unit_tests/value_cache_tests.rs
+++ b/linera-core/src/unit_tests/value_cache_tests.rs
@@ -6,9 +6,10 @@ use std::{borrow::Cow, collections::BTreeSet};
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Blob, BlockHeight},
+    hashed::Hashed,
     identifiers::{BlobId, ChainId},
 };
-use linera_chain::types::{Hashed, Timeout};
+use linera_chain::types::Timeout;
 use linera_execution::committee::Epoch;
 
 use super::{ValueCache, DEFAULT_VALUE_CACHE_SIZE};

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -17,6 +17,7 @@ use linera_base::{
     data_types::{
         Amount, Blob, BlockHeight, Bytecode, OracleResponse, Timestamp, UserApplicationDescription,
     },
+    hashed::Hashed,
     identifiers::{
         BytecodeId, ChainDescription, ChainId, Destination, MessageId, UserApplicationId,
     },
@@ -25,7 +26,7 @@ use linera_base::{
 use linera_chain::{
     data_types::{BlockExecutionOutcome, OutgoingMessage},
     test::{make_child_block, make_first_block, BlockTestExt},
-    types::{ConfirmedBlock, Hashed},
+    types::ConfirmedBlock,
 };
 use linera_execution::{
     committee::Epoch,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -19,6 +19,7 @@ use assert_matches::assert_matches;
 use linera_base::{
     crypto::{CryptoHash, *},
     data_types::*,
+    hashed::Hashed,
     identifiers::{
         Account, AccountOwner, ChainDescription, ChainId, ChannelName, Destination,
         GenericApplicationId, MessageId, Owner,
@@ -33,8 +34,8 @@ use linera_chain::{
     },
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
     types::{
-        CertificateValueT, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate, Hashed,
-        Timeout, ValidatedBlock,
+        CertificateValueT, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate, Timeout,
+        ValidatedBlock,
     },
     ChainError, ChainExecutionContext,
 };

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -34,7 +34,7 @@ use linera_chain::{
     },
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
     types::{
-        CertificateValueT, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate, Timeout,
+        CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate, Timeout,
         ValidatedBlock,
     },
     ChainError, ChainExecutionContext,
@@ -149,7 +149,7 @@ fn make_certificate<S, T>(
 ) -> GenericCertificate<T>
 where
     S: Storage,
-    T: CertificateValueT,
+    T: CertificateValue,
 {
     make_certificate_with_round(committee, worker, value, Round::MultiLeader(0))
 }
@@ -162,7 +162,7 @@ fn make_certificate_with_round<S, T>(
 ) -> GenericCertificate<T>
 where
     S: Storage,
-    T: CertificateValueT,
+    T: CertificateValue,
 {
     let vote = LiteVote::new(
         LiteValue::new(&value),

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -28,8 +28,8 @@ use linera_base::{
 use linera_chain::{
     data_types::{
         Block, BlockExecutionOutcome, BlockProposal, ChainAndHeight, ChannelFullName,
-        IncomingBundle, LiteVote, Medium, MessageAction, MessageBundle, Origin, OutgoingMessage,
-        PostedMessage, SignatureAggregator,
+        IncomingBundle, LiteValue, LiteVote, Medium, MessageAction, MessageBundle, Origin,
+        OutgoingMessage, PostedMessage, SignatureAggregator,
     },
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
     types::{
@@ -164,7 +164,7 @@ where
     T: CertificateValueT,
 {
     let vote = LiteVote::new(
-        value.lite(),
+        LiteValue::new(&value),
         round,
         worker.chain_worker_config.key_pair().unwrap(),
     );
@@ -3331,7 +3331,7 @@ where
         .await?;
     let vote = response.info.manager.pending.as_ref().unwrap();
     let value = Hashed::new(ConfirmedBlock::new(executed_block1.clone()));
-    assert_eq!(vote.value, value.lite());
+    assert_eq!(vote.value, LiteValue::new(&value));
 
     // Instead of submitting the confirmed block certificate, let rounds 2 to 4 time out, too.
     let certificate_timeout = make_certificate_with_round(
@@ -3385,7 +3385,7 @@ where
         &key_pairs[1],
         Vec::new(),
     );
-    let lite_value2 = value2.lite();
+    let lite_value2 = LiteValue::new(&value2);
     let (_, _) = worker.handle_block_proposal(proposal).await?;
     let (response, _) = worker.handle_chain_info_query(query_values.clone()).await?;
     assert_eq!(
@@ -3617,7 +3617,7 @@ where
         &key_pairs[1],
         Vec::new(),
     );
-    let lite_value2 = value2.lite();
+    let lite_value2 = LiteValue::new(&value2);
     let (_, _) = worker.handle_block_proposal(proposal).await?;
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
     let (response, _) = worker.handle_chain_info_query(query_values).await?;

--- a/linera-core/src/value_cache.rs
+++ b/linera-core/src/value_cache.rs
@@ -11,8 +11,7 @@ mod unit_tests;
 use std::{any::type_name, sync::LazyLock};
 use std::{borrow::Cow, hash::Hash, num::NonZeroUsize};
 
-use linera_base::{crypto::CryptoHash, data_types::Blob, identifiers::BlobId};
-use linera_chain::types::Hashed;
+use linera_base::{crypto::CryptoHash, data_types::Blob, hashed::Hashed, identifiers::BlobId};
 use lru::LruCache;
 use tokio::sync::Mutex;
 #[cfg(with_metrics)]

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -27,7 +27,7 @@ use linera_chain::{
         Block, BlockExecutionOutcome, BlockProposal, ExecutedBlock, MessageBundle, Origin, Target,
     },
     types::{
-        CertificateValueT, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate,
+        CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate,
         LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock, ValidatedBlockCertificate,
     },
     ChainError, ChainStateView,
@@ -433,7 +433,7 @@ where
 
 #[allow(async_fn_in_trait)]
 #[cfg_attr(not(web), trait_variant::make(Send))]
-pub trait ProcessableCertificate: CertificateValueT + Sized + 'static {
+pub trait ProcessableCertificate: CertificateValue + Sized + 'static {
     async fn process_certificate<S: Storage + Clone + Send + Sync + 'static>(
         worker: &WorkerState<S>,
         certificate: GenericCertificate<Self>,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -18,6 +18,7 @@ use linera_base::{
         ArithmeticError, Blob, BlockHeight, DecompressionError, Round, UserApplicationDescription,
     },
     doc_scalar,
+    hashed::Hashed,
     identifiers::{BlobId, ChainId, Owner, UserApplicationId},
     time::timer::{sleep, timeout},
 };
@@ -26,7 +27,7 @@ use linera_chain::{
         Block, BlockExecutionOutcome, BlockProposal, ExecutedBlock, MessageBundle, Origin, Target,
     },
     types::{
-        CertificateValueT, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate, Hashed,
+        CertificateValueT, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate,
         LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock, ValidatedBlockCertificate,
     },
     ChainError, ChainStateView,

--- a/linera-indexer/lib/src/indexer.rs
+++ b/linera-indexer/lib/src/indexer.rs
@@ -8,8 +8,10 @@ use std::{collections::BTreeMap, sync::Arc};
 use async_graphql::{EmptyMutation, EmptySubscription, Schema, SimpleObject};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{extract::Extension, routing::get, Router};
-use linera_base::{crypto::CryptoHash, data_types::BlockHeight, identifiers::ChainId};
-use linera_chain::types::{ConfirmedBlock, Hashed};
+use linera_base::{
+    crypto::CryptoHash, data_types::BlockHeight, hashed::Hashed, identifiers::ChainId,
+};
+use linera_chain::types::ConfirmedBlock;
 use linera_views::{
     context::{Context, ViewContext},
     map_view::MapView,

--- a/linera-indexer/lib/src/plugin.rs
+++ b/linera-indexer/lib/src/plugin.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 
 use async_graphql::{EmptyMutation, EmptySubscription, ObjectType, Schema};
 use axum::Router;
-use linera_chain::types::{ConfirmedBlock, Hashed};
+use linera_base::hashed::Hashed;
+use linera_chain::types::ConfirmedBlock;
 use linera_views::{context::ViewContext, store::KeyValueStore, views::View};
 use tokio::sync::Mutex;
 

--- a/linera-indexer/lib/src/service.rs
+++ b/linera-indexer/lib/src/service.rs
@@ -14,9 +14,10 @@ use futures::{
 use graphql_client::reqwest::post_graphql;
 use graphql_ws_client::{graphql::StreamingOperation, GraphQLClientClientBuilder};
 use linera_base::{
-    crypto::CryptoHash, data_types::BlockHeight, identifiers::ChainId, time::Duration,
+    crypto::CryptoHash, data_types::BlockHeight, hashed::Hashed, identifiers::ChainId,
+    time::Duration,
 };
-use linera_chain::types::{ConfirmedBlock, Hashed};
+use linera_chain::types::ConfirmedBlock;
 use linera_core::worker::Reason;
 use linera_service_graphql_client::{block, chains, notifications, Block, Chains, Notifications};
 use linera_views::store::KeyValueStore;

--- a/linera-indexer/plugins/src/operations.rs
+++ b/linera-indexer/plugins/src/operations.rs
@@ -8,8 +8,10 @@ use std::{
 
 use async_graphql::{OneofObject, SimpleObject};
 use axum::Router;
-use linera_base::{crypto::CryptoHash, data_types::BlockHeight, doc_scalar, identifiers::ChainId};
-use linera_chain::types::{ConfirmedBlock, Hashed};
+use linera_base::{
+    crypto::CryptoHash, data_types::BlockHeight, doc_scalar, hashed::Hashed, identifiers::ChainId,
+};
+use linera_chain::types::ConfirmedBlock;
 use linera_execution::Operation;
 use linera_indexer::{
     common::IndexerError,

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -5,13 +5,14 @@ use linera_base::{
     crypto::{CryptoError, CryptoHash, PublicKey, Signature},
     data_types::{BlobContent, BlockHeight},
     ensure,
+    hashed::Hashed,
     identifiers::{AccountOwner, BlobId, ChainId, Owner},
 };
 use linera_chain::{
     data_types::{BlockProposal, LiteValue, ProposalContent},
     types::{
-        Certificate, CertificateKind, ConfirmedBlock, ConfirmedBlockCertificate, Hashed,
-        LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock, ValidatedBlockCertificate,
+        Certificate, CertificateKind, ConfirmedBlock, ConfirmedBlockCertificate, LiteCertificate,
+        Timeout, TimeoutCertificate, ValidatedBlock, ValidatedBlockCertificate,
     },
 };
 use linera_core::{

--- a/linera-rpc/tests/format.rs
+++ b/linera-rpc/tests/format.rs
@@ -4,13 +4,14 @@
 
 use linera_base::{
     data_types::{BlobContent, OracleResponse, Round},
+    hashed::Hashed,
     identifiers::{AccountOwner, BlobType, ChainDescription, Destination, GenericApplicationId},
     ownership::ChainOwnership,
 };
 use linera_chain::{
     data_types::{Medium, MessageAction},
     manager::ChainManagerInfo,
-    types::{Certificate, CertificateKind, ConfirmedBlock, Hashed, Timeout, ValidatedBlock},
+    types::{Certificate, CertificateKind, ConfirmedBlock, Timeout, ValidatedBlock},
 };
 use linera_core::{data_types::CrossChainRequest, node::NodeError};
 use linera_execution::{

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -8,6 +8,7 @@
 use linera_base::{
     crypto::PublicKey,
     data_types::{Amount, ApplicationPermissions, Round, Timestamp},
+    hashed::Hashed,
     identifiers::{ApplicationId, ChainId, GenericApplicationId, Owner},
     ownership::TimeoutConfig,
 };
@@ -16,7 +17,7 @@ use linera_chain::{
         Block, ChannelFullName, IncomingBundle, LiteValue, LiteVote, Medium, MessageAction, Origin,
         SignatureAggregator,
     },
-    types::{ConfirmedBlock, ConfirmedBlockCertificate, Hashed},
+    types::{ConfirmedBlock, ConfirmedBlockCertificate},
 };
 use linera_execution::{
     system::{Recipient, SystemChannel, SystemOperation},

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -13,7 +13,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        Block, ChannelFullName, IncomingBundle, LiteVote, Medium, MessageAction, Origin,
+        Block, ChannelFullName, IncomingBundle, LiteValue, LiteVote, Medium, MessageAction, Origin,
         SignatureAggregator,
     },
     types::{ConfirmedBlock, ConfirmedBlockCertificate, Hashed},
@@ -217,7 +217,11 @@ impl BlockBuilder {
             .await?;
 
         let value = Hashed::new(ConfirmedBlock::new(executed_block));
-        let vote = LiteVote::new(value.lite(), Round::Fast, self.validator.key_pair());
+        let vote = LiteVote::new(
+            LiteValue::new(&value),
+            Round::Fast,
+            self.validator.key_pair(),
+        );
         let mut builder = SignatureAggregator::new(value, Round::Fast, self.validator.committee());
         let certificate = builder
             .append(vote.validator, vote.signature)

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -130,13 +130,13 @@ pub struct Transfer;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod from {
-    use linera_base::identifiers::StreamId;
+    use linera_base::{hashed::Hashed, identifiers::StreamId};
     use linera_chain::{
         data_types::{
             BlockExecutionOutcome, EventRecord, ExecutedBlock, IncomingBundle, MessageBundle,
             OutgoingMessage, PostedMessage,
         },
-        types::{ConfirmedBlock, Hashed},
+        types::ConfirmedBlock,
     };
 
     use super::*;

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -62,7 +62,8 @@ mod net_up_utils;
 
 #[cfg(feature = "benchmark")]
 use {
-    linera_chain::types::{ConfirmedBlock, Hashed},
+    linera_base::hashed::Hashed,
+    linera_chain::types::ConfirmedBlock,
     linera_core::data_types::ChainInfoResponse,
     linera_rpc::{HandleConfirmedCertificateRequest, RpcMessage},
     std::collections::HashSet,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -16,12 +16,13 @@ use futures::{lock::Mutex, Future};
 use linera_base::{
     crypto::{CryptoError, CryptoHash, PublicKey},
     data_types::{Amount, ApplicationPermissions, Bytecode, TimeDelta, UserApplicationDescription},
+    hashed::Hashed,
     identifiers::{ApplicationId, BytecodeId, ChainId, Owner, UserApplicationId},
     ownership::{ChainOwnership, TimeoutConfig},
     BcsHexParseError,
 };
 use linera_chain::{
-    types::{ConfirmedBlock, GenericCertificate, Hashed},
+    types::{ConfirmedBlock, GenericCertificate},
     ChainStateView,
 };
 use linera_client::chain_listener::{ChainListener, ChainListenerConfig, ClientContext};

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -630,10 +630,13 @@ impl<T> GrpcMessageLimiter<T> {
 
 #[cfg(test)]
 mod proto_message_cap {
-    use linera_base::crypto::{KeyPair, Signature};
+    use linera_base::{
+        crypto::{KeyPair, Signature},
+        hashed::Hashed,
+    };
     use linera_chain::{
         data_types::{BlockExecutionOutcome, ExecutedBlock},
-        types::{Certificate, ConfirmedBlock, ConfirmedBlockCertificate, Hashed},
+        types::{Certificate, ConfirmedBlock, ConfirmedBlockCertificate},
     };
     use linera_execution::committee::ValidatorName;
     use linera_sdk::base::{ChainId, TestString};

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -10,10 +10,11 @@ use dashmap::DashMap;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Blob, TimeDelta, Timestamp},
+    hashed::Hashed,
     identifiers::{BlobId, ChainId, UserApplicationId},
 };
 use linera_chain::{
-    types::{ConfirmedBlock, ConfirmedBlockCertificate, Hashed, LiteCertificate},
+    types::{ConfirmedBlock, ConfirmedBlockCertificate, LiteCertificate},
     ChainStateView,
 };
 use linera_execution::{

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -14,12 +14,13 @@ use dashmap::{mapref::entry::Entry, DashMap};
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
     data_types::{Amount, Blob, BlockHeight, TimeDelta, Timestamp, UserApplicationDescription},
+    hashed::Hashed,
     identifiers::{BlobId, ChainDescription, ChainId, GenericApplicationId, UserApplicationId},
     ownership::ChainOwnership,
 };
 use linera_chain::{
     data_types::ChannelFullName,
-    types::{ConfirmedBlock, ConfirmedBlockCertificate, Hashed},
+    types::{ConfirmedBlock, ConfirmedBlockCertificate},
     ChainError, ChainStateView,
 };
 use linera_execution::{


### PR DESCRIPTION
## Motivation

We are going to use `Hashed` for blobs, too, not only for certificate values.

## Proposal

Move it to `linera-base`.

Remove the `lite` method and create a `LiteValue::new` instead.

Also, rename `CertificateValueT` to `CertificateValue`.

## Test Plan

CI should catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
