### PR TITLE
Use `Mutex` inside `ServiceRuntime` to make it `Send`

### DIFF
--- a/examples/fungible/src/service.rs
+++ b/examples/fungible/src/service.rs
@@ -5,7 +5,7 @@
 
 mod state;
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
 use fungible::{Operation, Parameters};
@@ -21,7 +21,7 @@ use self::state::FungibleTokenState;
 #[derive(Clone)]
 pub struct FungibleTokenService {
     state: Arc<FungibleTokenState>,
-    runtime: Arc<Mutex<ServiceRuntime<Self>>>,
+    runtime: Arc<ServiceRuntime<Self>>,
 }
 
 linera_sdk::service!(FungibleTokenService);
@@ -39,7 +39,7 @@ impl Service for FungibleTokenService {
             .expect("Failed to load state");
         FungibleTokenService {
             state: Arc::new(state),
-            runtime: Arc::new(Mutex::new(runtime)),
+            runtime: Arc::new(runtime),
         }
     }
 
@@ -57,10 +57,6 @@ impl FungibleTokenService {
     }
 
     async fn ticker_symbol(&self) -> Result<String, async_graphql::Error> {
-        let runtime = self
-            .runtime
-            .try_lock()
-            .expect("Services only run in a single-thread");
-        Ok(runtime.application_parameters().ticker_symbol)
+        Ok(self.runtime.application_parameters().ticker_symbol)
     }
 }

--- a/examples/gen-nft/src/service.rs
+++ b/examples/gen-nft/src/service.rs
@@ -10,7 +10,7 @@ mod token;
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 use async_graphql::{Context, EmptySubscription, Object, Request, Response, Schema};
@@ -29,7 +29,7 @@ use crate::model::ModelContext;
 
 pub struct GenNftService {
     state: Arc<GenNftState>,
-    runtime: Arc<Mutex<ServiceRuntime<Self>>>,
+    runtime: Arc<ServiceRuntime<Self>>,
 }
 
 linera_sdk::service!(GenNftService);
@@ -47,7 +47,7 @@ impl Service for GenNftService {
             .expect("Failed to load state");
         GenNftService {
             state: Arc::new(state),
-            runtime: Arc::new(Mutex::new(runtime)),
+            runtime: Arc::new(runtime),
         }
     }
 
