### PR TITLE
fix: Fix variable declaration order Update compose.sh

### DIFF
--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -19,6 +19,7 @@ cleanup() {
     rm wallet.json
     SCYLLA_VOLUME=docker_linera-scylla-data
     SHARED_VOLUME=docker_linera-shared
+    # The following commands can now safely use the SCYLLA_VOLUME and SHARED_VOLUME variables
     docker rm -f $(docker ps -a -q --filter volume=$SCYLLA_VOLUME)
     docker volume rm $SCYLLA_VOLUME
     docker rm -f $(docker ps -a -q --filter volume=$SHARED_VOLUME)


### PR DESCRIPTION
## Motivation

I’ve rearranged the order of variable declarations for `SCYLLA_VOLUME` and `SHARED_VOLUME` in the `cleanup()` function. Previously, these variables were being referenced before they were properly declared and assigned, which could lead to errors or unexpected behavior. By moving their declaration and assignment above the Docker commands, I’ve ensured that they are correctly set before being used. This change improves code reliability and prevents potential issues during the cleanup process.
