### PR TITLE
Implement Witty traits for slices

### DIFF
--- a/linera-witty/src/type_traits/implementations/std/mod.rs
+++ b/linera-witty/src/type_traits/implementations/std/mod.rs
@@ -96,6 +96,7 @@ mod phantom_data;
 mod primitives;
 mod rc;
 mod result;
+mod slices;
 mod string;
 mod sync;
 mod time;

--- a/linera-witty/src/type_traits/implementations/std/primitives.rs
+++ b/linera-witty/src/type_traits/implementations/std/primitives.rs
@@ -98,7 +98,7 @@ where
 
 impl<'t, T> WitStore for &'t T
 where
-    T: WitStore,
+    T: WitStore + ?Sized,
 {
     fn store<Instance>(
         &self,

--- a/linera-witty/src/type_traits/implementations/std/primitives.rs
+++ b/linera-witty/src/type_traits/implementations/std/primitives.rs
@@ -80,19 +80,19 @@ impl WitStore for bool {
 
 impl<'t, T> WitType for &'t T
 where
-    T: WitType,
+    T: WitType + ?Sized,
 {
     const SIZE: u32 = T::SIZE;
 
     type Layout = T::Layout;
-    type Dependencies = HList![];
+    type Dependencies = T::Dependencies;
 
     fn wit_type_name() -> Cow<'static, str> {
-        panic!("Borrowed values can't be used in WIT files generated with Witty");
+        T::wit_type_name()
     }
 
     fn wit_type_declaration() -> Cow<'static, str> {
-        panic!("Borrowed values can't be used in WIT files generated with Witty");
+        T::wit_type_declaration()
     }
 }
 

--- a/linera-witty/src/type_traits/implementations/std/slices.rs
+++ b/linera-witty/src/type_traits/implementations/std/slices.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementations of the custom traits for slice types.
+
+use std::borrow::Cow;
+
+use frunk::HList;
+
+use crate::WitType;
+
+impl<T> WitType for [T]
+where
+    T: WitType,
+{
+    const SIZE: u32 = 8;
+
+    type Layout = HList![i32, i32];
+    type Dependencies = HList![T];
+
+    fn wit_type_name() -> Cow<'static, str> {
+        format!("list<{}>", T::wit_type_name()).into()
+    }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        // The native `list` type doesn't need to be declared
+        "".into()
+    }
+}

--- a/linera-witty/src/type_traits/implementations/std/slices.rs
+++ b/linera-witty/src/type_traits/implementations/std/slices.rs
@@ -77,3 +77,21 @@ where
         Ok(destination.lower(memory)? + hlist![length as i32])
     }
 }
+
+impl<T> WitType for Box<[T]>
+where
+    T: WitType,
+{
+    const SIZE: u32 = <[T] as WitType>::SIZE;
+
+    type Layout = <[T] as WitType>::Layout;
+    type Dependencies = <[T] as WitType>::Dependencies;
+
+    fn wit_type_name() -> Cow<'static, str> {
+        <[T] as WitType>::wit_type_name()
+    }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        <[T] as WitType>::wit_type_declaration()
+    }
+}

--- a/linera-witty/src/type_traits/implementations/std/slices.rs
+++ b/linera-witty/src/type_traits/implementations/std/slices.rs
@@ -3,7 +3,7 @@
 
 //! Implementations of the custom traits for slice types.
 
-use std::borrow::Cow;
+use std::{borrow::Cow, ops::Deref};
 
 use frunk::{hlist, hlist_pat, HList};
 
@@ -130,5 +130,33 @@ where
         (0..length)
             .map(|index| T::load(memory, address.index::<T>(index)))
             .collect()
+    }
+}
+
+impl<T> WitStore for Box<[T]>
+where
+    T: WitStore,
+{
+    fn store<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<(), RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        self.deref().store(memory, location)
+    }
+
+    fn lower<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+    ) -> Result<Self::Layout, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        self.deref().lower(memory)
     }
 }

--- a/linera-witty/src/type_traits/implementations/std/slices.rs
+++ b/linera-witty/src/type_traits/implementations/std/slices.rs
@@ -12,6 +12,20 @@ use crate::{
     WitLoad, WitStore, WitType,
 };
 
+/// A macro to implement [`WitType`], [`WitLoad`] and [`WitStore`] for a slice wrapper type.
+///
+/// This assumes that:
+/// - The type is `$wrapper<[T]>`
+/// - The type implements `From<Box<[T]>>`
+/// - The type implements `Deref<Target = [T]>`
+macro_rules! impl_wit_traits_for_slice_wrapper {
+    ($wrapper:ident) => {
+        impl_wit_type_as_slice!($wrapper);
+        impl_wit_store_as_slice!($wrapper);
+        impl_wit_load_as_boxed_slice!($wrapper);
+    };
+}
+
 /// A macro to implement [`WitType`] for a slice wrapper type.
 ///
 /// This assumes that:
@@ -217,6 +231,4 @@ where
     }
 }
 
-impl_wit_type_as_slice!(Rc);
-impl_wit_store_as_slice!(Rc);
-impl_wit_load_as_boxed_slice!(Rc);
+impl_wit_traits_for_slice_wrapper!(Rc);

--- a/linera-witty/src/type_traits/implementations/std/slices.rs
+++ b/linera-witty/src/type_traits/implementations/std/slices.rs
@@ -3,7 +3,7 @@
 
 //! Implementations of the custom traits for slice types.
 
-use std::{borrow::Cow, ops::Deref, rc::Rc};
+use std::{borrow::Cow, ops::Deref, rc::Rc, sync::Arc};
 
 use frunk::{hlist, hlist_pat, HList};
 
