### PR TITLE
Upload blobs for validated block certificates in separate messages.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -930,9 +930,7 @@ where
         // Replay the certificates locally.
         for certificate in certificates {
             // No required certificates from other chains: This is only used with benchmark.
-            node.handle_certificate(certificate, vec![], &())
-                .await
-                .unwrap();
+            node.handle_certificate(certificate, &()).await.unwrap();
         }
         // Last update the wallet.
         for chain in self.wallet.as_mut().chains_mut() {

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -106,7 +106,6 @@ where
     /// Process a validated block issued for this multi-owner chain.
     ProcessValidatedBlock {
         certificate: ValidatedBlockCertificate,
-        blobs: Vec<Blob>,
         #[debug(skip)]
         callback: oneshot::Sender<Result<(ChainInfoResponse, NetworkActions, bool), WorkerError>>,
     },
@@ -301,14 +300,9 @@ where
                     .is_ok(),
                 ChainWorkerRequest::ProcessValidatedBlock {
                     certificate,
-                    blobs,
                     callback,
                 } => callback
-                    .send(
-                        self.worker
-                            .process_validated_block(certificate, &blobs)
-                            .await,
-                    )
+                    .send(self.worker.process_validated_block(certificate).await)
                     .is_ok(),
                 ChainWorkerRequest::ProcessConfirmedBlock {
                     certificate,

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -149,6 +149,13 @@ where
         callback: oneshot::Sender<Result<Blob, WorkerError>>,
     },
 
+    /// Handle a blob that belongs to a pending proposal or validated block certificate.
+    HandlePendingBlob {
+        blob: Blob,
+        #[debug(skip)]
+        callback: oneshot::Sender<Result<ChainInfoResponse, WorkerError>>,
+    },
+
     /// Update the received certificate trackers to at least the given values.
     UpdateReceivedCertificateTrackers {
         new_trackers: BTreeMap<ValidatorName, u64>,
@@ -339,6 +346,9 @@ where
                     .is_ok(),
                 ChainWorkerRequest::DownloadPendingBlob { blob_id, callback } => callback
                     .send(self.worker.download_pending_blob(blob_id).await)
+                    .is_ok(),
+                ChainWorkerRequest::HandlePendingBlob { blob, callback } => callback
+                    .send(self.worker.handle_pending_blob(blob).await)
                     .is_ok(),
                 ChainWorkerRequest::UpdateReceivedCertificateTrackers {
                     new_trackers,

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -164,7 +164,6 @@ where
     pub(super) async fn process_validated_block(
         &mut self,
         certificate: ValidatedBlockCertificate,
-        blobs: &[Blob],
     ) -> Result<(ChainInfoResponse, NetworkActions, bool), WorkerError> {
         let executed_block = certificate.executed_block();
 
@@ -209,13 +208,9 @@ where
             .executed_block_values
             .insert(Cow::Borrowed(certificate.inner().inner()))
             .await;
-        let required_blob_ids = executed_block.required_blob_ids();
-        // Verify that no unrelated blobs were provided.
-        self.state
-            .check_for_unneeded_blobs(&required_blob_ids, blobs)?;
         let maybe_blobs = self
             .state
-            .maybe_get_required_blobs(executed_block, blobs)
+            .maybe_get_required_blobs(executed_block, &[])
             .await?;
         let missing_blob_ids = super::missing_blob_ids(&maybe_blobs);
         if !missing_blob_ids.is_empty() {

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -560,6 +560,16 @@ where
         Ok(())
     }
 
+    pub(super) async fn handle_pending_blob(
+        &mut self,
+        _blob: Blob, // TODO
+    ) -> Result<ChainInfoResponse, WorkerError> {
+        Ok(ChainInfoResponse::new(
+            &self.state.chain,
+            self.state.config.key_pair(),
+        ))
+    }
+
     /// Stores the chain state in persistent storage.
     ///
     /// Waits until the [`ChainStateView`] is no longer shared before persisting the changes.

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -300,6 +300,17 @@ where
         maybe_blob.ok_or_else(|| WorkerError::BlobsNotFound(vec![blob_id]))
     }
 
+    /// Adds the blob to pending blocks or validated block certificates that are missing it.
+    pub(super) async fn handle_pending_blob(
+        &mut self,
+        blob: Blob,
+    ) -> Result<ChainInfoResponse, WorkerError> {
+        ChainWorkerStateWithAttemptedChanges::new(&mut *self)
+            .await
+            .handle_pending_blob(blob)
+            .await
+    }
+
     /// Ensures that the current chain is active, returning an error otherwise.
     fn ensure_is_active(&mut self) -> Result<(), WorkerError> {
         if !self.knows_chain_is_active {

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -225,11 +225,10 @@ where
     pub(super) async fn process_validated_block(
         &mut self,
         certificate: ValidatedBlockCertificate,
-        blobs: &[Blob],
     ) -> Result<(ChainInfoResponse, NetworkActions, bool), WorkerError> {
         ChainWorkerStateWithAttemptedChanges::new(self)
             .await
-            .process_validated_block(certificate, blobs)
+            .process_validated_block(certificate)
             .await
     }
 
@@ -317,24 +316,6 @@ where
             self.chain.ensure_is_active()?;
             self.knows_chain_is_active = true;
         }
-        Ok(())
-    }
-
-    /// Returns an error if unrelated blobs were provided.
-    fn check_for_unneeded_blobs(
-        &self,
-        required_blob_ids: &HashSet<BlobId>,
-        blobs: &[Blob],
-    ) -> Result<(), WorkerError> {
-        // Find all certificates containing blobs used when executing this block.
-        for blob in blobs {
-            let blob_id = blob.id();
-            ensure!(
-                required_blob_ids.contains(&blob_id),
-                WorkerError::UnneededBlob { blob_id }
-            );
-        }
-
         Ok(())
     }
 

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -345,36 +345,50 @@ where
         executed_block: &ExecutedBlock,
         blobs: &[Blob],
     ) -> Result<BTreeMap<BlobId, Blob>, WorkerError> {
-        let mut blob_ids = executed_block.required_blob_ids();
-        let mut found_blobs = BTreeMap::new();
-
-        for blob in blobs {
-            if blob_ids.remove(&blob.id()) {
-                found_blobs.insert(blob.id(), blob.clone());
-            }
-        }
-        let mut missing_blob_ids = Vec::new();
-        for blob_id in blob_ids {
-            if let Some(blob) = self.chain.manager.pending_blob(&blob_id).await? {
-                found_blobs.insert(blob_id, blob);
-            } else {
-                missing_blob_ids.push(blob_id);
-            }
-        }
-        let blobs_from_storage = self.storage.read_blobs(&missing_blob_ids).await?;
-        let mut not_found_blob_ids = Vec::new();
-        for (blob_id, maybe_blob) in missing_blob_ids.into_iter().zip(blobs_from_storage) {
-            if let Some(blob) = maybe_blob {
-                found_blobs.insert(blob_id, blob);
-            } else {
-                not_found_blob_ids.push(blob_id);
-            }
-        }
+        let maybe_blobs = self.maybe_get_required_blobs(executed_block, blobs).await?;
+        let not_found_blob_ids = missing_blob_ids(&maybe_blobs);
         ensure!(
             not_found_blob_ids.is_empty(),
             WorkerError::BlobsNotFound(not_found_blob_ids)
         );
-        Ok(found_blobs)
+        Ok(maybe_blobs
+            .into_iter()
+            .filter_map(|(blob_id, maybe_blob)| Some((blob_id, maybe_blob?)))
+            .collect())
+    }
+
+    /// Returns the blobs required by the given executed block. The ones that are not passed in
+    /// are read from the chain manager or from storage.
+    async fn maybe_get_required_blobs(
+        &self,
+        executed_block: &ExecutedBlock,
+        provided_blobs: &[Blob],
+    ) -> Result<BTreeMap<BlobId, Option<Blob>>, WorkerError> {
+        let required_blob_ids = executed_block.required_blob_ids().into_iter();
+        let mut maybe_blobs = BTreeMap::from_iter(required_blob_ids.map(|blob_id| (blob_id, None)));
+
+        for blob in provided_blobs {
+            if let Some(maybe_blob) = maybe_blobs.get_mut(&blob.id()) {
+                *maybe_blob = Some(blob.clone());
+            }
+        }
+        for (blob_id, maybe_blob) in &mut maybe_blobs {
+            if maybe_blob.is_some() {
+                continue;
+            }
+            if let Some(blob) = self.chain.manager.pending_blob(blob_id).await? {
+                *maybe_blob = Some(blob);
+            } else if let Some(Some(blob)) = self.chain.pending_validated_blobs.get(blob_id).await?
+            {
+                *maybe_blob = Some(blob);
+            }
+        }
+        let missing_blob_ids = missing_blob_ids(&maybe_blobs);
+        let blobs_from_storage = self.storage.read_blobs(&missing_blob_ids).await?;
+        for (blob_id, maybe_blob) in missing_blob_ids.into_iter().zip(blobs_from_storage) {
+            maybe_blobs.insert(blob_id, maybe_blob);
+        }
+        Ok(maybe_blobs)
     }
 
     /// Adds any newly created chains to the set of `tracked_chains`, if the parent chain is
@@ -551,6 +565,15 @@ where
             .update_received_certificate_trackers(new_trackers)
             .await
     }
+}
+
+/// Returns the keys whose value is `None`.
+fn missing_blob_ids(maybe_blobs: &BTreeMap<BlobId, Option<Blob>>) -> Vec<BlobId> {
+    maybe_blobs
+        .iter()
+        .filter(|(_, maybe_blob)| maybe_blob.is_none())
+        .map(|(chain_id, _)| *chain_id)
+        .collect()
 }
 
 /// Returns an error if the block is not at the expected epoch.

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -116,6 +116,13 @@ pub trait ValidatorNode {
         blob_id: BlobId,
     ) -> Result<BlobContent, NodeError>;
 
