### PR TITLE
Rename `Proposal` back to `ProposedBlock`.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -43,8 +43,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     data_types::{
         BlockExecutionOutcome, ChainAndHeight, ChannelFullName, EventRecord, IncomingBundle,
-        MessageAction, MessageBundle, Origin, OutgoingMessage, PostedMessage, Proposal, Target,
-        Transaction,
+        MessageAction, MessageBundle, Origin, OutgoingMessage, PostedMessage, ProposedBlock,
+        Target, Transaction,
     },
     inbox::{Cursor, InboxError, InboxStateView},
     manager::ChainManager,
@@ -247,7 +247,7 @@ pub struct ChainTipState {
 impl ChainTipState {
     /// Checks that the proposed block is suitable, i.e. at the expected height and with the
     /// expected parent.
-    pub fn verify_block_chaining(&self, new_block: &Proposal) -> Result<(), ChainError> {
+    pub fn verify_block_chaining(&self, new_block: &ProposedBlock) -> Result<(), ChainError> {
         ensure!(
             new_block.height == self.next_block_height,
             ChainError::UnexpectedBlockHeight {
@@ -282,7 +282,7 @@ impl ChainTipState {
     /// Checks if the measurement counters would be valid.
     pub fn verify_counters(
         &self,
-        new_block: &Proposal,
+        new_block: &ProposedBlock,
         outcome: &BlockExecutionOutcome,
     ) -> Result<(), ChainError> {
         let num_incoming_bundles = u32::try_from(new_block.incoming_bundles.len())
@@ -664,7 +664,7 @@ where
     /// * Returns the outcome of the execution.
     pub async fn execute_block(
         &mut self,
-        block: &Proposal,
+        block: &ProposedBlock,
         local_time: Timestamp,
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
     ) -> Result<BlockExecutionOutcome, ChainError> {
@@ -934,7 +934,7 @@ where
         message_id: MessageId,
         posted_message: &PostedMessage,
         incoming_bundle: &IncomingBundle,
-        block: &Proposal,
+        block: &ProposedBlock,
         txn_index: u32,
         local_time: Timestamp,
         txn_tracker: &mut TransactionTracker,
@@ -1247,11 +1247,11 @@ where
 #[test]
 fn empty_block_size() {
     let executed_block = crate::data_types::ExecutedBlock {
-        proposal: crate::test::make_first_block(ChainId::root(0)),
+        block: crate::test::make_first_block(ChainId::root(0)),
         outcome: crate::data_types::BlockExecutionOutcome::default(),
     };
     let size = bcs::serialized_size(&crate::block::Block::new(
-        executed_block.proposal,
+        executed_block.block,
         executed_block.outcome,
     ))
     .unwrap();

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -400,14 +400,14 @@ impl OutgoingMessage {
     }
 }
 
-/// A [`Proposal`], together with the outcome from its execution.
+/// A [`ProposedBlock`], together with the outcome from its execution.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, SimpleObject)]
 pub struct ExecutedBlock {
     pub block: ProposedBlock,
     pub outcome: BlockExecutionOutcome,
 }
 
-/// The messages and the state hash resulting from a [`Proposal`]'s execution.
+/// The messages and the state hash resulting from a [`ProposedBlock`]'s execution.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
 #[cfg_attr(with_testing, derive(Default))]
 pub struct BlockExecutionOutcome {

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -48,7 +48,7 @@ mod data_types_tests;
 ///   received ahead of time in the inbox of the chain.
 /// * This constraint does not apply to the execution of confirmed blocks.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
-pub struct Proposal {
+pub struct ProposedBlock {
     /// The chain to which this block belongs.
     pub chain_id: ChainId,
     /// The number identifying the current configuration.
@@ -76,7 +76,7 @@ pub struct Proposal {
     pub previous_block_hash: Option<CryptoHash>,
 }
 
-impl Proposal {
+impl ProposedBlock {
     /// Returns all the published blob IDs in this block's operations.
     pub fn published_blob_ids(&self) -> BTreeSet<BlobId> {
         let mut blob_ids = BTreeSet::new();
@@ -403,7 +403,7 @@ impl OutgoingMessage {
 /// A [`Proposal`], together with the outcome from its execution.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, SimpleObject)]
 pub struct ExecutedBlock {
-    pub proposal: Proposal,
+    pub block: ProposedBlock,
     pub outcome: BlockExecutionOutcome,
 }
 
@@ -643,9 +643,9 @@ impl ExecutedBlock {
         certificate_hash: CryptoHash,
     ) -> impl Iterator<Item = (Epoch, MessageBundle)> + 'a {
         let mut index = 0u32;
-        let block_height = self.proposal.height;
-        let block_timestamp = self.proposal.timestamp;
-        let block_epoch = self.proposal.epoch;
+        let block_height = self.block.height;
+        let block_timestamp = self.block.timestamp;
+        let block_epoch = self.block.epoch;
 
         (0u32..)
             .zip(self.messages())
@@ -676,7 +676,7 @@ impl ExecutedBlock {
         operation_index: usize,
         message_index: u32,
     ) -> Option<MessageId> {
-        let block = &self.proposal;
+        let block = &self.block;
         let transaction_index = block.incoming_bundles.len().checked_add(operation_index)?;
         if message_index
             >= u32::try_from(self.outcome.messages.get(transaction_index)?.len()).ok()?
@@ -702,7 +702,7 @@ impl ExecutedBlock {
             height,
             index,
         } = message_id;
-        if self.proposal.chain_id != *chain_id || self.proposal.height != *height {
+        if self.block.chain_id != *chain_id || self.block.height != *height {
             return None;
         }
         let mut index = usize::try_from(*index).ok()?;
@@ -718,28 +718,28 @@ impl ExecutedBlock {
     /// Returns the message ID belonging to the `index`th outgoing message in this block.
     pub fn message_id(&self, index: u32) -> MessageId {
         MessageId {
-            chain_id: self.proposal.chain_id,
-            height: self.proposal.height,
+            chain_id: self.block.chain_id,
+            height: self.block.height,
             index,
         }
     }
 
     pub fn required_blob_ids(&self) -> HashSet<BlobId> {
         let mut blob_ids = self.outcome.oracle_blob_ids();
-        blob_ids.extend(self.proposal.published_blob_ids());
+        blob_ids.extend(self.block.published_blob_ids());
         blob_ids
     }
 
     pub fn requires_blob(&self, blob_id: &BlobId) -> bool {
         self.outcome.oracle_blob_ids().contains(blob_id)
-            || self.proposal.published_blob_ids().contains(blob_id)
+            || self.block.published_blob_ids().contains(blob_id)
     }
 }
 
 impl BlockExecutionOutcome {
-    pub fn with(self, block: Proposal) -> ExecutedBlock {
+    pub fn with(self, block: ProposedBlock) -> ExecutedBlock {
         ExecutedBlock {
-            proposal: block,
+            block,
             outcome: self,
         }
     }
@@ -768,7 +768,7 @@ impl BlockExecutionOutcome {
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ProposalContent {
     /// The proposed block.
-    pub proposal: Proposal,
+    pub block: ProposedBlock,
     /// The consensus round in which this proposal is made.
     pub round: Round,
     /// If this is a retry from an earlier round, the execution outcome.
@@ -779,13 +779,13 @@ pub struct ProposalContent {
 impl BlockProposal {
     pub fn new_initial(
         round: Round,
-        proposal: Proposal,
+        block: ProposedBlock,
         secret: &KeyPair,
         blobs: Vec<Blob>,
     ) -> Self {
         let content = ProposalContent {
             round,
-            proposal,
+            block,
             outcome: None,
         };
         let signature = Signature::new(&content, secret);
@@ -809,7 +809,7 @@ impl BlockProposal {
         let block = validated_block_certificate.into_inner().into_inner();
         let executed_block: ExecutedBlock = block.into();
         let content = ProposalContent {
-            proposal: executed_block.proposal,
+            block: executed_block.block,
             round,
             outcome: Some(executed_block.outcome),
         };

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -18,16 +18,16 @@ use linera_execution::{
 use crate::{
     block::ConfirmedBlock,
     data_types::{
-        BlockProposal, IncomingBundle, PostedMessage, Proposal, SignatureAggregator, Vote,
+        BlockProposal, IncomingBundle, PostedMessage, ProposedBlock, SignatureAggregator, Vote,
     },
     types::{CertificateValue, GenericCertificate},
 };
 
 /// Creates a new child of the given block, with the same timestamp.
-pub fn make_child_block(parent: &Hashed<ConfirmedBlock>) -> Proposal {
+pub fn make_child_block(parent: &Hashed<ConfirmedBlock>) -> ProposedBlock {
     let parent_value = parent.inner();
     let parent_header = &parent_value.block().header;
-    Proposal {
+    ProposedBlock {
         epoch: parent_header.epoch,
         chain_id: parent_header.chain_id,
         incoming_bundles: vec![],
@@ -40,8 +40,8 @@ pub fn make_child_block(parent: &Hashed<ConfirmedBlock>) -> Proposal {
 }
 
 /// Creates a block at height 0 for a new chain.
-pub fn make_first_block(chain_id: ChainId) -> Proposal {
-    Proposal {
+pub fn make_first_block(chain_id: ChainId) -> ProposedBlock {
+    ProposedBlock {
         epoch: Epoch::ZERO,
         chain_id,
         incoming_bundles: vec![],
@@ -86,7 +86,7 @@ pub trait BlockTestExt: Sized {
     fn into_proposal_with_round(self, key_pair: &KeyPair, round: Round) -> BlockProposal;
 }
 
-impl BlockTestExt for Proposal {
+impl BlockTestExt for ProposedBlock {
     fn with_authenticated_signer(mut self, authenticated_signer: Option<Owner>) -> Self {
         self.authenticated_signer = authenticated_signer;
         self

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -36,7 +36,9 @@ use {
         data_types::Amount,
         identifiers::{AccountOwner, ApplicationId, Owner},
     },
-    linera_chain::data_types::{BlockProposal, ExecutedBlock, Proposal, SignatureAggregator, Vote},
+    linera_chain::data_types::{
+        BlockProposal, ExecutedBlock, ProposedBlock, SignatureAggregator, Vote,
+    },
     linera_chain::types::{CertificateValue, GenericCertificate},
     linera_core::data_types::ChainInfoQuery,
     linera_execution::{
@@ -783,7 +785,7 @@ where
                 .take(transactions_per_block)
                 .collect();
             let chain = self.wallet.get(chain_id).expect("should have chain");
-            let block = Proposal {
+            let block = ProposedBlock {
                 epoch: Epoch::ZERO,
                 chain_id,
                 incoming_bundles: Vec::new(),
@@ -967,7 +969,10 @@ where
     }
 
     /// Stages the execution of a block proposal.
-    pub async fn stage_block_execution(&self, block: Proposal) -> Result<ExecutedBlock, Error> {
+    pub async fn stage_block_execution(
+        &self,
+        block: ProposedBlock,
+    ) -> Result<ExecutedBlock, Error> {
         Ok(self
             .client
             .local_node()

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -12,7 +12,7 @@ use linera_base::{
     ensure,
     identifiers::{BlobId, ChainDescription, ChainId, Owner},
 };
-use linera_chain::data_types::Proposal;
+use linera_chain::data_types::ProposedBlock;
 use linera_core::{client::ChainClient, node::ValidatorNodeProvider};
 use linera_storage::Storage;
 use rand::Rng as _;
@@ -210,7 +210,7 @@ pub struct UserChain {
     pub block_hash: Option<CryptoHash>,
     pub timestamp: Timestamp,
     pub next_block_height: BlockHeight,
-    pub pending_block: Option<Proposal>,
+    pub pending_block: Option<ProposedBlock>,
     pub pending_blobs: BTreeMap<BlobId, Blob>,
 }
 

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -17,7 +17,7 @@ use linera_base::{
     identifiers::{BlobId, ChainId, UserApplicationId},
 };
 use linera_chain::{
-    data_types::{BlockProposal, ExecutedBlock, MessageBundle, Origin, Proposal, Target},
+    data_types::{BlockProposal, ExecutedBlock, MessageBundle, Origin, ProposedBlock, Target},
     types::{Block, ConfirmedBlockCertificate, TimeoutCertificate, ValidatedBlockCertificate},
     ChainStateView,
 };
@@ -84,7 +84,7 @@ where
 
     /// Execute a block but discard any changes to the chain state.
     StageBlockExecution {
-        block: Proposal,
+        block: ProposedBlock,
         #[debug(skip)]
         callback: oneshot::Sender<Result<(ExecutedBlock, ChainInfoResponse), WorkerError>>,
     },

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -19,7 +19,9 @@ use linera_base::{
     identifiers::{BlobId, ChainId, UserApplicationId},
 };
 use linera_chain::{
-    data_types::{BlockProposal, ExecutedBlock, Medium, MessageBundle, Origin, Proposal, Target},
+    data_types::{
+        BlockProposal, ExecutedBlock, Medium, MessageBundle, Origin, ProposedBlock, Target,
+    },
     types::{Block, ConfirmedBlockCertificate, TimeoutCertificate, ValidatedBlockCertificate},
     ChainError, ChainStateView,
 };
@@ -176,7 +178,7 @@ where
     /// Executes a block without persisting any changes to the state.
     pub(super) async fn stage_block_execution(
         &mut self,
-        block: Proposal,
+        block: ProposedBlock,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
         ChainWorkerStateWithTemporaryChanges::new(self)
             .await
@@ -384,7 +386,7 @@ where
             if !tracked_chains
                 .read()
                 .expect("Panics should not happen while holding a lock to `tracked_chains`")
-                .contains(&executed_block.proposal.chain_id)
+                .contains(&executed_block.block.chain_id)
             {
                 return; // The parent chain is not tracked; don't track the child.
             }

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -15,7 +15,7 @@ use linera_base::{
 use linera_chain::{
     data_types::{
         BlockExecutionOutcome, BlockProposal, ChannelFullName, ExecutedBlock, IncomingBundle,
-        Medium, MessageAction, Proposal, ProposalContent,
+        Medium, MessageAction, ProposalContent, ProposedBlock,
     },
     manager,
     types::ValidatedBlock,
@@ -126,7 +126,7 @@ where
     /// Executes a block without persisting any changes to the state.
     pub(super) async fn stage_block_execution(
         &mut self,
-        proposal: Proposal,
+        proposal: ProposedBlock,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
         let local_time = self.0.storage.clock().current_time();
         let signer = proposal.authenticated_signer;
@@ -158,7 +158,7 @@ where
         let BlockProposal {
             content:
                 ProposalContent {
-                    proposal: block,
+                    block,
                     round,
                     outcome,
                 },

--- a/linera-core/src/client/chain_client_state.rs
+++ b/linera-core/src/client/chain_client_state.rs
@@ -11,7 +11,7 @@ use linera_base::{
     identifiers::{BlobId, Owner},
     ownership::ChainOwnership,
 };
-use linera_chain::data_types::Proposal;
+use linera_chain::data_types::ProposedBlock;
 use tokio::sync::Mutex;
 
 use super::ChainClientError;
@@ -30,7 +30,7 @@ pub struct ChainClientState {
     /// The block we are currently trying to propose for the next height, if any.
     ///
     /// This is always at the same height as `next_block_height`.
-    pending_proposal: Option<Proposal>,
+    pending_proposal: Option<ProposedBlock>,
     /// Known key pairs from present and past identities.
     known_key_pairs: BTreeMap<Owner, KeyPair>,
 
@@ -49,7 +49,7 @@ impl ChainClientState {
         block_hash: Option<CryptoHash>,
         timestamp: Timestamp,
         next_block_height: BlockHeight,
-        pending_block: Option<Proposal>,
+        pending_block: Option<ProposedBlock>,
         pending_blobs: BTreeMap<BlobId, Blob>,
     ) -> ChainClientState {
         let known_key_pairs = known_key_pairs
@@ -83,11 +83,11 @@ impl ChainClientState {
         self.next_block_height
     }
 
-    pub fn pending_proposal(&self) -> &Option<Proposal> {
+    pub fn pending_proposal(&self) -> &Option<ProposedBlock> {
         &self.pending_proposal
     }
 
-    pub(super) fn set_pending_proposal(&mut self, block: Proposal) {
+    pub(super) fn set_pending_proposal(&mut self, block: ProposedBlock) {
         if block.height == self.next_block_height {
             self.pending_proposal = Some(block);
         } else {

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -13,7 +13,7 @@ use linera_base::{
     identifiers::{BlobId, ChainId, MessageId, UserApplicationId},
 };
 use linera_chain::{
-    data_types::{BlockProposal, ExecutedBlock, Proposal},
+    data_types::{BlockProposal, ExecutedBlock, ProposedBlock},
     types::{ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
     ChainStateView,
 };
@@ -173,7 +173,7 @@ where
     #[instrument(level = "trace", skip_all)]
     pub async fn stage_block_execution(
         &self,
-        block: Proposal,
+        block: ProposedBlock,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), LocalNodeError> {
         Ok(self.node.state.stage_block_execution(block).await?)
     }

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -51,7 +51,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
         &self,
         proposal: Box<BlockProposal>,
     ) -> Result<Box<ChainInfo>, NodeError> {
-        let chain_id = proposal.content.proposal.chain_id;
+        let chain_id = proposal.content.block.chain_id;
         let response = self.node.handle_block_proposal(*proposal).await?;
         self.check_and_return_info(response, chain_id)
     }
@@ -155,8 +155,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
         let proposed = manager.requested_proposed.as_ref();
         let locked = manager.requested_locked.as_ref();
         ensure!(
-            proposed.map_or(true, |proposal| proposal.content.proposal.chain_id
-                == chain_id)
+            proposed.map_or(true, |proposal| proposal.content.block.chain_id == chain_id)
                 && locked.map_or(true, |cert| cert.chain_id() == chain_id)
                 && response.check(&self.name).is_ok(),
             NodeError::InvalidChainInfoResponse

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1511,7 +1511,7 @@ where
                 .requested_proposed
                 .unwrap()
                 .content
-                .proposal
+                .block
                 .operations,
             blob_0_1_operations,
         );
@@ -1684,7 +1684,7 @@ where
                 .requested_proposed
                 .unwrap()
                 .content
-                .proposal
+                .block
                 .operations,
             blob_0_1_operations,
         );
@@ -1750,7 +1750,7 @@ where
             .requested_proposed
             .unwrap()
             .content
-            .proposal
+            .block
             .operations,
         blob_2_3_operations,
     );

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -30,7 +30,7 @@ use linera_chain::{
     data_types::{
         BlockExecutionOutcome, BlockProposal, ChainAndHeight, ChannelFullName, ExecutedBlock,
         IncomingBundle, LiteValue, LiteVote, Medium, MessageAction, MessageBundle, Origin,
-        OutgoingMessage, PostedMessage, Proposal, SignatureAggregator,
+        OutgoingMessage, PostedMessage, ProposedBlock, SignatureAggregator,
     },
     manager::LockedBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
@@ -303,7 +303,7 @@ where
         })
         .collect::<Vec<_>>();
 
-    let block = Proposal {
+    let block = ProposedBlock {
         epoch,
         incoming_bundles,
         authenticated_signer,
@@ -690,7 +690,7 @@ where
         .clone()
         .into();
     // Multi-leader round - it's not confirmed yet.
-    assert_eq!(&executed_block.proposal, &block_proposal0.content.proposal);
+    assert_eq!(&executed_block.block, &block_proposal0.content.block);
     assert!(chain.manager.confirmed_vote().is_none());
     let block_certificate0 = make_certificate(
         &committee,
@@ -715,7 +715,7 @@ where
         .into();
 
     // Should be confirmed after handling the certificate.
-    assert_eq!(&executed_block.proposal, &block_proposal0.content.proposal);
+    assert_eq!(&executed_block.block, &block_proposal0.content.block);
     assert!(chain.manager.validated_vote().is_none());
     drop(chain);
 
@@ -740,7 +740,7 @@ where
         .block()
         .clone()
         .into();
-    assert_eq!(&executed_block.proposal, &block_proposal1.content.proposal);
+    assert_eq!(&executed_block.block, &block_proposal1.content.block);
     assert!(chain.manager.confirmed_vote().is_none());
     drop(chain);
     assert_matches!(
@@ -1074,7 +1074,7 @@ where
                     .await,
                     oracle_responses: vec![Vec::new(); 2],
                 }
-                .with(block_proposal.content.proposal),
+                .with(block_proposal.content.block),
             )),
         );
         worker

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -274,7 +274,7 @@ where
         proposal: Box<BlockProposal>,
         mut blob_ids: HashSet<BlobId>,
     ) -> Result<Box<ChainInfo>, ChainClientError> {
-        let chain_id = proposal.content.proposal.chain_id;
+        let chain_id = proposal.content.block.chain_id;
         let mut sent_cross_chain_updates = false;
         for blob in &proposal.blobs {
             blob_ids.remove(&blob.id()); // Keep only blobs we may need to resend.
@@ -411,7 +411,7 @@ where
     ) -> Result<LiteVote, ChainClientError> {
         let (target_block_height, chain_id) = match &action {
             CommunicateAction::SubmitBlock { proposal, .. } => {
-                let block = &proposal.content.proposal;
+                let block = &proposal.content.block;
                 (block.height, block.chain_id)
             }
             CommunicateAction::FinalizeBlock { certificate, .. } => (

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -24,7 +24,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        BlockExecutionOutcome, BlockProposal, ExecutedBlock, MessageBundle, Origin, Proposal,
+        BlockExecutionOutcome, BlockProposal, ExecutedBlock, MessageBundle, Origin, ProposedBlock,
         Target,
     },
     types::{
@@ -504,7 +504,7 @@ where
     #[instrument(level = "trace", skip(self, block))]
     pub async fn stage_block_execution(
         &self,
-        block: Proposal,
+        block: ProposedBlock,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
         self.query_chain_worker(block.chain_id, move |callback| {
             ChainWorkerRequest::StageBlockExecution { block, callback }
@@ -772,8 +772,8 @@ where
 
     #[instrument(skip_all, fields(
         nick = self.nickname,
-        chain_id = format!("{:.8}", proposal.content.proposal.chain_id),
-        height = %proposal.content.proposal.height,
+        chain_id = format!("{:.8}", proposal.content.block.chain_id),
+        height = %proposal.content.block.height,
     ))]
     pub async fn handle_block_proposal(
         &self,
@@ -783,7 +783,7 @@ where
         #[cfg(with_metrics)]
         let round = proposal.content.round;
         let response = self
-            .query_chain_worker(proposal.content.proposal.chain_id, move |callback| {
+            .query_chain_worker(proposal.content.block.chain_id, move |callback| {
                 ChainWorkerRequest::HandleBlockProposal { proposal, callback }
             })
             .await?;

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -194,7 +194,7 @@ impl TryFrom<BlockProposal> for api::BlockProposal {
 
     fn try_from(block_proposal: BlockProposal) -> Result<Self, Self::Error> {
         Ok(Self {
-            chain_id: Some(block_proposal.content.proposal.chain_id.into()),
+            chain_id: Some(block_proposal.content.block.chain_id.into()),
             content: bincode::serialize(&block_proposal.content)?,
             public_key: Some(block_proposal.public_key.into()),
             owner: Some(block_proposal.owner.into()),
@@ -214,7 +214,7 @@ impl TryFrom<api::BlockProposal> for BlockProposal {
     fn try_from(block_proposal: api::BlockProposal) -> Result<Self, Self::Error> {
         let content: ProposalContent = bincode::deserialize(&block_proposal.content)?;
         ensure!(
-            Some(content.proposal.chain_id.into()) == block_proposal.chain_id,
+            Some(content.block.chain_id.into()) == block_proposal.chain_id,
             GrpcProtoConversionError::InconsistentChainId
         );
         Ok(Self {
@@ -976,7 +976,7 @@ pub mod tests {
         data_types::{Amount, Blob, Round, Timestamp},
     };
     use linera_chain::{
-        data_types::{BlockExecutionOutcome, Proposal},
+        data_types::{BlockExecutionOutcome, ProposedBlock},
         test::make_first_block,
         types::CertificateKind,
     };
@@ -990,7 +990,7 @@ pub mod tests {
 
     impl<'de> BcsSignable<'de> for Foo {}
 
-    fn get_block() -> Proposal {
+    fn get_block() -> ProposedBlock {
         make_first_block(ChainId::root(0))
     }
 
@@ -1217,7 +1217,7 @@ pub mod tests {
         let public_key = KeyPair::generate().public();
         let block_proposal = BlockProposal {
             content: ProposalContent {
-                proposal: get_block(),
+                block: get_block(),
                 round: Round::SingleLeader(4),
                 outcome: Some(outcome),
             },

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -70,7 +70,7 @@ impl RpcMessage {
         use RpcMessage::*;
 
         let chain_id = match self {
-            BlockProposal(proposal) => proposal.content.proposal.chain_id,
+            BlockProposal(proposal) => proposal.content.block.chain_id,
             LiteCertificate(request) => request.certificate.value.chain_id,
             TimeoutCertificate(request) => request.certificate.inner().chain_id(),
             ValidatedCertificate(request) => request.certificate.inner().chain_id(),

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -721,7 +721,16 @@ PostedMessage:
     - index: U32
     - message:
         TYPENAME: Message
-Proposal:
+ProposalContent:
+  STRUCT:
+    - block:
+        TYPENAME: ProposedBlock
+    - round:
+        TYPENAME: Round
+    - outcome:
+        OPTION:
+          TYPENAME: BlockExecutionOutcome
+ProposedBlock:
   STRUCT:
     - chain_id:
         TYPENAME: ChainId
@@ -743,15 +752,6 @@ Proposal:
     - previous_block_hash:
         OPTION:
           TYPENAME: CryptoHash
-ProposalContent:
-  STRUCT:
-    - proposal:
-        TYPENAME: Proposal
-    - round:
-        TYPENAME: Round
-    - outcome:
-        OPTION:
-          TYPENAME: BlockExecutionOutcome
 PublicKey:
   NEWTYPESTRUCT:
     TUPLEARRAY:

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -14,7 +14,7 @@ use linera_base::{
 use linera_chain::{
     data_types::{
         ChannelFullName, IncomingBundle, LiteValue, LiteVote, Medium, MessageAction, Origin,
-        Proposal, SignatureAggregator,
+        ProposedBlock, SignatureAggregator,
     },
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
 };
@@ -29,7 +29,7 @@ use crate::ToBcsBytes;
 /// A helper type to build a block proposal using the builder pattern, and then signing them into
 /// [`ConfirmedBlockCertificate`]s using a [`TestValidator`].
 pub struct BlockBuilder {
-    block: Proposal,
+    block: ProposedBlock,
     validator: TestValidator,
 }
 
@@ -63,7 +63,7 @@ impl BlockBuilder {
             .unwrap_or_default();
 
         BlockBuilder {
-            block: Proposal {
+            block: ProposedBlock {
                 epoch: 0.into(),
                 chain_id,
                 incoming_bundles: vec![],

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -775,7 +775,7 @@ impl Runnable for Job {
                 for rpc_msg in &proposals {
                     if let RpcMessage::BlockProposal(proposal) = rpc_msg {
                         let executed_block = context
-                            .stage_block_execution(proposal.content.proposal.clone())
+                            .stage_block_execution(proposal.content.block.clone())
                             .await?;
                         let value = Hashed::new(ConfirmedBlock::new(executed_block));
                         values.insert(value.hash(), value);

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -711,7 +711,7 @@ mod proto_message_cap {
         let validator = ValidatorName(keypair.public());
         let signature = Signature::new(&TestString::new("Test"), &keypair);
         let executed_block = ExecutedBlock {
-            proposal: linera_chain::test::make_first_block(ChainId::root(0)),
+            block: linera_chain::test::make_first_block(ChainId::root(0)),
             outcome: BlockExecutionOutcome::default(),
         };
         let signatures = vec![(validator, signature)];


### PR DESCRIPTION
## Motivation

The discussion https://github.com/linera-io/linera-protocol/pull/3101#discussion_r1913251835 was never resolved; a proposal has a content, which has a proposal.

## Proposal

Rename `Proposal` to `ProposedBlock`, to distinguish it from the outer type.

(I also added some destructuring in `Block::new`, because I ran into a naming conflict and this way the compiler will warn us if we add any fields and forget them there.)

## Test Plan

Only renaming.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Related to #3101
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
