### PR TITLE
Validation round number oracle

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -105,7 +105,20 @@ pub struct BlockHeight(pub u64);
 
 /// An identifier for successive attempts to decide a value in a consensus protocol.
 #[derive(
-    Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug, Serialize, Deserialize,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Copy,
+    Clone,
+    Hash,
+    Default,
+    Debug,
+    Serialize,
+    Deserialize,
+    WitType,
+    WitLoad,
+    WitStore,
 )]
 pub enum Round {
     /// The initial fast round.
@@ -763,6 +776,8 @@ pub enum OracleResponse {
     Blob(BlobId),
     /// An assertion oracle that passed.
     Assert,
+    /// The block's validation round.
+    Round(Round),
 }
 
 impl Display for OracleResponse {
@@ -774,6 +789,7 @@ impl Display for OracleResponse {
             OracleResponse::Post(bytes) => write!(f, "Post:{}", STANDARD_NO_PAD.encode(bytes))?,
             OracleResponse::Blob(blob_id) => write!(f, "Blob:{}", blob_id)?,
             OracleResponse::Assert => write!(f, "Assert")?,
+            OracleResponse::Round(round) => write!(f, "Round:{round}")?,
         };
 
         Ok(())

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -105,20 +105,7 @@ pub struct BlockHeight(pub u64);
 
 /// An identifier for successive attempts to decide a value in a consensus protocol.
 #[derive(
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Copy,
-    Clone,
-    Hash,
-    Default,
-    Debug,
-    Serialize,
-    Deserialize,
-    WitType,
-    WitLoad,
-    WitStore,
+    Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug, Serialize, Deserialize,
 )]
 pub enum Round {
     /// The initial fast round.
@@ -616,6 +603,14 @@ impl Round {
         matches!(self, Round::MultiLeader(_))
     }
 
+    /// Returns the round number if this is a multi-leader round, `None` otherwise.
+    pub fn multi_leader(&self) -> Option<u32> {
+        match self {
+            Round::MultiLeader(number) => Some(*number),
+            _ => None,
+        }
+    }
+
     /// Whether the round is the fast round.
     pub fn is_fast(&self) -> bool {
         matches!(self, Round::Fast)
@@ -777,7 +772,7 @@ pub enum OracleResponse {
     /// An assertion oracle that passed.
     Assert,
     /// The block's validation round.
-    Round(Round),
+    Round(Option<u32>),
 }
 
 impl Display for OracleResponse {
@@ -789,7 +784,8 @@ impl Display for OracleResponse {
             OracleResponse::Post(bytes) => write!(f, "Post:{}", STANDARD_NO_PAD.encode(bytes))?,
             OracleResponse::Blob(blob_id) => write!(f, "Blob:{}", blob_id)?,
             OracleResponse::Assert => write!(f, "Assert")?,
-            OracleResponse::Round(round) => write!(f, "Round:{round}")?,
+            OracleResponse::Round(Some(round)) => write!(f, "Round:{round}")?,
+            OracleResponse::Round(None) => write!(f, "Round:None")?,
         };
 
         Ok(())

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -13,7 +13,7 @@ use futures::stream::{self, StreamExt, TryStreamExt};
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
-        Amount, ArithmeticError, Blob, BlockHeight, OracleResponse, Timestamp,
+        Amount, ArithmeticError, Blob, BlockHeight, OracleResponse, Round, Timestamp,
         UserApplicationDescription,
     },
     ensure,
@@ -666,6 +666,7 @@ where
         &mut self,
         block: &ProposedBlock,
         local_time: Timestamp,
+        round: Option<Round>,
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
     ) -> Result<BlockExecutionOutcome, ChainError> {
         #[cfg(with_metrics)]
@@ -785,6 +786,7 @@ where
                             posted_message,
                             incoming_bundle,
                             block,
+                            round,
                             txn_index,
                             local_time,
                             &mut txn_tracker,
@@ -803,6 +805,7 @@ where
                         chain_id,
                         height: block.height,
                         index: Some(txn_index),
+                        round,
                         authenticated_signer: block.authenticated_signer,
                         authenticated_caller_id: None,
                     };
@@ -935,6 +938,7 @@ where
         posted_message: &PostedMessage,
         incoming_bundle: &IncomingBundle,
         block: &ProposedBlock,
+        round: Option<Round>,
         txn_index: u32,
         local_time: Timestamp,
         txn_tracker: &mut TransactionTracker,
@@ -946,6 +950,7 @@ where
             chain_id: block.chain_id,
             is_bouncing: posted_message.is_bouncing(),
             height: block.height,
+            round,
             certificate_hash: incoming_bundle.bundle.certificate_hash,
             message_id,
             authenticated_signer: posted_message.authenticated_signer,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -13,7 +13,7 @@ use futures::stream::{self, StreamExt, TryStreamExt};
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
-        Amount, ArithmeticError, Blob, BlockHeight, OracleResponse, Round, Timestamp,
+        Amount, ArithmeticError, Blob, BlockHeight, OracleResponse, Timestamp,
         UserApplicationDescription,
     },
     ensure,
@@ -666,7 +666,7 @@ where
         &mut self,
         block: &ProposedBlock,
         local_time: Timestamp,
-        round: Option<Round>,
+        round: Option<u32>,
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
     ) -> Result<BlockExecutionOutcome, ChainError> {
         #[cfg(with_metrics)]
@@ -938,7 +938,7 @@ where
         posted_message: &PostedMessage,
         incoming_bundle: &IncomingBundle,
         block: &ProposedBlock,
-        round: Option<Round>,
+        round: Option<u32>,
         txn_index: u32,
         local_time: Timestamp,
         txn_tracker: &mut TransactionTracker,

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -160,7 +160,7 @@ async fn test_block_size_limit() {
             recipient: Recipient::root(0),
             amount: Amount::ONE,
         });
