### PR TITLE
Fetch locked blobs individually, not in `ChainManagerInfo`.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1092,7 +1092,7 @@ impl Blob {
         self.content.into_bytes()
     }
 
-    /// Loads data blob content from a file.
+    /// Loads data blob from a file.
     pub async fn load_data_blob_from_file(path: impl AsRef<Path>) -> io::Result<Self> {
         Ok(Self::new_data(fs::read(path)?))
     }

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -624,9 +624,6 @@ pub struct ChainManagerInfo {
     /// The timestamp when the current round times out.
     #[debug(skip_if = Option::is_none)]
     pub round_timeout: Option<Timestamp>,
-    /// These are blobs belonging to the locked block.
-    #[debug(skip_if = Vec::is_empty)]
-    pub locked_blobs: Vec<Blob>,
 }
 
 impl From<&ChainManager> for ChainManagerInfo {
@@ -650,7 +647,6 @@ impl From<&ChainManager> for ChainManagerInfo {
             current_round,
             leader: manager.round_leader(current_round).cloned(),
             round_timeout: manager.round_timeout,
-            locked_blobs: Vec::new(),
         }
     }
 }
@@ -660,7 +656,6 @@ impl ChainManagerInfo {
     pub fn add_values(&mut self, manager: &ChainManager) {
         self.requested_proposed = manager.proposed.clone().map(Box::new);
         self.requested_locked = manager.locked.clone().map(Box::new);
-        self.locked_blobs = manager.locked_blobs.values().cloned().collect();
         self.requested_confirmed = manager
             .confirmed_vote
             .as_ref()

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -14,7 +14,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Blob, BlockHeight, Timestamp, UserApplicationDescription},
     hashed::Hashed,
-    identifiers::{ChainId, UserApplicationId},
+    identifiers::{BlobId, ChainId, UserApplicationId},
 };
 use linera_chain::{
     data_types::{Block, BlockProposal, ExecutedBlock, MessageBundle, Origin, Target},
@@ -140,6 +140,13 @@ where
         query: ChainInfoQuery,
         #[debug(skip)]
         callback: oneshot::Sender<Result<(ChainInfoResponse, NetworkActions), WorkerError>>,
+    },
+
+    /// Get a blob if it belongs to the current locked block or pending proposal.
+    DownloadPendingBlob {
+        blob_id: BlobId,
+        #[debug(skip)]
+        callback: oneshot::Sender<Result<Blob, WorkerError>>,
     },
 
     /// Update the received certificate trackers to at least the given values.
@@ -329,6 +336,9 @@ where
                     .is_ok(),
                 ChainWorkerRequest::HandleChainInfoQuery { query, callback } => callback
                     .send(self.worker.handle_chain_info_query(query).await)