@@ -232,3 +232,4 @@ where
 }
 
 impl_wit_traits_for_slice_wrapper!(Rc);
+impl_wit_traits_for_slice_wrapper!(Arc);

--- a/linera-witty/src/type_traits/implementations/std/slices.rs
+++ b/linera-witty/src/type_traits/implementations/std/slices.rs
@@ -157,6 +157,9 @@ where
         Instance: InstanceWithMemory,
         <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
     {
+        // There's no need to account for padding between the elements, because the element's size
+        // is always aligned:
+        // https://github.com/WebAssembly/component-model/blob/cbdd15d9033446558571824af52a78022aaa3f58/design/mvp/CanonicalABI.md#element-size
         let length = u32::try_from(self.len())?;
         let size = length * T::SIZE;
 
@@ -178,6 +181,9 @@ where
         Instance: InstanceWithMemory,
         <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
     {
+        // There's no need to account for padding between the elements, because the element's size
+        // is always aligned:
+        // https://github.com/WebAssembly/component-model/blob/cbdd15d9033446558571824af52a78022aaa3f58/design/mvp/CanonicalABI.md#element-size
         let length = u32::try_from(self.len())?;
         let size = length * T::SIZE;
 

--- a/linera-witty/src/type_traits/implementations/std/vec.rs
+++ b/linera-witty/src/type_traits/implementations/std/vec.rs
@@ -3,9 +3,7 @@
 
 //! Implementations of the custom traits for the [`Vec`] type.
 
-use std::borrow::Cow;
-
-use frunk::{hlist, hlist_pat, HList};
+use std::{borrow::Cow, ops::Deref};
 
 use crate::{
     GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
@@ -16,18 +14,17 @@ impl<T> WitType for Vec<T>
 where
     T: WitType,
 {
-    const SIZE: u32 = 8;
+    const SIZE: u32 = <[T] as WitType>::SIZE;
 
-    type Layout = HList![i32, i32];
-    type Dependencies = HList![T];
+    type Layout = <[T] as WitType>::Layout;
+    type Dependencies = <[T] as WitType>::Dependencies;
 
     fn wit_type_name() -> Cow<'static, str> {
-        format!("list<{}>", T::wit_type_name()).into()
+        <[T] as WitType>::wit_type_name()
     }
 
     fn wit_type_declaration() -> Cow<'static, str> {
-        // The native `list` type doesn't need to be declared
-        "".into()
+        <[T] as WitType>::wit_type_declaration()
     }
 }
 
@@ -43,28 +40,18 @@ where
         Instance: InstanceWithMemory,
         <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
     {
-        let address = GuestPointer::load(memory, location)?;
-        let length = u32::load(memory, location.after::<GuestPointer>())?;
-
-        (0..length)
-            .map(|index| T::load(memory, address.index::<T>(index)))
-            .collect()
+        Box::load(memory, location).map(Vec::from)
     }
 
     fn lift_from<Instance>(
-        hlist_pat![address, length]: <Self::Layout as Layout>::Flat,
+        flat_layout: <Self::Layout as Layout>::Flat,
         memory: &Memory<'_, Instance>,
     ) -> Result<Self, RuntimeError>
     where
         Instance: InstanceWithMemory,
         <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
     {
-        let address = GuestPointer(address.try_into()?);
-        let length = length as u32;
-
-        (0..length)
-            .map(|index| T::load(memory, address.index::<T>(index)))
-            .collect()
+        Box::lift_from(flat_layout, memory).map(Vec::from)
     }
 }
 
@@ -81,17 +68,7 @@ where
         Instance: InstanceWithMemory,
         <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
     {
-        let length = u32::try_from(self.len())?;
-        let size = length * T::SIZE;
-
-        let destination = memory.allocate(size, <T::Layout as Layout>::ALIGNMENT)?;
-
-        destination.store(memory, location)?;
-        length.store(memory, location.after::<GuestPointer>())?;
-
-        self.iter()
-            .zip(0..)
-            .try_for_each(|(element, index)| element.store(memory, destination.index::<T>(index)))
+        self.deref().store(memory, location)
     }
 
     fn lower<Instance>(
@@ -102,15 +79,6 @@ where
         Instance: InstanceWithMemory,
         <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
     {
-        let length = u32::try_from(self.len())?;
-        let size = length * T::SIZE;
-
-        let destination = memory.allocate(size, <T::Layout as Layout>::ALIGNMENT)?;
-
-        self.iter().zip(0..).try_for_each(|(element, index)| {
-            element.store(memory, destination.index::<T>(index))
-        })?;
-
-        Ok(destination.lower(memory)? + hlist![length as i32])
+        self.deref().lower(memory)
     }
 }

