### PR TITLE
Update docker base image 1.81

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -54,6 +54,7 @@ jobs:
             -t ${{ env.DOCKER_IMAGE }}:${{ env.BRANCH_NAME }} \
             -t ${{ env.DOCKER_IMAGE }}:${{ env.GIT_COMMIT_SHORT }} \
             -t ${{ env.DOCKER_IMAGE }}:${{ env.GIT_COMMIT_LONG }}
+          docker run --rm linera ./linera --version
   
       - name: Push Docker image to Google Artifact Registry
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ ARG target=x86_64-unknown-linux-gnu
 ARG binaries=
 ARG copy=${binaries:+_copy}
 
-FROM rust:1.74-slim-bookworm AS builder
+FROM rust:1.81-slim-bookworm AS builder
 ARG git_commit
 ARG target
 


### PR DESCRIPTION
## Motivation

Some transient dependency broke the `linera` binary in Docker. It compiles yet it does not run.

## Proposal

Bump the docker image version to `1.81`. Also add an explicit version check in CI to catch this error in a more obvious way.

## Test Plan

CI.

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.
