### PR TITLE
Upload proposals' blobs separately.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -436,6 +436,7 @@ View or update the resource control policy
 * `--maximum-fuel-per-block <MAXIMUM_FUEL_PER_BLOCK>` — Set the maximum amount of fuel per block
 * `--maximum-executed-block-size <MAXIMUM_EXECUTED_BLOCK_SIZE>` — Set the maximum size of an executed block, in bytes
 * `--maximum-blob-size <MAXIMUM_BLOB_SIZE>` — Set the maximum size of data blobs, compressed bytecode and other binary blobs, in bytes
+* `--maximum-published-blobs <MAXIMUM_PUBLISHED_BLOBS>` — Set the maximum number of published blobs per block
 * `--maximum-bytecode-size <MAXIMUM_BYTECODE_SIZE>` — Set the maximum size of decompressed contract or service bytecode, in bytes
 * `--maximum-block-proposal-size <MAXIMUM_BLOCK_PROPOSAL_SIZE>` — Set the maximum size of a block proposal, in bytes
 * `--maximum-bytes-read-per-block <MAXIMUM_BYTES_READ_PER_BLOCK>` — Set the maximum read data per block
@@ -501,6 +502,7 @@ Create genesis configuration for a Linera deployment. Create initial user chains
 * `--maximum-executed-block-size <MAXIMUM_EXECUTED_BLOCK_SIZE>` — Set the maximum size of an executed block
 * `--maximum-bytecode-size <MAXIMUM_BYTECODE_SIZE>` — Set the maximum size of decompressed contract or service bytecode, in bytes
 * `--maximum-blob-size <MAXIMUM_BLOB_SIZE>` — Set the maximum size of data blobs, compressed bytecode and other binary blobs, in bytes
+* `--maximum-published-blobs <MAXIMUM_PUBLISHED_BLOBS>` — Set the maximum number of published blobs per block
 * `--maximum-block-proposal-size <MAXIMUM_BLOCK_PROPOSAL_SIZE>` — Set the maximum size of a block proposal, in bytes
 * `--maximum-bytes-read-per-block <MAXIMUM_BYTES_READ_PER_BLOCK>` — Set the maximum read data per block
 * `--maximum-bytes-written-per-block <MAXIMUM_BYTES_WRITTEN_PER_BLOCK>` — Set the maximum write data per block

--- a/linera-chain/src/certificate/lite.rs
+++ b/linera-chain/src/certificate/lite.rs
@@ -74,6 +74,13 @@ impl<'a> LiteCertificate<'a> {
         Ok(&self.value)
     }
 
