### PR TITLE
fix: fix typo Update node.rs

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -219,7 +219,7 @@ pub enum NodeError {
     #[error("We don't have the value for the certificate.")]
     MissingCertificateValue,
 
-    #[error("Response doesn't contain requested ceritifcates: {0:?}")]
+    #[error("Response doesn't contain requested certificates: {0:?}")]
     MissingCertificates(Vec<CryptoHash>),
 
     #[error("Validator's response to block proposal failed to include a vote")]


### PR DESCRIPTION
## Motivation

I noticed a typo in the word "ceritifcates" and corrected it to "certificates".
