### PR TITLE
Don't log api objects for gRPC requests.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1792,7 +1792,7 @@ where
                 }
 
                 let name = &remote_node.name;
-                warn!("Skipping proposal from {owner} and validator {name}: {err}",);
+                warn!("Skipping proposal from {owner} and validator {name}: {err}");
             }
         }
         Ok(())

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1696,7 +1696,7 @@ where
             let LockingBlock::Regular(validated) = locking else {
                 panic!("Unexpected locking fast block.");
             };
-            assert_eq!(validated.block().body.operations, blob_0_1_operations,);
+            assert_eq!(validated.block().body.operations, blob_0_1_operations);
         } else {
             assert!(validator_manager.requested_locking.is_none());
         }
@@ -1760,7 +1760,7 @@ where
     let LockingBlock::Regular(validated) = locking else {
         panic!("Unexpected locking fast block.");
     };
-    assert_eq!(validated.block().body.operations, blob_2_3_operations,);
+    assert_eq!(validated.block().body.operations, blob_2_3_operations);
 
     builder.set_fault_type([1], FaultType::Offline).await;
     builder.set_fault_type([0, 2, 3], FaultType::Honest).await;

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -117,7 +117,6 @@ impl GrpcClient {
         Fut: Future<Output = Result<tonic::Response<S>, Status>>,
         R: IntoRequest<R> + Clone,
     {
-        debug!(request = ?request, "sending gRPC request");
         let mut retry_count = 0;
         let request_inner = request.try_into().map_err(|_| NodeError::GrpcError {
             error: "could not convert request to proto".to_string(),
@@ -184,6 +183,11 @@ impl TryFrom<api::PendingBlobResult> for BlobContent {
 
 macro_rules! client_delegate {
     ($self:ident, $handler:ident, $req:ident) => {{
+        debug!(
+            handler = stringify!($handler),
+            request = ?$req,
+            "sending gRPC request"
+        );
         $self
             .delegate(
                 |mut client, req| async move { client.$handler(req).await },

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -132,7 +132,7 @@ impl GrpcClient {
                 }
                 Err(s) => {
                     return Err(NodeError::GrpcError {
-                        error: format!("remote request [{handler}] failed with status: {s:?}",),
+                        error: format!("remote request [{handler}] failed with status: {s:?}"),
                     });
                 }
                 Ok(result) => return Ok(result.into_inner()),

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -364,14 +364,12 @@ impl ValidatorNode for GrpcClient {
 
     #[instrument(target = "grpc_client", skip(self), err, fields(address = self.address))]
     async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError> {
-        let req = api::BlobContent::try_from(content)?;
-        Ok(client_delegate!(self, upload_blob, req)?.try_into()?)
+        Ok(client_delegate!(self, upload_blob, content)?.try_into()?)
     }
 
     #[instrument(target = "grpc_client", skip(self), err, fields(address = self.address))]
     async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
-        let req = api::BlobId::try_from(blob_id)?;
-        Ok(client_delegate!(self, download_blob, req)?.try_into()?)
+        Ok(client_delegate!(self, download_blob, blob_id)?.try_into()?)
     }
 
     #[instrument(target = "grpc_client", skip(self), err, fields(address = self.address))]
@@ -380,7 +378,7 @@ impl ValidatorNode for GrpcClient {
         chain_id: ChainId,
         blob_id: BlobId,
     ) -> Result<BlobContent, NodeError> {
-        let req = api::PendingBlobRequest::try_from((chain_id, blob_id))?;
+        let req = (chain_id, blob_id);
         client_delegate!(self, download_pending_blob, req)?.try_into()
     }
 
@@ -390,7 +388,7 @@ impl ValidatorNode for GrpcClient {
         chain_id: ChainId,
         blob: BlobContent,
     ) -> Result<ChainInfoResponse, NodeError> {
-        let req = api::HandlePendingBlobRequest::try_from((chain_id, blob))?;
+        let req = (chain_id, blob);
         GrpcClient::try_into_chain_info(client_delegate!(self, handle_pending_blob, req)?)
     }
 
@@ -445,14 +443,12 @@ impl ValidatorNode for GrpcClient {
 
     #[instrument(target = "grpc_client", skip(self), err, fields(address = self.address))]
     async fn blob_last_used_by(&self, blob_id: BlobId) -> Result<CryptoHash, NodeError> {
-        let req = api::BlobId::try_from(blob_id)?;
-        Ok(client_delegate!(self, blob_last_used_by, req)?.try_into()?)
+        Ok(client_delegate!(self, blob_last_used_by, blob_id)?.try_into()?)
     }
 
     #[instrument(target = "grpc_client", skip(self), err, fields(address = self.address))]
     async fn missing_blob_ids(&self, blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError> {
-        let req = api::BlobIds::try_from(blob_ids)?;
-        Ok(client_delegate!(self, missing_blob_ids, req)?.try_into()?)
+        Ok(client_delegate!(self, missing_blob_ids, blob_ids)?.try_into()?)
     }
 }
 

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -462,7 +462,8 @@ where
                             .with_label_values(&["handle_block_proposal"])
                             .inc();
                     }
-                    warn!(nickname = self.state.nickname(), %error, "Failed to handle block proposal");
+                    let nickname = self.state.nickname();
+                    warn!(nickname, %error, "Failed to handle block proposal");
                     NodeError::from(error).try_into()?
                 }
             },
@@ -512,10 +513,11 @@ where
                         .with_label_values(&["handle_lite_certificate"])
                         .inc();
                 }
+                let nickname = self.state.nickname();
                 if let WorkerError::MissingCertificateValue = &error {
-                    debug!(nickname = self.state.nickname(), %error, "Failed to handle lite certificate");
+                    debug!(nickname, %error, "Failed to handle lite certificate");
                 } else {
-                    error!(nickname = self.state.nickname(), %error, "Failed to handle lite certificate");
+                    error!(nickname, %error, "Failed to handle lite certificate");
                 }
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
@@ -565,7 +567,8 @@ where
                         .with_label_values(&["handle_confirmed_certificate"])
                         .inc();
                 }
-                error!(nickname = self.state.nickname(), %error, "Failed to handle confirmed certificate");
+                let nickname = self.state.nickname();
+                error!(nickname, %error, "Failed to handle confirmed certificate");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
         }
@@ -605,7 +608,8 @@ where
                         .with_label_values(&["handle_validated_certificate"])
                         .inc();
                 }
-                error!(nickname = self.state.nickname(), %error, "Failed to handle validated certificate");
+                let nickname = self.state.nickname();
+                error!(nickname, %error, "Failed to handle validated certificate");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
         }
@@ -644,7 +648,8 @@ where
                         .with_label_values(&["handle_timeout_certificate"])
                         .inc();
                 }
-                error!(nickname = self.state.nickname(), %error, "Failed to handle timeout certificate");
+                let nickname = self.state.nickname();
+                error!(nickname, %error, "Failed to handle timeout certificate");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
         }
