### PR TITLE
Add an option for open (permissionless) multi-leader rounds.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -200,6 +200,7 @@ Open (i.e. activate) a new multi-owner chain deriving the UID from an existing o
 
    If they are specified there must be exactly one weight for each owner. If no weights are given, every owner will have weight 100.
 * `--multi-leader-rounds <MULTI_LEADER_ROUNDS>` — The number of rounds in which every owner can propose blocks, i.e. the first round number in which only a single designated leader is allowed to propose blocks
+* `--open-multi-leader-rounds` — Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners. This should only be `true` on chains with restrictive application permissions and an application-based mechanism to select block proposers
 * `--fast-round-ms <FAST_ROUND_DURATION>` — The duration of the fast round, in milliseconds
 * `--base-timeout-ms <BASE_TIMEOUT>` — The duration of the first single-leader and all multi-leader rounds
 
@@ -236,6 +237,7 @@ Specify the complete set of new owners, by public key. Existing owners that are 
 
    If they are specified there must be exactly one weight for each owner. If no weights are given, every owner will have weight 100.
 * `--multi-leader-rounds <MULTI_LEADER_ROUNDS>` — The number of rounds in which every owner can propose blocks, i.e. the first round number in which only a single designated leader is allowed to propose blocks
+* `--open-multi-leader-rounds` — Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners. This should only be `true` on chains with restrictive application permissions and an application-based mechanism to select block proposers
 * `--fast-round-ms <FAST_ROUND_DURATION>` — The duration of the fast round, in milliseconds
 * `--base-timeout-ms <BASE_TIMEOUT>` — The duration of the first single-leader and all multi-leader rounds
 

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -57,8 +57,12 @@ pub struct ChainOwnership {
     /// The regular owners, with their weights that determine how often they are round leader.
     #[debug(skip_if = BTreeMap::is_empty)]
     pub owners: BTreeMap<Owner, u64>,
-    /// The number of initial rounds after 0 in which all owners are allowed to propose blocks.
+    /// The number of rounds in which all owners are allowed to propose blocks.
     pub multi_leader_rounds: u32,
+    /// Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners.
+    /// This should only be `true` on chains with restrictive application permissions and an
+    /// application-based mechanism to select block proposers.
+    pub open_multi_leader_rounds: bool,
     /// The timeout configuration: how long fast, multi-leader and single-leader rounds last.
     pub timeout_config: TimeoutConfig,
 }
@@ -70,6 +74,7 @@ impl ChainOwnership {
             super_owners: iter::once(owner).collect(),
             owners: BTreeMap::new(),
             multi_leader_rounds: 2,
+            open_multi_leader_rounds: false,
             timeout_config: TimeoutConfig::default(),
         }
     }
@@ -80,6 +85,7 @@ impl ChainOwnership {
             super_owners: BTreeSet::new(),
             owners: iter::once((owner, 100)).collect(),
             multi_leader_rounds: 2,
+            open_multi_leader_rounds: false,
             timeout_config: TimeoutConfig::default(),
         }
     }
@@ -94,6 +100,7 @@ impl ChainOwnership {
             super_owners: BTreeSet::new(),
             owners: owners_and_weights.into_iter().collect(),
             multi_leader_rounds,
+            open_multi_leader_rounds: false,
             timeout_config,
         }
     }
