### PR TITLE
Introduce the functionality of getting the list of blobs.

### DIFF
--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -434,6 +434,9 @@ pub enum ClientCommand {
         chain_id: Option<ChainId>,
     },
 
+    /// Show the list of BlobIds of the validator
+    ListAllBlobIds,
+
     /// Show the version and genesis config hash of a new validator, and print a warning if it is
     /// incompatible. Also print some information about the given chain while we are at it.
     QueryValidator {

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -97,6 +97,9 @@ pub trait ValidatorNode {
     /// Gets the version info for this validator node.
     async fn get_version_info(&self) -> Result<VersionInfo, NodeError>;
 
+    /// Gets list of blob ids for this validator node.
+    async fn get_list_all_blob_ids(&self) -> Result<Vec<BlobId>, NodeError>;
+
     /// Gets the network's genesis config hash.
     async fn get_genesis_config_hash(&self) -> Result<CryptoHash, NodeError>;
 

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -176,10 +176,8 @@ where
     }
 
     async fn get_list_all_blob_ids(&self) -> Result<Vec<BlobId>, NodeError> {
-        self.spawn_and_receive(move |validator, sender| {
-            validator.do_list_all_blob_ids(sender)
-        })
-        .await
+        self.spawn_and_receive(move |validator, sender| validator.do_list_all_blob_ids(sender))
+            .await
     }
 
     async fn get_genesis_config_hash(&self) -> Result<CryptoHash, NodeError> {

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -58,6 +58,9 @@ service ValidatorNode {
   // Request the node's version info.
   rpc GetVersionInfo(google.protobuf.Empty) returns (VersionInfo);
 
+  // Request the list of blob ids.
+  rpc GetListAllBlobIds(google.protobuf.Empty) returns (BlobIds);
+
   // Request the genesis configuration hash of the network this node is part of.
   rpc GetGenesisConfigHash(google.protobuf.Empty) returns (CryptoHash);
 

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -164,6 +164,15 @@ impl ValidatorNode for Client {
         })
     }
 
+    async fn get_list_all_blob_ids(&self) -> Result<Vec<BlobId>, NodeError> {
+        Ok(match self {
+            Client::Grpc(grpc_client) => grpc_client.get_list_all_blob_ids().await?,
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => simple_client.get_list_all_blob_ids().await?,
+        })
+    }
+
     async fn get_genesis_config_hash(&self) -> Result<CryptoHash, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => grpc_client.get_genesis_config_hash().await?,

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -344,6 +344,12 @@ impl ValidatorNode for GrpcClient {
     }
 
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
+    async fn get_list_all_blob_ids(&self) -> Result<Vec<BlobId>, NodeError> {
+        let req = ();
+        Ok(client_delegate!(self, get_list_all_blob_ids, req)?.try_into()?)
+    }
+
+    #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
     async fn get_genesis_config_hash(&self) -> Result<CryptoHash, NodeError> {
         let req = ();
         Ok(client_delegate!(self, get_genesis_config_hash, req)?.try_into()?)

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -38,6 +38,7 @@ pub enum RpcMessage {
     DownloadCertificates(Vec<CryptoHash>),
     BlobLastUsedBy(Box<BlobId>),
     MissingBlobIds(Box<Vec<BlobId>>),
+    ListAllBlobIds,
     VersionInfoQuery,
     GenesisConfigHashQuery,
 
@@ -52,6 +53,7 @@ pub enum RpcMessage {
     DownloadCertificatesResponse(Vec<ConfirmedBlockCertificate>),
     BlobLastUsedByResponse(Box<CryptoHash>),
     MissingBlobIdsResponse(Box<Vec<BlobId>>),
+    ListAllBlobIdsResponse(Box<Vec<BlobId>>),
 
     // Internal to a validator
     CrossChainRequest(Box<CrossChainRequest>),
@@ -88,6 +90,8 @@ impl RpcMessage {
             | BlobLastUsedByResponse(_)
             | MissingBlobIds(_)
             | MissingBlobIdsResponse(_)
+            | ListAllBlobIds
+            | ListAllBlobIdsResponse(_)
             | DownloadCertificatesResponse(_) => {
                 return None;
             }
@@ -108,6 +112,7 @@ impl RpcMessage {
             | DownloadConfirmedBlock(_)
             | BlobLastUsedBy(_)
             | MissingBlobIds(_)
+            | ListAllBlobIds
             | DownloadCertificates(_) => true,
             BlockProposal(_)
             | LiteCertificate(_)
@@ -125,6 +130,7 @@ impl RpcMessage {
             | DownloadConfirmedBlockResponse(_)
             | BlobLastUsedByResponse(_)
             | MissingBlobIdsResponse(_)
+            | ListAllBlobIdsResponse(_)
             | DownloadCertificatesResponse(_) => false,
         }
     }
@@ -202,6 +208,7 @@ impl TryFrom<RpcMessage> for Vec<BlobId> {
     fn try_from(message: RpcMessage) -> Result<Self, Self::Error> {
         match message {
             RpcMessage::MissingBlobIdsResponse(blob_ids) => Ok(*blob_ids),
+            RpcMessage::ListAllBlobIdsResponse(blob_ids) => Ok(*blob_ids),
             RpcMessage::Error(error) => Err(*error),
             _ => Err(NodeError::UnexpectedMessage),
         }

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -155,6 +155,10 @@ impl ValidatorNode for SimpleClient {
         self.query(RpcMessage::VersionInfoQuery).await
     }
 
+    async fn get_list_all_blob_ids(&self) -> Result<Vec<BlobId>, NodeError> {
+        self.query(RpcMessage::ListAllBlobIds).await
+    }
+
     async fn get_genesis_config_hash(&self) -> Result<CryptoHash, NodeError> {
         self.query(RpcMessage::GenesisConfigHashQuery).await
     }

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -355,6 +355,8 @@ where
             | RpcMessage::BlobLastUsedByResponse(_)
             | RpcMessage::MissingBlobIds(_)
             | RpcMessage::MissingBlobIdsResponse(_)
+            | RpcMessage::ListAllBlobIds
+            | RpcMessage::ListAllBlobIdsResponse(_)
             | RpcMessage::DownloadCertificates(_)
             | RpcMessage::DownloadCertificatesResponse(_) => Err(NodeError::UnexpectedMessage),
         };

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -22,7 +22,7 @@ use linera_base::{
     command::{resolve_binary, CommandExt},
     crypto::{CryptoHash, PublicKey},
     data_types::{Amount, Bytecode},
-    identifiers::{Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner},
+    identifiers::{Account, ApplicationId, BlobId, BytecodeId, ChainId, MessageId, Owner},
 };
 use linera_client::{config::GenesisConfig, wallet::Wallet};
 use linera_core::worker::Notification;
@@ -165,6 +165,7 @@ impl ClientWrapper {
         for argument in self.command_arguments() {
             command.arg(&*argument);
         }
+        println!("command={:?}", command);
         Ok(command)
     }
 
@@ -503,6 +504,21 @@ impl ClientWrapper {
             .parse()
             .context("error while parsing the result of `linera query-validator`")?;
         Ok(hash)
+    }
+
+    /// Runs `linera list-all-blob-ids`
+    pub async fn list_all_blob_ids(&self) -> Result<Vec<BlobId>> {
+        let mut command = self.command().await?;
+        command.arg("list-all-blob-ids");
+        let stdout = command.spawn_and_wait_for_stdout().await?;
+        println!("stdout={}", stdout.trim());
+        /*
+        let blob_ids = stdout
+            .trim()
+            .parse()
+        .context("error while parsing the result of `linera list-all-blob_ids`")?;
+        */
+        Ok(Vec::new())
     }
 
     /// Runs `linera query-validators`.

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -511,14 +511,14 @@ impl ClientWrapper {
         let mut command = self.command().await?;
         command.arg("list-all-blob-ids");
         let stdout = command.spawn_and_wait_for_stdout().await?;
-        println!("stdout={}", stdout.trim());
-        /*
-        let blob_ids = stdout
-            .trim()
-            .parse()
-        .context("error while parsing the result of `linera list-all-blob_ids`")?;
-        */
-        Ok(Vec::new())
+        let mut blob_ids = Vec::new();
+        for input in stdout.split('\n') {
+            if !input.is_empty() {
+                let blob_id = BlobId::from_str(input)?;
+                blob_ids.push(blob_id);
+            }
+        }
+        Ok(blob_ids)
     }
 
     /// Runs `linera query-validators`.

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -165,7 +165,6 @@ impl ClientWrapper {
         for argument in self.command_arguments() {
             command.arg(&*argument);
         }
-        println!("command={:?}", command);
         Ok(command)
     }
 

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -382,6 +382,20 @@ impl Runnable for Job {
                 );
             }
 
+            ListAllBlobIds => {
+                use linera_core::node::ValidatorNode as _;
+                let chain_id = context.default_chain();
+                let chain_client = context.make_chain_client(chain_id)?;
+                let result = chain_client.local_committee().await;
+                let committee = result.context("Failed to get local committee")?;
+                let (_name, validator_name) = committee.validators().first_key_value().unwrap();
+                let address = &validator_name.network_address;
+                let node_provider = context.make_node_provider();
+                let node = node_provider.make_node(address)?;
+                let blob_ids = node.get_list_all_blob_ids().await?;
+                println!("{:?}", blob_ids);
+            }
+
             QueryValidator {
                 address,
                 chain_id,
@@ -1419,6 +1433,7 @@ fn log_file_name_for(command: &ClientCommand) -> Cow<'static, str> {
         | ClientCommand::SyncBalance { .. }
         | ClientCommand::Sync { .. }
         | ClientCommand::ProcessInbox { .. }
+        | ClientCommand::ListAllBlobIds
         | ClientCommand::QueryValidator { .. }
         | ClientCommand::QueryValidators { .. }
         | ClientCommand::SetValidator { .. }

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -393,7 +393,9 @@ impl Runnable for Job {
                 let node_provider = context.make_node_provider();
                 let node = node_provider.make_node(address)?;
                 let blob_ids = node.get_list_all_blob_ids().await?;
-                println!("{:?}", blob_ids);
+                for blob_id in blob_ids {
+                    println!("{blob_id}");
+                }
             }
 
             QueryValidator {

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -468,6 +468,21 @@ where
     }
 
     #[instrument(skip_all, err(Display))]
+    async fn get_list_all_blob_ids(
+        &self,
+        _request: Request<()>,
+    ) -> Result<Response<BlobIds>, Status> {
+        // We assume each shard is running the same version as the proxy
+        let blob_ids = self
+            .0
+            .storage
+            .list_all_blob_ids()
+            .await
+            .map_err(|err| Status::from_error(Box::new(err)))?;
+        Ok(Response::new(blob_ids.try_into()?))
+    }
+
+    #[instrument(skip_all, err(Display))]
     async fn get_genesis_config_hash(
         &self,
         _request: Request<()>,

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -321,6 +321,9 @@ where
             MissingBlobIds(blob_ids) => Ok(Some(RpcMessage::MissingBlobIdsResponse(Box::new(
                 self.storage.missing_blobs(&blob_ids).await?,
             )))),
+            ListAllBlobIds => Ok(Some(RpcMessage::ListAllBlobIdsResponse(Box::new(
+                self.storage.list_all_blob_ids().await?,
+            )))),
             BlockProposal(_)
             | LiteCertificate(_)
             | TimeoutCertificate(_)
@@ -336,6 +339,7 @@ where
             | DownloadBlobContentResponse(_)
             | BlobLastUsedByResponse(_)
             | MissingBlobIdsResponse(_)
+            | ListAllBlobIdsResponse(_)
             | DownloadConfirmedBlockResponse(_)
             | DownloadCertificatesResponse(_) => {
                 Err(anyhow::Error::from(NodeError::UnexpectedMessage))

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -93,6 +93,10 @@ impl ValidatorNode for DummyValidatorNode {
         Err(NodeError::UnexpectedMessage)
     }
 
+    async fn get_list_all_blob_ids(&self) -> Result<Vec<BlobId>, NodeError> {
+        Err(NodeError::UnexpectedMessage)
+    }
+
     async fn get_genesis_config_hash(&self) -> Result<CryptoHash, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -989,9 +989,12 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
 
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
+    let client3 = net.make_client().await;
+    client3.wallet_init(&[], FaucetOption::None).await?;
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
+    let _chain3 = client1.open_and_assign(&client3, Amount::ZERO).await?;
 
     // The players
     let account_owner1 = get_fungible_account_owner(&client1);
@@ -1161,6 +1164,10 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
         hash: blob_hash,
         blob_type: BlobType::Data,
     };
+    let read_blob_ids = client3.list_all_blob_ids().await?;
+    for blob_id in &[blob_id1, blob_id2] {
+        assert!(read_blob_ids.contains(blob_id))
+    }
 
     let nft2_blob_hash = DataBlobHash(nft2_blob_hash);
 

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -29,7 +29,7 @@ use linera_base::{
     command::resolve_binary,
     crypto::CryptoHash,
     data_types::Amount,
-    identifiers::{Account, AccountOwner, ApplicationId, ChainId},
+    identifiers::{Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId},
 };
 use linera_chain::data_types::{Medium, Origin};
 use linera_core::worker::{Notification, Reason};
@@ -1023,6 +1023,10 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
         .publish_data_blob(&chain1, nft1_blob_bytes.clone())
         .await?;
     assert_eq!(nft1_blob_hash, blob_hash);
+    let blob_id1 = BlobId {
+        hash: blob_hash,
+        blob_type: BlobType::Data,
+    };
 
     let nft1_blob_hash = DataBlobHash(nft1_blob_hash);
 
@@ -1153,6 +1157,10 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
         .publish_data_blob(&chain2, nft2_blob_bytes.clone())
         .await?;
     assert_eq!(nft2_blob_hash, blob_hash);
+    let blob_id2 = BlobId {
+        hash: blob_hash,
+        blob_type: BlobType::Data,
+    };
 
     let nft2_blob_hash = DataBlobHash(nft2_blob_hash);
 

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -224,7 +224,6 @@ const INDEX_BLOB: u8 = 3;
 const INDEX_BLOB_STATE: u8 = 4;
 const BLOB_LENGTH: usize = std::mem::size_of::<BlobId>();
 
-
 impl BaseKey {
     /// We depend on the precise serialization to do queries and so we have to
     /// hardcode it.
@@ -234,17 +233,17 @@ impl BaseKey {
                 let mut vec = vec![INDEX_CHAIN_STATE];
                 vec.extend(bcs::to_bytes(&chain_id)?);
                 Ok(vec)
-            },
+            }
             BaseKey::Certificate(hash) => {
                 let mut vec = vec![INDEX_CERTIFICATE];
                 vec.extend(bcs::to_bytes(&hash)?);
                 Ok(vec)
-            },
+            }
             BaseKey::ConfirmedBlock(hash) => {
                 let mut vec = vec![INDEX_CONFIRMED_BLOCK];
                 vec.extend(bcs::to_bytes(&hash)?);
                 Ok(vec)
-            },
+            }
             BaseKey::Blob(blob_id) => {
                 let mut vec = vec![INDEX_BLOB];
                 vec.extend(bcs::to_bytes(&blob_id)?);
@@ -254,7 +253,7 @@ impl BaseKey {
                 let mut vec = vec![INDEX_BLOB_STATE];
                 vec.extend(bcs::to_bytes(&blob_id)?);
                 Ok(vec)
-            },
+            }
         }
     }
 }
@@ -414,7 +413,6 @@ where
             user_services: self.user_services.clone(),
         };
         let root_key = BaseKey::ChainState(chain_id).to_bytes()?;
-        println!("root_key={:?}", root_key);
         let store = self.store.clone_with_root_key(&root_key)?;
         let context = ViewContext::create_root_context(store, runtime_context).await?;
         ChainStateView::load(context).await
@@ -432,9 +430,7 @@ where
             let blob_id = bcs::from_bytes(key_red)?;
             blob_ids.insert(blob_id);
         }
