### PR TITLE
Fix links

### DIFF
--- a/examples/crowd-funding/README.md
+++ b/examples/crowd-funding/README.md
@@ -39,7 +39,7 @@ TODO: The following documentation involves `sleep`ing to avoid some race conditi
 ### Setting Up
 
 The WebAssembly binaries for the bytecode can be built and published using [steps from the
-book](https://linera-io.github.io/linera-documentation/getting_started/first_app.html),
+book](https://linera.dev/developers/getting_started.html),
 summarized below.
 
 Set up the path and the helper function.

--- a/examples/fungible/README.md
+++ b/examples/fungible/README.md
@@ -28,7 +28,7 @@ Tokens can be transferred from an account to different destinations, such as:
 ### Setting Up
 
 The WebAssembly binaries for the bytecode can be built and published using [steps from the
-book](https://linera-io.github.io/linera-documentation/getting_started/first_app.html),
+book](https://linera.dev/developers/getting_started.html),
 summarized below.
 
 Before getting started, make sure that the binary tools `linera*` corresponding to


### PR DESCRIPTION

1. **File:** `examples/crowd-funding/README.md`
   - **Old Code:** `- book](https://linera-io.github.io/linera-documentation/getting_started/first_app.html),`
   - **New Code:** `+ book](https://linera.dev/developers/getting_started.html),`

2. **File:** `examples/fungible/README.md`
   - **Old Code:** `- book](https://linera-io.github.io/linera-documentation/getting_started/first_app.html),`
   - **New Code:** `+ book](https://linera.dev/developers/getting_started.html),`

### Reason for Changes

Updated links in README files to point to the new documentation site, ensuring users have access to current information and improving user experience.