### PR TITLE
Increased gRPC message size limit to 32MiB.

### DIFF
--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -42,7 +42,7 @@ pub enum GrpcError {
 }
 
 const MEBIBYTE: usize = 1024 * 1024;
-pub const GRPC_MAX_MESSAGE_SIZE: usize = 16 * MEBIBYTE;
+pub const GRPC_MAX_MESSAGE_SIZE: usize = 32 * MEBIBYTE;
 
 /// Limit of gRPC message size up to which we will try to populate with data when estimating.
 /// We leave 30% of buffer for the rest of the message and potential underestimation.


### PR DESCRIPTION
## Motivation

Allow for larger message sizes.

## Proposal

Double the allowed gRPC message size.

## Test Plan

CI will catch regressions.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.