### PR TITLE
Use an std mutex in `ValueCache`

### DIFF
--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -147,14 +147,12 @@ where
             Some(Either::Left(vote)) => {
                 self.state
                     .block_values
-                    .insert(Cow::Borrowed(vote.value.inner().inner()))
-                    .await;
+                    .insert(Cow::Borrowed(vote.value.inner().inner()));
             }
             Some(Either::Right(vote)) => {
                 self.state
                     .block_values
-                    .insert(Cow::Borrowed(vote.value.inner().inner()))
-                    .await;
+                    .insert(Cow::Borrowed(vote.value.inner().inner()));
             }
             None => (),
         }
@@ -208,8 +206,7 @@ where
 
         self.state
             .block_values
-            .insert(Cow::Borrowed(certificate.inner().inner()))
-            .await;
+            .insert(Cow::Borrowed(certificate.inner().inner()));
         let required_blob_ids = block.required_blob_ids();
         let maybe_blobs = self
             .state
@@ -399,8 +396,7 @@ where
 
         self.state
             .block_values
-            .insert(Cow::Owned(certificate.into_inner().into_inner()))
-            .await;
+            .insert(Cow::Owned(certificate.into_inner().into_inner()));
 
         self.register_delivery_notifier(block_height, &actions, notify_when_messages_are_delivered)
             .await;

--- a/linera-core/src/unit_tests/value_cache_tests.rs
+++ b/linera-core/src/unit_tests/value_cache_tests.rs
@@ -15,189 +15,180 @@ use linera_execution::committee::Epoch;
 use super::{ValueCache, DEFAULT_VALUE_CACHE_SIZE};
 
 /// Tests attempt to retrieve non-existent value.
