### PR TITLE
Fix pending change after flushing `RegisterView`

### DIFF
--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -99,6 +99,7 @@ where
             self.stored_value = value;
         }
         self.delete_storage_first = false;
+        self.update = None;
         Ok(delete_view)
     }
 

--- a/linera-views/src/views/unit_tests/views.rs
+++ b/linera-views/src/views/unit_tests/views.rs
@@ -480,6 +480,22 @@ async fn test_reentrant_collection_view_has_pending_changes_after_try_load_entri
     Ok(())
 }
 
+/// Checks if a cleared [`RegisterView`] has no pending changes after flushing.
+#[tokio::test]
+async fn test_flushing_cleared_register_view() -> anyhow::Result<()> {
+    let context = create_test_memory_context();
+    let mut view = RegisterView::<_, bool>::load(context.clone()).await?;
+
+    assert!(!view.has_pending_changes().await);
+    view.clear();
+    assert!(view.has_pending_changes().await);
+
+    save_view(&context, &mut view).await?;
+    assert!(!view.has_pending_changes().await);
+
+    Ok(())
+}
+
 /// Saves a [`View`] into the [`MemoryContext<()>`] storage simulation.
 async fn save_view<C>(context: &C, view: &mut impl View<C>) -> anyhow::Result<()>
 where


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
@afck ran into an issue where an assertion caught unexpected pending changes after voting for a block proposal. After investigating the issue, the cause seems to be that `RegisterView::flush` had an edge case where it wouldn't clear it's `update` field.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Clear the `update` field after successfully flushing.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
A unit test was added to reproduce the issue.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- These changes should be backported to the latest `devnet` branch, then
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
