### PR TITLE
Fix verb tense in test documentation

### DIFF
--- a/linera-views/src/views/unit_tests/views.rs
+++ b/linera-views/src/views/unit_tests/views.rs
@@ -258,7 +258,7 @@ impl TestContextFactory for ScyllaDbContextFactory {
     }
 }
 
-/// Check if a cloned view contains the staged changes from its source.
+/// Checks if a cloned view contains the staged changes from its source.
 #[test_case(PhantomData::<TestCollectionView<_>>; "with CollectionView")]
 #[test_case(PhantomData::<TestLogView<_>>; "with LogView")]
 #[test_case(PhantomData::<TestMapView<_>>; "with MapView")]
@@ -282,7 +282,7 @@ where
     Ok(())
 }
 
-/// Check if new staged changes are separate between the cloned view and its source.
+/// Checks if new staged changes are separate between the cloned view and its source.
 #[test_case(PhantomData::<TestCollectionView<_>>; "with CollectionView")]
 #[test_case(PhantomData::<TestLogView<_>>; "with LogView")]
 #[test_case(PhantomData::<TestMapView<_>>; "with MapView")]
@@ -312,7 +312,7 @@ where
     Ok(())
 }
 
-/// Check if the cached hash value persisted in storage is cleared when flushing a cleared
+/// Checks if the cached hash value persisted in storage is cleared when flushing a cleared
 /// [`HashableRegisterView`].
 ///
 /// Otherwise `rollback` may set the cached staged hash value to an incorrect value.
@@ -381,7 +381,7 @@ async fn test_reentrant_collection_view_has_no_pending_changes_after_try_load_en
     Ok(())
 }
 
-/// Check if a [`ReentrantCollectionView`] has pending changes after adding an entry.
+/// Checks if a [`ReentrantCollectionView`] has pending changes after adding an entry.
 #[tokio::test]
 async fn test_reentrant_collection_view_has_pending_changes_after_new_entry() -> anyhow::Result<()>
 {
@@ -405,7 +405,7 @@ async fn test_reentrant_collection_view_has_pending_changes_after_new_entry() ->
     Ok(())
 }
 
-/// Check if a acquiring a write-lock to a sub-view causes the collection to have pending changes.
+/// Checks if a acquiring a write-lock to a sub-view causes the collection to have pending changes.
 #[tokio::test]
 async fn test_reentrant_collection_view_has_pending_changes_after_try_load_entry_mut(
 ) -> anyhow::Result<()> {
@@ -437,7 +437,7 @@ async fn test_reentrant_collection_view_has_pending_changes_after_try_load_entry
     Ok(())
 }
 
