### PR TITLE
Add a Request For Quotes example application

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4979,6 +4979,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfq"
+version = "0.1.0"
+dependencies = [
+ "async-graphql",
+ "fungible",
+ "linera-sdk",
+ "matching-engine",
+ "num-bigint",
+ "num-traits",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "meta-counter",
     "native-fungible",
     "non-fungible",
+    "rfq",
     "social",
 ]
 

--- a/examples/rfq/Cargo.toml
+++ b/examples/rfq/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "rfq"
+version = "0.1.0"
+authors = ["Linera <contact@linera.io>"]
+edition = "2021"
+
+[dependencies]
+async-graphql.workspace = true
+fungible.workspace = true
+linera-sdk.workspace = true
+matching-engine.workspace = true
+num-bigint.workspace = true
+num-traits.workspace = true
+serde.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+linera-sdk = { workspace = true, features = ["test", "wasmer"] }
+tokio = { workspace = true, features = ["rt", "sync"] }
+
+[[bin]]
+name = "rfq_contract"
+path = "src/contract.rs"
+
+[[bin]]
+name = "rfq_service"
+path = "src/service.rs"

--- a/examples/rfq/README.md
+++ b/examples/rfq/README.md
@@ -1,0 +1,327 @@
+<!-- cargo-rdme start -->
+
+# Automated Market Maker (AMM) Example Application
+
+This example implements an Automated Market Maker (AMM) which demonstrates DeFi capabilities of the
+Linera protocol. Prerequisite for the AMM application is the `fungible` application, as we will
+be adding/removing liquidity and also performing a swap.
+
+# How it works
+
+It supports the following operations. All operations need to be executed remotely.
+
+- Swap: For a given input token and an input amount, it swaps that token amount for an
+  amount of the other token calculated based on the current AMM ratio.
+
+- Add Liquidity: This operation allows adding liquidity to the AMM. Given a maximum
+  `token0` and `token1` amount that you're willing to add, it adds liquidity such that you'll be
+  adding at most `max_token0_amount` of `token0` and `max_token1_amount` of `token1`. The amounts
+  will be calculated based on the current AMM ratio. The owner, in this case, refers to the user
+  adding liquidity, which currently can only be a chain owner.
+
+- Remove Liquidity: This withdraws tokens from the AMM. Given the index of the token you'd
+  like to remove (can be 0 or 1), and an amount of that token that you'd like to remove, it calculates
+  how much of the other token will also be removed based on the current AMM ratio. Then it removes
+  the amounts from both tokens as a removal of liquidity. The owner, in this context, is the user
+  removing liquidity, which currently can only be a chain owner.
+
+# Usage
+
+## Setting Up
+
+Before getting started, make sure that the binary tools `linera*` corresponding to
+your version of `linera-sdk` are in your PATH. For scripting purposes, we also assume
+that the BASH function `linera_spawn_and_read_wallet_variables` is defined.
+
+From the root of Linera repository, this can be achieved as follows:
+
+```bash
+export PATH="$PWD/target/debug:$PATH"
+source /dev/stdin <<<"$(linera net helper 2>/dev/null)"
+```
+
+To start the local Linera network:
+
+```bash
+linera_spawn_and_read_wallet_variables linera net up --testing-prng-seed 37
+```
+
+We use the test-only CLI option `--testing-prng-seed` to make keys deterministic and simplify our
+explanation.
+
+```bash
+OWNER_1=d2115775b5b3c5c1ed3c1516319a7e850c75d0786a74b39f5250cf9decc88124
+OWNER_2=a477cb966190661c0dfbe50602616a78a48d2bef6cb5288d49deb3e05585d579
+CHAIN_1=673ce04da4b8ed773ee7cd5828a2083775bea4130498b847c5b34b2ed913b07f
+CHAIN_2=69705f85ac4c9fef6c02b4d83426aaaf05154c645ec1c61665f8e450f0468bc0
+CHAIN_AMM=e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65
+OWNER_AMM=7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f
+```
+
+Now we have to publish and create the fungible applications. The flag `--wait-for-outgoing-messages` waits until a quorum of validators has confirmed that all sent cross-chain messages have been delivered.
+
+```bash
+(cd examples/fungible && cargo build --release --target wasm32-unknown-unknown)
+
+FUN1_APP_ID=$(linera --wait-for-outgoing-messages \
+  publish-and-create examples/target/wasm32-unknown-unknown/release/fungible_{contract,service}.wasm \
+    --json-argument "{ \"accounts\": {
+        \"User:$OWNER_AMM\": \"100.\"
+    } }" \
+    --json-parameters "{ \"ticker_symbol\": \"FUN1\" }" \
+)
+
+FUN2_APP_ID=$(linera --wait-for-outgoing-messages \
+  publish-and-create examples/target/wasm32-unknown-unknown/release/fungible_{contract,service}.wasm \
+    --json-argument "{ \"accounts\": {
+        \"User:$OWNER_AMM\": \"100.\"
+    } }" \
+    --json-parameters "{ \"ticker_symbol\": \"FUN2\" }" \
+)
+
+(cd examples/amm && cargo build --release --target wasm32-unknown-unknown)
+AMM_APPLICATION_ID=$(linera --wait-for-outgoing-messages \
+  publish-and-create examples/target/wasm32-unknown-unknown/release/amm_{contract,service}.wasm \
+  --json-parameters "{\"tokens\":["\"$FUN1_APP_ID\"","\"$FUN2_APP_ID\""]}" \
+  --required-application-ids $FUN1_APP_ID $FUN2_APP_ID)
+```
+
+## Using the AMM Application
+
+First, a node service for the current wallet has to be started:
+
+```bash
+PORT=8080
+linera service --port $PORT &
+```
+
+### Using GraphiQL
+
+Type each of these in the GraphiQL interface and substitute the env variables with their actual
+values that we've defined above.
+
+To properly setup the tokens in the proper chains, we need to do some transfer operations:
+
+- Transfer 50 FUN1 from `$OWNER_AMM` in `$CHAIN_AMM` to `$OWNER_1` in `$CHAIN_1`, so they're in the proper chain.
+  Run `echo "http://localhost:8080/chains/$CHAIN_AMM/applications/$FUN1_APP_ID"` to print the URL
+  of the GraphiQL interface for the FUN1 app. Navigate to that URL and enter:
+
+```gql,uri=http://localhost:8080/chains/$CHAIN_AMM/applications/$FUN1_APP_ID
+    mutation {
+        transfer(
+            owner: "User:$OWNER_AMM",
+            amount: "50.",
+            targetAccount: {
+                chainId: "$CHAIN_1",
+                owner: "User:$OWNER_1",
+            }
+        )
+    }
+```
+
+- Transfer 50 FUN1 from `$OWNER_AMM` in `$CHAIN_AMM` to `$OWNER_2` in `$CHAIN_2`, so they're in the proper chain:
+
+```gql,uri=http://localhost:8080/chains/$CHAIN_AMM/applications/$FUN1_APP_ID
+    mutation {
+        transfer(
+            owner: "User:$OWNER_AMM",
+            amount: "50.",
+            targetAccount: {
+                chainId: "$CHAIN_2",
+                owner: "User:$OWNER_2",
+            }
+        )
+    }
+```
+
+- Transfer 50 FUN2 from `$OWNER_AMM` in `$CHAIN_AMM` to `$OWNER_1` in `$CHAIN_1`, so they're in the proper chain.
+  Since this is the other token, FUN2, we need to go to its own GraphiQL interface:
+  `echo "http://localhost:8080/chains/$CHAIN_AMM/applications/$FUN2_APP_ID"`.
+
+```gql,uri=http://localhost:8080/chains/$CHAIN_AMM/applications/$FUN2_APP_ID
+    mutation {
+        transfer(
+            owner: "User:$OWNER_AMM",
+            amount: "50.",
+            targetAccount: {
+                chainId: "$CHAIN_1",
+                owner: "User:$OWNER_1",
+            }
+        )
+    }
+```
+
+- Transfer 50 FUN2 from `$OWNER_AMM` in `$CHAIN_AMM` to `$OWNER_2` in `$CHAIN_2`, so they're in the proper chain:
+
+```gql,uri=http://localhost:8080/chains/$CHAIN_AMM/applications/$FUN2_APP_ID
+    mutation {
+        transfer(
+            owner: "User:$OWNER_AMM",
+            amount: "50.",
+            targetAccount: {
+                chainId: "$CHAIN_2",
+                owner: "User:$OWNER_2",
+            }
+        )
+    }
+```
+
+All operations can only be from a remote chain i.e. other than the chain on which `AMM` is deployed to.
+We can do it from GraphiQL by performing the `requestApplication` mutation so that we can perform the
+operation from the chain.
+
+```gql,uri=http://localhost:8080
+mutation {
+  requestApplication (
+    chainId:"$CHAIN_1",
+    applicationId: "$AMM_APPLICATION_ID",
+    targetChainId: "$CHAIN_AMM"
+  )
+}
+```
+
+Note: The above mutation has to be performed from `http://localhost:8080`.
+
+Before performing any operation we need to provide liquidity to it, so we will use the `AddLiquidity` operation,
+navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID"`.
+
+To perform the `AddLiquidity` operation:
+
+```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
+mutation {
+  addLiquidity(
+    owner: "User:$OWNER_1",
+    maxToken0Amount: "50",
+    maxToken1Amount: "50",
+  )
+}
+```
+
+```gql,uri=http://localhost:8080
+mutation {
+  requestApplication (
+    chainId:"$CHAIN_2",
+    applicationId: "$AMM_APPLICATION_ID",
+    targetChainId: "$CHAIN_AMM"
+  )
+}
+```
+
+Note: The above mutation has to be performed from `http://localhost:8080`.
+
+To perform the `Swap` operation, navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_2/applications/$AMM_APPLICATION_ID"` and
+perform the following mutation:
+
+```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$AMM_APPLICATION_ID
+mutation {
+  swap(
+    owner: "User:$OWNER_2",
+    inputTokenIdx: 1,
+    inputAmount: "1",
+  )
+}
+```
+
+To perform the `RemoveLiquidity` operation, navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID"` and
+perform the following mutation:
+
+```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
+mutation {
+  removeLiquidity(
+    owner: "User:$OWNER_1",
+    tokenToRemoveIdx: 1,
+    tokenToRemoveAmount: "1",
+  )
+}
+```
+
+To perform the `RemoveAllAddedLiquidity` operation, navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID"` and
+perform the following mutation:
+
+```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
+mutation {
+  removeAllAddedLiquidity(
+    owner: "User:$OWNER_1",
+  )
+}
+```
+
+### Atomic Swaps
+
+In general, if you send tokens to a chain owned by someone else, you rely on them
+for asset availability: If they don't handle your messages, you don't have access to
+your tokens.
+
+Fortunately, Linera provides a solution based on temporary chains:
+If the number of parties who want to swap tokens is limited, we can make them all chain
+owners, allow only AMM operations on the chain, and allow only the AMM to close the chain.
+In addition, we make an AMM operation per block mandatory, so owners cannot spam the chain
+with empty blocks.
+
+```bash
+PUB_KEY_AMM=fcf518d56455283ace2bbc11c71e684eb58af81bc98b96a18129e825ce24ea84
+PUB_KEY_2=ca909dcf60df014c166be17eb4a9f6e2f9383314a57510206a54cd841ade455e
+
+kill %% && sleep 1    # Kill the service so we can use CLI commands for chain 1.
+
+linera --wait-for-outgoing-messages change-ownership \
+    --owner-public-keys $PUB_KEY_AMM $PUB_KEY_2
+
+linera --wait-for-outgoing-messages change-application-permissions \
+    --execute-operations $AMM_APPLICATION_ID \
+    --mandatory-applications $AMM_APPLICATION_ID \
+    --close-chain $AMM_APPLICATION_ID
+
+linera service --port $PORT &
+```
+
+First, let's add some liquidity again to the AMM. Navigate to the URL you get by running
+`echo "http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID"` and perform the following mutation:
+
+```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
+mutation {
+  addLiquidity(
+    owner: "User:$OWNER_1",
+    maxToken0Amount: "40",
+    maxToken1Amount: "40",
+  )
+}
+```
+
+The only way to close the chain is via the application. Navigate to the URL you get by running
+`echo "http://localhost:8080/chains/$CHAIN_AMM/applications/$AMM_APPLICATION_ID"` and perform the following mutation:
+
+```gql,uri=http://localhost:8080/chains/$CHAIN_AMM/applications/$AMM_APPLICATION_ID
+mutation { closeChain }
+```
+
+Owner 1 should now get back their tokens, and have around 49 FUN1 left and 51 FUN2 left. To check that, navigate
+to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$FUN1_APP_ID"`, and perform the following mutation:
+
+```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$FUN1_APP_ID
+query {
+    accounts {
+        entry(
+            key: "User:$OWNER_1"
+        ) {
+            value
+        }
+    }
+}
+```
+
+Then navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$FUN2_APP_ID"`, and perform the following mutation:
+
+```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$FUN2_APP_ID
+query {
+    accounts {
+        entry(
+            key: "User:$OWNER_1"
+        ) {
+            value
+        }
+    }
+}
+```
+
+<!-- cargo-rdme end -->

