### PR TITLE
Serialize Confirmed and Validated blocks as their inner blocks.

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -17,29 +17,10 @@ use thiserror::Error;
 use crate::{data_types::ExecutedBlock, ChainError};
 
 /// Wrapper around an `ExecutedBlock` that has been validated.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct ValidatedBlock {
     executed_block: Hashed<ExecutedBlock>,
-}
-
-impl Serialize for ValidatedBlock {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.executed_block.serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for ValidatedBlock {
-    fn deserialize<D>(deserializer: D) -> Result<ValidatedBlock, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        Ok(ValidatedBlock {
-            executed_block: Hashed::deserialize(deserializer)?,
-        })
-    }
 }
 
 impl ValidatedBlock {
@@ -88,30 +69,11 @@ impl ValidatedBlock {
 impl<'de> BcsHashable<'de> for ValidatedBlock {}
 
 /// Wrapper around an `ExecutedBlock` that has been confirmed.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct ConfirmedBlock {
     // The executed block contained in this `ConfirmedBlock`.
     executed_block: Hashed<ExecutedBlock>,
-}
-
-impl Serialize for ConfirmedBlock {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.executed_block.serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for ConfirmedBlock {
-    fn deserialize<D>(deserializer: D) -> Result<ConfirmedBlock, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        Ok(ConfirmedBlock {
-            executed_block: Hashed::deserialize(deserializer)?,
-        })
-    }
 }
 
 #[async_graphql::Object(cache_control(no_cache))]

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -19,34 +19,30 @@ use crate::{data_types::ExecutedBlock, ChainError};
 /// Wrapper around an `ExecutedBlock` that has been validated.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct ValidatedBlock {
-    executed_block: Hashed<ExecutedBlock>,
-}
+pub struct ValidatedBlock(Hashed<ExecutedBlock>);
 
 impl ValidatedBlock {
     /// Creates a new `ValidatedBlock` from an `ExecutedBlock`.
     pub fn new(executed_block: ExecutedBlock) -> Self {
-        Self {
-            executed_block: Hashed::new(executed_block),
-        }
+        Self(Hashed::new(executed_block))
     }
 
     pub fn from_hashed(executed_block: Hashed<ExecutedBlock>) -> Self {
-        Self { executed_block }
+        Self(executed_block)
     }
 
     pub fn inner(&self) -> &Hashed<ExecutedBlock> {
-        &self.executed_block
+        &self.0
     }
 
     /// Returns a reference to the `ExecutedBlock` contained in this `ValidatedBlock`.
     pub fn executed_block(&self) -> &ExecutedBlock {
-        self.executed_block.inner()
+        self.0.inner()
     }
 
     /// Consumes this `ValidatedBlock`, returning the `ExecutedBlock` it contains.
     pub fn into_inner(self) -> ExecutedBlock {
-        self.executed_block.into_inner()
+        self.0.into_inner()
     }
 
     pub fn to_log_str(&self) -> &'static str {
@@ -54,15 +50,15 @@ impl ValidatedBlock {
     }
 
     pub fn chain_id(&self) -> ChainId {
-        self.executed_block().block.chain_id
+        self.0.inner().block.chain_id
     }
 
     pub fn height(&self) -> BlockHeight {
-        self.executed_block().block.height
+        self.0.inner().block.height
     }
 
     pub fn epoch(&self) -> Epoch {
-        self.executed_block().block.epoch
+        self.0.inner().block.epoch
     }
 }
 
@@ -71,16 +67,13 @@ impl<'de> BcsHashable<'de> for ValidatedBlock {}
 /// Wrapper around an `ExecutedBlock` that has been confirmed.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct ConfirmedBlock {
