### PR TITLE
Rename DownloadBlobContent → DownloadBlob

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -106,7 +106,7 @@ pub trait ValidatorNode {
     // certificate using this blob.
     async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError>;
 
-    async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError>;
+    async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError>;
 
     async fn download_certificate(
         &self,

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -242,7 +242,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
 
     #[instrument(level = "trace")]
     async fn try_download_blob(&self, blob_id: BlobId) -> Option<Blob> {
-        match self.node.download_blob_content(blob_id).await {
+        match self.node.download_blob(blob_id).await {
             Ok(blob) => {
                 let blob = Blob::new(blob);
                 if blob.id() != blob_id {

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -184,11 +184,9 @@ where
             .await
     }
 
-    async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
-        self.spawn_and_receive(move |validator, sender| {
-            validator.do_download_blob_content(blob_id, sender)
-        })
-        .await
+    async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
+        self.spawn_and_receive(move |validator, sender| validator.do_download_blob(blob_id, sender))
+            .await
     }
 
     async fn download_certificate(
@@ -477,7 +475,7 @@ where
         sender.send(result)
     }
 
-    async fn do_download_blob_content(
+    async fn do_download_blob(
         self,
         blob_id: BlobId,
         sender: oneshot::Sender<Result<BlobContent, NodeError>>,

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -62,7 +62,7 @@ service ValidatorNode {
   rpc GetGenesisConfigHash(google.protobuf.Empty) returns (CryptoHash);
 
   // Downloads a blob content.
-  rpc DownloadBlobContent(BlobId) returns (BlobContent);
+  rpc DownloadBlob(BlobId) returns (BlobContent);
 
   // Uploads a blob content. Returns an error if the validator has not seen a
   // certificate using this blob.

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -181,12 +181,12 @@ impl ValidatorNode for Client {
         })
     }
 
-    async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
+    async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
         Ok(match self {
-            Client::Grpc(grpc_client) => grpc_client.download_blob_content(blob_id).await?,
+            Client::Grpc(grpc_client) => grpc_client.download_blob(blob_id).await?,
 
             #[cfg(with_simple_network)]
-            Client::Simple(simple_client) => simple_client.download_blob_content(blob_id).await?,
+            Client::Simple(simple_client) => simple_client.download_blob(blob_id).await?,
         })
     }
 

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -354,9 +354,9 @@ impl ValidatorNode for GrpcClient {
     }
 
     #[instrument(target = "grpc_client", skip(self), err, fields(address = self.address))]
-    async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
+    async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
         let req = api::BlobId::try_from(blob_id)?;
-        Ok(client_delegate!(self, download_blob_content, req)?.try_into()?)
+        Ok(client_delegate!(self, download_blob, req)?.try_into()?)
     }
 
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -34,7 +34,7 @@ pub enum RpcMessage {
     LiteCertificate(Box<HandleLiteCertRequest<'static>>),
     ChainInfoQuery(Box<ChainInfoQuery>),
     UploadBlob(Box<BlobContent>),
-    DownloadBlobContent(Box<BlobId>),
+    DownloadBlob(Box<BlobId>),
     DownloadConfirmedBlock(Box<CryptoHash>),
     DownloadCertificates(Vec<CryptoHash>),
     BlobLastUsedBy(Box<BlobId>),
@@ -49,7 +49,7 @@ pub enum RpcMessage {
     VersionInfoResponse(Box<VersionInfo>),
     GenesisConfigHashResponse(Box<CryptoHash>),
     UploadBlobResponse(Box<BlobId>),
-    DownloadBlobContentResponse(Box<BlobContent>),
+    DownloadBlobResponse(Box<BlobContent>),
     DownloadConfirmedBlockResponse(Box<ConfirmedBlock>),
     DownloadCertificatesResponse(Vec<ConfirmedBlockCertificate>),
     BlobLastUsedByResponse(Box<CryptoHash>),
@@ -83,8 +83,8 @@ impl RpcMessage {
             | GenesisConfigHashResponse(_)
             | UploadBlob(_)
             | UploadBlobResponse(_)
-            | DownloadBlobContent(_)
-            | DownloadBlobContentResponse(_)
+            | DownloadBlob(_)
+            | DownloadBlobResponse(_)
             | DownloadConfirmedBlock(_)
             | DownloadConfirmedBlockResponse(_)
             | DownloadCertificates(_)
@@ -109,7 +109,7 @@ impl RpcMessage {
             VersionInfoQuery
             | GenesisConfigHashQuery
             | UploadBlob(_)
-            | DownloadBlobContent(_)
+            | DownloadBlob(_)
             | DownloadConfirmedBlock(_)
             | BlobLastUsedBy(_)
             | MissingBlobIds(_)
@@ -127,7 +127,7 @@ impl RpcMessage {
             | VersionInfoResponse(_)
             | GenesisConfigHashResponse(_)
             | UploadBlobResponse(_)
-            | DownloadBlobContentResponse(_)
+            | DownloadBlobResponse(_)
             | DownloadConfirmedBlockResponse(_)
             | BlobLastUsedByResponse(_)
             | MissingBlobIdsResponse(_)
@@ -162,7 +162,7 @@ impl TryFrom<RpcMessage> for BlobContent {
     type Error = NodeError;
     fn try_from(message: RpcMessage) -> Result<Self, Self::Error> {
         match message {
-            RpcMessage::DownloadBlobContentResponse(blob) => Ok(*blob),
+            RpcMessage::DownloadBlobResponse(blob) => Ok(*blob),
             RpcMessage::Error(error) => Err(*error),
             _ => Err(NodeError::UnexpectedMessage),
         }

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -166,8 +166,8 @@ impl ValidatorNode for SimpleClient {
         self.query(RpcMessage::UploadBlob(Box::new(content))).await
     }
 
-    async fn download_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
-        self.query(RpcMessage::DownloadBlobContent(Box::new(blob_id)))
+    async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
+        self.query(RpcMessage::DownloadBlob(Box::new(blob_id)))
             .await
     }
 

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -350,8 +350,8 @@ where
             | RpcMessage::VersionInfoResponse(_)
             | RpcMessage::GenesisConfigHashQuery
             | RpcMessage::GenesisConfigHashResponse(_)
-            | RpcMessage::DownloadBlobContent(_)
-            | RpcMessage::DownloadBlobContentResponse(_)
+            | RpcMessage::DownloadBlob(_)
+            | RpcMessage::DownloadBlobResponse(_)
             | RpcMessage::DownloadConfirmedBlock(_)
             | RpcMessage::DownloadConfirmedBlockResponse(_)
             | RpcMessage::BlobLastUsedBy(_)

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -802,7 +802,7 @@ RpcMessage:
         NEWTYPE:
           TYPENAME: BlobContent
     7:
-      DownloadBlobContent:
+      DownloadBlob:
         NEWTYPE:
           TYPENAME: BlobId
     8:
@@ -852,7 +852,7 @@ RpcMessage:
         NEWTYPE:
           TYPENAME: BlobId
     20:
-      DownloadBlobContentResponse:
+      DownloadBlobResponse:
         NEWTYPE:
           TYPENAME: BlobContent
     21:

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -488,7 +488,7 @@ where
     }
 
     #[instrument(skip_all, err(Display))]
-    async fn download_blob_content(
+    async fn download_blob(
         &self,
         request: Request<BlobId>,
     ) -> Result<Response<BlobContent>, Status> {

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -309,11 +309,9 @@ where
                 );
                 Ok(Some(RpcMessage::UploadBlobResponse(Box::new(id))))
             }
-            DownloadBlobContent(blob_id) => {
+            DownloadBlob(blob_id) => {
                 let content = self.storage.read_blob(*blob_id).await?.into_content();
-                Ok(Some(RpcMessage::DownloadBlobContentResponse(Box::new(
-                    content,
-                ))))
+                Ok(Some(RpcMessage::DownloadBlobResponse(Box::new(content))))
             }
             DownloadConfirmedBlock(hash) => {
                 Ok(Some(RpcMessage::DownloadConfirmedBlockResponse(Box::new(
@@ -345,7 +343,7 @@ where
             | ChainInfoResponse(_)
             | VersionInfoResponse(_)
             | GenesisConfigHashResponse(_)
-            | DownloadBlobContentResponse(_)
+            | DownloadBlobResponse(_)
             | BlobLastUsedByResponse(_)
             | MissingBlobIdsResponse(_)
             | DownloadConfirmedBlockResponse(_)

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -100,7 +100,7 @@ impl ValidatorNode for DummyValidatorNode {
         Err(NodeError::UnexpectedMessage)
     }
 
-    async fn download_blob_content(&self, _: BlobId) -> Result<BlobContent, NodeError> {
+    async fn download_blob(&self, _: BlobId) -> Result<BlobContent, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 


### PR DESCRIPTION
## Motivation

When I addressed https://github.com/linera-io/linera-protocol/pull/3108#discussion_r1909026114, I only renamed `UploadBlobContent` to `UploadBlob`. `DownloadBlobContent` has a name inconsistent with that now.

## Proposal

Rename `DownloadBlobContent` to `DownloadBlob`.

## Test Plan

(Only renaming.)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Original discussion: https://github.com/linera-io/linera-protocol/pull/3108#discussion_r1909026114
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
