### PR TITLE
Enable the listing of `BlobIds` from the command line.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -55,6 +55,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera storage check_absence`↴](#linera-storage-check_absence)
 * [`linera storage initialize`↴](#linera-storage-initialize)
 * [`linera storage list_namespaces`↴](#linera-storage-list_namespaces)
+* [`linera storage list_blob_ids`↴](#linera-storage-list_blob_ids)
 
 ## `linera`
 
@@ -937,6 +938,7 @@ Operation on the storage
 * `check_absence` — Check absence of a namespace in the database
 * `initialize` — Initialize a namespace in the database
 * `list_namespaces` — List the namespaces of the database
+* `list_blob_ids` — List the blobs of the database
 
 
 
@@ -1005,6 +1007,18 @@ Initialize a namespace in the database
 List the namespaces of the database
 
 **Usage:** `linera storage list_namespaces --storage <STORAGE_CONFIG>`
+
+###### **Options:**
+
+* `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
+
+
+
+## `linera storage list_blob_ids`
+
+List the blobs of the database
+
+**Usage:** `linera storage list_blob_ids --storage <STORAGE_CONFIG>`
 
 ###### **Options:**
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -966,7 +966,7 @@ pub enum DatabaseToolCommand {
     },
 
     /// List the blobs of the database
-    #[command(name = "list_blobs")]
+    #[command(name = "list_blob_ids")]
     ListBlobIds {
         /// Storage configuration for the blockchain history.
         #[arg(long = "storage")]

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -964,6 +964,14 @@ pub enum DatabaseToolCommand {
         #[arg(long = "storage")]
         storage_config: String,
     },
+
+    /// List the blobs of the database
+    #[command(name = "list_blobs")]
+    ListBlobIds {
+        /// Storage configuration for the blockchain history.
+        #[arg(long = "storage")]
+        storage_config: String,
+    },
 }
 
 impl DatabaseToolCommand {
@@ -975,6 +983,7 @@ impl DatabaseToolCommand {
             DatabaseToolCommand::CheckAbsence { storage_config } => storage_config,
             DatabaseToolCommand::Initialize { storage_config } => storage_config,
             DatabaseToolCommand::ListNamespaces { storage_config } => storage_config,
+            DatabaseToolCommand::ListBlobIds { storage_config } => storage_config,
         };
         Ok(storage_config.parse::<StorageConfigNamespace>()?)
     }

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -4,8 +4,9 @@
 use std::{fmt, str::FromStr};
 
 use async_trait::async_trait;
+use linera_base::identifiers::BlobId;
 use linera_execution::WasmRuntime;
-use linera_storage::{DbStorage, Storage};
+use linera_storage::{list_all_blob_ids, DbStorage, Storage};
 #[cfg(feature = "storage-service")]
 use linera_storage_service::{
     client::ServiceStoreClient,
@@ -551,6 +552,42 @@ impl StoreConfig {
             StoreConfig::ScyllaDb(config, _namespace) => {
                 let tables = ScyllaDbStore::list_all(&config).await?;
                 Ok(tables)
+            }
+        }
+    }
+
+    /// Lists all the namespaces of the storage
+    pub async fn list_blob_ids(self) -> Result<Vec<BlobId>, ViewError> {
+        let root_key = &[];
+        match self {
+            StoreConfig::Memory(_, _) => Err(ViewError::StoreError {
+                backend: "memory".to_string(),
+                error: "list_blob_ids is not supported for the memory storage".to_string(),
+            }),
+            #[cfg(feature = "storage-service")]
+            StoreConfig::Service(config, namespace) => {
+                let store =
+                    ServiceStoreClient::maybe_create_and_connect(&config, &namespace, root_key)
+                        .await?;
+                list_all_blob_ids(&store).await
+            }
+            #[cfg(feature = "rocksdb")]
+            StoreConfig::RocksDb(config, namespace) => {
+                let store =
+                    RocksDbStore::maybe_create_and_connect(&config, &namespace, root_key).await?;
+                list_all_blob_ids(&store).await
+            }
+            #[cfg(feature = "dynamodb")]
+            StoreConfig::DynamoDb(config, namespace) => {
+                let store =
+                    DynamoDbStore::maybe_create_and_connect(&config, &namespace, root_key).await?;
+                list_all_blob_ids(&store).await
+            }
+            #[cfg(feature = "scylladb")]
+            StoreConfig::ScyllaDb(config, namespace) => {
+                let store =
+                    ScyllaDbStore::maybe_create_and_connect(&config, &namespace, root_key).await?;
+                list_all_blob_ids(&store).await
             }
         }
     }

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -6,7 +6,9 @@ use std::{fmt, str::FromStr};
 use async_trait::async_trait;
 use linera_base::identifiers::BlobId;
 use linera_execution::WasmRuntime;
