### PR TITLE
Create a tool to extract a bash script from a Linera README file

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -55,7 +55,6 @@ This document contains the help content for the `linera` command-line program.
 * [`linera storage check_absence`↴](#linera-storage-check_absence)
 * [`linera storage initialize`↴](#linera-storage-initialize)
 * [`linera storage list_namespaces`↴](#linera-storage-list_namespaces)
-* [`linera extract-script-from-markdown`↴](#linera-extract-script-from-markdown)
 
 ## `linera`
 
@@ -99,7 +98,6 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `project` — Manage Linera projects
 * `net` — Manage a local Linera Network
 * `storage` — Operation on the storage
-* `extract-script-from-markdown` — Extract a Bash and GraphQL script embedded in a markdown file and print it on stdout
 
 ###### **Options:**
 
@@ -1002,27 +1000,6 @@ List the namespaces of the database
 ###### **Options:**
 
 * `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
-
-
-
-## `linera extract-script-from-markdown`
-
-Extract a Bash and GraphQL script embedded in a markdown file and print it on stdout
-
-**Usage:** `linera extract-script-from-markdown [OPTIONS] <PATH>`
-
-###### **Arguments:**
-
-* `<PATH>` — The source file
-
-###### **Options:**
-
-* `--pause-after-linera-service <PAUSE_AFTER_LINERA_SERVICE>` — Insert a pause of N seconds after calls to `linera service`
-
-  Default value: `3`
-* `--pause-after-gql-mutations <PAUSE_AFTER_GQL_MUTATIONS>` — Insert a pause of N seconds after GraphQL queries
-
-  Default value: `3`
 
 
 

--- a/CLI.md
+++ b/CLI.md
@@ -55,6 +55,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera storage check_absence`↴](#linera-storage-check_absence)
 * [`linera storage initialize`↴](#linera-storage-initialize)
 * [`linera storage list_namespaces`↴](#linera-storage-list_namespaces)
+* [`linera extract-script-from-markdown`↴](#linera-extract-script-from-markdown)
 
 ## `linera`
 
@@ -98,6 +99,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `project` — Manage Linera projects
 * `net` — Manage a local Linera Network
 * `storage` — Operation on the storage
+* `extract-script-from-markdown` — Extract a Bash and GraphQL script embedded in a markdown file and print it on stdout
 
 ###### **Options:**
 
@@ -1000,6 +1002,24 @@ List the namespaces of the database
 ###### **Options:**
 
 * `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
+
+
+
+## `linera extract-script-from-markdown`
+
+Extract a Bash and GraphQL script embedded in a markdown file and print it on stdout
+
+**Usage:** `linera extract-script-from-markdown [OPTIONS] <PATH>`
+
+###### **Arguments:**
+
+* `<PATH>` — The source file
+
+###### **Options:**
+
+* `--pause-after-gql-mutations <PAUSE_AFTER_GQL_MUTATIONS>` — Insert a pause of N seconds after GraphQL queries
+
+  Default value: `3`
 
 
 

--- a/CLI.md
+++ b/CLI.md
@@ -1017,6 +1017,9 @@ Extract a Bash and GraphQL script embedded in a markdown file and print it on st
 
 ###### **Options:**
 
+* `--pause-after-linera-service <PAUSE_AFTER_LINERA_SERVICE>` — Insert a pause of N seconds after calls to `linera service`
+
+  Default value: `3`
 * `--pause-after-gql-mutations <PAUSE_AFTER_GQL_MUTATIONS>` — Insert a pause of N seconds after GraphQL queries
 
   Default value: `3`

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -303,10 +303,6 @@ impl ClientOptions {
 
 #[derive(Clone, clap::Subcommand)]
 pub enum ClientCommand {
-    /// Print CLI help in Markdown format, and exit.
-    #[command(hide = true)]
-    HelpMarkdown,
-
     /// Transfer funds
     Transfer {
         /// Sending chain ID (must be one of our chains)
@@ -893,7 +889,25 @@ pub enum ClientCommand {
     /// Operation on the storage.
     #[command(subcommand)]
     Storage(DatabaseToolCommand),
+
+    /// Print CLI help in Markdown format, and exit.
+    #[command(hide = true)]
+    HelpMarkdown,
+
+    /// Extract a Bash and GraphQL script embedded in a markdown file and print it on
+    /// stdout.
+    ExtractScriptFromMarkdown {
+        /// The source file
+        path: PathBuf,
+
+        /// Insert a pause of N seconds after GraphQL queries.
+        #[arg(long, default_value = DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS, value_parser = util::parse_secs)]
+        pause_after_gql_mutations: Duration,
+    },
 }
+
+// Exported for readme e2e tests.
+pub static DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS: &str = "3";
 
 #[derive(Clone, clap::Parser)]
 pub enum DatabaseToolCommand {

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -900,6 +900,10 @@ pub enum ClientCommand {
         /// The source file
         path: PathBuf,
 
+        /// Insert a pause of N seconds after calls to `linera service`.
+        #[arg(long, default_value = DEFAULT_PAUSE_AFTER_LINERA_SERVICE_SECS, value_parser = util::parse_secs)]
+        pause_after_linera_service: Duration,
+
         /// Insert a pause of N seconds after GraphQL queries.
         #[arg(long, default_value = DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS, value_parser = util::parse_secs)]
         pause_after_gql_mutations: Duration,
@@ -907,6 +911,7 @@ pub enum ClientCommand {
 }
 
 // Exported for readme e2e tests.
+pub static DEFAULT_PAUSE_AFTER_LINERA_SERVICE_SECS: &str = "3";
 pub static DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS: &str = "3";
 
 #[derive(Clone, clap::Parser)]

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -896,6 +896,7 @@ pub enum ClientCommand {
 
     /// Extract a Bash and GraphQL script embedded in a markdown file and print it on
     /// stdout.
+    #[command(hide = true)]
     ExtractScriptFromMarkdown {
         /// The source file
         path: PathBuf,

--- a/linera-client/src/util.rs
+++ b/linera-client/src/util.rs
@@ -17,6 +17,10 @@ pub fn parse_millis(s: &str) -> Result<Duration, ParseIntError> {
     Ok(Duration::from_millis(s.parse()?))
 }
 
+pub fn parse_secs(s: &str) -> Result<Duration, ParseIntError> {
+    Ok(Duration::from_secs(s.parse()?))
+}
+
 pub fn parse_millis_delta(s: &str) -> Result<TimeDelta, ParseIntError> {
     Ok(TimeDelta::from_millis(s.parse()?))
 }

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1460,15 +1460,25 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
 
         ClientCommand::ExtractScriptFromMarkdown {
             path,
+            pause_after_linera_service,
             pause_after_gql_mutations,
         } => {
             let file = crate::util::Markdown::new(path)?;
-            let sleep = if pause_after_gql_mutations.is_zero() {
+            let pause_after_linera_service = if pause_after_linera_service.is_zero() {
+                None
+            } else {
+                Some(*pause_after_linera_service)
+            };
+            let pause_after_gql_mutations = if pause_after_gql_mutations.is_zero() {
                 None
             } else {
                 Some(*pause_after_gql_mutations)
             };
-            file.extract_bash_script_to(std::io::stdout(), sleep)?;
+            file.extract_bash_script_to(
+                std::io::stdout(),
+                pause_after_linera_service,
+                pause_after_gql_mutations,
+            )?;
             Ok(0)
         }
 

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1464,16 +1464,10 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
             pause_after_gql_mutations,
         } => {
             let file = crate::util::Markdown::new(path)?;
-            let pause_after_linera_service = if pause_after_linera_service.is_zero() {
-                None
-            } else {
-                Some(*pause_after_linera_service)
-            };
-            let pause_after_gql_mutations = if pause_after_gql_mutations.is_zero() {
-                None
-            } else {
-                Some(*pause_after_gql_mutations)
-            };
+            let pause_after_linera_service =
+                Some(*pause_after_linera_service).filter(|p| !p.is_zero());
+            let pause_after_gql_mutations =
+                Some(*pause_after_gql_mutations).filter(|p| !p.is_zero());
             file.extract_bash_script_to(
                 std::io::stdout(),
                 pause_after_linera_service,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1410,9 +1410,7 @@ fn main() -> anyhow::Result<()> {
 /// Returns the log file name to use based on the [`ClientCommand`] that will run.
 fn log_file_name_for(command: &ClientCommand) -> Cow<'static, str> {
     match command {
-        ClientCommand::HelpMarkdown
-        | ClientCommand::ExtractScriptFromMarkdown { .. }
-        | ClientCommand::Transfer { .. }
+        ClientCommand::Transfer { .. }
         | ClientCommand::OpenChain { .. }
         | ClientCommand::OpenMultiOwnerChain { .. }
         | ClientCommand::ChangeOwnership { .. }
@@ -1448,6 +1446,9 @@ fn log_file_name_for(command: &ClientCommand) -> Cow<'static, str> {
         ClientCommand::Storage { .. } => "storage".into(),
         ClientCommand::Service { port, .. } => format!("service-{port}").into(),
         ClientCommand::Faucet { .. } => "faucet".into(),
+        ClientCommand::HelpMarkdown | ClientCommand::ExtractScriptFromMarkdown { .. } => {
+            "tool".into()
+        }
     }
 }
 

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1218,6 +1218,7 @@ impl Runnable for Job {
             | Net(_)
             | Storage { .. }
             | Wallet(_)
+            | ExtractScriptFromMarkdown { .. }
             | HelpMarkdown => {
                 unreachable!()
             }
@@ -1410,6 +1411,7 @@ fn main() -> anyhow::Result<()> {
 fn log_file_name_for(command: &ClientCommand) -> Cow<'static, str> {
     match command {
         ClientCommand::HelpMarkdown
+        | ClientCommand::ExtractScriptFromMarkdown { .. }
         | ClientCommand::Transfer { .. }
         | ClientCommand::OpenChain { .. }
         | ClientCommand::OpenMultiOwnerChain { .. }
@@ -1453,6 +1455,20 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
     match &options.command {
         ClientCommand::HelpMarkdown => {
             clap_markdown::print_help_markdown::<ClientOptions>();
+            Ok(0)
+        }
+
+        ClientCommand::ExtractScriptFromMarkdown {
+            path,
+            pause_after_gql_mutations,
+        } => {
+            let file = crate::util::Markdown::new(path)?;
+            let sleep = if pause_after_gql_mutations.is_zero() {
+                None
+            } else {
+                Some(*pause_after_gql_mutations)
+            };
+            file.extract_bash_script_to(std::io::stdout(), sleep)?;
             Ok(0)
         }
 

--- a/linera-service/tests/readme_test.rs
+++ b/linera-service/tests/readme_test.rs
@@ -9,7 +9,12 @@ mod common;
 use std::{env, path::PathBuf};
 
 use common::INTEGRATION_TEST_GUARD;
-use linera_client::client_options::DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS;
+use linera_client::{
+    client_options::{
+        DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS, DEFAULT_PAUSE_AFTER_LINERA_SERVICE_SECS,
+    },
+    util::parse_secs,
+};
 use linera_service::{test_name, util::Markdown};
 use tempfile::tempdir;
 use tokio::process::Command;
@@ -35,8 +40,13 @@ async fn test_script_in_readme_with_storage_service(path: &str) -> std::io::Resu
     let tmp_dir = tempdir()?;
     let path = tmp_dir.path().join("test.sh");
     let mut script = fs_err::File::create(&path)?;
-    let duration = linera_client::util::parse_secs(DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS).unwrap();
-    file.extract_bash_script_to(&mut script, Some(duration))?;
+    let pause_after_linera_service = parse_secs(DEFAULT_PAUSE_AFTER_LINERA_SERVICE_SECS).unwrap();
+    let pause_after_gql_mutations = parse_secs(DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS).unwrap();
+    file.extract_bash_script_to(
+        &mut script,
+        Some(pause_after_linera_service),
+        Some(pause_after_gql_mutations),
+    )?;
 
     let mut command = Command::new("bash");
     command

--- a/linera-service/tests/readme_test.rs
+++ b/linera-service/tests/readme_test.rs
@@ -9,9 +9,10 @@ mod common;
 use std::{env, path::PathBuf};
 
 use common::INTEGRATION_TEST_GUARD;
+use linera_client::client_options::DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS;
 use linera_service::{test_name, util::Markdown};
 use tempfile::tempdir;
-use tokio::{process::Command, time::Duration};
+use tokio::process::Command;
 
 #[test_case::test_case(".." ; "main")]
 #[test_case::test_case("../examples/amm" ; "amm")]
@@ -34,7 +35,8 @@ async fn test_script_in_readme_with_storage_service(path: &str) -> std::io::Resu
     let tmp_dir = tempdir()?;
     let path = tmp_dir.path().join("test.sh");
     let mut script = fs_err::File::create(&path)?;
-    file.extract_bash_script_to(&mut script, Some(Duration::from_secs(3)))?;
+    let duration = linera_client::util::parse_secs(DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS).unwrap();
+    file.extract_bash_script_to(&mut script, Some(duration))?;
 
     let mut command = Command::new("bash");
     command


### PR DESCRIPTION
## Motivation

This was suggested by the community and team members also hacked a local solution at times.

fixes #1456

## Proposal

* Some light refactoring
* Add a command `linera extract-script-from-markdown`. The command is hidden because we may arbitrarily change or remove it in the future.

## Test Plan

CI
```
cargo build
target/debug/linera extract-script-from-markdown examples/fungible/README.md | bash
```

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