@@ -197,6 +204,7 @@ mod tests {
             super_owners: BTreeSet::from_iter([super_owner]),
             owners: BTreeMap::from_iter([(owner, 100)]),
             multi_leader_rounds: 10,
+            open_multi_leader_rounds: false,
             timeout_config: TimeoutConfig {
                 fast_round_duration: Some(TimeDelta::from_secs(5)),
                 base_timeout: TimeDelta::from_secs(10),

--- a/linera-base/src/unit_tests.rs
+++ b/linera-base/src/unit_tests.rs
@@ -147,6 +147,7 @@ fn chain_ownership_test_case() -> ChainOwnership {
         super_owners,
         owners,
         multi_leader_rounds: 5,
+        open_multi_leader_rounds: false,
         timeout_config: TimeoutConfig {
             fast_round_duration: None,
             base_timeout: TimeDelta::ZERO,

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -579,8 +579,9 @@ where
                 false // Only super owners can propose in the first round.
             }
             Round::MultiLeader(_) => {
+                let ownership = self.ownership.get();
                 // Not in leader rotation mode; any owner is allowed to propose.
-                self.ownership.get().owners.contains_key(owner)
+                ownership.open_multi_leader_rounds || ownership.owners.contains_key(owner)
             }
             Round::SingleLeader(r) => {
                 let Some(index) = self.round_leader_index(r) else {

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -112,7 +112,7 @@ async fn test_block_size_limit() {
     let mut chain = ChainStateView::new(chain_id).await;
 
     // The size of the executed valid block below.
-    let maximum_executed_block_size = 675;
+    let maximum_executed_block_size = 676;
 
     // Initialize the chain.
     let mut config = make_open_chain_config();

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -1236,6 +1236,12 @@ pub struct ChainOwnershipConfig {
     #[arg(long)]
     multi_leader_rounds: Option<u32>,
 
+    /// Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners.
+    /// This should only be `true` on chains with restrictive application permissions and an
+    /// application-based mechanism to select block proposers.
+    #[arg(long)]
+    open_multi_leader_rounds: bool,
+
     /// The duration of the fast round, in milliseconds.
     #[arg(long = "fast-round-ms", value_parser = util::parse_millis_delta)]
     fast_round_duration: Option<TimeDelta>,
@@ -1277,6 +1283,7 @@ impl TryFrom<ChainOwnershipConfig> for ChainOwnership {
             owner_weights,
             multi_leader_rounds,
             fast_round_duration,
+            open_multi_leader_rounds,
             base_timeout,
             timeout_increment,
             fallback_duration,
@@ -1303,6 +1310,7 @@ impl TryFrom<ChainOwnershipConfig> for ChainOwnership {
             super_owners,
             owners,
             multi_leader_rounds,
+            open_multi_leader_rounds,
             timeout_config,
         })
     }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2646,6 +2646,7 @@ where
             super_owners: vec![new_owner],
             owners: Vec::new(),
             multi_leader_rounds: 2,
+            open_multi_leader_rounds: false,
             timeout_config: TimeoutConfig::default(),
         }))
         .await
@@ -2671,6 +2672,7 @@ where
                 super_owners: Vec::new(),
                 owners,
                 multi_leader_rounds: ownership.multi_leader_rounds,
+                open_multi_leader_rounds: ownership.open_multi_leader_rounds,
                 timeout_config: ownership.timeout_config,
             })];
             match self.execute_block(operations).await? {
@@ -2701,6 +2703,7 @@ where
             super_owners: ownership.super_owners.into_iter().collect(),
             owners: ownership.owners.into_iter().collect(),
             multi_leader_rounds: ownership.multi_leader_rounds,
+            open_multi_leader_rounds: ownership.open_multi_leader_rounds,
             timeout_config: ownership.timeout_config.clone(),
         }))
         .await

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1448,6 +1448,7 @@ where
         super_owners: Vec::new(),
         owners: vec![(owner2_a, 50), (owner2_b, 50)],
         multi_leader_rounds: 10,
+        open_multi_leader_rounds: false,
         timeout_config: TimeoutConfig::default(),
     });
     client2_a
@@ -1579,6 +1580,7 @@ where
         super_owners: Vec::new(),
         owners: vec![(owner3_a, 50), (owner3_b, 50), (owner3_c, 50)],
         multi_leader_rounds: 10,
+        open_multi_leader_rounds: false,
         timeout_config: TimeoutConfig::default(),
     });
     client3_a

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -146,6 +146,10 @@ pub enum SystemOperation {
         owners: Vec<(Owner, u64)>,
         /// The number of initial rounds after 0 in which all owners are allowed to propose blocks.
         multi_leader_rounds: u32,
+        /// Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners.
+        /// This should only be `true` on chains with restrictive application permissions and an
+        /// application-based mechanism to select block proposers.
+        open_multi_leader_rounds: bool,
         /// The timeout configuration: how long fast, multi-leader and single-leader rounds last.
         timeout_config: TimeoutConfig,
     },
@@ -472,12 +476,14 @@ where
                 super_owners,
                 owners,
                 multi_leader_rounds,
+                open_multi_leader_rounds,
                 timeout_config,
             } => {
                 self.ownership.set(ChainOwnership {
                     super_owners: super_owners.into_iter().collect(),
                     owners: owners.into_iter().collect(),
                     multi_leader_rounds,
+                    open_multi_leader_rounds,
                     timeout_config,
                 });
             }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -320,6 +320,7 @@ ChainOwnership:
             TYPENAME: Owner
           VALUE: U64
     - multi_leader_rounds: U32