@@ -679,7 +684,8 @@ where
                         .with_label_values(&["handle_chain_info_query"])
                         .inc();
                 }
-                error!(nickname = self.state.nickname(), %error, "Failed to handle chain info query");
+                let nickname = self.state.nickname();
+                error!(nickname, %error, "Failed to handle chain info query");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
         }
@@ -718,7 +724,8 @@ where
                         .with_label_values(&["download_pending_blob"])
                         .inc();
                 }
-                error!(nickname = self.state.nickname(), %error, "Failed to download pending blob");
+                let nickname = self.state.nickname();
+                error!(nickname, %error, "Failed to download pending blob");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
         }
@@ -754,7 +761,8 @@ where
                         .with_label_values(&["handle_pending_blob"])
                         .inc();
                 }
-                error!(nickname = self.state.nickname(), %error, "Failed to handle pending blob");
+                let nickname = self.state.nickname();
+                error!(nickname, %error, "Failed to handle pending blob");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
         }
@@ -788,7 +796,8 @@ where
                         .with_label_values(&["handle_cross_chain_request"])
                         .inc();
                 }
-                error!(nickname = self.state.nickname(), %error, "Failed to handle cross-chain request");
+                let nickname = self.state.nickname();
+                error!(nickname, %error, "Failed to handle cross-chain request");
             }
         }
         Ok(Response::new(()))

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -209,7 +209,8 @@ where
                         Ok(Some(RpcMessage::ChainInfoResponse(Box::new(info))))
                     }
                     Err(error) => {
-                        warn!(nickname = self.server.state.nickname(), %error, "Failed to handle block proposal");
+                        let nickname = self.server.state.nickname();
+                        warn!(nickname, %error, "Failed to handle block proposal");
                         Err(error.into())
                     }
                 }
@@ -237,10 +238,11 @@ where
                         Ok(Some(RpcMessage::ChainInfoResponse(Box::new(info))))
                     }
                     Err(error) => {
+                        let nickname = self.server.state.nickname();
                         if let WorkerError::MissingCertificateValue = &error {
-                            debug!(nickname = self.server.state.nickname(), %error, "Failed to handle lite certificate");
+                            debug!(nickname, %error, "Failed to handle lite certificate");
                         } else {
-                            error!(nickname = self.server.state.nickname(), %error, "Failed to handle lite certificate");
+                            error!(nickname, %error, "Failed to handle lite certificate");
                         }
                         Err(error.into())
                     }