-        let blob_ids = blob_ids.into_iter().collect::<Vec<_>>();
-        println!("db_storage, blob_ids={:?}", blob_ids);
-        Ok(blob_ids)
+        Ok(blob_ids.into_iter().collect::<Vec<_>>())
     }
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -79,6 +79,9 @@ pub trait Storage: Sized {
     /// Returns what blobs from the input are missing from storage.
     async fn missing_blobs(&self, blob_ids: &[BlobId]) -> Result<Vec<BlobId>, ViewError>;
 
+    /// List all blob ids of the storage.
+    async fn list_all_blob_ids(&self) -> Result<Vec<BlobId>, ViewError>;
+
     /// Tests existence of a blob state with the given blob ID.
     async fn contains_blob_state(&self, blob_id: BlobId) -> Result<bool, ViewError>;
 


### PR DESCRIPTION
## Motivation

It is a useful functionality for obtaining the list of storage blobs. We introduce it here.

## Proposal

It is important to access the list of ChainIDs and BlobIDs from the command line. Accessing
the ChainIDs is more complicated than expected since we need to access the list of root keys
and the functionality is missing right now. So we limit ourselves to BlobIDs.

The BlobIDs are accessed through the `find_keys_by_prefix`. The problem is that the keys are
obtained from the serialization of the `BaseKey`. Therefore, in order to avoid leaking the inner
logic of the serialization into the code, we introduce a `to_bytes` function.

The BlobIDs access is added to the storage and also to the validator functionality in a
straightforward way.

## Test Plan

A test has been added for the functionality. We only check for the BlobsIDs to be contained. We cannot
check for equality before 

## Release Plan

This functionality could be useful for operators on DevNet / TestNet.

## Links

None.