### PR TITLE
Simplify chain manager logic.

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -23,6 +23,7 @@ use crate::{
         BlockExecutionOutcome, EventRecord, ExecutedBlock, IncomingBundle, Medium, MessageBundle,
         OutgoingMessage, ProposedBlock,
     },
+    types::CertificateValue,
     ChainError,
 };
 
@@ -153,6 +154,28 @@ impl ConfirmedBlock {
                 actual: hashed_certificate_value.hash(),
             })
         }
+    }
+
+    /// Returns whether this block matches the proposal.
+    pub fn matches_proposal(&self, block: &ProposedBlock) -> bool {
+        let ProposedBlock {
+            chain_id,
+            epoch,
+            incoming_bundles,
+            operations,
+            height,
+            timestamp,
+            authenticated_signer,
+            previous_block_hash,
+        } = block;
+        *chain_id == self.chain_id()
+            && *epoch == self.epoch()
+            && *incoming_bundles == self.block().body.incoming_bundles
+            && *operations == self.block().body.operations
+            && *height == self.block().header.height
+            && *timestamp == self.block().header.timestamp
+            && *authenticated_signer == self.block().header.authenticated_signer
+            && *previous_block_hash == self.block().header.previous_block_hash
     }
 }
 

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -157,7 +157,7 @@ impl ConfirmedBlock {
     }
 
     /// Returns whether this block matches the proposal.
