### PR TITLE
Allow specifying a custom WIT type name when deriving `WitType`

### DIFF
--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -34,10 +34,13 @@ pub fn derive_wit_type(input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as DeriveInput);
 
     let specializations = apply_specialization_attribute(&mut input);
+    let wit_name = wit_type::discover_wit_name(&input.attrs, &input.ident);
 
     let body = match &input.data {
-        Data::Struct(struct_item) => wit_type::derive_for_struct(&input.ident, &struct_item.fields),
-        Data::Enum(enum_item) => wit_type::derive_for_enum(&input.ident, enum_item.variants.iter()),
+        Data::Struct(struct_item) => wit_type::derive_for_struct(wit_name, &struct_item.fields),
+        Data::Enum(enum_item) => {
+            wit_type::derive_for_enum(&input.ident, wit_name, enum_item.variants.iter())
+        }
         Data::Union(_union_item) => {
             abort!(input.ident, "Can't derive `WitType` for `union`s")
         }

--- a/linera-witty-macros/src/wit_type.rs
+++ b/linera-witty-macros/src/wit_type.rs
@@ -69,10 +69,9 @@ pub fn discover_wit_name(attributes: &[Attribute], rust_name: &Ident) -> LitStr 
 /// Returns the body of the `WitType` implementation for the Rust `struct` with the specified
 /// `fields`.
 pub fn derive_for_struct<'input>(
-    name: &Ident,
+    wit_name: LitStr,
     fields: impl Into<FieldsInformation<'input>>,
 ) -> TokenStream {
-    let wit_name = LitStr::new(&name.to_string().to_kebab_case(), name.span());
     let fields = fields.into();
     let fields_hlist = fields.hlist_type();
     let field_wit_names = fields.wit_names();
@@ -109,10 +108,9 @@ pub fn derive_for_struct<'input>(
 /// `variants`.
 pub fn derive_for_enum<'variants>(
     name: &Ident,
+    wit_name: LitStr,
     variants: impl DoubleEndedIterator<Item = &'variants Variant> + Clone,
 ) -> TokenStream {
-    let wit_name = LitStr::new(&name.to_string().to_kebab_case(), name.span());
-
     let variant_count = variants.clone().count();
     let variant_fields: Vec<_> = variants
         .clone()

--- a/linera-witty-macros/src/wit_type.rs
+++ b/linera-witty-macros/src/wit_type.rs
@@ -7,12 +7,64 @@ use heck::ToKebabCase;
 use proc_macro2::TokenStream;
 use proc_macro_error::abort;
 use quote::quote;
-use syn::{Ident, LitStr, Variant};
+use syn::{Attribute, Ident, LitStr, MacroDelimiter, Meta, Variant};
 
 use crate::util::FieldsInformation;
 
 #[path = "unit_tests/wit_type.rs"]
 mod tests;
+
+/// Returns a [`LitStr`] with the type name to use in the WIT declaration.
+///
+/// The name is either obtained from a custom `#[wit_name = ""]` attribute, or as the
+/// kebab-case version of the Rust type name.
+pub fn discover_wit_name(attributes: &[Attribute], rust_name: &Ident) -> LitStr {
+    let custom_name = attributes
+        .iter()
+        .filter_map(|attribute| {
+            let Meta::List(meta) = &attribute.meta else {
+                return None;
+            };
+            let MacroDelimiter::Paren(_) = meta.delimiter else {
+                return None;
+            };
+            if !meta.path.is_ident("witty") {
+                return None;
+            }
+
+            let mut wit_name = None;
+            meta.parse_nested_meta(|witty_attribute| {
+                if witty_attribute.path.is_ident("name") {
+                    if wit_name.is_some() {
+                        abort!(
+                            witty_attribute.path,
+                            "Multiple attributes configuring the WIT type name"
+                        );
+                    }
+
+                    let value = witty_attribute.value()?;
+                    let name = value.parse::<LitStr>()?;
+
+                    wit_name = Some(name.clone());
+                }
+
+                Ok(())
+            })
+            .unwrap_or_else(|_| {
+                abort!(
+                    meta,
+                    "Failed to parse WIT type name attribute. \
+                    Expected `#[witrty(name = \"custom-wit-type-name\")]`."
+                );
+            });
+
+            wit_name
+        })
+        .next();
+
+    custom_name
+        .unwrap_or_else(|| LitStr::new(&rust_name.to_string().to_kebab_case(), rust_name.span()))
+}
 
 /// Returns the body of the `WitType` implementation for the Rust `struct` with the specified
 /// `fields`.


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
The `WitType` trait allows generating WIT snippets. The WIT type name used is by default the kebab-case version of the Rust type name. However, it is sometimes necessary or desirable to use a custom name in the WIT snippet.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Add a `#[witty(name = "custom-wit-type-name")]` attribute to allow overriding the default WIT type name.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
A unit test was added to test the usage of the new attribute.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- These changes follow the usual release cycle, as it introduces a new backwards compatible Witty feature.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Closes #2613