-    // The executed block contained in this `ConfirmedBlock`.
-    executed_block: Hashed<ExecutedBlock>,
-}
+pub struct ConfirmedBlock(Hashed<ExecutedBlock>);
 
 #[async_graphql::Object(cache_control(no_cache))]
 impl ConfirmedBlock {
     #[graphql(derived(name = "executed_block"))]
     async fn _executed_block(&self) -> ExecutedBlock {
-        self.executed_block.inner().clone()
+        self.0.inner().clone()
     }
 
     async fn status(&self) -> String {
@@ -92,35 +85,33 @@ impl<'de> BcsHashable<'de> for ConfirmedBlock {}
 
 impl ConfirmedBlock {
     pub fn new(executed_block: ExecutedBlock) -> Self {
-        Self {
-            executed_block: Hashed::new(executed_block),
-        }
+        Self(Hashed::new(executed_block))
     }
 
     pub fn from_hashed(executed_block: Hashed<ExecutedBlock>) -> Self {
-        Self { executed_block }
+        Self(executed_block)
     }
 
     pub fn inner(&self) -> &Hashed<ExecutedBlock> {
-        &self.executed_block
+        &self.0
     }
 
     /// Returns a reference to the `ExecutedBlock` contained in this `ConfirmedBlock`.
     pub fn executed_block(&self) -> &ExecutedBlock {
-        self.executed_block.inner()
+        self.0.inner()
     }
 
     /// Consumes this `ConfirmedBlock`, returning the `ExecutedBlock` it contains.
     pub fn into_inner(self) -> ExecutedBlock {
-        self.executed_block.into_inner()
+        self.0.into_inner()
     }
 
     pub fn chain_id(&self) -> ChainId {
-        self.executed_block.inner().block.chain_id
+        self.0.inner().block.chain_id
     }
 
     pub fn height(&self) -> BlockHeight {
-        self.executed_block.inner().block.height
+        self.0.inner().block.height
     }
 
     pub fn to_log_str(&self) -> &'static str {

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -17,9 +17,29 @@ use thiserror::Error;
 use crate::{data_types::ExecutedBlock, ChainError};
 
 /// Wrapper around an `ExecutedBlock` that has been validated.
-#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ValidatedBlock {
     executed_block: Hashed<ExecutedBlock>,
+}
+
+impl Serialize for ValidatedBlock {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.executed_block.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ValidatedBlock {
+    fn deserialize<D>(deserializer: D) -> Result<ValidatedBlock, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(ValidatedBlock {
+            executed_block: Hashed::deserialize(deserializer)?,
+        })
+    }
 }
 
 impl ValidatedBlock {
@@ -68,10 +88,30 @@ impl ValidatedBlock {
 impl<'de> BcsHashable<'de> for ValidatedBlock {}
 
 /// Wrapper around an `ExecutedBlock` that has been confirmed.
-#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ConfirmedBlock {
     // The executed block contained in this `ConfirmedBlock`.
     executed_block: Hashed<ExecutedBlock>,
+}
+
+impl Serialize for ConfirmedBlock {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.executed_block.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ConfirmedBlock {
+    fn deserialize<D>(deserializer: D) -> Result<ConfirmedBlock, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(ConfirmedBlock {
+            executed_block: Hashed::deserialize(deserializer)?,
+        })
+    }
 }
 
 #[async_graphql::Object(cache_control(no_cache))]

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -32,7 +32,6 @@ fn test_signed_values() {
 
     let validated_value = Hashed::new(ValidatedBlock::new(executed_block));
     let validated_vote = LiteVote::new(LiteValue::new(&validated_value), Round::Fast, &key1);
-    assert!(validated_vote.check().is_ok());
     assert_ne!(
         confirmed_vote.value, validated_vote.value,
         "Confirmed and validated votes should be different, even if for the same executed block"
@@ -41,6 +40,24 @@ fn test_signed_values() {
     let mut v = LiteVote::new(LiteValue::new(&confirmed_value), Round::Fast, &key2);
     v.validator = name1;
     assert!(v.check().is_err());
+
+    assert!(validated_vote.check().is_ok());
+    assert!(confirmed_vote.check().is_ok());
+
+    let mut v = validated_vote.clone();
+    // Use signature from ConfirmedBlock to sign a ValidatedBlock.
+    v.signature = confirmed_vote.signature;
+    assert!(
+        v.check().is_err(),
+        "Confirmed and validated votes must not be interchangeable"
+    );
+
+    let mut v = confirmed_vote.clone();
+    v.signature = validated_vote.signature;
+    assert!(
+        v.check().is_err(),
+        "Confirmed and validated votes must not be interchangeable"
+    );
 }
 
 #[test]

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -59,7 +59,7 @@ fn test_hashes() {
     let confirmed_hashed = Hashed::new(ConfirmedBlock::new(executed_block.clone()));
     let validated_hashed = Hashed::new(ValidatedBlock::new(executed_block));
 
-    assert_ne!(confirmed_hashed.hash(), validated_hashed.hash());
+    assert_eq!(confirmed_hashed.hash(), validated_hashed.hash());
 }
 
 #[test]

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -273,10 +273,10 @@ ChainManagerInfo:
           TYPENAME: LiteVote
     - requested_confirmed:
         OPTION:
-          TYPENAME: ConfirmedBlock
+          TYPENAME: ExecutedBlock
     - requested_validated:
         OPTION:
-          TYPENAME: ValidatedBlock
+          TYPENAME: ExecutedBlock
     - current_round:
         TYPENAME: Round
     - leader:
@@ -331,14 +331,10 @@ Committee:
             TYPENAME: ValidatorState
     - policy:
         TYPENAME: ResourceControlPolicy
-ConfirmedBlock:
-  STRUCT:
-    - executed_block:
-        TYPENAME: ExecutedBlock
 ConfirmedBlockCertificate:
   STRUCT:
     - value:
-        TYPENAME: ConfirmedBlock
+        TYPENAME: ExecutedBlock
     - round:
         TYPENAME: Round
     - signatures:
@@ -857,7 +853,7 @@ RpcMessage:
     19:
       DownloadConfirmedBlockResponse:
         NEWTYPE:
-          TYPENAME: ConfirmedBlock
+          TYPENAME: ExecutedBlock
     20:
       DownloadCertificatesResponse:
         NEWTYPE:
@@ -1098,14 +1094,10 @@ UserApplicationDescription:
     - required_application_ids:
         SEQ:
           TYPENAME: ApplicationId
-ValidatedBlock:
-  STRUCT:
-    - executed_block:
-        TYPENAME: ExecutedBlock
 ValidatedBlockCertificate:
   STRUCT:
     - value:
-        TYPENAME: ValidatedBlock
+        TYPENAME: ExecutedBlock
     - round:
         TYPENAME: Round
     - signatures:


### PR DESCRIPTION
## Motivation

As described in https://github.com/linera-io/linera-protocol/issues/2980 we've started to see a lot of logs about validator forgetting a block it had already signed. As @afck correctly observed - the problem was that when inserting a `ConfirmedBlock` (and `ValidatedBlock`) into the `ExecutedBlock` cache, they were inserted under a hash of the wrapper type (`ConfirmedBlock`/`ValidatedBlock`) rather than the hash of `ExecutedBlock` they contained. This meant that when looking up the cached value we always failed to find it (since the keys were different) – hence the error log.


## Proposal

Here we serialize `ConfirmedBlock` and `ValidatedBlock` as their inner `ExecutedBlock`s they contain. This means that their hashes are now equivalent (which fixes the original problem with the cache) but could also mean their serialized forms are now interchangeable. This is potentially problematic but not critical (i.e. for the protocol). Note that the _votes_ are still different - i.e. vote for a `ConfirmedBlock` will be different from a vote for `ValidatedBlock` containing the same `ExecutedBlock` (TODO: add link to the `test_signed_values` unit test).

Interestingly, we now drop the `ConfirmedBlock` and `ValidatedBlock` types from the RPC (see [Update RPC format](https://github.com/linera-io/linera-protocol/pull/3076/commits/1a8fb06be48aebae7500b8647a8cf94d18154b13)) which actually might be considered a change for the better since they were a "intermediate", wrapper types and the _kind_ of the certificate is encoded in the certificates' types themselves - `ValidatedBlockCertificate` and `ConfirmedBlockCertificate`.

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->

## Test Plan

I've updated the `test_hashes` unit test and verified that we no longer get `"validator forgot a certificate they signed before"` in the logs by running
```
cargo test test_end_to_end_publish_data_blob_in_cli::storage_test_service_grpc -- --nocapture 2>&1 | grep forgot
```
<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

Since this doesn't affect the correctness (or safety) of the protocol, I propose:

- Nothing to do / These changes follow the usual release cycle.

## Links

Fixes https://github.com/linera-io/linera-protocol/issues/2980
<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