+    /// Handles a blob that belongs to a pending proposal or validated block certificate.
+    async fn handle_pending_blob(
+        &self,
+        chain_id: ChainId,
+        blob: Blob,
+    ) -> Result<ChainInfoResponse, NodeError>;
+
     async fn download_certificate(
         &self,
         hash: CryptoHash,

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -9,7 +9,7 @@ use futures::stream::LocalBoxStream as BoxStream;
 use futures::stream::Stream;
 use linera_base::{
     crypto::{CryptoError, CryptoHash},
-    data_types::{ArithmeticError, Blob, BlobContent, BlockHeight},
+    data_types::{ArithmeticError, BlobContent, BlockHeight},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::{
@@ -78,7 +78,6 @@ pub trait ValidatorNode {
     async fn handle_validated_certificate(
         &self,
         certificate: GenericCertificate<ValidatedBlock>,
-        blobs: Vec<Blob>,
     ) -> Result<ChainInfoResponse, NodeError>;
 
     /// Processes a timeout certificate.

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -120,7 +120,7 @@ pub trait ValidatorNode {
     async fn handle_pending_blob(
         &self,
         chain_id: ChainId,
-        blob: Blob,
+        blob: BlobContent,
     ) -> Result<ChainInfoResponse, NodeError>;
 
     async fn download_certificate(

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -232,7 +232,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
     ) -> Result<(), NodeError> {
         let tasks = blobs
             .into_iter()
-            .map(|blob| self.node.handle_pending_blob(chain_id, blob));
+            .map(|blob| self.node.handle_pending_blob(chain_id, blob.into_content()));
         try_join_all(tasks).await?;
         Ok(())
     }

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -81,12 +81,11 @@ impl<N: ValidatorNode> RemoteNode<N> {
     pub(crate) async fn handle_validated_certificate(
         &self,
         certificate: ValidatedBlockCertificate,
-        blobs: Vec<Blob>,
     ) -> Result<Box<ChainInfo>, NodeError> {
         let chain_id = certificate.inner().chain_id();
         let response = self
             .node
-            .handle_validated_certificate(certificate, blobs)
+            .handle_validated_certificate(certificate, vec![])
             .await?;
         self.check_and_return_info(response, chain_id)
     }
@@ -124,8 +123,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
                 _ => return result,
             }
         }
-        self.handle_validated_certificate(certificate.clone(), vec![])
-            .await
+        self.handle_validated_certificate(certificate.clone()).await
     }
 
     pub(crate) async fn handle_optimized_confirmed_certificate(
@@ -221,6 +219,20 @@ impl<N: ValidatorNode> RemoteNode<N> {
         let tasks = blobs
             .into_iter()
             .map(|blob| self.node.upload_blob(blob.into()));
+        try_join_all(tasks).await?;
+        Ok(())
+    }
+
+    /// Sends a pending validated block's blobs to the validator.
+    #[instrument(level = "trace")]
+    pub(crate) async fn send_pending_blobs(
+        &self,
+        chain_id: ChainId,
+        blobs: Vec<Blob>,
+    ) -> Result<(), NodeError> {
+        let tasks = blobs
+            .into_iter()
+            .map(|blob| self.node.handle_pending_blob(chain_id, blob));
         try_join_all(tasks).await?;
         Ok(())
     }

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -83,10 +83,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
         certificate: ValidatedBlockCertificate,
     ) -> Result<Box<ChainInfo>, NodeError> {
         let chain_id = certificate.inner().chain_id();
-        let response = self
-            .node
-            .handle_validated_certificate(certificate, vec![])
-            .await?;
+        let response = self.node.handle_validated_certificate(certificate).await?;
         self.check_and_return_info(response, chain_id)
     }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1378,15 +1378,20 @@ where
     let LockedBlock::Regular(validated) = locked else {
         panic!("Unexpected locked fast block.");
     };
-    let blobs = vec![blob1];
-    let response = builder
-        .node(3)
-        .handle_validated_certificate(validated.clone(), blobs)
-        .await?;
-    assert_eq!(
-        response.info.manager.pending.unwrap().round,
-        Round::MultiLeader(0)
-    );
+    {
+        let node3 = builder.node(3);
+        let result = node3.handle_validated_certificate(validated.clone()).await;
+        assert_matches!(result, Err(NodeError::BlobsNotFound(_)));
+        let content1 = blob1.into_content();
+        node3.handle_pending_blob(chain_id2, content1).await?;
+        let response = node3
+            .handle_validated_certificate(validated.clone())
+            .await?;
+        assert_eq!(
+            response.info.manager.pending.unwrap().round,
+            Round::MultiLeader(0)
+        );
+    }
 
     // Client 2B should be able to synchronize the locked block and the blobs from validator 3.
     client2_b.synchronize_from_validators().await.unwrap();
@@ -1678,9 +1683,9 @@ where
     };
     let resubmission_result = builder
         .node(2)
-        .handle_validated_certificate(validated_block_certificate, vec![blob1])
+        .handle_validated_certificate(validated_block_certificate)
         .await;
-    assert!(resubmission_result.is_err());
+    assert_matches!(resubmission_result, Err(NodeError::ClientIoError { .. }));
 
     for i in 0..=2 {
         let validator_manager = builder
@@ -1748,9 +1753,9 @@ where
     };
     let resubmission_result = builder
         .node(3)
-        .handle_validated_certificate(validated_block_certificate, vec![blob3])
+        .handle_validated_certificate(validated_block_certificate)
         .await;
-    assert!(resubmission_result.is_err());
+    assert_matches!(resubmission_result, Err(NodeError::ClientIoError { .. }));
 
     let validator_manager = builder
         .node(3)
@@ -2129,7 +2134,7 @@ where
     };
     builder
         .node(0)
-        .handle_validated_certificate(validated_block_certificate, Vec::new())
+        .handle_validated_certificate(validated_block_certificate)
         .await
         .unwrap();
 

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -129,7 +129,7 @@ where
         certificate: GenericCertificate<Timeout>,
     ) -> Result<ChainInfoResponse, NodeError> {
         self.spawn_and_receive(move |validator, sender| {
-            validator.do_handle_certificate(certificate, vec![], sender)
+            validator.do_handle_certificate(certificate, sender)
         })
         .await
     }
