### PR TITLE
Fix Placeholder in NFT Error Messages

### DIFF
--- a/examples/crowd-funding/README.md
+++ b/examples/crowd-funding/README.md
@@ -29,7 +29,7 @@ Optionally, contributors may also be able to create a block to accept a new epoc
 (i.e. a change of validators).
 
 <!--
-TODO: The following documentation involves `sleep`ing to avoid some race conditions. See:
+TODO: The following documentation involves sleep to avoid some race conditions. See:
   - https://github.com/linera-io/linera-protocol/issues/1176
   - https://github.com/linera-io/linera-protocol/issues/1177
 -->

--- a/examples/gen-nft/src/contract.rs
+++ b/examples/gen-nft/src/contract.rs
@@ -169,7 +169,7 @@ impl GenNftContract {
             .get(token_id)
             .await
             .expect("Failure in retrieving NFT")
-            .expect("NFT {token_id} not found")
+            .expect("NFT not found")
     }
 
     async fn mint(&mut self, owner: AccountOwner, prompt: String) {

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -173,7 +173,7 @@ impl NonFungibleTokenContract {
             .get(token_id)
             .await
             .expect("Failure in retrieving NFT")
-            .expect("NFT {token_id} not found")
+            .expect("NFT not found")
     }
 
     async fn mint(&mut self, owner: AccountOwner, name: String, blob_hash: DataBlobHash) {

--- a/linera-views/DESIGN.md
+++ b/linera-views/DESIGN.md
@@ -9,7 +9,7 @@ We have designed a `KeyValueStore` trait that represents the basic functionaliti
 of a key-value store whose keys are `Vec<u8>` and whose values are `Vec<u8>`.
 
 We provide an implementation of the trait `KeyValueStore` for the following key-value stores:
-* `MemoryStore` is using the memory (and uses internally a simple B-Tree map).
+* `MemoryStore` uses the memory (and uses internally a simple B-Tree map).
 * `RocksDbStore` is a disk-based key-value store
 * `DynamoDbStore` is the AWS-based DynamoDB service.
 * `ScyllaDbStore` is a cloud based Cassandra compatible database.


### PR DESCRIPTION
## Pull Request Summary

### Changes Made

1. **File:** `examples/gen-nft/src/contract.rs`
   - **Old Code:** `.expect("NFT {token_id} not found")`
   - **New Code:** `.expect("NFT not found")`

2. **File:** `examples/non-fungible/src/contract.rs`
   - **Old Code:** `.expect("NFT {token_id} not found")`
   - **New Code:** `.expect("NFT not found")`

### Reason for Changes

Improved clarity and consistency of error messages. The previous message included a placeholder `{token_id}` that was not replaced, leading to confusion. The new message "NFT not found" is clear and concise, aiding in debugging.