+                    .is_ok(),
+                ChainWorkerRequest::DownloadPendingBlob { blob_id, callback } => callback
+                    .send(self.worker.download_pending_blob(blob_id).await)
                     .is_ok(),
                 ChainWorkerRequest::UpdateReceivedCertificateTrackers {
                     new_trackers,

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -106,8 +106,10 @@ pub trait ValidatorNode {
     // certificate using this blob.
     async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError>;
 
+    /// Downloads a blob. Returns an error if the validator does not have the blob.
     async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError>;
 
+    /// Downloads a blob that belongs to a pending proposal or the locked block on a chain.
     async fn download_pending_blob(
         &self,
         chain_id: ChainId,

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -102,11 +102,17 @@ pub trait ValidatorNode {
     /// Subscribes to receiving notifications for a collection of chains.
     async fn subscribe(&self, chains: Vec<ChainId>) -> Result<Self::NotificationStream, NodeError>;
 
-    // Uploads a blob content. Returns an error if the validator has not seen a
+    // Uploads a blob. Returns an error if the validator has not seen a
     // certificate using this blob.
     async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError>;
 
     async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError>;
+
+    async fn download_pending_blob(
+        &self,
+        chain_id: ChainId,
+        blob_id: BlobId,
+    ) -> Result<BlobContent, NodeError>;
 
     async fn download_certificate(
         &self,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -925,6 +925,32 @@ where
 
     #[instrument(skip_all, fields(
         nick = self.nickname,
+        chain_id = format!("{:.8}", chain_id)
+    ))]
+    pub async fn download_pending_blob(
+        &self,
+        chain_id: ChainId,
+        blob_id: BlobId,
+    ) -> Result<Blob, WorkerError> {
+        trace!(
+            "{} <-- download_pending_blob({chain_id:8}, {blob_id:8})",
+            self.nickname
+        );
+        let result = self
+            .query_chain_worker(chain_id, move |callback| {
+                ChainWorkerRequest::DownloadPendingBlob { blob_id, callback }
+            })
+            .await;
+        trace!(
+            "{} --> {:?}",
+            self.nickname,
+            result.as_ref().map(|_| blob_id)
+        );
+        result
+    }
+
+    #[instrument(skip_all, fields(
+        nick = self.nickname,
         chain_id = format!("{:.8}", request.target_chain_id())
     ))]
     pub async fn handle_cross_chain_request(

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -618,7 +618,7 @@ pub trait BaseRuntime {
     /// owner, not a super owner.
     fn assert_before(&mut self, timestamp: Timestamp) -> Result<(), ExecutionError>;
 
-    /// Reads a data blob content specified by a given hash.
+    /// Reads a data blob specified by a given hash.
     fn read_data_blob(&mut self, hash: &CryptoHash) -> Result<Vec<u8>, ExecutionError>;
 
     /// Asserts the existence of a data blob with the given hash.

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -31,6 +31,9 @@ service ValidatorWorker {
   // Handle information queries for this chain.
   rpc HandleChainInfoQuery(ChainInfoQuery) returns (ChainInfoResult);
 
+  // Download a blob that belongs to a pending block on the given chain.
+  rpc DownloadPendingBlob(PendingBlobRequest) returns (PendingBlobResult);
+
   // Handle a (trusted!) cross-chain request.
   rpc HandleCrossChainRequest(CrossChainRequest) returns (google.protobuf.Empty);
 }
@@ -61,23 +64,26 @@ service ValidatorNode {
   // Request the genesis configuration hash of the network this node is part of.
   rpc GetGenesisConfigHash(google.protobuf.Empty) returns (CryptoHash);
 
-  // Downloads a blob content.
+  // Download a blob.
   rpc DownloadBlob(BlobId) returns (BlobContent);
 
-  // Uploads a blob content. Returns an error if the validator has not seen a
+  // Download a blob that belongs to a pending block on the given chain.
+  rpc DownloadPendingBlob(PendingBlobRequest) returns (PendingBlobResult);
+
+  // Upload a blob. Returns an error if the validator has not seen a
   // certificate using this blob.
   rpc UploadBlob(BlobContent) returns (BlobId);
 
-  // Downloads a certificate.
+  // Download a certificate.
   rpc DownloadCertificate(CryptoHash) returns (Certificate);
 
-  // Downloads a batch of certificates.
+  // Download a batch of certificates.
   rpc DownloadCertificates(CertificatesBatchRequest) returns (CertificatesBatchResponse);
 
-  // Returns the hash of the `Certificate` that last used a blob.
+  // Return the hash of the `Certificate` that last used a blob.
   rpc BlobLastUsedBy(BlobId) returns (CryptoHash);
 
-  // Returns the `BlobId`s that are not contained as `Blob`.
+  // Return the `BlobId`s that are not contained as `Blob`.
   rpc MissingBlobIds(BlobIds) returns (BlobIds);
 }
 
@@ -261,6 +267,21 @@ message HandleConfirmedCertificateRequest {
   // Wait until all outgoing cross-chain messages from this certificate have
   // been received by the target chains.
   bool wait_for_outgoing_messages = 3;
+}
+
+// A request for a pending blob.
+message PendingBlobRequest {
+  ChainId chain_id = 1;
+  BlobId blob_id = 2;
+}
+
+// A requested pending blob, or an error.
+message PendingBlobResult {
+  oneof inner {
+    BlobContent blob = 1;
+    // a bincode wrapper around `NodeError`
+    bytes error = 2;
+  }
 }
 
 // A certified statement from the committee.

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -190,6 +190,25 @@ impl ValidatorNode for Client {
         })
     }
 
