### PR TITLE
deploy-validator.sh uses release images.

### DIFF
--- a/scripts/deploy-validator.sh
+++ b/scripts/deploy-validator.sh
@@ -69,7 +69,7 @@ if [ -z "$REMOTE_IMAGE" ]; then
   echo "Building local image from commit $GIT_COMMIT..."
   docker build --build-arg git_commit="$GIT_COMMIT" -f  docker/Dockerfile . -t linera
 else
-  export LINERA_IMAGE="us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:$BRANCH_NAME"
+  export LINERA_IMAGE="us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:${BRANCH_NAME}_release"
   echo "Using remote image $LINERA_IMAGE..."
 fi
 


### PR DESCRIPTION
## Motivation

The existing `deploy_validator.sh` script uses `linera:$BRANCH_NAME` tag.

Our existing CI machinery tags every image with the branch name - indicating that it is the latest commit for that branch.

More granular control is required on which images are used for release, which is why we're adding the `release` suffix.

## Proposal

Add the `_release` suffix to the image tag.