@@ -162,10 +162,7 @@ impl QueryRoot {
     }
 
     async fn prompt(&self, ctx: &Context<'_>, prompt: String) -> String {
-        let runtime = ctx
-            .data::<Arc<Mutex<ServiceRuntime<GenNftService>>>>()
-            .unwrap();
-        let runtime = runtime.lock().unwrap();
+        let runtime = ctx.data::<Arc<ServiceRuntime<GenNftService>>>().unwrap();
         info!("prompt: {}", prompt);
         let raw_weights = runtime.fetch_url("http://localhost:10001/model.bin");
         info!("got weights: {}B", raw_weights.len());

--- a/examples/hex-game/src/service.rs
+++ b/examples/hex-game/src/service.rs
@@ -5,7 +5,7 @@
 
 mod state;
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use async_graphql::{ComplexObject, Context, EmptySubscription, Request, Response, Schema};
 use hex_game::{Operation, Player};
@@ -17,7 +17,7 @@ use self::state::HexState;
 
 #[derive(Clone)]
 pub struct HexService {
-    runtime: Arc<Mutex<ServiceRuntime<HexService>>>,
+    runtime: Arc<ServiceRuntime<HexService>>,
     state: Arc<HexState>,
 }
 
@@ -35,7 +35,7 @@ impl Service for HexService {
             .await
             .expect("Failed to load state");
         HexService {
-            runtime: Arc::new(Mutex::new(runtime)),
+            runtime: Arc::new(runtime),
             state: Arc::new(state),
         }
     }
@@ -59,10 +59,8 @@ impl HexState {
             return Some(winner);
         }
         let active = self.board.get().active_player();
-        let runtime = ctx
-            .data::<Arc<Mutex<ServiceRuntime<HexService>>>>()
-            .unwrap();
-        let block_time = runtime.lock().unwrap().system_time();
+        let runtime = ctx.data::<Arc<ServiceRuntime<HexService>>>().unwrap();
+        let block_time = runtime.system_time();
         if self.clock.get().timed_out(block_time, active) {
             return Some(active.other());
         }
@@ -87,7 +85,7 @@ mod tests {
 
         let service = HexService {
             state: Arc::new(state),
-            runtime: Arc::new(Mutex::new(runtime)),
+            runtime: Arc::new(runtime),
         };
 
         let response = service

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -157,12 +157,12 @@ where
     }
 
     /// Reads a data blob with the given hash from storage.
-    pub fn read_data_blob(&mut self, hash: DataBlobHash) -> Vec<u8> {
+    pub fn read_data_blob(&self, hash: DataBlobHash) -> Vec<u8> {
         wit::read_data_blob(hash.0.into())
     }
 
     /// Asserts that a data blob with the given hash exists in storage.
-    pub fn assert_data_blob_exists(&mut self, hash: DataBlobHash) {
+    pub fn assert_data_blob_exists(&self, hash: DataBlobHash) {
         wit::assert_data_blob_exists(hash.0.into())
     }
 }

--- a/linera-sdk/src/service/test_runtime.rs
+++ b/linera-sdk/src/service/test_runtime.rs
@@ -3,10 +3,7 @@
 
 //! Runtime types to simulate interfacing with the host executing the service.
 
-use std::{
-    cell::{Cell, RefCell},
-    collections::HashMap,
-};
+use std::{collections::HashMap, sync::Mutex};
 
 use linera_base::{
     abi::ServiceAbi,
@@ -21,16 +18,16 @@ pub struct MockServiceRuntime<Application>
 where
     Application: Service,
 {
-    application_parameters: Cell<Option<Application::Parameters>>,
-    application_id: Cell<Option<ApplicationId<Application::Abi>>>,
-    chain_id: Cell<Option<ChainId>>,
-    next_block_height: Cell<Option<BlockHeight>>,
-    timestamp: Cell<Option<Timestamp>>,
-    chain_balance: Cell<Option<Amount>>,
-    owner_balances: RefCell<Option<HashMap<AccountOwner, Amount>>>,
-    query_application_handler: RefCell<Option<QueryApplicationHandler>>,
-    url_blobs: RefCell<Option<HashMap<String, Vec<u8>>>>,
-    blobs: RefCell<Option<HashMap<DataBlobHash, Vec<u8>>>>,
+    application_parameters: Mutex<Option<Application::Parameters>>,
+    application_id: Mutex<Option<ApplicationId<Application::Abi>>>,
+    chain_id: Mutex<Option<ChainId>>,
+    next_block_height: Mutex<Option<BlockHeight>>,
+    timestamp: Mutex<Option<Timestamp>>,
+    chain_balance: Mutex<Option<Amount>>,
+    owner_balances: Mutex<Option<HashMap<AccountOwner, Amount>>>,
+    query_application_handler: Mutex<Option<QueryApplicationHandler>>,
+    url_blobs: Mutex<Option<HashMap<String, Vec<u8>>>>,
+    blobs: Mutex<Option<HashMap<DataBlobHash, Vec<u8>>>>,
     key_value_store: KeyValueStore,
 }
 
@@ -50,16 +47,16 @@ where
     /// Creates a new [`MockServiceRuntime`] instance for a service.
     pub fn new() -> Self {
         MockServiceRuntime {
-            application_parameters: Cell::new(None),
-            application_id: Cell::new(None),
-            chain_id: Cell::new(None),
-            next_block_height: Cell::new(None),
-            timestamp: Cell::new(None),
-            chain_balance: Cell::new(None),
-            owner_balances: RefCell::new(None),
-            query_application_handler: RefCell::new(None),
-            url_blobs: RefCell::new(None),
-            blobs: RefCell::new(None),
+            application_parameters: Mutex::new(None),
+            application_id: Mutex::new(None),
+            chain_id: Mutex::new(None),
+            next_block_height: Mutex::new(None),
+            timestamp: Mutex::new(None),
+            chain_balance: Mutex::new(None),
+            owner_balances: Mutex::new(None),
+            query_application_handler: Mutex::new(None),
+            url_blobs: Mutex::new(None),
+            blobs: Mutex::new(None),
             key_value_store: KeyValueStore::mock(),
         }
     }
@@ -79,8 +76,7 @@ where
         self,
         application_parameters: Application::Parameters,
     ) -> Self {
-        self.application_parameters
-            .set(Some(application_parameters));
+        *self.application_parameters.lock().unwrap() = Some(application_parameters);
         self
     }
 
@@ -89,8 +85,7 @@ where
         &self,
         application_parameters: Application::Parameters,
     ) -> &Self {
-        self.application_parameters
-            .set(Some(application_parameters));
+        *self.application_parameters.lock().unwrap() = Some(application_parameters);
         self
     }
 
@@ -105,13 +100,13 @@ where
 
     /// Configures the application ID to return during the test.
     pub fn with_application_id(self, application_id: ApplicationId<Application::Abi>) -> Self {
-        self.application_id.set(Some(application_id));
+        *self.application_id.lock().unwrap() = Some(application_id);
         self
     }
 
     /// Configures the application ID to return during the test.
     pub fn set_application_id(&self, application_id: ApplicationId<Application::Abi>) -> &Self {
-        self.application_id.set(Some(application_id));
+        *self.application_id.lock().unwrap() = Some(application_id);
         self
     }
 
@@ -126,13 +121,13 @@ where
 
     /// Configures the chain ID to return during the test.
     pub fn with_chain_id(self, chain_id: ChainId) -> Self {
-        self.chain_id.set(Some(chain_id));
+        *self.chain_id.lock().unwrap() = Some(chain_id);
         self
     }
 
     /// Configures the chain ID to return during the test.
     pub fn set_chain_id(&self, chain_id: ChainId) -> &Self {
-        self.chain_id.set(Some(chain_id));
+        *self.chain_id.lock().unwrap() = Some(chain_id);
         self
     }
 
@@ -147,13 +142,13 @@ where
 
     /// Configures the next block height to return during the test.
     pub fn with_next_block_height(self, next_block_height: BlockHeight) -> Self {
-        self.next_block_height.set(Some(next_block_height));
+        *self.next_block_height.lock().unwrap() = Some(next_block_height);
         self
     }
 
     /// Configures the block height to return during the test.
     pub fn set_next_block_height(&self, next_block_height: BlockHeight) -> &Self {
-        self.next_block_height.set(Some(next_block_height));
+        *self.next_block_height.lock().unwrap() = Some(next_block_height);
         self
     }
 
@@ -168,13 +163,13 @@ where
 
     /// Configures the system time to return during the test.
     pub fn with_system_time(self, timestamp: Timestamp) -> Self {
-        self.timestamp.set(Some(timestamp));
+        *self.timestamp.lock().unwrap() = Some(timestamp);
         self
     }
 
     /// Configures the system time to return during the test.
     pub fn set_system_time(&self, timestamp: Timestamp) -> &Self {
-        self.timestamp.set(Some(timestamp));
+        *self.timestamp.lock().unwrap() = Some(timestamp);
         self
     }
 
@@ -189,13 +184,13 @@ where
 
     /// Configures the chain balance to return during the test.
     pub fn with_chain_balance(self, chain_balance: Amount) -> Self {
-        self.chain_balance.set(Some(chain_balance));
+        *self.chain_balance.lock().unwrap() = Some(chain_balance);
         self
     }
 
     /// Configures the chain balance to return during the test.
     pub fn set_chain_balance(&self, chain_balance: Amount) -> &Self {
-        self.chain_balance.set(Some(chain_balance));
+        *self.chain_balance.lock().unwrap() = Some(chain_balance);
         self
     }
 
@@ -213,7 +208,7 @@ where
         self,
         owner_balances: impl IntoIterator<Item = (AccountOwner, Amount)>,
     ) -> Self {
-        *self.owner_balances.borrow_mut() = Some(owner_balances.into_iter().collect());
+        *self.owner_balances.lock().unwrap() = Some(owner_balances.into_iter().collect());
         self
     }
 
