### PR TITLE
Increase linera-core helmfile release timeout

### DIFF
--- a/kubernetes/linera-validator/helmfile.yaml
+++ b/kubernetes/linera-validator/helmfile.yaml
@@ -12,7 +12,7 @@ releases:
   - name: linera-core
     namespace: default
     chart: .
-    timeout: 900
+    timeout: 1200
     needs:
       - scylla/scylla
     values:


### PR DESCRIPTION
## Motivation

Seems like we're timing out when trying to run `helmfile sync`

## Proposal

Increase the timeout for the `linera-core` release, which is the one timing out

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