@@ -137,10 +137,9 @@ where
     async fn handle_validated_certificate(
         &self,
         certificate: GenericCertificate<ValidatedBlock>,
-        blobs: Vec<Blob>,
     ) -> Result<ChainInfoResponse, NodeError> {
         self.spawn_and_receive(move |validator, sender| {
-            validator.do_handle_certificate(certificate, blobs, sender)
+            validator.do_handle_certificate(certificate, sender)
         })
         .await
     }
@@ -151,7 +150,7 @@ where
         _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         self.spawn_and_receive(move |validator, sender| {
-            validator.do_handle_certificate(certificate, vec![], sender)
+            validator.do_handle_certificate(certificate, sender)
         })
         .await
     }
@@ -355,7 +354,6 @@ where
     async fn handle_certificate<T: ProcessableCertificate>(
         certificate: GenericCertificate<T>,
         validator: &mut MutexGuard<'_, LocalValidator<S>>,
-        blobs: Vec<Blob>,
     ) -> Option<Result<ChainInfoResponse, NodeError>> {
         match validator.fault_type {
             FaultType::DontProcessValidated if T::KIND == CertificateKind::Validated => None,
@@ -366,11 +364,7 @@ where
             | FaultType::DontSendValidateVote => Some(
                 validator
                     .state
-                    .fully_handle_certificate_with_notifications(
-                        certificate,
-                        blobs,
-                        &validator.notifier,
-                    )
+                    .fully_handle_certificate_with_notifications(certificate, &validator.notifier)
                     .await
                     .map_err(Into::into),
             ),
@@ -388,11 +382,11 @@ where
         let result = async move {
             match validator.state.full_certificate(certificate).await? {
                 Either::Left(confirmed) => {
-                    self.do_handle_certificate_internal(confirmed, &mut validator, vec![])
+                    self.do_handle_certificate_internal(confirmed, &mut validator)
                         .await
                 }
                 Either::Right(validated) => {
-                    self.do_handle_certificate_internal(validated, &mut validator, vec![])
+                    self.do_handle_certificate_internal(validated, &mut validator)
                         .await
                 }
             }
@@ -405,10 +399,8 @@ where
         &self,
         certificate: GenericCertificate<T>,
         validator: &mut MutexGuard<'_, LocalValidator<S>>,
-        blobs: Vec<Blob>,
     ) -> Result<ChainInfoResponse, NodeError> {
-        let handle_certificate_result =
-            Self::handle_certificate(certificate, validator, blobs).await;
+        let handle_certificate_result = Self::handle_certificate(certificate, validator).await;
         match handle_certificate_result {
             Some(Err(NodeError::BlobsNotFound(_))) => {
                 handle_certificate_result.expect("handle_certificate_result should be Some")
@@ -438,12 +430,11 @@ where
     async fn do_handle_certificate<T: ProcessableCertificate>(
         self,
         certificate: GenericCertificate<T>,
-        blobs: Vec<Blob>,
         sender: oneshot::Sender<Result<ChainInfoResponse, NodeError>>,
     ) -> Result<(), Result<ChainInfoResponse, NodeError>> {
         let mut validator = self.client.lock().await;
         let result = self
-            .do_handle_certificate_internal(certificate, &mut validator, blobs)
+            .do_handle_certificate_internal(certificate, &mut validator)
             .await;
         sender.send(result)
     }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -203,7 +203,7 @@ where
     async fn handle_pending_blob(
         &self,
         chain_id: ChainId,
-        blob: Blob,
+        blob: BlobContent,
     ) -> Result<ChainInfoResponse, NodeError> {
         self.spawn_and_receive(move |validator, sender| {
             validator.do_handle_pending_blob(chain_id, blob, sender)
@@ -530,13 +530,13 @@ where
     async fn do_handle_pending_blob(
         self,
         chain_id: ChainId,
-        blob: Blob,
+        blob: BlobContent,
         sender: oneshot::Sender<Result<ChainInfoResponse, NodeError>>,
     ) -> Result<(), Result<ChainInfoResponse, NodeError>> {
         let validator = self.client.lock().await;
         let result = validator
             .state
-            .handle_pending_blob(chain_id, blob)
+            .handle_pending_blob(chain_id, Blob::new(blob))
             .await
             .map_err(Into::into);
         sender.send(result)

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -157,7 +157,7 @@ where
 
     assert_matches!(
         worker
-            .fully_handle_certificate_with_notifications(publish_certificate.clone(), vec![], &())
+            .fully_handle_certificate_with_notifications(publish_certificate.clone(), &())
             .await,
         Err(WorkerError::BlobsNotFound(_))
     );
@@ -165,7 +165,7 @@ where
         .write_blobs(&[contract_blob.clone(), service_blob.clone()])
         .await?;
     let info = worker
-        .fully_handle_certificate_with_notifications(publish_certificate.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(publish_certificate.clone(), &())
         .await
         .unwrap()
         .info;
@@ -248,7 +248,7 @@ where
     let create_certificate = make_certificate(&committee, &worker, create_block_proposal);
 
     let info = worker
-        .fully_handle_certificate_with_notifications(create_certificate.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(create_certificate.clone(), &())
         .await
         .unwrap()
         .info;
@@ -301,7 +301,7 @@ where
     let run_certificate = make_certificate(&committee, &worker, run_block_proposal);
 
     let info = worker
-        .fully_handle_certificate_with_notifications(run_certificate.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(run_certificate.clone(), &())
         .await
         .unwrap()
         .info;

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -564,7 +564,7 @@ where
         make_certificate(&committee, &worker, value)
     };
     worker
-        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
 
     {
@@ -702,7 +702,7 @@ where
     drop(chain);
 
     worker
-        .handle_validated_certificate(block_certificate0, vec![])
+        .handle_validated_certificate(block_certificate0)
         .await?;
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
@@ -858,10 +858,10 @@ where
     // Run transfers
     let notifications = Arc::new(Mutex::new(Vec::new()));
     worker
-        .fully_handle_certificate_with_notifications(certificate0.clone(), vec![], &notifications)
+        .fully_handle_certificate_with_notifications(certificate0.clone(), &notifications)
         .await?;
     worker
-        .fully_handle_certificate_with_notifications(certificate1.clone(), vec![], &notifications)
+        .fully_handle_certificate_with_notifications(certificate1.clone(), &notifications)
         .await?;
     assert_eq!(
         *notifications.lock().unwrap(),
@@ -1201,7 +1201,7 @@ where
     drop(chain);
 
     let (chain_info_response, _actions) = worker
-        .handle_validated_certificate(validated_certificate, vec![])
+        .handle_validated_certificate(validated_certificate)
         .await?;
     chain_info_response.check(&ValidatorName(worker.public_key()))?;
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
@@ -1290,7 +1290,7 @@ where
     .await;
     assert_matches!(
         worker
-            .fully_handle_certificate_with_notifications(certificate, vec![], &())
+            .fully_handle_certificate_with_notifications(certificate, &())
             .await,
         Err(WorkerError::ChainError(error)) if matches!(*error, ChainError::InactiveChain {..})
     );
@@ -1368,7 +1368,7 @@ where
     ));
     let certificate = make_certificate(&committee, &worker, value);
     let info = worker
-        .fully_handle_certificate_with_notifications(certificate, vec![], &())
+        .fully_handle_certificate_with_notifications(certificate, &())
         .await?
         .info;
     assert_eq!(info.next_block_height, BlockHeight::from(1));
@@ -1415,7 +1415,7 @@ where
     // compute the hash of the execution state.
     assert_matches!(
         worker
-            .fully_handle_certificate_with_notifications(certificate, vec![], &())
+            .fully_handle_certificate_with_notifications(certificate, &())
             .await,
         Err(WorkerError::IncorrectOutcome { .. })
     );
@@ -1462,10 +1462,10 @@ where
     .await;
     // Replays are ignored.
     worker
-        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
     worker
-        .fully_handle_certificate_with_notifications(certificate, vec![], &())
+        .fully_handle_certificate_with_notifications(certificate, &())
         .await?;
     Ok(())
 }
@@ -1523,7 +1523,7 @@ where
     )
     .await;
     worker
-        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
@@ -1613,7 +1613,7 @@ where
     )
     .await;
     worker
-        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
     let new_sender_chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(new_sender_chain.is_active());
@@ -1669,7 +1669,7 @@ where
     )
     .await;
     worker
-        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
@@ -1940,7 +1940,7 @@ where
     .await;
 
     let info = worker
-        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?
         .info;
     assert_eq!(ChainId::root(1), info.chain_id);
@@ -1983,7 +1983,7 @@ where
     )
     .await;
     worker
-        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
 
     assert_eq!(
@@ -2066,7 +2066,7 @@ where
     .await;
 
     let info = worker
-        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?
         .info;
     assert_eq!(ChainId::root(1), info.chain_id);
@@ -2137,7 +2137,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate_with_notifications(certificate00.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate00.clone(), &())
         .await?;
 
     let certificate01 = make_transfer_certificate(
@@ -2171,7 +2171,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate_with_notifications(certificate01.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate01.clone(), &())
         .await?;
 
     {
@@ -2197,7 +2197,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate_with_notifications(certificate1.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate1.clone(), &())
         .await?;
 
     let certificate2 = make_transfer_certificate(
@@ -2216,7 +2216,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate_with_notifications(certificate2.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate2.clone(), &())
         .await?;
 
     // Reject the first transfer and try to use the money of the second one.
@@ -2269,7 +2269,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
 
     {
@@ -2310,7 +2310,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate_with_notifications(certificate3.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate3.clone(), &())
         .await?;
 
     {
@@ -2414,7 +2414,7 @@ where
         )),
     );
     worker
-        .fully_handle_certificate_with_notifications(certificate0.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate0.clone(), &())
         .await?;
     {
         let admin_chain = worker.chain_state_view(admin_id).await?;
@@ -2476,7 +2476,7 @@ where
         )),
     );
     worker
-        .fully_handle_certificate_with_notifications(certificate1.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate1.clone(), &())
         .await?;
 
     {
@@ -2628,7 +2628,7 @@ where
         )),
     );
     worker
-        .fully_handle_certificate_with_notifications(certificate3, vec![], &())
+        .fully_handle_certificate_with_notifications(certificate3, &())
         .await?;
     {
         let user_chain = worker.chain_state_view(user_id).await?;
@@ -2767,12 +2767,12 @@ where
         )),
     );
     worker
-        .fully_handle_certificate_with_notifications(certificate1.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate1.clone(), &())
         .await?;
 
     // Try to execute the transfer.
     worker
-        .fully_handle_certificate_with_notifications(certificate0.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate0.clone(), &())
         .await?;
 
     // The transfer was started..
@@ -2904,12 +2904,12 @@ where
         )),
     );
     worker
