### PR TITLE
Stop printing the blob bytes

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -967,6 +967,7 @@ pub struct BlobContent {
     blob_type: BlobType,
     /// The binary data.
     #[serde(with = "serde_bytes")]
+    #[debug(skip)]
     bytes: Box<[u8]>,
 }
 


### PR DESCRIPTION
## Motivation

I think we weren't printing this, but we accidentally removed this. This creates a huge amount of pollution in the test logs.

## Proposal

Stop printing it again.

## Test Plan

CI + check logs to see that it's not there

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