@@ -222,7 +217,7 @@ where
         &self,
         owner_balances: impl IntoIterator<Item = (AccountOwner, Amount)>,
     ) -> &Self {
-        *self.owner_balances.borrow_mut() = Some(owner_balances.into_iter().collect());
+        *self.owner_balances.lock().unwrap() = Some(owner_balances.into_iter().collect());
         self
     }
 
@@ -235,7 +230,8 @@ where
     /// Configures the balance of one account on the chain to use during the test.
     pub fn set_owner_balance(&self, owner: AccountOwner, balance: Amount) -> &Self {
         self.owner_balances
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .get_or_insert_with(HashMap::new)
             .insert(owner, balance);
         self
@@ -244,7 +240,8 @@ where
     /// Returns the balance of one of the accounts on this chain.
     pub fn owner_balance(&self, owner: AccountOwner) -> Amount {
         self.owner_balances
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .as_mut()
             .and_then(|owner_balances| owner_balances.get(&owner).copied())
             .unwrap_or_else(|| {
@@ -259,7 +256,8 @@ where
     /// Returns the balances of all accounts on the chain.
     pub fn owner_balances(&self) -> Vec<(AccountOwner, Amount)> {
         self.owner_balances
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .as_ref()
             .expect(
                 "Owner balances have not been mocked, \
@@ -273,7 +271,8 @@ where
     /// Returns the owners of accounts on this chain.
     pub fn balance_owners(&self) -> Vec<AccountOwner> {
         self.owner_balances
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .as_ref()
             .expect(
                 "Owner balances have not been mocked, \
@@ -289,7 +288,7 @@ where
         self,
         handler: impl FnMut(ApplicationId, Vec<u8>) -> Vec<u8> + Send + 'static,
     ) -> Self {
-        *self.query_application_handler.borrow_mut() = Some(Box::new(handler));
+        *self.query_application_handler.lock().unwrap() = Some(Box::new(handler));
         self
     }
 
@@ -298,7 +297,7 @@ where
         &self,
         handler: impl FnMut(ApplicationId, Vec<u8>) -> Vec<u8> + Send + 'static,
     ) -> &Self {
-        *self.query_application_handler.borrow_mut() = Some(Box::new(handler));
+        *self.query_application_handler.lock().unwrap() = Some(Box::new(handler));
         self
     }
 
@@ -311,7 +310,7 @@ where
         let query_bytes =
             serde_json::to_vec(&query).expect("Failed to serialize query to another application");
 
-        let mut handler_guard = self.query_application_handler.borrow_mut();
+        let mut handler_guard = self.query_application_handler.lock().unwrap();
         let handler = handler_guard.as_mut().expect(
             "Handler for `query_application` has not been mocked, \
             please call `MockServiceRuntime::set_query_application_handler` first",
@@ -325,13 +324,13 @@ where
 
     /// Configures the blobs returned when fetching from URLs during the test.
     pub fn with_url_blobs(self, url_blobs: impl IntoIterator<Item = (String, Vec<u8>)>) -> Self {
-        *self.url_blobs.borrow_mut() = Some(url_blobs.into_iter().collect());
+        *self.url_blobs.lock().unwrap() = Some(url_blobs.into_iter().collect());
         self
     }
 
     /// Configures the blobs returned when fetching from URLs during the test.
     pub fn set_url_blobs(&self, url_blobs: impl IntoIterator<Item = (String, Vec<u8>)>) -> &Self {
-        *self.url_blobs.borrow_mut() = Some(url_blobs.into_iter().collect());
+        *self.url_blobs.lock().unwrap() = Some(url_blobs.into_iter().collect());
         self
     }
 
@@ -344,7 +343,8 @@ where
     /// Configures the `blob` returned when fetching from the `url` during the test.
     pub fn set_url_blob(&self, url: impl Into<String>, blob: Vec<u8>) -> &Self {
         self.url_blobs
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .get_or_insert_with(HashMap::new)
             .insert(url.into(), blob);
         self
@@ -353,7 +353,8 @@ where
     /// Fetches a blob of bytes from a given URL.
     pub fn fetch_url(&self, url: &str) -> Vec<u8> {
         self.url_blobs
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .as_mut()
             .and_then(|url_blobs| url_blobs.get(url).cloned())
             .unwrap_or_else(|| {
@@ -366,13 +367,13 @@ where
 
     /// Configures the `blobs` returned when fetching from hashes during the test.
     pub fn with_blobs(self, blobs: impl IntoIterator<Item = (DataBlobHash, Vec<u8>)>) -> Self {
-        *self.blobs.borrow_mut() = Some(blobs.into_iter().collect());
+        *self.blobs.lock().unwrap() = Some(blobs.into_iter().collect());
         self
     }
 
     /// Configures the `blobs` returned when fetching from hashes during the test.
     pub fn set_blobs(&self, blobs: impl IntoIterator<Item = (DataBlobHash, Vec<u8>)>) -> &Self {
-        *self.blobs.borrow_mut() = Some(blobs.into_iter().collect());
+        *self.blobs.lock().unwrap() = Some(blobs.into_iter().collect());
         self
     }
 
@@ -385,7 +386,8 @@ where
     /// Configures the `blob` returned when fetching from the hash during the test.
     pub fn set_blob(&self, hash: impl Into<DataBlobHash>, blob: Vec<u8>) -> &Self {
         self.blobs
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .get_or_insert_with(HashMap::new)
             .insert(hash.into(), blob);
         self
@@ -394,7 +396,8 @@ where
     /// Fetches a blob from a given hash.
     pub fn read_data_blob(&mut self, hash: DataBlobHash) -> Vec<u8> {
         self.blobs
-            .borrow()
+            .lock()
+            .unwrap()
             .as_ref()
             .and_then(|blobs| blobs.get(&hash).cloned())
             .unwrap_or_else(|| {
@@ -408,7 +411,8 @@ where
     /// Asserts that a blob with the given hash exists in storage.
     pub fn assert_blob_exists(&mut self, hash: DataBlobHash) {
         self.blobs
-            .borrow()
+            .lock()
+            .unwrap()
             .as_ref()
             .map(|blobs| blobs.contains_key(&hash))
             .unwrap_or_else(|| {
@@ -419,14 +423,12 @@ where
             });
     }
 
-    /// Loads a mocked value from the `cell` cache or panics with a provided `message`.
-    fn fetch_mocked_value<T>(cell: &Cell<Option<T>>, message: &str) -> T
+    /// Loads a mocked value from the `slot` cache or panics with a provided `message`.
+    fn fetch_mocked_value<T>(slot: &Mutex<Option<T>>, message: &str) -> T
     where
         T: Clone,
     {
-        let value = cell.take().expect(message);
-        cell.set(Some(value.clone()));
-        value
+        slot.lock().unwrap().clone().expect(message)
     }
 }
 

--- a/linera-sdk/src/service/test_runtime.rs
+++ b/linera-sdk/src/service/test_runtime.rs
@@ -394,7 +394,7 @@ where
     }
 
     /// Fetches a blob from a given hash.
-    pub fn read_data_blob(&mut self, hash: DataBlobHash) -> Vec<u8> {
+    pub fn read_data_blob(&self, hash: DataBlobHash) -> Vec<u8> {
         self.blobs
             .lock()
             .unwrap()
@@ -409,7 +409,7 @@ where
     }
 
     /// Asserts that a blob with the given hash exists in storage.
-    pub fn assert_blob_exists(&mut self, hash: DataBlobHash) {
+    pub fn assert_blob_exists(&self, hash: DataBlobHash) {
         self.blobs
             .lock()
             .unwrap()


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
Using the `ServiceRuntime` in services that use GraphQL requires wrapping the `ServiceRuntime` inside an `Arc<Mutex<_>>`, because the `async_graphql` crate requires the handler to be `Send`. This is bit burdensome for application developers, and is redundant because the `Service` is single-threaded and uses `Cell` for interior mutability.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Replace usages of `Cell` with `Mutex` inside the `ServiceRuntime`, and also do the same for `MockServiceRuntime`.

Update the examples to remove the redundant `Mutex`es.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
This is an internal refactor, and application end-to-end tests should catch any regressions.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle, because it only affects the SDK.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