-        .fully_handle_certificate_with_notifications(certificate1.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate1.clone(), &())
         .await?;
 
     // Try to execute the transfer from the user chain to the admin chain.
     worker
-        .fully_handle_certificate_with_notifications(certificate0.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate0.clone(), &())
         .await?;
 
     {
@@ -2972,7 +2972,7 @@ where
         )),
     );
     worker
-        .fully_handle_certificate_with_notifications(certificate2.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate2.clone(), &())
         .await?;
 
     {
@@ -2988,7 +2988,7 @@ where
     // Try again to execute the transfer from the user chain to the admin chain.
     // This time, the epoch verification should be overruled.
     worker
-        .fully_handle_certificate_with_notifications(certificate0.clone(), vec![], &())
+        .fully_handle_certificate_with_notifications(certificate0.clone(), &())
         .await?;
 
     {
@@ -3252,7 +3252,7 @@ where
     let value0 = Hashed::new(ConfirmedBlock::new(executed_block0));
     let certificate0 = make_certificate(&committee, &worker, value0.clone());
     let response = worker
-        .fully_handle_certificate_with_notifications(certificate0, vec![], &())
+        .fully_handle_certificate_with_notifications(certificate0, &())
         .await?;
 
     // The leader sequence is pseudorandom but deterministic. The first leader is owner 1.
@@ -3314,7 +3314,7 @@ where
     let vote = response.info.manager.pending.clone().unwrap();
     let certificate1 = vote.with_value(value1.clone()).unwrap().into_certificate();
     let (response, _) = worker
-        .handle_validated_certificate(certificate1.clone(), vec![])
+        .handle_validated_certificate(certificate1.clone())
         .await?;
     let vote = response.info.manager.pending.as_ref().unwrap();
     let value = Hashed::new(ConfirmedBlock::new(executed_block1.clone()));
@@ -3343,9 +3343,7 @@ where
     let value2 = Hashed::new(ValidatedBlock::new(executed_block2.clone()));
     let certificate =
         make_certificate_with_round(&committee, &worker, value2.clone(), Round::SingleLeader(2));
-    worker
-        .handle_validated_certificate(certificate, vec![])
-        .await?;
+    worker.handle_validated_certificate(certificate).await?;
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
     let (response, _) = worker.handle_chain_info_query(query_values.clone()).await?;
     assert_eq!(
@@ -3417,7 +3415,7 @@ where
         make_certificate_with_round(&committee, &worker, value1, Round::SingleLeader(7));
     let worker = worker.with_key_pair(None).await; // Forget validator keys.
     worker
-        .handle_validated_certificate(certificate.clone(), vec![])
+        .handle_validated_certificate(certificate.clone())
         .await?;
     let (response, _) = worker.handle_chain_info_query(query_values).await?;
     assert_eq!(
@@ -3458,7 +3456,7 @@ where
     let value0 = Hashed::new(ConfirmedBlock::new(executed_block0));
     let certificate0 = make_certificate(&committee, &worker, value0.clone());
     let response = worker
-        .fully_handle_certificate_with_notifications(certificate0, vec![], &())
+        .fully_handle_certificate_with_notifications(certificate0, &())
         .await?;
 
     // The first round is the fast-block round, and owner 0 is a super owner.
@@ -3546,7 +3544,7 @@ where
     let value0 = Hashed::new(ConfirmedBlock::new(executed_block0));
     let certificate0 = make_certificate(&committee, &worker, value0.clone());
     let response = worker
-        .fully_handle_certificate_with_notifications(certificate0, vec![], &())
+        .fully_handle_certificate_with_notifications(certificate0, &())
         .await?;
 
     // The first round is the fast-block round, and owner 0 is a super owner.
@@ -3667,7 +3665,7 @@ where
     let value = Hashed::new(ConfirmedBlock::new(executed_block));
     let certificate = make_certificate(&committee, &worker, value);
     worker
-        .fully_handle_certificate_with_notifications(certificate, vec![], &())
+        .fully_handle_certificate_with_notifications(certificate, &())
         .await?;
 
     // The message only just arrived: No fallback mode.

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -252,7 +252,7 @@ where
             Err(original_err @ NodeError::BlobsNotFound(blob_ids)) => {
                 self.remote_node
                     .check_blobs_not_found(&certificate, blob_ids)?;
-                let chain_id = certificate.inner().executed_block().block.chain_id;
+                let chain_id = certificate.inner().chain_id();
                 // The certificate is for a validated block, i.e. for our locked block.
                 // Take the missing blobs from our local chain manager.
                 let blobs = self
@@ -260,8 +260,9 @@ where
                     .get_locked_blobs(blob_ids, chain_id)
                     .await?
                     .ok_or_else(|| original_err.clone())?;
+                self.remote_node.send_pending_blobs(chain_id, blobs).await?;
                 self.remote_node
-                    .handle_validated_certificate(certificate, blobs)
+                    .handle_validated_certificate(certificate)
                     .await
             }
             _ => result,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -951,6 +951,33 @@ where
 
     #[instrument(skip_all, fields(
         nick = self.nickname,
+        chain_id = format!("{:.8}", chain_id)
+    ))]
+    pub async fn handle_pending_blob(
+        &self,
+        chain_id: ChainId,
+        blob: Blob,
+    ) -> Result<ChainInfoResponse, WorkerError> {
+        let blob_id = blob.id();
+        trace!(
+            "{} <-- handle_pending_blob({chain_id:8}, {blob_id:8})",
+            self.nickname
+        );
+        let result = self
+            .query_chain_worker(chain_id, move |callback| {
+                ChainWorkerRequest::HandlePendingBlob { blob, callback }
+            })
+            .await;
+        trace!(
+            "{} --> {:?}",
+            self.nickname,
+            result.as_ref().map(|_| blob_id)
+        );
+        result
+    }
+
+    #[instrument(skip_all, fields(
+        nick = self.nickname,
         chain_id = format!("{:.8}", request.target_chain_id())
     ))]
     pub async fn handle_cross_chain_request(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -437,7 +437,6 @@ pub trait ProcessableCertificate: CertificateValue + Sized + 'static {
     async fn process_certificate<S: Storage + Clone + Send + Sync + 'static>(
         worker: &WorkerState<S>,
         certificate: GenericCertificate<Self>,
-        blobs: Vec<Blob>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError>;
 }
 
