### PR TITLE
Upload blobs for confirmed certificates separately.

### DIFF
--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -114,7 +114,6 @@ where
     /// Process a confirmed block (a commit).
     ProcessConfirmedBlock {
         certificate: ConfirmedBlockCertificate,
-        blobs: Vec<Blob>,
         #[debug(with = "elide_option")]
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
         #[debug(skip)]
@@ -299,7 +298,6 @@ where
                     .is_ok(),
                 ChainWorkerRequest::ProcessConfirmedBlock {
                     certificate,
-                    blobs,
                     notify_when_messages_are_delivered,
                     callback,
                 } => callback
@@ -307,7 +305,6 @@ where
                         self.worker
                             .process_confirmed_block(
                                 certificate,
-                                &blobs,
                                 notify_when_messages_are_delivered,
                             )
                             .await,

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -239,7 +239,6 @@ where
     pub(super) async fn process_confirmed_block(
         &mut self,
         certificate: ConfirmedBlockCertificate,
-        blobs: &[Blob],
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         let executed_block = certificate.executed_block();
@@ -298,33 +297,30 @@ where
         );
 
         let required_blob_ids = executed_block.required_blob_ids();
-        // Verify that no unrelated blobs were provided.
-        self.state
-            .check_for_unneeded_blobs(&required_blob_ids, blobs)?;
-        let blobs = self.state.get_required_blobs(executed_block, blobs).await?;
-        let blobs = blobs.into_values().collect::<Vec<_>>();
+        let blobs_result = self.state.get_required_blobs(executed_block, &[]).await;
+        let blobs_result = blobs_result.map(|blobs| blobs.into_values().collect::<Vec<_>>());
 
-        let certificate_hash = certificate.hash();
-
-        self.state
-            .storage
-            .write_blobs_and_certificate(&blobs, &certificate)
-            .await?;
+        if let Ok(blobs) = &blobs_result {
+            self.state
+                .storage
+                .write_blobs_and_certificate(blobs, &certificate)
+                .await?;
+        }
 
         // Update the blob state with last used certificate hash.
         let blob_state = BlobState {
-            last_used_by: certificate_hash,
+            last_used_by: certificate.hash(),
             chain_id: block.chain_id,
             block_height,
             epoch: block.epoch,
         };
+        let overwrite = blobs_result.is_ok(); // Overwrite only if we wrote the certificate.
+        let blob_ids = required_blob_ids.into_iter().collect::<Vec<_>>();
         self.state
             .storage
-            .maybe_write_blob_states(
-                &required_blob_ids.into_iter().collect::<Vec<_>>(),
-                blob_state,
-            )
+            .maybe_write_blob_states(&blob_ids, blob_state, overwrite)
             .await?;
+        blobs_result?;
 
         // Execute the block and update inboxes.
         self.state.chain.remove_bundles_from_inboxes(block).await?;

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -297,8 +297,11 @@ where
         );
 
         let required_blob_ids = executed_block.required_blob_ids();
-        let blobs_result = self.state.get_required_blobs(executed_block, &[]).await;
-        let blobs_result = blobs_result.map(|blobs| blobs.into_values().collect::<Vec<_>>());
+        let blobs_result = self
+            .state
+            .get_required_blobs(executed_block, &[])
+            .await
+            .map(|blobs| blobs.into_values().collect::<Vec<_>>());
 
         if let Ok(blobs) = &blobs_result {
             self.state

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -237,12 +237,11 @@ where
     pub(super) async fn process_confirmed_block(
         &mut self,
         certificate: ConfirmedBlockCertificate,
-        blobs: &[Blob],
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         ChainWorkerStateWithAttemptedChanges::new(self)
             .await
-            .process_confirmed_block(certificate, blobs, notify_when_messages_are_delivered)
+            .process_confirmed_block(certificate, notify_when_messages_are_delivered)
             .await
     }
 

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -210,6 +210,13 @@ where
             .collect())
     }
 