-use linera_storage::{list_all_blob_ids, DbStorage, Storage};
+#[cfg(with_storage)]
+use linera_storage::list_all_blob_ids;
+use linera_storage::{DbStorage, Storage};
 #[cfg(feature = "storage-service")]
 use linera_storage_service::{
     client::ServiceStoreClient,

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -558,7 +558,6 @@ impl StoreConfig {
 
     /// Lists all the namespaces of the storage
     pub async fn list_blob_ids(self) -> Result<Vec<BlobId>, ViewError> {
-        let root_key = &[];
         match self {
             StoreConfig::Memory(_, _) => Err(ViewError::StoreError {
                 backend: "memory".to_string(),
@@ -567,26 +566,26 @@ impl StoreConfig {
             #[cfg(feature = "storage-service")]
             StoreConfig::Service(config, namespace) => {
                 let store =
-                    ServiceStoreClient::maybe_create_and_connect(&config, &namespace, root_key)
+                    ServiceStoreClient::maybe_create_and_connect(&config, &namespace, ROOT_KEY)
                         .await?;
                 list_all_blob_ids(&store).await
             }
             #[cfg(feature = "rocksdb")]
             StoreConfig::RocksDb(config, namespace) => {
                 let store =
-                    RocksDbStore::maybe_create_and_connect(&config, &namespace, root_key).await?;
+                    RocksDbStore::maybe_create_and_connect(&config, &namespace, ROOT_KEY).await?;
                 list_all_blob_ids(&store).await
             }
             #[cfg(feature = "dynamodb")]
             StoreConfig::DynamoDb(config, namespace) => {
                 let store =
-                    DynamoDbStore::maybe_create_and_connect(&config, &namespace, root_key).await?;
+                    DynamoDbStore::maybe_create_and_connect(&config, &namespace, ROOT_KEY).await?;
                 list_all_blob_ids(&store).await
             }
             #[cfg(feature = "scylladb")]
             StoreConfig::ScyllaDb(config, namespace) => {
                 let store =
-                    ScyllaDbStore::maybe_create_and_connect(&config, &namespace, root_key).await?;
+                    ScyllaDbStore::maybe_create_and_connect(&config, &namespace, ROOT_KEY).await?;
                 list_all_blob_ids(&store).await
             }
         }

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1770,6 +1770,11 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                     );
                     println!("The list of namespaces is {:?}", namespaces);
                 }
+                DatabaseToolCommand::ListBlobIds { .. } => {
+                    let blob_ids = Box::pin(full_storage_config.list_blob_ids()).await?;
+                    info!("Blob IDs listed in {} ms", start_time.elapsed().as_millis());
+                    println!("The list of blob IDs is {:?}", blob_ids);
+                }
             }
             Ok(0)
         }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -43,7 +43,7 @@ use {
 
 #[cfg(with_testing)]
 pub use crate::db_storage::TestClock;
-pub use crate::db_storage::{ChainStatesFirstAssignment, DbStorage, WallClock};
+pub use crate::db_storage::{list_all_blob_ids, ChainStatesFirstAssignment, DbStorage, WallClock};
 #[cfg(with_metrics)]
 pub use crate::db_storage::{
     READ_CERTIFICATE_COUNTER, READ_HASHED_CONFIRMED_BLOCK_COUNTER, WRITE_CERTIFICATE_COUNTER,


### PR DESCRIPTION
## Motivation

Knowing the blobs that are in storage is useful for debugging. We implement this feature here.


## Proposal

The functionality is implemented from the `db_storage`. The problem is that the implementation depends on the serialization so a test is added for this.

## Test Plan

The CI.

For the feature itself, it was tested locally from the command line for the non-fungible test.

## Release Plan

A new functionality is added, but no break of storage schema occurs.

## Links

None.