--- a/examples/rfq/src/contract.rs
+++ b/examples/rfq/src/contract.rs
@@ -1,0 +1,268 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+mod state;
+
+use fungible::FungibleTokenAbi;
+use linera_sdk::{
+    base::{
+        Amount, ApplicationPermissions, ChainId, ChainOwnership, PublicKey, TimeoutConfig,
+        WithContractAbi,
+    },
+    views::{RootView, View},
+    Contract, ContractRuntime,
+};
+use matching_engine::{
+    MatchingEngineAbi, Operation as MEOperation, Order, Parameters as MEParameters,
+};
+use rfq::{Message, Operation, Parameters, RequestId, RfqAbi};
+
+use self::state::RfqState;
+
+pub struct RfqContract {
+    state: RfqState,
+    runtime: ContractRuntime<Self>,
+}
+
+linera_sdk::contract!(RfqContract);
+
+impl WithContractAbi for RfqContract {
+    type Abi = RfqAbi;
+}
+
+impl Contract for RfqContract {
+    type Message = Message;
+    type InstantiationArgument = ();
+    type Parameters = Parameters;
+
+    async fn load(runtime: ContractRuntime<Self>) -> Self {
+        let state = RfqState::load(runtime.root_view_storage_context())
+            .await
+            .expect("Failed to load state");
+        RfqContract { state, runtime }
+    }
+
+    async fn instantiate(&mut self, _argument: ()) {
+        // Validate that the application parameters were configured correctly.
+        let _ = self.runtime.application_parameters();
+    }
+
+    async fn execute_operation(&mut self, operation: Self::Operation) -> Self::Response {
+        match operation {
+            Operation::RequestQuote {
+                target,
+                token_pair,
+                amount,
+            } => {
+                let seq_number =
+                    self.state
+                        .create_new_request(target.clone(), token_pair.clone(), amount);
+                let message = Message::RequestQuote {
+                    seq_number,
+                    token_pair,
+                    amount,
+                };
+                self.runtime
+                    .prepare_message(message)
+                    .with_authentication()
+                    .send_to(target);
+            }
+            Operation::ProvideQuote {
+                request_id,
+                quote,
+                quoter_pub_key,
+                quoter_account,
+            } => {
+                self.state
+                    .update_state_with_quote(
+                        &request_id,
+                        quote,
+                        quoter_pub_key,
+                        Some(quoter_account),
+                    )
+                    .await;
+                let message = Message::ProvideQuote {
+                    seq_number: request_id.seq_number(),
+                    quote,
+                    quoter_pub_key,
+                };
+                self.runtime
+                    .prepare_message(message)
+                    .with_authentication()
+                    .send_to(request_id.chain_id())
+            }
+            Operation::AcceptQuote {
+                request_id,
+                account_owner,
+                pub_key,
+                fee_budget,
+            } => {
+                let (exchange_order, quoter_pub_key) =
+                    self.state.get_bid_order(&request_id, account_owner).await;
+                let matching_engine_chain_id = self
+                    .start_exchange(
+                        &request_id,
+                        exchange_order,
+                        pub_key,
+                        quoter_pub_key,
+                        fee_budget,
+                    )
+                    .await;
+                self.state
+                    .start_exchange(&request_id, matching_engine_chain_id.clone())
+                    .await;
+            }
+            Operation::CancelRequest { request_id } => {
+                let _maybe_matching_engine_chain_id = self.state.cancel_request(&request_id).await;
+                // TODO: close the chain if it exists
+                let message = Message::CancelRequest {
+                    seq_number: request_id.seq_number(),
+                };
+                self.runtime
+                    .prepare_message(message)
+                    .with_authentication()
+                    .send_to(request_id.chain_id())
+            }
+        }
+    }
+
+    async fn execute_message(&mut self, message: Self::Message) {
+        let request_id = RequestId::new(self.get_message_creation_chain_id(), message.seq_number());
+        match message {
+            Message::RequestQuote {
+                token_pair, amount, ..
+            } => {
+                self.state.register_request(request_id, token_pair, amount);
+            }
+            Message::ProvideQuote {
+                quote,
+                quoter_pub_key,
+                ..
+            } => {
+                self.state
+                    .update_state_with_quote(&request_id, quote, quoter_pub_key, None)
+                    .await;
+            }
+            Message::QuoteAccepted {
+                request_id,
+                matching_engine_message_id: _,
+                matching_engine_app_id,
+                ..
+            } => {
+                let owner = self.state.get_quoter_account(&request_id).await;
+                let order = self.state.get_ask_order(&request_id, owner).await;
+                // the message should have been sent from the temporary chain
+                let matching_engine_chain_id = self.get_message_creation_chain_id();
+                self.state
+                    .start_exchange(&request_id, matching_engine_chain_id)
+                    .await;
+                self.runtime.call_application(
+                    true,
+                    matching_engine_app_id.with_abi::<MatchingEngineAbi>(),
+                    &MEOperation::ExecuteOrder { order },
+                );
+            }
+            Message::CancelRequest { .. } => {
+                let _maybe_matching_engine_chain_id = self.state.cancel_request(&request_id).await;
+                // TODO: close the chain if it exists
+            }
+            // the message below should only be executed on the temporary chains
+            Message::StartMatchingEngine {
+                request_id,
+                initiator,
+                token_pair,
+                order,
+                matching_engine_message_id,
+            } => {
+                // create the matching engine app
+                let parameters = self.runtime.application_parameters();
+                let me_parameters = MEParameters {
+                    tokens: [
+                        token_pair.token_offered.with_abi::<FungibleTokenAbi>(),
+                        token_pair.token_asked.with_abi::<FungibleTokenAbi>(),
+                    ],
+                };
+                let me_application_id = self
+                    .runtime
+                    .create_application::<MatchingEngineAbi, MEParameters, ()>(
+                        parameters.me_bytecode_id,
+                        &me_parameters,
+                        &(),
+                        vec![],
+                    );
+                // save the info in the app state
+                self.state.init_temp_chain_state(
+                    request_id.clone(),
+                    initiator,
+                    me_application_id.forget_abi(),
+                );
+                // submit the order in the name of the temp chain creator
+                self.runtime.call_application(
+                    true,
+                    me_application_id,
+                    &MEOperation::ExecuteOrder { order },
+                );
+                // inform the other side that the temporary chain is ready
+                self.runtime.send_message(
+                    request_id.chain_id(),
+                    Message::QuoteAccepted {
+                        request_id: RequestId::new(initiator, request_id.seq_number()),
+                        matching_engine_message_id,
+                        matching_engine_app_id: me_application_id.forget_abi(),
+                    },
+                );
+            }
+        }
+    }
+
+    async fn store(mut self) {
+        self.state.save().await.expect("Failed to save state");
+    }
+}
+
+impl RfqContract {
+    fn get_message_creation_chain_id(&mut self) -> ChainId {
+        self.runtime
+            .message_id()
+            .expect("Getting message id should not fail")
+            .chain_id
+    }
+
+    async fn start_exchange(
+        &mut self,
+        request_id: &RequestId,
+        order: Order,
+        our_pub_key: PublicKey,
+        quoter_pub_key: PublicKey,
+        fee_budget: Amount,
+    ) -> ChainId {
+        // TODO: start the new chain with matching engine and send the order there
+        let ownership = ChainOwnership::multiple(
+            [(our_pub_key, 100), (quoter_pub_key, 100)],
+            100,
+            TimeoutConfig::default(),
+        );
+        let app_id = self.runtime.application_id();
+        let permissions = ApplicationPermissions::new_single(app_id.forget_abi());
+        let (matching_engine_message_id, matching_engine_chain_id) =
+            self.runtime.open_chain(ownership, permissions, fee_budget);
+
+        // create an application and submit the order!
+        let initiator = self.runtime.chain_id();
+        let token_pair = self.state.token_pair(request_id).await;
+        self.runtime.send_message(
+            matching_engine_chain_id,
+            Message::StartMatchingEngine {
+                initiator,
+                request_id: request_id.clone(),
+                order,
+                token_pair,
+                matching_engine_message_id,
+            },
+        );
+
+        matching_engine_chain_id
+    }
+}