+    /// Writes the given blobs to storage if there is an appropriate blob state.
+    pub async fn store_blobs(&self, blobs: &[Blob]) -> Result<(), LocalNodeError> {
+        let storage = self.storage_client();
+        storage.maybe_write_blobs(blobs).await?;
+        Ok(())
+    }
+
     /// Returns a read-only view of the [`ChainStateView`] of a chain referenced by its
     /// [`ChainId`].
     ///

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -103,6 +103,10 @@ pub trait ValidatorNode {
     /// Subscribes to receiving notifications for a collection of chains.
     async fn subscribe(&self, chains: Vec<ChainId>) -> Result<Self::NotificationStream, NodeError>;
 
+    // Uploads a blob content. Returns an error if the validator has not seen a
+    // certificate using this blob.
+    async fn upload_blob_content(&self, content: BlobContent) -> Result<BlobId, NodeError>;
+
     async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError>;
 
     async fn download_certificate(

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -104,7 +104,7 @@ pub trait ValidatorNode {
 
     // Uploads a blob content. Returns an error if the validator has not seen a
     // certificate using this blob.
-    async fn upload_blob_content(&self, content: BlobContent) -> Result<BlobId, NodeError>;
+    async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError>;
 
     async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError>;
 

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -71,7 +71,6 @@ pub trait ValidatorNode {
     async fn handle_confirmed_certificate(
         &self,
         certificate: GenericCertificate<ConfirmedBlock>,
-        blobs: Vec<Blob>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError>;
 

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -4,7 +4,7 @@
 use std::collections::HashSet;
 
 use custom_debug_derive::Debug;
-use futures::{stream::FuturesUnordered, StreamExt};
+use futures::{future::try_join_all, stream::FuturesUnordered, StreamExt};
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Blob, BlockHeight},
@@ -68,13 +68,12 @@ impl<N: ValidatorNode> RemoteNode<N> {
     pub(crate) async fn handle_confirmed_certificate(
         &self,
         certificate: ConfirmedBlockCertificate,
-        blobs: Vec<Blob>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, NodeError> {
         let chain_id = certificate.inner().chain_id();
         let response = self
             .node
-            .handle_confirmed_certificate(certificate, blobs, delivery)
+            .handle_confirmed_certificate(certificate, delivery)
             .await?;
         self.check_and_return_info(response, chain_id)
     }
@@ -148,7 +147,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
                 _ => return result,
             }
         }
-        self.handle_confirmed_certificate(certificate.clone(), vec![], delivery)
+        self.handle_confirmed_certificate(certificate.clone(), delivery)
             .await
     }
 
@@ -215,6 +214,16 @@ impl<N: ValidatorNode> RemoteNode<N> {
             return Err(NodeError::InvalidCertificateForBlob(blob_id));
         }
         Ok(certificate)
+    }
+
+    /// Uploads the blobs to the validator.
+    #[instrument(level = "trace")]
+    pub(crate) async fn upload_blobs(&self, blobs: Vec<Blob>) -> Result<(), NodeError> {
+        let tasks = blobs
+            .into_iter()
+            .map(|blob| self.node.upload_blob_content(blob.into()));
+        try_join_all(tasks).await?;
+        Ok(())
     }
 
     /// Tries to download the given blobs from this node. Returns `None` if not all could be found.

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -221,7 +221,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
     pub(crate) async fn upload_blobs(&self, blobs: Vec<Blob>) -> Result<(), NodeError> {
         let tasks = blobs
             .into_iter()
-            .map(|blob| self.node.upload_blob_content(blob.into()));
+            .map(|blob| self.node.upload_blob(blob.into()));
         try_join_all(tasks).await?;
         Ok(())
     }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -148,11 +148,10 @@ where
     async fn handle_confirmed_certificate(
         &self,
         certificate: GenericCertificate<ConfirmedBlock>,
-        blobs: Vec<Blob>,
         _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         self.spawn_and_receive(move |validator, sender| {
-            validator.do_handle_certificate(certificate, blobs, sender)
+            validator.do_handle_certificate(certificate, vec![], sender)
         })
         .await
     }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -179,11 +179,9 @@ where
         Ok(CryptoHash::test_hash("genesis config"))
     }
 
-    async fn upload_blob_content(&self, content: BlobContent) -> Result<BlobId, NodeError> {
-        self.spawn_and_receive(move |validator, sender| {
-            validator.do_upload_blob_content(content, sender)
-        })
-        .await
+    async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError> {
+        self.spawn_and_receive(move |validator, sender| validator.do_upload_blob(content, sender))
+            .await
     }
 
     async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
@@ -462,7 +460,7 @@ where
         sender.send(Ok(stream))
     }
 
-    async fn do_upload_blob_content(
+    async fn do_upload_blob(
         self,
         content: BlobContent,
         sender: oneshot::Sender<Result<BlobId, NodeError>>,

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -103,7 +103,7 @@ where
     let creator_key_pair = KeyPair::generate();
     let creator_chain = ChainDescription::Root(2);
     let (committee, worker) = init_worker_with_chains(
-        storage,
+        storage.clone(),
         vec![
             (publisher_chain, publisher_key_pair.public(), Amount::ZERO),
             (creator_chain, creator_key_pair.public(), Amount::ZERO),
@@ -153,12 +153,11 @@ where
     ));
     let publish_certificate = make_certificate(&committee, &worker, publish_block_proposal);
 
+    storage
+        .write_blobs(&[contract_blob.clone(), service_blob.clone()])
+        .await?;
     let info = worker
-        .fully_handle_certificate_with_notifications(
-            publish_certificate.clone(),
-            vec![contract_blob.clone(), service_blob.clone()],
-            &(),
-        )
+        .fully_handle_certificate_with_notifications(publish_certificate.clone(), vec![], &())
         .await
         .unwrap()
         .info;

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -12,6 +12,7 @@
 
 use std::collections::BTreeSet;
 
+use assert_matches::assert_matches;
 use linera_base::{
     crypto::KeyPair,
     data_types::{
@@ -46,6 +47,7 @@ use linera_views::{memory::MemoryStore, views::CryptoHashView};
 use test_case::test_case;
 
 use super::{init_worker_with_chains, make_certificate};
+use crate::worker::WorkerError;
 
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -153,6 +155,12 @@ where
     ));
     let publish_certificate = make_certificate(&committee, &worker, publish_block_proposal);
 
+    assert_matches!(
+        worker
+            .fully_handle_certificate_with_notifications(publish_certificate.clone(), vec![], &())
+            .await,
+        Err(WorkerError::BlobsNotFound(_))
+    );
     storage
         .write_blobs(&[contract_blob.clone(), service_blob.clone()])
         .await?;

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -728,7 +728,7 @@ where
     drop(chain);
 
     worker
-        .handle_confirmed_certificate(certificate0, vec![], None)
+        .handle_confirmed_certificate(certificate0, None)
         .await?;
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     drop(chain);
@@ -858,7 +858,7 @@ where
     // Missing earlier blocks
     assert_matches!(
         worker
-            .handle_confirmed_certificate(certificate1.clone(), vec![], None)
+            .handle_confirmed_certificate(certificate1.clone(), None)
             .await,
         Err(WorkerError::MissingEarlierBlocks { .. })
     );
@@ -1088,7 +1088,7 @@ where
             )),
         );
         worker