@@ -445,7 +444,6 @@ impl ProcessableCertificate for ConfirmedBlock {
     async fn process_certificate<S: Storage + Clone + Send + Sync + 'static>(
         worker: &WorkerState<S>,
         certificate: ConfirmedBlockCertificate,
-        _blobs: Vec<Blob>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         worker.handle_confirmed_certificate(certificate, None).await
     }
@@ -455,11 +453,8 @@ impl ProcessableCertificate for ValidatedBlock {
     async fn process_certificate<S: Storage + Clone + Send + Sync + 'static>(
         worker: &WorkerState<S>,
         certificate: ValidatedBlockCertificate,
-        blobs: Vec<Blob>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
-        worker
-            .handle_validated_certificate(certificate, blobs)
-            .await
+        worker.handle_validated_certificate(certificate).await
     }
 }
 
@@ -467,7 +462,6 @@ impl ProcessableCertificate for Timeout {
     async fn process_certificate<S: Storage + Clone + Send + Sync + 'static>(
         worker: &WorkerState<S>,
         certificate: TimeoutCertificate,
-        _blobs: Vec<Blob>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         worker.handle_timeout_certificate(certificate).await
     }
@@ -482,7 +476,6 @@ where
     pub async fn fully_handle_certificate_with_notifications<T>(
         &self,
         certificate: GenericCertificate<T>,
-        blobs: Vec<Blob>,
         notifier: &impl Notifier,
     ) -> Result<ChainInfoResponse, WorkerError>
     where
