### PR TITLE
Agent example uses DeepSeek.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -357,6 +357,7 @@ jobs:
         cargo clippy --all-targets --all-features --target x86_64-unknown-linux-gnu --locked
         cd agent
         cargo fmt -- --check
+        cargo clippy --all-targets --all-features --locked
 
   lint-cargo-clippy:
     runs-on: ubuntu-latest

--- a/examples/agent/Cargo.lock
+++ b/examples/agent/Cargo.lock
@@ -936,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "rig-core"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db412a240081bfa42e95c84b5e2c75e29a6b9b06060623f2b735b40abe08f535"
+checksum = "7f8190b6b290cc0b9bd7ff44156e288f0df82c2d3cbccc9ffa1c44493b38ffc4"
 dependencies = [
  "futures",
  "glob",

--- a/examples/agent/Cargo.toml
+++ b/examples/agent/Cargo.toml
@@ -10,7 +10,7 @@ clap = { version = "4.5.26", features = ["derive"] }
 reqwest = { version = "0.11.24", default-features = false, features = [
     "rustls-tls",
 ] }
-rig-core = "0.6.1"
+rig-core = "0.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
## Motivation

The new DeepSeek model r1 is powerful and cheap on a per-token basis

## Proposal

Enable the agent example to use DeepSeek.

Since `Agent` is generic over a `CompletionModel` and `CompletionModel` has an associated type `CompletionModel::Response` there wasn't a nice way to do this polymorphically (i.e. return a `Box<dyn CompletionModel>` from a model parser.

## Test Plan

Tested manually (TBD DeepSeek API is down).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.