-    let result = chain.execute_block(&invalid_block, time, None).await;
+    let result = chain.execute_block(&invalid_block, time, None, None).await;
     assert_matches!(
         result,
         Err(ChainError::ExecutionError(
@@ -170,7 +170,10 @@ async fn test_block_size_limit() {
     );
 
     // The valid block is accepted...
-    let outcome = chain.execute_block(&valid_block, time, None).await.unwrap();
+    let outcome = chain
+        .execute_block(&valid_block, time, None, None)
+        .await
+        .unwrap();
     let block = Block::new(valid_block, outcome);
 
     // ...because its size is exactly at the allowed limit.
@@ -231,7 +234,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     let invalid_block = make_first_block(chain_id)
         .with_incoming_bundle(bundle.clone())
         .with_simple_transfer(chain_id, Amount::ONE);
-    let result = chain.execute_block(&invalid_block, time, None).await;
+    let result = chain.execute_block(&invalid_block, time, None, None).await;
     assert_matches!(result, Err(ChainError::AuthorizedApplications(app_ids))
         if app_ids == vec![application_id]
     );
@@ -247,7 +250,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
         .with_incoming_bundle(bundle)
         .with_operation(app_operation.clone());
     let executed_block = chain
-        .execute_block(&valid_block, time, None)
+        .execute_block(&valid_block, time, None, None)
         .await?
         .with(valid_block);
     let value = Hashed::new(ConfirmedBlock::new(executed_block));
@@ -256,14 +259,14 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     let invalid_block = make_child_block(&value.clone())
         .with_simple_transfer(chain_id, Amount::ONE)
         .with_operation(app_operation.clone());
-    let result = chain.execute_block(&invalid_block, time, None).await;
+    let result = chain.execute_block(&invalid_block, time, None, None).await;
     assert_matches!(result, Err(ChainError::AuthorizedApplications(app_ids))
         if app_ids == vec![application_id]
     );
 
     // Also, blocks without an application operation or incoming message are forbidden.
     let invalid_block = make_child_block(&value.clone());
-    let result = chain.execute_block(&invalid_block, time, None).await;
+    let result = chain.execute_block(&invalid_block, time, None, None).await;
     assert_matches!(result, Err(ChainError::MissingMandatoryApplications(app_ids))
         if app_ids == vec![application_id]
     );
@@ -272,7 +275,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     application.expect_call(ExpectedCall::execute_operation(|_, _, _| Ok(vec![])));
     application.expect_call(ExpectedCall::default_finalize());
     let valid_block = make_child_block(&value).with_operation(app_operation);
-    chain.execute_block(&valid_block, time, None).await?;
+    chain.execute_block(&valid_block, time, None, None).await?;
 
     Ok(())
 }

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -33,7 +33,7 @@ use {
     futures::{stream, StreamExt as _, TryStreamExt as _},
     linera_base::{
         crypto::PublicKey,
-        data_types::{Amount, Round},
+        data_types::Amount,
         identifiers::{AccountOwner, ApplicationId, Owner},
     },
     linera_chain::data_types::{
@@ -972,7 +972,7 @@ where
     pub async fn stage_block_execution(
         &self,
         block: ProposedBlock,
-        round: Option<Round>,
+        round: Option<u32>,
     ) -> Result<ExecutedBlock, Error> {
         Ok(self
             .client

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -33,7 +33,7 @@ use {
     futures::{stream, StreamExt as _, TryStreamExt as _},
     linera_base::{
         crypto::PublicKey,
-        data_types::Amount,
+        data_types::{Amount, Round},
         identifiers::{AccountOwner, ApplicationId, Owner},
     },
     linera_chain::data_types::{
@@ -972,11 +972,12 @@ where
     pub async fn stage_block_execution(
         &self,
         block: ProposedBlock,
+        round: Option<Round>,
     ) -> Result<ExecutedBlock, Error> {
         Ok(self
             .client
             .local_node()
-            .stage_block_execution(block)
+            .stage_block_execution(block, round)
             .await?
             .0)
     }

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -12,7 +12,7 @@ use std::{
 use custom_debug_derive::Debug;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, BlockHeight, Timestamp, UserApplicationDescription},
+    data_types::{Blob, BlockHeight, Round, Timestamp, UserApplicationDescription},
     hashed::Hashed,
     identifiers::{BlobId, ChainId, UserApplicationId},
 };
@@ -85,6 +85,7 @@ where
     /// Execute a block but discard any changes to the chain state.
     StageBlockExecution {
         block: ProposedBlock,
+        round: Option<Round>,
         #[debug(skip)]
         callback: oneshot::Sender<Result<(ExecutedBlock, ChainInfoResponse), WorkerError>>,
     },
@@ -286,8 +287,12 @@ where
                 } => callback
                     .send(self.worker.describe_application(application_id).await)
                     .is_ok(),
-                ChainWorkerRequest::StageBlockExecution { block, callback } => callback
-                    .send(self.worker.stage_block_execution(block).await)
+                ChainWorkerRequest::StageBlockExecution {
+                    block,
+                    round,
+                    callback,
+                } => callback
+                    .send(self.worker.stage_block_execution(block, round).await)
                     .is_ok(),
                 ChainWorkerRequest::ProcessTimeout {
                     certificate,

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -12,7 +12,7 @@ use std::{
 use custom_debug_derive::Debug;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, BlockHeight, Round, Timestamp, UserApplicationDescription},
+    data_types::{Blob, BlockHeight, Timestamp, UserApplicationDescription},
     hashed::Hashed,
     identifiers::{BlobId, ChainId, UserApplicationId},
 };
@@ -85,7 +85,7 @@ where
     /// Execute a block but discard any changes to the chain state.
     StageBlockExecution {
         block: ProposedBlock,
-        round: Option<Round>,
+        round: Option<u32>,
         #[debug(skip)]
         callback: oneshot::Sender<Result<(ExecutedBlock, ChainInfoResponse), WorkerError>>,
     },

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -359,6 +359,7 @@ where
         let verified_outcome = Box::pin(self.state.chain.execute_block(
             &executed_block.block,
             local_time,
+            None,
             Some(executed_block.outcome.oracle_responses.clone()),
         ))
         .await?;

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -13,7 +13,7 @@ use std::{
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, BlockHeight, Round, UserApplicationDescription},
+    data_types::{Blob, BlockHeight, UserApplicationDescription},
     ensure,
     hashed::Hashed,
     identifiers::{BlobId, ChainId, UserApplicationId},
@@ -179,7 +179,7 @@ where
     pub(super) async fn stage_block_execution(
         &mut self,
         block: ProposedBlock,
-        round: Option<Round>,
+        round: Option<u32>,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
         ChainWorkerStateWithTemporaryChanges::new(self)
             .await

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -13,7 +13,7 @@ use std::{
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, BlockHeight, UserApplicationDescription},
+    data_types::{Blob, BlockHeight, Round, UserApplicationDescription},
     ensure,
     hashed::Hashed,
     identifiers::{BlobId, ChainId, UserApplicationId},
@@ -179,10 +179,11 @@ where
     pub(super) async fn stage_block_execution(
         &mut self,
         block: ProposedBlock,
+        round: Option<Round>,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
         ChainWorkerStateWithTemporaryChanges::new(self)
             .await
-            .stage_block_execution(block)
+            .stage_block_execution(block, round)
             .await
     }
 

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     data_types::{
-        ArithmeticError, Blob, BlobContent, CompressedBytecode, Round, Timestamp,
+        ArithmeticError, Blob, BlobContent, CompressedBytecode, Timestamp,
         UserApplicationDescription,
     },
     ensure,
@@ -127,7 +127,7 @@ where
     pub(super) async fn stage_block_execution(
         &mut self,
         block: ProposedBlock,
-        round: Option<Round>,
+        round: Option<u32>,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
         let local_time = self.0.storage.clock().current_time();
         let signer = block.authenticated_signer;
@@ -242,7 +242,7 @@ where
             Box::pin(
                 self.0
                     .chain
-                    .execute_block(block, local_time, Some(*round), None),
+                    .execute_block(block, local_time, round.multi_leader(), None),
             )
             .await?
         };

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     data_types::{
-        ArithmeticError, Blob, BlobContent, CompressedBytecode, Timestamp,
+        ArithmeticError, Blob, BlobContent, CompressedBytecode, Round, Timestamp,
         UserApplicationDescription,
     },
     ensure,
@@ -126,14 +126,15 @@ where
     /// Executes a block without persisting any changes to the state.
     pub(super) async fn stage_block_execution(
         &mut self,
-        proposal: ProposedBlock,
+        block: ProposedBlock,
+        round: Option<Round>,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
         let local_time = self.0.storage.clock().current_time();
-        let signer = proposal.authenticated_signer;
+        let signer = block.authenticated_signer;
 
-        let executed_block = Box::pin(self.0.chain.execute_block(&proposal, local_time, None))
+        let executed_block = Box::pin(self.0.chain.execute_block(&block, local_time, round, None))
             .await?
-            .with(proposal);
+            .with(block);
 
         let mut response = ChainInfoResponse::new(&self.0.chain, None);
         if let Some(signer) = signer {
@@ -238,7 +239,12 @@ where
         let outcome = if let Some(outcome) = outcome {
             outcome.clone()
         } else {
-            Box::pin(self.0.chain.execute_block(block, local_time, None)).await?
+            Box::pin(
+                self.0
+                    .chain
+                    .execute_block(block, local_time, Some(*round), None),
+            )
+            .await?
         };
 
         let executed_block = outcome.with(block.clone());

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -9,7 +9,7 @@ use std::{
 
 use futures::{future::Either, stream, StreamExt as _, TryStreamExt as _};
 use linera_base::{
-    data_types::{ArithmeticError, Blob, BlockHeight, Round, UserApplicationDescription},
+    data_types::{ArithmeticError, Blob, BlockHeight, UserApplicationDescription},
     identifiers::{BlobId, ChainId, MessageId, UserApplicationId},
 };
 use linera_chain::{
@@ -174,7 +174,7 @@ where
     pub async fn stage_block_execution(
         &self,
         block: ProposedBlock,
-        round: Option<Round>,
+        round: Option<u32>,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), LocalNodeError> {
         Ok(self.node.state.stage_block_execution(block, round).await?)
     }

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -9,7 +9,7 @@ use std::{
 
 use futures::{future::Either, stream, StreamExt as _, TryStreamExt as _};
 use linera_base::{
-    data_types::{ArithmeticError, Blob, BlockHeight, UserApplicationDescription},
+    data_types::{ArithmeticError, Blob, BlockHeight, Round, UserApplicationDescription},
     identifiers::{BlobId, ChainId, MessageId, UserApplicationId},
 };
 use linera_chain::{
@@ -174,8 +174,9 @@ where
     pub async fn stage_block_execution(
         &self,
         block: ProposedBlock,
+        round: Option<Round>,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), LocalNodeError> {
-        Ok(self.node.state.stage_block_execution(block).await?)
+        Ok(self.node.state.stage_block_execution(block, round).await?)
     }
 
     /// Reads blobs from storage.

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -16,7 +16,8 @@ use assert_matches::assert_matches;
 use linera_base::{
     crypto::KeyPair,
     data_types::{
-        Amount, Blob, BlockHeight, Bytecode, OracleResponse, Timestamp, UserApplicationDescription,
+        Amount, Blob, BlockHeight, Bytecode, OracleResponse, Round, Timestamp,
+        UserApplicationDescription,
     },
     hashed::Hashed,
     identifiers::{
@@ -273,6 +274,7 @@ where
         authenticated_signer: None,
         authenticated_caller_id: None,
         height: run_block.height,
+        round: Some(Round::MultiLeader(0)),
         index: Some(0),
     };
     let mut controller = ResourceController::default();

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -16,8 +16,7 @@ use assert_matches::assert_matches;
 use linera_base::{
     crypto::KeyPair,
     data_types::{
-        Amount, Blob, BlockHeight, Bytecode, OracleResponse, Round, Timestamp,
-        UserApplicationDescription,
+        Amount, Blob, BlockHeight, Bytecode, OracleResponse, Timestamp, UserApplicationDescription,
     },
     hashed::Hashed,
     identifiers::{
@@ -274,7 +273,7 @@ where
         authenticated_signer: None,
         authenticated_caller_id: None,
         height: run_block.height,
-        round: Some(Round::MultiLeader(0)),
+        round: Some(0),
         index: Some(0),
     };
     let mut controller = ResourceController::default();

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3234,7 +3234,7 @@ where
             timeout_config: TimeoutConfig::default(),
         })
         .with_authenticated_signer(Some(owner0));
-    let (executed_block0, _) = worker.stage_block_execution(block0).await?;
+    let (executed_block0, _) = worker.stage_block_execution(block0, None).await?;
     let value0 = Hashed::new(ConfirmedBlock::new(executed_block0));
     let certificate0 = make_certificate(&committee, &worker, value0.clone());
     let response = worker
@@ -3283,7 +3283,7 @@ where
 
     // Now owner 0 can propose a block, but owner 1 can't.
     let block1 = make_child_block(&value0.clone());
-    let (executed_block1, _) = worker.stage_block_execution(block1.clone()).await?;
+    let (executed_block1, _) = worker.stage_block_execution(block1.clone(), None).await?;
     let proposal1_wrong_owner = block1
         .clone()
         .with_authenticated_signer(Some(owner1))
@@ -3322,7 +3322,7 @@ where
     // Create block2, also at height 1, but different from block 1.
     let amount = Amount::from_tokens(1);
     let block2 = make_child_block(&value0.clone()).with_simple_transfer(ChainId::root(1), amount);
-    let (executed_block2, _) = worker.stage_block_execution(block2.clone()).await?;
+    let (executed_block2, _) = worker.stage_block_execution(block2.clone(), None).await?;
 
     // Since round 3 is already over, the validator won't vote for a validated block from round 3.
     let value2 = Hashed::new(ValidatedBlock::new(executed_block2.clone()));
@@ -3439,7 +3439,7 @@ where
             ..TimeoutConfig::default()
         },
     });
-    let (executed_block0, _) = worker.stage_block_execution(block0).await?;
+    let (executed_block0, _) = worker.stage_block_execution(block0, None).await?;
     let value0 = Hashed::new(ConfirmedBlock::new(executed_block0));
     let certificate0 = make_certificate(&committee, &worker, value0.clone());
     let response = worker
@@ -3528,8 +3528,9 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (change_ownership_executed_block, _) =
-        worker.stage_block_execution(change_ownership_block).await?;
+    let (change_ownership_executed_block, _) = worker
+        .stage_block_execution(change_ownership_block, None)
+        .await?;
     let change_ownership_value = Hashed::new(ConfirmedBlock::new(change_ownership_executed_block));
     let change_ownership_certificate =
         make_certificate(&committee, &worker, change_ownership_value.clone());
@@ -3552,7 +3553,7 @@ where
     let proposal = make_child_block(&change_ownership_value)
         .into_proposal_with_round(&KeyPair::generate(), Round::MultiLeader(0));
     let (executed_block, _) = worker
-        .stage_block_execution(proposal.content.block.clone())
+        .stage_block_execution(proposal.content.block.clone(), None)
         .await?;
     let value = Hashed::new(ConfirmedBlock::new(executed_block));
     let (response, _) = worker.handle_block_proposal(proposal).await?;
@@ -3591,7 +3592,7 @@ where
             ..TimeoutConfig::default()
         },
     });
-    let (executed_block0, _) = worker.stage_block_execution(block0).await?;
+    let (executed_block0, _) = worker.stage_block_execution(block0, None).await?;
     let value0 = Hashed::new(ConfirmedBlock::new(executed_block0));
     let certificate0 = make_certificate(&committee, &worker, value0.clone());
     let response = worker
@@ -3607,7 +3608,7 @@ where
     let proposal1 = block1
         .clone()
         .into_proposal_with_round(&key_pairs[0], Round::Fast);
-    let (executed_block1, _) = worker.stage_block_execution(block1.clone()).await?;
+    let (executed_block1, _) = worker.stage_block_execution(block1.clone(), None).await?;
     let value1 = Hashed::new(ConfirmedBlock::new(executed_block1));
     let (response, _) = worker.handle_block_proposal(proposal1).await?;
     let vote = response.info.manager.pending.as_ref().unwrap();
@@ -3653,7 +3654,7 @@ where
     worker.handle_block_proposal(proposal3).await?;
 
     // A validated block certificate from a later round can override the locked fast block.
-    let (executed_block2, _) = worker.stage_block_execution(block2.clone()).await?;
+    let (executed_block2, _) = worker.stage_block_execution(block2.clone(), None).await?;
     let value2 = Hashed::new(ValidatedBlock::new(executed_block2.clone()));
     let certificate2 =
         make_certificate_with_round(&committee, &worker, value2.clone(), Round::MultiLeader(0));
@@ -3712,7 +3713,7 @@ where
     let block = make_first_block(chain_id)
         .with_simple_transfer(chain_id, Amount::ONE)
         .with_authenticated_signer(Some(key_pair.public().into()));
-    let (executed_block, _) = worker.stage_block_execution(block).await?;
+    let (executed_block, _) = worker.stage_block_execution(block, None).await?;
     let value = Hashed::new(ConfirmedBlock::new(executed_block));
     let certificate = make_certificate(&committee, &worker, value);
     worker

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -505,9 +505,14 @@ where
     pub async fn stage_block_execution(
         &self,
         block: ProposedBlock,
+        round: Option<Round>,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
         self.query_chain_worker(block.chain_id, move |callback| {
-            ChainWorkerRequest::StageBlockExecution { block, callback }
+            ChainWorkerRequest::StageBlockExecution {
+                block,
+                round,
+                callback,
+            }
         })
         .await
     }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -505,7 +505,7 @@ where
     pub async fn stage_block_execution(
         &self,
         block: ProposedBlock,
-        round: Option<Round>,
+        round: Option<u32>,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
         self.query_chain_worker(block.chain_id, move |callback| {
             ChainWorkerRequest::StageBlockExecution {

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -8,7 +8,7 @@ use std::{
 
 use futures::{stream::FuturesOrdered, FutureExt, StreamExt, TryStreamExt};
 use linera_base::{
-    data_types::{Amount, BlockHeight, Round, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, AccountOwner, ChainId, Destination, Owner},
 };
 use linera_views::{
@@ -75,7 +75,7 @@ where
             authenticated_signer: None,
             authenticated_caller_id: None,
             height: application_description.creation.height,
-            round: Some(Round::Fast),
+            round: None,
             index: Some(0),
         };
 
@@ -150,7 +150,7 @@ impl UserAction {
         }
     }
 
-    pub(crate) fn round(&self) -> Option<Round> {
+    pub(crate) fn round(&self) -> Option<u32> {
         match self {
             UserAction::Instantiate(context, _) => context.round,
             UserAction::Operation(context, _) => context.round,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -8,7 +8,7 @@ use std::{
 
 use futures::{stream::FuturesOrdered, FutureExt, StreamExt, TryStreamExt};
 use linera_base::{
-    data_types::{Amount, BlockHeight, Timestamp},
+    data_types::{Amount, BlockHeight, Round, Timestamp},
     identifiers::{Account, AccountOwner, ChainId, Destination, Owner},
 };
 use linera_views::{
@@ -75,6 +75,7 @@ where
             authenticated_signer: None,
             authenticated_caller_id: None,
             height: application_description.creation.height,
+            round: Some(Round::Fast),
             index: Some(0),
         };
 
@@ -146,6 +147,14 @@ impl UserAction {
             UserAction::Instantiate(context, _) => context.height,
             UserAction::Operation(context, _) => context.height,
             UserAction::Message(context, _) => context.height,
+        }
+    }
+
+    pub(crate) fn round(&self) -> Option<Round> {
+        match self {
+            UserAction::Instantiate(context, _) => context.round,
+            UserAction::Operation(context, _) => context.round,
+            UserAction::Message(context, _) => context.round,
         }
     }
 }

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -12,7 +12,7 @@ use std::{collections::BTreeMap, sync::Arc, thread, vec};
 
 use linera_base::{
     crypto::{BcsSignable, CryptoHash},
-    data_types::{Amount, Blob, BlockHeight, CompressedBytecode, OracleResponse, Timestamp},
+    data_types::{Amount, Blob, BlockHeight, CompressedBytecode, OracleResponse, Round, Timestamp},
     identifiers::{
         AccountOwner, ApplicationId, BlobId, BlobType, BytecodeId, ChainId, MessageId, Owner,
     },
@@ -68,6 +68,7 @@ pub fn create_dummy_operation_context() -> OperationContext {
     OperationContext {
         chain_id: ChainId::root(0),
         height: BlockHeight(0),
+        round: Some(Round::MultiLeader(0)),
         index: Some(0),
         authenticated_signer: None,
         authenticated_caller_id: None,
@@ -82,6 +83,7 @@ pub fn create_dummy_message_context(authenticated_signer: Option<Owner>) -> Mess
         authenticated_signer,
         refund_grant_to: None,
         height: BlockHeight(0),
+        round: Some(Round::MultiLeader(0)),
         certificate_hash: CryptoHash::test_hash("block receiving a message"),
         message_id: MessageId {
             chain_id: ChainId::root(0),

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -12,7 +12,7 @@ use std::{collections::BTreeMap, sync::Arc, thread, vec};
 
 use linera_base::{
     crypto::{BcsSignable, CryptoHash},
-    data_types::{Amount, Blob, BlockHeight, CompressedBytecode, OracleResponse, Round, Timestamp},
+    data_types::{Amount, Blob, BlockHeight, CompressedBytecode, OracleResponse, Timestamp},
     identifiers::{
         AccountOwner, ApplicationId, BlobId, BlobType, BytecodeId, ChainId, MessageId, Owner,
     },
@@ -68,7 +68,7 @@ pub fn create_dummy_operation_context() -> OperationContext {
     OperationContext {
         chain_id: ChainId::root(0),
         height: BlockHeight(0),
-        round: Some(Round::MultiLeader(0)),
+        round: Some(0),
         index: Some(0),
         authenticated_signer: None,
         authenticated_caller_id: None,
@@ -83,7 +83,7 @@ pub fn create_dummy_message_context(authenticated_signer: Option<Owner>) -> Mess
         authenticated_signer,
         refund_grant_to: None,
         height: BlockHeight(0),
-        round: Some(Round::MultiLeader(0)),
+        round: Some(0),
         certificate_hash: CryptoHash::test_hash("block receiving a message"),
         message_id: MessageId {
             chain_id: ChainId::root(0),

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -13,7 +13,7 @@ use std::{
 use futures::{channel::mpsc, StreamExt};
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{BlockHeight, Round, Timestamp},
+    data_types::{BlockHeight, Timestamp},
     identifiers::{ApplicationId, BytecodeId, ChainDescription, MessageId},
 };
 use linera_views::batch::Batch;
@@ -178,7 +178,7 @@ fn create_runtime<Application>() -> (
     let runtime = SyncRuntimeInternal::new(
         chain_id,
         BlockHeight(0),
-        Some(Round::MultiLeader(0)),
+        Some(0),
         Timestamp::from(0),
         None,
         None,

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -13,7 +13,7 @@ use std::{
 use futures::{channel::mpsc, StreamExt};
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{BlockHeight, Timestamp},
+    data_types::{BlockHeight, Round, Timestamp},
     identifiers::{ApplicationId, BytecodeId, ChainDescription, MessageId},
 };
 use linera_views::batch::Batch;
@@ -178,6 +178,7 @@ fn create_runtime<Application>() -> (
     let runtime = SyncRuntimeInternal::new(
         chain_id,
         BlockHeight(0),
+        Some(Round::MultiLeader(0)),
         Timestamp::from(0),
         None,
         None,

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_base::{
-    data_types::{Blob, BlockHeight, Bytecode},
+    data_types::{Blob, BlockHeight, Bytecode, Round},
     identifiers::ApplicationId,
 };
 use linera_views::context::MemoryContext;
@@ -22,6 +22,7 @@ async fn new_view_and_context() -> (
         authenticated_signer: None,
         authenticated_caller_id: None,
         height: BlockHeight::from(7),
+        round: Some(Round::MultiLeader(0)),
         index: Some(2),
     };
     let state = SystemExecutionState {

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_base::{
-    data_types::{Blob, BlockHeight, Bytecode, Round},
+    data_types::{Blob, BlockHeight, Bytecode},
     identifiers::ApplicationId,
 };
 use linera_views::context::MemoryContext;
@@ -22,7 +22,7 @@ async fn new_view_and_context() -> (
         authenticated_signer: None,
         authenticated_caller_id: None,
         height: BlockHeight::from(7),
-        round: Some(Round::MultiLeader(0)),
+        round: Some(0),
         index: Some(2),
     };
     let state = SystemExecutionState {

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -5,9 +5,7 @@ use std::{any::Any, collections::HashMap, marker::PhantomData};
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{
-        Amount, ApplicationPermissions, BlockHeight, Round, SendMessageRequest, Timestamp,
-    },
+    data_types::{Amount, ApplicationPermissions, BlockHeight, SendMessageRequest, Timestamp},
     identifiers::{
         Account, AccountOwner, ApplicationId, ChainId, ChannelName, MessageId, Owner, StreamName,
     },
@@ -428,7 +426,7 @@ where
     }
 
     /// Returns the round in which this block was validated.
-    fn validation_round(caller: &mut Caller) -> Result<Round, RuntimeError> {
+    fn validation_round(caller: &mut Caller) -> Result<Option<u32>, RuntimeError> {
         caller
             .user_data_mut()
             .runtime_mut()

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -5,7 +5,9 @@ use std::{any::Any, collections::HashMap, marker::PhantomData};
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, ApplicationPermissions, BlockHeight, SendMessageRequest, Timestamp},
+    data_types::{
+        Amount, ApplicationPermissions, BlockHeight, Round, SendMessageRequest, Timestamp,
+    },
     identifiers::{
         Account, AccountOwner, ApplicationId, ChainId, ChannelName, MessageId, Owner, StreamName,
     },
@@ -423,6 +425,15 @@ where
             .runtime_mut()
             .consume_fuel(fuel)
             .map_err(|e| RuntimeError::Custom(e.into()))
+    }
+
+    /// Returns the round in which this block was validated.
+    fn validation_round(caller: &mut Caller) -> Result<Round, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime_mut()
+            .validation_round()
+            .map_err(|error| RuntimeError::Custom(error.into()))
     }
 }
 

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -9,7 +9,7 @@ use std::{sync::Arc, vec};
 
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, BlockHeight, Timestamp},
+    data_types::{Amount, BlockHeight, Round, Timestamp},
     identifiers::{Account, AccountOwner, ChainDescription, ChainId, MessageId, Owner},
 };
 use linera_execution::{
@@ -190,6 +190,7 @@ async fn test_fee_consumption(
         authenticated_signer,
         refund_grant_to,
         height: BlockHeight(0),
+        round: Some(Round::MultiLeader(0)),
         certificate_hash: CryptoHash::default(),
         message_id: MessageId::default(),
     };

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -9,7 +9,7 @@ use std::{sync::Arc, vec};
 
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, BlockHeight, Round, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, AccountOwner, ChainDescription, ChainId, MessageId, Owner},
 };
 use linera_execution::{
@@ -190,7 +190,7 @@ async fn test_fee_consumption(
         authenticated_signer,
         refund_grant_to,
         height: BlockHeight(0),
-        round: Some(Round::MultiLeader(0)),
+        round: Some(0),
         certificate_hash: CryptoHash::default(),
         message_id: MessageId::default(),
     };

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::{CryptoHash, KeyPair},
-    data_types::{Amount, BlockHeight, Timestamp},
+    data_types::{Amount, BlockHeight, Round, Timestamp},
     identifiers::{Account, AccountOwner, ChainDescription, ChainId, MessageId, Owner},
     ownership::ChainOwnership,
 };
@@ -37,6 +37,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
     let context = OperationContext {
         chain_id: ChainId::root(0),
         height: BlockHeight(0),
+        round: Some(Round::MultiLeader(0)),
         index: Some(0),
         authenticated_signer: Some(owner),
         authenticated_caller_id: None,
@@ -83,6 +84,7 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         chain_id: ChainId::root(0),
         is_bouncing: false,
         height: BlockHeight(0),
+        round: Some(Round::MultiLeader(0)),
         certificate_hash: CryptoHash::test_hash("certificate"),
         message_id: MessageId {
             chain_id: ChainId::root(1),

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::{CryptoHash, KeyPair},
-    data_types::{Amount, BlockHeight, Round, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, AccountOwner, ChainDescription, ChainId, MessageId, Owner},
     ownership::ChainOwnership,
 };
@@ -37,7 +37,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
     let context = OperationContext {
         chain_id: ChainId::root(0),
         height: BlockHeight(0),
-        round: Some(Round::MultiLeader(0)),
+        round: Some(0),
         index: Some(0),
         authenticated_signer: Some(owner),
         authenticated_caller_id: None,
@@ -84,7 +84,7 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         chain_id: ChainId::root(0),
         is_bouncing: false,
         height: BlockHeight(0),
-        round: Some(Round::MultiLeader(0)),
+        round: Some(0),
         certificate_hash: CryptoHash::test_hash("certificate"),
         message_id: MessageId {
             chain_id: ChainId::root(1),

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use linera_base::{
-    data_types::{Amount, BlockHeight, Timestamp},
+    data_types::{Amount, BlockHeight, Round, Timestamp},
     identifiers::{Account, ChainDescription, ChainId},
 };
 use linera_execution::{
@@ -69,6 +69,7 @@ async fn test_fuel_for_counter_wasm_application(
     let context = OperationContext {
         chain_id: ChainId::root(0),
         height: BlockHeight(0),
+        round: Some(Round::MultiLeader(0)),
         index: Some(0),
         authenticated_signer: None,
         authenticated_caller_id: None,

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use linera_base::{
-    data_types::{Amount, BlockHeight, Round, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, ChainDescription, ChainId},
 };
 use linera_execution::{
@@ -69,7 +69,7 @@ async fn test_fuel_for_counter_wasm_application(
     let context = OperationContext {
         chain_id: ChainId::root(0),
         height: BlockHeight(0),
-        round: Some(Round::MultiLeader(0)),
+        round: Some(0),
         index: Some(0),
         authenticated_signer: None,
         authenticated_caller_id: None,

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -682,6 +682,10 @@ OracleResponse:
           TYPENAME: BlobId
     3:
       Assert: UNIT
+    4:
+      Round:
+        NEWTYPE:
+          TYPENAME: Round
 Origin:
   STRUCT:
     - sender:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -685,7 +685,7 @@ OracleResponse:
     4:
       Round:
         NEWTYPE:
-          TYPENAME: Round
+          OPTION: U32
 Origin:
   STRUCT:
     - sender:

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, BlockHeight, Round, TimeDelta, Timestamp},
+    data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
     identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, CloseChainError, TimeoutConfig},
 };
@@ -132,17 +132,6 @@ impl From<wit_system_api::CloseChainError> for CloseChainError {
     fn from(guest: wit_system_api::CloseChainError) -> Self {
         match guest {
             wit_system_api::CloseChainError::NotPermitted => CloseChainError::NotPermitted,
-        }
-    }
-}
-
-impl From<wit_system_api::Round> for Round {
-    fn from(round: wit_system_api::Round) -> Self {
-        match round {
-            wit_system_api::Round::Fast => Self::Fast,
-            wit_system_api::Round::MultiLeader(r) => Self::MultiLeader(r),
-            wit_system_api::Round::SingleLeader(r) => Self::SingleLeader(r),
-            wit_system_api::Round::Validator(r) => Self::Validator(r),
         }
     }
 }

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
+    data_types::{Amount, BlockHeight, Round, TimeDelta, Timestamp},
     identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, CloseChainError, TimeoutConfig},
 };
@@ -132,6 +132,17 @@ impl From<wit_system_api::CloseChainError> for CloseChainError {
     fn from(guest: wit_system_api::CloseChainError) -> Self {
         match guest {
             wit_system_api::CloseChainError::NotPermitted => CloseChainError::NotPermitted,
+        }
+    }
+}
+
+impl From<wit_system_api::Round> for Round {
+    fn from(round: wit_system_api::Round) -> Self {
+        match round {
+            wit_system_api::Round::Fast => Self::Fast,
+            wit_system_api::Round::MultiLeader(r) => Self::MultiLeader(r),
+            wit_system_api::Round::SingleLeader(r) => Self::SingleLeader(r),
+            wit_system_api::Round::Validator(r) => Self::Validator(r),
         }
     }
 }

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -6,8 +6,8 @@
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, Resources, Round, SendMessageRequest,
-        TimeDelta, Timestamp,
+        Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, TimeDelta,
+        Timestamp,
     },
     identifiers::{
         Account, AccountOwner, ApplicationId, BytecodeId, ChainId, ChannelName, Destination,
@@ -252,17 +252,6 @@ impl From<ChainOwnership> for wit_system_api::ChainOwnership {
             multi_leader_rounds,
             open_multi_leader_rounds,
             timeout_config: timeout_config.into(),
-        }
-    }
-}
-
-impl From<Round> for wit_system_api::Round {
-    fn from(round: Round) -> Self {
-        match round {
-            Round::Fast => Self::Fast,
-            Round::MultiLeader(r) => Self::MultiLeader(r),
-            Round::SingleLeader(r) => Self::SingleLeader(r),
-            Round::Validator(r) => Self::Validator(r),
         }
     }
 }

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -6,8 +6,8 @@
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, TimeDelta,
-        Timestamp,
+        Amount, ApplicationPermissions, BlockHeight, Resources, Round, SendMessageRequest,
+        TimeDelta, Timestamp,
     },
     identifiers::{
         Account, AccountOwner, ApplicationId, BytecodeId, ChainId, ChannelName, Destination,
@@ -252,6 +252,17 @@ impl From<ChainOwnership> for wit_system_api::ChainOwnership {
             multi_leader_rounds,
             open_multi_leader_rounds,
             timeout_config: timeout_config.into(),
+        }
+    }
+}
+
+impl From<Round> for wit_system_api::Round {
+    fn from(round: Round) -> Self {
+        match round {
+            Round::Fast => Self::Fast,
+            Round::MultiLeader(r) => Self::MultiLeader(r),
+            Round::SingleLeader(r) => Self::SingleLeader(r),
+            Round::Validator(r) => Self::Validator(r),
         }
     }
 }

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -6,7 +6,8 @@
 use linera_base::{
     abi::{ContractAbi, ServiceAbi},
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, Timestamp,
+        Amount, ApplicationPermissions, BlockHeight, Resources, Round, SendMessageRequest,
+        Timestamp,
     },
     identifiers::{
         Account, AccountOwner, ApplicationId, BytecodeId, ChainId, ChannelName, Destination,
@@ -318,6 +319,11 @@ where
     /// Asserts that a data blob with the given hash exists in storage.
     pub fn assert_data_blob_exists(&mut self, hash: DataBlobHash) {
         wit::assert_data_blob_exists(hash.0.into())
+    }
+
+    /// Returns the round in which this block was validated.
+    pub fn validation_round(&mut self) -> Round {
+        wit::validation_round().into()
     }
 }
 

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -6,8 +6,7 @@
 use linera_base::{
     abi::{ContractAbi, ServiceAbi},
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, Resources, Round, SendMessageRequest,
-        Timestamp,
+        Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, Timestamp,
     },
     identifiers::{
         Account, AccountOwner, ApplicationId, BytecodeId, ChainId, ChannelName, Destination,
@@ -322,8 +321,8 @@ where
     }
 
     /// Returns the round in which this block was validated.
-    pub fn validation_round(&mut self) -> Round {
-        wit::validation_round().into()
+    pub fn validation_round(&mut self) -> Option<u32> {
+        wit::validation_round()
     }
 }
 

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -11,8 +11,7 @@ use std::{
 use linera_base::{
     abi::{ContractAbi, ServiceAbi},
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, Resources, Round, SendMessageRequest,
-        Timestamp,
+        Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, Timestamp,
     },
     identifiers::{
         Account, AccountOwner, ApplicationId, BytecodeId, ChainId, ChannelName, Destination,
@@ -43,7 +42,7 @@ where
     chain_id: Option<ChainId>,
     authenticated_signer: Option<Option<Owner>>,
     block_height: Option<BlockHeight>,
-    round: Option<Round>,
+    round: Option<u32>,
     message_id: Option<Option<MessageId>>,
     message_is_bouncing: Option<Option<bool>>,
     authenticated_caller_id: Option<Option<ApplicationId>>,
@@ -254,14 +253,14 @@ where
         self
     }
 
-    /// Configures the round number to return during the test.
-    pub fn with_round(mut self, round: Round) -> Self {
+    /// Configures the multi-leader round number to return during the test.
+    pub fn with_round(mut self, round: u32) -> Self {
         self.round = Some(round);
         self
     }
 
-    /// Configures the round number to return during the test.
-    pub fn set_round(&mut self, round: Round) -> &mut Self {
+    /// Configures the multi-leader round number to return during the test.
+    pub fn set_round(&mut self, round: u32) -> &mut Self {
         self.round = Some(round);
         self
     }
@@ -841,8 +840,8 @@ where
     }
 
     /// Returns the round in which this block was validated.
-    pub fn validation_round(&mut self) -> Round {
-        self.round.expect("Missing round number")
+    pub fn validation_round(&mut self) -> Option<u32> {
+        self.round
     }
 }
 

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -11,7 +11,8 @@ use std::{
 use linera_base::{
     abi::{ContractAbi, ServiceAbi},
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, Timestamp,
+        Amount, ApplicationPermissions, BlockHeight, Resources, Round, SendMessageRequest,
+        Timestamp,
     },
     identifiers::{
         Account, AccountOwner, ApplicationId, BytecodeId, ChainId, ChannelName, Destination,
@@ -42,6 +43,7 @@ where
     chain_id: Option<ChainId>,
     authenticated_signer: Option<Option<Owner>>,
     block_height: Option<BlockHeight>,
+    round: Option<Round>,
     message_id: Option<Option<MessageId>>,
     message_is_bouncing: Option<Option<bool>>,
     authenticated_caller_id: Option<Option<ApplicationId>>,
@@ -89,6 +91,7 @@ where
             chain_id: None,
             authenticated_signer: None,
             block_height: None,
+            round: None,
             message_id: None,
             message_is_bouncing: None,
             authenticated_caller_id: None,
@@ -248,6 +251,18 @@ where
     /// Configures the block height to return during the test.
     pub fn set_block_height(&mut self, block_height: BlockHeight) -> &mut Self {
         self.block_height = Some(block_height);
+        self
+    }
+
+    /// Configures the round number to return during the test.
+    pub fn with_round(mut self, round: Round) -> Self {
+        self.round = Some(round);
+        self
+    }
+
+    /// Configures the round number to return during the test.
+    pub fn set_round(&mut self, round: Round) -> &mut Self {
+        self.round = Some(round);
         self
     }
 
@@ -823,6 +838,11 @@ where
             maybe_request.expect("Unexpected assert_data_blob_exists request");
         assert_eq!(hash, expected_blob_hash);
         response.expect("Blob does not exist!");
+    }
+
+    /// Returns the round in which this block was validated.
+    pub fn validation_round(&mut self) -> Round {
+        self.round.expect("Missing round number")
     }
 }
 

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -215,7 +215,7 @@ impl BlockBuilder {
         let (executed_block, _) = self
             .validator
             .worker()
-            .stage_block_execution(self.block)
+            .stage_block_execution(self.block, None)
             .await?;
 
         let value = Hashed::new(ConfirmedBlock::new(executed_block));

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -31,7 +31,7 @@ interface contract-system-api {
     assert-data-blob-exists: func(hash: crypto-hash);
     log: func(message: string, level: log-level);
     consume-fuel: func(fuel: u64);
-    validation-round: func() -> round;
+    validation-round: func() -> option<u32>;
 
     record account {
         chain-id: chain-id,
@@ -126,13 +126,6 @@ interface contract-system-api {
         messages: u32,
         message-size: u32,
         storage-size-delta: u32,
-    }
-
-    variant round {
-        fast,
-        multi-leader(u32),
-        single-leader(u32),
-        validator(u32),
     }
 
     record send-message-request {

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -31,6 +31,7 @@ interface contract-system-api {
     assert-data-blob-exists: func(hash: crypto-hash);
     log: func(message: string, level: log-level);
     consume-fuel: func(fuel: u64);
+    validation-round: func() -> round;
 
     record account {
         chain-id: chain-id,
@@ -125,6 +126,13 @@ interface contract-system-api {
         messages: u32,
         message-size: u32,
         storage-size-delta: u32,
+    }
+
+    variant round {
+        fast,
+        multi-leader(u32),
+        single-leader(u32),
+        validator(u32),
     }
 
     record send-message-request {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -775,7 +775,7 @@ impl Runnable for Job {
                 for rpc_msg in &proposals {
                     if let RpcMessage::BlockProposal(proposal) = rpc_msg {
                         let executed_block = context
-                            .stage_block_execution(proposal.content.block.clone())
+                            .stage_block_execution(proposal.content.block.clone(), None)
                             .await?;
                         let value = Hashed::new(ConfirmedBlock::new(executed_block));
                         values.insert(value.hash(), value);


### PR DESCRIPTION
## Motivation

For most uses of permissionless rounds (#3162), applications need to have access to the round number, at least in multi-leader rounds.

## Proposal

Expose the round number in which the block is being validated to the contract.

This is only `Some` in multi-leader rounds.

## Test Plan

An example application using this will be added in a separate PR.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #3164.
- Closes #3162.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