+    async fn download_pending_blob(
+        &self,
+        chain_id: ChainId,
+        blob_id: BlobId,
+    ) -> Result<BlobContent, NodeError> {
+        Ok(match self {
+            Client::Grpc(grpc_client) => {
+                grpc_client.download_pending_blob(chain_id, blob_id).await?
+            }
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => {
+                simple_client
+                    .download_pending_blob(chain_id, blob_id)
+                    .await?
+            }
+        })
+    }
+
     async fn download_certificate(
         &self,
         hash: CryptoHash,

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -32,10 +32,7 @@ use {
 };
 
 use super::{
-    api::{
-        self, chain_info_result::Inner, validator_node_client::ValidatorNodeClient,
-        SubscriptionRequest,
-    },
+    api::{self, validator_node_client::ValidatorNodeClient, SubscriptionRequest},
     transport, GRPC_MAX_MESSAGE_SIZE,
 };
 use crate::{
@@ -146,22 +143,40 @@ impl GrpcClient {
     fn try_into_chain_info(
         result: api::ChainInfoResult,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
-        let inner = result.inner.ok_or(NodeError::GrpcError {
+        let inner = result.inner.ok_or_else(|| NodeError::GrpcError {
             error: "missing body from response".to_string(),
         })?;
         match inner {
-            Inner::ChainInfoResponse(response) => {
+            api::chain_info_result::Inner::ChainInfoResponse(response) => {
                 Ok(response.try_into().map_err(|err| NodeError::GrpcError {
                     error: format!("failed to unmarshal response: {}", err),
                 })?)
             }
-            Inner::Error(error) => {
-                Err(
-                    bincode::deserialize(&error).map_err(|err| NodeError::GrpcError {
-                        error: format!("failed to unmarshal error message: {}", err),
-                    })?,
-                )
+            api::chain_info_result::Inner::Error(error) => Err(bincode::deserialize(&error)
+                .map_err(|err| NodeError::GrpcError {
+                    error: format!("failed to unmarshal error message: {}", err),
+                })?),
+        }
+    }
+}
+
+impl TryFrom<api::PendingBlobResult> for BlobContent {
+    type Error = NodeError;
+
+    fn try_from(result: api::PendingBlobResult) -> Result<Self, Self::Error> {
+        let inner = result.inner.ok_or_else(|| NodeError::GrpcError {
+            error: "missing body from response".to_string(),
+        })?;
+        match inner {
+            api::pending_blob_result::Inner::Blob(blob) => {
+                Ok(blob.try_into().map_err(|err| NodeError::GrpcError {
+                    error: format!("failed to unmarshal response: {}", err),
+                })?)
             }
+            api::pending_blob_result::Inner::Error(error) => Err(bincode::deserialize(&error)
+                .map_err(|err| NodeError::GrpcError {
+                    error: format!("failed to unmarshal error message: {}", err),
+                })?),
         }
     }
 }
@@ -359,6 +374,16 @@ impl ValidatorNode for GrpcClient {
         Ok(client_delegate!(self, download_blob, req)?.try_into()?)
     }
 
+    #[instrument(target = "grpc_client", skip(self), err, fields(address = self.address))]
+    async fn download_pending_blob(
+        &self,
+        chain_id: ChainId,
+        blob_id: BlobId,
+    ) -> Result<BlobContent, NodeError> {
+        let req = api::PendingBlobRequest::try_from((chain_id, blob_id))?;
+        client_delegate!(self, download_pending_blob, req)?.try_into()
+    }
+
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
     async fn download_certificate(
         &self,
@@ -459,12 +484,12 @@ impl mass_client::MassClient for GrpcClient {
                         .inner
                         .ok_or(GrpcProtoConversionError::MissingField)?
                     {
-                        Inner::ChainInfoResponse(chain_info_response) => {
+                        api::chain_info_result::Inner::ChainInfoResponse(chain_info_response) => {
                             Ok(Some(RpcMessage::ChainInfoResponse(Box::new(
                                 chain_info_response.try_into()?,
                             ))))
                         }
-                        Inner::Error(error) => {
+                        api::chain_info_result::Inner::Error(error) => {
                             let error = bincode::deserialize::<NodeError>(&error)
                                 .map_err(GrpcProtoConversionError::BincodeError)?;
                             tracing::error!(?error, "received error response");

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -43,6 +43,7 @@ use super::{
         validator_worker_client::ValidatorWorkerClient,
         validator_worker_server::{ValidatorWorker as ValidatorWorkerRpc, ValidatorWorkerServer},
         BlockProposal, ChainInfoQuery, ChainInfoResult, CrossChainRequest, LiteCertificate,
+        PendingBlobRequest, PendingBlobResult,
     },
     pool::GrpcConnectionPool,
     GrpcError, GRPC_MAX_MESSAGE_SIZE,
@@ -694,6 +695,45 @@ where
             chain_id = ?request.get_ref().chain_id()
         )
     )]
+    async fn download_pending_blob(
+        &self,
+        request: Request<PendingBlobRequest>,
+    ) -> Result<Response<PendingBlobResult>, Status> {
+        let start = Instant::now();
+        let (chain_id, blob_id) = request.into_inner().try_into()?;
+        trace!(?chain_id, ?blob_id, "Download pending blob");
+        match self
+            .state
+            .clone()
+            .download_pending_blob(chain_id, blob_id)
+            .await
+        {
+            Ok(blob) => {
+                Self::log_request_success_and_latency(start, "download_pending_blob");
+                Ok(Response::new(blob.into_content().try_into()?))
+            }
+            Err(error) => {
+                #[cfg(with_metrics)]
+                {
+                    SERVER_REQUEST_ERROR
+                        .with_label_values(&["download_pending_blob"])
+                        .inc();
+                }
+                error!(nickname = self.state.nickname(), %error, "Failed to download pending blob");
+                Ok(Response::new(NodeError::from(error).try_into()?))
+            }
+        }
+    }
+
+    #[instrument(
+        target = "grpc_server",
+        skip_all,
+        err,
+        fields(
+            nickname = self.state.nickname(),
+            chain_id = ?request.get_ref().chain_id()
+        )
+    )]
     async fn handle_cross_chain_request(
         &self,
         request: Request<CrossChainRequest>,
@@ -757,6 +797,12 @@ impl GrpcProxyable for api::HandleValidatedCertificateRequest {
 }
 
 impl GrpcProxyable for ChainInfoQuery {
+    fn chain_id(&self) -> Option<ChainId> {
+        self.chain_id.clone()?.try_into().ok()
+    }
+}
+
+impl GrpcProxyable for PendingBlobRequest {
     fn chain_id(&self) -> Option<ChainId> {
         self.chain_id.clone()?.try_into().ok()
     }

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -35,6 +35,7 @@ pub enum RpcMessage {
     ChainInfoQuery(Box<ChainInfoQuery>),
     UploadBlob(Box<BlobContent>),
     DownloadBlob(Box<BlobId>),
+    DownloadPendingBlob(Box<(ChainId, BlobId)>),
     DownloadConfirmedBlock(Box<CryptoHash>),
     DownloadCertificates(Vec<CryptoHash>),
     BlobLastUsedBy(Box<BlobId>),
@@ -50,6 +51,7 @@ pub enum RpcMessage {
     GenesisConfigHashResponse(Box<CryptoHash>),
     UploadBlobResponse(Box<BlobId>),
     DownloadBlobResponse(Box<BlobContent>),
+    DownloadPendingBlobResponse(Box<BlobContent>),
     DownloadConfirmedBlockResponse(Box<ConfirmedBlock>),
     DownloadCertificatesResponse(Vec<ConfirmedBlockCertificate>),
     BlobLastUsedByResponse(Box<CryptoHash>),
@@ -74,6 +76,7 @@ impl RpcMessage {
             ConfirmedCertificate(request) => request.certificate.inner().chain_id(),
             ChainInfoQuery(query) => query.chain_id,
             CrossChainRequest(request) => request.target_chain_id(),
+            DownloadPendingBlob(request) => request.0,
             Vote(_)
             | Error(_)
             | ChainInfoResponse(_)
@@ -85,6 +88,7 @@ impl RpcMessage {
             | UploadBlobResponse(_)
             | DownloadBlob(_)
             | DownloadBlobResponse(_)
+            | DownloadPendingBlobResponse(_)
             | DownloadConfirmedBlock(_)
             | DownloadConfirmedBlockResponse(_)
             | DownloadCertificates(_)
@@ -127,6 +131,8 @@ impl RpcMessage {
             | VersionInfoResponse(_)
             | GenesisConfigHashResponse(_)
             | UploadBlobResponse(_)
+            | DownloadPendingBlob(_)
+            | DownloadPendingBlobResponse(_)
             | DownloadBlobResponse(_)
             | DownloadConfirmedBlockResponse(_)
             | BlobLastUsedByResponse(_)
@@ -162,7 +168,8 @@ impl TryFrom<RpcMessage> for BlobContent {
     type Error = NodeError;
     fn try_from(message: RpcMessage) -> Result<Self, Self::Error> {
         match message {
-            RpcMessage::DownloadBlobResponse(blob) => Ok(*blob),
+            RpcMessage::DownloadBlobResponse(blob)
+            | RpcMessage::DownloadPendingBlobResponse(blob) => Ok(*blob),
             RpcMessage::Error(error) => Err(*error),
             _ => Err(NodeError::UnexpectedMessage),
         }

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -171,6 +171,17 @@ impl ValidatorNode for SimpleClient {
             .await
     }
 
+    async fn download_pending_blob(
+        &self,
+        chain_id: ChainId,
+        blob_id: BlobId,
+    ) -> Result<BlobContent, NodeError> {
+        self.query(RpcMessage::DownloadPendingBlob(Box::new((
+            chain_id, blob_id,
+        ))))
+        .await
+    }
+
     async fn download_certificate(
         &self,
         hash: CryptoHash,

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -339,6 +339,24 @@ where
                 // No user to respond to.
                 Ok(None)
             }
+            RpcMessage::DownloadPendingBlob(request) => {
+                let (chain_id, blob_id) = *request;
+                match self
+                    .server
+                    .state
+                    .download_pending_blob(chain_id, blob_id)
+                    .await
+                {
+                    Ok(blob) => Ok(Some(RpcMessage::DownloadPendingBlobResponse(Box::new(
+                        blob.into(),
+                    )))),
+                    Err(error) => {
+                        let nickname = self.server.state.nickname();
+                        error!(nickname, %error, "Failed to handle pending blob request");
+                        Err(error.into())
+                    }
+                }
+            }
 
             RpcMessage::VersionInfoQuery => {
                 Ok(Some(RpcMessage::VersionInfoResponse(Box::default())))
@@ -352,6 +370,7 @@ where
             | RpcMessage::GenesisConfigHashResponse(_)
             | RpcMessage::DownloadBlob(_)
             | RpcMessage::DownloadBlobResponse(_)
+            | RpcMessage::DownloadPendingBlobResponse(_)
             | RpcMessage::DownloadConfirmedBlock(_)
             | RpcMessage::DownloadConfirmedBlockResponse(_)
             | RpcMessage::BlobLastUsedBy(_)

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -285,9 +285,6 @@ ChainManagerInfo:
     - round_timeout:
         OPTION:
           TYPENAME: Timestamp
-    - locked_blobs:
-        SEQ:
-          TYPENAME: BlobContent
 ChainOwnership:
   STRUCT:
     - super_owners:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -806,74 +806,84 @@ RpcMessage:
         NEWTYPE:
           TYPENAME: BlobId
     8:
+      DownloadPendingBlob:
+        NEWTYPE:
+          TUPLE:
+            - TYPENAME: ChainId
+            - TYPENAME: BlobId
+    9:
       DownloadConfirmedBlock:
         NEWTYPE:
           TYPENAME: CryptoHash
-    9:
+    10:
       DownloadCertificates:
         NEWTYPE:
           SEQ:
             TYPENAME: CryptoHash
-    10:
+    11:
       BlobLastUsedBy:
         NEWTYPE:
           TYPENAME: BlobId
-    11:
+    12:
       MissingBlobIds:
         NEWTYPE:
           SEQ:
             TYPENAME: BlobId
-    12:
-      VersionInfoQuery: UNIT
     13:
-      GenesisConfigHashQuery: UNIT
+      VersionInfoQuery: UNIT
     14:
+      GenesisConfigHashQuery: UNIT
+    15:
       Vote:
         NEWTYPE:
           TYPENAME: LiteVote
-    15:
+    16:
       ChainInfoResponse:
         NEWTYPE:
           TYPENAME: ChainInfoResponse
-    16:
+    17:
       Error:
         NEWTYPE:
           TYPENAME: NodeError
-    17:
+    18:
       VersionInfoResponse:
         NEWTYPE:
           TYPENAME: VersionInfo
-    18:
+    19:
       GenesisConfigHashResponse:
         NEWTYPE:
           TYPENAME: CryptoHash
-    19:
+    20:
       UploadBlobResponse:
         NEWTYPE:
           TYPENAME: BlobId
-    20:
+    21:
       DownloadBlobResponse:
         NEWTYPE:
           TYPENAME: BlobContent
-    21:
+    22:
+      DownloadPendingBlobResponse:
+        NEWTYPE:
+          TYPENAME: BlobContent
+    23:
       DownloadConfirmedBlockResponse:
         NEWTYPE:
           TYPENAME: ExecutedBlock
-    22:
+    24:
       DownloadCertificatesResponse:
         NEWTYPE:
           SEQ:
             TYPENAME: ConfirmedBlockCertificate
-    23:
+    25:
       BlobLastUsedByResponse:
         NEWTYPE:
           TYPENAME: CryptoHash
-    24:
+    26:
       MissingBlobIdsResponse:
         NEWTYPE:
           SEQ:
             TYPENAME: BlobId
-    25:
+    27:
       CrossChainRequest:
         NEWTYPE:
           TYPENAME: CrossChainRequest

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -509,6 +509,7 @@ where
         request: Request<PendingBlobRequest>,
     ) -> Result<Response<PendingBlobResult>, Status> {
         let (mut client, inner) = self.worker_client(request).await?;
+        #[cfg_attr(not(with_metrics), expect(clippy::needless_match))]
         match client.download_pending_blob(inner).await {
             Ok(blob_result) => {
                 #[cfg(with_metrics)]

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -344,6 +344,8 @@ where
             | VersionInfoResponse(_)
             | GenesisConfigHashResponse(_)
             | DownloadBlobResponse(_)
+            | DownloadPendingBlob(_)
+            | DownloadPendingBlobResponse(_)
             | BlobLastUsedByResponse(_)
             | MissingBlobIdsResponse(_)
             | DownloadConfirmedBlockResponse(_)

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -84,6 +84,10 @@ impl ValidatorNode for DummyValidatorNode {
         Err(NodeError::UnexpectedMessage)
     }
 
+    async fn download_pending_blob(&self, _: ChainId, _: BlobId) -> Result<BlobContent, NodeError> {
+        Err(NodeError::UnexpectedMessage)
+    }
+
     async fn subscribe(&self, _: Vec<ChainId>) -> Result<NotificationStream, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }


### PR DESCRIPTION
## Motivation

Ultimately we want to transfer all blobs separately, rather than in a single message. (https://github.com/linera-io/linera-protocol/issues/3048)

This PR is one step towards that goal: When the client fetches the locked block from a validator, it now requests the corresponding blobs one by one, rather than all at once.

## Proposal

Add a `DownloadPendingBlob` endpoint; remove the locked blobs from the `ChainManagerInfo`.

## Test Plan

Existing tests exercise this scenario, e.g. `test_finalize_locked_block_with_blobs`. 

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Part of #3048.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