--- a/examples/rfq/src/lib.rs
+++ b/examples/rfq/src/lib.rs
@@ -82,6 +82,12 @@ pub enum Operation {
         account_owner: AccountOwner,
         fee_budget: Amount,
     },
+    FinalizeDeal {
+        request_id: RequestId,
+    },
+    CloseRequest {
+        request_id: RequestId,
+    },
     CancelRequest {
         request_id: RequestId,
     },
@@ -116,6 +122,14 @@ pub enum Message {
         token_pair: TokenPair,
         matching_engine_message_id: MessageId,
     },
+    TokensSent {
+        matching_engine_app_id: ApplicationId,
+        order: Order,
+    },
+    RequestClosed {
+        seq_number: u64,
+        matching_engine_chain_id: ChainId,
+    },
 }
 
 impl Message {
@@ -123,9 +137,14 @@ impl Message {
         match self {
             Message::RequestQuote { seq_number, .. }
             | Message::ProvideQuote { seq_number, .. }
-            | Message::CancelRequest { seq_number, .. } => *seq_number,
+            | Message::CancelRequest { seq_number, .. }
+            | Message::RequestClosed { seq_number, .. } => *seq_number,
             Message::StartMatchingEngine { request_id, .. }
             | Message::QuoteAccepted { request_id, .. } => request_id.seq_num,
+            Message::TokensSent { .. } => {
+                // not important, we can just return 0
+                0
+            }
         }
     }
 }