+    /// Checks whether the value matches this certificate.
+    pub fn check_value<T: CertificateValue>(&self, value: &Hashed<T>) -> bool {
+        self.value.chain_id == value.inner().chain_id()
+            && T::KIND == self.value.kind
+            && self.value.value_hash == value.hash()
+    }
+
     /// Returns the [`GenericCertificate`] with the specified value, if it matches.
     pub fn with_value<T: CertificateValue>(
         self,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -20,6 +20,7 @@ use linera_base::{
         ChainId, ChannelName, Destination, GenericApplicationId, MessageId, Owner, StreamId,
         UserApplicationId,
     },
+    ownership::ChainOwnership,
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
@@ -594,6 +595,10 @@ where
             .system
             .current_committee()
             .ok_or_else(|| ChainError::InactiveChain(self.chain_id()))
+    }
+
+    pub fn ownership(&self) -> &ChainOwnership {
+        self.execution_state.system.ownership.get()
     }
 
     /// Removes the incoming message bundles in the block from the inboxes.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -13,13 +13,12 @@ use futures::stream::{self, StreamExt, TryStreamExt};
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
-        Amount, ArithmeticError, Blob, BlockHeight, OracleResponse, Timestamp,
-        UserApplicationDescription,
+        Amount, ArithmeticError, BlockHeight, OracleResponse, Timestamp, UserApplicationDescription,
     },
     ensure,
     identifiers::{
-        BlobId, ChainId, ChannelName, Destination, GenericApplicationId, MessageId, Owner,
-        StreamId, UserApplicationId,
+        ChainId, ChannelName, Destination, GenericApplicationId, MessageId, Owner, StreamId,
+        UserApplicationId,
     },
 };
 use linera_execution::{
@@ -31,7 +30,6 @@ use linera_execution::{
 use linera_views::{
     context::Context,
     log_view::LogView,
-    map_view::MapView,
     queue_view::QueueView,
     reentrant_collection_view::ReentrantCollectionView,
     register_view::RegisterView,
@@ -49,7 +47,7 @@ use crate::{
     inbox::{Cursor, InboxError, InboxStateView},
     manager::ChainManager,
     outbox::OutboxStateView,
-    types::ValidatedBlockCertificate,
+    pending_blobs::PendingBlobsView,
     ChainError, ChainExecutionContext, ExecutionResultExt,
 };
 
@@ -201,10 +199,8 @@ where
     /// Consensus state.
     pub manager: ChainManager<C>,
     /// Pending validated block that is still missing blobs.
-    #[graphql(skip)]
-    pub pending_validated_block: RegisterView<C, Option<ValidatedBlockCertificate>>,
     /// The incomplete set of blobs for the pending validated block.
-    pub pending_validated_blobs: MapView<C, BlobId, Option<Blob>>,
+    pub pending_validated_blobs: PendingBlobsView<C>,
 
     /// Hashes of all certified blocks for this sender.
     /// This ends with `block_hash` and has length `usize::from(next_block_height)`.
@@ -891,7 +887,6 @@ where
         let maybe_committee = self.execution_state.system.current_committee().into_iter();
 
         self.pending_validated_blobs.clear();
-        self.pending_validated_block.set(None);
         self.manager.reset(
             self.execution_state.system.ownership.get().clone(),
             block.height.try_add_one()?,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -201,6 +201,8 @@ where
     /// Pending validated block that is still missing blobs.
     /// The incomplete set of blobs for the pending validated block.
     pub pending_validated_blobs: PendingBlobsView<C>,
+    /// The incomplete sets of blobs for upcoming proposals.
+    pub pending_proposed_blobs: ReentrantCollectionView<C, Owner, PendingBlobsView<C>>,
 
     /// Hashes of all certified blocks for this sender.
     /// This ends with `block_hash` and has length `usize::from(next_block_height)`.
@@ -887,6 +889,7 @@ where
         let maybe_committee = self.execution_state.system.current_committee().into_iter();
 
         self.pending_validated_blobs.clear();
+        self.pending_proposed_blobs.clear();
         self.manager.reset(
             self.execution_state.system.ownership.get().clone(),
             block.height.try_add_one()?,

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -144,12 +144,8 @@ impl ProposedBlock {
         Some((in_bundle, posted_message, config))
     }
 
-    pub fn check_proposal_size(
-        &self,
-        maximum_block_proposal_size: u64,
-        blobs: &[Blob],
-    ) -> Result<(), ChainError> {
-        let size = bcs::serialized_size(&(self, blobs))?;
+    pub fn check_proposal_size(&self, maximum_block_proposal_size: u64) -> Result<(), ChainError> {
+        let size = bcs::serialized_size(self)?;
         ensure!(
             size <= usize::try_from(maximum_block_proposal_size).unwrap_or(usize::MAX),
             ChainError::BlockProposalTooLarge
@@ -744,7 +740,7 @@ impl BlockExecutionOutcome {
         }
     }
 
-    fn oracle_blob_ids(&self) -> HashSet<BlobId> {
+    pub fn oracle_blob_ids(&self) -> HashSet<BlobId> {
         let mut required_blob_ids = HashSet::new();
         for responses in &self.oracle_responses {
             for response in responses {
@@ -824,8 +820,8 @@ impl BlockProposal {
         }
     }
 
-    pub fn check_signature(&self, public_key: PublicKey) -> Result<(), CryptoError> {
-        self.signature.check(&self.content, public_key)
+    pub fn check_signature(&self) -> Result<(), CryptoError> {
+        self.signature.check(&self.content, self.public_key)
     }
 }
 

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -17,6 +17,7 @@ pub mod data_types;
 mod inbox;
 pub mod manager;
 mod outbox;
+mod pending_blobs;
 #[cfg(with_testing)]
 pub mod test;
 

--- a/linera-chain/src/pending_blobs.rs
+++ b/linera-chain/src/pending_blobs.rs
@@ -26,6 +26,12 @@ where
 {
     /// The round in which the block is validated.
     pub round: RegisterView<C, Round>,
+    /// Whether these blobs were already validated.
+    ///
+    /// This is only `false` for _new_ block proposals, not when re-proposing blocks from earlier
+    /// rounds or when handling validated block certificates. If it is false, the pending blobs are
+    /// only the ones published by the new block, not the ones that are only read.
+    pub validated: RegisterView<C, bool>,
     /// The map of blobs needed to process the block.
     pub pending_blobs: MapView<C, BlobId, Option<Blob>>,
 }
@@ -51,6 +57,7 @@ where
     pub async fn update(
         &mut self,
         round: Round,
+        validated: bool,
         maybe_blobs: BTreeMap<BlobId, Option<Blob>>,
     ) -> Result<(), ChainError> {
         let existing_round = *self.round.get();
@@ -61,6 +68,7 @@ where
         if existing_round < round {
             self.clear();
             self.round.set(round);
+            self.validated.set(validated);
         }
         for (blob_id, maybe_blob) in maybe_blobs {
             self.pending_blobs.insert(&blob_id, maybe_blob)?;

--- a/linera-chain/src/pending_blobs.rs
+++ b/linera-chain/src/pending_blobs.rs
@@ -1,0 +1,70 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use async_graphql::SimpleObject;
+use linera_base::{
+    data_types::{Blob, Round},
+    ensure,
+    identifiers::BlobId,
+};
+use linera_views::{
+    context::Context,
+    map_view::MapView,
+    register_view::RegisterView,
+    views::{ClonableView, View, ViewError},
+};
+
+use crate::ChainError;
+
+/// The pending blobs belonging to a block that can't be processed without them.
+#[derive(Debug, View, ClonableView, SimpleObject)]
+pub struct PendingBlobsView<C>
+where
+    C: Clone + Context + Send + Sync + 'static,
+{
+    /// The round in which the block is validated.
+    pub round: RegisterView<C, Round>,
+    /// The map of blobs needed to process the block.
+    pub pending_blobs: MapView<C, BlobId, Option<Blob>>,
+}
+
+impl<C> PendingBlobsView<C>
+where
+    C: Clone + Context + Send + Sync + 'static,
+{
+    pub async fn get(&self, blob_id: &BlobId) -> Result<Option<Blob>, ViewError> {
+        Ok(self.pending_blobs.get(blob_id).await?.flatten())
+    }
+
+    pub async fn maybe_insert(&mut self, blob: &Blob) -> Result<(), ViewError> {
+        let blob_id = blob.id();
+        if let Some(maybe_blob) = self.pending_blobs.get_mut(&blob_id).await? {
+            if maybe_blob.is_none() {
+                *maybe_blob = Some(blob.clone());
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn update(
+        &mut self,
+        round: Round,
+        maybe_blobs: BTreeMap<BlobId, Option<Blob>>,
+    ) -> Result<(), ChainError> {
+        let existing_round = *self.round.get();
+        ensure!(
+            existing_round <= round,
+            ChainError::InsufficientRound(existing_round)
+        );
+        if existing_round < round {
+            self.clear();
+            self.round.set(round);
+        }
+        for (blob_id, maybe_blob) in maybe_blobs {
+            self.pending_blobs.insert(&blob_id, maybe_blob)?;
+        }
+        Ok(())
+    }
+}

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -125,7 +125,7 @@ impl BlockTestExt for ProposedBlock {
     }
 
     fn into_proposal_with_round(self, key_pair: &KeyPair, round: Round) -> BlockProposal {
-        BlockProposal::new_initial(round, self, key_pair, vec![])
+        BlockProposal::new_initial(round, self, key_pair)
     }
 }
 

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -112,7 +112,7 @@ async fn test_block_size_limit() {
     let mut chain = ChainStateView::new(chain_id).await;
 
     // The size of the executed valid block below.
-    let maximum_executed_block_size = 677;
+    let maximum_executed_block_size = 685;
 
     // Initialize the chain.
     let mut config = make_open_chain_config();

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -800,7 +800,6 @@ where
                 linera_base::data_types::Round::Fast,
                 block.clone(),
                 key_pair,
-                vec![],
             );
             proposals.push(RpcMessage::BlockProposal(Box::new(proposal)));
             next_recipient = chain.chain_id;

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -543,6 +543,10 @@ pub enum ClientCommand {
         #[arg(long)]
         maximum_blob_size: Option<u64>,
 
+        /// Set the maximum number of published blobs per block.
+        #[arg(long)]
+        maximum_published_blobs: Option<u64>,
+
         /// Set the maximum size of decompressed contract or service bytecode, in bytes.
         #[arg(long)]
         maximum_bytecode_size: Option<u64>,
@@ -673,6 +677,10 @@ pub enum ClientCommand {
         /// in bytes.
         #[arg(long)]
         maximum_blob_size: Option<u64>,
+
+        /// Set the maximum number of published blobs per block.
+        #[arg(long)]
+        maximum_published_blobs: Option<u64>,
 
         /// Set the maximum size of a block proposal, in bytes.
         #[arg(long)]

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -182,6 +182,18 @@ where
             .await?;
         let missing_blob_ids = super::missing_blob_ids(&maybe_blobs);
         if !missing_blob_ids.is_empty() {
+            if self
+                .state
+                .chain
+                .execution_state
+                .system
+                .ownership
+                .get()
+                .open_multi_leader_rounds
+            {
+                // TODO(#3203): Allow multiple pending proposals on permissionless chains.
+                self.state.chain.pending_proposed_blobs.clear();
+            }
             self.state
                 .chain
                 .pending_proposed_blobs

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -364,8 +364,7 @@ where
             }
             if let Some(blob) = self.chain.manager.pending_blob(blob_id).await? {
                 *maybe_blob = Some(blob);
-            } else if let Some(Some(blob)) = self.chain.pending_validated_blobs.get(blob_id).await?
-            {
+            } else if let Some(blob) = self.chain.pending_validated_blobs.get(blob_id).await? {
                 *maybe_blob = Some(blob);
             }
         }

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -161,7 +161,6 @@ where
                 },
             public_key: _,
             owner: _,
-            blobs: _,
             validated_block_certificate,
             signature: _,
         } = proposal;

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2138,13 +2138,10 @@ where
         let (executed_block, _) = self
             .stage_block_execution_and_discard_failing_messages(block, round)
             .await?;
-        let blobs = self
-            .read_local_blobs(executed_block.required_blob_ids())
-            .await?;
         let block = &executed_block.block;
         let committee = self.local_committee().await?;
         let max_size = committee.policy().maximum_block_proposal_size;
-        block.check_proposal_size(max_size, &blobs)?;
+        block.check_proposal_size(max_size)?;
         self.state_mut().set_pending_proposal(block.clone());
         Ok(Hashed::new(ConfirmedBlock::new(executed_block)))
     }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3362,12 +3362,8 @@ where
     // But with the validated block certificate for block2, it is allowed.
     let certificate2 =
         make_certificate_with_round(&committee, &worker, value2.clone(), Round::SingleLeader(4));
-    let proposal = BlockProposal::new_retry(
-        Round::SingleLeader(5),
-        certificate2.clone(),
-        &key_pairs[1],
-        Vec::new(),
-    );
+    let proposal =
+        BlockProposal::new_retry(Round::SingleLeader(5), certificate2.clone(), &key_pairs[1]);
     let lite_value2 = LiteValue::new(&value2);
     let (_, _) = worker.handle_block_proposal(proposal).await?;
     let (response, _) = worker.handle_chain_info_query(query_values.clone()).await?;
@@ -3670,12 +3666,8 @@ where
     let value2 = Hashed::new(ValidatedBlock::new(executed_block2.clone()));
     let certificate2 =
         make_certificate_with_round(&committee, &worker, value2.clone(), Round::MultiLeader(0));
-    let proposal = BlockProposal::new_retry(
-        Round::MultiLeader(3),
-        certificate2.clone(),
-        &key_pairs[1],
-        Vec::new(),
-    );
+    let proposal =
+        BlockProposal::new_retry(Round::MultiLeader(3), certificate2.clone(), &key_pairs[1]);
     let lite_value2 = LiteValue::new(&value2);
     let (_, _) = worker.handle_block_proposal(proposal).await?;
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -209,10 +209,6 @@ pub enum WorkerError {
     MissingCertificateValue,
     #[error("The hash certificate doesn't match its value.")]
     InvalidLiteCertificate,
-    #[error("An additional blob was provided that is not required: {blob_id}.")]
-    UnneededBlob { blob_id: BlobId },
-    #[error("The blobs provided in the proposal were not the published ones, in order.")]
-    WrongBlobsInProposal,
     #[error("Fast blocks cannot query oracles")]
     FastBlockUsingOracles,
     #[error("Blobs not found: {0:?}")]

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -227,6 +227,8 @@ pub enum WorkerError {
     BlobTooLarge,
     #[error("Bytecode exceeds size limit")]
     BytecodeTooLarge,
+    #[error("Number of published blobs per block must not exceed {0}")]
+    TooManyPublishedBlobs(u64),
     #[error(transparent)]
     Decompression(#[from] DecompressionError),
 }

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -47,6 +47,8 @@ pub struct ResourceControlPolicy {
     pub maximum_bytecode_size: u64,
     /// The maximum size of a blob.
     pub maximum_blob_size: u64,
+    /// The maximum number of published blobs per block.
+    pub maximum_published_blobs: u64,
     /// The maximum size of a block proposal.
     pub maximum_block_proposal_size: u64,
     /// The maximum data to read per block
@@ -72,6 +74,7 @@ impl fmt::Display for ResourceControlPolicy {
             maximum_fuel_per_block,
             maximum_executed_block_size,
             maximum_blob_size,
+            maximum_published_blobs,
             maximum_bytecode_size,
             maximum_block_proposal_size,
             maximum_bytes_read_per_block,
@@ -94,6 +97,7 @@ impl fmt::Display for ResourceControlPolicy {
             {maximum_fuel_per_block} maximum fuel per block\n\
             {maximum_executed_block_size} maximum size of an executed block\n\
             {maximum_blob_size} maximum size of a data blob, bytecode or other binary blob\n\
+            {maximum_published_blobs} maximum number of blobs published per block\n\
             {maximum_bytecode_size} maximum size of service and contract bytecode\n\
             {maximum_block_proposal_size} maximum size of a block proposal\n\
             {maximum_bytes_read_per_block} maximum number bytes read per block\n\
@@ -119,6 +123,7 @@ impl Default for ResourceControlPolicy {
             maximum_fuel_per_block: u64::MAX,
             maximum_executed_block_size: u64::MAX,
             maximum_blob_size: u64::MAX,
+            maximum_published_blobs: u64::MAX,
             maximum_bytecode_size: u64::MAX,
             maximum_block_proposal_size: u64::MAX,
             maximum_bytes_read_per_block: u64::MAX,
@@ -241,6 +246,7 @@ impl ResourceControlPolicy {
             maximum_fuel_per_block: 100_000_000,
             maximum_executed_block_size: 1_000_000,
             maximum_blob_size: 1_000_000,
+            maximum_published_blobs: 10,
             maximum_bytecode_size: 10_000_000,
             maximum_block_proposal_size: 13_000_000,
             maximum_bytes_read_per_block: 100_000_000,

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -146,10 +146,11 @@ async fn test_fee_consumption(
         maximum_fuel_per_block: 4_868_145_137,
         maximum_executed_block_size: 37,
         maximum_blob_size: 41,
-        maximum_bytecode_size: 43,
-        maximum_block_proposal_size: 47,
-        maximum_bytes_read_per_block: 53,
-        maximum_bytes_written_per_block: 59,
+        maximum_published_blobs: 43,
+        maximum_bytecode_size: 47,
+        maximum_block_proposal_size: 53,
+        maximum_bytes_read_per_block: 59,
+        maximum_bytes_written_per_block: 61,
     };
 
     let consumed_fees = spends

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -215,9 +215,6 @@ message BlockProposal {
 
   // A lite certificate for a validated block that justifies the proposal in this round.
   optional bytes validated_block_certificate = 6;
-
-  // Required blob
-  bytes blobs = 7;
 }
 
 // A certified statement from the committee, without the value.

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -199,7 +199,6 @@ impl TryFrom<BlockProposal> for api::BlockProposal {
             public_key: Some(block_proposal.public_key.into()),
             owner: Some(block_proposal.owner.into()),
             signature: Some(block_proposal.signature.into()),
-            blobs: bincode::serialize(&block_proposal.blobs)?,
             validated_block_certificate: block_proposal
                 .validated_block_certificate
                 .map(|cert| bincode::serialize(&cert))
@@ -222,7 +221,6 @@ impl TryFrom<api::BlockProposal> for BlockProposal {
             public_key: try_proto_convert(block_proposal.public_key)?,
             owner: try_proto_convert(block_proposal.owner)?,
             signature: try_proto_convert(block_proposal.signature)?,
-            blobs: bincode::deserialize(&block_proposal.blobs)?,
             validated_block_certificate: block_proposal
                 .validated_block_certificate
                 .map(|bytes| bincode::deserialize(&bytes))
@@ -1224,7 +1222,6 @@ pub mod tests {
             owner: Owner::from(public_key),
             public_key,
             signature: Signature::new(&Foo("test".into()), &KeyPair::generate()),
-            blobs: vec![],
             validated_block_certificate: Some(cert),
         };
 

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -798,6 +798,7 @@ ResourceControlPolicy:
     - maximum_executed_block_size: U64
     - maximum_bytecode_size: U64
     - maximum_blob_size: U64
+    - maximum_published_blobs: U64
     - maximum_block_proposal_size: U64
     - maximum_bytes_read_per_block: U64
     - maximum_bytes_written_per_block: U64

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -153,9 +153,6 @@ BlockProposal:
         TYPENAME: PublicKey
     - signature:
         TYPENAME: Signature
-    - blobs:
-        SEQ:
-          TYPENAME: BlobContent
     - validated_block_certificate:
         OPTION:
           TYPENAME: LiteCertificate

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -1085,6 +1085,10 @@ input ResourceControlPolicy {
 	"""
 	maximumBlobSize: Int!
 	"""
+	The maximum number of published blobs per block.
+	"""
+	maximumPublishedBlobs: Int!
+	"""
 	The maximum size of a block proposal.
 	"""
 	maximumBlockProposalSize: Int!

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -923,6 +923,14 @@ type PendingBlobsView {
 	"""
 	round: Round!
 	"""
+	Whether these blobs were already validated.
+	
+	This is only `false` for _new_ block proposals, not when re-proposing blocks from earlier
+	rounds or when handling validated block certificates. If it is false, the pending blobs are
+	only the ones published by the new block, not the ones that are only read.
+	"""
+	validated: Boolean!
+	"""
 	The map of blobs needed to process the block.
 	"""
 	pendingBlobs: MapView_BlobId_Blob_9f0b41f3!

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -225,6 +225,10 @@ type ChainManager {
 	"""
 	seed: Int!
 	"""
+	These are blobs published or read by the proposed block.
+	"""
+	proposedBlobs: MapView_BlobId_Blob_3711e760!
+	"""
 	These are blobs published or read by the locking block.
 	"""
 	lockingBlobs: MapView_BlobId_Blob_3711e760!

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -276,6 +276,10 @@ type ChainStateExtendedView {
 	"""
 	pendingValidatedBlobs: PendingBlobsView!
 	"""
+	The incomplete sets of blobs for upcoming proposals.
+	"""
+	pendingProposedBlobs: ReentrantCollectionView_Owner_PendingBlobsView_3247061959!
+	"""
 	Hashes of all certified blocks for this sender.
 	This ends with `block_hash` and has length `usize::from(next_block_height)`.
 	"""
@@ -478,6 +482,14 @@ type Entry_Origin_InboxStateView_c4db01d6 {
 """
 A GraphQL-visible map item, complete with key.
 """
+type Entry_Owner_PendingBlobsView_c4f6af6f {
+	key: Owner!
+	value: PendingBlobsView!
+}
+
+"""
+A GraphQL-visible map item, complete with key.
+"""
 type Entry_Target_OutboxStateView_50a86149 {
 	key: Target!
 	value: OutboxStateView!
@@ -608,6 +620,10 @@ input MapFilters_Origin_742d451b {
 	keys: [Origin!]
 }
 
+input MapFilters_Owner_6898ce22 {
+	keys: [Owner!]
+}
+
 input MapFilters_Target_7aac1e1c {
 	keys: [Target!]
 }
@@ -626,6 +642,10 @@ input MapInput_ChannelFullName_3b59bf69 {
 
 input MapInput_Origin_742d451b {
 	filters: MapFilters_Origin_742d451b
+}
+
+input MapInput_Owner_6898ce22 {
+	filters: MapFilters_Owner_6898ce22
 }
 
 input MapInput_Target_7aac1e1c {
@@ -973,6 +993,12 @@ type ReentrantCollectionView_Origin_InboxStateView_3699835794 {
 	keys: [Origin!]!
 	entry(key: Origin!): Entry_Origin_InboxStateView_c4db01d6!
 	entries(input: MapInput_Origin_742d451b): [Entry_Origin_InboxStateView_c4db01d6!]!
+}
+
+type ReentrantCollectionView_Owner_PendingBlobsView_3247061959 {
+	keys: [Owner!]!
+	entry(key: Owner!): Entry_Owner_PendingBlobsView_c4f6af6f!
+	entries(input: MapInput_Owner_6898ce22): [Entry_Owner_PendingBlobsView_c4f6af6f!]!
 }
 
 type ReentrantCollectionView_Target_OutboxStateView_2789119133 {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -271,9 +271,10 @@ type ChainStateExtendedView {
 	"""
 	manager: ChainManager!
 	"""
+	Pending validated block that is still missing blobs.
 	The incomplete set of blobs for the pending validated block.
 	"""
-	pendingValidatedBlobs: MapView_BlobId_Blob_9f0b41f3!
+	pendingValidatedBlobs: PendingBlobsView!
 	"""
 	Hashes of all certified blocks for this sender.
 	This ends with `block_hash` and has length `usize::from(next_block_height)`.
@@ -888,6 +889,20 @@ type OutgoingMessage {
 The owner of a chain. This is currently the hash of the owner's public key used to verify signatures.
 """
 scalar Owner
+
+"""
+The pending blobs belonging to a block that can't be processed without them.
+"""
+type PendingBlobsView {
+	"""
+	The round in which the block is validated.
+	"""
+	round: Round!
+	"""
+	The map of blobs needed to process the block.
+	"""
+	pendingBlobs: MapView_BlobId_Blob_9f0b41f3!
+}
 
 """
 A message together with kind, authentication and grant information.

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -249,6 +249,7 @@ impl ClientWrapper {
             maximum_fuel_per_block,
             maximum_executed_block_size,
             maximum_blob_size,
+            maximum_published_blobs,
             maximum_bytecode_size,
             maximum_block_proposal_size,
             maximum_bytes_read_per_block,
@@ -283,6 +284,10 @@ impl ClientWrapper {
                 &maximum_executed_block_size.to_string(),
             ])
             .args(["--maximum-blob-size", &maximum_blob_size.to_string()])
+            .args([
+                "--maximum-published-blobs",
+                &maximum_published_blobs.to_string(),
+            ])
             .args([
                 "--maximum-bytecode-size",
                 &maximum_bytecode_size.to_string(),

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -617,6 +617,7 @@ impl Runnable for Job {
                                     maximum_fuel_per_block,
                                     maximum_executed_block_size,
                                     maximum_blob_size,
+                                    maximum_published_blobs,
                                     maximum_bytecode_size,
                                     maximum_block_proposal_size,
                                     maximum_bytes_read_per_block,
@@ -669,6 +670,9 @@ impl Runnable for Job {
                                     }
                                     if let Some(maximum_blob_size) = maximum_blob_size {
                                         policy.maximum_blob_size = maximum_blob_size;
+                                    }
+                                    if let Some(maximum_published_blobs) = maximum_published_blobs {
+                                        policy.maximum_published_blobs = maximum_published_blobs;
                                     }
                                     if let Some(maximum_block_proposal_size) =
                                         maximum_block_proposal_size
@@ -1495,6 +1499,7 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
             maximum_fuel_per_block,
             maximum_executed_block_size,
             maximum_blob_size,
+            maximum_published_blobs,
             maximum_bytecode_size,
             maximum_block_proposal_size,
             maximum_bytes_read_per_block,
@@ -1511,6 +1516,7 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                 maximum_bytes_written_per_block.unwrap_or(u64::MAX);
             let maximum_executed_block_size = maximum_executed_block_size.unwrap_or(u64::MAX);
             let maximum_blob_size = maximum_blob_size.unwrap_or(u64::MAX);
+            let maximum_published_blobs = maximum_published_blobs.unwrap_or(u64::MAX);
             let maximum_bytecode_size = maximum_bytecode_size.unwrap_or(u64::MAX);
             let maximum_block_proposal_size = maximum_block_proposal_size.unwrap_or(u64::MAX);
             let policy = ResourceControlPolicy {
@@ -1528,6 +1534,7 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                 maximum_fuel_per_block,
                 maximum_executed_block_size,
                 maximum_blob_size,
+                maximum_published_blobs,
                 maximum_bytecode_size,
                 maximum_block_proposal_size,
                 maximum_bytes_read_per_block,


### PR DESCRIPTION
## Motivation

Including blobs with the gRPC message that contains a block proposal or certificate severely limits the total size of the blobs. (See https://github.com/linera-io/linera-protocol/issues/3048.)

## Proposal

Remove the `blobs` field from block proposals, and handle blobs separately, with one message each.

I added a `maximum_published_blobs` limit per block, and limited the number of pending proposals with blobs to 1 for permissionless chains. (See https://github.com/linera-io/linera-protocol/issues/3203.)

## Test Plan

The tests have been updated where necessary. Otherwise they already cover different scenarios involving proposals with blobs.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #3202
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