-            .handle_confirmed_certificate(certificate.clone(), vec![], None)
+            .handle_confirmed_certificate(certificate.clone(), None)
             .await?;
 
         // Then receive the next two messages.
@@ -3922,7 +3922,7 @@ where
     ));
     let certificate = make_certificate(&committee, &worker, value);
     worker
-        .handle_confirmed_certificate(certificate, vec![], None)
+        .handle_confirmed_certificate(certificate, None)
         .await?;
 
     for query_context in query_contexts_after_new_block.clone() {

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -229,8 +229,9 @@ where
                 // The certificate is confirmed, so the blobs must be in storage.
                 let maybe_blobs = self.local_node.read_blobs_from_storage(blob_ids).await?;
                 let blobs = maybe_blobs.ok_or_else(|| original_err.clone())?;
+                self.remote_node.upload_blobs(blobs.clone()).await?;
                 self.remote_node
-                    .handle_confirmed_certificate(certificate, blobs, delivery)
+                    .handle_confirmed_certificate(certificate, delivery)
                     .await
             }
             _ => result,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -445,11 +445,9 @@ impl ProcessableCertificate for ConfirmedBlock {
     async fn process_certificate<S: Storage + Clone + Send + Sync + 'static>(
         worker: &WorkerState<S>,
         certificate: ConfirmedBlockCertificate,
-        blobs: Vec<Blob>,
+        _blobs: Vec<Blob>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
-        worker
-            .handle_confirmed_certificate(certificate, blobs, None)
-            .await
+        worker.handle_confirmed_certificate(certificate, None).await
     }
 }
 
@@ -551,12 +549,11 @@ where
     /// Processes a confirmed block (aka a commit).
     #[instrument(
         level = "trace",