@@ -492,7 +485,7 @@ where
         let this = self.clone();
         linera_base::task::spawn(async move {
             let (response, actions) =
-                ProcessableCertificate::process_certificate(&this, certificate, blobs).await?;
+                ProcessableCertificate::process_certificate(&this, certificate).await?;
             notifications.notify(&actions.notifications);
             let mut requests = VecDeque::from(actions.cross_chain_requests);
             while let Some(request) = requests.pop_front() {
@@ -579,14 +572,12 @@ where
     async fn process_validated_block(
         &self,
         certificate: ValidatedBlockCertificate,
-        blobs: &[Blob],
     ) -> Result<(ChainInfoResponse, NetworkActions, bool), WorkerError> {
         let chain_id = certificate.executed_block().block.chain_id;
 
         self.query_chain_worker(chain_id, move |callback| {
             ChainWorkerRequest::ProcessValidatedBlock {
                 certificate,
-                blobs: blobs.to_owned(),
                 callback,
             }
         })
@@ -815,7 +806,7 @@ where
                 self.handle_confirmed_certificate(confirmed, notify_when_messages_are_delivered)
                     .await
             }
-            Either::Right(validated) => self.handle_validated_certificate(validated, vec![]).await,
+            Either::Right(validated) => self.handle_validated_certificate(validated).await,
         }
     }
 
@@ -869,7 +860,6 @@ where
     pub async fn handle_validated_certificate(
         &self,
         certificate: ValidatedBlockCertificate,
-        blobs: Vec<Blob>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname, certificate);
 
@@ -878,8 +868,7 @@ where
         #[cfg(with_metrics)]
         let cert_str = certificate.inner().to_log_str();
 
-        let (info, actions, _duplicated) =
-            self.process_validated_block(certificate, &blobs).await?;
+        let (info, actions, _duplicated) = self.process_validated_block(certificate).await?;
         #[cfg(with_metrics)]
         {
             if !_duplicated {

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -34,6 +34,9 @@ service ValidatorWorker {
   // Download a blob that belongs to a pending block on the given chain.
   rpc DownloadPendingBlob(PendingBlobRequest) returns (PendingBlobResult);
 
+  // Handle a blob that belongs to a pending block on the given chain.
+  rpc HandlePendingBlob(HandlePendingBlobRequest) returns (ChainInfoResult);
+
   // Handle a (trusted!) cross-chain request.
   rpc HandleCrossChainRequest(CrossChainRequest) returns (google.protobuf.Empty);
 }
@@ -69,6 +72,9 @@ service ValidatorNode {
 
   // Download a blob that belongs to a pending block on the given chain.
   rpc DownloadPendingBlob(PendingBlobRequest) returns (PendingBlobResult);
+
+  // Handle a blob that belongs to a pending block on the given chain.
+  rpc HandlePendingBlob(HandlePendingBlobRequest) returns (ChainInfoResult);
 
   // Upload a blob. Returns an error if the validator has not seen a
   // certificate using this blob.
@@ -282,6 +288,12 @@ message PendingBlobResult {
     // a bincode wrapper around `NodeError`
     bytes error = 2;
   }
+}
+
+// A request to handle a pending blob.
+message HandlePendingBlobRequest {
+  ChainId chain_id = 1;
+  BlobContent blob = 2;
 }
 
 // A certified statement from the committee.

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -256,9 +256,6 @@ message HandleValidatedCertificateRequest {
 
   // A certified statement from the committee.
   Certificate certificate = 2;
-
-  // Blobs required by this certificate
-  bytes blobs = 3;
 }
 
 // A certified statement from the committee, together with other certificates

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -212,7 +212,7 @@ impl ValidatorNode for Client {
     async fn handle_pending_blob(
         &self,
         chain_id: ChainId,
-        blob: Blob,
+        blob: BlobContent,
     ) -> Result<ChainInfoResponse, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => grpc_client.handle_pending_blob(chain_id, blob).await?,

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -3,7 +3,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, BlobContent},
+    data_types::BlobContent,
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::{
@@ -115,19 +115,16 @@ impl ValidatorNode for Client {
     async fn handle_validated_certificate(
         &self,
         certificate: ValidatedBlockCertificate,
-        blobs: Vec<Blob>,
     ) -> Result<ChainInfoResponse, NodeError> {
         match self {
             Client::Grpc(grpc_client) => {
-                grpc_client
-                    .handle_validated_certificate(certificate, blobs)
-                    .await
+                grpc_client.handle_validated_certificate(certificate).await
             }
 
             #[cfg(with_simple_network)]
             Client::Simple(simple_client) => {
                 simple_client
-                    .handle_validated_certificate(certificate, blobs)
+                    .handle_validated_certificate(certificate)
                     .await
             }
         }

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -209,6 +209,21 @@ impl ValidatorNode for Client {
         })
     }
 
+    async fn handle_pending_blob(
+        &self,
+        chain_id: ChainId,
+        blob: Blob,
+    ) -> Result<ChainInfoResponse, NodeError> {
+        Ok(match self {
+            Client::Grpc(grpc_client) => grpc_client.handle_pending_blob(chain_id, blob).await?,
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => {
+                simple_client.handle_pending_blob(chain_id, blob).await?
+            }
+        })
+    }
+
     async fn download_certificate(
         &self,
         hash: CryptoHash,

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -6,7 +6,7 @@ use std::{fmt, future::Future, iter};
 use futures::{future, stream, StreamExt};
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, BlobContent},
+    data_types::BlobContent,
     ensure,
     identifiers::{BlobId, ChainId},
     time::Duration,
@@ -241,9 +241,8 @@ impl ValidatorNode for GrpcClient {
     async fn handle_validated_certificate(
         &self,
         certificate: GenericCertificate<ValidatedBlock>,
-        blobs: Vec<Blob>,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
-        let request = HandleValidatedCertificateRequest { certificate, blobs };
+        let request = HandleValidatedCertificateRequest { certificate };
         GrpcClient::try_into_chain_info(client_delegate!(
             self,
             handle_validated_certificate,

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -389,9 +389,9 @@ impl ValidatorNode for GrpcClient {
     async fn handle_pending_blob(
         &self,
         chain_id: ChainId,
-        blob: Blob,
+        blob: BlobContent,
     ) -> Result<ChainInfoResponse, NodeError> {
-        let req = api::HandlePendingBlobRequest::try_from((chain_id, blob.into_content()))?;
+        let req = api::HandlePendingBlobRequest::try_from((chain_id, blob))?;
         GrpcClient::try_into_chain_info(client_delegate!(self, handle_pending_blob, req)?)
     }
 

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -19,6 +19,7 @@ use linera_chain::{
     },
 };
 use linera_core::{
+    data_types::ChainInfoResponse,
     node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
     worker::Notification,
 };
@@ -382,6 +383,16 @@ impl ValidatorNode for GrpcClient {
     ) -> Result<BlobContent, NodeError> {
         let req = api::PendingBlobRequest::try_from((chain_id, blob_id))?;
         client_delegate!(self, download_pending_blob, req)?.try_into()
+    }
+
+    #[instrument(target = "grpc_client", skip(self), err, fields(address = self.address))]
+    async fn handle_pending_blob(
+        &self,
+        chain_id: ChainId,
+        blob: Blob,
+    ) -> Result<ChainInfoResponse, NodeError> {
+        let req = api::HandlePendingBlobRequest::try_from((chain_id, blob.into_content()))?;
+        GrpcClient::try_into_chain_info(client_delegate!(self, handle_pending_blob, req)?)
     }
 
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -712,6 +712,28 @@ impl TryFrom<api::PendingBlobRequest> for (ChainId, BlobId) {
     }
 }
 
+impl TryFrom<(ChainId, BlobContent)> for api::HandlePendingBlobRequest {
+    type Error = GrpcProtoConversionError;
+
+    fn try_from((chain_id, blob_content): (ChainId, BlobContent)) -> Result<Self, Self::Error> {
+        Ok(Self {
+            chain_id: Some(chain_id.into()),
+            blob: Some(blob_content.try_into()?),
+        })
+    }
+}
+
+impl TryFrom<api::HandlePendingBlobRequest> for (ChainId, BlobContent) {
+    type Error = GrpcProtoConversionError;
+
+    fn try_from(request: api::HandlePendingBlobRequest) -> Result<Self, Self::Error> {
+        Ok((
+            try_proto_convert(request.chain_id)?,
+            try_proto_convert(request.blob)?,
+        ))
+    }
+}
+
 impl TryFrom<BlobContent> for api::PendingBlobResult {
     type Error = GrpcProtoConversionError;
 
@@ -1097,6 +1119,14 @@ pub mod tests {
     pub fn test_pending_blob_result() {
         let blob = BlobContent::new_data(*b"foo");
         round_trip_check::<_, api::PendingBlobResult>(blob);
+    }
+
+    #[test]
+    pub fn test_handle_pending_blob_request() {
+        let chain_id = ChainId::root(2);
+        let blob_content = BlobContent::new_data(*b"foo");
+        let pending_blob_request = (chain_id, blob_content);
+        round_trip_check::<_, api::HandlePendingBlobRequest>(pending_blob_request);
     }
 
     #[test]

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -375,8 +375,7 @@ impl TryFrom<api::HandleValidatedCertificateRequest> for HandleValidatedCertific
             certificate.inner().chain_id() == req_chain_id,
             GrpcProtoConversionError::InconsistentChainId
         );
-        let blobs = bincode::deserialize(&cert_request.blobs)?;
-        Ok(HandleValidatedCertificateRequest { certificate, blobs })
+        Ok(HandleValidatedCertificateRequest { certificate })
     }
 }
 
@@ -424,7 +423,6 @@ impl TryFrom<HandleValidatedCertificateRequest> for api::HandleValidatedCertific
         Ok(Self {
             chain_id: Some(request.certificate.inner().chain_id().into()),
             certificate: Some(request.certificate.try_into()?),
-            blobs: bincode::serialize(&request.blobs)?,
         })
     }
 }
@@ -1169,10 +1167,7 @@ pub mod tests {
                 Signature::new(&Foo("test".into()), &key_pair),
             )],
         );
-        let request = HandleValidatedCertificateRequest {
-            certificate,
-            blobs: vec![],
-        };
+        let request = HandleValidatedCertificateRequest { certificate };
 
         round_trip_check::<_, api::HandleValidatedCertificateRequest>(request);
     }

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -585,13 +585,12 @@ where
         request: Request<api::HandleValidatedCertificateRequest>,
     ) -> Result<Response<ChainInfoResult>, Status> {
         let start = Instant::now();
-        let HandleValidatedCertificateRequest { certificate, blobs } =
-            request.into_inner().try_into()?;
+        let HandleValidatedCertificateRequest { certificate } = request.into_inner().try_into()?;
         trace!(?certificate, "Handling certificate");
         match self
             .state
             .clone()
-            .handle_validated_certificate(certificate, blobs)
+            .handle_validated_certificate(certificate)
             .await
         {
             Ok((info, actions)) => {

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -15,7 +15,7 @@ use futures::{
     future::BoxFuture,
     FutureExt as _, StreamExt,
 };
-use linera_base::identifiers::ChainId;
+use linera_base::{data_types::Blob, identifiers::ChainId};
 use linera_core::{
     node::NodeError,
     worker::{NetworkActions, Notification, WorkerError, WorkerState},
@@ -42,8 +42,8 @@ use super::{
         notifier_service_client::NotifierServiceClient,
         validator_worker_client::ValidatorWorkerClient,
         validator_worker_server::{ValidatorWorker as ValidatorWorkerRpc, ValidatorWorkerServer},
-        BlockProposal, ChainInfoQuery, ChainInfoResult, CrossChainRequest, LiteCertificate,
-        PendingBlobRequest, PendingBlobResult,
+        BlockProposal, ChainInfoQuery, ChainInfoResult, CrossChainRequest,
+        HandlePendingBlobRequest, LiteCertificate, PendingBlobRequest, PendingBlobResult,
     },
     pool::GrpcConnectionPool,
     GrpcError, GRPC_MAX_MESSAGE_SIZE,
@@ -731,6 +731,42 @@ where
         err,
         fields(
             nickname = self.state.nickname(),
+            chain_id = ?request.get_ref().chain_id
+        )
+    )]
+    async fn handle_pending_blob(
+        &self,
+        request: Request<HandlePendingBlobRequest>,
+    ) -> Result<Response<ChainInfoResult>, Status> {
+        let start = Instant::now();
+        let (chain_id, blob_content) = request.into_inner().try_into()?;
+        let blob = Blob::new(blob_content);
+        let blob_id = blob.id();
+        trace!(?chain_id, ?blob_id, "Handle pending blob");
+        match self.state.clone().handle_pending_blob(chain_id, blob).await {
+            Ok(info) => {
+                Self::log_request_success_and_latency(start, "handle_pending_blob");
+                Ok(Response::new(info.try_into()?))
+            }
+            Err(error) => {
+                #[cfg(with_metrics)]
+                {
+                    SERVER_REQUEST_ERROR
+                        .with_label_values(&["handle_pending_blob"])
+                        .inc();
+                }
+                error!(nickname = self.state.nickname(), %error, "Failed to handle pending blob");
+                Ok(Response::new(NodeError::from(error).try_into()?))
+            }
+        }
+    }
+
+    #[instrument(
+        target = "grpc_server",
+        skip_all,
+        err,
+        fields(
+            nickname = self.state.nickname(),
             chain_id = ?request.get_ref().chain_id()
         )
     )]
