### PR TITLE
Remember a fast block proposal: it remains locked even if re-proposed.

### DIFF
--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -108,8 +108,8 @@ pub enum Outcome {
 
 pub type ValidatedOrConfirmedVote<'a> = Either<&'a Vote<ValidatedBlock>, &'a Vote<ConfirmedBlock>>;
 
-/// The current locked block: Validators are only allowed to sign any proposal with a different
-/// block if they see a `ValidatedBlock` certificate with a higher round.
+/// The current locked block: Validators are allowed to sign a different block (from the locked
+/// block) iff they see a `ValidatedBlockCertificate` for it with a higher round.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 pub enum LockedBlock {

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -183,7 +183,7 @@ where
         check_block_epoch(epoch, block)?;
         certificate.check(committee)?;
         let mut actions = NetworkActions::default();
-        let already_validated_block = self
+        let already_committed_block = self
             .state
             .chain
             .tip_state
@@ -196,7 +196,7 @@ where
                 .check_validated_block(&certificate)
                 .map(|outcome| outcome == manager::Outcome::Skip)
         };
-        if already_validated_block || should_skip_validated_block()? {
+        if already_committed_block || should_skip_validated_block()? {
             // If we just processed the same pending block, return the chain info unchanged.
             return Ok((
                 ChainInfoResponse::new(&self.state.chain, self.state.config.key_pair()),

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -44,6 +44,7 @@ use linera_chain::{
         Block, BlockProposal, ChainAndHeight, ExecutedBlock, IncomingBundle, LiteVote,
         MessageAction,
     },
+    manager::LockedBlock,
     types::{
         CertificateKind, CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate,
         GenericCertificate, LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock,
@@ -1764,13 +1765,38 @@ where
                 break;
             }
         }
-        if let Some(cert) = info.manager.requested_locked {
-            let hash = cert.hash();
-            if let Err(err) = self.try_process_locked_block_from(remote_node, cert).await {
-                warn!(
-                    "Skipping certificate {hash} from validator {}: {err}",
-                    remote_node.name
-                );
+        if let Some(locked) = info.manager.requested_locked {
+            match *locked {
+                LockedBlock::Fast(proposal) => {
+                    let owner = proposal.owner;
+                    while let Err(original_err) = self
+                        .client
+                        .local_node
+                        .handle_block_proposal(proposal.clone())
+                        .await
+                    {
+                        if let LocalNodeError::BlobsNotFound(blob_ids) = &original_err {
+                            self.update_local_node_with_blobs_from(blob_ids.clone(), remote_node)
+                                .await?;
+                            continue; // We found the missing blobs: retry.
+                        }
+
+                        warn!(
+                            "Skipping proposal from {} and validator {}: {}",
+                            owner, remote_node.name, original_err
+                        );
+                        break;
+                    }
+                }
+                LockedBlock::Regular(cert) => {
+                    let hash = cert.hash();
+                    if let Err(err) = self.try_process_locked_block_from(remote_node, cert).await {
+                        warn!(
+                            "Skipping certificate {hash} from validator {}: {err}",
+                            remote_node.name
+                        );
+                    }
+                }
             }
         }
         Ok(())
@@ -1779,10 +1805,10 @@ where
     async fn try_process_locked_block_from(
         &self,
         remote_node: &RemoteNode<P::Node>,
-        certificate: Box<GenericCertificate<ValidatedBlock>>,
+        certificate: GenericCertificate<ValidatedBlock>,
     ) -> Result<(), ChainClientError> {
         let chain_id = certificate.inner().chain_id();
-        match self.process_certificate(*certificate.clone(), vec![]).await {
+        match self.process_certificate(certificate.clone(), vec![]).await {
             Err(LocalNodeError::BlobsNotFound(blob_ids)) => {
                 let mut blobs = Vec::new();
                 for blob_id in blob_ids {
@@ -1792,7 +1818,7 @@ where
                         .await?;
                     blobs.push(Blob::new(blob_content));
                 }
-                self.process_certificate(*certificate, blobs).await?;
+                self.process_certificate(certificate, blobs).await?;
                 Ok(())
             }
             Err(err) => Err(err.into()),
@@ -2398,28 +2424,26 @@ where
         let info = self.request_leader_timeout_if_needed().await?;
 
         // If there is a validated block in the current round, finalize it.
-        if info.manager.has_locked_block_in_current_round() {
+        if info.manager.has_locked_block_in_current_round() && !info.manager.current_round.is_fast()
+        {
             return self.finalize_locked_block(info).await;
         }
 
         // Otherwise we have to re-propose the highest validated block, if there is one.
-        let executed_block = if let Some(certificate) = &info.manager.requested_locked {
-            certificate.executed_block().clone()
-        } else {
-            let block = if let Some(proposal) = info
-                .manager
-                .requested_proposed
-                .as_ref()
-                .filter(|proposal| proposal.content.round.is_fast())
-            {
-                // The fast block counts as "locked", too. If there is one, re-propose that.
-                proposal.content.block.clone()
-            } else if let Some(block) = self.state().pending_block() {
-                block.clone() // Otherwise we are free to propose our own pending block.
-            } else {
-                return Ok(ClientOutcome::Committed(None)); // Nothing to do.
-            };
+        let pending: Option<Block> = self.state().pending_block().clone();
+        let executed_block = if let Some(locked) = &info.manager.requested_locked {
+            match &**locked {
+                LockedBlock::Regular(certificate) => certificate.executed_block().clone(),
+                LockedBlock::Fast(proposal) => {
+                    let block = proposal.content.block.clone();
+                    self.stage_block_execution(block).await?.0
+                }
+            }
+        } else if let Some(block) = pending {
+            // Otherwise we are free to propose our own pending block.
             self.stage_block_execution(block).await?.0
+        } else {
+            return Ok(ClientOutcome::Committed(None)); // Nothing to do.
         };
 
         let identity = self.identity().await?;
@@ -2434,8 +2458,15 @@ where
         let already_handled_locally = info.manager.already_handled_proposal(round, block);
         let key_pair = self.key_pair().await?;
         // Create the final block proposal.
-        let proposal = if let Some(cert) = info.manager.requested_locked {
-            Box::new(BlockProposal::new_retry(round, *cert, &key_pair, blobs))
+        let proposal = if let Some(locked) = info.manager.requested_locked {
+            Box::new(match *locked {
+                LockedBlock::Regular(cert) => {
+                    BlockProposal::new_retry(round, cert, &key_pair, blobs)
+                }
+                LockedBlock::Fast(proposal) => {
+                    BlockProposal::new_initial(round, proposal.content.block, &key_pair, blobs)
+                }
+            })
         } else {
             let block = executed_block.block.clone();
             Box::new(BlockProposal::new_initial(round, block, &key_pair, blobs))
@@ -2488,12 +2519,15 @@ where
         &self,
         info: Box<ChainInfo>,
     ) -> Result<ClientOutcome<Option<ConfirmedBlockCertificate>>, ChainClientError> {
-        let certificate = info
+        let locked = info
             .manager
             .requested_locked
             .expect("Should have a locked block");
+        let LockedBlock::Regular(certificate) = *locked else {
+            panic!("Should have a locked validated block");
+        };
         let committee = self.local_committee().await?;
-        match self.finalize_block(&committee, *certificate.clone()).await {
+        match self.finalize_block(&committee, certificate.clone()).await {
             Ok(certificate) => Ok(ClientOutcome::Committed(Some(certificate))),
             Err(ChainClientError::CommunicationError(error)) => {
                 // Communication errors in this case often mean that someone else already

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -161,8 +161,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
         let locked = manager.requested_locked.as_ref();
         ensure!(
             proposed.map_or(true, |proposal| proposal.content.block.chain_id == chain_id)
-                && locked.map_or(true, |cert| cert.executed_block().block.chain_id
-                    == chain_id)
+                && locked.map_or(true, |locked| locked.chain_id() == chain_id)
                 && response.check(&self.name).is_ok(),
             NodeError::InvalidChainInfoResponse
         );

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -32,6 +32,7 @@ use linera_chain::{
         IncomingBundle, LiteValue, LiteVote, Medium, MessageAction, MessageBundle, Origin,
         OutgoingMessage, PostedMessage, SignatureAggregator,
     },
+    manager::LockedBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
     types::{
         CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate, Timeout,
@@ -3349,7 +3350,7 @@ where
     let (response, _) = worker.handle_chain_info_query(query_values.clone()).await?;
     assert_eq!(
         response.info.manager.requested_locked,
-        Some(Box::new(certificate1))
+        Some(Box::new(LockedBlock::Regular(certificate1)))
     );
 
     // Proposing block2 now would fail.
@@ -3376,7 +3377,7 @@ where
     let (response, _) = worker.handle_chain_info_query(query_values.clone()).await?;
     assert_eq!(
         response.info.manager.requested_locked,
-        Some(Box::new(certificate2))
+        Some(Box::new(LockedBlock::Regular(certificate2)))
     );
     let vote = response.info.manager.pending.as_ref().unwrap();
     assert_eq!(vote.value, lite_value2);
@@ -3421,7 +3422,7 @@ where
     let (response, _) = worker.handle_chain_info_query(query_values).await?;
     assert_eq!(
         response.info.manager.requested_locked,
-        Some(Box::new(certificate))
+        Some(Box::new(LockedBlock::Regular(certificate)))
     );
     Ok(())
 }
@@ -3619,7 +3620,7 @@ where
     let (response, _) = worker.handle_chain_info_query(query_values).await?;
     assert_eq!(
         response.info.manager.requested_locked,
-        Some(Box::new(certificate2))
+        Some(Box::new(LockedBlock::Regular(certificate2)))
     );
     let vote = response.info.manager.pending.as_ref().unwrap();
     assert_eq!(vote.value, lite_value2);

--- a/linera-rpc/tests/format.rs
+++ b/linera-rpc/tests/format.rs
@@ -10,7 +10,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{Medium, MessageAction},
-    manager::ChainManagerInfo,
+    manager::{ChainManagerInfo, LockedBlock},
     types::{Certificate, CertificateKind, ConfirmedBlock, Timeout, ValidatedBlock},
 };
 use linera_core::{data_types::CrossChainRequest, node::NodeError};
@@ -52,6 +52,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<ChainDescription>(&samples)?;
     tracer.trace_type::<ChainOwnership>(&samples)?;
     tracer.trace_type::<GenericApplicationId>(&samples)?;
+    tracer.trace_type::<LockedBlock>(&samples)?;
     tracer.trace_type::<ChainManagerInfo>(&samples)?;
     tracer.trace_type::<CrossChainRequest>(&samples)?;
     tracer.trace_type::<NodeError>(&samples)?;

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -258,7 +258,7 @@ ChainManagerInfo:
           TYPENAME: BlockProposal
     - requested_locked:
         OPTION:
-          TYPENAME: ValidatedBlockCertificate
+          TYPENAME: LockedBlock
     - timeout:
         OPTION:
           TYPENAME: TimeoutCertificate
@@ -468,6 +468,16 @@ LiteVote:
         TYPENAME: ValidatorName
     - signature:
         TYPENAME: Signature
+LockedBlock:
+  ENUM:
+    0:
+      Fast:
+        NEWTYPE:
+          TYPENAME: BlockProposal
+    1:
+      Regular:
+        NEWTYPE:
+          TYPENAME: ValidatedBlockCertificate
 Medium:
   ENUM:
     0:


### PR DESCRIPTION
## Motivation

In the fast round, the validators sign to confirm right away, so the block proposal must count as locked.

However, if the same block is re-proposed in a later round, the `proposed` field is overwritten and, due to the different round, is now not considered locked anymore.

## Proposal

Keep track of the fast round proposal as part of the `locked` field, too.

## Test Plan

The problem was reproduced by extending `test_fast_proposal_is_locked`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Fixes https://github.com/linera-io/linera-protocol/issues/3134.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