--- a/examples/rfq/src/lib.rs
+++ b/examples/rfq/src/lib.rs
@@ -5,10 +5,7 @@
 
 use async_graphql::{scalar, InputObject, Request, Response, SimpleObject};
 use linera_sdk::{
-    base::{
-        AccountOwner, Amount, ApplicationId, BytecodeId, ChainId, ContractAbi, MessageId,
-        PublicKey, ServiceAbi,
-    },
+    base::{Amount, ApplicationId, BytecodeId, ChainId, ContractAbi, MessageId, Owner, ServiceAbi},
     graphql::GraphQLMutationRoot,
 };
 use matching_engine::{Order, Price};
@@ -73,13 +70,11 @@ pub enum Operation {
     ProvideQuote {
         request_id: RequestId,
         quote: Price,
-        quoter_pub_key: PublicKey,
-        quoter_account: AccountOwner,
+        quoter_owner: Owner,
     },
     AcceptQuote {
         request_id: RequestId,
-        pub_key: PublicKey,
-        account_owner: AccountOwner,
+        owner: Owner,
         fee_budget: Amount,
     },
     FinalizeDeal {
@@ -105,7 +100,7 @@ pub enum Message {
     ProvideQuote {
         seq_number: u64,
         quote: Price,
-        quoter_pub_key: PublicKey,
+        quoter_owner: Owner,
     },
     QuoteAccepted {
         request_id: RequestId,

--- a/examples/rfq/src/lib.rs
+++ b/examples/rfq/src/lib.rs
@@ -121,9 +121,9 @@ pub enum Message {
         matching_engine_app_id: ApplicationId,
         order: Order,
     },
-    RequestClosed {
-        seq_number: u64,
-        matching_engine_chain_id: ChainId,
+    CloseChain,
+    ChainClosed {
+        request_id: RequestId,
     },
 }
 
@@ -132,11 +132,11 @@ impl Message {
         match self {
             Message::RequestQuote { seq_number, .. }
             | Message::ProvideQuote { seq_number, .. }
-            | Message::CancelRequest { seq_number, .. }
-            | Message::RequestClosed { seq_number, .. } => *seq_number,
+            | Message::CancelRequest { seq_number, .. } => *seq_number,
             Message::StartMatchingEngine { request_id, .. }
-            | Message::QuoteAccepted { request_id, .. } => request_id.seq_num,
-            Message::TokensSent { .. } => {
+            | Message::QuoteAccepted { request_id, .. }
+            | Message::ChainClosed { request_id } => request_id.seq_num,
+            Message::TokensSent { .. } | Message::CloseChain => {
                 // not important, we can just return 0
                 0
             }

--- a/examples/rfq/src/service.rs
+++ b/examples/rfq/src/service.rs
@@ -1,0 +1,50 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+#[allow(unused)]
+mod state;
+
+use std::sync::Arc;
+
+use async_graphql::{EmptySubscription, Request, Response, Schema};
+use linera_sdk::{
+    base::WithServiceAbi, graphql::GraphQLMutationRoot, views::View, Service, ServiceRuntime,
+};
+use rfq::Operation;
+
+use self::state::RfqState;
+
+pub struct RfqService {
+    state: Arc<RfqState>,
+}
+
+linera_sdk::service!(RfqService);
+
+impl WithServiceAbi for RfqService {
+    type Abi = rfq::RfqAbi;
+}
+
+impl Service for RfqService {
+    type Parameters = ();
+
+    async fn new(runtime: ServiceRuntime<Self>) -> Self {
+        let state = RfqState::load(runtime.root_view_storage_context())
+            .await
+            .expect("Failed to load state");
+        RfqService {
+            state: Arc::new(state),
+        }
+    }
+
+    async fn handle_query(&self, request: Request) -> Response {
+        let schema = Schema::build(
+            self.state.clone(),
+            Operation::mutation_root(),
+            EmptySubscription,
+        )
+        .finish();
+        schema.execute(request).await
+    }
+}

--- a/examples/rfq/src/state.rs
+++ b/examples/rfq/src/state.rs
@@ -1,0 +1,258 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{InputObject, SimpleObject, Union};
+use linera_sdk::{
+    base::{AccountOwner, Amount, ApplicationId, ChainId, PublicKey},
+    views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
+};
+use matching_engine::{Order, OrderNature, Price};
+use serde::{Deserialize, Serialize};
+
+use rfq::{RequestId, TokenPair};
+
+#[derive(Clone, Debug, Serialize, Deserialize, SimpleObject, InputObject)]
+pub struct QuoteRequested {
+    token_pair: TokenPair,
+    amount: Amount,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, SimpleObject, InputObject)]
+pub struct QuoteProvided {
+    token_pair: TokenPair,
+    amount: Amount,
+    price: Price,
+    quoter_pub_key: PublicKey,
+    maybe_quoter_account: Option<AccountOwner>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, SimpleObject, InputObject)]
+pub struct ExchangeInProgress {
+    exchange_chain_id: ChainId,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Union)]
+pub enum RequestState {
+    QuoteRequested(QuoteRequested),
+    QuoteProvided(QuoteProvided),
+    ExchangeInProgress(ExchangeInProgress),
+}
+
+impl RequestState {
+    fn token_pair(&self) -> TokenPair {
+        match self {
+            RequestState::QuoteRequested(QuoteRequested { token_pair, .. })
+            | RequestState::QuoteProvided(QuoteProvided { token_pair, .. }) => token_pair.clone(),
+            _ => panic!("invalid state for reading the token pair"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, SimpleObject)]
+pub struct RequestData {
+    state: RequestState,
+    we_requested: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, SimpleObject)]
+pub struct TempChainState {
+    request_id: RequestId,
+    initiator: ChainId,
+    me_application_id: ApplicationId,
+}
+
+#[derive(RootView, SimpleObject)]
+#[view(context = "ViewStorageContext")]
+pub struct RfqState {
+    next_seq_number: RegisterView<u64>,
+    requests: MapView<RequestId, RequestData>,
+    temp_chain_state: RegisterView<Option<TempChainState>>,
+}
+
+impl RfqState {
+    pub fn create_new_request(
+        &mut self,
+        target: ChainId,
+        token_pair: TokenPair,
+        amount: Amount,
+    ) -> u64 {
+        let seq_number = *self.next_seq_number.get();
+        let request_state = RequestState::QuoteRequested(QuoteRequested { token_pair, amount });
+        self.requests
+            .insert(
+                &RequestId::new(target, seq_number),
+                RequestData {
+                    state: request_state,
+                    we_requested: true,
+                },
+            )
+            .expect("Couldn't insert a new request state");
+        self.next_seq_number.set(seq_number + 1);
+        seq_number
+    }
+
+    pub fn register_request(
+        &mut self,
+        request_id: RequestId,
+        token_pair: TokenPair,
+        amount: Amount,
+    ) {
+        self.requests
+            .insert(
+                &request_id,
+                RequestData {
+                    state: RequestState::QuoteRequested(QuoteRequested { token_pair, amount }),
+                    we_requested: false,
+                },
+            )
+            .expect("Couldn't insert a new request state");
+    }
+
+    pub async fn update_state_with_quote(
+        &mut self,
+        request_id: &RequestId,
+        quote: Price,
+        quoter_pub_key: PublicKey,
+        maybe_quoter_account: Option<AccountOwner>,
+    ) {
+        let req_data = self
+            .requests
+            .get_mut(request_id)
+            .await
+            .expect("ViewError")
+            .expect("Request not found");
+        match &req_data.state {
+            RequestState::QuoteRequested(QuoteRequested { token_pair, amount }) => {
+                req_data.state = RequestState::QuoteProvided(QuoteProvided {
+                    token_pair: token_pair.clone(),
+                    amount: *amount,
+                    price: quote,
+                    quoter_pub_key,
+                    maybe_quoter_account,
+                });
+            }
+            _ => panic!("Request not in the QuoteRequested state!"),
+        }
+    }
+
+    pub async fn get_bid_order(
+        &mut self,
+        request_id: &RequestId,
+        owner: AccountOwner,
+    ) -> (Order, PublicKey) {
+        let req_data = self
+            .requests
+            .get_mut(request_id)
+            .await
+            .expect("ViewError")
+            .expect("Request not found");
+        match &req_data.state {
+            RequestState::QuoteProvided(QuoteProvided {
+                amount,
+                price,
+                quoter_pub_key,
+                ..
+            }) => (
+                Order::Insert {
+                    owner,
+                    amount: *amount,
+                    nature: OrderNature::Bid,
+                    price: *price,
+                },
+                *quoter_pub_key,
+            ),
+            _ => panic!("Request not in the QuoteProvided state!"),
+        }
+    }
+
+    pub async fn get_quoter_account(&self, request_id: &RequestId) -> AccountOwner {
+        let req_data = self
+            .requests
+            .get(request_id)
+            .await
+            .expect("ViewError")
+            .expect("Request not found");
+        match &req_data.state {
+            RequestState::QuoteProvided(QuoteProvided {
+                maybe_quoter_account: Some(quoter_account),
+                ..
+            }) => quoter_account.clone(),
+            _ => panic!("Request not in the QuoteProvided state, or quoter account doesn't exist!"),
+        }
+    }
+
+    pub async fn get_ask_order(&self, request_id: &RequestId, owner: AccountOwner) -> Order {
+        let req_data = self
+            .requests
+            .get(request_id)
+            .await
+            .expect("ViewError")
+            .expect("Request not found");
+        match &req_data.state {
+            RequestState::QuoteProvided(QuoteProvided { amount, price, .. }) => Order::Insert {
+                owner,
+                amount: *amount,
+                price: *price,
+                nature: OrderNature::Ask,
+            },
+            _ => panic!("Request not in the QuoteProvided state!"),
+        }
+    }
+
+    pub async fn start_exchange(&mut self, request_id: &RequestId, exchange_chain_id: ChainId) {
+        let req_data = self
+            .requests
+            .get_mut(request_id)
+            .await
+            .expect("ViewError")
+            .expect("Request not found");
+        match &req_data.state {
+            RequestState::QuoteProvided { .. } => {
+                req_data.state =
+                    RequestState::ExchangeInProgress(ExchangeInProgress { exchange_chain_id });
+            }
+            _ => panic!("Request not in the QuoteProvided state!"),
+        }
+    }
+
+    pub async fn cancel_request(&mut self, request_id: &RequestId) -> Option<ChainId> {
+        let req_data = self
+            .requests
+            .get(request_id)
+            .await
+            .expect("ViewError")
+            .expect("Request not found");
+        self.requests.remove(request_id).expect("Request not found");
+        match req_data.state {
+            RequestState::ExchangeInProgress(ExchangeInProgress { exchange_chain_id })
+                if req_data.we_requested =>
+            {
+                Some(exchange_chain_id)
+            }
+            _ => None,
+        }
+    }
+
+    pub async fn token_pair(&self, request_id: &RequestId) -> TokenPair {
+        self.requests
+            .get(request_id)
+            .await
+            .expect("ViewError")
+            .expect("Request not found")
+            .state
+            .token_pair()
+    }
+
+    pub fn init_temp_chain_state(
+        &mut self,
+        request_id: RequestId,
+        initiator: ChainId,
+        me_application_id: ApplicationId,
+    ) {
+        self.temp_chain_state.set(Some(TempChainState {
+            request_id,
+            initiator,
+            me_application_id,
+        }));
+    }
+}

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -716,6 +716,10 @@ pub struct ApplicationPermissions {
     #[graphql(default)]
     #[debug(skip_if = Vec::is_empty)]
     pub close_chain: Vec<ApplicationId>,
+    /// These applications are allowed to change the application permissions using the system API.
+    #[graphql(default)]
+    #[debug(skip_if = Vec::is_empty)]
+    pub change_application_permissions: Vec<ApplicationId>,
 }
 
 impl ApplicationPermissions {
@@ -726,6 +730,7 @@ impl ApplicationPermissions {
             execute_operations: Some(vec![app_id]),
             mandatory_applications: vec![app_id],
             close_chain: vec![app_id],
+            change_application_permissions: vec![app_id],
         }
     }
 
@@ -741,6 +746,12 @@ impl ApplicationPermissions {
     /// Returns whether the given application is allowed to close this chain.
     pub fn can_close_chain(&self, app_id: &ApplicationId) -> bool {
         self.close_chain.contains(app_id)
+    }
+
+    /// Returns whether the given application is allowed to change the application
+    /// permissions for this chain.
+    pub fn can_change_application_permissions(&self, app_id: &ApplicationId) -> bool {
+        self.change_application_permissions.contains(app_id)
     }
 }
 

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -187,6 +187,14 @@ pub enum CloseChainError {
     NotPermitted,
 }
 
+/// Errors that can happen when attempting to change the application permissions.
+#[derive(Clone, Copy, Debug, Error, WitStore, WitType)]
+pub enum ChangeApplicationPermissionsError {
+    /// Authenticated signer wasn't allowed to change the application permissions.
+    #[error("Unauthorized attempt to change the application permissions")]
+    NotPermitted,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -1329,6 +1329,10 @@ pub struct ApplicationPermissionsConfig {
     /// These applications are allowed to close the current chain using the system API.
     #[arg(long)]
     pub close_chain: Option<Vec<ApplicationId>>,
+    /// These applications are allowed to change the application permissions on the current chain
+    /// using the system API.
+    #[arg(long)]
+    pub change_application_permissions: Option<Vec<ApplicationId>>,
 }
 
 impl From<ApplicationPermissionsConfig> for ApplicationPermissions {
@@ -1337,6 +1341,9 @@ impl From<ApplicationPermissionsConfig> for ApplicationPermissions {
             execute_operations: config.execute_operations,
             mandatory_applications: config.mandatory_applications.unwrap_or_default(),
             close_chain: config.close_chain.unwrap_or_default(),
+            change_application_permissions: config
+                .change_application_permissions
+                .unwrap_or_default(),
         }
     }
 }

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -289,6 +289,22 @@ where
                 }
             }
 
+            ChangeApplicationPermissions {
+                application_id,
+                application_permissions,
+                callback,
+            } => {
+                let app_permissions = self.system.application_permissions.get();
+                if !app_permissions.can_change_application_permissions(&application_id) {
+                    callback.respond(Err(ExecutionError::UnauthorizedApplication(application_id)));
+                } else {
+                    self.system
+                        .application_permissions
+                        .set(application_permissions);
+                    callback.respond(Ok(()));
+                }
+            }
+
             CreateApplication {
                 next_message_id,
                 bytecode_id,
@@ -482,6 +498,13 @@ pub enum ExecutionRequest {
 
     CloseChain {
         application_id: UserApplicationId,
+        #[debug(skip)]
+        callback: oneshot::Sender<Result<(), ExecutionError>>,
+    },
+
+    ChangeApplicationPermissions {
+        application_id: UserApplicationId,
+        application_permissions: ApplicationPermissions,
         #[debug(skip)]
         callback: oneshot::Sender<Result<(), ExecutionError>>,
     },

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -711,6 +711,12 @@ pub trait ContractRuntime: BaseRuntime {
     /// Closes the current chain.
     fn close_chain(&mut self) -> Result<(), ExecutionError>;
 
+    /// Changes the application permissions on the current chain.
+    fn change_application_permissions(
+        &mut self,
+        application_permissions: ApplicationPermissions,
+    ) -> Result<(), ExecutionError>;
+
     /// Creates a new application on chain.
     fn create_application(
         &mut self,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1416,6 +1416,21 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             .recv_response()?
     }
 
+    fn change_application_permissions(
+        &mut self,
+        application_permissions: ApplicationPermissions,
+    ) -> Result<(), ExecutionError> {
+        let mut this = self.inner();
+        let application_id = this.current_application().id;
+        this.execution_state_sender
+            .send_request(|callback| ExecutionRequest::ChangeApplicationPermissions {
+                application_id,
+                application_permissions,
+                callback,
+            })?
+            .recv_response()?
+    }
+
     fn create_application(
         &mut self,
         bytecode_id: BytecodeId,

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -9,7 +9,7 @@ use linera_base::{
     identifiers::{
         Account, AccountOwner, ApplicationId, ChainId, ChannelName, MessageId, Owner, StreamName,
     },
-    ownership::{ChainOwnership, CloseChainError},
+    ownership::{ChainOwnership, ChangeApplicationPermissionsError, CloseChainError},
 };
 use linera_views::batch::{Batch, WriteOperation};
 use linera_witty::{wit_export, Instance, RuntimeError};
@@ -296,6 +296,25 @@ where
             Ok(()) => Ok(Ok(())),
             Err(ExecutionError::UnauthorizedApplication(_)) => {
                 Ok(Err(CloseChainError::NotPermitted))
+            }
+            Err(error) => Err(RuntimeError::Custom(error.into())),
+        }
+    }
+
+    /// Changes the application permissions for the current chain. Returns an error if the
+    /// application doesn't have permission to do so.
+    fn change_application_permissions(
+        caller: &mut Caller,
+        application_permissions: ApplicationPermissions,
+    ) -> Result<Result<(), ChangeApplicationPermissionsError>, RuntimeError> {
+        match caller
+            .user_data_mut()
+            .runtime
+            .change_application_permissions(application_permissions)
+        {
+            Ok(()) => Ok(Ok(())),
+            Err(ExecutionError::UnauthorizedApplication(_)) => {
+                Ok(Err(ChangeApplicationPermissionsError::NotPermitted))
             }
             Err(error) => Err(RuntimeError::Custom(error.into())),
         }

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -7,7 +7,9 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
     identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
-    ownership::{ChainOwnership, CloseChainError, TimeoutConfig},
+    ownership::{
+        ChainOwnership, ChangeApplicationPermissionsError, CloseChainError, TimeoutConfig,
+    },
 };
 
 use super::wit::contract_system_api as wit_system_api;
@@ -132,6 +134,16 @@ impl From<wit_system_api::CloseChainError> for CloseChainError {
     fn from(guest: wit_system_api::CloseChainError) -> Self {
         match guest {
             wit_system_api::CloseChainError::NotPermitted => CloseChainError::NotPermitted,
+        }
+    }
+}
+
+impl From<wit_system_api::ChangeApplicationPermissionsError> for ChangeApplicationPermissionsError {
+    fn from(guest: wit_system_api::ChangeApplicationPermissionsError) -> Self {
+        match guest {
+            wit_system_api::ChangeApplicationPermissionsError::NotPermitted => {
+                ChangeApplicationPermissionsError::NotPermitted
+            }
         }
     }
 }

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -224,12 +224,17 @@ impl From<ApplicationPermissions> for wit_system_api::ApplicationPermissions {
             execute_operations,
             mandatory_applications,
             close_chain,
+            change_application_permissions,
         } = permissions;
         Self {
             execute_operations: execute_operations
                 .map(|app_ids| app_ids.into_iter().map(Into::into).collect()),
             mandatory_applications: mandatory_applications.into_iter().map(Into::into).collect(),
             close_chain: close_chain.into_iter().map(Into::into).collect(),
+            change_application_permissions: change_application_permissions
+                .into_iter()
+                .map(Into::into)
+                .collect(),
         }
     }
 }

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -12,7 +12,7 @@ use linera_base::{
         Account, AccountOwner, ApplicationId, BytecodeId, ChainId, ChannelName, Destination,
         MessageId, Owner, StreamName,
     },
-    ownership::{ChainOwnership, CloseChainError},
+    ownership::{ChainOwnership, ChangeApplicationPermissionsError, CloseChainError},
 };
 use serde::Serialize;
 
@@ -223,6 +223,15 @@ where
             balance.into(),
         );
         (message_id.into(), chain_id.into())
+    }
+
+    /// Changes the application permissions for the current chain.
+    pub fn change_application_permissions(
+        &mut self,
+        application_permissions: ApplicationPermissions,
+    ) -> Result<(), ChangeApplicationPermissionsError> {
+        wit::change_application_permissions(&application_permissions.into())
+            .map_err(|error| error.into())
     }
 
     /// Creates a new on-chain application, based on the supplied bytecode and parameters.

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -226,16 +226,21 @@ where
     }
 
     /// Creates a new on-chain application, based on the supplied bytecode and parameters.