+    - open_multi_leader_rounds: BOOL
     - timeout_config:
         TYPENAME: TimeoutConfig
 ChannelFullName:
@@ -1053,6 +1054,7 @@ SystemOperation:
                   - TYPENAME: Owner
                   - U64
           - multi_leader_rounds: U32
+          - open_multi_leader_rounds: BOOL
           - timeout_config:
               TYPENAME: TimeoutConfig
     5:

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -112,6 +112,7 @@ impl From<wit_system_api::ChainOwnership> for ChainOwnership {
             super_owners,
             owners,
             multi_leader_rounds,
+            open_multi_leader_rounds,
             timeout_config,
         } = guest;
         ChainOwnership {
@@ -121,6 +122,7 @@ impl From<wit_system_api::ChainOwnership> for ChainOwnership {
                 .map(|(owner, weight)| (owner.into(), weight))
                 .collect(),
             multi_leader_rounds,
+            open_multi_leader_rounds,
             timeout_config: timeout_config.into(),
         }
     }

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -240,6 +240,7 @@ impl From<ChainOwnership> for wit_system_api::ChainOwnership {
             super_owners,
             owners,
             multi_leader_rounds,
+            open_multi_leader_rounds,
             timeout_config,
         } = ownership;
         Self {
@@ -249,6 +250,7 @@ impl From<ChainOwnership> for wit_system_api::ChainOwnership {
                 .map(|(owner, weight)| (owner.into(), weight))
                 .collect(),
             multi_leader_rounds,
+            open_multi_leader_rounds,
             timeout_config: timeout_config.into(),
         }
     }

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -120,12 +120,14 @@ impl BlockBuilder {
         super_owners: Vec<Owner>,
         owners: Vec<(Owner, u64)>,
         multi_leader_rounds: u32,
+        open_multi_leader_rounds: bool,
         timeout_config: TimeoutConfig,
     ) -> &mut Self {
         self.with_system_operation(SystemOperation::ChangeOwnership {
             super_owners,
             owners,
             multi_leader_rounds,
+            open_multi_leader_rounds,
             timeout_config,
         })
     }

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -74,6 +74,7 @@ interface contract-system-api {
         super-owners: list<owner>,
         owners: list<tuple<owner, u64>>,
         multi-leader-rounds: u32,
+        open-multi-leader-rounds: bool,
         timeout-config: timeout-config,
     }
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -748,7 +748,7 @@ type MutationRoot {
 	"""
 	Changes the authentication key of the chain.
 	"""
-	changeMultipleOwners(		chainId: ChainId!,		newOwners: [Owner!]!,		newWeights: [Int!]!,		multiLeaderRounds: Int!,
+	changeMultipleOwners(		chainId: ChainId!,		newOwners: [Owner!]!,		newWeights: [Int!]!,		multiLeaderRounds: Int!,		openMultiLeaderRounds: Boolean!,
 		"""
 		The duration of the fast round, in milliseconds; default: no timeout
 		"""

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -436,6 +436,7 @@ where
             super_owners: vec![new_owner],
             owners: Vec::new(),
             multi_leader_rounds: 2,
+            open_multi_leader_rounds: false,
             timeout_config: TimeoutConfig::default(),
         };
         self.execute_system_operation(operation, chain_id).await
@@ -449,6 +450,7 @@ where
         new_owners: Vec<Owner>,
         new_weights: Vec<u64>,
         multi_leader_rounds: u32,
+        open_multi_leader_rounds: bool,
         #[graphql(desc = "The duration of the fast round, in milliseconds; default: no timeout")]
         fast_round_ms: Option<u64>,
         #[graphql(
@@ -473,6 +475,7 @@ where
             super_owners: Vec::new(),
             owners: new_owners.into_iter().zip(new_weights).collect(),
             multi_leader_rounds,
+            open_multi_leader_rounds,
             timeout_config: TimeoutConfig {
                 fast_round_duration: fast_round_ms.map(TimeDelta::from_millis),
                 base_timeout: TimeDelta::from_millis(base_timeout_ms),


### PR DESCRIPTION
## Motivation

For https://github.com/linera-io/linera-protocol/issues/3162, some chains need to be "permissionless", i.e. admit any signer as a block proposer, as far as the chain manager is concerned.

## Proposal

Add an `open_multi_leader_rounds` option. If it is `true`, the multi-leader rounds are not restricted to the chain owners anymore. (All other round types still are restricted as usual.)

## Test Plan

A test was added.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #3163.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