@@ -803,6 +839,12 @@ impl GrpcProxyable for ChainInfoQuery {
 }
 
 impl GrpcProxyable for PendingBlobRequest {
+    fn chain_id(&self) -> Option<ChainId> {
+        self.chain_id.clone()?.try_into().ok()
+    }
+}
+
+impl GrpcProxyable for HandlePendingBlobRequest {
     fn chain_id(&self) -> Option<ChainId> {
         self.chain_id.clone()?.try_into().ok()
     }

--- a/linera-rpc/src/lib.rs
+++ b/linera-rpc/src/lib.rs
@@ -42,7 +42,6 @@ pub struct HandleConfirmedCertificateRequest {
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 pub struct HandleValidatedCertificateRequest {
     pub certificate: linera_chain::types::ValidatedBlockCertificate,
-    pub blobs: Vec<linera_base::data_types::Blob>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -36,6 +36,7 @@ pub enum RpcMessage {
     UploadBlob(Box<BlobContent>),
     DownloadBlob(Box<BlobId>),
     DownloadPendingBlob(Box<(ChainId, BlobId)>),
+    HandlePendingBlob(Box<(ChainId, BlobContent)>),
     DownloadConfirmedBlock(Box<CryptoHash>),
     DownloadCertificates(Vec<CryptoHash>),
     BlobLastUsedBy(Box<BlobId>),
@@ -77,6 +78,7 @@ impl RpcMessage {
             ChainInfoQuery(query) => query.chain_id,
             CrossChainRequest(request) => request.target_chain_id(),
             DownloadPendingBlob(request) => request.0,
+            HandlePendingBlob(request) => request.0,
             Vote(_)
             | Error(_)
             | ChainInfoResponse(_)
@@ -133,6 +135,7 @@ impl RpcMessage {
             | UploadBlobResponse(_)
             | DownloadPendingBlob(_)
             | DownloadPendingBlobResponse(_)
+            | HandlePendingBlob(_)
             | DownloadBlobResponse(_)
             | DownloadConfirmedBlockResponse(_)
             | BlobLastUsedByResponse(_)

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use futures::{sink::SinkExt, stream::StreamExt};
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, BlobContent},
+    data_types::BlobContent,
     identifiers::{BlobId, ChainId},
     time::{timer, Duration},
 };
@@ -105,9 +105,8 @@ impl ValidatorNode for SimpleClient {
     async fn handle_validated_certificate(
         &self,
         certificate: ValidatedBlockCertificate,
-        blobs: Vec<Blob>,
     ) -> Result<ChainInfoResponse, NodeError> {
-        let request = HandleValidatedCertificateRequest { certificate, blobs };
+        let request = HandleValidatedCertificateRequest { certificate };
         let request = RpcMessage::ValidatedCertificate(Box::new(request));
         self.query(request).await
     }

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -185,13 +185,10 @@ impl ValidatorNode for SimpleClient {
     async fn handle_pending_blob(
         &self,
         chain_id: ChainId,
-        blob: Blob,
+        blob: BlobContent,
     ) -> Result<ChainInfoResponse, NodeError> {
-        self.query(RpcMessage::HandlePendingBlob(Box::new((
-            chain_id,
-            blob.into_content(),
-        ))))
-        .await
+        self.query(RpcMessage::HandlePendingBlob(Box::new((chain_id, blob))))
+            .await
     }
 
     async fn download_certificate(

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -182,6 +182,18 @@ impl ValidatorNode for SimpleClient {
         .await
     }
 
+    async fn handle_pending_blob(
+        &self,
+        chain_id: ChainId,
+        blob: Blob,
+    ) -> Result<ChainInfoResponse, NodeError> {
+        self.query(RpcMessage::HandlePendingBlob(Box::new((
+            chain_id,
+            blob.into_content(),
+        ))))
+        .await
+    }
+
     async fn download_certificate(
         &self,
         hash: CryptoHash,

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -269,7 +269,7 @@ where
                 match self
                     .server
                     .state
-                    .handle_validated_certificate(request.certificate, request.blobs)
+                    .handle_validated_certificate(request.certificate)
                     .await
                 {
                     Ok((info, actions)) => {
@@ -279,7 +279,10 @@ where
                         Ok(Some(RpcMessage::ChainInfoResponse(Box::new(info))))
                     }
                     Err(error) => {
-                        error!(nickname = self.server.state.nickname(), %error, "Failed to handle validated certificate");
+                        error!(
+                            nickname = self.server.state.nickname(), %error,
+                            "Failed to handle validated certificate"
+                        );
                         Err(error.into())
                     }
                 }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -819,78 +819,84 @@ RpcMessage:
             - TYPENAME: ChainId
             - TYPENAME: BlobId
     9:
+      HandlePendingBlob:
+        NEWTYPE:
+          TUPLE:
+            - TYPENAME: ChainId
+            - TYPENAME: BlobContent
+    10:
       DownloadConfirmedBlock:
         NEWTYPE:
           TYPENAME: CryptoHash
-    10:
+    11:
       DownloadCertificates:
         NEWTYPE:
           SEQ:
             TYPENAME: CryptoHash
-    11:
+    12:
       BlobLastUsedBy:
         NEWTYPE:
           TYPENAME: BlobId
-    12:
+    13:
       MissingBlobIds:
         NEWTYPE:
           SEQ:
             TYPENAME: BlobId
-    13:
-      VersionInfoQuery: UNIT
     14:
-      GenesisConfigHashQuery: UNIT
+      VersionInfoQuery: UNIT
     15:
+      GenesisConfigHashQuery: UNIT
+    16:
       Vote:
         NEWTYPE:
           TYPENAME: LiteVote
-    16:
+    17:
       ChainInfoResponse:
         NEWTYPE:
           TYPENAME: ChainInfoResponse
-    17:
+    18:
       Error:
         NEWTYPE:
           TYPENAME: NodeError
-    18:
+    19:
       VersionInfoResponse:
         NEWTYPE:
           TYPENAME: VersionInfo
-    19:
+    20:
       GenesisConfigHashResponse:
         NEWTYPE:
           TYPENAME: CryptoHash
-    20:
+    21:
       UploadBlobResponse:
         NEWTYPE:
           TYPENAME: BlobId
-    21:
+    22:
       DownloadBlobResponse:
         NEWTYPE:
           TYPENAME: BlobContent
-    22:
+    23:
       DownloadPendingBlobResponse:
         NEWTYPE:
           TYPENAME: BlobContent
-    23:
+    24:
       DownloadConfirmedBlockResponse:
         NEWTYPE:
           TYPENAME: ExecutedBlock
-    24:
+    25:
       DownloadCertificatesResponse:
         NEWTYPE:
           SEQ:
             TYPENAME: ConfirmedBlockCertificate
-    25:
+    26:
       BlobLastUsedByResponse:
         NEWTYPE:
           TYPENAME: CryptoHash
-    26:
+    27:
       MissingBlobIdsResponse:
         NEWTYPE:
           SEQ:
             TYPENAME: BlobId
-    27:
+    28:
       CrossChainRequest:
         NEWTYPE:
           TYPENAME: CrossChainRequest

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -428,9 +428,6 @@ HandleValidatedCertificateRequest:
   STRUCT:
     - certificate:
         TYPENAME: ValidatedBlockCertificate
-    - blobs:
-        SEQ:
-          TYPENAME: BlobContent
 IncomingBundle:
   STRUCT:
     - origin:

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -143,13 +143,13 @@ impl ActiveChain {
         let result = self
             .validator
             .worker()
-            .fully_handle_certificate_with_notifications(certificate.clone(), blobs.clone(), &())
+            .fully_handle_certificate_with_notifications(certificate.clone(), &())
             .await;
         if let Err(WorkerError::BlobsNotFound(_)) = &result {
             self.validator.storage().maybe_write_blobs(&blobs).await?;
             self.validator
                 .worker()
-                .fully_handle_certificate_with_notifications(certificate.clone(), vec![], &())
+                .fully_handle_certificate_with_notifications(certificate.clone(), &())
                 .await
                 .expect("Rejected certificate");
         } else {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -234,6 +234,10 @@ type ChainStateExtendedView {
 	"""
 	manager: ChainManager!
 	"""
+	The incomplete set of blobs for the pending validated block.
+	"""
+	pendingValidatedBlobs: MapView_BlobId_Blob_9f0b41f3!
+	"""
 	Hashes of all certified blocks for this sender.
 	This ends with `block_hash` and has length `usize::from(next_block_height)`.
 	"""
@@ -399,6 +403,14 @@ A GraphQL-visible map item, complete with key.
 type Entry_AccountOwner_Amount_aaf96548 {
 	key: AccountOwner!
 	value: Amount
+}
+
+"""
+A GraphQL-visible map item, complete with key.
+"""
+type Entry_BlobId_Blob_50b95aa1 {
+	key: BlobId!
+	value: Blob
 }
 
 """
@@ -600,6 +612,12 @@ type MapView_BlobId_Blob_3711e760 {
 	keys(count: Int): [BlobId!]!
 	entry(key: BlobId!): Entry_BlobId_Blob_9f0b41f3!
 	entries(input: MapInput_BlobId_4d2a0555): [Entry_BlobId_Blob_9f0b41f3!]!
+}
+
+type MapView_BlobId_Blob_9f0b41f3 {
+	keys(count: Int): [BlobId!]!
+	entry(key: BlobId!): Entry_BlobId_Blob_50b95aa1!
+	entries(input: MapInput_BlobId_4d2a0555): [Entry_BlobId_Blob_50b95aa1!]!
 }
 
 """

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -346,6 +346,7 @@ where
             | DownloadBlobResponse(_)
             | DownloadPendingBlob(_)
             | DownloadPendingBlobResponse(_)
+            | HandlePendingBlob(_)
             | BlobLastUsedByResponse(_)
             | MissingBlobIdsResponse(_)
             | DownloadConfirmedBlockResponse(_)

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -4,7 +4,7 @@
 use async_trait::async_trait;
 use linera_base::{
     crypto::{CryptoHash, KeyPair},
-    data_types::{Blob, BlobContent, Timestamp},
+    data_types::{BlobContent, Timestamp},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::{
@@ -72,7 +72,6 @@ impl ValidatorNode for DummyValidatorNode {
     async fn handle_validated_certificate(
         &self,
         _: GenericCertificate<ValidatedBlock>,
-        _: Vec<Blob>,
     ) -> Result<ChainInfoResponse, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -91,7 +91,7 @@ impl ValidatorNode for DummyValidatorNode {
     async fn handle_pending_blob(
         &self,
         _: ChainId,
-        _: Blob,
+        _: BlobContent,
     ) -> Result<ChainInfoResponse, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -88,6 +88,14 @@ impl ValidatorNode for DummyValidatorNode {
         Err(NodeError::UnexpectedMessage)
     }
 
+    async fn handle_pending_blob(
+        &self,
+        _: ChainId,
+        _: Blob,
+    ) -> Result<ChainInfoResponse, NodeError> {
+        Err(NodeError::UnexpectedMessage)
+    }
+
     async fn subscribe(&self, _: Vec<ChainId>) -> Result<NotificationStream, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }


### PR DESCRIPTION
## Motivation

Ultimately we want to transfer all blobs separately, rather than in a single message. (https://github.com/linera-io/linera-protocol/issues/3048)

This PR is another step towards that goal: The blobs required by a validated block certificate are now uploaded separately, rather than in the same message as the certificate itself.

## Proposal

Add a map of missing blobs for the highest-round validated block to the chain state, and a `HandlePendingBlob` endpoint to populate that map.

## Test Plan

There are already tests covering different scenarios with validated blocks' blobs. Where necessary, these were updated.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #3152.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
