### PR TITLE
Use service to query ethereum node in Ethereum Tracker example

### DIFF
--- a/examples/ethereum-tracker/src/contract.rs
+++ b/examples/ethereum-tracker/src/contract.rs
@@ -9,7 +9,6 @@ use alloy::primitives::U256;
 use ethereum_tracker::{EthereumTrackerAbi, InstantiationArgument};
 use linera_sdk::{
     base::WithContractAbi,
-    ethereum::ContractEthereumClient,
     views::{RootView, View},
     Contract, ContractRuntime,
 };
@@ -76,13 +75,6 @@ impl Contract for EthereumTrackerContract {
 }
 
 impl EthereumTrackerContract {
-    fn get_endpoints(&self) -> (ContractEthereumClient, String) {
-        let url = self.state.ethereum_endpoint.get().clone();
-        let contract_address = self.state.contract_address.get().clone();
-        let ethereum_client = ContractEthereumClient { url };
-        (ethereum_client, contract_address)
-    }
-
     /// Reads the initial event emitted by the Ethereum contract, with the initial account and its
     /// balance.
     async fn read_initial(&mut self) {

--- a/examples/ethereum-tracker/src/contract.rs
+++ b/examples/ethereum-tracker/src/contract.rs
@@ -8,7 +8,7 @@ mod state;
 use ethereum_tracker::{EthereumTrackerAbi, InstantiationArgument, U256Cont};
 use linera_sdk::{
     base::WithContractAbi,
-    ethereum::{EthereumClient, EthereumDataType, EthereumQueries as _},
+    ethereum::{ContractEthereumClient, EthereumDataType, EthereumQueries as _},
     views::{RootView, View},
     Contract, ContractRuntime,
 };
@@ -69,10 +69,10 @@ impl Contract for EthereumTrackerContract {
 }
 
 impl EthereumTrackerContract {
-    fn get_endpoints(&self) -> (EthereumClient, String) {
+    fn get_endpoints(&self) -> (ContractEthereumClient, String) {
         let url = self.state.ethereum_endpoint.get().clone();
         let contract_address = self.state.contract_address.get().clone();
-        let ethereum_client = EthereumClient { url };
+        let ethereum_client = ContractEthereumClient { url };
         (ethereum_client, contract_address)
     }
 

--- a/examples/ethereum-tracker/src/lib.rs
+++ b/examples/ethereum-tracker/src/lib.rs
@@ -50,3 +50,9 @@ pub struct U256Cont {
     pub value: U256,
 }
 scalar!(U256Cont);
+
+impl From<U256> for U256Cont {
+    fn from(value: U256) -> Self {
+        U256Cont { value }
+    }
+}

--- a/examples/ethereum-tracker/src/service.rs
+++ b/examples/ethereum-tracker/src/service.rs
@@ -7,11 +7,17 @@ mod state;
 
 use std::sync::Arc;
 
+use alloy::primitives::U256;
 use async_graphql::{EmptySubscription, Request, Response, Schema};
 use ethereum_tracker::Operation;
 use linera_sdk::{
-    base::WithServiceAbi, graphql::GraphQLMutationRoot, views::View, Service, ServiceRuntime,
+    base::WithServiceAbi,
+    ethereum::{EthereumDataType, EthereumEvent, EthereumQueries, ServiceEthereumClient},
+    graphql::GraphQLMutationRoot,
+    views::View,
+    Service, ServiceRuntime,
 };
+use serde::{Deserialize, Serialize};
 
 use self::state::EthereumTrackerState;
 
@@ -57,7 +63,67 @@ impl Service for EthereumTrackerService {
 
 /// The service handler for GraphQL queries.
 #[derive(async_graphql::SimpleObject)]
+#[graphql(complex)]
 pub struct Query {
     #[graphql(flatten)]
     service: EthereumTrackerService,
 }
+
+#[async_graphql::ComplexObject]
+impl Query {
+    /// Reads the initial Ethereum event emitted by the monitored contract.
+    async fn read_initial_event(&self) -> InitialEvent {
+        let start_block = *self.service.state.start_block.get();
+        let mut events = self
+            .read_events("Initial(address,uint256)", start_block, start_block + 1)
+            .await;
+
+        assert_eq!(events.len(), 1);
+        let mut event_values = events.pop().unwrap().values.into_iter();
+
+        let address_value = event_values.next().expect("Missing initial address value");
+        let balance_value = event_values.next().expect("Missing initial balance value");
+
+        let EthereumDataType::Address(address) = address_value else {
+            panic!("wrong type for the first entry");
+        };
+        let EthereumDataType::Uint256(balance) = balance_value else {
+            panic!("wrong type for the second entry");
+        };
+
+        InitialEvent { address, balance }
+    }
+}
+
+impl Query {
+    /// Reads events of type `event_name` from the monitored contract emitted during the requested
+    /// block height range.
+    async fn read_events(
+        &self,
+        event_name: &str,
+        start_block: u64,
+        end_block: u64,
+    ) -> Vec<EthereumEvent> {
+        let url = self.service.state.ethereum_endpoint.get().clone();
+        let contract_address = self.service.state.contract_address.get().clone();
+        let ethereum_client = ServiceEthereumClient { url };
+
+        ethereum_client
+            .read_events(&contract_address, event_name, start_block, end_block)
+            .await
+            .unwrap_or_else(|error| {
+                panic!(
+                    "Failed to read Ethereum events for {contract_address} \
+                    from block {start_block} to block {end_block}: {error}"
+                )
+            })
+    }
+}
+
+/// The initial event emitted by the contract.
+#[derive(Clone, Default, Deserialize, Serialize)]
+pub struct InitialEvent {
+    address: String,
+    balance: U256,
+}
+async_graphql::scalar!(InitialEvent);

--- a/linera-sdk/src/ethereum.rs
+++ b/linera-sdk/src/ethereum.rs
@@ -16,6 +16,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{contract::wit::contract_system_api, service::wit::service_system_api};
 
+// TODO(#3143): Unify the two types into a single `EthereumClient` type.
+
 /// A wrapper for a URL that implements `JsonRpcClient` and uses the JSON oracle to make requests.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct ContractEthereumClient {

--- a/linera-sdk/src/ethereum.rs
+++ b/linera-sdk/src/ethereum.rs
@@ -14,25 +14,25 @@ pub use linera_ethereum::{
 use linera_ethereum::{client::JsonRpcClient, common::EthereumServiceError};
 use serde::{Deserialize, Serialize};
 
-use crate::contract::wit::contract_system_api;
+use crate::{contract::wit::contract_system_api, service::wit::service_system_api};
 
 /// A wrapper for a URL that implements `JsonRpcClient` and uses the JSON oracle to make requests.
 #[derive(Debug, Default, Deserialize, Serialize)]
-pub struct EthereumClient {
+pub struct ContractEthereumClient {
     /// The URL of the JSON-RPC server, without the method or parameters.
     pub url: String,
 }
-scalar!(EthereumClient);
+scalar!(ContractEthereumClient);
 
-impl EthereumClient {
-    /// Creates a new `EthereumClient` from an URL.
+impl ContractEthereumClient {
+    /// Creates a new [`ContractEthereumClient`] from an URL.
     pub fn new(url: String) -> Self {
         Self { url }
     }
 }
 
 #[async_trait]
-impl JsonRpcClient for EthereumClient {
+impl JsonRpcClient for ContractEthereumClient {
     type Error = EthereumServiceError;
 
     async fn get_id(&self) -> u64 {
@@ -42,6 +42,39 @@ impl JsonRpcClient for EthereumClient {
     async fn request_inner(&self, payload: Vec<u8>) -> Result<Vec<u8>, Self::Error> {
         let content_type = "application/json";
         Ok(contract_system_api::http_post(
+            &self.url,
+            content_type,
+            &payload,
+        ))
+    }
+}
+
+/// A wrapper for a URL that implements `JsonRpcClient` and uses the JSON oracle to make requests.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct ServiceEthereumClient {
+    /// The URL of the JSON-RPC server, without the method or parameters.
+    pub url: String,
+}
+scalar!(ServiceEthereumClient);
+
+impl ServiceEthereumClient {
+    /// Creates a new [`ServiceEthereumClient`] from an URL.
+    pub fn new(url: String) -> Self {
+        Self { url }
+    }
+}
+
+#[async_trait]
+impl JsonRpcClient for ServiceEthereumClient {
+    type Error = EthereumServiceError;
+
+    async fn get_id(&self) -> u64 {
+        1
+    }
+
+    async fn request_inner(&self, payload: Vec<u8>) -> Result<Vec<u8>, Self::Error> {
+        let content_type = "application/json";
+        Ok(service_system_api::http_post(
             &self.url,
             content_type,
             &payload,


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
While working on PR #2631, the end-to-end test for the Ethereum Tracker example started failing. That happened because the updated HTTP request API also included the response headers in the oracle recording, and a "Date" header made the response non-deterministic.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Use the service to perform the HTTP request, and only send back to the contract the actual deterministic information that matters.

In order to do so, the `EthereumClient` had to be split in two, so that it could use either the contract system APIs or the service system APIs.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
The end-to-end test passes locally in my repository when this fix is applied to the changes in PR #2631.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle, as it only changes the example and the SDK.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
