### PR TITLE
fix: Fix grammar mistake Update delivery_notifier.rs

### DIFF
--- a/linera-core/src/chain_worker/delivery_notifier.rs
+++ b/linera-core/src/chain_worker/delivery_notifier.rs
@@ -21,7 +21,7 @@ use tracing::warn;
 /// from specific [`BlockHeight`]s.
 ///
 /// The notifier instance can be cheaply `clone`d and works as a shared reference.
-/// However, its methods still require `&mut self` to hint that it should only changed by
+/// However, its methods still require `&mut self` to hint that it should only be changed by
 /// [`ChainWorkerStateWithAttemptedChanges`](super::ChainWorkerStateWithAttemptedChanges).
 #[derive(Clone, Default)]
 pub struct DeliveryNotifier {


### PR DESCRIPTION
## Motivation

I noticed a grammar error in the phrase:  
> "it should only changed by"  

This has been corrected to:  
> "it should only be changed by"  

Thanks!  