### PR TITLE
Make the chain manager a `View`.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -195,7 +195,7 @@ where
     pub tip_state: RegisterView<C, ChainTipState>,
 
     /// Consensus state.
-    pub manager: RegisterView<C, ChainManager>,
+    pub manager: ChainManager<C>,
 
     /// Hashes of all certified blocks for this sender.
     /// This ends with `block_hash` and has length `usize::from(next_block_height)`.
@@ -571,8 +571,8 @@ where
         self.execution_state_hash.set(Some(hash));
         let maybe_committee = self.execution_state.system.current_committee().into_iter();
         // Last, reset the consensus state based on the current ownership.
-        self.manager.get_mut().reset(
-            self.execution_state.system.ownership.get(),
+        self.manager.reset(
+            self.execution_state.system.ownership.get().clone(),
             BlockHeight(0),
             local_time,
             maybe_committee.flat_map(|(_, committee)| committee.keys_and_weights()),
@@ -873,8 +873,8 @@ where
         self.execution_state_hash.set(Some(state_hash));
         // Last, reset the consensus state based on the current ownership.
         let maybe_committee = self.execution_state.system.current_committee().into_iter();
-        self.manager.get_mut().reset(
-            self.execution_state.system.ownership.get(),
+        self.manager.reset(
+            self.execution_state.system.ownership.get().clone(),
             block.height.try_add_one()?,
             local_time,
             maybe_committee.flat_map(|(_, committee)| committee.keys_and_weights()),

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -381,7 +381,7 @@ where
 
     /// Returns true if there are no more outgoing messages in flight up to the given
     /// block height.
-    pub fn all_messages_delivered_up_to(&mut self, height: BlockHeight) -> bool {
+    pub fn all_messages_delivered_up_to(&self, height: BlockHeight) -> bool {
         tracing::debug!(
             "Messages left in {:.8}'s outbox: {:?}",
             self.chain_id(),

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -499,6 +499,16 @@ where
         Ok(())
     }
 
+    /// Returns the requested blob if it belongs to the proposal or the locked block.
+    pub async fn pending_blob(&self, blob_id: &BlobId) -> Result<Option<Blob>, ViewError> {
+        if let Some(proposal) = self.proposed.get() {
+            if let Some(blob) = proposal.blobs.iter().find(|blob| blob.id() == *blob_id) {
+                return Ok(Some(blob.clone()));
+            }
+        }
+        self.locked_blobs.get(blob_id).await
+    }
+
     /// Updates `current_round` and `round_timeout` if necessary.
     ///
     /// This must be after every change to `timeout`, `locked` or `proposed`.

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -221,6 +221,7 @@ where
         let round_duration = ownership.round_timeout(current_round);
         let round_timeout = round_duration.map(|rd| local_time.saturating_add(rd));
 
+        self.clear();
         self.seed.set(height.0);
         self.ownership.set(ownership);
         self.distribution.set(distribution);

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -158,7 +158,7 @@ where
     /// Having a leader timeout certificate in any given round causes the next one to become
     /// current. Seeing a validated block certificate or a valid proposal in any round causes that
     /// round to become current, unless a higher one already is.
-    #[graphql(skip)] // Part of `ComplexObject` below.
+    #[graphql(skip)]
     pub current_round: RegisterView<C, Round>,
     /// The owners that take over in fallback mode.
     pub fallback_owners: RegisterView<C, BTreeMap<Owner, (PublicKey, u64)>>,
@@ -177,14 +177,13 @@ where
     /// round to become current, unless a higher one already is.
     #[graphql(derived(name = "current_round"))]
     async fn _current_round(&self) -> Round {
-        *self.current_round.get()
+        self.current_round()
     }
 }
 
 impl<C> ChainManager<C>
 where
     C: Context + Clone + Send + Sync + 'static,
-    C::Extra: ExecutionRuntimeContext,
 {
     /// Replaces `self` with a new chain manager.
     pub fn reset<'a>(
@@ -696,7 +695,6 @@ pub struct ChainManagerInfo {
 impl<C> From<&ChainManager<C>> for ChainManagerInfo
 where
     C: Context + Clone + Send + Sync + 'static,
-    C::Extra: ExecutionRuntimeContext,
 {
     fn from(manager: &ChainManager<C>) -> Self {
         let current_round = manager.current_round();

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -408,11 +408,7 @@ where
             {
                 let value = Hashed::new(ValidatedBlock::new(executed_block.clone()));
                 if let Some(certificate) = lite_cert.clone().with_value(value) {
-                    self.locked.set(Some(certificate));
-                    self.locked_blobs.clear();
-                    for (blob_id, blob) in blobs {
-                        self.locked_blobs.insert(&blob_id, blob)?;
-                    }
+                    self.set_locked(certificate, blobs)?;
                 }
             }
         }
@@ -462,11 +458,7 @@ where
             return Ok(());
         }
         let confirmed_block = ConfirmedBlock::new(validated.inner().executed_block().clone());
-        self.locked.set(Some(validated));
-        self.locked_blobs.clear();
-        for (blob_id, blob) in blobs {
-            self.locked_blobs.insert(&blob_id, blob)?;
-        }
+        self.set_locked(validated, blobs)?;
         self.update_current_round(local_time);
         if let Some(key_pair) = key_pair {
             // Vote to confirm.
@@ -602,6 +594,20 @@ where
     /// Returns whether the owner is a super owner.
     fn is_super(&self, owner: &Owner) -> bool {
         self.ownership.get().super_owners.contains_key(owner)
+    }
+
+    /// Sets the locked block and the associated blobs.
+    fn set_locked(
+        &mut self,
+        certificate: ValidatedBlockCertificate,
+        blobs: BTreeMap<BlobId, Blob>,
+    ) -> Result<(), ViewError> {
+        self.locked.set(Some(certificate));
+        self.locked_blobs.clear();
+        for (blob_id, blob) in blobs {
+            self.locked_blobs.insert(&blob_id, blob)?;
+        }
+        Ok(())
     }
 }
 

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -100,15 +100,14 @@ where
                 actions,
             ));
         }
-        let old_round = self.state.chain.manager.get().current_round;
+        let old_round = *self.state.chain.manager.current_round.get();
         let timeout_chainid = certificate.inner().chain_id;
         let timeout_height = certificate.inner().height;
         self.state
             .chain
             .manager
-            .get_mut()
             .handle_timeout_certificate(certificate, self.state.storage.clock().current_time());
-        let round = self.state.chain.manager.get().current_round;
+        let round = *self.state.chain.manager.current_round.get();
         if round > old_round {
             actions.notifications.push(Notification {
                 chain_id: timeout_chainid,
@@ -140,8 +139,8 @@ where
             BTreeMap::new()
         };
         let key_pair = self.state.config.key_pair();
-        let manager = self.state.chain.manager.get_mut();
-        match manager.create_vote(proposal, executed_block, key_pair, local_time, blobs) {
+        let manager = &mut self.state.chain.manager;
+        match manager.create_vote(proposal, executed_block, key_pair, local_time, blobs)? {
             // Cache the value we voted on, so the client doesn't have to send it again.
             Some(Either::Left(vote)) => {
                 self.state
@@ -194,7 +193,6 @@ where
             self.state
                 .chain
                 .manager
-                .get()
                 .check_validated_block(&certificate)
                 .map(|outcome| outcome == manager::Outcome::Skip)
         };
@@ -216,16 +214,16 @@ where
         self.state
             .check_for_unneeded_blobs(&required_blob_ids, blobs)?;
         let blobs = self.state.get_required_blobs(executed_block, blobs).await?;
-        let old_round = self.state.chain.manager.get().current_round;
-        self.state.chain.manager.get_mut().create_final_vote(
+        let old_round = *self.state.chain.manager.current_round.get();
+        self.state.chain.manager.create_final_vote(
             certificate,
             self.state.config.key_pair(),
             self.state.storage.clock().current_time(),
             blobs,
-        );
+        )?;
         let info = ChainInfoResponse::new(&self.state.chain, self.state.config.key_pair());
         self.save().await?;
-        let round = self.state.chain.manager.get().current_round;
+        let round = *self.state.chain.manager.current_round.get();
         if round > old_round {
             actions.notifications.push(Notification {
                 chain_id: self.state.chain_id(),
@@ -523,8 +521,10 @@ where
             let height = chain.tip_state.get().next_block_height;
             let key_pair = self.state.config.key_pair();
             let local_time = self.state.storage.clock().current_time();
-            let manager = chain.manager.get_mut();
-            if manager.vote_timeout(chain_id, height, *epoch, key_pair, local_time) {
+            if chain
+                .manager
+                .vote_timeout(chain_id, height, *epoch, key_pair, local_time)
+            {
                 self.save().await?;
             }
         }
@@ -549,8 +549,10 @@ where
                 let chain_id = chain.chain_id();
                 let height = chain.tip_state.get().next_block_height;
                 let key_pair = self.state.config.key_pair();
-                let manager = chain.manager.get_mut();
-                if manager.vote_fallback(chain_id, height, *epoch, key_pair) {
+                if chain
+                    .manager
+                    .vote_fallback(chain_id, height, *epoch, key_pair)
+                {
                     self.save().await?;
                 }
             }

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -100,14 +100,14 @@ where
                 actions,
             ));
         }
-        let old_round = *self.state.chain.manager.current_round.get();
+        let old_round = self.state.chain.manager.current_round();
         let timeout_chainid = certificate.inner().chain_id;
         let timeout_height = certificate.inner().height;
         self.state
             .chain
             .manager
             .handle_timeout_certificate(certificate, self.state.storage.clock().current_time());
-        let round = *self.state.chain.manager.current_round.get();
+        let round = self.state.chain.manager.current_round();
         if round > old_round {
             actions.notifications.push(Notification {
                 chain_id: timeout_chainid,
@@ -214,7 +214,7 @@ where
         self.state
             .check_for_unneeded_blobs(&required_blob_ids, blobs)?;
         let blobs = self.state.get_required_blobs(executed_block, blobs).await?;
-        let old_round = *self.state.chain.manager.current_round.get();
+        let old_round = self.state.chain.manager.current_round();
         self.state.chain.manager.create_final_vote(
             certificate,
             self.state.config.key_pair(),
@@ -223,7 +223,7 @@ where
         )?;
         let info = ChainInfoResponse::new(&self.state.chain, self.state.config.key_pair());
         self.save().await?;
-        let round = *self.state.chain.manager.current_round.get();
+        let round = self.state.chain.manager.current_round();
         if round > old_round {
             actions.notifications.push(Notification {
                 chain_id: self.state.chain_id(),

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -493,7 +493,7 @@ where
     /// Returns true if there are no more outgoing messages in flight up to the given
     /// block height.
     pub async fn all_messages_to_tracked_chains_delivered_up_to(
-        &mut self,
+        &self,
         height: BlockHeight,
     ) -> Result<bool, WorkerError> {
         if self.chain.all_messages_delivered_up_to(height) {

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -191,7 +191,6 @@ where
             .0
             .chain
             .manager
-            .get()
             .verify_owner(proposal)
             .ok_or(WorkerError::InvalidOwner)?;
         proposal.check_signature(public_key)?;
@@ -205,7 +204,7 @@ where
         // Check if the chain is ready for this new block proposal.
         // This should always pass for nodes without voting key.
         self.0.chain.tip_state.get().verify_block_chaining(block)?;
-        if self.0.chain.manager.get().check_proposed_block(proposal)? == manager::Outcome::Skip {
+        if self.0.chain.manager.check_proposed_block(proposal)? == manager::Outcome::Skip {
             return Ok(None);
         }
         // Update the inboxes so that we can verify the provided hashed certificate values are
@@ -340,7 +339,7 @@ where
             info.requested_received_log = chain.received_log.read(start..).await?;
         }
         if query.request_manager_values {
-            info.manager.add_values(chain.manager.get());
+            info.manager.add_values(&chain.manager);
         }
         Ok(ChainInfoResponse::new(info, self.0.config.key_pair()))
     }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1955,12 +1955,7 @@ where
 
             let maybe_blob = {
                 let chain_state_view = self.chain_state_view().await?;
-                chain_state_view
-                    .manager
-                    .get()
-                    .locked_blobs
-                    .get(&blob_id)
-                    .cloned()
+                chain_state_view.manager.locked_blobs.get(&blob_id).await?
             };
 
             if let Some(blob) = maybe_blob {

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -275,7 +275,7 @@ where
             chain_id: view.chain_id(),
             epoch: *system_state.epoch.get(),
             description: *system_state.description.get(),
-            manager: Box::new(ChainManagerInfo::from(view.manager.get())),
+            manager: Box::new(ChainManagerInfo::from(&view.manager)),
             chain_balance: *system_state.balance.get(),
             block_hash: tip_state.block_hash,
             next_block_height: tip_state.next_block_height,

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -203,11 +203,14 @@ where
         chain_id: ChainId,
     ) -> Result<Option<Vec<Blob>>, LocalNodeError> {
         let chain = self.chain_state_view(chain_id).await?;
-        let manager = chain.manager.get();
-        Ok(blob_ids
-            .iter()
-            .map(|blob_id| manager.locked_blobs.get(blob_id).cloned())
-            .collect())
+        let mut blobs = Vec::new();
+        for blob_id in blob_ids {
+            match chain.manager.locked_blobs.get(blob_id).await? {
+                None => return Ok(None),
+                Some(blob) => blobs.push(blob),
+            }
+        }
+        Ok(Some(blobs))
     }
 
     /// Writes the given blobs to storage if there is an appropriate blob state.

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -454,8 +454,8 @@ where
     );
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
-    assert!(chain.manager.get().confirmed_vote().is_none());
-    assert!(chain.manager.get().validated_vote().is_none());
+    assert!(chain.manager.confirmed_vote().is_none());
+    assert!(chain.manager.validated_vote().is_none());
     Ok(())
 }
 
@@ -504,8 +504,8 @@ where
     );
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
-    assert!(chain.manager.get().confirmed_vote().is_none());
-    assert!(chain.manager.get().validated_vote().is_none());
+    assert!(chain.manager.confirmed_vote().is_none());
+    assert!(chain.manager.validated_vote().is_none());
     Ok(())
 }
 
@@ -617,8 +617,8 @@ where
     );
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
-    assert!(chain.manager.get().confirmed_vote().is_none());
-    assert!(chain.manager.get().validated_vote().is_none());
+    assert!(chain.manager.confirmed_vote().is_none());
+    assert!(chain.manager.validated_vote().is_none());
     Ok(())
 }
 
@@ -672,8 +672,8 @@ where
     );
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
-    assert!(chain.manager.get().confirmed_vote().is_none());
-    assert!(chain.manager.get().validated_vote().is_none());
+    assert!(chain.manager.confirmed_vote().is_none());
+    assert!(chain.manager.validated_vote().is_none());
 
     drop(chain);
     worker
@@ -684,7 +684,6 @@ where
     assert_eq!(
         &chain
             .manager
-            .get()
             .validated_vote()
             .unwrap()
             .value()
@@ -693,17 +692,11 @@ where
             .block,
         &block_proposal0.content.block
     ); // Multi-leader round - it's not confirmed yet.
-    assert!(chain.manager.get().confirmed_vote().is_none());
+    assert!(chain.manager.confirmed_vote().is_none());
     let block_certificate0 = make_certificate(
         &committee,
         &worker,
-        chain
-            .manager
-            .get()
-            .validated_vote()
-            .unwrap()
-            .value()
-            .clone(),
+        chain.manager.validated_vote().unwrap().value().clone(),
     );
     drop(chain);
 
@@ -715,7 +708,6 @@ where
     assert_eq!(
         &chain
             .manager
-            .get()
             .confirmed_vote()
             .unwrap()
             .value()
@@ -724,7 +716,7 @@ where
             .block,
         &block_proposal0.content.block
     ); // Should be confirmed after handling the certificate.
-    assert!(chain.manager.get().validated_vote().is_none());
+    assert!(chain.manager.validated_vote().is_none());
     drop(chain);
 
     worker
@@ -742,7 +734,6 @@ where
     assert_eq!(
         &chain
             .manager
-            .get()
             .validated_vote()
             .unwrap()
             .value()
@@ -751,7 +742,7 @@ where
             .block,
         &block_proposal1.content.block
     );
-    assert!(chain.manager.get().confirmed_vote().is_none());
+    assert!(chain.manager.confirmed_vote().is_none());
     drop(chain);
     assert_matches!(
         worker.handle_block_proposal(block_proposal0).await,
@@ -1166,8 +1157,8 @@ where
     );
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
-    assert!(chain.manager.get().confirmed_vote().is_none());
-    assert!(chain.manager.get().validated_vote().is_none());
+    assert!(chain.manager.confirmed_vote().is_none());
+    assert!(chain.manager.validated_vote().is_none());
     Ok(())
 }
 
@@ -1199,18 +1190,12 @@ where
     chain_info_response.check(&ValidatorName(worker.public_key()))?;
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
-    assert!(chain.manager.get().confirmed_vote().is_none()); // It was a multi-leader
-                                                             // round.
+    assert!(chain.manager.confirmed_vote().is_none()); // It was a multi-leader
+                                                       // round.
     let validated_certificate = make_certificate(
         &committee,
         &worker,
-        chain
-            .manager
-            .get()
-            .validated_vote()
-            .unwrap()
-            .value()
-            .clone(),
+        chain.manager.validated_vote().unwrap().value().clone(),
     );
     drop(chain);
 
@@ -1220,8 +1205,8 @@ where
     chain_info_response.check(&ValidatorName(worker.public_key()))?;
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
-    assert!(chain.manager.get().validated_vote().is_none()); // Should be confirmed by now.
-    let pending_vote = chain.manager.get().confirmed_vote().unwrap().lite();
+    assert!(chain.manager.validated_vote().is_none()); // Should be confirmed by now.
+    let pending_vote = chain.manager.confirmed_vote().unwrap().lite();
     assert_eq!(
         chain_info_response.info.manager.pending.unwrap(),
         pending_vote
@@ -2017,7 +2002,7 @@ where
             *recipient_chain.execution_state.system.balance.get(),
             Amount::from_tokens(4)
         );
-        let ownership = &recipient_chain.manager.get().ownership;
+        let ownership = &recipient_chain.manager.ownership.get();
         assert!(
             ownership
                 .owners

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -338,11 +338,11 @@ where
         // Obtain the missing blocks and the manager state from the local node.
         let range: Range<usize> =
             initial_block_height.try_into()?..target_block_height.try_into()?;
-        let (keys, manager) = {
+        let (keys, timeout) = {
             let chain = self.local_node.chain_state_view(chain_id).await?;
             (
                 chain.confirmed_log.read(range).await?,
-                chain.manager.get().clone(),
+                chain.manager.timeout.get().clone(),
             )
         };
         if !keys.is_empty() {
@@ -353,7 +353,7 @@ where
                 self.send_confirmed_certificate(cert, delivery).await?;
             }
         }
-        if let Some(cert) = manager.timeout {
+        if let Some(cert) = timeout {
             if cert.inner().chain_id == chain_id {
                 // Timeouts are small and don't have blobs, so we can call `handle_certificate`
                 // directly.

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -116,7 +116,16 @@ query Chain(
       blockHash
       nextBlockHeight
     }
-    manager
+    manager {
+      ownership
+      seed
+      lockedBlobs {
+        keys
+      }
+      roundTimeout
+      fallbackOwners
+      currentRound
+    }
     confirmedLog {
       entries
     }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -196,7 +196,11 @@ type ChainManager {
 	"""
 	roundTimeout: Timestamp
 	"""
-	The lowest round where we can still vote to validate or confirm a block. This is
+	The owners that take over in fallback mode.
+	"""
+	fallbackOwners: JSONObject!
+	"""
+	Returns the lowest round where we can still vote to validate or confirm a block. This is
 	the round to which the timeout applies.
 	
 	Having a leader timeout certificate in any given round causes the next one to become
@@ -204,10 +208,6 @@ type ChainManager {
 	round to become current, unless a higher one already is.
 	"""
 	currentRound: Round!
-	"""
-	The owners that take over in fallback mode.
-	"""
-	fallbackOwners: JSONObject!
 }
 
 """

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -46,6 +46,16 @@ input ApplicationPermissions {
 }
 
 """
+A blob of binary data, with its content-addressed blob ID.
+"""
+scalar Blob
+
+"""
+A content-addressed blob ID i.e. the hash of the `BlobContent`
+"""
+scalar BlobId
+
+"""
 A block containing operations to apply on a given chain, as well as the
 acknowledgment of a number of incoming messages from other chains.
 * Incoming messages must be selected in the order they were
@@ -166,9 +176,39 @@ The unique identifier (UID) of a chain. This is currently computed as the hash v
 scalar ChainId
 
 """
-The state of the certification process for a chain's next block
+The state of the certification process for a chain's next block.
 """
-scalar ChainManager
+type ChainManager {
+	"""
+	The public keys, weights and types of the chain's owners.
+	"""
+	ownership: ChainOwnership!
+	"""
+	The seed for the pseudo-random number generator that determines the round leaders.
+	"""
+	seed: Int!
+	"""
+	These are blobs published or read by the locked block.
+	"""
+	lockedBlobs: MapView_BlobId_Blob_3711e760!
+	"""
+	The time after which we are ready to sign a timeout certificate for the current round.
+	"""
+	roundTimeout: Timestamp
+	"""
+	The lowest round where we can still vote to validate or confirm a block. This is
+	the round to which the timeout applies.
+	
+	Having a leader timeout certificate in any given round causes the next one to become
+	current. Seeing a validated block certificate or a valid proposal in any round causes that
+	round to become current, unless a higher one already is.
+	"""
+	currentRound: Round!
+	"""
+	The owners that take over in fallback mode.
+	"""
+	fallbackOwners: JSONObject!
+}
 
 """
 Represents the owner(s) of a chain
@@ -364,6 +404,14 @@ type Entry_AccountOwner_Amount_aaf96548 {
 """
 A GraphQL-visible map item, complete with key.
 """
+type Entry_BlobId_Blob_9f0b41f3 {
+	key: BlobId!
+	value: Blob
+}
+
+"""
+A GraphQL-visible map item, complete with key.
+"""
 type Entry_ChannelFullName_ChannelStateView_ef52a064 {
 	key: ChannelFullName!
 	value: ChannelStateView!
@@ -506,6 +554,10 @@ input MapFilters_AccountOwner_d6668c53 {
 	keys: [AccountOwner!]
 }
 
+input MapFilters_BlobId_4d2a0555 {
+	keys: [BlobId!]
+}
+
 input MapFilters_ChannelFullName_3b59bf69 {
 	keys: [ChannelFullName!]
 }
@@ -520,6 +572,10 @@ input MapFilters_Target_7aac1e1c {
 
 input MapInput_AccountOwner_d6668c53 {
 	filters: MapFilters_AccountOwner_d6668c53
+}
+
+input MapInput_BlobId_4d2a0555 {
+	filters: MapFilters_BlobId_4d2a0555
 }
 
 input MapInput_ChannelFullName_3b59bf69 {
@@ -538,6 +594,12 @@ type MapView_AccountOwner_Amount_11ef1379 {
 	keys(count: Int): [AccountOwner!]!
 	entry(key: AccountOwner!): Entry_AccountOwner_Amount_aaf96548!
 	entries(input: MapInput_AccountOwner_d6668c53): [Entry_AccountOwner_Amount_aaf96548!]!
+}
+
+type MapView_BlobId_Blob_3711e760 {
+	keys(count: Int): [BlobId!]!
+	entry(key: BlobId!): Entry_BlobId_Blob_9f0b41f3!
+	entries(input: MapInput_BlobId_4d2a0555): [Entry_BlobId_Blob_9f0b41f3!]!
 }
 
 """
@@ -940,6 +1002,11 @@ input ResourceControlPolicy {
 	"""
 	maximumBytesWrittenPerBlock: Int!
 }
+
+"""
+A number to identify successive attempts to decide a value in a consensus protocol.
+"""
+scalar Round
 
 """
 An event stream ID.

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -4,10 +4,10 @@
 use graphql_client::GraphQLQuery;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, BlockHeight, OracleResponse, Timestamp},
+    data_types::{Amount, BlockHeight, OracleResponse, Round, Timestamp},
     identifiers::{
-        Account, ChainDescription, ChainId, ChannelName, Destination, GenericApplicationId, Owner,
-        StreamName,
+        Account, BlobId, ChainDescription, ChainId, ChannelName, Destination, GenericApplicationId,
+        Owner, StreamName,
     },
 };
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -208,8 +208,8 @@ pub trait Storage: Sized {
         let id = description.into();
         let mut chain = self.load_chain(id).await?;
         assert!(!chain.is_active(), "Attempting to create a chain twice");
-        chain.manager.get_mut().reset(
-            &ChainOwnership::single(public_key),
+        chain.manager.reset(
+            ChainOwnership::single(public_key),
             BlockHeight(0),
             self.clock().current_time(),
             committee.keys_and_weights(),


### PR DESCRIPTION
## Motivation

Currently the chain manager is serialized as a whole and stored in a `RegisterView` in the chain state view. Since it contains blobs it can be very large, and the blobs are not needed every time the chain manager is loaded.

## Proposal

Make the chain manager a `View`, and put the blobs in a `MapView`.

## Test Plan

This doesn't change any logic, so CI should catch regressions. (In fact, it already did: https://github.com/linera-io/linera-protocol/pull/3133)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- In preparation for: https://github.com/linera-io/linera-protocol/issues/3048
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
