### PR TITLE
Have a Cursor inside MessageBundle

### DIFF
--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -14,7 +14,7 @@ pub mod types {
 
 mod chain;
 pub mod data_types;
-mod inbox;
+pub mod inbox;
 pub mod manager;
 mod outbox;
 #[cfg(with_testing)]

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -33,6 +33,7 @@ use linera_views::{
 use crate::{
     block::ConfirmedBlock,
     data_types::{IncomingBundle, MessageAction, MessageBundle, Origin},
+    inbox::Cursor,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt},
     ChainError, ChainExecutionContext, ChainStateView,
 };
@@ -141,8 +142,10 @@ async fn test_block_size_limit() {
         origin: Origin::chain(admin_id()),
         bundle: MessageBundle {
             certificate_hash: CryptoHash::test_hash("certificate"),
-            height: BlockHeight(1),
-            transaction_index: 0,
+            cursor: Cursor {
+                height: BlockHeight(1),
+                index: 0,
+            },
             timestamp: time,
             messages: vec![Message::System(SystemMessage::OpenChain(config))
                 .to_posted(0, MessageKind::Protected)],
@@ -216,8 +219,10 @@ async fn test_application_permissions() -> anyhow::Result<()> {
         origin: Origin::chain(admin_id()),
         bundle: MessageBundle {
             certificate_hash: CryptoHash::test_hash("certificate"),
-            height: BlockHeight(1),
-            transaction_index: 0,
+            cursor: Cursor {
+                height: BlockHeight(1),
+                index: 0,
+            },
             timestamp: Timestamp::from(0),
             messages: vec![
                 open_chain_message.to_posted(0, MessageKind::Protected),

--- a/linera-chain/src/unit_tests/inbox_tests.rs
+++ b/linera-chain/src/unit_tests/inbox_tests.rs
@@ -21,9 +21,11 @@ fn make_bundle(
     };
     MessageBundle {
         certificate_hash,
-        height: BlockHeight::from(height),
+        cursor: Cursor {
+            height: BlockHeight::from(height),
+            index,
+        },
         timestamp: Timestamp::default(),
-        transaction_index: index,
         messages: vec![message.to_posted(index, MessageKind::Simple)],
     }
 }

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -92,7 +92,7 @@ where
         Ok(bundles
             .find(|bundle| {
                 bundle.certificate_hash == certificate_hash
-                    && bundle.height == height
+                    && bundle.cursor.height == height
                     && bundle.messages.iter().any(|msg| msg.index == index)
             })
             .cloned())

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -254,8 +254,10 @@ impl CrossChainRequest {
         match self {
             CrossChainRequest::UpdateRecipient { bundle_vecs, .. } => {
                 bundle_vecs.iter().any(|(_, bundles)| {
-                    debug_assert!(bundles.windows(2).all(|w| w[0].1.height <= w[1].1.height));
-                    matches!(bundles.first(), Some((_, h)) if h.height <= height)
+                    debug_assert!(bundles
+                        .windows(2)
+                        .all(|w| w[0].1.cursor.height <= w[1].1.cursor.height));
+                    matches!(bundles.first(), Some((_, h)) if h.cursor.height <= height)
                 })
             }
             _ => false,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -239,10 +239,10 @@ where
         // Both `Claim` messages were included in the block.
         assert_eq!(messages.len(), 2);
         // The first one was rejected.
-        assert_eq!(messages[0].bundle.height, BlockHeight::from(2));
+        assert_eq!(messages[0].bundle.cursor.height, BlockHeight::from(2));
         assert_eq!(messages[0].action, MessageAction::Reject);
         // The second was accepted.
-        assert_eq!(messages[1].bundle.height, BlockHeight::from(3));
+        assert_eq!(messages[1].bundle.cursor.height, BlockHeight::from(3));
         assert_eq!(messages[1].action, MessageAction::Accept);
     }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -32,6 +32,7 @@ use linera_chain::{
         IncomingBundle, LiteValue, LiteVote, Medium, MessageAction, MessageBundle, Origin,
         OutgoingMessage, PostedMessage, SignatureAggregator,
     },
+    inbox::Cursor,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
     types::{
         CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate, Timeout,
@@ -928,9 +929,11 @@ where
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
                     certificate_hash: certificate0.hash(),
-                    height: BlockHeight::ZERO,
+                    cursor: Cursor {
+                        height: BlockHeight::ZERO,
+                        index: 0,
+                    },
                     timestamp: Timestamp::from(0),
-                    transaction_index: 0,
                     messages: vec![
                         system_credit_message(Amount::ONE).to_posted(0, MessageKind::Tracked)
                     ],
@@ -941,9 +944,11 @@ where
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
                     certificate_hash: certificate0.hash(),
-                    height: BlockHeight::ZERO,
+                    cursor: Cursor {
+                        height: BlockHeight::ZERO,
+                        index: 1,
+                    },
                     timestamp: Timestamp::from(0),
-                    transaction_index: 1,
                     messages: vec![system_credit_message(Amount::from_tokens(2))
                         .to_posted(0, MessageKind::Tracked)],
                 },
@@ -953,9 +958,11 @@ where
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
                     certificate_hash: certificate1.hash(),
-                    height: BlockHeight::from(1),
+                    cursor: Cursor {
+                        height: BlockHeight::from(1),
+                        index: 0,
+                    },
                     timestamp: Timestamp::from(0),
-                    transaction_index: 0,
                     messages: vec![
                         system_credit_message(Amount::from_tokens(2)) // wrong amount
                             .to_posted(0, MessageKind::Tracked),
@@ -979,9 +986,11 @@ where
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
                     certificate_hash: certificate0.hash(),
-                    height: BlockHeight::ZERO,
+                    cursor: Cursor {
+                        height: BlockHeight::ZERO,
+                        index: 1,
+                    },
                     timestamp: Timestamp::from(0),
-                    transaction_index: 1,
                     messages: vec![system_credit_message(Amount::from_tokens(2))
                         .to_posted(1, MessageKind::Tracked)],
                 },
@@ -1003,9 +1012,11 @@ where
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
                     certificate_hash: certificate1.hash(),
-                    height: BlockHeight::from(1),
+                    cursor: Cursor {
+                        height: BlockHeight::from(1),
+                        index: 0,
+                    },
                     timestamp: Timestamp::from(0),
-                    transaction_index: 0,
                     messages: vec![system_credit_message(Amount::from_tokens(3))
                         .to_posted(0, MessageKind::Tracked)],
                 },
@@ -1015,9 +1026,11 @@ where
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
                     certificate_hash: certificate0.hash(),
-                    height: BlockHeight::ZERO,
+                    cursor: Cursor {
+                        height: BlockHeight::ZERO,
+                        index: 0,
+                    },
                     timestamp: Timestamp::from(0),
-                    transaction_index: 0,
                     messages: vec![
                         system_credit_message(Amount::ONE).to_posted(0, MessageKind::Tracked)
                     ],
@@ -1028,9 +1041,11 @@ where
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
                     certificate_hash: certificate0.hash(),
-                    height: BlockHeight::ZERO,
+                    cursor: Cursor {
+                        height: BlockHeight::ZERO,
+                        index: 1,
+                    },
                     timestamp: Timestamp::from(0),
-                    transaction_index: 1,
                     messages: vec![system_credit_message(Amount::from_tokens(2))
                         .to_posted(1, MessageKind::Tracked)],
                 },
@@ -1052,9 +1067,11 @@ where
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
                     certificate_hash: certificate0.hash(),
-                    height: BlockHeight::ZERO,
+                    cursor: Cursor {
+                        height: BlockHeight::ZERO,
+                        index: 0,
+                    },
                     timestamp: Timestamp::from(0),
-                    transaction_index: 0,
                     messages: vec![
                         system_credit_message(Amount::ONE).to_posted(0, MessageKind::Tracked)
                     ],
@@ -1098,9 +1115,11 @@ where
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
                     certificate_hash: certificate0.hash(),
-                    height: BlockHeight::from(0),
+                    cursor: Cursor {
+                        height: BlockHeight::from(0),
+                        index: 1,
+                    },
                     timestamp: Timestamp::from(0),
-                    transaction_index: 1,
                     messages: vec![system_credit_message(Amount::from_tokens(2))
                         .to_posted(1, MessageKind::Tracked)],
                 },
@@ -1110,9 +1129,11 @@ where
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
                     certificate_hash: certificate1.hash(),
-                    height: BlockHeight::from(1),
+                    cursor: Cursor {
+                        height: BlockHeight::from(1),
+                        index: 0,
+                    },
                     timestamp: Timestamp::from(0),
-                    transaction_index: 0,
                     messages: vec![system_credit_message(Amount::from_tokens(3))
                         .to_posted(0, MessageKind::Tracked)],
                 },
@@ -1356,9 +1377,11 @@ where
         origin: Origin::chain(ChainId::root(3)),
         bundle: MessageBundle {
             certificate_hash: CryptoHash::test_hash("certificate"),
-            height: BlockHeight::ZERO,
+            cursor: Cursor {
+                height: BlockHeight::ZERO,
+                index: 0,
+            },
             timestamp: Timestamp::from(0),
-            transaction_index: 0,
             messages: vec![Message::System(SystemMessage::OpenChain(OpenChainConfig {
                 ownership,
                 admin_id,
@@ -1522,9 +1545,11 @@ where
             origin: Origin::chain(ChainId::root(3)),
             bundle: MessageBundle {
                 certificate_hash: CryptoHash::test_hash("certificate"),
-                height: BlockHeight::ZERO,
+                cursor: Cursor {
+                    height: BlockHeight::ZERO,
+                    index: 0,
+                },
                 timestamp: Timestamp::from(0),
-                transaction_index: 0,
                 messages: vec![system_credit_message(Amount::from_tokens(995))
                     .to_posted(0, MessageKind::Tracked)],
             },
@@ -1561,9 +1586,11 @@ where
             .unwrap(),
         MessageBundle {
             certificate_hash,
-            height,
+            cursor: Cursor {
+                height,
+                index: 0,
+            },
             timestamp,
-            transaction_index: 0,
             messages,
         } if certificate_hash == CryptoHash::test_hash("certificate")
             && height == BlockHeight::ZERO
@@ -1698,9 +1725,11 @@ where
         inbox.added_bundles.front().await?.unwrap(),
         MessageBundle {
             certificate_hash,
-            height,
+            cursor: Cursor {
+                height,
+                index: 0,
+            },
             timestamp,
-            transaction_index: 0,
             messages,
         } if certificate_hash == certificate.hash()
         && height == BlockHeight::ZERO
@@ -1779,9 +1808,11 @@ where
             .unwrap(),
         MessageBundle {
             certificate_hash,
-            height,
+            cursor: Cursor {
+                height,
+                index: 0,
+            },
             timestamp,
-            transaction_index: 0,
             messages,
         } if certificate_hash == certificate.hash()
         && height == BlockHeight::ZERO
@@ -1982,9 +2013,11 @@ where
             origin: Origin::chain(ChainId::root(1)),
             bundle: MessageBundle {
                 certificate_hash: certificate.hash(),
-                height: BlockHeight::ZERO,
+                cursor: Cursor {
+                    height: BlockHeight::ZERO,
+                    index: 0,
+                },
                 timestamp: Timestamp::from(0),
-                transaction_index: 0,
                 messages: vec![system_credit_message(Amount::from_tokens(5))
                     .to_posted(0, MessageKind::Tracked)],
             },
@@ -2164,9 +2197,11 @@ where
             origin: Origin::chain(ChainId::root(1)),
             bundle: MessageBundle {
                 certificate_hash: certificate00.hash(),
-                height: BlockHeight::from(0),
+                cursor: Cursor {
+                    height: BlockHeight::from(0),
+                    index: 0,
+                },
                 timestamp: Timestamp::from(0),
-                transaction_index: 0,
                 messages: vec![Message::System(SystemMessage::Credit {
                     source: None,
                     target: Some(AccountOwner::User(sender)),
@@ -2245,9 +2280,11 @@ where
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
                     certificate_hash: certificate1.hash(),
-                    height: BlockHeight::from(2),
+                    cursor: Cursor {
+                        height: BlockHeight::from(2),
+                        index: 0,
+                    },
                     timestamp: Timestamp::from(0),
-                    transaction_index: 0,
                     messages: vec![Message::System(SystemMessage::Credit {
                         source: Some(AccountOwner::User(sender)),
                         target: Some(AccountOwner::User(recipient)),
@@ -2261,9 +2298,11 @@ where
                 origin: Origin::chain(ChainId::root(1)),
                 bundle: MessageBundle {
                     certificate_hash: certificate2.hash(),
-                    height: BlockHeight::from(3),
+                    cursor: Cursor {
+                        height: BlockHeight::from(3),
+                        index: 0,
+                    },
                     timestamp: Timestamp::from(0),
-                    transaction_index: 0,
                     messages: vec![Message::System(SystemMessage::Credit {
                         source: Some(AccountOwner::User(sender)),
                         target: Some(AccountOwner::User(recipient)),
@@ -2303,9 +2342,11 @@ where
             origin: Origin::chain(ChainId::root(2)),
             bundle: MessageBundle {
                 certificate_hash: certificate.hash(),
-                height: BlockHeight::from(0),
+                cursor: Cursor {
+                    height: BlockHeight::from(0),
+                    index: 0,
+                },
                 timestamp: Timestamp::from(0),
-                transaction_index: 0,
                 messages: vec![Message::System(SystemMessage::Credit {
                     source: Some(AccountOwner::User(sender)),
                     target: Some(AccountOwner::User(recipient)),
@@ -2594,9 +2635,11 @@ where
                         origin: Origin::chain(admin_id),
                         bundle: MessageBundle {
                             certificate_hash: certificate0.hash(),
-                            height: BlockHeight::from(0),
+                            cursor: Cursor {
+                                height: BlockHeight::from(0),
+                                index: 0,
+                            },
                             timestamp: Timestamp::from(0),
-                            transaction_index: 0,
                             messages: vec![Message::System(SystemMessage::OpenChain(
                                 OpenChainConfig {
                                     ownership: ChainOwnership::single(key_pair.public()),
@@ -2615,9 +2658,11 @@ where
                         origin: admin_channel_origin.clone(),
                         bundle: MessageBundle {
                             certificate_hash: certificate1.hash(),
-                            height: BlockHeight::from(1),
+                            cursor: Cursor {
+                                height: BlockHeight::from(1),
+                                index: 0,
+                            },
                             timestamp: Timestamp::from(0),
-                            transaction_index: 0,
                             messages: vec![Message::System(SystemMessage::CreateCommittee {
                                 epoch: Epoch::from(1),
                                 committee: committee.clone(),
@@ -2630,9 +2675,11 @@ where
                         origin: Origin::chain(admin_id),
                         bundle: MessageBundle {
                             certificate_hash: certificate1.hash(),
-                            height: BlockHeight::from(1),
+                            cursor: Cursor {
+                                height: BlockHeight::from(1),
+                                index: 1,
+                            },
                             timestamp: Timestamp::from(0),
-                            transaction_index: 1,
                             messages: vec![system_credit_message(Amount::from_tokens(2))
                                 .to_posted(1, MessageKind::Tracked)],
                         },
@@ -2974,9 +3021,11 @@ where
                         origin: Origin::chain(user_id),
                         bundle: MessageBundle {
                             certificate_hash: certificate0.hash(),
-                            height: BlockHeight::ZERO,
                             timestamp: Timestamp::from(0),
-                            transaction_index: 0,
+                            cursor: Cursor {
+                                height: BlockHeight::ZERO,
+                                index: 0,
+                            },
                             messages: vec![system_credit_message(Amount::ONE)
                                 .to_posted(0, MessageKind::Tracked)],
                         },

--- a/linera-explorer/src/components/Block.test.ts
+++ b/linera-explorer/src/components/Block.test.ts
@@ -24,7 +24,10 @@ test('Block mounting', () => {
                 },
                 bundle: {
                   certificateHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
-                  height: 5,
+                  cursor: {
+                    height: 5,
+                    index: 0,
+                  },
                   messages: [{
                     authenticatedSigner: null,
                     message: { System: { BytecodePublished: { operation_index: 0 } } },
@@ -32,7 +35,6 @@ test('Block mounting', () => {
                     index: 4,
                     kind: "Tracked"
                   }],
-                  transactionIndex: 0,
                   timestamp: 1694097510206912
                 },
                 action: "Accept",

--- a/linera-explorer/src/components/Blocks.test.ts
+++ b/linera-explorer/src/components/Blocks.test.ts
@@ -26,7 +26,10 @@ test('Blocks mounting', () => {
                     },
                     bundle: {
                       certificateHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
-                      height: 5,
+                      cursor: {
+                        height: 5,
+                        index: 0,
+                      },
                       messages: [{
                         authenticatedSigner: null,
                         message: { System: { BytecodePublished: { operation_index: 0 } } },
@@ -34,7 +37,6 @@ test('Blocks mounting', () => {
                         index: 4,
                         kind: "Tracked"
                       }],
-                      transactionIndex: 0,
                       timestamp: 1694097510206912
                     },
                     action: "Accept",

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -381,6 +381,11 @@ CryptoHash:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 32
+Cursor:
+  STRUCT:
+    - height:
+        TYPENAME: BlockHeight
+    - index: U32
 Destination:
   ENUM:
     0:
@@ -502,13 +507,12 @@ MessageAction:
       Reject: UNIT
 MessageBundle:
   STRUCT:
-    - height:
-        TYPENAME: BlockHeight
     - timestamp:
         TYPENAME: Timestamp
     - certificate_hash:
         TYPENAME: CryptoHash
-    - transaction_index: U32
+    - cursor:
+        TYPENAME: Cursor
     - messages:
         SEQ:
           TYPENAME: PostedMessage

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -53,10 +53,12 @@ query ChainInbox($chainId: ChainId!, $origin: Origin!) {
           }
           addedBundles {
             entries {
-              height
               timestamp
               certificateHash
-              transactionIndex
+              cursor {
+                height
+                index
+              }
               messages {
                 authenticatedSigner
                 grant
@@ -69,10 +71,12 @@ query ChainInbox($chainId: ChainId!, $origin: Origin!) {
           }
           removedBundles {
             entries {
-              height
               timestamp
               certificateHash
-              transactionIndex
+              cursor {
+                height
+                index
+              }
               messages {
                 authenticatedSigner
                 grant
@@ -141,10 +145,12 @@ query Chain(
           }
           addedBundles {
             entries {
-              height
               timestamp
               certificateHash
-              transactionIndex
+              cursor {
+                height
+                index
+              }
               messages {
                 authenticatedSigner
                 grant
@@ -157,10 +163,12 @@ query Chain(
           }
           removedBundles {
             entries {
-              height
               timestamp
               certificateHash
-              transactionIndex
+              cursor {
+                height
+                index
+              }
               messages {
                 authenticatedSigner
                 grant
@@ -227,10 +235,12 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
           incomingBundles {
             origin
             bundle {
-              height
               timestamp
               certificateHash
-              transactionIndex
+              cursor {
+                height
+                index
+              }
               messages {
                 authenticatedSigner
                 grant
@@ -285,10 +295,12 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
           incomingBundles {
             origin
             bundle {
-              height
               timestamp
               certificateHash
-              transactionIndex
+              cursor {
+                height
+                index
+              }
               messages {
                 authenticatedSigner
                 grant

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -555,10 +555,6 @@ A set of messages from a single block, for a single destination.
 """
 type MessageBundle {
 	"""
-	The block height.
-	"""
-	height: BlockHeight!
-	"""
 	The block's timestamp.
 	"""
 	timestamp: Timestamp!
@@ -567,9 +563,9 @@ type MessageBundle {
 	"""
 	certificateHash: CryptoHash!
 	"""
-	The index of the transaction in the block that is sending this bundle.
+	The cursor of the block.
 	"""
-	transactionIndex: Int!
+	cursor: Cursor!
 	"""
 	The relevant messages.
 	"""

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -136,6 +136,7 @@ mod from {
             BlockExecutionOutcome, EventRecord, ExecutedBlock, IncomingBundle, MessageBundle,
             OutgoingMessage, PostedMessage,
         },
+        inbox::Cursor,
         types::ConfirmedBlock,
     };
 
@@ -159,19 +160,30 @@ mod from {
     impl From<block::BlockBlockValueExecutedBlockBlockIncomingBundlesBundle> for MessageBundle {
         fn from(val: block::BlockBlockValueExecutedBlockBlockIncomingBundlesBundle) -> Self {
             let block::BlockBlockValueExecutedBlockBlockIncomingBundlesBundle {
-                height,
                 timestamp,
                 certificate_hash,
-                transaction_index,
+                cursor,
                 messages,
             } = val;
             let messages = messages.into_iter().map(PostedMessage::from).collect();
             MessageBundle {
-                height,
+                cursor: cursor.into(),
                 timestamp,
                 certificate_hash,
-                transaction_index: transaction_index as u32,
                 messages,
+            }
+        }
+    }
+
+    impl From<block::BlockBlockValueExecutedBlockBlockIncomingBundlesBundleCursor> for Cursor {
+        fn from(val: block::BlockBlockValueExecutedBlockBlockIncomingBundlesBundleCursor) -> Self {
+            let block::BlockBlockValueExecutedBlockBlockIncomingBundlesBundleCursor {
+                height,
+                index,
+            } = val;
+            Cursor {
+                height,
+                index: index as u32,
             }
         }
     }

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -3194,7 +3194,7 @@ async fn test_end_to_end_repeated_transfers(config: impl LineraNetConfig) -> Res
             .query_node(&format!(
                 "query {{ block(hash: \"{hash2}\", chainId: \"{chain_id2}\") {{ \
                     value {{ executedBlock {{ block {{ incomingBundles {{ \
-                        origin bundle {{ height }} \
+                        origin bundle {{ cursor {{ height }} }} \
                     }} }} }} }} \
                 }} }}"
             ))
@@ -3205,7 +3205,7 @@ async fn test_end_to_end_repeated_transfers(config: impl LineraNetConfig) -> Res
         assert_eq!(origin.sender, chain_id1);
         assert_eq!(origin.medium, Medium::Direct);
         let sender_height =
-            serde_json::from_value::<BlockHeight>(bundle["bundle"]["height"].take())?;
+            serde_json::from_value::<BlockHeight>(bundle["bundle"]["cursor"]["height"].take())?;
         assert_eq!(sender_height + BlockHeight(1), next_height1);
     }
 


### PR DESCRIPTION
## Motivation

`MessageBundle` already has the fields for a `Cursor`, and we even had a conversion function.

## Proposal

Just have a `Cursor` in there to make things cleaner

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
