### PR TITLE
refactor(crowd-funding): Get fungible token ID from required applications

### DIFF
--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -85,9 +85,13 @@ impl Contract for CrowdFundingContract {
 
 impl CrowdFundingContract {
     fn fungible_id(&mut self) -> ApplicationId<FungibleTokenAbi> {
-        // TODO(#723): We should be able to pull the fungible ID from the
-        // `required_application_ids` of the application description.
-        self.runtime.application_parameters()
+        // Get the fungible token ID from the required applications
+        self.runtime
+            .required_application_ids()
+            .into_iter()
+            .find(|id| id.is::<FungibleTokenAbi>())
+            .expect("Fungible token application ID not found in required applications")
+            .cast()
     }
 
     /// Adds a pledge from a local account to the remote campaign chain.


### PR DESCRIPTION
Changed the fungible_id() method to get the fungible token application ID
from the required_application_ids list instead of application parameters.
This makes the code more robust by ensuring the dependency is explicitly
declared in the application description.

Resolves #723