--- a/linera-witty/src/type_traits/mod.rs
+++ b/linera-witty/src/type_traits/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// A type that is representable by fundamental WIT types.
-pub trait WitType: Sized {
+pub trait WitType {
     /// The size of the type when laid out in memory.
     const SIZE: u32;
 
@@ -32,7 +32,7 @@ pub trait WitType: Sized {
 }
 
 /// A type that can be loaded from a guest Wasm module.
-pub trait WitLoad: WitType {
+pub trait WitLoad: WitType + Sized {
     /// Loads an instance of the type from the `location` in the guest's `memory`.
     fn load<Instance>(
         memory: &Memory<'_, Instance>,

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -85,3 +85,7 @@ pub struct StructWithLists {
     pub vec: Vec<SimpleWrapper>,
     pub second_vec: Vec<TupleWithPadding>,
 }
+
+/// A type that wraps a slice.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitStore)]
+pub struct SliceWrapper<'slice>(pub &'slice [TupleWithoutPadding]);

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -84,6 +84,7 @@ pub struct StructWithHeapFields {
 pub struct StructWithLists {
     pub vec: Vec<SimpleWrapper>,
     pub boxed_slice: Box<[TupleWithPadding]>,
+    pub rced_slice: Rc<[Leaf]>,
 }
 
 /// A type that wraps a slice.

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -85,6 +85,7 @@ pub struct StructWithLists {
     pub vec: Vec<SimpleWrapper>,
     pub boxed_slice: Box<[TupleWithPadding]>,
     pub rced_slice: Rc<[Leaf]>,
+    pub arced_slice: Arc<[RecordWithDoublePadding]>,
 }
 
 /// A type that wraps a slice.

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -83,7 +83,7 @@ pub struct StructWithHeapFields {
 #[derive(Clone, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
 pub struct StructWithLists {
     pub vec: Vec<SimpleWrapper>,
-    pub second_vec: Vec<TupleWithPadding>,
+    pub boxed_slice: Box<[TupleWithPadding]>,
 }
 
 /// A type that wraps a slice.

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -430,6 +430,51 @@ fn test_rced_slice() {
     test_lift_from_flat_layout(hlist![0_i32, 3_i32], expected, &memory[8..]);
 }
 
+/// Checks that an arc-ed slice type is properly loaded from memory and lifted from its flat
+/// layout.
+#[test]
+fn test_arced_slice() {
+    let expected: Arc<[RecordWithDoublePadding]> = Arc::new([
+        RecordWithDoublePadding {
+            first: 0x0908,
+            second: 0x0f0e_0d0c,
+            third: 0x10,
+            fourth: 0x1f1e_1d1c_1b1a_1918,
+        },
+        RecordWithDoublePadding {
+            first: 0x2120,
+            second: 0x2726_2524,
+            third: 0x28,
+            fourth: 0x3736_3534_3332_3130,
+        },
+    ]);
+
+    let memory = iter::empty()
+        .chain([8, 0, 0, 0, 2, 0, 0, 0])
+        .chain(
+            iter::empty()
+                .chain([0x08, 0x09])
+                .chain(10..12)
+                .chain([0x0c, 0x0d, 0x0e, 0x0f])
+                .chain([0x10])
+                .chain(17..24)
+                .chain([0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f]),
+        )
+        .chain(
+            iter::empty()
+                .chain([0x20, 0x21])
+                .chain(34..36)
+                .chain([0x24, 0x25, 0x26, 0x27])
+                .chain([0x28])
+                .chain(41..48)
+                .chain([0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37]),
+        )
+        .collect::<Vec<u8>>();
+
+    test_load_from_memory(&memory, expected.clone());
+    test_lift_from_flat_layout(hlist![0_i32, 2_i32], expected, &memory[8..]);
+}
+
 /// Checks that a type with list fields is properly loaded from memory and lifted from its
 /// flat layout.
 #[test]

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -391,6 +391,45 @@ fn test_boxed_slice() {
     test_lift_from_flat_layout(hlist![0_i32, 2_i32], expected, &memory[8..]);
 }
 
+/// Checks that an rc-ed slice type is properly loaded from memory and lifted from its flat
+/// layout.
+#[test]
+fn test_rced_slice() {
+    let expected: Rc<[Leaf]> = Rc::new([
+        Leaf {
+            first: false,
+            second: 0x1716_1514_1312_1110_0f0e_0d0c_0b0a_0908,
+        },
+        Leaf {
+            first: true,
+            second: 0x2f2e_2d2c_2b2a_2928_2726_2524_2322_2120,
+        },
+        Leaf {
+            first: false,
+            second: 0x4746_4544_4342_4140_3f3e_3d3c_3b3a_3938,
+        },
+    ]);
+
+    let memory = iter::empty()
+        .chain([8, 0, 0, 0, 3, 0, 0, 0])
+        .chain(iter::empty().chain([0]).chain(1..8).chain([
+            0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+            0x16, 0x17,
+        ]))
+        .chain(iter::empty().chain([1]).chain(25..32).chain([
+            0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d,
+            0x2e, 0x2f,
+        ]))
+        .chain(iter::empty().chain([0]).chain(49..56).chain([
+            0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45,
+            0x46, 0x47,
+        ]))
+        .collect::<Vec<u8>>();
+
+    test_load_from_memory(&memory, expected.clone());
+    test_lift_from_flat_layout(hlist![0_i32, 3_i32], expected, &memory[8..]);
+}
+
 /// Checks that a type with list fields is properly loaded from memory and lifted from its
 /// flat layout.
 #[test]

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -486,83 +486,120 @@ fn test_list_fields() {
             SimpleWrapper(false),
         ],
         boxed_slice: Box::new([
-            TupleWithPadding(0x2120, 0x2726_2524, 0x2f2e_2d2c_2b2a_2928),
-            TupleWithPadding(0x3130, 0x3736_3534, 0x3f3e_3d3c_3b3a_3938),
+            TupleWithPadding(0x2928, 0x2f2e_2d2c, 0x3736_3534_3332_3130),
+            TupleWithPadding(0x3938, 0x3f3e_3d3c, 0x4746_4544_4342_4140),
         ]),
         rced_slice: Rc::new([
             Leaf {
                 first: true,
-                second: 0x5756_5554_5352_5150_4f4e_4d4c_4b4a_4948,
+                second: 0x5f5e_5d5c_5b5a_5958_5756_5554_5352_5150,
             },
             Leaf {
                 first: true,
-                second: 0x6f6e_6d6c_6b6a_6968_6766_6564_6362_6160,
+                second: 0x7776_7574_7372_7170_6f6e_6d6c_6b6a_6968,
             },
             Leaf {
                 first: false,
-                second: 0x8786_8584_8382_8180_7f7e_7d7c_7b7a_7978,
+                second: 0x8f8e_8d8c_8b8a_8988_8786_8584_8382_8180,
             },
             Leaf {
                 first: false,
-                second: 0x9f9e_9d9c_9b9a_9998_9796_9594_9392_9190,
+                second: 0xa7a6_a5a4_a3a2_a1a0_9f9e_9d9c_9b9a_9998,
+            },
+        ]),
+        arced_slice: Arc::new([
+            RecordWithDoublePadding {
+                first: 0xa9a8,
+                second: 0xafae_adac,
+                third: 0xb0_u8 as i8,
+                fourth: 0xbfbe_bdbc_bbba_b9b8_u64 as i64,
+            },
+            RecordWithDoublePadding {
+                first: 0xc1c0,
+                second: 0xc7c6_c5c4,
+                third: 0xc8_u8 as i8,
+                fourth: 0xd7d6_d5d4_d3d2_d1d0_u64 as i64,
             },
         ]),
     };
 
-    let vec_metadata = [24, 0, 0, 0, 3, 0, 0, 0];
+    let vec_metadata = [32, 0, 0, 0, 3, 0, 0, 0];
     let vec_contents = [1, 1, 0];
 
-    let boxed_metadata = [32, 0, 0, 0, 2, 0, 0, 0];
+    let boxed_metadata = [40, 0, 0, 0, 2, 0, 0, 0];
     let boxed_contents = iter::empty()
         .chain(
             iter::empty()
-                .chain([0x20, 0x21])
-                .chain(34..36)
-                .chain([0x24, 0x25, 0x26, 0x27])
-                .chain([0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f]),
+                .chain([0x28, 0x29])
+                .chain(42..44)
+                .chain([0x2c, 0x2d, 0x2e, 0x2f])
+                .chain([0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37]),
         )
         .chain(
             iter::empty()
-                .chain([0x30, 0x31])
-                .chain(50..52)
-                .chain([0x34, 0x35, 0x36, 0x37])
-                .chain([0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f]),
+                .chain([0x38, 0x39])
+                .chain(58..60)
+                .chain([0x3c, 0x3d, 0x3e, 0x3f])
+                .chain([0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47]),
         );
 
-    let rced_metadata = [64, 0, 0, 0, 4, 0, 0, 0];
+    let rced_metadata = [72, 0, 0, 0, 4, 0, 0, 0];
     let rced_contents = iter::empty()
-        .chain(iter::empty().chain([1]).chain(65..72).chain([
-            0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55,
-            0x56, 0x57,
+        .chain(iter::empty().chain([1]).chain(73..80).chain([
+            0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d,
+            0x5e, 0x5f,
         ]))
-        .chain(iter::empty().chain([1]).chain(89..96).chain([
-            0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d,
-            0x6e, 0x6f,
+        .chain(iter::empty().chain([1]).chain(97..104).chain([
+            0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75,
+            0x76, 0x77,
         ]))
-        .chain(iter::empty().chain([0]).chain(113..120).chain([
-            0x78, 0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f, 0x80, 0x81, 0x82, 0x83, 0x84, 0x85,
-            0x86, 0x87,
+        .chain(iter::empty().chain([0]).chain(121..128).chain([
+            0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d,
+            0x8e, 0x8f,
         ]))
-        .chain(iter::empty().chain([0]).chain(137..144).chain([
-            0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9a, 0x9b, 0x9c, 0x9d,
-            0x9e, 0x9f,
+        .chain(iter::empty().chain([0]).chain(145..152).chain([
+            0x98, 0x99, 0x9a, 0x9b, 0x9c, 0x9d, 0x9e, 0x9f, 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5,
+            0xa6, 0xa7,
         ]));
+
+    let arced_metadata = [168, 0, 0, 0, 2, 0, 0, 0];
+    let arced_contents = iter::empty()
+        .chain(
+            iter::empty()
+                .chain([0xa8, 0xa9])
+                .chain(170..172)
+                .chain([0xac, 0xad, 0xae, 0xaf])
+                .chain([0xb0])
+                .chain(177..184)
+                .chain([0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf]),
+        )
+        .chain(
+            iter::empty()
+                .chain([0xc0, 0xc1])
+                .chain(194..196)
+                .chain([0xc4, 0xc5, 0xc6, 0xc7])
+                .chain([0xc8])
+                .chain(201..208)
+                .chain([0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7]),
+        );
 
     let memory = iter::empty()
         .chain(vec_metadata)
         .chain(boxed_metadata)
         .chain(rced_metadata)
+        .chain(arced_metadata)
         .chain(vec_contents)
-        .chain(27..32)
+        .chain(35..40)
         .chain(boxed_contents)
         .chain(rced_contents)
+        .chain(arced_contents)
         .collect::<Vec<u8>>();
 
     test_load_from_memory(&memory, expected.clone());
     test_lift_from_flat_layout(
-        hlist![0_i32, 3_i32, 8_i32, 2_i32, 40_i32, 4_i32],
+        hlist![0_i32, 3_i32, 8_i32, 2_i32, 40_i32, 4_i32, 136_i32, 2_i32],
         expected,
-        &memory[24..],
+        &memory[32..],
     );
 }
 

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -441,41 +441,84 @@ fn test_list_fields() {
             SimpleWrapper(false),
         ],
         boxed_slice: Box::new([
-            TupleWithPadding(0x1918, 0x1f1e_1d1c, 0x2726_2524_2322_2120),
-            TupleWithPadding(0x2928, 0x2f2e_2d2c, 0x3736_3534_3332_3130),
+            TupleWithPadding(0x2120, 0x2726_2524, 0x2f2e_2d2c_2b2a_2928),
+            TupleWithPadding(0x3130, 0x3736_3534, 0x3f3e_3d3c_3b3a_3938),
+        ]),
+        rced_slice: Rc::new([
+            Leaf {
+                first: true,
+                second: 0x5756_5554_5352_5150_4f4e_4d4c_4b4a_4948,
+            },
+            Leaf {
+                first: true,
+                second: 0x6f6e_6d6c_6b6a_6968_6766_6564_6362_6160,
+            },
+            Leaf {
+                first: false,
+                second: 0x8786_8584_8382_8180_7f7e_7d7c_7b7a_7978,
+            },
+            Leaf {
+                first: false,
+                second: 0x9f9e_9d9c_9b9a_9998_9796_9594_9392_9190,
+            },
         ]),
     };
 
-    let vec_metadata = [16, 0, 0, 0, 3, 0, 0, 0];
+    let vec_metadata = [24, 0, 0, 0, 3, 0, 0, 0];
     let vec_contents = [1, 1, 0];
 
-    let boxed_metadata = [24, 0, 0, 0, 2, 0, 0, 0];
+    let boxed_metadata = [32, 0, 0, 0, 2, 0, 0, 0];
     let boxed_contents = iter::empty()
         .chain(
             iter::empty()
-                .chain([0x18, 0x19])
-                .chain(26..28)
-                .chain([0x1c, 0x1d, 0x1e, 0x1f])
-                .chain([0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27]),
+                .chain([0x20, 0x21])
+                .chain(34..36)
+                .chain([0x24, 0x25, 0x26, 0x27])
+                .chain([0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f]),
         )
         .chain(
             iter::empty()
-                .chain([0x28, 0x29])
-                .chain(42..44)
-                .chain([0x2c, 0x2d, 0x2e, 0x2f])
-                .chain([0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37]),
+                .chain([0x30, 0x31])
+                .chain(50..52)
+                .chain([0x34, 0x35, 0x36, 0x37])
+                .chain([0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f]),
         );
+
+    let rced_metadata = [64, 0, 0, 0, 4, 0, 0, 0];
+    let rced_contents = iter::empty()
+        .chain(iter::empty().chain([1]).chain(65..72).chain([
+            0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55,
+            0x56, 0x57,
+        ]))
+        .chain(iter::empty().chain([1]).chain(89..96).chain([
+            0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d,
+            0x6e, 0x6f,
+        ]))
+        .chain(iter::empty().chain([0]).chain(113..120).chain([
+            0x78, 0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f, 0x80, 0x81, 0x82, 0x83, 0x84, 0x85,
+            0x86, 0x87,
+        ]))
+        .chain(iter::empty().chain([0]).chain(137..144).chain([
+            0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9a, 0x9b, 0x9c, 0x9d,
+            0x9e, 0x9f,
+        ]));
 
     let memory = iter::empty()
         .chain(vec_metadata)
         .chain(boxed_metadata)
+        .chain(rced_metadata)
         .chain(vec_contents)
-        .chain(19..24)
+        .chain(27..32)
         .chain(boxed_contents)
+        .chain(rced_contents)
         .collect::<Vec<u8>>();
 
     test_load_from_memory(&memory, expected.clone());
-    test_lift_from_flat_layout(hlist![0_i32, 3_i32, 8_i32, 2_i32], expected, &memory[16..]);
+    test_lift_from_flat_layout(
+        hlist![0_i32, 3_i32, 8_i32, 2_i32, 40_i32, 4_i32],
+        expected,
+        &memory[24..],
+    );
 }
 
 /// Tests that the type `T` and wrapped versions of it can be loaded from an `input` sequence of

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -428,6 +428,39 @@ fn test_vec() {
     test_lower_to_flat_layout(data, hlist![0_i32, 3_i32,], &[1, 0, 1]);
 }
 
+/// Check that a boxed slice type is properly stored in memory and lowered into its flat layout.
+#[test]
+fn test_boxed_slice() {
+    let data: Box<[Enum]> = Box::new([
+        Enum::LargeVariantWithLooseAlignment(10, 20, 30, 40, 50, 60, 70, 80, 90, 100),
+        Enum::Empty,
+        Enum::Empty,
+        Enum::SmallerVariantWithStrictAlignment { inner: 0xFFFF_FFFF },
+    ]);
+
+    let heap_memory = iter::empty()
+        .chain(
+            iter::empty()
+                .chain([1])
+                .chain([0; 7])
+                .chain([10, 20, 30, 40, 50, 60, 70, 80, 90, 100])
+                .chain([0; 6]),
+        )
+        .chain(iter::empty().chain([0]).chain([0; 23]))
+        .chain(iter::empty().chain([0]).chain([0; 23]))
+        .chain(
+            iter::empty()
+                .chain([2])
+                .chain([0; 7])
+                .chain([0xff, 0xff, 0xff, 0xff])
+                .chain([0; 12]),
+        )
+        .collect::<Vec<u8>>();
+
+    test_store_in_memory(data.clone(), &[8, 0, 0, 0, 4, 0, 0, 0], &heap_memory);
+    test_lower_to_flat_layout(data, hlist![0_i32, 4_i32,], &heap_memory);
+}
+
 /// Check that a type with a slice field is properly stored in memory and lowered into its
 /// flat layout.
 #[test]

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -461,6 +461,35 @@ fn test_boxed_slice() {
     test_lower_to_flat_layout(data, hlist![0_i32, 4_i32,], &heap_memory);
 }
 
+/// Check that a rc-ed slice type is properly stored in memory and lowered into its flat layout.
+#[test]
+fn test_rced_slice() {
+    let data: Rc<[Leaf]> = Rc::new([
+        Leaf {
+            first: true,
+            second: 0x0011_2233_4455_6677_8899_aabb_ccdd_eeff,
+        },
+        Leaf {
+            first: false,
+            second: 0xffee_ddcc_bbaa_9988_7766_5544_3322_1100,
+        },
+    ]);
+
+    let heap_memory = iter::empty()
+        .chain(iter::empty().chain([1]).chain([0; 7]).chain([
+            0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22,
+            0x11, 0x00,
+        ]))
+        .chain(iter::empty().chain([0]).chain([0; 7]).chain([
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+            0xee, 0xff,
+        ]))
+        .collect::<Vec<u8>>();
+
+    test_store_in_memory(data.clone(), &[8, 0, 0, 0, 2, 0, 0, 0], &heap_memory);
+    test_lower_to_flat_layout(data, hlist![0_i32, 2_i32,], &heap_memory);
+}
+
 /// Check that a type with a slice field is properly stored in memory and lowered into its
 /// flat layout.
 #[test]

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -511,16 +511,31 @@ fn test_list_fields() {
             SimpleWrapper(false),
             SimpleWrapper(true),
         ],
-        second_vec: vec![TupleWithPadding(1, 0, -1), TupleWithPadding(10, 11, 12)],
+        boxed_slice: Box::new([TupleWithPadding(1, 0, -1), TupleWithPadding(10, 11, 12)]),
     };
 
-    let expected_heap = [0, 1, 0, 1]
-        .into_iter()
+    let vec_contents = [0, 1, 0, 1];
+
+    let boxed_contents = iter::empty()
+        .chain(
+            iter::empty()
+                .chain([1, 0])
+                .chain([0; 2])
+                .chain([0, 0, 0, 0])
+                .chain([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+        )
+        .chain(
+            iter::empty()
+                .chain([10, 0])
+                .chain([0; 2])
+                .chain([11, 0, 0, 0])
+                .chain([12, 0, 0, 0, 0, 0, 0, 0]),
+        );
+
+    let expected_heap = iter::empty()
+        .chain(vec_contents)
         .chain([0; 4])
-        .chain([
-            1, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-        ])
-        .chain([10, 0, 0, 0, 11, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0])
+        .chain(boxed_contents)
         .collect::<Vec<_>>();
 
     test_store_in_memory(

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -401,6 +401,20 @@ fn test_heap_allocated_fields() {
     );
 }
 
+/// Check that a slice type is properly stored in memory and lowered into its flat layout.
+#[test]
+fn test_slice() {
+    let data = [
+        SimpleWrapper(false),
+        SimpleWrapper(false),
+        SimpleWrapper(true),
+        SimpleWrapper(true),
+    ];
+
+    test_store_in_memory(data.as_slice(), &[8, 0, 0, 0, 4, 0, 0, 0], &[0, 0, 1, 1]);
+    test_lower_to_flat_layout(data.as_slice(), hlist![0_i32, 4_i32,], &[0, 0, 1, 1]);
+}
+
 /// Checks that a [`Vec`] type is properly stored in memory and lowered into its flat layout.
 #[test]
 fn test_vec() {

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -6,14 +6,14 @@
 #[path = "common/types.rs"]
 mod types;
 
-use std::{fmt::Debug, rc::Rc, sync::Arc};
+use std::{fmt::Debug, iter, rc::Rc, sync::Arc};
 
 use linera_witty::{hlist, InstanceWithMemory, Layout, MockInstance, WitStore};
 
 use self::types::{
-    Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, SpecializedGenericEnum,
-    SpecializedGenericStruct, StructWithHeapFields, StructWithLists, TupleWithPadding,
-    TupleWithoutPadding,
+    Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, SliceWrapper,
+    SpecializedGenericEnum, SpecializedGenericStruct, StructWithHeapFields, StructWithLists,
+    TupleWithPadding, TupleWithoutPadding,
 };
 
 /// Checks that a wrapper type is properly stored in memory and lowered into its flat layout.
@@ -426,6 +426,45 @@ fn test_vec() {
 
     test_store_in_memory(data.clone(), &[8, 0, 0, 0, 3, 0, 0, 0], &[1, 0, 1]);
     test_lower_to_flat_layout(data, hlist![0_i32, 3_i32,], &[1, 0, 1]);
+}
+
+/// Check that a type with a slice field is properly stored in memory and lowered into its
+/// flat layout.
+#[test]
+fn test_slice_field() {
+    let slice = [
+        TupleWithoutPadding(0, 1, 2),
+        TupleWithoutPadding(3, 4, 5),
+        TupleWithoutPadding(6, 7, 8),
+    ];
+    let data = SliceWrapper(&slice);
+
+    let expected_memory = iter::empty()
+        .chain(
+            iter::empty()
+                .chain([0, 0, 0, 0, 0, 0, 0, 0])
+                .chain([1, 0, 0, 0])
+                .chain([2, 0])
+                .chain([0; 2]),
+        )
+        .chain(
+            iter::empty()
+                .chain([3, 0, 0, 0, 0, 0, 0, 0])
+                .chain([4, 0, 0, 0])
+                .chain([5, 0])
+                .chain([0; 2]),
+        )
+        .chain(
+            iter::empty()
+                .chain([6, 0, 0, 0, 0, 0, 0, 0])
+                .chain([7, 0, 0, 0])
+                .chain([8, 0])
+                .chain([0; 2]),
+        )
+        .collect::<Vec<u8>>();
+
+    test_store_in_memory(data, &[8, 0, 0, 0, 3, 0, 0, 0], &expected_memory);
+    test_lower_to_flat_layout(data, hlist![0_i32, 3_i32], &expected_memory);
 }
 
 /// Checks that a type with list fields is properly stored in memory and lowered into its

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -598,6 +598,20 @@ fn test_list_fields() {
                 second: 0xf0e1_d2c3_b4a5_9687_7869_5a4b_3c2d_1e0f,
             },
         ]),
+        arced_slice: Arc::new([
+            RecordWithDoublePadding {
+                first: 0x1020,
+                second: 0x0a0b_0c0d,
+                third: 0x7a,
+                fourth: -0x0abb_ccdd_eeff_0011,
+            },
+            RecordWithDoublePadding {
+                first: 0x1525,
+                second: 0x8191_a1b1,
+                third: -0x7a,
+                fourth: 0x0abb_ccdd_eeff_0011,
+            },
+        ]),
     };
 
     let vec_contents = [0, 1, 0, 1];
@@ -632,23 +646,45 @@ fn test_list_fields() {
             0xe1, 0xf0,
         ]));
 
+    let arced_contents = iter::empty()
+        .chain(
+            iter::empty()
+                .chain([0x20, 0x10])
+                .chain([0; 2])
+                .chain([0x0d, 0x0c, 0x0b, 0x0a])
+                .chain([0x7a])
+                .chain([0; 7])
+                .chain([0xef, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0xf5]),
+        )
+        .chain(
+            iter::empty()
+                .chain([0x25, 0x15])
+                .chain([0; 2])
+                .chain([0xb1, 0xa1, 0x91, 0x81])
+                .chain([0x86])
+                .chain([0; 7])
+                .chain([0x11, 0x00, 0xff, 0xee, 0xdd, 0xcc, 0xbb, 0x0a]),
+        );
+
     let expected_heap = iter::empty()
         .chain(vec_contents)
         .chain([0; 4])
         .chain(boxed_contents)
         .chain(rced_contents)
+        .chain(arced_contents)
         .collect::<Vec<_>>();
 
     test_store_in_memory(
         data.clone(),
         &[
-            24, 0, 0, 0, 4, 0, 0, 0, 32, 0, 0, 0, 2, 0, 0, 0, 64, 0, 0, 0, 3, 0, 0, 0,
+            32, 0, 0, 0, 4, 0, 0, 0, 40, 0, 0, 0, 2, 0, 0, 0, 72, 0, 0, 0, 3, 0, 0, 0, 144, 0, 0,
+            0, 2, 0, 0, 0,
         ],
         &expected_heap,
     );
     test_lower_to_flat_layout(
         data,
-        hlist![0_i32, 4_i32, 8_i32, 2_i32, 40_i32, 3_i32],
+        hlist![0_i32, 4_i32, 8_i32, 2_i32, 40_i32, 3_i32, 112_i32, 2_i32],
         &expected_heap,
     );
 }

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -263,9 +263,12 @@ struct ExpectedMetadata {
 /// their implementations.
 fn test_wit_type_implementation<T>(expected: ExpectedMetadata)
 where
-    T: WitType,
+    T: WitType + ?Sized + 'static,
+    Box<T>: WitType,
+    Rc<T>: WitType,
+    Arc<T>: WitType,
 {
-    test_single_wit_type_implementation::<T>(expected);
+    test_single_wit_type_implementation::<&'static T>(expected);
     test_single_wit_type_implementation::<Box<T>>(expected);
     test_single_wit_type_implementation::<Rc<T>>(expected);
     test_single_wit_type_implementation::<Arc<T>>(expected);

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -210,6 +210,21 @@ fn test_heap_allocated_fields() {
     });
 }
 
+/// Checks the memory size, layout and WIT declaration derived for a slice type.
+#[test]
+fn test_slice() {
+    test_wit_type_implementation::<[SimpleWrapper]>(ExpectedMetadata {
+        size: 8,
+        alignment: 4,
+        flat_layout_length: 2,
+        declaration: concat!(
+            "    record simple-wrapper {\n",
+            "        inner0: bool,\n",
+            "    }\n"
+        ),
+    });
+}
+
 /// Checks the memory size, layout and WIT declaration derived for a [`Vec`] type.
 #[test]
 fn test_vec() {

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -300,22 +300,28 @@ fn test_slice_field() {
 #[test]
 fn test_list_fields() {
     test_wit_type_implementation::<StructWithLists>(ExpectedMetadata {
-        size: 16,
+        size: 24,
         alignment: 4,
-        flat_layout_length: 4,
+        flat_layout_length: 6,
         declaration: concat!(
+            "    record leaf {\n",
+            "        first: bool,\n",
+            "        second: u128,\n",
+            "    }\n\n",
             "    record simple-wrapper {\n",
             "        inner0: bool,\n",
             "    }\n\n",
             "    record struct-with-lists {\n",
             "        vec: list<simple-wrapper>,\n",
             "        boxed-slice: list<tuple-with-padding>,\n",
+            "        rced-slice: list<leaf>,\n",
             "    }\n\n",
             "    record tuple-with-padding {\n",
             "        inner0: u16,\n",
             "        inner1: u32,\n",
             "        inner2: s64,\n",
-            "    }\n"
+            "    }\n\n",
+            "    type u128 = tuple<u64, u64>;\n"
         ),
     });
 }

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -11,9 +11,9 @@ use std::{collections::BTreeMap, rc::Rc, sync::Arc};
 use linera_witty::{HList, Layout, RegisterWitTypes, WitType};
 
 use self::types::{
-    Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, SpecializedGenericEnum,
-    SpecializedGenericStruct, StructWithHeapFields, StructWithLists, TupleWithPadding,
-    TupleWithoutPadding,
+    Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, SliceWrapper,
+    SpecializedGenericEnum, SpecializedGenericStruct, StructWithHeapFields, StructWithLists,
+    TupleWithPadding, TupleWithoutPadding,
 };
 
 /// Checks the memory size, layout and WIT type declaration derived for a wrapper type.
@@ -235,6 +235,27 @@ fn test_vec() {
         declaration: concat!(
             "    record simple-wrapper {\n",
             "        inner0: bool,\n",
+            "    }\n"
+        ),
+    });
+}
+
+/// Check the memory size, layout and WIT declaration derived for a type that has a slice
+/// field.
+#[test]
+fn test_slice_field() {
+    test_wit_type_implementation::<SliceWrapper>(ExpectedMetadata {
+        size: 8,
+        alignment: 4,
+        flat_layout_length: 2,
+        declaration: concat!(
+            "    record slice-wrapper {\n",
+            "        inner0: list<tuple-without-padding>,\n",
+            "    }\n\n",
+            "    record tuple-without-padding {\n",
+            "        inner0: u64,\n",
+            "        inner1: s32,\n",
+            "        inner2: s16,\n",
             "    }\n"
         ),
     });

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -274,6 +274,24 @@ fn test_rced_slice() {
     });
 }
 
+/// Checks the memory size, layout and WIT declaration derived for an arc-ed slice type.
+#[test]
+fn test_arced_slice() {
+    test_wit_type_implementation::<Arc<[RecordWithDoublePadding]>>(ExpectedMetadata {
+        size: 8,
+        alignment: 4,
+        flat_layout_length: 2,
+        declaration: concat!(
+            "    record record-with-double-padding {\n",
+            "        first: u16,\n",
+            "        second: u32,\n",
+            "        third: s8,\n",
+            "        fourth: s64,\n",
+            "    }\n"
+        ),
+    });
+}
+
 /// Check the memory size, layout and WIT declaration derived for a type that has a slice
 /// field.
 #[test]

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -318,13 +318,19 @@ fn test_slice_field() {
 #[test]
 fn test_list_fields() {
     test_wit_type_implementation::<StructWithLists>(ExpectedMetadata {
-        size: 24,
+        size: 32,
         alignment: 4,
-        flat_layout_length: 6,
+        flat_layout_length: 8,
         declaration: concat!(
             "    record leaf {\n",
             "        first: bool,\n",
             "        second: u128,\n",
+            "    }\n\n",
+            "    record record-with-double-padding {\n",
+            "        first: u16,\n",
+            "        second: u32,\n",
+            "        third: s8,\n",
+            "        fourth: s64,\n",
             "    }\n\n",
             "    record simple-wrapper {\n",
             "        inner0: bool,\n",
@@ -333,6 +339,7 @@ fn test_list_fields() {
             "        vec: list<simple-wrapper>,\n",
             "        boxed-slice: list<tuple-with-padding>,\n",
             "        rced-slice: list<leaf>,\n",
+            "        arced-slice: list<record-with-double-padding>,\n",
             "    }\n\n",
             "    record tuple-with-padding {\n",
             "        inner0: u16,\n",

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -292,7 +292,7 @@ fn test_list_fields() {
             "    }\n\n",
             "    record struct-with-lists {\n",
             "        vec: list<simple-wrapper>,\n",
-            "        second-vec: list<tuple-with-padding>,\n",
+            "        boxed-slice: list<tuple-with-padding>,\n",
             "    }\n\n",
             "    record tuple-with-padding {\n",
             "        inner0: u16,\n",

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -257,6 +257,23 @@ fn test_boxed_slice() {
     });
 }
 
+/// Checks the memory size, layout and WIT declaration derived for an rc-ed slice type.
+#[test]
+fn test_rced_slice() {
+    test_wit_type_implementation::<Rc<[Leaf]>>(ExpectedMetadata {
+        size: 8,
+        alignment: 4,
+        flat_layout_length: 2,
+        declaration: concat!(
+            "    record leaf {\n",
+            "        first: bool,\n",
+            "        second: u128,\n",
+            "    }\n\n",
+            "    type u128 = tuple<u64, u64>;\n"
+        ),
+    });
+}
+
 /// Check the memory size, layout and WIT declaration derived for a type that has a slice
 /// field.
 #[test]

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -240,6 +240,23 @@ fn test_vec() {
     });
 }
 
+/// Checks the memory size, layout and WIT declaration derived for a boxed slice type.
+#[test]
+fn test_boxed_slice() {
+    test_wit_type_implementation::<Box<[TupleWithPadding]>>(ExpectedMetadata {
+        size: 8,
+        alignment: 4,
+        flat_layout_length: 2,
+        declaration: concat!(
+            "    record tuple-with-padding {\n",
+            "        inner0: u16,\n",
+            "        inner1: u32,\n",
+            "        inner2: s64,\n",
+            "    }\n"
+        ),
+    });
+}
+
 /// Check the memory size, layout and WIT declaration derived for a type that has a slice
 /// field.
 #[test]


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
The WIT specification supports a `list` type, which Witty mapped only to `Vec` types. However, it's also possible to use arbitrary slices with that type. Heap slices (`Box<[T]>`, `Rc<[T]>`, `Arc<[T]>`) can be used to load and store from host to guest, while more generic slices (`&[T]`) can only be stored on the guest.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Implement `WitType`, `WitLoad` and `WitStore` for all slice types. More specifically, implement `WitType` and `WitStore` for generic slices (`&[T]`) and `WitLoad` for boxed slices (`Box<[T]>`). Then delegate implementations of all other types to them (including `Vec`, in order to avoid having duplicate code that's easy to get wrong).

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
Unit tests were added to cover the new types.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
