### PR TITLE
Pin ScyllaDB minor version.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   scylla:
-    image: scylladb/scylla:6.1
+    image: scylladb/scylla:6.1.3
     container_name: scylla
     volumes:
       - linera-scylla-data:/var/lib/scylla


### PR DESCRIPTION
## Motivation

Pin the ScyllaDB minor version to avoid accidentally pulling upstream changes.

## Proposal

Pin the image version in Docker Compose.

## Test Plan

CI will catch regressions.