### PR TITLE
Reduced the number of validators in the Local Kube tests to 1.

### DIFF
--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -97,7 +97,7 @@ impl SharedLocalKubernetesNetTestingConfig {
             testing_prng_seed: Some(37),
             num_other_initial_chains: 2,
             initial_amount: Amount::from_tokens(2000),
-            num_initial_validators: 4,
+            num_initial_validators: 1,
             num_shards: 4,
             binaries,
             no_build: false,


### PR DESCRIPTION
## Motivation

Having 4 validators for the `kind` tests is unnecessary. Storage service tests will catch any consensus related regressions.

## Proposal

Reduce the number of validators to 1.

## Test Plan

CI will catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
