### PR TITLE
Fix race condition waiting for rounds.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -435,6 +435,7 @@ where
 
         loop {
             // Try applying f. Return if committed.
+            client.prepare_chain().await?;
             let result = f(client).await;
             self.update_and_save_wallet(client).await?;
             let timeout = match result? {


### PR DESCRIPTION
## Motivation

`test_end_to_end_listen_for_new_rounds::storage_test_service_grpc` is flaky for me locally and sometimes hangs, even though it seems fine on CI.

The logs suggest that the two clients are both waiting for round notifications forever, even though one of them should be the leader in the current round.

## Proposal

Adding an explicit `prepare_chain` fixes the issue.

## Test Plan

Running the test in a loop locally failed quite often. With this change it passed 50 times in a row.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