-    pub fn matches_proposal(&self, block: &ProposedBlock) -> bool {
+    pub fn matches_proposed_block(&self, block: &ProposedBlock) -> bool {
         let ProposedBlock {
             chain_id,
             epoch,

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -127,8 +127,10 @@ pub enum ChainError {
     InsufficientRoundStrict(Round),
     #[error("Round number should be {0:?}")]
     WrongRound(Round),
-    #[error("A different block for height {0:?} was already locked at round number {1:?}")]
+    #[error("Already voted to confirm a different block for height {0:?} at round number {1:?}")]
     HasIncompatibleConfirmedVote(BlockHeight, Round),
+    #[error("Proposal for height {0:?} is not newer than locking block in round {1:?}")]
+    MustBeNewerThanLockingBlock(BlockHeight, Round),
     #[error("Cannot confirm a block before its predecessors: {current_block_height:?}")]
     MissingEarlierBlocks { current_block_height: BlockHeight },
     #[error("Signatures in a certificate must be from different validators")]

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -128,7 +128,7 @@ pub enum ChainError {
     #[error("Round number should be {0:?}")]
     WrongRound(Round),
     #[error("A different block for height {0:?} was already locked at round number {1:?}")]
-    HasLockedBlock(BlockHeight, Round),
+    HasIncompatibleConfirmedVote(BlockHeight, Round),
     #[error("Cannot confirm a block before its predecessors: {current_block_height:?}")]
     MissingEarlierBlocks { current_block_height: BlockHeight },
     #[error("Signatures in a certificate must be from different validators")]

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -141,7 +141,7 @@ where
         callback: oneshot::Sender<Result<(ChainInfoResponse, NetworkActions), WorkerError>>,
     },
 
-    /// Get a blob if it belongs to the current locked block or pending proposal.
+    /// Get a blob if it belongs to the current locking block or pending proposal.
     DownloadPendingBlob {
         blob_id: BlobId,
         #[debug(skip)]

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -295,7 +295,7 @@ where
         Ok((response, actions))
     }
 
-    /// Returns the requested blob, if it belongs to the current locked block or pending proposal.
+    /// Returns the requested blob, if it belongs to the current locking block or pending proposal.
     pub(super) async fn download_pending_blob(&self, blob_id: BlobId) -> Result<Blob, WorkerError> {
         let maybe_blob = self.chain.manager.pending_blob(&blob_id).await?;
         maybe_blob.ok_or_else(|| WorkerError::BlobsNotFound(vec![blob_id]))

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -187,9 +187,9 @@ where
         Ok(storage.read_blobs(blob_ids).await?.into_iter().collect())
     }
 
-    /// Looks for the specified blobs in the local chain manager's locked blobs.
+    /// Looks for the specified blobs in the local chain manager's locking blobs.
     /// Returns `Ok(None)` if any of the blobs is not found.
-    pub async fn get_locked_blobs(
+    pub async fn get_locking_blobs(
         &self,
         blob_ids: &[BlobId],
         chain_id: ChainId,
@@ -197,7 +197,7 @@ where
         let chain = self.chain_state_view(chain_id).await?;
         let mut blobs = Vec::new();
         for blob_id in blob_ids {
-            match chain.manager.locked_blobs.get(blob_id).await? {
+            match chain.manager.locking_blobs.get(blob_id).await? {
                 None => return Ok(None),
                 Some(blob) => blobs.push(blob),
             }

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -108,7 +108,7 @@ pub trait ValidatorNode {
     /// Downloads a blob. Returns an error if the validator does not have the blob.
     async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError>;
 
-    /// Downloads a blob that belongs to a pending proposal or the locked block on a chain.
+    /// Downloads a blob that belongs to a pending proposal or the locking block on a chain.
     async fn download_pending_blob(
         &self,
         chain_id: ChainId,

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -153,10 +153,10 @@ impl<N: ValidatorNode> RemoteNode<N> {
     ) -> Result<Box<ChainInfo>, NodeError> {
         let manager = &response.info.manager;
         let proposed = manager.requested_proposed.as_ref();
-        let locked = manager.requested_locked.as_ref();
+        let locking = manager.requested_locking.as_ref();
         ensure!(
             proposed.map_or(true, |proposal| proposal.content.block.chain_id == chain_id)
-                && locked.map_or(true, |cert| cert.chain_id() == chain_id)
+                && locking.map_or(true, |cert| cert.chain_id() == chain_id)
                 && response.check(&self.name).is_ok(),
             NodeError::InvalidChainInfoResponse
         );

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3344,7 +3344,7 @@ where
         .into_proposal_with_round(&key_pairs[1], Round::SingleLeader(5));
     let result = worker.handle_block_proposal(proposal.clone()).await;
     assert_matches!(result, Err(WorkerError::ChainError(error))
-         if matches!(*error, ChainError::HasLockedBlock(_, _))
+         if matches!(*error, ChainError::HasIncompatibleConfirmedVote(_, _))
     );
 
     // But with the validated block certificate for block2, it is allowed.
@@ -3384,7 +3384,7 @@ where
     let proposal = block1.into_proposal_with_round(&key_pairs[0], Round::SingleLeader(6));
     let result = worker.handle_block_proposal(proposal.clone()).await;
     assert_matches!(result, Err(WorkerError::ChainError(error))
-         if matches!(*error, ChainError::HasLockedBlock(_, _))
+         if matches!(*error, ChainError::HasIncompatibleConfirmedVote(_, _))
     );
 
     // Let rounds 6 and 7 time out.
@@ -3646,7 +3646,7 @@ where
         .into_proposal_with_round(&key_pairs[1], Round::MultiLeader(1));
     let result = worker.handle_block_proposal(proposal2).await;
     assert_matches!(result, Err(WorkerError::ChainError(err))
-        if matches!(*err, ChainError::HasLockedBlock(_, Round::Fast))
+        if matches!(*err, ChainError::HasIncompatibleConfirmedVote(_, Round::Fast))
     );
     let proposal3 = block1
         .clone()

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -32,7 +32,7 @@ use linera_chain::{
         IncomingBundle, LiteValue, LiteVote, Medium, MessageAction, MessageBundle, Origin,
         OutgoingMessage, PostedMessage, ProposedBlock, SignatureAggregator,
     },
-    manager::LockedBlock,
+    manager::LockingBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
     types::{
         CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate, Timeout,
@@ -3360,8 +3360,8 @@ where
     let (_, _) = worker.handle_block_proposal(proposal).await?;
     let (response, _) = worker.handle_chain_info_query(query_values.clone()).await?;
     assert_eq!(
-        response.info.manager.requested_locked,
-        Some(Box::new(LockedBlock::Regular(certificate2)))
+        response.info.manager.requested_locking,
+        Some(Box::new(LockingBlock::Regular(certificate2)))
     );
     let vote = response.info.manager.pending.as_ref().unwrap();
     assert_eq!(vote.value, lite_value2);
@@ -3395,8 +3395,7 @@ where
         .await?;
     assert_eq!(response.info.manager.current_round, Round::SingleLeader(8));
 
-    // If the worker does not belong to a validator, it does update its locked block even if it's
-    // from a past round.
+    // The worker updates its locking block even if it's from a past round.
     let certificate =
         make_certificate_with_round(&committee, &worker, value1, Round::SingleLeader(7));
     let worker = worker.with_key_pair(None).await; // Forget validator keys.
@@ -3405,8 +3404,8 @@ where
         .await?;
     let (response, _) = worker.handle_chain_info_query(query_values).await?;
     assert_eq!(
-        response.info.manager.requested_locked,
-        Some(Box::new(LockedBlock::Regular(certificate)))
+        response.info.manager.requested_locking,
+        Some(Box::new(LockingBlock::Regular(certificate)))
     );
     Ok(())
 }
@@ -3669,8 +3668,8 @@ where
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
     let (response, _) = worker.handle_chain_info_query(query_values).await?;
     assert_eq!(
-        response.info.manager.requested_locked,
-        Some(Box::new(LockedBlock::Regular(certificate2)))
+        response.info.manager.requested_locking,
+        Some(Box::new(LockingBlock::Regular(certificate2)))
     );
     let vote = response.info.manager.pending.as_ref().unwrap();
     assert_eq!(vote.value, lite_value2);

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -253,11 +253,11 @@ where
                 self.remote_node
                     .check_blobs_not_found(&certificate, blob_ids)?;
                 let chain_id = certificate.inner().chain_id();
-                // The certificate is for a validated block, i.e. for our locked block.
+                // The certificate is for a validated block, i.e. for our locking block.
                 // Take the missing blobs from our local chain manager.
                 let blobs = self
                     .local_node
-                    .get_locked_blobs(blob_ids, chain_id)
+                    .get_locking_blobs(blob_ids, chain_id)
                     .await?
                     .ok_or_else(|| original_err.clone())?;
                 self.remote_node.send_pending_blobs(chain_id, blobs).await?;

--- a/linera-rpc/tests/format.rs
+++ b/linera-rpc/tests/format.rs
@@ -10,7 +10,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{Medium, MessageAction},
-    manager::{ChainManagerInfo, LockedBlock},
+    manager::{ChainManagerInfo, LockingBlock},
     types::{Certificate, CertificateKind, ConfirmedBlock, Timeout, ValidatedBlock},
 };
 use linera_core::{data_types::CrossChainRequest, node::NodeError};
@@ -52,7 +52,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<ChainDescription>(&samples)?;
     tracer.trace_type::<ChainOwnership>(&samples)?;
     tracer.trace_type::<GenericApplicationId>(&samples)?;
-    tracer.trace_type::<LockedBlock>(&samples)?;
+    tracer.trace_type::<LockingBlock>(&samples)?;
     tracer.trace_type::<ChainManagerInfo>(&samples)?;
     tracer.trace_type::<CrossChainRequest>(&samples)?;
     tracer.trace_type::<NodeError>(&samples)?;

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -280,9 +280,9 @@ ChainManagerInfo:
     - requested_proposed:
         OPTION:
           TYPENAME: BlockProposal
-    - requested_locked:
+    - requested_locking:
         OPTION:
-          TYPENAME: LockedBlock
+          TYPENAME: LockingBlock
     - timeout:
         OPTION:
           TYPENAME: TimeoutCertificate
@@ -478,7 +478,7 @@ LiteVote:
         TYPENAME: ValidatorName
     - signature:
         TYPENAME: Signature
-LockedBlock:
+LockingBlock:
   ENUM:
     0:
       Fast:

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -119,7 +119,7 @@ query Chain(
     manager {
       ownership
       seed
-      lockedBlobs {
+      lockingBlobs {
         keys
       }
       roundTimeout

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -221,9 +221,9 @@ type ChainManager {
 	"""
 	seed: Int!
 	"""
-	These are blobs published or read by the locked block.
+	These are blobs published or read by the locking block.
 	"""
-	lockedBlobs: MapView_BlobId_Blob_3711e760!
+	lockingBlobs: MapView_BlobId_Blob_3711e760!
 	"""
 	The time after which we are ready to sign a timeout certificate for the current round.
 	"""


### PR DESCRIPTION
## Motivation

We are using the chain manager's `locked` field for two purposes:
* In validators, this is meant to track _this validator's_ locked block, i.e. the latest proposal it signed to confirm.
* In the client, it tracks the highest validated block (or fast proposal) we have seen, i.e. the highest block that _might_ be locked for any honest validator, so that the client knows which block it should re-propose in the next round.

This is confusing, and makes it more difficult to tackle issues like https://github.com/linera-io/linera-protocol/issues/2971.

## Proposal

Use the `locked` field for the first purpose, both in clients and validators: to track the highest block that _might_ be locked for any of the validators.

In a validator's chain manager, the block that is locked for _that validator_ is the one it has last voted to confirm, i.e. the `confirmed_vote` field.

## Test Plan

The tests already cover lots of scenarios involving locked blocks, and should catch any regressions. They have been updated where appropriate.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/3170.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