-#[tokio::test]
-async fn test_retrieve_missing_value() {
+#[test]
+fn test_retrieve_missing_value() {
     let cache = ValueCache::<CryptoHash, Hashed<Timeout>>::default();
     let hash = CryptoHash::test_hash("Missing value");
 
-    assert!(cache.get(&hash).await.is_none());
-    assert!(cache.keys::<Vec<_>>().await.is_empty());
+    assert!(cache.get(&hash).is_none());
+    assert!(cache.keys::<Vec<_>>().is_empty());
 }
 
 /// Tests inserting a certificate value in the cache.
-#[tokio::test]
-async fn test_insert_single_certificate_value() {
+#[test]
+fn test_insert_single_certificate_value() {
     let cache = ValueCache::<CryptoHash, Hashed<Timeout>>::default();
     let value = create_dummy_certificate_value(0);
     let hash = value.hash();
 
-    assert!(cache.insert(Cow::Borrowed(&value)).await);
-    assert!(cache.contains(&hash).await);
-    assert_eq!(cache.get(&hash).await, Some(value));
-    assert_eq!(cache.keys::<BTreeSet<_>>().await, BTreeSet::from([hash]));
+    assert!(cache.insert(Cow::Borrowed(&value)));
+    assert!(cache.contains(&hash));
+    assert_eq!(cache.get(&hash), Some(value));
+    assert_eq!(cache.keys::<BTreeSet<_>>(), BTreeSet::from([hash]));
 }
 
 /// Tests inserting a blob in the cache.
-#[tokio::test]
-async fn test_insert_single_blob() {
+#[test]
+fn test_insert_single_blob() {
     let cache = ValueCache::<BlobId, Blob>::default();
     let value = create_dummy_blob(0);
     let blob_id = value.id();
 
-    assert!(cache.insert(Cow::Borrowed(&value)).await);
-    assert!(cache.contains(&blob_id).await);
-    assert_eq!(cache.get(&blob_id).await, Some(value));
-    assert_eq!(cache.keys::<BTreeSet<_>>().await, BTreeSet::from([blob_id]));
+    assert!(cache.insert(Cow::Borrowed(&value)));
+    assert!(cache.contains(&blob_id));
+    assert_eq!(cache.get(&blob_id), Some(value));
+    assert_eq!(cache.keys::<BTreeSet<_>>(), BTreeSet::from([blob_id]));
 }
 
 /// Tests inserting many certificate values in the cache, one-by-one.
-#[tokio::test]
-async fn test_insert_many_certificate_values_individually() {
+#[test]
+fn test_insert_many_certificate_values_individually() {
     let cache = ValueCache::<CryptoHash, Hashed<Timeout>>::default();
     let values =
         create_dummy_certificate_values(0..(DEFAULT_VALUE_CACHE_SIZE as u64)).collect::<Vec<_>>();
 
     for value in &values {
-        assert!(cache.insert(Cow::Borrowed(value)).await);
+        assert!(cache.insert(Cow::Borrowed(value)));
     }
 
     for value in &values {
-        assert!(cache.contains(&value.hash()).await);
-        assert_eq!(cache.get(&value.hash()).await.as_ref(), Some(value));
+        assert!(cache.contains(&value.hash()));
+        assert_eq!(cache.get(&value.hash()).as_ref(), Some(value));
     }
 
     assert_eq!(
-        cache.keys::<BTreeSet<_>>().await,
+        cache.keys::<BTreeSet<_>>(),
         BTreeSet::from_iter(values.iter().map(Hashed::hash))
     );
 }
 
 /// Tests inserting many blobs in the cache, one-by-one.
-#[tokio::test]
-async fn test_insert_many_blobs_individually() {
+#[test]
+fn test_insert_many_blobs_individually() {
     let cache = ValueCache::<BlobId, Blob>::default();
     let blobs = create_dummy_blobs();
 
     for blob in &blobs {
-        assert!(cache.insert(Cow::Borrowed(blob)).await);
+        assert!(cache.insert(Cow::Borrowed(blob)));
     }
 
     for blob in &blobs {
-        assert!(cache.contains(&blob.id()).await);
-        assert_eq!(cache.get(&blob.id()).await.as_ref(), Some(blob));
+        assert!(cache.contains(&blob.id()));
+        assert_eq!(cache.get(&blob.id()).as_ref(), Some(blob));
     }
 
     assert_eq!(
-        cache.keys::<BTreeSet<_>>().await,
+        cache.keys::<BTreeSet<_>>(),
         BTreeSet::from_iter(blobs.iter().map(Blob::id))
     );
 }
 
 /// Tests inserting many values in the cache, all-at-once.
-#[tokio::test]
-async fn test_insert_many_values_together() {
+#[test]
+fn test_insert_many_values_together() {
     let cache = ValueCache::<CryptoHash, Hashed<Timeout>>::default();
     let values =
         create_dummy_certificate_values(0..(DEFAULT_VALUE_CACHE_SIZE as u64)).collect::<Vec<_>>();
 
-    cache.insert_all(values.iter().map(Cow::Borrowed)).await;
+    cache.insert_all(values.iter().map(Cow::Borrowed));
 
     for value in &values {
-        assert!(cache.contains(&value.hash()).await);
-        assert_eq!(cache.get(&value.hash()).await.as_ref(), Some(value));
+        assert!(cache.contains(&value.hash()));
+        assert_eq!(cache.get(&value.hash()).as_ref(), Some(value));
     }
 
     assert_eq!(
-        cache.keys::<BTreeSet<_>>().await,
+        cache.keys::<BTreeSet<_>>(),
         BTreeSet::from_iter(values.iter().map(|el| el.hash()))
     );
 }
 
 /// Tests re-inserting many values in the cache, all-at-once.
-#[tokio::test]
-async fn test_reinsertion_of_values() {
+#[test]
+fn test_reinsertion_of_values() {
     let cache = ValueCache::<CryptoHash, Hashed<Timeout>>::default();
     let values =
         create_dummy_certificate_values(0..(DEFAULT_VALUE_CACHE_SIZE as u64)).collect::<Vec<_>>();
 
-    cache.insert_all(values.iter().map(Cow::Borrowed)).await;
+    cache.insert_all(values.iter().map(Cow::Borrowed));
 
     for value in &values {
-        assert!(!cache.insert(Cow::Borrowed(value)).await);
+        assert!(!cache.insert(Cow::Borrowed(value)));
     }
 
     for value in &values {
-        assert!(cache.contains(&value.hash()).await);
-        assert_eq!(cache.get(&value.hash()).await.as_ref(), Some(value));
+        assert!(cache.contains(&value.hash()));
+        assert_eq!(cache.get(&value.hash()).as_ref(), Some(value));
     }
 
     assert_eq!(
-        cache.keys::<BTreeSet<_>>().await,
+        cache.keys::<BTreeSet<_>>(),
         BTreeSet::from_iter(values.iter().map(Hashed::hash))
     );
 }
 
 /// Tests eviction of one entry.
-#[tokio::test]
-async fn test_one_eviction() {
+#[test]
+fn test_one_eviction() {
     let cache = ValueCache::<CryptoHash, Hashed<Timeout>>::default();
     let values =
         create_dummy_certificate_values(0..=(DEFAULT_VALUE_CACHE_SIZE as u64)).collect::<Vec<_>>();
 
-    cache.insert_all(values.iter().map(Cow::Borrowed)).await;
+    cache.insert_all(values.iter().map(Cow::Borrowed));
 
-    assert!(!cache.contains(&values[0].hash()).await);
-    assert!(cache.get(&values[0].hash()).await.is_none());
+    assert!(!cache.contains(&values[0].hash()));
+    assert!(cache.get(&values[0].hash()).is_none());
 
     for value in values.iter().skip(1) {
-        assert!(cache.contains(&value.hash()).await);
-        assert_eq!(cache.get(&value.hash()).await.as_ref(), Some(value));
+        assert!(cache.contains(&value.hash()));
+        assert_eq!(cache.get(&value.hash()).as_ref(), Some(value));
     }
 
     assert_eq!(
-        cache.keys::<BTreeSet<_>>().await,
+        cache.keys::<BTreeSet<_>>(),
         BTreeSet::from_iter(values.iter().skip(1).map(Hashed::hash))
     );
 }
 
 /// Tests eviction of the second entry.
-#[tokio::test]
-async fn test_eviction_of_second_entry() {
+#[test]
+fn test_eviction_of_second_entry() {
     let cache = ValueCache::<CryptoHash, Hashed<Timeout>>::default();
     let values =
         create_dummy_certificate_values(0..=(DEFAULT_VALUE_CACHE_SIZE as u64)).collect::<Vec<_>>();
 
-    cache
-        .insert_all(
-            values
-                .iter()
-                .take(DEFAULT_VALUE_CACHE_SIZE)
-                .map(Cow::Borrowed),
-        )
-        .await;
-    cache.get(&values[0].hash()).await;
-    assert!(
-        cache
-            .insert(Cow::Borrowed(&values[DEFAULT_VALUE_CACHE_SIZE]))
-            .await
+    cache.insert_all(
+        values
+            .iter()
+            .take(DEFAULT_VALUE_CACHE_SIZE)
+            .map(Cow::Borrowed),
     );
+    cache.get(&values[0].hash());
+    assert!(cache.insert(Cow::Borrowed(&values[DEFAULT_VALUE_CACHE_SIZE])));
 
-    assert!(cache.contains(&values[0].hash()).await);
-    assert_eq!(
-        cache.get(&values[0].hash()).await.as_ref(),
-        Some(&values[0])
-    );
+    assert!(cache.contains(&values[0].hash()));
+    assert_eq!(cache.get(&values[0].hash()).as_ref(), Some(&values[0]));
 
-    assert!(!cache.contains(&values[1].hash()).await);
-    assert!(cache.get(&values[1].hash()).await.is_none());
+    assert!(!cache.contains(&values[1].hash()));
+    assert!(cache.get(&values[1].hash()).is_none());
 
     for value in values.iter().skip(2) {
-        assert!(cache.contains(&value.hash()).await);
-        assert_eq!(cache.get(&value.hash()).await.as_ref(), Some(value));
+        assert!(cache.contains(&value.hash()));
+        assert_eq!(cache.get(&value.hash()).as_ref(), Some(value));
     }
 
     assert_eq!(
-        cache.keys::<BTreeSet<_>>().await,
+        cache.keys::<BTreeSet<_>>(),
         BTreeSet::from_iter(
             values
                 .iter()
@@ -209,43 +200,34 @@ async fn test_eviction_of_second_entry() {
 }
 
 /// Tests if reinsertion of the first entry promotes it so that it's not evicted so soon.
-#[tokio::test]
-async fn test_promotion_of_reinsertion() {
+#[test]
+fn test_promotion_of_reinsertion() {
     let cache = ValueCache::<CryptoHash, Hashed<Timeout>>::default();
     let values =
         create_dummy_certificate_values(0..=(DEFAULT_VALUE_CACHE_SIZE as u64)).collect::<Vec<_>>();
 
-    cache
-        .insert_all(
-            values
-                .iter()
-                .take(DEFAULT_VALUE_CACHE_SIZE)
-                .map(Cow::Borrowed),
-        )
-        .await;
-    assert!(!cache.insert(Cow::Borrowed(&values[0])).await);
-    assert!(
-        cache
-            .insert(Cow::Borrowed(&values[DEFAULT_VALUE_CACHE_SIZE]))
-            .await
+    cache.insert_all(
+        values
+            .iter()
+            .take(DEFAULT_VALUE_CACHE_SIZE)
+            .map(Cow::Borrowed),
     );
+    assert!(!cache.insert(Cow::Borrowed(&values[0])));
+    assert!(cache.insert(Cow::Borrowed(&values[DEFAULT_VALUE_CACHE_SIZE])));
 
-    assert!(cache.contains(&values[0].hash()).await);
-    assert_eq!(
-        cache.get(&values[0].hash()).await.as_ref(),
-        Some(&values[0])
-    );
+    assert!(cache.contains(&values[0].hash()));
+    assert_eq!(cache.get(&values[0].hash()).as_ref(), Some(&values[0]));
 
-    assert!(!cache.contains(&values[1].hash()).await);
-    assert!(cache.get(&values[1].hash()).await.is_none());
+    assert!(!cache.contains(&values[1].hash()));
+    assert!(cache.get(&values[1].hash()).is_none());
 
     for value in values.iter().skip(2) {
-        assert!(cache.contains(&value.hash()).await);
-        assert_eq!(cache.get(&value.hash()).await.as_ref(), Some(value));
+        assert!(cache.contains(&value.hash()));
+        assert_eq!(cache.get(&value.hash()).as_ref(), Some(value));
     }
 
     assert_eq!(
-        cache.keys::<BTreeSet<_>>().await,
+        cache.keys::<BTreeSet<_>>(),
         BTreeSet::from_iter(
             values
                 .iter()
@@ -257,8 +239,8 @@ async fn test_promotion_of_reinsertion() {
 }
 
 /// Test that the cache correctly filters out cached items from an iterator.
-#[tokio::test]
-async fn test_filtering_out_cached_items() {
+#[test]
+fn test_filtering_out_cached_items() {
     #[derive(Debug, Eq, PartialEq)]
     struct DummyWrapper(CryptoHash);
 
@@ -266,13 +248,9 @@ async fn test_filtering_out_cached_items() {
     let items = create_dummy_certificate_values(0..10).map(|value| DummyWrapper(value.hash()));
 
     let cache = ValueCache::<CryptoHash, Hashed<Timeout>>::default();
-    cache
-        .insert_all(cached_values.iter().map(Cow::Borrowed))
-        .await;
+    cache.insert_all(cached_values.iter().map(Cow::Borrowed));
 
-    let output = cache
-        .subtract_cached_items_from::<_, Vec<_>>(items, |item| &item.0)
-        .await;
+    let output = cache.subtract_cached_items_from::<_, Vec<_>>(items, |item| &item.0);
 
     let expected = create_dummy_certificate_values(0..3)
         .chain(create_dummy_certificate_values(7..10))
@@ -282,7 +260,7 @@ async fn test_filtering_out_cached_items() {
     assert_eq!(output, expected);
 
     assert_eq!(
-        cache.keys::<BTreeSet<_>>().await,
+        cache.keys::<BTreeSet<_>>(),
         BTreeSet::from_iter(cached_values.iter().map(|el| el.hash()))
     );
 }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -407,7 +407,6 @@ where
         let executed_block = self
             .executed_block_cache
             .get(&certificate.value.value_hash)
-            .await
             .ok_or(WorkerError::MissingCertificateValue)?;
 
         match certificate.value.kind {


### PR DESCRIPTION
## Motivation

`ValueCache` is just an in-memory cache; it should not need an async mutex.

## Proposal

Use the standard library's `Mutex` instead. All `await`s have been removed from `value_cache.rs` and none of its methods return any locks, so no lock is held across an `await`.

## Test Plan

CI should catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
