### PR TITLE
Improve Variable Naming for Clarity in next_timestamp Function

### DIFF
--- a/examples/hex-game/src/service.rs
+++ b/examples/hex-game/src/service.rs
@@ -60,8 +60,8 @@ impl HexState {
         }
         let active = self.board.get().active_player();
         let runtime = ctx.data::<Arc<ServiceRuntime<HexService>>>().unwrap();
-        let block_time = runtime.system_time();
-        if self.clock.get().timed_out(block_time, active) {
+        let current_time = runtime.system_time();
+        if self.clock.get().timed_out(current_time, active) {
             return Some(active.other());
         }
         None

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2156,7 +2156,7 @@ where
     fn next_timestamp(
         &self,
         incoming_bundles: &[IncomingBundle],
-        block_time: Timestamp,
+        current_time: Timestamp,
     ) -> Timestamp {
         let local_time = self.storage_client().clock().current_time();
         incoming_bundles
@@ -2164,7 +2164,7 @@ where
             .map(|msg| msg.bundle.timestamp)
             .max()
             .map_or(local_time, |timestamp| timestamp.max(local_time))
-            .max(block_time)
+            .max(current_time)
     }
 
     /// Queries an application.


### PR DESCRIPTION
The variable name `block_time` was changed to `current_time` to enhance code clarity. The new name better reflects the purpose of the variable, indicating that it holds the current time rather than the time associated with a block. This change improves the readability and maintainability of the code.
