### PR TITLE
`impl<T: CertificateValue> From<&Hashed<T>> for LiteValue`

### DIFF
--- a/linera-chain/src/certificate/generic.rs
+++ b/linera-chain/src/certificate/generic.rs
@@ -115,7 +115,7 @@ impl<T> GenericCertificate<T> {
         T: CertificateValue,
     {
         crate::certificate::LiteCertificate {
-            value: LiteValue::new(&self.value),
+            value: LiteValue::from(&self.value),
             round: self.round,
             signatures: std::borrow::Cow::Borrowed(&self.signatures),
         }

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -441,8 +441,8 @@ pub struct LiteValue {
     pub kind: CertificateKind,
 }
 
-impl LiteValue {
-    pub fn new<T: CertificateValue>(value: &Hashed<T>) -> Self {
+impl<T: CertificateValue> From<&Hashed<T>> for LiteValue {
+    fn from(value: &Hashed<T>) -> Self {
         LiteValue {
             value_hash: value.hash(),
             chain_id: value.inner().chain_id(),
@@ -486,7 +486,7 @@ impl<T> Vote<T> {
         T: CertificateValue,
     {
         LiteVote {
-            value: LiteValue::new(&self.value),
+            value: LiteValue::from(&self.value),
             round: self.round,
             validator: self.validator,
             signature: self.signature,

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -27,18 +27,18 @@ fn test_signed_values() {
     .with(block);
     let confirmed_value = Hashed::new(ConfirmedBlock::new(executed_block.clone()));
 
-    let confirmed_vote = LiteVote::new(LiteValue::new(&confirmed_value), Round::Fast, &key1);
+    let confirmed_vote = LiteVote::new(LiteValue::from(&confirmed_value), Round::Fast, &key1);
     assert!(confirmed_vote.check().is_ok());
 
     let validated_value = Hashed::new(ValidatedBlock::new(executed_block));
-    let validated_vote = LiteVote::new(LiteValue::new(&validated_value), Round::Fast, &key1);
+    let validated_vote = LiteVote::new(LiteValue::from(&validated_value), Round::Fast, &key1);
     assert!(validated_vote.check().is_ok());
     assert_ne!(
         confirmed_vote.value, validated_vote.value,
         "Confirmed and validated votes should be different, even if for the same executed block"
     );
 
-    let mut v = LiteVote::new(LiteValue::new(&confirmed_value), Round::Fast, &key2);
+    let mut v = LiteVote::new(LiteValue::from(&confirmed_value), Round::Fast, &key2);
     v.validator = name1;
     assert!(v.check().is_err());
 }
@@ -83,9 +83,9 @@ fn test_certificates() {
     .with(block);
     let value = Hashed::new(ConfirmedBlock::new(executed_block));
 
-    let v1 = LiteVote::new(LiteValue::new(&value), Round::Fast, &key1);
-    let v2 = LiteVote::new(LiteValue::new(&value), Round::Fast, &key2);
-    let v3 = LiteVote::new(LiteValue::new(&value), Round::Fast, &key3);
+    let v1 = LiteVote::new(LiteValue::from(&value), Round::Fast, &key1);
+    let v2 = LiteVote::new(LiteValue::from(&value), Round::Fast, &key2);
+    let v3 = LiteVote::new(LiteValue::from(&value), Round::Fast, &key3);
 
     let mut builder = SignatureAggregator::new(value.clone(), Round::Fast, &committee);
     assert!(builder

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -165,7 +165,7 @@ where
     T: CertificateValue,
 {
     let vote = LiteVote::new(
-        LiteValue::new(&value),
+        LiteValue::from(&value),
         round,
         worker.chain_worker_config.key_pair().unwrap(),
     );
@@ -3332,7 +3332,7 @@ where
         .await?;
     let vote = response.info.manager.pending.as_ref().unwrap();
     let value = Hashed::new(ConfirmedBlock::new(executed_block1.clone()));
-    assert_eq!(vote.value, LiteValue::new(&value));
+    assert_eq!(vote.value, LiteValue::from(&value));
 
     // Instead of submitting the confirmed block certificate, let rounds 2 to 4 time out, too.
     let certificate_timeout = make_certificate_with_round(
@@ -3386,7 +3386,7 @@ where
         &key_pairs[1],
         Vec::new(),
     );
-    let lite_value2 = LiteValue::new(&value2);
+    let lite_value2 = LiteValue::from(&value2);
     let (_, _) = worker.handle_block_proposal(proposal).await?;
     let (response, _) = worker.handle_chain_info_query(query_values.clone()).await?;
     assert_eq!(
@@ -3618,7 +3618,7 @@ where
         &key_pairs[1],
         Vec::new(),
     );
-    let lite_value2 = LiteValue::new(&value2);
+    let lite_value2 = LiteValue::from(&value2);
     let (_, _) = worker.handle_block_proposal(proposal).await?;
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
     let (response, _) = worker.handle_chain_info_query(query_values).await?;

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -219,7 +219,7 @@ impl BlockBuilder {
 
         let value = Hashed::new(ConfirmedBlock::new(executed_block));
         let vote = LiteVote::new(
-            LiteValue::new(&value),
+            LiteValue::from(&value),
             Round::Fast,
             self.validator.key_pair(),
         );


### PR DESCRIPTION
## Motivation

This addresses https://github.com/linera-io/linera-protocol/pull/3064#discussion_r1893807182.

## Proposal

`impl<T: CertificateValue> From<&Hashed<T>> for LiteValue`

Since we use the reference and don't consume the `Hashed<T>`, we still need to call `LiteValue::from(&value)` explicitly, or `(&value).into()`, but `value.into()` wouldn't work.

## Test Plan

Minor refactoring. CI will catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Original comment: https://github.com/linera-io/linera-protocol/pull/3064#discussion_r1893807182
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
