### PR TITLE
Add a `create_application` contract API method

### DIFF
--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -711,6 +711,15 @@ pub trait ContractRuntime: BaseRuntime {
     /// Closes the current chain.
     fn close_chain(&mut self) -> Result<(), ExecutionError>;
 
+    /// Creates a new application on chain.
+    fn create_application(
+        &mut self,
+        bytecode_id: BytecodeId,
+        parameters: Vec<u8>,
+        argument: Vec<u8>,
+        required_application_ids: Vec<UserApplicationId>,
+    ) -> Result<UserApplicationId, ExecutionError>;
+
     /// Writes a batch of changes.
     fn write_batch(&mut self, batch: Batch) -> Result<(), ExecutionError>;
 }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -29,8 +29,9 @@ use crate::{
     execution::UserAction,
     execution_state_actor::{ExecutionRequest, ExecutionStateSender},
     resources::ResourceController,
+    system::CreateApplicationResult,
     util::{ReceiverExt, UnboundedSenderExt},
-    BaseRuntime, ContractRuntime, ExecutionError, FinalizeContext, MessageContext,
+    BaseRuntime, BytecodeId, ContractRuntime, ExecutionError, FinalizeContext, MessageContext,
     OperationContext, QueryContext, RawExecutionOutcome, ServiceRuntime, TransactionTracker,
     UserApplicationDescription, UserApplicationId, UserContractCode, UserContractInstance,
     UserServiceCode, UserServiceInstance, MAX_EVENT_KEY_LEN, MAX_STREAM_NAME_LEN,
@@ -1115,6 +1116,22 @@ impl ContractSyncRuntime {
         chain_id: ChainId,
         action: UserAction,
     ) -> Result<(ResourceController, TransactionTracker), ExecutionError> {
+        self.deref_mut()
+            .run_action(application_id, chain_id, action)?;
+        let runtime = self
+            .into_inner()
+            .expect("Runtime clones should have been freed by now");
+        Ok((runtime.resource_controller, runtime.transaction_tracker))
+    }
+}
+
+impl ContractSyncRuntimeHandle {
+    fn run_action(
+        &mut self,
+        application_id: UserApplicationId,
+        chain_id: ChainId,
+        action: UserAction,
+    ) -> Result<(), ExecutionError> {
         let finalize_context = FinalizeContext {
             authenticated_signer: action.signer(),
             chain_id,
@@ -1135,10 +1152,7 @@ impl ContractSyncRuntime {
             UserAction::Message(context, message) => code.execute_message(context, message),
         })?;
         self.finalize(finalize_context)?;
-        let runtime = self
-            .into_inner()
-            .expect("Runtime clones should have been freed by now");
-        Ok((runtime.resource_controller, runtime.transaction_tracker))
+        Ok(())
     }
 
     /// Notifies all loaded applications that execution is finalizing.
@@ -1399,6 +1413,57 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
                 callback,
             })?
             .recv_response()?
+    }
+
+    fn create_application(
+        &mut self,
+        bytecode_id: BytecodeId,
+        parameters: Vec<u8>,
+        argument: Vec<u8>,
+        required_application_ids: Vec<UserApplicationId>,
+    ) -> Result<UserApplicationId, ExecutionError> {
+        let chain_id = self.inner().chain_id;
+        let context = OperationContext {
+            chain_id,
+            authenticated_signer: self.authenticated_signer()?,
+            authenticated_caller_id: self.authenticated_caller_id()?,
+            height: self.block_height()?,
+            index: None,
+        };
+
+        let mut this = self.inner();
+        let message_id = MessageId {
+            chain_id: context.chain_id,
+            height: context.height,
+            index: this.transaction_tracker.next_message_index(),
+        };
+        let CreateApplicationResult {
+            app_id,
+            message,
+            blobs_to_register,
+        } = this
+            .execution_state_sender
+            .send_request(|callback| ExecutionRequest::CreateApplication {
+                next_message_id: message_id,
+                bytecode_id,
+                parameters,
+                required_application_ids,
+                callback,
+            })?
+            .recv_response()??;
+        for blob_id in blobs_to_register {
+            this.transaction_tracker
+                .replay_oracle_response(OracleResponse::Blob(blob_id))?;
+        }
+        let outcome = RawExecutionOutcome::default().with_message(message);
+        this.transaction_tracker.add_system_outcome(outcome)?;
+
+        drop(this);
+
+        let user_action = UserAction::Instantiate(context, argument);
+        self.run_action(app_id, chain_id, user_action)?;
+
+        Ok(app_id)
     }
 
     fn write_batch(&mut self, batch: Batch) -> Result<(), ExecutionError> {

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -17,8 +17,8 @@ use tracing::log;
 
 use super::WasmExecutionError;
 use crate::{
-    BaseRuntime, ContractRuntime, ContractSyncRuntimeHandle, ExecutionError, ServiceRuntime,
-    ServiceSyncRuntimeHandle,
+    BaseRuntime, BytecodeId, ContractRuntime, ContractSyncRuntimeHandle, ExecutionError,
+    ServiceRuntime, ServiceSyncRuntimeHandle,
 };
 
 /// Common host data used as the `UserData` of the system API implementations.
@@ -299,6 +299,22 @@ where
             }
             Err(error) => Err(RuntimeError::Custom(error.into())),
         }