-/// Check if a acquiring multiple write-locks to sub-views causes the collection to have pending
+/// Checks if a acquiring multiple write-locks to sub-views causes the collection to have pending
 /// changes.
 #[tokio::test]
 async fn test_reentrant_collection_view_has_pending_changes_after_try_load_entries_mut(

--- a/linera-witty-macros/src/unit_tests/specialization.rs
+++ b/linera-witty-macros/src/unit_tests/specialization.rs
@@ -9,7 +9,7 @@ use syn::{parse_quote, DeriveInput, Ident};
 
 use super::{super::apply_specialization_attribute, Specialization, Specializations};
 
-/// Check that the [`DeriveInput`] of a `struct` is changed.
+/// Checks that the [`DeriveInput`] of a `struct` is changed.
 #[test]
 fn derive_input_changes() {
     let mut input: DeriveInput = parse_quote! {
@@ -66,7 +66,7 @@ fn derive_input_changes() {
     );
 }
 
-/// Check that [`Specialization`] generates correctly specialized [`Generics`].
+/// Checks that [`Specialization`] generates correctly specialized [`Generics`].
 #[test]
 fn generics_are_specialized() {
     let specializations = Specializations(vec![

--- a/linera-witty-macros/src/unit_tests/wit_load.rs
+++ b/linera-witty-macros/src/unit_tests/wit_load.rs
@@ -10,7 +10,7 @@ use syn::{parse_quote, Fields, ItemEnum, ItemStruct};
 
 use super::{derive_for_enum, derive_for_struct};
 
-/// Check the generated code for the body of the implementation of `WitLoad` for a unit struct.
+/// Checks the generated code for the body of the implementation of `WitLoad` for a unit struct.
 #[test]
 fn zero_sized_type() {
     let input = Fields::Unit;
@@ -51,7 +51,7 @@ fn zero_sized_type() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitLoad` for a named struct.
+/// Checks the generated code for the body of the implementation of `WitLoad` for a named struct.
 #[test]
 fn named_struct() {
     let input: ItemStruct = parse_quote! {
@@ -103,7 +103,7 @@ fn named_struct() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitLoad` for a tuple struct.
+/// Checks the generated code for the body of the implementation of `WitLoad` for a tuple struct.
 #[test]
 fn tuple_struct() {
     let input: ItemStruct = parse_quote! {
@@ -152,7 +152,7 @@ fn tuple_struct() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitType` for an enum.
+/// Checks the generated code for the body of the implementation of `WitType` for an enum.
 #[test]
 fn enum_type() {
     let input: ItemEnum = parse_quote! {
@@ -270,7 +270,7 @@ fn enum_type() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitLoad` for a named struct
+/// Checks the generated code for the body of the implementation of `WitLoad` for a named struct
 /// with some ignored fields.
 #[test]
 fn named_struct_with_skipped_fields() {
@@ -355,7 +355,7 @@ fn named_struct_with_skipped_fields() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitLoad` for a tuple struct
+/// Checks the generated code for the body of the implementation of `WitLoad` for a tuple struct
 /// with some ignored fields.
 #[test]
 fn tuple_struct_with_skipped_fields() {
@@ -419,7 +419,7 @@ fn tuple_struct_with_skipped_fields() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitType` for an enum with some
+/// Checks the generated code for the body of the implementation of `WitType` for an enum with some
 /// ignored fields.
 #[test]
 fn enum_type_with_skipped_fields() {

--- a/linera-witty-macros/src/unit_tests/wit_store.rs
+++ b/linera-witty-macros/src/unit_tests/wit_store.rs
@@ -10,7 +10,7 @@ use syn::{parse_quote, Fields, ItemEnum, ItemStruct};
 
 use super::{derive_for_enum, derive_for_struct};
 
-/// Check the generated code for the body of the implementation of `WitStore` for a unit struct.
+/// Checks the generated code for the body of the implementation of `WitStore` for a unit struct.
 #[test]
 fn zero_sized_type() {
     let input = Fields::Unit;
@@ -48,7 +48,7 @@ fn zero_sized_type() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitStore` for a named struct.
+/// Checks the generated code for the body of the implementation of `WitStore` for a named struct.
 #[test]
 fn named_struct() {
     let input: ItemStruct = parse_quote! {
@@ -91,7 +91,7 @@ fn named_struct() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitStore` for a tuple struct.
+/// Checks the generated code for the body of the implementation of `WitStore` for a tuple struct.
 #[test]
 fn tuple_struct() {
     let input: ItemStruct = parse_quote! {
@@ -131,7 +131,7 @@ fn tuple_struct() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitStore` for a enum.
+/// Checks the generated code for the body of the implementation of `WitStore` for a enum.
 #[test]
 fn enum_type() {
     let input: ItemEnum = parse_quote! {
@@ -235,7 +235,7 @@ fn enum_type() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitStore` for a named struct
+/// Checks the generated code for the body of the implementation of `WitStore` for a named struct
 /// with a single ignored fields.
 #[test]
 fn named_struct_with_one_skipped_field() {
@@ -281,7 +281,7 @@ fn named_struct_with_one_skipped_field() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitStore` for a named struct
+/// Checks the generated code for the body of the implementation of `WitStore` for a named struct
 /// with some ignored fields.
 #[test]
 fn named_struct_with_skipped_fields() {
@@ -333,7 +333,7 @@ fn named_struct_with_skipped_fields() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitStore` for a tuple struct
+/// Checks the generated code for the body of the implementation of `WitStore` for a tuple struct
 /// with some ignored fields.
 #[test]
 fn tuple_struct_with_skipped_fields() {
@@ -382,7 +382,7 @@ fn tuple_struct_with_skipped_fields() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitStore` for a enum with some
+/// Checks the generated code for the body of the implementation of `WitStore` for a enum with some
 /// ignored fields.
 #[test]
 fn enum_type_with_skipped_fields() {

--- a/linera-witty-macros/src/unit_tests/wit_type.rs
+++ b/linera-witty-macros/src/unit_tests/wit_type.rs
@@ -11,7 +11,7 @@ use syn::{parse_quote, Fields, ItemEnum, ItemStruct, LitStr};
 
 use super::{derive_for_enum, derive_for_struct, discover_wit_name};
 
-/// Check the generated code for the body of the implementation of `WitType` for a unit struct.
+/// Checks the generated code for the body of the implementation of `WitType` for a unit struct.
 #[test]
 fn zero_sized_type() {
     let input = Fields::Unit;
@@ -38,7 +38,7 @@ fn zero_sized_type() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitType` for a named struct.
+/// Checks the generated code for the body of the implementation of `WitType` for a named struct.
 #[test]
 fn named_struct() {
     let input: ItemStruct = parse_quote! {
@@ -83,7 +83,7 @@ fn named_struct() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitType` for a tuple struct.
+/// Checks the generated code for the body of the implementation of `WitType` for a tuple struct.
 #[test]
 fn tuple_struct() {
     let input: ItemStruct = parse_quote! {
@@ -134,7 +134,7 @@ fn tuple_struct() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitType` for an enum.
+/// Checks the generated code for the body of the implementation of `WitType` for an enum.
 #[test]
 fn enum_type() {
     let input: ItemEnum = parse_quote! {
@@ -249,7 +249,7 @@ fn enum_type() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitType` for a named struct
+/// Checks the generated code for the body of the implementation of `WitType` for a named struct
 /// with some ignored fields.
 #[test]
 fn named_struct_with_skipped_fields() {
@@ -303,7 +303,7 @@ fn named_struct_with_skipped_fields() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitType` for a tuple struct
+/// Checks the generated code for the body of the implementation of `WitType` for a tuple struct
 /// with some ignored fields.
 #[test]
 fn tuple_struct_with_skipped_fields() {
@@ -363,7 +363,7 @@ fn tuple_struct_with_skipped_fields() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitType` for an enum
+/// Checks the generated code for the body of the implementation of `WitType` for an enum
 /// with some ignored fields.
 #[test]
 fn enum_type_with_skipped_fields() {
@@ -485,7 +485,7 @@ fn enum_type_with_skipped_fields() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitType` for a struct
+/// Checks the generated code for the body of the implementation of `WitType` for a struct
 /// with a custom WIT type name.
 #[test]
 fn struct_with_a_custom_wit_name() {

--- a/linera-witty/src/runtime/unit_tests/memory.rs
+++ b/linera-witty/src/runtime/unit_tests/memory.rs
@@ -7,7 +7,7 @@ use super::GuestPointer;
 
 /// Test aligning memory addresses.
 ///
-/// Check that the resulting address is aligned and that it never advances more than the alignment
+/// Checks that the resulting address is aligned and that it never advances more than the alignment
 /// amount.
 #[test]
 fn align_guest_pointer() {

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -17,7 +17,7 @@ use self::types::{
     TupleWithoutPadding,
 };
 
-/// Check that a wrapper type is properly loaded from memory and lifted from its flat layout.
+/// Checks that a wrapper type is properly loaded from memory and lifted from its flat layout.
 #[test]
 fn test_simple_bool_wrapper() {
     test_load_from_memory(&[1], SimpleWrapper(true));
@@ -27,7 +27,7 @@ fn test_simple_bool_wrapper() {
     test_lift_from_flat_layout(hlist![0], SimpleWrapper(false), &[]);
 }
 
-/// Check that a type with multiple fields ordered in a way that doesn't require any padding is
+/// Checks that a type with multiple fields ordered in a way that doesn't require any padding is
 /// properly loaded from memory and lifted from its flat layout.
 #[test]
 fn test_tuple_struct_without_padding() {
@@ -44,7 +44,7 @@ fn test_tuple_struct_without_padding() {
     );
 }
 
-/// Check that a type with multiple fields ordered in a way that requires padding between two of its
+/// Checks that a type with multiple fields ordered in a way that requires padding between two of its
 /// fields is properly loaded from memory and lifted from its flat layout.
 #[test]
 fn test_tuple_struct_with_padding() {
@@ -61,7 +61,7 @@ fn test_tuple_struct_with_padding() {
     );
 }
 
-/// Check that a type with multiple named fields ordered in a way that requires padding before two
+/// Checks that a type with multiple named fields ordered in a way that requires padding before two
 /// fields is properly loaded from memory and lifted from its flat layout.
 #[test]
 fn test_named_struct_with_double_padding() {
@@ -90,7 +90,7 @@ fn test_named_struct_with_double_padding() {
     );
 }
 
-/// Check that a type that contains a field with a type that also has `WitStore` derived for it is
+/// Checks that a type that contains a field with a type that also has `WitStore` derived for it is
 /// properly loaded from memory and lifted from its flat layout.
 #[test]
 fn test_nested_types() {
@@ -129,7 +129,7 @@ fn test_nested_types() {
     );
 }
 
-/// Check that an enum type's variants are properly loaded from memory and lifted from its flat
+/// Checks that an enum type's variants are properly loaded from memory and lifted from its flat
 /// layout.
 #[test]
 fn test_enum_type() {
@@ -184,7 +184,7 @@ fn test_enum_type() {
     );
 }
 
-/// Check that a generic type with a specialization request is properly loaded from memory and
+/// Checks that a generic type with a specialization request is properly loaded from memory and
 /// lifted from its flat layout.
 #[test]
 fn test_specialized_generic_struct() {
@@ -207,7 +207,7 @@ fn test_specialized_generic_struct() {
     );
 }
 
-/// Check that a generic enum with a specialization request type's variants are properly loaded
+/// Checks that a generic enum with a specialization request type's variants are properly loaded
 /// from memory and lifted from its flat layout.
 #[test]
 fn test_specialized_generic_enum_type() {
@@ -244,7 +244,7 @@ fn test_specialized_generic_enum_type() {
     test_lift_from_flat_layout(hlist![2_i32, 1_i32, 0x0c0b_0a09_i32], expected, &[]);
 }
 
-/// Check that an invalid discriminant reports a useful error.
+/// Checks that an invalid discriminant reports a useful error.
 #[test]
 fn test_invalid_discriminant() {
     let mut instance = MockInstance::<()>::default();
@@ -308,7 +308,7 @@ fn test_invalid_discriminant() {
     );
 }
 
-/// Check that a type with fields stored in the heap is properly loaded from memory and lifted from
+/// Checks that a type with fields stored in the heap is properly loaded from memory and lifted from
 /// its flat layout.
 #[test]
 fn test_heap_allocated_fields() {
@@ -354,7 +354,7 @@ fn test_heap_allocated_fields() {
     );
 }
 
-/// Check that a [`Vec`] type is properly loaded from memory and lifted from its flat
+/// Checks that a [`Vec`] type is properly loaded from memory and lifted from its flat
 /// layout.
 #[test]
 fn test_vec() {
@@ -364,7 +364,7 @@ fn test_vec() {
     test_lift_from_flat_layout(hlist![0_i32, 2_i32], expected, &[0, 1]);
 }
 
-/// Check that a type with list fields is properly loaded from memory and lifted from its
+/// Checks that a type with list fields is properly loaded from memory and lifted from its
 /// flat layout.
 #[test]
 fn test_list_fields() {

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -16,7 +16,7 @@ use self::types::{
     TupleWithoutPadding,
 };
 
-/// Check that a wrapper type is properly stored in memory and lowered into its flat layout.
+/// Checks that a wrapper type is properly stored in memory and lowered into its flat layout.
 #[test]
 fn test_simple_bool_wrapper() {
     test_store_in_memory(SimpleWrapper(true), &[1], &[]);
@@ -26,7 +26,7 @@ fn test_simple_bool_wrapper() {
     test_lower_to_flat_layout(SimpleWrapper(false), hlist![0], &[]);
 }
 
-/// Check that a type with multiple fields ordered in a way that doesn't require any padding is
+/// Checks that a type with multiple fields ordered in a way that doesn't require any padding is
 /// properly stored in memory and lowered into its flat layout.
 #[test]
 fn test_tuple_struct_without_padding() {
@@ -47,7 +47,7 @@ fn test_tuple_struct_without_padding() {
     );
 }
 
-/// Check that a type with multiple fields ordered in a way that requires padding between two of its
+/// Checks that a type with multiple fields ordered in a way that requires padding between two of its
 /// fields is properly stored in memory and lowered into its flat layout.
 #[test]
 fn test_tuple_struct_with_padding() {
@@ -68,7 +68,7 @@ fn test_tuple_struct_with_padding() {
     );
 }
 
-/// Check that a type with multiple named fields ordered in a way that requires padding before two
+/// Checks that a type with multiple named fields ordered in a way that requires padding before two
 /// fields is properly stored in memory and lowered into its flat layout.
 #[test]
 fn test_named_struct_with_double_padding() {
@@ -99,7 +99,7 @@ fn test_named_struct_with_double_padding() {
     );
 }
 
-/// Check that a type that contains a field with a type that also has `WitStore` derived for it is
+/// Checks that a type that contains a field with a type that also has `WitStore` derived for it is
 /// properly stored in memory and lowered into its flat layout.
 #[test]
 fn test_nested_types() {
@@ -140,7 +140,7 @@ fn test_nested_types() {
     );
 }
 
-/// Check that an enum type's variants are properly stored in memory and lowered into its flat
+/// Checks that an enum type's variants are properly stored in memory and lowered into its flat
 /// layout.
 #[test]
 fn test_enum_type() {
@@ -231,7 +231,7 @@ fn test_enum_type() {
     );
 }
 
-/// Check that a generic type with a specialization request is properly stored in memory and
+/// Checks that a generic type with a specialization request is properly stored in memory and
 /// lowered into its flat layout.
 #[test]
 fn test_specialized_generic_struct() {
@@ -259,7 +259,7 @@ fn test_specialized_generic_struct() {
     );
 }
 
-/// Check that a generic enum with a specialization request type's variants are properly stored in
+/// Checks that a generic enum with a specialization request type's variants are properly stored in
 /// memory and lowered into its flat layout.
 #[test]
 fn test_specialized_generic_enum_type() {
@@ -401,7 +401,7 @@ fn test_heap_allocated_fields() {
     );
 }
 
-/// Check that a [`Vec`] type is properly stored in memory and lowered into its flat layout.
+/// Checks that a [`Vec`] type is properly stored in memory and lowered into its flat layout.
 #[test]
 fn test_vec() {
     let data = vec![
@@ -414,7 +414,7 @@ fn test_vec() {
     test_lower_to_flat_layout(data, hlist![0_i32, 3_i32,], &[1, 0, 1]);
 }
 
-/// Check that a type with list fields is properly stored in memory and lowered into its
+/// Checks that a type with list fields is properly stored in memory and lowered into its
 /// flat layout.
 #[test]
 fn test_list_fields() {

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -16,7 +16,7 @@ use self::types::{
     TupleWithoutPadding,
 };
 
-/// Check the memory size, layout and WIT type declaration derived for a wrapper type.
+/// Checks the memory size, layout and WIT type declaration derived for a wrapper type.
 #[test]
 fn test_simple_bool_wrapper() {
     test_wit_type_implementation::<SimpleWrapper>(ExpectedMetadata {
@@ -31,7 +31,7 @@ fn test_simple_bool_wrapper() {
     });
 }
 
-/// Check the memory size, layout and WIT type declaration derived for a type with multiple fields
+/// Checks the memory size, layout and WIT type declaration derived for a type with multiple fields
 /// ordered in a way that doesn't require any padding.
 #[test]
 fn test_tuple_struct_without_padding() {
@@ -49,7 +49,7 @@ fn test_tuple_struct_without_padding() {
     });
 }
 
-/// Check the memory size, layout and WIT type declaration derived for a type with multiple fields
+/// Checks the memory size, layout and WIT type declaration derived for a type with multiple fields
 /// ordered in a way that requires padding between all fields.
 #[test]
 fn test_tuple_struct_with_padding() {
@@ -67,7 +67,7 @@ fn test_tuple_struct_with_padding() {
     });
 }
 
-/// Check the memory size, layout and WIT type declaration derived for a type with multiple named
+/// Checks the memory size, layout and WIT type declaration derived for a type with multiple named
 /// fields ordered in a way that requires padding before two fields.
 #[test]
 fn test_named_struct_with_double_padding() {
@@ -86,7 +86,7 @@ fn test_named_struct_with_double_padding() {
     });
 }
 
-/// Check the memory size, layout and WIT type declarations derived for a type that contains a
+/// Checks the memory size, layout and WIT type declarations derived for a type that contains a
 /// field with a type that also has `WitType` derived for it.
 #[test]
 fn test_nested_types() {
@@ -122,7 +122,7 @@ fn test_nested_types() {
     });
 }
 
-/// Check the memory size, layout and WIT type declaration derived for an `enum` type.
+/// Checks the memory size, layout and WIT type declaration derived for an `enum` type.
 #[test]
 fn test_enum_type() {
     test_wit_type_implementation::<Enum>(ExpectedMetadata {
@@ -141,7 +141,7 @@ fn test_enum_type() {
     });
 }
 
-/// Check the memory size, layout and WIT type declaration derived for a specialized generic
+/// Checks the memory size, layout and WIT type declaration derived for a specialized generic
 /// `struct` type.
 #[test]
 fn test_specialized_generic_struct() {
@@ -159,7 +159,7 @@ fn test_specialized_generic_struct() {
     });
 }
 
-/// Check the memory size, layout and WIT type declaration derived for a specialized generic `enum`
+/// Checks the memory size, layout and WIT type declaration derived for a specialized generic `enum`
 /// type.
 #[test]
 fn test_specialized_generic_enum_type() {
@@ -210,7 +210,7 @@ fn test_heap_allocated_fields() {
     });
 }
 
-/// Check the memory size, layout and WIT declaration derived for a [`Vec`] type.
+/// Checks the memory size, layout and WIT declaration derived for a [`Vec`] type.
 #[test]
 fn test_vec() {
     test_wit_type_implementation::<Vec<SimpleWrapper>>(ExpectedMetadata {
@@ -225,7 +225,7 @@ fn test_vec() {
     });
 }
 
-/// Check the memory size, layout and WIT declaration derived for a type that has list
+/// Checks the memory size, layout and WIT declaration derived for a type that has list
 /// fields.
 #[test]
 fn test_list_fields() {


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
Some tests were using "check" instead of "checks", which is different from the convention used everywhere else.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Fix the documentation to use "checks".

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
Nothing needed, because this only affects documentation.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do, because this only affects documentation.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