@@ -260,7 +262,8 @@ where
                         Ok(Some(RpcMessage::ChainInfoResponse(Box::new(info))))
                     }
                     Err(error) => {
-                        error!(nickname = self.server.state.nickname(), %error, "Failed to handle timeout certificate");
+                        let nickname = self.server.state.nickname();
+                        error!(nickname, %error, "Failed to handle timeout certificate");
                         Err(error.into())
                     }
                 }
@@ -310,7 +313,8 @@ where
                         Ok(Some(RpcMessage::ChainInfoResponse(Box::new(info))))
                     }
                     Err(error) => {
-                        error!(nickname = self.server.state.nickname(), %error, "Failed to handle confirmed certificate");
+                        let nickname = self.server.state.nickname();
+                        error!(nickname, %error, "Failed to handle confirmed certificate");
                         Err(error.into())
                     }
                 }
@@ -324,7 +328,8 @@ where
                         Ok(Some(RpcMessage::ChainInfoResponse(Box::new(info))))
                     }
                     Err(error) => {
-                        error!(nickname = self.server.state.nickname(), %error, "Failed to handle chain info query");
+                        let nickname = self.server.state.nickname();
+                        error!(nickname, %error, "Failed to handle chain info query");
                         Err(error.into())
                     }
                 }

--- a/linera-witty-macros/src/unit_tests/wit_load.rs
+++ b/linera-witty-macros/src/unit_tests/wit_load.rs
@@ -177,7 +177,7 @@ fn enum_type() {
             <Instance::Runtime as linera_witty::Runtime>::Memory:
                 linera_witty::RuntimeMemory<Instance>,
         {
-            let discriminant = <u8 as linera_witty::WitLoad>::load(memory, location,)?;
+            let discriminant = <u8 as linera_witty::WitLoad>::load(memory, location)?;
             location = location
                 .after::<u8>()
                 .after_padding_for::<linera_witty::HList![]>()
@@ -451,7 +451,7 @@ fn enum_type_with_skipped_fields() {
             <Instance::Runtime as linera_witty::Runtime>::Memory:
                 linera_witty::RuntimeMemory<Instance>,
         {
-            let discriminant = <u8 as linera_witty::WitLoad>::load(memory, location,)?;
+            let discriminant = <u8 as linera_witty::WitLoad>::load(memory, location)?;
             location = location
                 .after::<u8>()
                 .after_padding_for::<linera_witty::HList![]>()

--- a/linera-witty-macros/src/unit_tests/wit_load.rs
+++ b/linera-witty-macros/src/unit_tests/wit_load.rs
@@ -177,7 +177,7 @@ fn enum_type() {
             <Instance::Runtime as linera_witty::Runtime>::Memory:
                 linera_witty::RuntimeMemory<Instance>,
         {
-            let discriminant = <u8 as linera_witty::WitLoad>::load(memory, location)?;
+            let discriminant = <u8 as linera_witty::WitLoad>::load(memory, location,)?;
             location = location
                 .after::<u8>()
                 .after_padding_for::<linera_witty::HList![]>()
@@ -451,7 +451,7 @@ fn enum_type_with_skipped_fields() {
             <Instance::Runtime as linera_witty::Runtime>::Memory:
                 linera_witty::RuntimeMemory<Instance>,
         {
-            let discriminant = <u8 as linera_witty::WitLoad>::load(memory, location)?;
+            let discriminant = <u8 as linera_witty::WitLoad>::load(memory, location,)?;
             location = location
                 .after::<u8>()
                 .after_padding_for::<linera_witty::HList![]>()


### PR DESCRIPTION
## Motivation

Some gRPC debug log messages are very large. This is because we are logging the protocol types from the `api` module in some cases.

## Proposal

Log the requests before converting them to the `api` types. Conversion happens automatically inside `delegate` anyway, and for our own types we try to keep `Debug` impls concise.

Also, log the handler name in addition to the request data.

(I also fixed some lines that exceeded the maximum length.)

## Test Plan

Running locally, I now get e.g.:

```
sending gRPC request handler="download_blob" request=BlobId { blob_type: Data, hash: 465ed2f46f7ca6bc }
```

instead of:

```
sending gRPC request request=BlobId { bytes: [232, 108, 237, 16, 232, 93, 5, 167, 144, 2, 73, 160, 123, 228, 178, 55, 103, 1, 0, 221, 203, 106, 106, 155, 170, 44, 130, 138, 194, 98, 14, 2, 0, 0, 0, 0] }
```

The difference is even greater for e.g. `upload_blob`.

If we find any remaining spammy logs we should improve our `Debug` impls.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #2864.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