+    }
+
+    /// Creates a new application on the chain, based on the supplied bytecode and
+    /// parameters.
+    fn create_application(
+        caller: &mut Caller,
+        bytecode_id: BytecodeId,
+        parameters: Vec<u8>,
+        argument: Vec<u8>,
+        required_application_ids: Vec<ApplicationId>,
+    ) -> Result<ApplicationId, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .create_application(bytecode_id, parameters, argument, required_application_ids)
+            .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
     /// Calls another application.

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -232,7 +232,7 @@ where
         parameters: &A::Parameters,
         argument: &A::InstantiationArgument,
         required_application_ids: Vec<ApplicationId>,
-    ) -> ApplicationId {
+    ) -> ApplicationId<A::Abi> {
         let parameters = bcs::to_bytes(parameters)
             .expect("Failed to serialize `Parameters` type for a cross-application call");
         let argument = bcs::to_bytes(argument).expect(
@@ -248,7 +248,7 @@ where
             &argument,
             &converted_application_ids,
         );
-        application_id.into()
+        ApplicationId::from(application_id).with_abi::<A::Abi>()
     }
 
     /// Calls another application.

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -9,8 +9,8 @@ use linera_base::{
         Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, Timestamp,
     },
     identifiers::{
-        Account, AccountOwner, ApplicationId, ChainId, ChannelName, Destination, MessageId, Owner,
-        StreamName,
+        Account, AccountOwner, ApplicationId, BytecodeId, ChainId, ChannelName, Destination,
+        MessageId, Owner, StreamName,
     },
     ownership::{ChainOwnership, CloseChainError},
 };
@@ -223,6 +223,32 @@ where
             balance.into(),
         );
         (message_id.into(), chain_id.into())
+    }
+
+    /// Creates a new on-chain application, based on the supplied bytecode and parameters.
+    pub fn create_application<A: Contract>(
+        &mut self,
+        bytecode_id: BytecodeId,
+        parameters: &A::Parameters,
+        argument: &A::InstantiationArgument,
+        required_application_ids: Vec<ApplicationId>,
+    ) -> ApplicationId {
+        let parameters = bcs::to_bytes(parameters)
+            .expect("Failed to serialize `Parameters` type for a cross-application call");
+        let argument = bcs::to_bytes(argument).expect(
+            "Failed to serialize `InstantiationArgument` type for a cross-application call",
+        );
+        let converted_application_ids: Vec<_> = required_application_ids
+            .into_iter()
+            .map(From::from)
+            .collect();
+        let application_id = wit::create_application(
+            bytecode_id.into(),
+            &parameters,
+            &argument,
+            &converted_application_ids,
+        );
+        application_id.into()
     }
 
     /// Calls another application.

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -14,8 +14,8 @@ use linera_base::{
         Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, Timestamp,
     },
     identifiers::{
-        Account, AccountOwner, ApplicationId, ChainId, ChannelName, Destination, MessageId, Owner,
-        StreamName,
+        Account, AccountOwner, ApplicationId, BytecodeId, ChainId, ChannelName, Destination,
+        MessageId, Owner, StreamName,
     },
     ownership::{ChainOwnership, CloseChainError},
 };
