### PR TITLE
Add `linera sync-validator` CLI command

### DIFF
--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -455,6 +455,16 @@ pub enum ClientCommand {
         chain_id: Option<ChainId>,
     },
 
+    /// Synchronizes a validator with the local state of chains.
+    SyncValidator {
+        /// The public key of the validator to synchronize.
+        name: ValidatorName,
+
+        /// The chains to synchronize, or the default chain if empty.
+        #[arg(long, num_args = 0..)]
+        chains: Vec<ChainId>,
+    },
+
     /// Add or modify a validator (admin only)
     SetValidator {
         /// The public key of the validator.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -3366,6 +3366,55 @@ where
             },
         )
     }
+
+    /// Attempts to update a validator with the local information.
+    #[instrument(level = "trace")]
+    pub async fn sync_validator(
+        &self,
+        remote_node: RemoteNode<P::Node>,
+    ) -> Result<(), ChainClientError> {
+        let validator_chain_state = remote_node
+            .handle_chain_info_query(ChainInfoQuery::new(self.chain_id))
+            .await?;
+        let local_chain_state = self.client.local_node.chain_info(self.chain_id).await?;
+
+        let Some(missing_certificate_count) = local_chain_state
+            .next_block_height
+            .0
+            .checked_sub(validator_chain_state.next_block_height.0)
+        else {
+            debug!("Validator is up-to-date with local state");
+            return Ok(());
+        };
+
+        let missing_certificates_end = usize::try_from(local_chain_state.next_block_height.0)
+            .expect("`usize` should be at least `u64`");
+        let missing_certificates_start = missing_certificates_end
+            - usize::try_from(missing_certificate_count).expect("`usize` should be at least `u64`");
+
+        let missing_certificate_hashes = self
+            .client
+            .local_node
+            .chain_state_view(self.chain_id)
+            .await?
+            .confirmed_log
+            .read(missing_certificates_start..missing_certificates_end)
+            .await?;
+
+        for certificate_hash in missing_certificate_hashes {
+            let certificate = self
+                .client
+                .storage
+                .read_certificate(certificate_hash)
+                .await?;
+
+            remote_node
+                .handle_confirmed_certificate(certificate, CrossChainMessageDelivery::NonBlocking)
+                .await?;
+        }
+
+        Ok(())
+    }
 }
 
 /// The outcome of trying to commit a list of incoming messages and operations to the chain.

--- a/linera-rpc/src/lib.rs
+++ b/linera-rpc/src/lib.rs
@@ -21,8 +21,9 @@ pub mod simple;
 
 pub mod grpc;
 
+pub use client::Client;
 pub use message::RpcMessage;
-pub use node_provider::NodeOptions;
+pub use node_provider::{NodeOptions, NodeProvider};
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -627,6 +627,14 @@ impl LocalNet {
         self.running_validators.insert(validator, validator_proxy);
         Ok(())
     }
+
+    /// Terminates all the processes of a given `validator`.
+    pub async fn stop_validator(&mut self, validator: usize) -> Result<()> {
+        if let Some(mut validator) = self.running_validators.remove(&validator) {
+            validator.terminate().await?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(with_testing)]

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -20,6 +20,7 @@ use linera_base::{
     data_types::Amount,
 };
 use linera_client::storage::{StorageConfig, StorageConfigNamespace};
+use linera_core::node::ValidatorNodeProvider;
 use linera_execution::ResourceControlPolicy;
 #[cfg(all(feature = "storage-service", with_testing))]
 use linera_storage_service::common::storage_service_test_endpoint;
@@ -634,6 +635,26 @@ impl LocalNet {
             validator.terminate().await?;
         }
         Ok(())
+    }
+
+    /// Returns a [`linera_rpc::Client`] to interact directly with a `validator`.
+    pub async fn validator_client(&mut self, validator: usize) -> Result<linera_rpc::Client> {
+        let node_provider = linera_rpc::NodeProvider::new(linera_rpc::NodeOptions {
+            send_timeout: Duration::from_secs(1),
+            recv_timeout: Duration::from_secs(1),
+            retry_delay: Duration::ZERO,
+            max_retries: 0,
+        });
+
+        let port = Self::proxy_port(validator);
+        let schema = match self.network.internal {
+            Network::Grpc | Network::Grpcs => "grpc",
+            Network::Tcp => "tcp",
+            Network::Udp => "udp",
+        };
+        let address = format!("{schema}:localhost:{port}");
+
+        Ok(node_provider.make_node(&address)?)
     }
 }
 

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -516,6 +516,26 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera sync-validator`.
+    pub async fn sync_validator(
+        &self,
+        chain_ids: impl IntoIterator<Item = &ChainId>,
+        validator_name: ValidatorName,
+    ) -> Result<()> {
+        let mut command = self.command().await?;
+        command
+            .arg("sync-validator")
+            .arg(validator_name.to_string());
+        let mut chain_ids = chain_ids.into_iter().peekable();
+        if chain_ids.peek().is_some() {
+            command
+                .arg("--chains")
+                .args(chain_ids.map(ChainId::to_string));
+        }
+        command.spawn_and_wait_for_stdout().await?;
+        Ok(())
+    }
+
     /// Runs `linera faucet`.
     pub async fn run_faucet(
         &self,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -519,6 +519,33 @@ impl Runnable for Job {
                 println!("{}/{} OK.", num_ok_validators, committee.validators().len());
             }
 
+            SyncValidator { name, mut chains } => {
+                if chains.is_empty() {
+                    chains.push(context.default_chain());
+                }
+
+                let first_chain_id = chains[0];
+                let first_chain = context.make_chain_client(first_chain_id)?;
+                let committee = first_chain.local_committee().await?;
+
+                let validator_address = committee.network_address(&name).ok_or_else(|| {
+                    anyhow!("Validator {name} is not known by the chain {first_chain_id}")
+                })?;
+                let validator_node = context.make_node_provider().make_node(validator_address)?;
+                let validator = RemoteNode {
+                    name,
+                    node: validator_node,
+                };
+
+                first_chain.sync_validator(validator.clone()).await?;
+
+                for chain_id in chains.into_iter().skip(1) {
+                    let chain = context.make_chain_client(chain_id)?;
+
+                    chain.sync_validator(validator.clone()).await?;
+                }
+            }
+
             command @ (SetValidator { .. }
             | RemoveValidator { .. }
             | ResourceControlPolicy { .. }) => {
@@ -1422,6 +1449,7 @@ fn log_file_name_for(command: &ClientCommand) -> Cow<'static, str> {
         | ClientCommand::ProcessInbox { .. }
         | ClientCommand::QueryValidator { .. }
         | ClientCommand::QueryValidators { .. }
+        | ClientCommand::SyncValidator { .. }
         | ClientCommand::SetValidator { .. }
         | ClientCommand::RemoveValidator { .. }
         | ClientCommand::ResourceControlPolicy { .. }


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
Some testnet validators started lagging, and that made clients stop sending certificates to them, which made them lag even more.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
As a quick-fix, a `linera sync-validator` CLI command was added that pushes local certificates that are missing from a specified validator.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
A simple end-to-end test was written to ensure that it behaves as expected.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle, because it adds a new feature without breaking any backward compatibility.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
