### PR TITLE
fix: improve readability Update hashed.rs

### DIFF
--- a/linera-base/src/hashed.rs
+++ b/linera-base/src/hashed.rs
@@ -86,7 +86,7 @@ impl<T: Clone> Clone for Hashed<T> {
 
 impl<T: async_graphql::OutputType> async_graphql::TypeName for Hashed<T> {
     fn type_name() -> Cow<'static, str> {
-        format!("Hashed{}", T::type_name(),).into()
+        format!("Hashed{}", T::type_name()).into()
     }
 }
 


### PR DESCRIPTION
The comma after `T::type_name()` doesn't cause an error, but it is redundant, so I removed it to improve readability.