@@ -55,6 +55,13 @@ where
     expected_assert_data_blob_exists_requests: VecDeque<(DataBlobHash, Option<()>)>,
     expected_open_chain_calls:
         VecDeque<(ChainOwnership, ApplicationPermissions, Amount, MessageId)>,
+    expected_create_application_calls: VecDeque<(
+        BytecodeId,
+        Vec<u8>,
+        Vec<u8>,
+        Vec<ApplicationId>,
+        ApplicationId,
+    )>,
     key_value_store: KeyValueStore,
 }
 
@@ -100,6 +107,7 @@ where
             expected_read_data_blob_requests: VecDeque::new(),
             expected_assert_data_blob_exists_requests: VecDeque::new(),
             expected_open_chain_calls: VecDeque::new(),
+            expected_create_application_calls: VecDeque::new(),
             key_value_store: KeyValueStore::mock().to_mut(),
         }
     }
@@ -618,6 +626,59 @@ where
         assert_eq!(balance, expected_balance);
         let chain_id = ChainId::child(message_id);
         (message_id, chain_id)
+    }
+
+    /// Adds a new expected call to `create_application`.
+    pub fn add_expected_create_application_call<A: Contract>(
+        &mut self,
+        bytecode_id: BytecodeId,
+        parameters: &A::Parameters,
+        argument: &A::InstantiationArgument,
+        required_application_ids: Vec<ApplicationId>,
+        app_id: ApplicationId,
+    ) {
+        let parameters = bcs::to_bytes(parameters)
+            .expect("Failed to serialize `Parameters` type for a cross-application call");
+        let argument = bcs::to_bytes(argument).expect(
+            "Failed to serialize `InstantiationArgument` type for a cross-application call",
+        );
+        self.expected_create_application_calls.push_back((
+            bytecode_id,
+            parameters,
+            argument,
+            required_application_ids,
+            app_id,
+        ));
+    }
+
+    /// Creates a new on-chain application, based on the supplied bytecode and parameters.
+    pub fn create_application<A: Contract>(
+        &mut self,
+        bytecode_id: BytecodeId,
+        parameters: &A::Parameters,
+        argument: &A::InstantiationArgument,
+        required_application_ids: Vec<ApplicationId>,
+    ) -> ApplicationId<A::Abi> {
+        let (
+            expected_bytecode_id,
+            expected_parameters,
+            expected_argument,
+            expected_required_app_ids,
+            app_id,
+        ) = self
+            .expected_create_application_calls
+            .pop_front()
+            .expect("Unexpected create_application call");
+        let parameters = bcs::to_bytes(parameters)
+            .expect("Failed to serialize `Parameters` type for a cross-application call");
+        let argument = bcs::to_bytes(argument).expect(
+            "Failed to serialize `InstantiationArgument` type for a cross-application call",
+        );
+        assert_eq!(bytecode_id, expected_bytecode_id);
+        assert_eq!(parameters, expected_parameters);
+        assert_eq!(argument, expected_argument);
+        assert_eq!(required_application_ids, expected_required_app_ids);
+        app_id.with_abi::<A::Abi>()
     }
 
     /// Configures the handler for cross-application calls made during the test.

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -21,6 +21,7 @@ interface contract-system-api {
     get-chain-ownership: func() -> chain-ownership;
     open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: amount) -> tuple<message-id, chain-id>;
     close-chain: func() -> result<tuple<>, close-chain-error>;
+    create-application: func(bytecode-id: bytecode-id, parameters: list<u8>, argument: list<u8>, required-application-ids: list<application-id>) -> application-id;
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
     emit: func(name: stream-name, key: list<u8>, value: list<u8>);
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;


### PR DESCRIPTION
## Motivation

In some applications, we might want to instantiate other application as part of their functionality. For example, the "Requests for Quotes" app will want to instantiate the Matching Engine.

## Proposal

Add a `create_application` method to the contract API, callable from within applications, reflecting the flow of manually instantiating a new application.

## Test Plan

This will be tested during test runs of the Requests for Quotes application.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