-    pub fn create_application<A: Contract>(
+    pub fn create_application<Abi, Parameters, InstantiationArgument>(
         &mut self,
         bytecode_id: BytecodeId,
-        parameters: &A::Parameters,
-        argument: &A::InstantiationArgument,
+        parameters: &Parameters,
+        argument: &InstantiationArgument,
         required_application_ids: Vec<ApplicationId>,
-    ) -> ApplicationId<A::Abi> {
-        let parameters = bcs::to_bytes(parameters)
+    ) -> ApplicationId<Abi>
+    where
+        Abi: ContractAbi,
+        Parameters: Serialize,
+        InstantiationArgument: Serialize,
+    {
+        let parameters = serde_json::to_vec(parameters)
             .expect("Failed to serialize `Parameters` type for a cross-application call");
-        let argument = bcs::to_bytes(argument).expect(
+        let argument = serde_json::to_vec(argument).expect(
             "Failed to serialize `InstantiationArgument` type for a cross-application call",
         );
         let converted_application_ids: Vec<_> = required_application_ids
@@ -248,7 +253,7 @@ where
             &argument,
             &converted_application_ids,
         );
-        ApplicationId::from(application_id).with_abi::<A::Abi>()
+        ApplicationId::from(application_id).with_abi::<Abi>()
     }
 
     /// Calls another application.

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -21,6 +21,7 @@ interface contract-system-api {
     get-chain-ownership: func() -> chain-ownership;
     open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: amount) -> tuple<message-id, chain-id>;
     close-chain: func() -> result<tuple<>, close-chain-error>;
+    change-application-permissions: func(application-permissions: application-permissions) -> result<tuple<>, change-application-permissions-error>;
     create-application: func(bytecode-id: bytecode-id, parameters: list<u8>, argument: list<u8>, required-application-ids: list<application-id>) -> application-id;
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
     emit: func(name: stream-name, key: list<u8>, value: list<u8>);
@@ -55,6 +56,7 @@ interface contract-system-api {
         execute-operations: option<list<application-id>>,
         mandatory-applications: list<application-id>,
         close-chain: list<application-id>,
+        change-application-permissions: list<application-id>,
     }
 
     record block-height {
@@ -76,6 +78,10 @@ interface contract-system-api {
         multi-leader-rounds: u32,
         open-multi-leader-rounds: bool,
         timeout-config: timeout-config,
+    }
+
+    enum change-application-permissions-error {
+        not-permitted,
     }
 
     record channel-name {

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -493,11 +493,13 @@ where
         close_chain: Vec<ApplicationId>,
         execute_operations: Option<Vec<ApplicationId>>,
         mandatory_applications: Vec<ApplicationId>,
+        change_application_permissions: Vec<ApplicationId>,
     ) -> Result<CryptoHash, Error> {
         let operation = SystemOperation::ChangeApplicationPermissions(ApplicationPermissions {
             execute_operations,
             mandatory_applications,
             close_chain,
+            change_application_permissions,
         });
         self.execute_system_operation(operation, chain_id).await
     }


### PR DESCRIPTION
## Motivation

Current example solutions for atomic swaps require lots of manual setup and can only be used once per application instance. We could use an application that automates some of the rough edges and enables performing multiple atomic swaps.

## Proposal

The RFQ application works by having users request quotes from other users, and automatically setting up an atomic swap on a temporary chain when both sides agree upon a quote.

## Test Plan

Manual testing by running the scenario described in the README has been performed.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Issue #3003 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
