### PR TITLE
Add BTreeSet impls to Witty.

### DIFF
--- a/linera-witty/src/type_traits/implementations/std/collections.rs
+++ b/linera-witty/src/type_traits/implementations/std/collections.rs
@@ -3,7 +3,10 @@
 
 //! Implementations of the custom traits for the Rust collection types.
 
-use std::{borrow::Cow, collections::BTreeMap};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet},
+};
 
 use frunk::HList;
 
@@ -92,6 +95,84 @@ where
         <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
     {
         let entries = self.iter().collect::<Vec<(&K, &V)>>();
+        entries.lower(memory)
+    }
+}
+
+impl<T> WitType for BTreeSet<T>
+where
+    T: WitType,
+{
+    const SIZE: u32 = <Vec<T> as WitType>::SIZE;
+
+    type Layout = <Vec<T> as WitType>::Layout;
+    type Dependencies = HList![T];
+
+    fn wit_type_name() -> Cow<'static, str> {
+        <Vec<T> as WitType>::wit_type_name()
+    }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        <Vec<T> as WitType>::wit_type_declaration()
+    }
+}
+
+impl<T> WitLoad for BTreeSet<T>
+where
+    T: WitType + Ord + WitLoad,
+{
+    fn load<Instance>(
+        memory: &Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let entries = <Vec<T> as WitLoad>::load(memory, location)?;
+        Ok(entries.into_iter().collect())
+    }
+
+    fn lift_from<Instance>(
+        flat_layout: <Self::Layout as Layout>::Flat,
+        memory: &Memory<'_, Instance>,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let entries = <Vec<T> as WitLoad>::lift_from(flat_layout, memory)?;
+        Ok(entries.into_iter().collect())
+    }
+}
+
+impl<T> WitStore for BTreeSet<T>
+where
+    T: WitType + WitStore,
+    for<'a> &'a T: WitStore,
+{
+    fn store<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<(), RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let entries = self.iter().collect::<Vec<&T>>();
+        entries.store(memory, location)
+    }
+
+    fn lower<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+    ) -> Result<Self::Layout, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let entries = self.iter().collect::<Vec<&T>>();
         entries.lower(memory)
     }
 }


### PR DESCRIPTION
## Motivation

The Witty traits are implemented for `BTreeMap`, but not `BTreeSet`.

## Proposal

Implement them for `BTreeSet`, too.

## Test Plan

The implementation is trivial, and I couldn't find any tests for `BTreeMap` either.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- 
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
