### PR TITLE
Allow running a faucet from linera net up

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -903,6 +903,13 @@ Start a Local Linera Network
 * `--external-protocol <EXTERNAL_PROTOCOL>` — External protocol used, either grpc or grpcs
 
   Default value: `grpc`
+* `--with-faucet-chain <WITH_FAUCET_CHAIN>` — If present, a faucet is started using the given chain root nummber (0 for the admin chain, 1 for the first non-admin initial chain, etc)
+* `--faucet-port <FAUCET_PORT>` — The port on which to run the faucet server
+
+  Default value: `8080`
+* `--faucet-amount <FAUCET_AMOUNT>` — The number of tokens to send to each new chain created by the faucet
+
+  Default value: `1000`
 
 
 

--- a/CLI.md
+++ b/CLI.md
@@ -903,7 +903,7 @@ Start a Local Linera Network
 * `--external-protocol <EXTERNAL_PROTOCOL>` — External protocol used, either grpc or grpcs
 
   Default value: `grpc`
-* `--with-faucet-chain <WITH_FAUCET_CHAIN>` — If present, a faucet is started using the given chain root nummber (0 for the admin chain, 1 for the first non-admin initial chain, etc)
+* `--with-faucet-chain <WITH_FAUCET_CHAIN>` — If present, a faucet is started using the given chain root number (0 for the admin chain, 1 for the first non-admin initial chain, etc)
 * `--faucet-port <FAUCET_PORT>` — The port on which to run the faucet server
 
   Default value: `8080`

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -1054,7 +1054,7 @@ pub enum NetCommand {
         #[arg(long, default_value = "grpc")]
         external_protocol: String,
 
-        /// If present, a faucet is started using the given chain root nummber (0 for the
+        /// If present, a faucet is started using the given chain root number (0 for the
         /// admin chain, 1 for the first non-admin initial chain, etc).
         #[arg(long)]
         with_faucet_chain: Option<u32>,

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -712,7 +712,7 @@ pub enum ClientCommand {
         config: ChainListenerConfig,
 
         /// The port on which to run the server
-        #[arg(long = "port", default_value = "8080")]
+        #[arg(long, default_value = "8080")]
         port: NonZeroU16,
     },
 
@@ -723,11 +723,11 @@ pub enum ClientCommand {
         chain_id: Option<ChainId>,
 
         /// The port on which to run the server
-        #[arg(long = "port", default_value = "8080")]
+        #[arg(long, default_value = "8080")]
         port: NonZeroU16,
 
         /// The number of tokens to send to each new chain.
-        #[arg(long = "amount")]
+        #[arg(long)]
         amount: Amount,
 
         /// The end timestamp: The faucet will rate-limit the token supply so it runs out of money
@@ -980,6 +980,7 @@ impl DatabaseToolCommand {
     }
 }
 
+#[expect(clippy::large_enum_variant)]
 #[derive(Clone, clap::Parser)]
 pub enum NetCommand {
     /// Start a Local Linera Network
@@ -1052,6 +1053,19 @@ pub enum NetCommand {
         /// External protocol used, either grpc or grpcs.
         #[arg(long, default_value = "grpc")]
         external_protocol: String,
+
+        /// If present, a faucet is started using the given chain root nummber (0 for the
+        /// admin chain, 1 for the first non-admin initial chain, etc).
+        #[arg(long)]
+        with_faucet_chain: Option<u32>,
+
+        /// The port on which to run the faucet server
+        #[arg(long, default_value = "8080")]
+        faucet_port: NonZeroU16,
+
+        /// The number of tokens to send to each new chain created by the faucet.
+        #[arg(long, default_value = "1000")]
+        faucet_amount: Amount,
     },
 
     /// Print a bash helper script to make `linera net up` easier to use. The script is

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -980,7 +980,7 @@ impl DatabaseToolCommand {
     }
 }
 
-#[expect(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, clap::Parser)]
 pub enum NetCommand {
     /// Start a Local Linera Network

--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -35,7 +35,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 use linera_execution::ResourceControlPolicy;
 pub use wallet::{
-    ApplicationWrapper, ClientWrapper, Faucet, FaucetOption, NodeService, OnClientDrop,
+    ApplicationWrapper, ClientWrapper, Faucet, FaucetOption, FaucetService, NodeService,
+    OnClientDrop,
 };
 
 /// The information needed to start a Linera net of a particular kind.

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -1012,14 +1012,12 @@ impl Drop for ClientWrapper {
         let chain_ids = match self.find_owned_chains() {
             Ok(ids) => ids,
             Err(err) => {
-                warn!("Skipping closing chains because of error: {}", err);
+                warn!("Not closing chains because an error occurred: {}", err);
                 return;
             }
         };
-
         let binary_path = self.binary_path.lock().unwrap();
-        let binary_path = binary_path.as_ref().expect("Binary was used successfully");
-
+        let binary_path = binary_path.as_ref().expect("Binary was used before");
         let working_directory = self.path_provider.path();
 
         for chain_id in chain_ids {

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -32,7 +32,7 @@ use serde::{de::DeserializeOwned, ser::Serialize};
 use serde_json::{json, Value};
 use tempfile::TempDir;
 use tokio::process::{Child, Command};
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 
 use crate::{
     cli_wrappers::{
@@ -99,6 +99,53 @@ impl ClientWrapper {
             path_provider,
             on_drop,
         }
+    }
+
+    /// Runs `linera wallet show --short --owned` to find the list of chain ids in the
+    /// wallet. Not async to be usable in `Drop`.
+    pub fn find_owned_chains(&self) -> Result<Vec<String>> {
+        let binary_path = self.binary_path.lock().unwrap();
+
+        let Some(binary_path) = binary_path.as_ref() else {
+            bail!(
+                "The command binary was never resolved. \
+                 Make sure that the client has been used once before."
+            );
+        };
+
+        let working_directory = self.path_provider.path();
+        let mut wallet_show_command = std::process::Command::new(binary_path);
+
+        for argument in self.command_arguments() {
+            wallet_show_command.arg(&*argument);
+        }
+
+        let Ok(wallet_show_output) = wallet_show_command
+            .current_dir(working_directory)
+            .args(["wallet", "show", "--short", "--owned"])
+            .output()
+        else {
+            bail!("Failed to execute `wallet show --short` to list chains in the wallet");
+        };
+
+        if !wallet_show_output.status.success() {
+            bail!("Failed to list chains in the wallet");
+        }
+
+        let Ok(chain_list_string) = String::from_utf8(wallet_show_output.stdout) else {
+            bail!(
+                "Failed to list chains because `linera wallet show --short` \
+                returned a non-UTF-8 output"
+            );
+        };
+
+        let chain_ids = chain_list_string
+            .split('\n')
+            .map(|line| line.trim().to_string())
+            .filter(|line| !line.is_empty())
+            .collect();
+
+        Ok(chain_ids)
     }
 
     /// Runs `linera project new`.
@@ -958,61 +1005,25 @@ impl ClientWrapper {
 
 impl Drop for ClientWrapper {
     fn drop(&mut self) {
-        use std::process::Command as SyncCommand;
-
         if self.on_drop != OnClientDrop::CloseChains {
             return;
         }
 
-        let Ok(binary_path) = self.binary_path.lock() else {
-            error!("Failed to close chains because a thread panicked with a lock to `binary_path`");
-            return;
+        let chain_ids = match self.find_owned_chains() {
+            Ok(ids) => ids,
+            Err(err) => {
+                warn!("Skipping closing chains because of error: {}", err);
+                return;
+            }
         };
 
-        let Some(binary_path) = binary_path.as_ref() else {
-            warn!(
-                "Assuming no chains need to be closed, because the command binary was never \
-                resolved and therefore presumably never called"
-            );
-            return;
-        };
+        let binary_path = self.binary_path.lock().unwrap();
+        let binary_path = binary_path.as_ref().expect("Binary was used successfully");
 
         let working_directory = self.path_provider.path();
-        let mut wallet_show_command = SyncCommand::new(binary_path);
-
-        for argument in self.command_arguments() {
-            wallet_show_command.arg(&*argument);
-        }
-
-        let Ok(wallet_show_output) = wallet_show_command
-            .current_dir(working_directory)
-            .args(["wallet", "show", "--short", "--owned"])
-            .output()
-        else {
-            warn!("Failed to execute `wallet show --short` to list chains to close");
-            return;
-        };
-
-        if !wallet_show_output.status.success() {
-            warn!("Failed to list chains in the wallet to close them");
-            return;
-        }
-
-        let Ok(chain_list_string) = String::from_utf8(wallet_show_output.stdout) else {
-            warn!(
-                "Failed to close chains because `linera wallet show --short` \
-                returned a non-UTF-8 output"
-            );
-            return;
-        };
-
-        let chain_ids = chain_list_string
-            .split('\n')
-            .map(|line| line.trim())
-            .filter(|line| !line.is_empty());
 
         for chain_id in chain_ids {
-            let mut close_chain_command = SyncCommand::new(binary_path);
+            let mut close_chain_command = std::process::Command::new(binary_path);
 
             for argument in self.command_arguments() {
                 close_chain_command.arg(&*argument);
@@ -1020,7 +1031,10 @@ impl Drop for ClientWrapper {
 
             close_chain_command.current_dir(working_directory);
 
-            match close_chain_command.args(["close-chain", chain_id]).status() {
+            match close_chain_command
+                .args(["close-chain", &chain_id])
+                .status()
+            {
                 Ok(status) if status.success() => (),
                 Ok(failure) => warn!("Failed to close chain {chain_id}: {failure}"),
                 Err(error) => warn!("Failed to close chain {chain_id}: {error}"),

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1639,6 +1639,9 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                 path: _,
                 storage: _,
                 external_protocol: _,
+                with_faucet_chain,
+                faucet_port,
+                faucet_amount,
             } => {
                 net_up_utils::handle_net_up_kubernetes(
                     *extra_wallets,
@@ -1651,6 +1654,9 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                     *no_build,
                     docker_image_name.clone(),
                     policy_config.into_policy(),
+                    *with_faucet_chain,
+                    *faucet_port,
+                    *faucet_amount,
                 )
                 .boxed()
                 .await?;
@@ -1668,6 +1674,9 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                 path,
                 storage,
                 external_protocol,
+                with_faucet_chain,
+                faucet_port,
+                faucet_amount,
                 ..
             } => {
                 net_up_utils::handle_net_up_service(
@@ -1681,6 +1690,9 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                     path,
                     storage,
                     external_protocol.clone(),
+                    *with_faucet_chain,
+                    *faucet_port,
+                    *faucet_amount,
                 )
                 .boxed()
                 .await?;

--- a/linera-service/src/linera/net_up_utils.rs
+++ b/linera-service/src/linera/net_up_utils.rs
@@ -4,7 +4,7 @@
 use std::{num::NonZeroU16, str::FromStr};
 
 use colored::Colorize as _;
-use linera_base::{data_types::Amount, time::Duration};
+use linera_base::{data_types::Amount, identifiers::ChainId, time::Duration};
 use linera_client::storage::{StorageConfig, StorageConfigNamespace};
 use linera_execution::ResourceControlPolicy;
 use linera_service::{
@@ -320,16 +320,10 @@ async fn create_wallets_and_faucets(
 
     // Run the faucet,
     let faucet_service = if let Some(faucet_chain) = with_faucet_chain {
-        let chain_ids = client
-            .find_owned_chains()
-            .expect("Cannot retrieve chains from linera wallet");
-        let chain_id = chain_ids.get(faucet_chain as usize).expect(
-            "Was expecting a number `faucet_chain` in the range `0..=num_other_initial_chains`",
-        );
         let service = client
             .run_faucet(
                 Some(faucet_port.into()),
-                str::parse(chain_id)?,
+                ChainId::root(faucet_chain),
                 faucet_amount,
             )
             .await?;

--- a/linera-service/src/linera/net_up_utils.rs
+++ b/linera-service/src/linera/net_up_utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::str::FromStr;
+use std::{num::NonZeroU16, str::FromStr};
 
 use colored::Colorize as _;
 use linera_base::{data_types::Amount, time::Duration};
@@ -10,7 +10,8 @@ use linera_execution::ResourceControlPolicy;
 use linera_service::{
     cli_wrappers::{
         local_net::{Database, LocalNetConfig, PathProvider, StorageConfigBuilder},
-        ClientWrapper, FaucetOption, LineraNet, LineraNetConfig, Network, NetworkConfig,
+        ClientWrapper, FaucetOption, FaucetService, LineraNet, LineraNetConfig, Network,
+        NetworkConfig,
     },
     util::listen_for_shutdown_signals,
 };
@@ -113,6 +114,9 @@ pub async fn handle_net_up_kubernetes(
     no_build: bool,
     docker_image_name: String,
     policy: ResourceControlPolicy,
+    with_faucet_chain: Option<u32>,
+    faucet_port: NonZeroU16,
+    faucet_amount: Amount,
 ) -> anyhow::Result<()> {
     if num_initial_validators < 1 {
         panic!("The local test network must have at least one validator.");
@@ -136,9 +140,17 @@ pub async fn handle_net_up_kubernetes(
         docker_image_name,
         policy,
     };
-    let (mut net, client1) = config.instantiate().await?;
-    net_up(extra_wallets, &mut net, client1).await?;
-    wait_for_shutdown(shutdown_notifier, &mut net).await
+    let (mut net, client) = config.instantiate().await?;
+    let faucet_service = create_wallets_and_faucets(
+        extra_wallets,
+        &mut net,
+        client,
+        with_faucet_chain,
+        faucet_port,
+        faucet_amount,
+    )
+    .await?;
+    wait_for_shutdown(shutdown_notifier, &mut net, faucet_service).await
 }
 
 #[expect(clippy::too_many_arguments)]
@@ -153,6 +165,9 @@ pub async fn handle_net_up_service(
     path: &Option<String>,
     storage: &Option<String>,
     external_protocol: String,
+    with_faucet_chain: Option<u32>,
+    faucet_port: NonZeroU16,
+    faucet_amount: Amount,
 ) -> anyhow::Result<()> {
     if num_initial_validators < 1 {
         panic!("The local test network must have at least one validator.");
@@ -190,29 +205,46 @@ pub async fn handle_net_up_service(
         storage_config_builder,
         path_provider,
     };
-    let (mut net, client1) = config.instantiate().await?;
-    net_up(extra_wallets, &mut net, client1).await?;
-    wait_for_shutdown(shutdown_notifier, &mut net).await
+    let (mut net, client) = config.instantiate().await?;
+    let faucet_service = create_wallets_and_faucets(
+        extra_wallets,
+        &mut net,
+        client,
+        with_faucet_chain,
+        faucet_port,
+        faucet_amount,
+    )
+    .await?;
+    wait_for_shutdown(shutdown_notifier, &mut net, faucet_service).await
 }
 
 async fn wait_for_shutdown(
     shutdown_notifier: CancellationToken,
     net: &mut impl LineraNet,
+    faucet_service: Option<FaucetService>,
 ) -> anyhow::Result<()> {
     shutdown_notifier.cancelled().await;
-    eprintln!("\nTerminating the local test network");
+    eprintln!();
+    if let Some(service) = faucet_service {
+        eprintln!("Terminating the faucet service");
+        service.terminate().await?;
+    }
+    eprintln!("Terminating the local test network");
     net.terminate().await?;
-    eprintln!("\nDone.");
+    eprintln!("Done.");
 
     Ok(())
 }
 
-async fn net_up(
+async fn create_wallets_and_faucets(
     extra_wallets: Option<usize>,
     net: &mut impl LineraNet,
-    client1: ClientWrapper,
-) -> Result<(), anyhow::Error> {
-    let default_chain = client1
+    client: ClientWrapper,
+    with_faucet_chain: Option<u32>,
+    faucet_port: NonZeroU16,
+    faucet_amount: Amount,
+) -> Result<Option<FaucetService>, anyhow::Error> {
+    let default_chain = client
         .default_chain()
         .expect("Initialized clients should always have a default chain");
 
@@ -241,7 +273,7 @@ async fn net_up(
         "{}",
         format!(
             "export LINERA_WALLET{suffix}=\"{}\"",
-            client1.wallet_path().display()
+            client.wallet_path().display()
         )
         .bold()
     );
@@ -249,7 +281,7 @@ async fn net_up(
         "{}",
         format!(
             "export LINERA_STORAGE{suffix}=\"{}\"\n",
-            client1.storage_path()
+            client.storage_path()
         )
         .bold()
     );
@@ -260,7 +292,7 @@ async fn net_up(
             let extra_wallet = net.make_client().await;
             extra_wallet.wallet_init(&[], FaucetOption::None).await?;
             let unassigned_key = extra_wallet.keygen().await?;
-            let new_chain_msg_id = client1
+            let new_chain_msg_id = client
                 .open_chain(default_chain, Some(unassigned_key), Amount::ZERO)
                 .await?
                 .0;
@@ -286,9 +318,29 @@ async fn net_up(
         }
     }
 
+    // Run the faucet,
+    let faucet_service = if let Some(faucet_chain) = with_faucet_chain {
+        let chain_ids = client
+            .find_owned_chains()
+            .expect("Cannot retrieve chains from linera wallet");
+        let chain_id = chain_ids.get(faucet_chain as usize).expect(
+            "Was expecting a number `faucet_chain` in the range `0..=num_other_initial_chains`",
+        );
+        let service = client
+            .run_faucet(
+                Some(faucet_port.into()),
+                str::parse(chain_id)?,
+                faucet_amount,
+            )
+            .await?;
+        Some(service)
+    } else {
+        None
+    };
+
     eprintln!(
         "\nREADY!\nPress ^C to terminate the local test network and clean the temporary directory."
     );
 
-    Ok(())
+    Ok(faucet_service)
 }


### PR DESCRIPTION
## Motivation

First step in addressing #2890

## Proposal

* Make a function of `find_owned_chains` out of the code in `ClientWrapper::drop()`
* Add an option `--with-faucet-chain N` to `linera net up` as well as `--faucet-port` and `--faucet-amount`
* Add a simple test

The only caveat is that `N` cannot be a chain-id (since we wouldn't know what to write) so we use the index amongst root chains (typically 1 for the first non-admin initial chain).

## Test Plan

CI