-        skip(self, certificate, blobs, notify_when_messages_are_delivered)
+        skip(self, certificate, notify_when_messages_are_delivered)
     )]
     async fn process_confirmed_block(
         &self,
         certificate: ConfirmedBlockCertificate,
-        blobs: &[Blob],
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         let chain_id = certificate.executed_block().block.chain_id;
@@ -565,7 +562,6 @@ where
             .query_chain_worker(chain_id, move |callback| {
                 ChainWorkerRequest::ProcessConfirmedBlock {
                     certificate,
-                    blobs: blobs.to_owned(),
                     notify_when_messages_are_delivered,
                     callback,
                 }
@@ -816,12 +812,8 @@ where
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         match self.full_certificate(certificate).await? {
             Either::Left(confirmed) => {
-                self.handle_confirmed_certificate(
-                    confirmed,
-                    vec![],
-                    notify_when_messages_are_delivered,
-                )
-                .await
+                self.handle_confirmed_certificate(confirmed, notify_when_messages_are_delivered)
+                    .await
             }
             Either::Right(validated) => self.handle_validated_certificate(validated, vec![]).await,
         }
@@ -836,7 +828,6 @@ where
     pub async fn handle_confirmed_certificate(
         &self,
         certificate: ConfirmedBlockCertificate,
-        blobs: Vec<Blob>,
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname, certificate);
@@ -865,7 +856,7 @@ where
             }
         }
 
-        self.process_confirmed_block(certificate, &blobs, notify_when_messages_are_delivered)
+        self.process_confirmed_block(certificate, notify_when_messages_are_delivered)
             .await
     }
 

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -261,9 +261,6 @@ message HandleConfirmedCertificateRequest {
   // Wait until all outgoing cross-chain messages from this certificate have
   // been received by the target chains.
   bool wait_for_outgoing_messages = 3;
-
-  // Blobs required by this certificate
-  bytes blobs = 4;
 }
 
 // A certified statement from the committee.

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -64,6 +64,10 @@ service ValidatorNode {
   // Downloads a blob content.
   rpc DownloadBlobContent(BlobId) returns (BlobContent);
 
+  // Uploads a blob content. Returns an error if the validator has not seen a
+  // certificate using this blob.
+  rpc UploadBlobContent(BlobContent) returns (BlobId);
+
   // Downloads a certificate.
   rpc DownloadCertificate(CryptoHash) returns (Certificate);
 

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -66,7 +66,7 @@ service ValidatorNode {
 
   // Uploads a blob content. Returns an error if the validator has not seen a
   // certificate using this blob.
-  rpc UploadBlobContent(BlobContent) returns (BlobId);
+  rpc UploadBlob(BlobContent) returns (BlobId);
 
   // Downloads a certificate.
   rpc DownloadCertificate(CryptoHash) returns (Certificate);

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -94,20 +94,19 @@ impl ValidatorNode for Client {
     async fn handle_confirmed_certificate(
         &self,
         certificate: ConfirmedBlockCertificate,
-        blobs: Vec<Blob>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         match self {
             Client::Grpc(grpc_client) => {
                 grpc_client
-                    .handle_confirmed_certificate(certificate, blobs, delivery)
+                    .handle_confirmed_certificate(certificate, delivery)
                     .await
             }
 
             #[cfg(with_simple_network)]
             Client::Simple(simple_client) => {
                 simple_client
-                    .handle_confirmed_certificate(certificate, blobs, delivery)
+                    .handle_confirmed_certificate(certificate, delivery)
                     .await
             }
         }

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -172,12 +172,12 @@ impl ValidatorNode for Client {
         })
     }
 
-    async fn upload_blob_content(&self, content: BlobContent) -> Result<BlobId, NodeError> {
+    async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError> {
         Ok(match self {
-            Client::Grpc(grpc_client) => grpc_client.upload_blob_content(content).await?,
+            Client::Grpc(grpc_client) => grpc_client.upload_blob(content).await?,
 
             #[cfg(with_simple_network)]
-            Client::Simple(simple_client) => simple_client.upload_blob_content(content).await?,
+            Client::Simple(simple_client) => simple_client.upload_blob(content).await?,
         })
     }
 

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -173,6 +173,15 @@ impl ValidatorNode for Client {
         })
     }
 
+    async fn upload_blob_content(&self, content: BlobContent) -> Result<BlobId, NodeError> {
+        Ok(match self {
+            Client::Grpc(grpc_client) => grpc_client.upload_blob_content(content).await?,
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => simple_client.upload_blob_content(content).await?,
+        })
+    }
+
     async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => grpc_client.download_blob_content(blob_id).await?,

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -348,9 +348,9 @@ impl ValidatorNode for GrpcClient {
     }
 
     #[instrument(target = "grpc_client", skip(self), err, fields(address = self.address))]
-    async fn upload_blob_content(&self, content: BlobContent) -> Result<BlobId, NodeError> {
+    async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError> {
         let req = api::BlobContent::try_from(content)?;
-        Ok(client_delegate!(self, upload_blob_content, req)?.try_into()?)
+        Ok(client_delegate!(self, upload_blob, req)?.try_into()?)
     }
 
     #[instrument(target = "grpc_client", skip(self), err, fields(address = self.address))]

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -207,13 +207,11 @@ impl ValidatorNode for GrpcClient {
     async fn handle_confirmed_certificate(
         &self,
         certificate: GenericCertificate<ConfirmedBlock>,
-        blobs: Vec<Blob>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
         let wait_for_outgoing_messages: bool = delivery.wait_for_outgoing_messages();
         let request = HandleConfirmedCertificateRequest {
             certificate,
-            blobs,
             wait_for_outgoing_messages,
         };
         GrpcClient::try_into_chain_info(client_delegate!(

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -350,6 +350,12 @@ impl ValidatorNode for GrpcClient {
     }
 
     #[instrument(target = "grpc_client", skip(self), err, fields(address = self.address))]
+    async fn upload_blob_content(&self, content: BlobContent) -> Result<BlobId, NodeError> {
+        let req = api::BlobContent::try_from(content)?;
+        Ok(client_delegate!(self, upload_blob_content, req)?.try_into()?)
+    }
+
+    #[instrument(target = "grpc_client", skip(self), err, fields(address = self.address))]
     async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
         let req = api::BlobId::try_from(blob_id)?;
         Ok(client_delegate!(self, download_blob_content, req)?.try_into()?)

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -398,11 +398,9 @@ impl TryFrom<api::HandleConfirmedCertificateRequest> for HandleConfirmedCertific
             certificate.inner().chain_id() == req_chain_id,
             GrpcProtoConversionError::InconsistentChainId
         );
-        let blobs = bincode::deserialize(&cert_request.blobs)?;
         Ok(HandleConfirmedCertificateRequest {
             certificate,
             wait_for_outgoing_messages: cert_request.wait_for_outgoing_messages,
-            blobs,
         })
     }
 }
@@ -414,7 +412,6 @@ impl TryFrom<HandleConfirmedCertificateRequest> for api::HandleConfirmedCertific
         Ok(Self {
             chain_id: Some(request.certificate.inner().chain_id().into()),
             certificate: Some(request.certificate.try_into()?),
-            blobs: bincode::serialize(&request.blobs)?,
             wait_for_outgoing_messages: request.wait_for_outgoing_messages,
         })
     }

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -537,7 +537,6 @@ where
         let start = Instant::now();
         let HandleConfirmedCertificateRequest {
             certificate,
-            blobs,
             wait_for_outgoing_messages,
         } = request.into_inner().try_into()?;
         trace!(?certificate, "Handling certificate");
@@ -545,7 +544,7 @@ where
         match self
             .state
             .clone()
-            .handle_confirmed_certificate(certificate, blobs, sender)
+            .handle_confirmed_certificate(certificate, sender)
             .await
         {
             Ok((info, actions)) => {

--- a/linera-rpc/src/lib.rs
+++ b/linera-rpc/src/lib.rs
@@ -36,7 +36,6 @@ pub struct HandleLiteCertRequest<'a> {
 pub struct HandleConfirmedCertificateRequest {
     pub certificate: linera_chain::types::ConfirmedBlockCertificate,
     pub wait_for_outgoing_messages: bool,
-    pub blobs: Vec<linera_base::data_types::Blob>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -33,7 +33,7 @@ pub enum RpcMessage {
     ConfirmedCertificate(Box<HandleConfirmedCertificateRequest>),
     LiteCertificate(Box<HandleLiteCertRequest<'static>>),
     ChainInfoQuery(Box<ChainInfoQuery>),
-    UploadBlobContent(Box<BlobContent>),
+    UploadBlob(Box<BlobContent>),
     DownloadBlobContent(Box<BlobId>),
     DownloadConfirmedBlock(Box<CryptoHash>),
     DownloadCertificates(Vec<CryptoHash>),
@@ -48,7 +48,7 @@ pub enum RpcMessage {
     Error(Box<NodeError>),
     VersionInfoResponse(Box<VersionInfo>),
     GenesisConfigHashResponse(Box<CryptoHash>),
-    UploadBlobContentResponse(Box<BlobId>),
+    UploadBlobResponse(Box<BlobId>),
     DownloadBlobContentResponse(Box<BlobContent>),
     DownloadConfirmedBlockResponse(Box<ConfirmedBlock>),
     DownloadCertificatesResponse(Vec<ConfirmedBlockCertificate>),
@@ -81,8 +81,8 @@ impl RpcMessage {
             | VersionInfoResponse(_)
             | GenesisConfigHashQuery
             | GenesisConfigHashResponse(_)
-            | UploadBlobContent(_)
-            | UploadBlobContentResponse(_)
+            | UploadBlob(_)
+            | UploadBlobResponse(_)
             | DownloadBlobContent(_)
             | DownloadBlobContentResponse(_)
             | DownloadConfirmedBlock(_)
@@ -108,7 +108,7 @@ impl RpcMessage {
         match self {
             VersionInfoQuery
             | GenesisConfigHashQuery
-            | UploadBlobContent(_)
+            | UploadBlob(_)
             | DownloadBlobContent(_)
             | DownloadConfirmedBlock(_)
             | BlobLastUsedBy(_)
@@ -126,7 +126,7 @@ impl RpcMessage {
             | ChainInfoResponse(_)
             | VersionInfoResponse(_)
             | GenesisConfigHashResponse(_)
-            | UploadBlobContentResponse(_)
+            | UploadBlobResponse(_)
             | DownloadBlobContentResponse(_)
             | DownloadConfirmedBlockResponse(_)
             | BlobLastUsedByResponse(_)
@@ -218,7 +218,7 @@ impl TryFrom<RpcMessage> for BlobId {
     type Error = NodeError;
     fn try_from(message: RpcMessage) -> Result<Self, Self::Error> {
         match message {
-            RpcMessage::UploadBlobContentResponse(blob_id) => Ok(*blob_id),
+            RpcMessage::UploadBlobResponse(blob_id) => Ok(*blob_id),
             RpcMessage::Error(error) => Err(*error),
             _ => Err(NodeError::UnexpectedMessage),
         }

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -162,9 +162,8 @@ impl ValidatorNode for SimpleClient {
         self.query(RpcMessage::GenesisConfigHashQuery).await
     }
 
-    async fn upload_blob_content(&self, content: BlobContent) -> Result<BlobId, NodeError> {
-        self.query(RpcMessage::UploadBlobContent(Box::new(content)))
-            .await
+    async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError> {
+        self.query(RpcMessage::UploadBlob(Box::new(content))).await
     }
 
     async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -164,6 +164,11 @@ impl ValidatorNode for SimpleClient {
         self.query(RpcMessage::GenesisConfigHashQuery).await
     }
 
+    async fn upload_blob_content(&self, content: BlobContent) -> Result<BlobId, NodeError> {
+        self.query(RpcMessage::UploadBlobContent(Box::new(content)))
+            .await
+    }
+
     async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
         self.query(RpcMessage::DownloadBlobContent(Box::new(blob_id)))
             .await
@@ -208,8 +213,7 @@ impl ValidatorNode for SimpleClient {
     }
 
     async fn missing_blob_ids(&self, blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError> {
-        self.query(RpcMessage::MissingBlobIds(Box::new(blob_ids)))
-            .await
+        self.query(RpcMessage::MissingBlobIds(blob_ids)).await
     }
 }
 

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -116,13 +116,11 @@ impl ValidatorNode for SimpleClient {
     async fn handle_confirmed_certificate(
         &self,
         certificate: ConfirmedBlockCertificate,
-        blobs: Vec<Blob>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
         let request = HandleConfirmedCertificateRequest {
             certificate,
-            blobs,
             wait_for_outgoing_messages,
         };
         let request = RpcMessage::ConfirmedCertificate(Box::new(request));

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -359,7 +359,9 @@ where
             | RpcMessage::MissingBlobIds(_)
             | RpcMessage::MissingBlobIdsResponse(_)
             | RpcMessage::DownloadCertificates(_)
-            | RpcMessage::DownloadCertificatesResponse(_) => Err(NodeError::UnexpectedMessage),
+            | RpcMessage::DownloadCertificatesResponse(_)
+            | RpcMessage::UploadBlobContent(_)
+            | RpcMessage::UploadBlobContentResponse(_) => Err(NodeError::UnexpectedMessage),
         };
 
         self.server.packets_processed += 1;

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -292,7 +292,7 @@ where
                 match self
                     .server
                     .state
-                    .handle_confirmed_certificate(request.certificate, request.blobs, sender)
+                    .handle_confirmed_certificate(request.certificate, sender)
                     .await
                 {
                     Ok((info, actions)) => {

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -360,8 +360,8 @@ where
             | RpcMessage::MissingBlobIdsResponse(_)
             | RpcMessage::DownloadCertificates(_)
             | RpcMessage::DownloadCertificatesResponse(_)
-            | RpcMessage::UploadBlobContent(_)
-            | RpcMessage::UploadBlobContentResponse(_) => Err(NodeError::UnexpectedMessage),
+            | RpcMessage::UploadBlob(_)
+            | RpcMessage::UploadBlobResponse(_) => Err(NodeError::UnexpectedMessage),
         };
 
         self.server.packets_processed += 1;

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -801,74 +801,82 @@ RpcMessage:
         NEWTYPE:
           TYPENAME: ChainInfoQuery
     6:
+      UploadBlobContent:
+        NEWTYPE:
+          TYPENAME: BlobContent
+    7:
       DownloadBlobContent:
         NEWTYPE:
           TYPENAME: BlobId
-    7:
+    8:
       DownloadConfirmedBlock:
         NEWTYPE:
           TYPENAME: CryptoHash
-    8:
+    9:
       DownloadCertificates:
         NEWTYPE:
           SEQ:
             TYPENAME: CryptoHash
-    9:
+    10:
       BlobLastUsedBy:
         NEWTYPE:
           TYPENAME: BlobId
-    10:
+    11:
       MissingBlobIds:
         NEWTYPE:
           SEQ:
             TYPENAME: BlobId
-    11:
-      VersionInfoQuery: UNIT
     12:
-      GenesisConfigHashQuery: UNIT
+      VersionInfoQuery: UNIT
     13:
+      GenesisConfigHashQuery: UNIT
+    14:
       Vote:
         NEWTYPE:
           TYPENAME: LiteVote
-    14:
+    15:
       ChainInfoResponse:
         NEWTYPE:
           TYPENAME: ChainInfoResponse
-    15:
+    16:
       Error:
         NEWTYPE:
           TYPENAME: NodeError
-    16:
+    17:
       VersionInfoResponse:
         NEWTYPE:
           TYPENAME: VersionInfo
-    17:
+    18:
       GenesisConfigHashResponse:
         NEWTYPE:
           TYPENAME: CryptoHash
-    18:
+    19:
+      UploadBlobContentResponse:
+        NEWTYPE:
+          TYPENAME: BlobId
+    20:
       DownloadBlobContentResponse:
         NEWTYPE:
           TYPENAME: BlobContent
-    19:
+    21:
       DownloadConfirmedBlockResponse:
         NEWTYPE:
           TYPENAME: ExecutedBlock
-    20:
+    22:
       DownloadCertificatesResponse:
         NEWTYPE:
           SEQ:
             TYPENAME: ConfirmedBlockCertificate
-    21:
+    23:
       BlobLastUsedByResponse:
         NEWTYPE:
           TYPENAME: CryptoHash
-    22:
+    24:
       MissingBlobIdsResponse:
         NEWTYPE:
           SEQ:
             TYPENAME: BlobId
-    23:
+    25:
       CrossChainRequest:
         NEWTYPE:
           TYPENAME: CrossChainRequest

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -418,9 +418,6 @@ HandleConfirmedCertificateRequest:
     - certificate:
         TYPENAME: ConfirmedBlockCertificate
     - wait_for_outgoing_messages: BOOL
-    - blobs:
-        SEQ:
-          TYPENAME: BlobContent
 HandleLiteCertRequest:
   STRUCT:
     - certificate:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -798,7 +798,7 @@ RpcMessage:
         NEWTYPE:
           TYPENAME: ChainInfoQuery
     6:
-      UploadBlobContent:
+      UploadBlob:
         NEWTYPE:
           TYPENAME: BlobContent
     7:
@@ -848,7 +848,7 @@ RpcMessage:
         NEWTYPE:
           TYPENAME: CryptoHash
     19:
-      UploadBlobContentResponse:
+      UploadBlobResponse:
         NEWTYPE:
           TYPENAME: BlobId
     20:

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -45,6 +45,7 @@ use crate::ContractAbi;
 pub struct TestValidator {
     key_pair: KeyPair,
     committee: Committee,
+    storage: DbStorage<MemoryStore, TestClock>,
     worker: WorkerState<DbStorage<MemoryStore, TestClock>>,
     clock: TestClock,
     chains: Arc<DashMap<ChainId, ActiveChain>>,
@@ -55,6 +56,7 @@ impl Clone for TestValidator {
         TestValidator {
             key_pair: self.key_pair.copy(),
             committee: self.committee.clone(),
+            storage: self.storage.clone(),
             worker: self.worker.clone(),
             clock: self.clock.clone(),
             chains: self.chains.clone(),
@@ -75,13 +77,14 @@ impl TestValidator {
         let worker = WorkerState::new(
             "Single validator node".to_string(),
             Some(key_pair.copy()),
-            storage,
+            storage.clone(),
             NonZeroUsize::new(20).expect("Chain worker limit should not be zero"),
         );
 
         let validator = TestValidator {
             key_pair,
             committee,
+            storage,
             worker,
             clock,
             chains: Arc::default(),
@@ -134,6 +137,11 @@ impl TestValidator {
             .await;
 
         (validator, application_id, creator)
+    }
+
+    /// Returns this validator's storage.
+    pub(crate) fn storage(&self) -> &DbStorage<MemoryStore, TestClock> {
+        &self.storage
     }
 
     /// Returns the locked [`WorkerState`] of this validator.

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -809,7 +809,6 @@ impl Runnable for Job {
                         RpcMessage::ConfirmedCertificate(Box::new(
                             HandleConfirmedCertificateRequest {
                                 certificate: certificate.clone(),
-                                blobs: vec![],
                                 wait_for_outgoing_messages: true,
                             },
                         ))

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -476,10 +476,7 @@ where
     }
 
     #[instrument(skip_all, err(Display))]
-    async fn upload_blob_content(
-        &self,
-        request: Request<BlobContent>,
-    ) -> Result<Response<BlobId>, Status> {
+    async fn upload_blob(&self, request: Request<BlobContent>) -> Result<Response<BlobId>, Status> {
         let content: linera_sdk::base::BlobContent = request.into_inner().try_into()?;
         let blob = Blob::new(content);
         let id = blob.id();

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -41,7 +41,7 @@ use linera_rpc::{
         GRPC_MAX_MESSAGE_SIZE,
     },
 };
-use linera_sdk::views::ViewError;
+use linera_sdk::{base::Blob, views::ViewError};
 use linera_storage::Storage;
 use prost::Message;
 use tokio::{select, task::JoinSet};
@@ -473,6 +473,21 @@ where
         _request: Request<()>,
     ) -> Result<Response<CryptoHash>, Status> {
         Ok(Response::new(self.0.genesis_config.hash().into()))
+    }
+
+    #[instrument(skip_all, err(Display))]
+    async fn upload_blob_content(
+        &self,
+        request: Request<BlobContent>,
+    ) -> Result<Response<BlobId>, Status> {
+        let content: linera_sdk::base::BlobContent = request.into_inner().try_into()?;
+        let blob = Blob::new(content);
+        let id = blob.id();
+        let result = self.0.storage.maybe_write_blobs(&[blob]).await;
+        if !result.map_err(Self::error_to_status)?[0] {
+            return Err(Status::not_found("Blob not found"));
+        }
+        Ok(Response::new(id.try_into()?))
     }
 
     #[instrument(skip_all, err(Display))]

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -5,7 +5,7 @@
 
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
-use anyhow::{bail, Result};
+use anyhow::{bail, ensure, Result};
 use async_trait::async_trait;
 use futures::{FutureExt as _, SinkExt, StreamExt};
 use linera_client::{
@@ -21,6 +21,7 @@ use linera_rpc::{
     simple::{MessageHandler, TransportProtocol},
     RpcMessage,
 };
+use linera_sdk::base::Blob;
 #[cfg(with_metrics)]
 use linera_service::prometheus_server;
 use linera_service::util;
@@ -299,6 +300,15 @@ where
             GenesisConfigHashQuery => Ok(Some(RpcMessage::GenesisConfigHashResponse(Box::new(
                 self.genesis_config.hash(),
             )))),
+            UploadBlobContent(content) => {
+                let blob = Blob::new(*content);
+                let id = blob.id();
+                ensure!(
+                    self.storage.maybe_write_blobs(&[blob]).await?[0],
+                    "Blob not found"
+                );
+                Ok(Some(RpcMessage::UploadBlobContentResponse(Box::new(id))))
+            }
             DownloadBlobContent(blob_id) => {
                 let content = self.storage.read_blob(*blob_id).await?.into_content();
                 Ok(Some(RpcMessage::DownloadBlobContentResponse(Box::new(
@@ -320,9 +330,9 @@ where
             BlobLastUsedBy(blob_id) => Ok(Some(RpcMessage::BlobLastUsedByResponse(Box::new(
                 self.storage.read_blob_state(*blob_id).await?.last_used_by,
             )))),
-            MissingBlobIds(blob_ids) => Ok(Some(RpcMessage::MissingBlobIdsResponse(Box::new(
+            MissingBlobIds(blob_ids) => Ok(Some(RpcMessage::MissingBlobIdsResponse(
                 self.storage.missing_blobs(&blob_ids).await?,
-            )))),
+            ))),
             BlockProposal(_)
             | LiteCertificate(_)
             | TimeoutCertificate(_)
@@ -339,7 +349,8 @@ where
             | BlobLastUsedByResponse(_)
             | MissingBlobIdsResponse(_)
             | DownloadConfirmedBlockResponse(_)
-            | DownloadCertificatesResponse(_) => {
+            | DownloadCertificatesResponse(_)
+            | UploadBlobContentResponse(_) => {
                 Err(anyhow::Error::from(NodeError::UnexpectedMessage))
             }
         }

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -300,14 +300,14 @@ where
             GenesisConfigHashQuery => Ok(Some(RpcMessage::GenesisConfigHashResponse(Box::new(
                 self.genesis_config.hash(),
             )))),
-            UploadBlobContent(content) => {
+            UploadBlob(content) => {
                 let blob = Blob::new(*content);
                 let id = blob.id();
                 ensure!(
                     self.storage.maybe_write_blobs(&[blob]).await?[0],
                     "Blob not found"
                 );
-                Ok(Some(RpcMessage::UploadBlobContentResponse(Box::new(id))))
+                Ok(Some(RpcMessage::UploadBlobResponse(Box::new(id))))
             }
             DownloadBlobContent(blob_id) => {
                 let content = self.storage.read_blob(*blob_id).await?.into_content();
@@ -350,9 +350,7 @@ where
             | MissingBlobIdsResponse(_)
             | DownloadConfirmedBlockResponse(_)
             | DownloadCertificatesResponse(_)
-            | UploadBlobContentResponse(_) => {
-                Err(anyhow::Error::from(NodeError::UnexpectedMessage))
-            }
+            | UploadBlobResponse(_) => Err(anyhow::Error::from(NodeError::UnexpectedMessage)),
         }
     }
 }

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -96,7 +96,7 @@ impl ValidatorNode for DummyValidatorNode {
         Err(NodeError::UnexpectedMessage)
     }
 
-    async fn upload_blob_content(&self, _: BlobContent) -> Result<BlobId, NodeError> {
+    async fn upload_blob(&self, _: BlobContent) -> Result<BlobId, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -64,7 +64,6 @@ impl ValidatorNode for DummyValidatorNode {
     async fn handle_confirmed_certificate(
         &self,
         _: GenericCertificate<ConfirmedBlock>,
-        _: Vec<Blob>,
         _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         Err(NodeError::UnexpectedMessage)

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -97,6 +97,10 @@ impl ValidatorNode for DummyValidatorNode {
         Err(NodeError::UnexpectedMessage)
     }
 
+    async fn upload_blob_content(&self, _: BlobContent) -> Result<BlobId, NodeError> {
+        Err(NodeError::UnexpectedMessage)
+    }
+
     async fn download_blob_content(&self, _: BlobId) -> Result<BlobContent, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -530,6 +530,7 @@ where
         &self,
         blob_ids: &[BlobId],
         blob_state: BlobState,
+        overwrite: bool,
     ) -> Result<Vec<Epoch>, ViewError> {
         if blob_ids.is_empty() {
             return Ok(Vec::new());
@@ -549,7 +550,7 @@ where
             let (should_write, latest_epoch) = match maybe_blob_state {
                 None => (true, blob_state.epoch),
                 Some(current_blob_state) => (
-                    current_blob_state.epoch < blob_state.epoch,
+                    overwrite && current_blob_state.epoch < blob_state.epoch,
                     current_blob_state.epoch.max(blob_state.epoch),
                 ),
             };

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -124,6 +124,10 @@ pub trait Storage: Sized {
         blob_state: &BlobState,
     ) -> Result<(), ViewError>;
 
+    /// Writes the given blobs, but only if they already have a blob state. Returns `true` for the
+    /// blobs that were written.
+    async fn maybe_write_blobs(&self, blobs: &[Blob]) -> Result<Vec<bool>, ViewError>;
+
     /// Attempts to write the given blob state. Returns the latest `Epoch` to have used this blob.
     async fn maybe_write_blob_state(
         &self,

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -140,6 +140,7 @@ pub trait Storage: Sized {
         &self,
         blob_ids: &[BlobId],
         blob_state: BlobState,
+        overwrite: bool,
     ) -> Result<Vec<Epoch>, ViewError>;
 
     /// Writes several blobs.


### PR DESCRIPTION
## Motivation

Including blobs with the gRPC message that contains a block proposal or certificate severely limits the total size of the blobs. (See #3048.)

## Proposal

As a first step, remove the blobs from the `handle_confirmed_certificate` functions and messages.

Instead, when a validator sees a fully signed confirmed block it creates the blob states in its local storage even if it doesn't have the blobs yet. The client can then upload the blobs one by one, and the validator will accept them. Finally, the client can retry sending the certificate.

We don't do this for block proposals or validated blocks yet: These will need to be handled differently, because in these cases the blob has not necessarily been successfully published yet, so we should _not_ create a blob state. Instead, we will put these blobs into a temporary cache.

## Test Plan

The existing tests are now using the new flow for confirmed block certificates.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Part of #3048
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
