### PR TITLE
Change mutations to schedule operations using a system API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,7 +2054,6 @@ name = "counter"
 version = "0.1.0"
 dependencies = [
  "async-graphql",
- "bcs",
  "futures",
  "linera-sdk",
  "serde_json",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1504,7 +1504,6 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "async-graphql",
- "bcs",
  "futures",
  "linera-sdk",
  "serde_json",

--- a/examples/amm/src/service.rs
+++ b/examples/amm/src/service.rs
@@ -17,6 +17,7 @@ use self::state::AmmState;
 
 pub struct AmmService {
     state: Arc<AmmState>,
+    runtime: Arc<ServiceRuntime<Self>>,
 }
 
 linera_sdk::service!(AmmService);
@@ -34,6 +35,7 @@ impl Service for AmmService {
             .expect("Failed to load state");
         AmmService {
             state: Arc::new(state),
+            runtime: Arc::new(runtime),
         }
     }
 

--- a/examples/amm/src/service.rs
+++ b/examples/amm/src/service.rs
@@ -42,7 +42,7 @@ impl Service for AmmService {
     async fn handle_query(&self, request: Request) -> Response {
         let schema = Schema::build(
             self.state.clone(),
-            Operation::mutation_root(),
+            Operation::mutation_root(self.runtime.clone()),
             EmptySubscription,
         )
         .finish();

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 async-graphql.workspace = true
-bcs.workspace = true
 futures.workspace = true
 linera-sdk.workspace = true
 serde_json.workspace = true

--- a/examples/counter/src/service.rs
+++ b/examples/counter/src/service.rs
@@ -57,9 +57,9 @@ struct MutationRoot {
 
 #[Object]
 impl MutationRoot {
-    async fn increment(&self, value: u64) -> Vec<u8> {
+    async fn increment(&self, value: u64) -> [u8; 0] {
         self.runtime.schedule_operation(&value);
-        bcs::to_bytes(&value).unwrap()
+        []
     }
 }
 

--- a/examples/counter/src/service.rs
+++ b/examples/counter/src/service.rs
@@ -65,6 +65,8 @@ impl QueryRoot {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use async_graphql::{Request, Response, Value};
     use futures::FutureExt as _;
     use linera_sdk::{util::BlockingWait, views::View, Service, ServiceRuntime};
@@ -75,13 +77,13 @@ mod tests {
     #[test]
     fn query() {
         let value = 61_098_721_u64;
-        let runtime = ServiceRuntime::<CounterService>::new();
+        let runtime = Arc::new(ServiceRuntime::<CounterService>::new());
         let mut state = CounterState::load(runtime.root_view_storage_context())
             .blocking_wait()
             .expect("Failed to read from mock key value store");
         state.value.set(value);
 
-        let service = CounterService { state };
+        let service = CounterService { state, runtime };
         let request = Request::new("{ value }");
 
         let response = service

--- a/examples/counter/tests/single_chain.rs
+++ b/examples/counter/tests/single_chain.rs
@@ -5,7 +5,7 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
-use linera_sdk::test::TestValidator;
+use linera_sdk::test::{QueryOutcome, TestValidator};
 
 /// Test setting a counter and testing its coherency across microchains.
 ///
@@ -30,7 +30,8 @@ async fn single_chain_test() {
         .await;
 
     let final_value = initial_state + increment;
-    let response = chain.graphql_query(application_id, "query { value }").await;
+    let QueryOutcome { response, .. } =
+        chain.graphql_query(application_id, "query { value }").await;
     let state_value = response["value"].as_u64().expect("Failed to get the u64");
     assert_eq!(state_value, final_value);
 }

--- a/examples/crowd-funding/src/service.rs
+++ b/examples/crowd-funding/src/service.rs
@@ -44,7 +44,7 @@ impl Service for CrowdFundingService {
     async fn handle_query(&self, request: Request) -> Response {
         let schema = Schema::build(
             self.state.clone(),
-            Operation::mutation_root(),
+            Operation::mutation_root(self.runtime.clone()),
             EmptySubscription,
         )
         .finish();

--- a/examples/crowd-funding/src/service.rs
+++ b/examples/crowd-funding/src/service.rs
@@ -19,6 +19,7 @@ use state::CrowdFundingState;
 
 pub struct CrowdFundingService {
     state: Arc<CrowdFundingState>,
+    runtime: Arc<ServiceRuntime<Self>>,
 }
 
 linera_sdk::service!(CrowdFundingService);
@@ -36,6 +37,7 @@ impl Service for CrowdFundingService {
             .expect("Failed to load state");
         CrowdFundingService {
             state: Arc::new(state),
+            runtime: Arc::new(runtime),
         }
     }
 

--- a/examples/ethereum-tracker/src/service.rs
+++ b/examples/ethereum-tracker/src/service.rs
@@ -43,7 +43,7 @@ impl Service for EthereumTrackerService {
     async fn handle_query(&self, request: Request) -> Response {
         let schema = Schema::build(
             self.state.clone(),
-            Operation::mutation_root(),
+            Operation::mutation_root(self.runtime.clone()),
             EmptySubscription,
         )
         .finish();

--- a/examples/ethereum-tracker/src/service.rs
+++ b/examples/ethereum-tracker/src/service.rs
@@ -18,6 +18,7 @@ use self::state::EthereumTrackerState;
 #[derive(Clone)]
 pub struct EthereumTrackerService {
     state: Arc<EthereumTrackerState>,
+    runtime: Arc<ServiceRuntime<Self>>,
 }
 
 linera_sdk::service!(EthereumTrackerService);
@@ -35,6 +36,7 @@ impl Service for EthereumTrackerService {
             .expect("Failed to load state");
         EthereumTrackerService {
             state: Arc::new(state),
+            runtime: Arc::new(runtime),
         }
     }
 

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -12,7 +12,7 @@ use {
     futures::{stream, StreamExt},
     linera_sdk::{
         base::{ApplicationId, BytecodeId},
-        test::{ActiveChain, TestValidator},
+        test::{ActiveChain, QueryOutcome, TestValidator},
     },
 };
 
@@ -127,7 +127,7 @@ pub async fn query_account(
         "query {{ accounts {{ entry(key: {}) {{ value }} }} }}",
         account_owner.to_value()
     );
-    let response = chain.graphql_query(application_id, query).await;
+    let QueryOutcome { response, .. } = chain.graphql_query(application_id, query).await;
     let balance = response.pointer("/accounts/entry/value")?.as_str()?;
 
     Some(

--- a/examples/fungible/src/service.rs
+++ b/examples/fungible/src/service.rs
@@ -44,8 +44,12 @@ impl Service for FungibleTokenService {
     }
 
     async fn handle_query(&self, request: Request) -> Response {
-        let schema =
-            Schema::build(self.clone(), Operation::mutation_root(), EmptySubscription).finish();
+        let schema = Schema::build(
+            self.clone(),
+            Operation::mutation_root(self.runtime.clone()),
+            EmptySubscription,
+        )
+        .finish();
         schema.execute(request).await
     }
 }

--- a/examples/gen-nft/src/service.rs
+++ b/examples/gen-nft/src/service.rs
@@ -57,7 +57,9 @@ impl Service for GenNftService {
             QueryRoot {
                 non_fungible_token: self.state.clone(),
             },
-            MutationRoot,
+            MutationRoot {
+                runtime: self.runtime.clone(),
+            },
             EmptySubscription,
         )
         .data(runtime)
@@ -175,12 +177,16 @@ impl QueryRoot {
     }
 }
 
-struct MutationRoot;
+struct MutationRoot {
+    runtime: Arc<ServiceRuntime<GenNftService>>,
+}
 
 #[Object]
 impl MutationRoot {
     async fn mint(&self, minter: AccountOwner, prompt: String) -> Vec<u8> {
-        bcs::to_bytes(&Operation::Mint { minter, prompt }).unwrap()
+        let operation = Operation::Mint { minter, prompt };
+        self.runtime.schedule_operation(&operation);
+        bcs::to_bytes(&operation).unwrap()
     }
 
     async fn transfer(
@@ -189,14 +195,15 @@ impl MutationRoot {
         token_id: String,
         target_account: Account,
     ) -> Vec<u8> {
-        bcs::to_bytes(&Operation::Transfer {
+        let operation = Operation::Transfer {
             source_owner,
             token_id: TokenId {
                 id: STANDARD_NO_PAD.decode(token_id).unwrap(),
             },
             target_account,
-        })
-        .unwrap()
+        };
+        self.runtime.schedule_operation(&operation);
+        bcs::to_bytes(&operation).unwrap()
     }
 
     async fn claim(
@@ -205,13 +212,14 @@ impl MutationRoot {
         token_id: String,
         target_account: Account,
     ) -> Vec<u8> {
-        bcs::to_bytes(&Operation::Claim {
+        let operation = Operation::Claim {
             source_account,
             token_id: TokenId {
                 id: STANDARD_NO_PAD.decode(token_id).unwrap(),
             },
             target_account,
-        })
-        .unwrap()
+        };
+        self.runtime.schedule_operation(&operation);
+        bcs::to_bytes(&operation).unwrap()
     }
 }

--- a/examples/gen-nft/src/service.rs
+++ b/examples/gen-nft/src/service.rs
@@ -183,10 +183,10 @@ struct MutationRoot {
 
 #[Object]
 impl MutationRoot {
-    async fn mint(&self, minter: AccountOwner, prompt: String) -> Vec<u8> {
+    async fn mint(&self, minter: AccountOwner, prompt: String) -> [u8; 0] {
         let operation = Operation::Mint { minter, prompt };
         self.runtime.schedule_operation(&operation);
-        bcs::to_bytes(&operation).unwrap()
+        []
     }
 
     async fn transfer(
@@ -194,7 +194,7 @@ impl MutationRoot {
         source_owner: AccountOwner,
         token_id: String,
         target_account: Account,
-    ) -> Vec<u8> {
+    ) -> [u8; 0] {
         let operation = Operation::Transfer {
             source_owner,
             token_id: TokenId {
@@ -203,7 +203,7 @@ impl MutationRoot {
             target_account,
         };
         self.runtime.schedule_operation(&operation);
-        bcs::to_bytes(&operation).unwrap()
+        []
     }
 
     async fn claim(
@@ -211,7 +211,7 @@ impl MutationRoot {
         source_account: Account,
         token_id: String,
         target_account: Account,
-    ) -> Vec<u8> {
+    ) -> [u8; 0] {
         let operation = Operation::Claim {
             source_account,
             token_id: TokenId {
@@ -220,6 +220,6 @@ impl MutationRoot {
             target_account,
         };
         self.runtime.schedule_operation(&operation);
-        bcs::to_bytes(&operation).unwrap()
+        []
     }
 }

--- a/examples/hex-game/src/service.rs
+++ b/examples/hex-game/src/service.rs
@@ -43,7 +43,7 @@ impl Service for HexService {
     async fn handle_query(&self, request: Request) -> Response {
         let schema = Schema::build(
             self.state.clone(),
-            Operation::mutation_root(),
+            Operation::mutation_root(self.runtime.clone()),
             EmptySubscription,
         )
         .data(self.runtime.clone())

--- a/examples/hex-game/tests/hex_game.rs
+++ b/examples/hex-game/tests/hex_game.rs
@@ -8,7 +8,7 @@
 use hex_game::{HexAbi, Operation, Timeouts};
 use linera_sdk::{
     base::{Amount, ChainDescription, KeyPair, TimeDelta},
-    test::{ActiveChain, TestValidator},
+    test::{ActiveChain, QueryOutcome, TestValidator},
 };
 
 #[test_log::test(tokio::test)]
@@ -57,7 +57,7 @@ async fn hex_game() {
         })
         .await;
 
-    let response = chain.graphql_query(app_id, "query { winner }").await;
+    let QueryOutcome { response, .. } = chain.graphql_query(app_id, "query { winner }").await;
     assert!(response["winner"].is_null());
 
     chain.set_key_pair(key_pair2.copy());
@@ -67,7 +67,7 @@ async fn hex_game() {
         })
         .await;
 
-    let response = chain.graphql_query(app_id, "query { winner }").await;
+    let QueryOutcome { response, .. } = chain.graphql_query(app_id, "query { winner }").await;
     assert_eq!(Some("TWO"), response["winner"].as_str());
     assert!(chain.is_closed().await);
 }
@@ -154,6 +154,6 @@ async fn hex_game_clock() {
         })
         .await;
 
-    let response = chain.graphql_query(app_id, "query { winner }").await;
+    let QueryOutcome { response, .. } = chain.graphql_query(app_id, "query { winner }").await;
     assert_eq!(Some("ONE"), response["winner"].as_str());
 }

--- a/examples/matching-engine/src/service.rs
+++ b/examples/matching-engine/src/service.rs
@@ -42,7 +42,7 @@ impl Service for MatchingEngineService {
     async fn handle_query(&self, request: Request) -> Response {
         let schema = Schema::build(
             self.state.clone(),
-            Operation::mutation_root(),
+            Operation::mutation_root(self.runtime.clone()),
             EmptySubscription,
         )
         .finish();

--- a/examples/matching-engine/src/service.rs
+++ b/examples/matching-engine/src/service.rs
@@ -17,6 +17,7 @@ use crate::state::MatchingEngineState;
 
 pub struct MatchingEngineService {
     state: Arc<MatchingEngineState>,
+    runtime: Arc<ServiceRuntime<Self>>,
 }
 
 linera_sdk::service!(MatchingEngineService);
@@ -34,6 +35,7 @@ impl Service for MatchingEngineService {
             .expect("Failed to load state");
         MatchingEngineService {
             state: Arc::new(state),
+            runtime: Arc::new(runtime),
         }
     }
 

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -8,7 +8,7 @@
 use async_graphql::InputType;
 use linera_sdk::{
     base::{AccountOwner, Amount, ApplicationId, ApplicationPermissions},
-    test::{ActiveChain, TestValidator},
+    test::{ActiveChain, QueryOutcome, TestValidator},
 };
 use matching_engine::{
     MatchingEngineAbi, Operation, Order, OrderId, OrderNature, Parameters, Price,
@@ -23,8 +23,8 @@ pub async fn get_orders(
         "query {{ accountInfo {{ entry(key: {}) {{ value {{ orders }} }} }} }}",
         account_owner.to_value()
     );
-    let value = chain.graphql_query(application_id, query).await;
-    let orders = &value["accountInfo"]["entry"]["value"]["orders"];
+    let QueryOutcome { response, .. } = chain.graphql_query(application_id, query).await;
+    let orders = &response["accountInfo"]["entry"]["value"]["orders"];
     let values = orders
         .as_array()?
         .iter()

--- a/examples/native-fungible/src/service.rs
+++ b/examples/native-fungible/src/service.rs
@@ -35,8 +35,12 @@ impl Service for NativeFungibleTokenService {
     }
 
     async fn handle_query(&self, request: Request) -> Response {
-        let schema =
-            Schema::build(self.clone(), Operation::mutation_root(), EmptySubscription).finish();
+        let schema = Schema::build(
+            self.clone(),
+            Operation::mutation_root(self.runtime.clone()),
+            EmptySubscription,
+        )
+        .finish();
         schema.execute(request).await
     }
 }

--- a/examples/non-fungible/src/service.rs
+++ b/examples/non-fungible/src/service.rs
@@ -168,14 +168,14 @@ struct MutationRoot {
 
 #[Object]
 impl MutationRoot {
-    async fn mint(&self, minter: AccountOwner, name: String, blob_hash: DataBlobHash) -> Vec<u8> {
+    async fn mint(&self, minter: AccountOwner, name: String, blob_hash: DataBlobHash) -> [u8; 0] {
         let operation = Operation::Mint {
             minter,
             name,
             blob_hash,
         };
         self.runtime.schedule_operation(&operation);
-        bcs::to_bytes(&operation).unwrap()
+        []
     }
 
     async fn transfer(
@@ -183,7 +183,7 @@ impl MutationRoot {
         source_owner: AccountOwner,
         token_id: String,
         target_account: Account,
-    ) -> Vec<u8> {
+    ) -> [u8; 0] {
         let operation = Operation::Transfer {
             source_owner,
             token_id: TokenId {
@@ -192,7 +192,7 @@ impl MutationRoot {
             target_account,
         };
         self.runtime.schedule_operation(&operation);
-        bcs::to_bytes(&operation).unwrap()
+        []
     }
 
     async fn claim(
@@ -200,7 +200,7 @@ impl MutationRoot {
         source_account: Account,
         token_id: String,
         target_account: Account,
-    ) -> Vec<u8> {
+    ) -> [u8; 0] {
         let operation = Operation::Claim {
             source_account,
             token_id: TokenId {
@@ -209,6 +209,6 @@ impl MutationRoot {
             target_account,
         };
         self.runtime.schedule_operation(&operation);
-        bcs::to_bytes(&operation).unwrap()
+        []
     }
 }

--- a/examples/rfq/src/service.rs
+++ b/examples/rfq/src/service.rs
@@ -43,7 +43,7 @@ impl Service for RfqService {
     async fn handle_query(&self, request: Request) -> Response {
         let schema = Schema::build(
             self.state.clone(),
-            Operation::mutation_root(),
+            Operation::mutation_root(self.runtime.clone()),
             EmptySubscription,
         )
         .finish();

--- a/examples/rfq/src/service.rs
+++ b/examples/rfq/src/service.rs
@@ -18,6 +18,7 @@ use self::state::RfqState;
 
 pub struct RfqService {
     state: Arc<RfqState>,
+    runtime: Arc<ServiceRuntime<Self>>,
 }
 
 linera_sdk::service!(RfqService);
@@ -35,6 +36,7 @@ impl Service for RfqService {
             .expect("Failed to load state");
         RfqService {
             state: Arc::new(state),
+            runtime: Arc::new(runtime),
         }
     }
 

--- a/examples/social/src/service.rs
+++ b/examples/social/src/service.rs
@@ -16,6 +16,7 @@ use state::SocialState;
 
 pub struct SocialService {
     state: Arc<SocialState>,
+    runtime: Arc<ServiceRuntime<Self>>,
 }
 
 linera_sdk::service!(SocialService);
@@ -33,6 +34,7 @@ impl Service for SocialService {
             .expect("Failed to load state");
         SocialService {
             state: Arc::new(state),
+            runtime: Arc::new(runtime),
         }
     }
 

--- a/examples/social/src/service.rs
+++ b/examples/social/src/service.rs
@@ -41,7 +41,7 @@ impl Service for SocialService {
     async fn handle_query(&self, request: Request) -> Response {
         let schema = Schema::build(
             self.state.clone(),
-            Operation::mutation_root(),
+            Operation::mutation_root(self.runtime.clone()),
             EmptySubscription,
         )
         .finish();

--- a/examples/social/tests/cross_chain.rs
+++ b/examples/social/tests/cross_chain.rs
@@ -5,7 +5,7 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
-use linera_sdk::test::TestValidator;
+use linera_sdk::test::{QueryOutcome, TestValidator};
 use social::Operation;
 
 /// Test posting messages across microchains.
@@ -56,13 +56,13 @@ async fn test_cross_chain_posting() {
 
     // Querying the own posts
     let query = "query { ownPosts { entries(start: 0, end: 1) { timestamp, text } } }";
-    let response = chain2.graphql_query(application_id, query).await;
+    let QueryOutcome { response, .. } = chain2.graphql_query(application_id, query).await;
     let value = response["ownPosts"]["entries"][0]["text"].clone();
     assert_eq!(value, "Linera is the new Mastodon".to_string());
 
     // Now handling the received messages
     let query = "query { receivedPosts { keys { timestamp, author, index } } }";
-    let response = chain1.graphql_query(application_id, query).await;
+    let QueryOutcome { response, .. } = chain1.graphql_query(application_id, query).await;
     let author = response["receivedPosts"]["keys"][0]["author"].clone();
     assert_eq!(author, chain2.id().to_string());
 }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -25,8 +25,8 @@ use linera_base::{
 use linera_execution::{
     committee::ValidatorName, system::OpenChainConfig, ExecutionOutcome, ExecutionRuntimeContext,
     ExecutionStateView, Message, MessageContext, Operation, OperationContext, Query, QueryContext,
-    QueryOutcome, QueryResponse, RawExecutionOutcome, RawOutgoingMessage, ResourceController,
-    ResourceTracker, ServiceRuntimeEndpoint, TransactionTracker,
+    QueryOutcome, RawExecutionOutcome, RawOutgoingMessage, ResourceController, ResourceTracker,
+    ServiceRuntimeEndpoint, TransactionTracker,
 };
 use linera_views::{
     context::Context,
@@ -334,7 +334,7 @@ where
         local_time: Timestamp,
         query: Query,
         service_runtime_endpoint: Option<&mut ServiceRuntimeEndpoint>,
-    ) -> Result<QueryResponse, ChainError> {
+    ) -> Result<QueryOutcome, ChainError> {
         let context = QueryContext {
             chain_id: self.chain_id(),
             next_block_height: self.tip_state.get().next_block_height,
@@ -344,7 +344,6 @@ where
             .query_application(context, query, service_runtime_endpoint)
             .await
             .with_execution_context(ChainExecutionContext::Query)
-            .map(|QueryOutcome { response }| response)
     }
 
     pub async fn describe_application(

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -25,7 +25,7 @@ use linera_base::{
 use linera_execution::{
     committee::ValidatorName, system::OpenChainConfig, ExecutionOutcome, ExecutionRuntimeContext,
     ExecutionStateView, Message, MessageContext, Operation, OperationContext, Query, QueryContext,
-    RawExecutionOutcome, RawOutgoingMessage, ResourceController, ResourceTracker, Response,
+    QueryResponse, RawExecutionOutcome, RawOutgoingMessage, ResourceController, ResourceTracker,
     ServiceRuntimeEndpoint, TransactionTracker,
 };
 use linera_views::{
@@ -334,7 +334,7 @@ where
         local_time: Timestamp,
         query: Query,
         service_runtime_endpoint: Option<&mut ServiceRuntimeEndpoint>,
-    ) -> Result<Response, ChainError> {
+    ) -> Result<QueryResponse, ChainError> {
         let context = QueryContext {
             chain_id: self.chain_id(),
             next_block_height: self.tip_state.get().next_block_height,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -25,8 +25,8 @@ use linera_base::{
 use linera_execution::{
     committee::ValidatorName, system::OpenChainConfig, ExecutionOutcome, ExecutionRuntimeContext,
     ExecutionStateView, Message, MessageContext, Operation, OperationContext, Query, QueryContext,
-    QueryResponse, RawExecutionOutcome, RawOutgoingMessage, ResourceController, ResourceTracker,
-    ServiceRuntimeEndpoint, TransactionTracker,
+    QueryOutcome, QueryResponse, RawExecutionOutcome, RawOutgoingMessage, ResourceController,
+    ResourceTracker, ServiceRuntimeEndpoint, TransactionTracker,
 };
 use linera_views::{
     context::Context,
@@ -344,6 +344,7 @@ where
             .query_application(context, query, service_runtime_endpoint)
             .await
             .with_execution_context(ChainExecutionContext::Query)
+            .map(|QueryOutcome { response }| response)
     }
 
     pub async fn describe_application(

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -23,7 +23,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Epoch, ValidatorName},
-    Query, QueryContext, Response, ServiceRuntimeEndpoint, ServiceSyncRuntime,
+    Query, QueryContext, QueryResponse, ServiceRuntimeEndpoint, ServiceSyncRuntime,
 };
 use linera_storage::Storage;
 use tokio::sync::{mpsc, oneshot, OwnedRwLockReadGuard};
@@ -72,7 +72,7 @@ where
     QueryApplication {
         query: Query,
         #[debug(skip)]
-        callback: oneshot::Sender<Result<Response, WorkerError>>,
+        callback: oneshot::Sender<Result<QueryResponse, WorkerError>>,
     },
 
     /// Describe an application.

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -23,7 +23,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Epoch, ValidatorName},
-    Query, QueryContext, QueryResponse, ServiceRuntimeEndpoint, ServiceSyncRuntime,
+    Query, QueryContext, QueryOutcome, QueryResponse, ServiceRuntimeEndpoint, ServiceSyncRuntime,
 };
 use linera_storage::Storage;
 use tokio::sync::{mpsc, oneshot, OwnedRwLockReadGuard};
@@ -279,7 +279,12 @@ where
                     callback.send(self.worker.chain_state_view().await).is_ok()
                 }
                 ChainWorkerRequest::QueryApplication { query, callback } => callback
-                    .send(self.worker.query_application(query).await)
+                    .send(
+                        self.worker
+                            .query_application(query)
+                            .await
+                            .map(|QueryOutcome { response }| response),
+                    )
                     .is_ok(),
                 ChainWorkerRequest::DescribeApplication {
                     application_id,

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -23,7 +23,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Epoch, ValidatorName},
-    Query, QueryContext, QueryOutcome, QueryResponse, ServiceRuntimeEndpoint, ServiceSyncRuntime,
+    Query, QueryContext, QueryOutcome, ServiceRuntimeEndpoint, ServiceSyncRuntime,
 };
 use linera_storage::Storage;
 use tokio::sync::{mpsc, oneshot, OwnedRwLockReadGuard};
@@ -72,7 +72,7 @@ where
     QueryApplication {
         query: Query,
         #[debug(skip)]
-        callback: oneshot::Sender<Result<QueryResponse, WorkerError>>,
+        callback: oneshot::Sender<Result<QueryOutcome, WorkerError>>,
     },
 
     /// Describe an application.
@@ -279,12 +279,7 @@ where
                     callback.send(self.worker.chain_state_view().await).is_ok()
                 }
                 ChainWorkerRequest::QueryApplication { query, callback } => callback
-                    .send(
-                        self.worker
-                            .query_application(query)
-                            .await
-                            .map(|QueryOutcome { response }| response),
-                    )
+                    .send(self.worker.query_application(query).await)
                     .is_ok(),
                 ChainWorkerRequest::DescribeApplication {
                     application_id,

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -27,7 +27,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Epoch, ValidatorName},
-    Message, Query, QueryContext, Response, ServiceRuntimeEndpoint, SystemMessage,
+    Message, Query, QueryContext, QueryResponse, ServiceRuntimeEndpoint, SystemMessage,
 };
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::{ClonableView, ViewError};
@@ -157,7 +157,7 @@ where
     pub(super) async fn query_application(
         &mut self,
         query: Query,
-    ) -> Result<Response, WorkerError> {
+    ) -> Result<QueryResponse, WorkerError> {
         ChainWorkerStateWithTemporaryChanges::new(self)
             .await
             .query_application(query)

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -27,7 +27,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Epoch, ValidatorName},
-    Message, Query, QueryContext, QueryResponse, ServiceRuntimeEndpoint, SystemMessage,
+    Message, Query, QueryContext, QueryOutcome, ServiceRuntimeEndpoint, SystemMessage,
 };
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::{ClonableView, ViewError};
@@ -157,7 +157,7 @@ where
     pub(super) async fn query_application(
         &mut self,
         query: Query,
-    ) -> Result<QueryResponse, WorkerError> {
+    ) -> Result<QueryOutcome, WorkerError> {
         ChainWorkerStateWithTemporaryChanges::new(self)
             .await
             .query_application(query)

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -20,7 +20,9 @@ use linera_chain::{
     manager,
     types::ValidatedBlock,
 };
-use linera_execution::{ChannelSubscription, Query, QueryResponse, ResourceControlPolicy};
+use linera_execution::{
+    ChannelSubscription, Query, QueryOutcome, QueryResponse, ResourceControlPolicy,
+};
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::View;
 #[cfg(with_testing)]
@@ -105,7 +107,7 @@ where
     ) -> Result<QueryResponse, WorkerError> {
         self.0.ensure_is_active()?;
         let local_time = self.0.storage.clock().current_time();
-        let response = self
+        let QueryOutcome { response } = self
             .0
             .chain
             .query_application(local_time, query, self.0.service_runtime_endpoint.as_mut())

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -20,9 +20,7 @@ use linera_chain::{
     manager,
     types::ValidatedBlock,
 };
-use linera_execution::{
-    ChannelSubscription, Query, QueryOutcome, QueryResponse, ResourceControlPolicy,
-};
+use linera_execution::{ChannelSubscription, Query, QueryOutcome, ResourceControlPolicy};
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::View;
 #[cfg(with_testing)]
@@ -104,15 +102,15 @@ where
     pub(super) async fn query_application(
         &mut self,
         query: Query,
-    ) -> Result<QueryResponse, WorkerError> {
+    ) -> Result<QueryOutcome, WorkerError> {
         self.0.ensure_is_active()?;
         let local_time = self.0.storage.clock().current_time();
-        let QueryOutcome { response } = self
+        let outcome = self
             .0
             .chain
             .query_application(local_time, query, self.0.service_runtime_endpoint.as_mut())
             .await?;
-        Ok(response)
+        Ok(outcome)
     }
 
     /// Returns an application's description.

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -20,7 +20,7 @@ use linera_chain::{
     manager,
     types::ValidatedBlock,
 };
-use linera_execution::{ChannelSubscription, Query, ResourceControlPolicy, Response};
+use linera_execution::{ChannelSubscription, Query, QueryResponse, ResourceControlPolicy};
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::View;
 #[cfg(with_testing)]
@@ -102,7 +102,7 @@ where
     pub(super) async fn query_application(
         &mut self,
         query: Query,
-    ) -> Result<Response, WorkerError> {
+    ) -> Result<QueryResponse, WorkerError> {
         self.0.ensure_is_active()?;
         let local_time = self.0.storage.clock().current_time();
         let response = self

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2185,13 +2185,19 @@ where
         &self,
         query: SystemQuery,
     ) -> Result<QueryOutcome<SystemResponse>, ChainClientError> {
-        let QueryOutcome { response } = self
+        let QueryOutcome {
+            response,
+            operations,
+        } = self
             .client
             .local_node
             .query_application(self.chain_id, Query::System(query))
             .await?;
         match response {
-            QueryResponse::System(response) => Ok(QueryOutcome { response }),
+            QueryResponse::System(response) => Ok(QueryOutcome {
+                response,
+                operations,
+            }),
             _ => Err(ChainClientError::InternalError(
                 "Unexpected response for system query",
             )),
@@ -2206,7 +2212,10 @@ where
         query: &A::Query,
     ) -> Result<QueryOutcome<A::QueryResponse>, ChainClientError> {
         let query = Query::user(application_id, query)?;
-        let QueryOutcome { response } = self
+        let QueryOutcome {
+            response,
+            operations,
+        } = self
             .client
             .local_node
             .query_application(self.chain_id, query)
@@ -2214,7 +2223,10 @@ where
         match response {
             QueryResponse::User(response_bytes) => {
                 let response = serde_json::from_slice(&response_bytes)?;
-                Ok(QueryOutcome { response })
+                Ok(QueryOutcome {
+                    response,
+                    operations,
+                })
             }
             _ => Err(ChainClientError::InternalError(
                 "Unexpected response for user query",

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2184,14 +2184,14 @@ where
     pub async fn query_system_application(
         &self,
         query: SystemQuery,
-    ) -> Result<SystemResponse, ChainClientError> {
+    ) -> Result<QueryOutcome<SystemResponse>, ChainClientError> {
         let QueryOutcome { response } = self
             .client
             .local_node
             .query_application(self.chain_id, Query::System(query))
             .await?;
         match response {
-            QueryResponse::System(response) => Ok(response),
+            QueryResponse::System(response) => Ok(QueryOutcome { response }),
             _ => Err(ChainClientError::InternalError(
                 "Unexpected response for system query",
             )),

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2204,7 +2204,7 @@ where
         &self,
         application_id: UserApplicationId<A>,
         query: &A::Query,
-    ) -> Result<A::QueryResponse, ChainClientError> {
+    ) -> Result<QueryOutcome<A::QueryResponse>, ChainClientError> {
         let query = Query::user(application_id, query)?;
         let QueryOutcome { response } = self
             .client
@@ -2212,7 +2212,10 @@ where
             .query_application(self.chain_id, query)
             .await?;
         match response {
-            QueryResponse::User(response) => Ok(serde_json::from_slice(&response)?),
+            QueryResponse::User(response_bytes) => {
+                let response = serde_json::from_slice(&response_bytes)?;
+                Ok(QueryOutcome { response })
+            }
             _ => Err(ChainClientError::InternalError(
                 "Unexpected response for user query",
             )),

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -58,8 +58,8 @@ use linera_execution::{
         AdminOperation, OpenChainConfig, Recipient, SystemChannel, SystemOperation,
         CREATE_APPLICATION_MESSAGE_INDEX, OPEN_CHAIN_MESSAGE_INDEX,
     },
-    ExecutionError, Operation, Query, QueryResponse, SystemExecutionError, SystemQuery,
-    SystemResponse,
+    ExecutionError, Operation, Query, QueryOutcome, QueryResponse, SystemExecutionError,
+    SystemQuery, SystemResponse,
 };
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::ViewError;
@@ -2171,7 +2171,7 @@ where
     /// Queries an application.
     #[instrument(level = "trace", skip(query))]
     pub async fn query_application(&self, query: Query) -> Result<QueryResponse, ChainClientError> {
-        let response = self
+        let QueryOutcome { response } = self
             .client
             .local_node
             .query_application(self.chain_id, query)
@@ -2185,7 +2185,7 @@ where
         &self,
         query: SystemQuery,
     ) -> Result<SystemResponse, ChainClientError> {
-        let response = self
+        let QueryOutcome { response } = self
             .client
             .local_node
             .query_application(self.chain_id, Query::System(query))
@@ -2206,7 +2206,7 @@ where
         query: &A::Query,
     ) -> Result<A::QueryResponse, ChainClientError> {
         let query = Query::user(application_id, query)?;
-        let response = self
+        let QueryOutcome { response } = self
             .client
             .local_node
             .query_application(self.chain_id, query)

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -58,7 +58,8 @@ use linera_execution::{
         AdminOperation, OpenChainConfig, Recipient, SystemChannel, SystemOperation,
         CREATE_APPLICATION_MESSAGE_INDEX, OPEN_CHAIN_MESSAGE_INDEX,
     },
-    ExecutionError, Operation, Query, Response, SystemExecutionError, SystemQuery, SystemResponse,
+    ExecutionError, Operation, Query, QueryResponse, SystemExecutionError, SystemQuery,
+    SystemResponse,
 };
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::ViewError;
@@ -2169,7 +2170,7 @@ where
 
     /// Queries an application.
     #[instrument(level = "trace", skip(query))]
-    pub async fn query_application(&self, query: Query) -> Result<Response, ChainClientError> {
+    pub async fn query_application(&self, query: Query) -> Result<QueryResponse, ChainClientError> {
         let response = self
             .client
             .local_node
@@ -2190,7 +2191,7 @@ where
             .query_application(self.chain_id, Query::System(query))
             .await?;
         match response {
-            Response::System(response) => Ok(response),
+            QueryResponse::System(response) => Ok(response),
             _ => Err(ChainClientError::InternalError(
                 "Unexpected response for system query",
             )),
@@ -2211,7 +2212,7 @@ where
             .query_application(self.chain_id, query)
             .await?;
         match response {
-            Response::User(response) => Ok(serde_json::from_slice(&response)?),
+            QueryResponse::User(response) => Ok(serde_json::from_slice(&response)?),
             _ => Err(ChainClientError::InternalError(
                 "Unexpected response for user query",
             )),

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2170,13 +2170,13 @@ where
 
     /// Queries an application.
     #[instrument(level = "trace", skip(query))]
-    pub async fn query_application(&self, query: Query) -> Result<QueryResponse, ChainClientError> {
-        let QueryOutcome { response } = self
+    pub async fn query_application(&self, query: Query) -> Result<QueryOutcome, ChainClientError> {
+        let outcome = self
             .client
             .local_node
             .query_application(self.chain_id, query)
             .await?;
-        Ok(response)
+        Ok(outcome)
     }
 
     /// Queries a system application.

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -17,7 +17,7 @@ use linera_chain::{
     types::{ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
     ChainStateView,
 };
-use linera_execution::{committee::ValidatorName, Query, QueryResponse};
+use linera_execution::{committee::ValidatorName, Query, QueryOutcome, QueryResponse};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
 use thiserror::Error;
@@ -252,7 +252,7 @@ where
         chain_id: ChainId,
         query: Query,
     ) -> Result<QueryResponse, LocalNodeError> {
-        let response = self.node.state.query_application(chain_id, query).await?;
+        let QueryOutcome { response } = self.node.state.query_application(chain_id, query).await?;
         Ok(response)
     }
 

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -17,7 +17,7 @@ use linera_chain::{
     types::{ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
     ChainStateView,
 };
-use linera_execution::{committee::ValidatorName, Query, QueryOutcome, QueryResponse};
+use linera_execution::{committee::ValidatorName, Query, QueryOutcome};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
 use thiserror::Error;
@@ -251,9 +251,9 @@ where
         &self,
         chain_id: ChainId,
         query: Query,
-    ) -> Result<QueryResponse, LocalNodeError> {
-        let QueryOutcome { response } = self.node.state.query_application(chain_id, query).await?;
-        Ok(response)
+    ) -> Result<QueryOutcome, LocalNodeError> {
+        let outcome = self.node.state.query_application(chain_id, query).await?;
+        Ok(outcome)
     }
 
     #[instrument(level = "trace", skip(self))]

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -17,7 +17,7 @@ use linera_chain::{
     types::{ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
     ChainStateView,
 };
-use linera_execution::{committee::ValidatorName, Query, Response};
+use linera_execution::{committee::ValidatorName, Query, QueryResponse};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
 use thiserror::Error;
@@ -251,7 +251,7 @@ where
         &self,
         chain_id: ChainId,
         query: Query,
-    ) -> Result<Response, LocalNodeError> {
+    ) -> Result<QueryResponse, LocalNodeError> {
         let response = self.node.state.query_application(chain_id, query).await?;
         Ok(response)
     }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -867,7 +867,8 @@ where
             response: SystemResponse {
                 chain_id: client1.chain_id(),
                 balance: Amount::from_tokens(3),
-            }
+            },
+            operations: vec![],
         }
     );
     let certificate = client1
@@ -889,8 +890,9 @@ where
             response: SystemResponse {
                 chain_id: client1.chain_id(),
                 balance: Amount::ZERO,
-            }
-        }
+            },
+            operations: vec![],
+        },
     );
 
     assert_eq!(
@@ -911,8 +913,9 @@ where
             response: SystemResponse {
                 chain_id: client2.chain_id(),
                 balance: Amount::from_tokens(0),
-            }
-        }
+            },
+            operations: vec![],
+        },
     );
 
     // Process the inbox and send back some money.
@@ -937,8 +940,9 @@ where
             response: SystemResponse {
                 chain_id: client2.chain_id(),
                 balance: Amount::from_tokens(2),
-            }
-        }
+            },
+            operations: vec![],
+        },
     );
     Ok(())
 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -22,8 +22,8 @@ use linera_chain::{
 use linera_execution::{
     committee::{Committee, Epoch},
     system::{Recipient, SystemOperation},
-    ExecutionError, Message, MessageKind, Operation, ResourceControlPolicy, SystemExecutionError,
-    SystemMessage, SystemQuery, SystemResponse,
+    ExecutionError, Message, MessageKind, Operation, QueryOutcome, ResourceControlPolicy,
+    SystemExecutionError, SystemMessage, SystemQuery, SystemResponse,
 };
 use linera_storage::{DbStorage, TestClock};
 use linera_views::memory::MemoryStore;
@@ -863,9 +863,11 @@ where
     );
     assert_eq!(
         client1.query_system_application(SystemQuery).await.unwrap(),
-        SystemResponse {
-            chain_id: client1.chain_id(),
-            balance: Amount::from_tokens(3),
+        QueryOutcome {
+            response: SystemResponse {
+                chain_id: client1.chain_id(),
+                balance: Amount::from_tokens(3),
+            }
         }
     );
     let certificate = client1
@@ -883,9 +885,11 @@ where
     assert_eq!(client1.local_balance().await.unwrap(), Amount::ZERO);
     assert_eq!(
         client1.query_system_application(SystemQuery).await.unwrap(),
-        SystemResponse {
-            chain_id: client1.chain_id(),
-            balance: Amount::ZERO,
+        QueryOutcome {
+            response: SystemResponse {
+                chain_id: client1.chain_id(),
+                balance: Amount::ZERO,
+            }
         }
     );
 
@@ -903,9 +907,11 @@ where
     assert_eq!(client2.local_balance().await.unwrap(), Amount::ZERO);
     assert_eq!(
         client2.query_system_application(SystemQuery).await.unwrap(),
-        SystemResponse {
-            chain_id: client2.chain_id(),
-            balance: Amount::from_tokens(0),
+        QueryOutcome {
+            response: SystemResponse {
+                chain_id: client2.chain_id(),
+                balance: Amount::from_tokens(0),
+            }
         }
     );
 
@@ -927,9 +933,11 @@ where
     // Local balance from client2 is now consolidated.
     assert_eq!(
         client2.query_system_application(SystemQuery).await.unwrap(),
-        SystemResponse {
-            chain_id: client2.chain_id(),
-            balance: Amount::from_tokens(2),
+        QueryOutcome {
+            response: SystemResponse {
+                chain_id: client2.chain_id(),
+                balance: Amount::from_tokens(2),
+            }
         }
     );
     Ok(())

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -25,7 +25,8 @@ use linera_base::{
 };
 use linera_chain::data_types::{EventRecord, MessageAction, OutgoingMessage};
 use linera_execution::{
-    Message, MessageKind, Operation, ResourceControlPolicy, SystemMessage, WasmRuntime,
+    Message, MessageKind, Operation, QueryOutcome, ResourceControlPolicy, SystemMessage,
+    WasmRuntime,
 };
 use serde_json::json;
 use test_case::test_case;
@@ -137,7 +138,7 @@ where
         .unwrap();
 
     let query = Request::new("{ value }");
-    let response = creator
+    let QueryOutcome { response } = creator
         .query_user_application(application_id, &query)
         .await
         .unwrap();
@@ -361,7 +362,7 @@ where
     receiver.process_inbox().await.unwrap();
 
     let query = Request::new("{ value }");
-    let response = receiver
+    let QueryOutcome { response } = receiver
         .query_user_application(application_id2, &query)
         .await
         .unwrap();
@@ -779,7 +780,7 @@ where
         .any(|msg| matches!(&msg.bundle.messages[0].message, Message::User { .. })));
 
     let query = async_graphql::Request::new("{ receivedPosts { keys { author, index } } }");
-    let posts = receiver
+    let QueryOutcome { response: posts } = receiver
         .query_user_application(application_id, &query)
         .await?;
     let expected = async_graphql::Response::new(
@@ -833,7 +834,7 @@ where
 
     // There is still only one post it can see.
     let query = async_graphql::Request::new("{ receivedPosts { keys { author, index } } }");
-    let posts = receiver
+    let QueryOutcome { response: posts } = receiver
         .query_user_application(application_id, &query)
         .await
         .unwrap();

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -138,16 +138,19 @@ where
         .unwrap();
 
     let query = Request::new("{ value }");
-    let QueryOutcome { response } = creator
+    let outcome = creator
         .query_user_application(application_id, &query)
         .await
         .unwrap();
 
-    let expected = async_graphql::Response::new(
-        async_graphql::Value::from_json(json!({"value": 15})).unwrap(),
-    );
+    let expected = QueryOutcome {
+        response: async_graphql::Response::new(
+            async_graphql::Value::from_json(json!({"value": 15})).unwrap(),
+        ),
+        operations: vec![],
+    };
 
-    assert_eq!(expected, response);
+    assert_eq!(outcome, expected);
     // Creating the application used fuel because of the `instantiate` call.
     let balance_after_init = creator.local_balance().await?;
     assert!(balance_after_init < balance_after_messaging);
@@ -362,15 +365,19 @@ where
     receiver.process_inbox().await.unwrap();
 
     let query = Request::new("{ value }");
-    let QueryOutcome { response } = receiver
+    let outcome = receiver
         .query_user_application(application_id2, &query)
         .await
         .unwrap();
 
-    let expected =
-        async_graphql::Response::new(async_graphql::Value::from_json(json!({"value": 5})).unwrap());
+    let expected = QueryOutcome {
+        response: async_graphql::Response::new(
+            async_graphql::Value::from_json(json!({"value": 5})).unwrap(),
+        ),
+        operations: vec![],
+    };
 
-    assert_eq!(expected, response);
+    assert_eq!(outcome, expected);
 
     // Try again with a value that will make the (untracked) message fail.
     let operation = meta_counter::Operation::fail(receiver_id);
@@ -780,20 +787,23 @@ where
         .any(|msg| matches!(&msg.bundle.messages[0].message, Message::User { .. })));
 
     let query = async_graphql::Request::new("{ receivedPosts { keys { author, index } } }");
-    let QueryOutcome { response: posts } = receiver
+    let outcome = receiver
         .query_user_application(application_id, &query)
         .await?;
-    let expected = async_graphql::Response::new(
-        async_graphql::Value::from_json(json!({
-            "receivedPosts": {
-                "keys": [
-                    { "author": sender.chain_id, "index": 0 }
-                ]
-            }
-        }))
-        .unwrap(),
-    );
-    assert_eq!(posts, expected);
+    let expected = QueryOutcome {
+        response: async_graphql::Response::new(
+            async_graphql::Value::from_json(json!({
+                "receivedPosts": {
+                    "keys": [
+                        { "author": sender.chain_id, "index": 0 }
+                    ]
+                }
+            }))
+            .unwrap(),
+        ),
+        operations: vec![],
+    };
+    assert_eq!(outcome, expected);
 
     // Request to unsubscribe from the sender.
     let request_unsubscribe = social::Operation::Unsubscribe {
@@ -834,19 +844,22 @@ where
 
     // There is still only one post it can see.
     let query = async_graphql::Request::new("{ receivedPosts { keys { author, index } } }");
-    let QueryOutcome { response: posts } = receiver
+    let outcome = receiver
         .query_user_application(application_id, &query)
         .await
         .unwrap();
-    let expected = async_graphql::Response::new(
-        async_graphql::Value::from_json(json!({
-            "receivedPosts": {
-                "keys": [ { "author": sender.chain_id, "index": 0 } ]
-            }
-        }))
-        .unwrap(),
-    );
-    assert_eq!(posts, expected);
+    let expected = QueryOutcome {
+        response: async_graphql::Response::new(
+            async_graphql::Value::from_json(json!({
+                "receivedPosts": {
+                    "keys": [ { "author": sender.chain_id, "index": 0 } ]
+                }
+            }))
+            .unwrap(),
+        ),
+        operations: vec![],
+    };
+    assert_eq!(outcome, expected);
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -46,8 +46,8 @@ use linera_execution::{
         AdminOperation, OpenChainConfig, Recipient, SystemChannel, SystemMessage, SystemOperation,
     },
     test_utils::{ExpectedCall, RegisterMockApplication, SystemExecutionState},
-    ChannelSubscription, ExecutionError, Message, MessageKind, Query, QueryContext, QueryResponse,
-    SystemExecutionError, SystemQuery, SystemResponse,
+    ChannelSubscription, ExecutionError, Message, MessageKind, Query, QueryContext, QueryOutcome,
+    QueryResponse, SystemExecutionError, SystemQuery, SystemResponse,
 };
 use linera_storage::{DbStorage, Storage, TestClock};
 use linera_views::{
@@ -1907,19 +1907,23 @@ where
         worker
             .query_application(ChainId::root(1), Query::System(SystemQuery))
             .await?,
-        QueryResponse::System(SystemResponse {
-            chain_id: ChainId::root(1),
-            balance: Amount::from_tokens(5),
-        })
+        QueryOutcome {
+            response: QueryResponse::System(SystemResponse {
+                chain_id: ChainId::root(1),
+                balance: Amount::from_tokens(5),
+            })
+        }
     );
     assert_eq!(
         worker
             .query_application(ChainId::root(2), Query::System(SystemQuery))
             .await?,
-        QueryResponse::System(SystemResponse {
-            chain_id: ChainId::root(2),
-            balance: Amount::ZERO,
-        })
+        QueryOutcome {
+            response: QueryResponse::System(SystemResponse {
+                chain_id: ChainId::root(2),
+                balance: Amount::ZERO,
+            })
+        }
     );
 
     let certificate = make_simple_transfer_certificate(
@@ -1948,10 +1952,12 @@ where
         worker
             .query_application(ChainId::root(1), Query::System(SystemQuery))
             .await?,
-        QueryResponse::System(SystemResponse {
-            chain_id: ChainId::root(1),
-            balance: Amount::ZERO,
-        })
+        QueryOutcome {
+            response: QueryResponse::System(SystemResponse {
+                chain_id: ChainId::root(1),
+                balance: Amount::ZERO,
+            })
+        }
     );
 
     // Try to use the money. This requires selecting the incoming message in a next block.
@@ -1986,10 +1992,12 @@ where
         worker
             .query_application(ChainId::root(2), Query::System(SystemQuery))
             .await?,
-        QueryResponse::System(SystemResponse {
-            chain_id: ChainId::root(2),
-            balance: Amount::from_tokens(4),
-        })
+        QueryOutcome {
+            response: QueryResponse::System(SystemResponse {
+                chain_id: ChainId::root(2),
+                balance: Amount::from_tokens(4),
+            })
+        }
     );
 
     {
@@ -3818,7 +3826,9 @@ where
 
         assert_eq!(
             worker.query_application(chain_id, query.clone()).await?,
-            QueryResponse::User(vec![])
+            QueryOutcome {
+                response: QueryResponse::User(vec![])
+            }
         );
     }
 
@@ -3925,7 +3935,9 @@ where
 
         assert_eq!(
             worker.query_application(chain_id, query.clone()).await?,
-            QueryResponse::User(vec![])
+            QueryOutcome {
+                response: QueryResponse::User(vec![])
+            }
         );
     }
 
@@ -3940,7 +3952,9 @@ where
 
         assert_eq!(
             worker.query_application(chain_id, query.clone()).await?,
-            QueryResponse::User(vec![])
+            QueryOutcome {
+                response: QueryResponse::User(vec![])
+            }
         );
     }
 
@@ -3986,7 +4000,9 @@ where
 
         assert_eq!(
             worker.query_application(chain_id, query.clone()).await?,
-            QueryResponse::User(vec![])
+            QueryOutcome {
+                response: QueryResponse::User(vec![])
+            }
         );
     }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -1911,7 +1911,8 @@ where
             response: QueryResponse::System(SystemResponse {
                 chain_id: ChainId::root(1),
                 balance: Amount::from_tokens(5),
-            })
+            }),
+            operations: vec![],
         }
     );
     assert_eq!(
@@ -1922,7 +1923,8 @@ where
             response: QueryResponse::System(SystemResponse {
                 chain_id: ChainId::root(2),
                 balance: Amount::ZERO,
-            })
+            }),
+            operations: vec![],
         }
     );
 
@@ -1956,7 +1958,8 @@ where
             response: QueryResponse::System(SystemResponse {
                 chain_id: ChainId::root(1),
                 balance: Amount::ZERO,
-            })
+            }),
+            operations: vec![],
         }
     );
 
@@ -1996,7 +1999,8 @@ where
             response: QueryResponse::System(SystemResponse {
                 chain_id: ChainId::root(2),
                 balance: Amount::from_tokens(4),
-            })
+            }),
+            operations: vec![],
         }
     );
 
@@ -3827,7 +3831,8 @@ where
         assert_eq!(
             worker.query_application(chain_id, query.clone()).await?,
             QueryOutcome {
-                response: QueryResponse::User(vec![])
+                response: QueryResponse::User(vec![]),
+                operations: vec![],
             }
         );
     }
@@ -3936,7 +3941,8 @@ where
         assert_eq!(
             worker.query_application(chain_id, query.clone()).await?,
             QueryOutcome {
-                response: QueryResponse::User(vec![])
+                response: QueryResponse::User(vec![]),
+                operations: vec![],
             }
         );
     }
@@ -3953,7 +3959,8 @@ where
         assert_eq!(
             worker.query_application(chain_id, query.clone()).await?,
             QueryOutcome {
-                response: QueryResponse::User(vec![])
+                response: QueryResponse::User(vec![]),
+                operations: vec![],
             }
         );
     }
@@ -4001,7 +4008,8 @@ where
         assert_eq!(
             worker.query_application(chain_id, query.clone()).await?,
             QueryOutcome {
-                response: QueryResponse::User(vec![])
+                response: QueryResponse::User(vec![]),
+                operations: vec![],
             }
         );
     }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -46,7 +46,7 @@ use linera_execution::{
         AdminOperation, OpenChainConfig, Recipient, SystemChannel, SystemMessage, SystemOperation,
     },
     test_utils::{ExpectedCall, RegisterMockApplication, SystemExecutionState},
-    ChannelSubscription, ExecutionError, Message, MessageKind, Query, QueryContext, Response,
+    ChannelSubscription, ExecutionError, Message, MessageKind, Query, QueryContext, QueryResponse,
     SystemExecutionError, SystemQuery, SystemResponse,
 };
 use linera_storage::{DbStorage, Storage, TestClock};
@@ -1907,7 +1907,7 @@ where
         worker
             .query_application(ChainId::root(1), Query::System(SystemQuery))
             .await?,
-        Response::System(SystemResponse {
+        QueryResponse::System(SystemResponse {
             chain_id: ChainId::root(1),
             balance: Amount::from_tokens(5),
         })
@@ -1916,7 +1916,7 @@ where
         worker
             .query_application(ChainId::root(2), Query::System(SystemQuery))
             .await?,
-        Response::System(SystemResponse {
+        QueryResponse::System(SystemResponse {
             chain_id: ChainId::root(2),
             balance: Amount::ZERO,
         })
@@ -1948,7 +1948,7 @@ where
         worker
             .query_application(ChainId::root(1), Query::System(SystemQuery))
             .await?,
-        Response::System(SystemResponse {
+        QueryResponse::System(SystemResponse {
             chain_id: ChainId::root(1),
             balance: Amount::ZERO,
         })
@@ -1986,7 +1986,7 @@ where
         worker
             .query_application(ChainId::root(2), Query::System(SystemQuery))
             .await?,
-        Response::System(SystemResponse {
+        QueryResponse::System(SystemResponse {
             chain_id: ChainId::root(2),
             balance: Amount::from_tokens(4),
         })
@@ -3818,7 +3818,7 @@ where
 
         assert_eq!(
             worker.query_application(chain_id, query.clone()).await?,
-            Response::User(vec![])
+            QueryResponse::User(vec![])
         );
     }
 
@@ -3925,7 +3925,7 @@ where
 
         assert_eq!(
             worker.query_application(chain_id, query.clone()).await?,
-            Response::User(vec![])
+            QueryResponse::User(vec![])
         );
     }
 
@@ -3940,7 +3940,7 @@ where
 
         assert_eq!(
             worker.query_application(chain_id, query.clone()).await?,
-            Response::User(vec![])
+            QueryResponse::User(vec![])
         );
     }
 
@@ -3986,7 +3986,7 @@ where
 
         assert_eq!(
             worker.query_application(chain_id, query.clone()).await?,
-            Response::User(vec![])
+            QueryResponse::User(vec![])
         );
     }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -35,7 +35,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Epoch, ValidatorName},
-    ExecutionError, Query, QueryOutcome, QueryResponse,
+    ExecutionError, Query, QueryOutcome,
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;
@@ -523,12 +523,11 @@ where
         &self,
         chain_id: ChainId,
         query: Query,
-    ) -> Result<QueryResponse, WorkerError> {
+    ) -> Result<QueryOutcome, WorkerError> {
         self.query_chain_worker(chain_id, move |callback| {
             ChainWorkerRequest::QueryApplication { query, callback }
         })
         .await
-        .map(|QueryOutcome { response }| response)
     }
 
     #[instrument(level = "trace", skip(self, chain_id, application_id))]

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -35,7 +35,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Epoch, ValidatorName},
-    ExecutionError, Query, Response,
+    ExecutionError, Query, QueryResponse,
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;
@@ -523,7 +523,7 @@ where
         &self,
         chain_id: ChainId,
         query: Query,
-    ) -> Result<Response, WorkerError> {
+    ) -> Result<QueryResponse, WorkerError> {
         self.query_chain_worker(chain_id, move |callback| {
             ChainWorkerRequest::QueryApplication { query, callback }
         })

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -35,7 +35,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Epoch, ValidatorName},
-    ExecutionError, Query, QueryResponse,
+    ExecutionError, Query, QueryOutcome, QueryResponse,
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;
@@ -528,6 +528,7 @@ where
             ChainWorkerRequest::QueryApplication { query, callback }
         })
         .await
+        .map(|QueryOutcome { response }| response)
     }
 
     #[instrument(level = "trace", skip(self, chain_id, application_id))]

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -32,9 +32,9 @@ use super::{runtime::ServiceRuntimeRequest, ExecutionRequest};
 use crate::{
     resources::ResourceController, system::SystemExecutionStateView, ContractSyncRuntime,
     ExecutionError, ExecutionOutcome, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message,
-    MessageContext, MessageKind, Operation, OperationContext, Query, QueryContext, QueryResponse,
-    RawExecutionOutcome, RawOutgoingMessage, ServiceSyncRuntime, SystemMessage, TransactionTracker,
-    UserApplicationDescription, UserApplicationId,
+    MessageContext, MessageKind, Operation, OperationContext, Query, QueryContext, QueryOutcome,
+    QueryResponse, RawExecutionOutcome, RawOutgoingMessage, ServiceSyncRuntime, SystemMessage,
+    TransactionTracker, UserApplicationDescription, UserApplicationId,
 };
 
 /// A view accessing the execution state of a chain.
@@ -489,7 +489,7 @@ where
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         match query {
             Query::System(query) => {
-                let response = self.system.handle_query(context, query).await?;
+                let QueryOutcome { response } = self.system.handle_query(context, query).await?;
                 Ok(QueryResponse::System(response))
             }
             Query::User {

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -33,8 +33,8 @@ use crate::{
     resources::ResourceController, system::SystemExecutionStateView, ContractSyncRuntime,
     ExecutionError, ExecutionOutcome, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message,
     MessageContext, MessageKind, Operation, OperationContext, Query, QueryContext, QueryOutcome,
-    QueryResponse, RawExecutionOutcome, RawOutgoingMessage, ServiceSyncRuntime, SystemMessage,
-    TransactionTracker, UserApplicationDescription, UserApplicationId,
+    RawExecutionOutcome, RawOutgoingMessage, ServiceSyncRuntime, SystemMessage, TransactionTracker,
+    UserApplicationDescription, UserApplicationId,
 };
 
 /// A view accessing the execution state of a chain.
@@ -485,19 +485,19 @@ where
         context: QueryContext,
         query: Query,
         endpoint: Option<&mut ServiceRuntimeEndpoint>,
-    ) -> Result<QueryResponse, ExecutionError> {
+    ) -> Result<QueryOutcome, ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         match query {
             Query::System(query) => {
-                let QueryOutcome { response } = self.system.handle_query(context, query).await?;
-                Ok(QueryResponse::System(response))
+                let outcome = self.system.handle_query(context, query).await?;
+                Ok(outcome.into())
             }
             Query::User {
                 application_id,
                 bytes,
             } => {
                 let ExecutionRuntimeConfig {} = self.context().extra().execution_runtime_config();
-                let QueryOutcome { response } = match endpoint {
+                let outcome = match endpoint {
                     Some(endpoint) => {
                         self.query_user_application_with_long_lived_service(
                             application_id,
@@ -513,7 +513,7 @@ where
                             .await?
                     }
                 };
-                Ok(QueryResponse::User(response))
+                Ok(outcome.into())
             }
         }
     }

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -32,9 +32,9 @@ use super::{runtime::ServiceRuntimeRequest, ExecutionRequest};
 use crate::{
     resources::ResourceController, system::SystemExecutionStateView, ContractSyncRuntime,
     ExecutionError, ExecutionOutcome, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message,
-    MessageContext, MessageKind, Operation, OperationContext, Query, QueryContext,
-    RawExecutionOutcome, RawOutgoingMessage, Response, ServiceSyncRuntime, SystemMessage,
-    TransactionTracker, UserApplicationDescription, UserApplicationId,
+    MessageContext, MessageKind, Operation, OperationContext, Query, QueryContext, QueryResponse,
+    RawExecutionOutcome, RawOutgoingMessage, ServiceSyncRuntime, SystemMessage, TransactionTracker,
+    UserApplicationDescription, UserApplicationId,
 };
 
 /// A view accessing the execution state of a chain.
@@ -485,12 +485,12 @@ where
         context: QueryContext,
         query: Query,
         endpoint: Option<&mut ServiceRuntimeEndpoint>,
-    ) -> Result<Response, ExecutionError> {
+    ) -> Result<QueryResponse, ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         match query {
             Query::System(query) => {
                 let response = self.system.handle_query(context, query).await?;
-                Ok(Response::System(response))
+                Ok(QueryResponse::System(response))
             }
             Query::User {
                 application_id,
@@ -513,7 +513,7 @@ where
                             .await?
                     }
                 };
-                Ok(Response::User(response))
+                Ok(QueryResponse::User(response))
             }
         }
     }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -641,6 +641,9 @@ pub trait ServiceRuntime: BaseRuntime {
 
     /// Fetches blob of bytes from an arbitrary URL.
     fn fetch_url(&mut self, url: &str) -> Result<Vec<u8>, ExecutionError>;
+
+    /// Schedules an operation to be included in the block proposed after execution.
+    fn schedule_operation(&mut self, operation: Vec<u8>) -> Result<(), ExecutionError>;
 }
 
 pub trait ContractRuntime: BaseRuntime {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -785,7 +785,7 @@ pub enum Query {
 
 /// The response to a query.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
-pub enum Response {
+pub enum QueryResponse {
     /// A system response.
     System(SystemResponse),
     /// A user response (in serialized form).
@@ -1247,15 +1247,15 @@ impl Query {
     }
 }
 
-impl From<SystemResponse> for Response {
+impl From<SystemResponse> for QueryResponse {
     fn from(response: SystemResponse) -> Self {
-        Response::System(response)
+        QueryResponse::System(response)
     }
 }
 
-impl From<Vec<u8>> for Response {
+impl From<Vec<u8>> for QueryResponse {
     fn from(response: Vec<u8>) -> Self {
-        Response::User(response)
+        QueryResponse::User(response)
     }
 }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -783,6 +783,32 @@ pub enum Query {
     },
 }
 
+/// The outcome of the execution of a query.
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub struct QueryOutcome<Response = QueryResponse> {
+    pub response: Response,
+}
+
+impl From<QueryOutcome<SystemResponse>> for QueryOutcome {
+    fn from(system_outcome: QueryOutcome<SystemResponse>) -> Self {
+        let QueryOutcome { response } = system_outcome;
+
+        QueryOutcome {
+            response: QueryResponse::System(response),
+        }
+    }
+}
+
+impl From<QueryOutcome<Vec<u8>>> for QueryOutcome {
+    fn from(user_service_outcome: QueryOutcome<Vec<u8>>) -> Self {
+        let QueryOutcome { response } = user_service_outcome;
+
+        QueryOutcome {
+            response: QueryResponse::User(response),
+        }
+    }
+}
+
 /// The response to a query.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub enum QueryResponse {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -787,24 +787,33 @@ pub enum Query {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct QueryOutcome<Response = QueryResponse> {
     pub response: Response,
+    pub operations: Vec<Operation>,
 }
 
 impl From<QueryOutcome<SystemResponse>> for QueryOutcome {
     fn from(system_outcome: QueryOutcome<SystemResponse>) -> Self {
-        let QueryOutcome { response } = system_outcome;
+        let QueryOutcome {
+            response,
+            operations,
+        } = system_outcome;
 
         QueryOutcome {
             response: QueryResponse::System(response),
+            operations,
         }
     }
 }
 
 impl From<QueryOutcome<Vec<u8>>> for QueryOutcome {
     fn from(user_service_outcome: QueryOutcome<Vec<u8>>) -> Self {
-        let QueryOutcome { response } = user_service_outcome;
+        let QueryOutcome {
+            response,
+            operations,
+        } = user_service_outcome;
 
         QueryOutcome {
             response: QueryResponse::User(response),
+            operations,
         }
     }
 }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1691,6 +1691,18 @@ impl ServiceRuntime for ServiceSyncRuntimeHandle {
             .send_request(|callback| ExecutionRequest::FetchUrl { url, callback })?
             .recv_response()
     }
+
+    fn schedule_operation(&mut self, operation: Vec<u8>) -> Result<(), ExecutionError> {
+        let mut this = self.inner();
+        let application_id = this.application_id()?;
+
+        this.scheduled_operations.push(Operation::User {
+            application_id,
+            bytes: operation,
+        });
+
+        Ok(())
+    }
 }
 
 /// A request to the service runtime actor.

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -975,7 +975,10 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
                 let sender = self.execution_state_sender.clone();
                 let outcome =
                     ServiceSyncRuntime::new(sender, context).run_query(application_id, query)?;
-                let QueryOutcome { response } = outcome;
+                let QueryOutcome {
+                    response,
+                    operations: _,
+                } = outcome;
                 response
             };
         self.transaction_tracker
@@ -1627,7 +1630,10 @@ impl ServiceSyncRuntime {
             .handle_mut()
             .try_query_application(application_id, query)?;
 
-        Ok(QueryOutcome { response })
+        Ok(QueryOutcome {
+            response,
+            operations: vec![],
+        })
     }
 
     /// Obtains the [`SyncRuntimeHandle`] stored in this [`ServiceSyncRuntime`].

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -32,7 +32,7 @@ use crate::{
     system::CreateApplicationResult,
     util::{ReceiverExt, UnboundedSenderExt},
     BaseRuntime, BytecodeId, ContractRuntime, ExecutionError, FinalizeContext, MessageContext,
-    OperationContext, QueryContext, QueryOutcome, RawExecutionOutcome, ServiceRuntime,
+    Operation, OperationContext, QueryContext, QueryOutcome, RawExecutionOutcome, ServiceRuntime,
     TransactionTracker, UserApplicationDescription, UserApplicationId, UserContractCode,
     UserContractInstance, UserServiceCode, UserServiceInstance, MAX_EVENT_KEY_LEN,
     MAX_STREAM_NAME_LEN,
@@ -95,6 +95,8 @@ pub struct SyncRuntimeInternal<UserInstance> {
     active_applications: HashSet<UserApplicationId>,
     /// The tracking information for this transaction.
     transaction_tracker: TransactionTracker,
+    /// The operations scheduled during this query.
+    scheduled_operations: Vec<Operation>,
 
     /// Track application states based on views.
     view_user_states: BTreeMap<UserApplicationId, ViewUserState>,
@@ -312,6 +314,7 @@ impl<UserInstance> SyncRuntimeInternal<UserInstance> {
             refund_grant_to,
             resource_controller,
             transaction_tracker,
+            scheduled_operations: Vec::new(),
         }
     }
 
@@ -973,12 +976,13 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
                     local_time: self.local_time,
                 };
                 let sender = self.execution_state_sender.clone();
-                let outcome =
-                    ServiceSyncRuntime::new(sender, context).run_query(application_id, query)?;
+
                 let QueryOutcome {
                     response,
-                    operations: _,
-                } = outcome;
+                    operations,
+                } = ServiceSyncRuntime::new(sender, context).run_query(application_id, query)?;
+
+                self.scheduled_operations.extend(operations);
                 response
             };
         self.transaction_tracker
@@ -1626,13 +1630,13 @@ impl ServiceSyncRuntime {
         application_id: UserApplicationId,
         query: Vec<u8>,
     ) -> Result<QueryOutcome<Vec<u8>>, ExecutionError> {
-        let response = self
-            .handle_mut()
-            .try_query_application(application_id, query)?;
+        let this = self.handle_mut();
+        let response = this.try_query_application(application_id, query)?;
+        let operations = mem::take(&mut this.inner().scheduled_operations);
 
         Ok(QueryOutcome {
             response,
-            operations: vec![],
+            operations,
         })
     }
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -46,8 +46,8 @@ use crate::{
     committee::{Committee, Epoch},
     ApplicationRegistryView, ChannelName, ChannelSubscription, Destination,
     ExecutionRuntimeContext, MessageContext, MessageKind, OperationContext, QueryContext,
-    RawExecutionOutcome, RawOutgoingMessage, TransactionTracker, UserApplicationDescription,
-    UserApplicationId,
+    QueryOutcome, RawExecutionOutcome, RawOutgoingMessage, TransactionTracker,
+    UserApplicationDescription, UserApplicationId,
 };
 
 /// The relative index of the `OpenChain` message created by the `OpenChain` operation.
@@ -942,12 +942,12 @@ where
         &mut self,
         context: QueryContext,
         _query: SystemQuery,
-    ) -> Result<SystemResponse, SystemExecutionError> {
+    ) -> Result<QueryOutcome<SystemResponse>, SystemExecutionError> {
         let response = SystemResponse {
             chain_id: context.chain_id,
             balance: *self.balance.get(),
         };
-        Ok(response)
+        Ok(QueryOutcome { response })
     }
 
     /// Returns the messages to open a new chain, and subtracts the new chain's balance

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -947,7 +947,10 @@ where
             chain_id: context.chain_id,
             balance: *self.balance.get(),
         };
-        Ok(QueryOutcome { response })
+        Ok(QueryOutcome {
+            response,
+            operations: vec![],
+        })
     }
 
     /// Returns the messages to open a new chain, and subtracts the new chain's balance

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -559,6 +559,15 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
+    /// Schedules an operation to be included in the block being built by this query.
+    fn schedule_operation(caller: &mut Caller, operation: Vec<u8>) -> Result<(), RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .schedule_operation(operation)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
     /// Queries another application.
     fn try_query_application(
         caller: &mut Caller,

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -27,9 +27,9 @@ use linera_execution::{
         SystemExecutionState,
     },
     BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome, ExecutionRuntimeContext,
-    Message, MessageKind, Operation, OperationContext, Query, QueryContext, QueryResponse,
-    RawExecutionOutcome, RawOutgoingMessage, ResourceControlPolicy, ResourceController,
-    SystemOperation, TransactionTracker,
+    Message, MessageKind, Operation, OperationContext, Query, QueryContext, QueryOutcome,
+    QueryResponse, RawExecutionOutcome, RawOutgoingMessage, ResourceControlPolicy,
+    ResourceController, SystemOperation, TransactionTracker,
 };
 use linera_views::{batch::Batch, context::Context, views::View};
 use test_case::test_case;
@@ -222,7 +222,9 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         )
         .await
         .unwrap(),
-        QueryResponse::User(dummy_operation.clone())
+        QueryOutcome {
+            response: QueryResponse::User(dummy_operation.clone())
+        }
     );
 
     assert_eq!(
@@ -236,7 +238,9 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         )
         .await
         .unwrap(),
-        QueryResponse::User(dummy_operation)
+        QueryOutcome {
+            response: QueryResponse::User(dummy_operation)
+        }
     );
     Ok(())
 }

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -27,9 +27,9 @@ use linera_execution::{
         SystemExecutionState,
     },
     BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome, ExecutionRuntimeContext,
-    Message, MessageKind, Operation, OperationContext, Query, QueryContext, RawExecutionOutcome,
-    RawOutgoingMessage, ResourceControlPolicy, ResourceController, Response, SystemOperation,
-    TransactionTracker,
+    Message, MessageKind, Operation, OperationContext, Query, QueryContext, QueryResponse,
+    RawExecutionOutcome, RawOutgoingMessage, ResourceControlPolicy, ResourceController,
+    SystemOperation, TransactionTracker,
 };
 use linera_views::{batch::Batch, context::Context, views::View};
 use test_case::test_case;
@@ -222,7 +222,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         )
         .await
         .unwrap(),
-        Response::User(dummy_operation.clone())
+        QueryResponse::User(dummy_operation.clone())
     );
 
     assert_eq!(
@@ -236,7 +236,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         )
         .await
         .unwrap(),
-        Response::User(dummy_operation)
+        QueryResponse::User(dummy_operation)
     );
     Ok(())
 }

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -223,7 +223,8 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         .await
         .unwrap(),
         QueryOutcome {
-            response: QueryResponse::User(dummy_operation.clone())
+            response: QueryResponse::User(dummy_operation.clone()),
+            operations: vec![],
         }
     );
 
@@ -239,7 +240,8 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         .await
         .unwrap(),
         QueryOutcome {
-            response: QueryResponse::User(dummy_operation)
+            response: QueryResponse::User(dummy_operation),
+            operations: vec![],
         }
     );
     Ok(())

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -11,9 +11,9 @@ use linera_base::{
 };
 use linera_execution::{
     system::Recipient, test_utils::SystemExecutionState, ExecutionOutcome, Message, MessageContext,
-    Operation, OperationContext, Query, QueryContext, QueryResponse, RawExecutionOutcome,
-    ResourceController, SystemMessage, SystemOperation, SystemQuery, SystemResponse,
-    TransactionTracker,
+    Operation, OperationContext, Query, QueryContext, QueryOutcome, QueryResponse,
+    RawExecutionOutcome, ResourceController, SystemMessage, SystemOperation, SystemQuery,
+    SystemResponse, TransactionTracker,
 };
 
 #[tokio::test]
@@ -127,7 +127,7 @@ async fn test_simple_system_query() -> anyhow::Result<()> {
         next_block_height: BlockHeight(0),
         local_time: Timestamp::from(0),
     };
-    let response = view
+    let QueryOutcome { response } = view
         .query_application(context, Query::System(SystemQuery), None)
         .await
         .unwrap();

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -11,8 +11,9 @@ use linera_base::{
 };
 use linera_execution::{
     system::Recipient, test_utils::SystemExecutionState, ExecutionOutcome, Message, MessageContext,
-    Operation, OperationContext, Query, QueryContext, RawExecutionOutcome, ResourceController,
-    Response, SystemMessage, SystemOperation, SystemQuery, SystemResponse, TransactionTracker,
+    Operation, OperationContext, Query, QueryContext, QueryResponse, RawExecutionOutcome,
+    ResourceController, SystemMessage, SystemOperation, SystemQuery, SystemResponse,
+    TransactionTracker,
 };
 
 #[tokio::test]
@@ -132,7 +133,7 @@ async fn test_simple_system_query() -> anyhow::Result<()> {
         .unwrap();
     assert_eq!(
         response,
-        Response::System(SystemResponse {
+        QueryResponse::System(SystemResponse {
             chain_id: ChainId::root(0),
             balance: Amount::from_tokens(4)
         })

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -127,7 +127,10 @@ async fn test_simple_system_query() -> anyhow::Result<()> {
         next_block_height: BlockHeight(0),
         local_time: Timestamp::from(0),
     };
-    let QueryOutcome { response } = view
+    let QueryOutcome {
+        response,
+        operations,
+    } = view
         .query_application(context, Query::System(SystemQuery), None)
         .await
         .unwrap();
@@ -138,5 +141,6 @@ async fn test_simple_system_query() -> anyhow::Result<()> {
             balance: Amount::from_tokens(4)
         })
     );
+    assert!(operations.is_empty());
     Ok(())
 }

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -12,7 +12,7 @@ use linera_base::{
 use linera_execution::{
     test_utils::{create_dummy_user_application_description, SystemExecutionState},
     ExecutionOutcome, ExecutionRuntimeConfig, ExecutionRuntimeContext, Operation, OperationContext,
-    Query, QueryContext, QueryResponse, RawExecutionOutcome, ResourceControlPolicy,
+    Query, QueryContext, QueryOutcome, QueryResponse, RawExecutionOutcome, ResourceControlPolicy,
     ResourceController, ResourceTracker, TransactionTracker, WasmContractModule, WasmRuntime,
     WasmServiceModule,
 };
@@ -135,13 +135,16 @@ async fn test_fuel_for_counter_wasm_application(
             .unwrap(),
     );
     let request = async_graphql::Request::new("query { value }");
-    let QueryResponse::User(serialized_value) = view
+    let outcome = view
         .query_application(
             context,
             Query::user_without_abi(app_id, &request).unwrap(),
             Some(&mut service_runtime_endpoint),
         )
-        .await?
+        .await?;
+    let QueryOutcome {
+        response: QueryResponse::User(serialized_value),
+    } = outcome
     else {
         panic!("unexpected response")
     };

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -12,8 +12,8 @@ use linera_base::{
 use linera_execution::{
     test_utils::{create_dummy_user_application_description, SystemExecutionState},
     ExecutionOutcome, ExecutionRuntimeConfig, ExecutionRuntimeContext, Operation, OperationContext,
-    Query, QueryContext, RawExecutionOutcome, ResourceControlPolicy, ResourceController,
-    ResourceTracker, Response, TransactionTracker, WasmContractModule, WasmRuntime,
+    Query, QueryContext, QueryResponse, RawExecutionOutcome, ResourceControlPolicy,
+    ResourceController, ResourceTracker, TransactionTracker, WasmContractModule, WasmRuntime,
     WasmServiceModule,
 };
 use linera_views::{context::Context as _, views::View};
@@ -135,7 +135,7 @@ async fn test_fuel_for_counter_wasm_application(
             .unwrap(),
     );
     let request = async_graphql::Request::new("query { value }");
-    let Response::User(serialized_value) = view
+    let QueryResponse::User(serialized_value) = view
         .query_application(
             context,
             Query::user_without_abi(app_id, &request).unwrap(),

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -144,6 +144,7 @@ async fn test_fuel_for_counter_wasm_application(
         .await?;
     let QueryOutcome {
         response: QueryResponse::User(serialized_value),
+        operations,
     } = outcome
     else {
         panic!("unexpected response")
@@ -152,5 +153,6 @@ async fn test_fuel_for_counter_wasm_application(
         serde_json::from_slice::<async_graphql::Response>(&serialized_value).unwrap(),
         expected_value
     );
+    assert!(operations.is_empty());
     Ok(())
 }

--- a/linera-sdk-derive/src/lib.rs
+++ b/linera-sdk-derive/src/lib.rs
@@ -80,22 +80,34 @@ fn generate_mutation_root_code(input: ItemEnum, crate_root: &str) -> TokenStream
 
     quote! {
         /// Mutation root
-        pub struct #mutation_root_name;
-
-        #[async_graphql::Object]
-        impl #mutation_root_name {
-            #
-
-            (#methods)
-
-            *
+        pub struct #mutation_root_name<Application>
+        where
+            Application: #crate_root::Service,
+            #crate_root::ServiceRuntime<Application>: Send + Sync,
+        {
+            runtime: ::std::sync::Arc<#crate_root::ServiceRuntime<Application>>,
         }
 
-        impl #crate_root::graphql::GraphQLMutationRoot for #enum_name {
-            type MutationRoot = #mutation_root_name;
+        #[async_graphql::Object]
+        impl<Application> #mutation_root_name<Application>
+        where
+            Application: #crate_root::Service,
+            #crate_root::ServiceRuntime<Application>: Send + Sync,
+        {
+            #(#methods)*
+        }
 
-            fn mutation_root() -> Self::MutationRoot {
-                #mutation_root_name
+        impl<Application> #crate_root::graphql::GraphQLMutationRoot<Application> for #enum_name
+        where
+            Application: #crate_root::Service,
+            #crate_root::ServiceRuntime<Application>: Send + Sync,
+        {
+            type MutationRoot = #mutation_root_name<Application>;
+
+            fn mutation_root(
+                runtime: ::std::sync::Arc<#crate_root::ServiceRuntime<Application>>,
+            ) -> Self::MutationRoot {
+                #mutation_root_name { runtime }
             }
         }
     }
@@ -134,10 +146,20 @@ pub mod tests {
 
         let expected = quote! {
             /// Mutation root
-            pub struct SomeOperationMutationRoot;
+            pub struct SomeOperationMutationRoot<Application>
+            where
+                Application: linera_sdk::Service,
+                linera_sdk::ServiceRuntime<Application>: Send + Sync,
+            {
+                runtime: ::std::sync::Arc<linera_sdk::ServiceRuntime<Application>>,
+            }
 
             #[async_graphql::Object]
-            impl SomeOperationMutationRoot {
+            impl<Application> SomeOperationMutationRoot<Application>
+            where
+                Application: linera_sdk::Service,
+                linera_sdk::ServiceRuntime<Application>: Send + Sync,
+            {
                 async fn tuple_variant(&self, field0: String,) -> Vec<u8> {
                     linera_sdk::bcs::to_bytes(&SomeOperation::TupleVariant(field0,)).unwrap()
                 }
@@ -149,11 +171,18 @@ pub mod tests {
                 }
             }
 
-            impl linera_sdk::graphql::GraphQLMutationRoot for SomeOperation {
-                type MutationRoot = SomeOperationMutationRoot;
+            impl<Application> linera_sdk::graphql::GraphQLMutationRoot<Application>
+                for SomeOperation
+            where
+                Application: linera_sdk::Service,
+                linera_sdk::ServiceRuntime<Application>: Send + Sync,
+            {
+                type MutationRoot = SomeOperationMutationRoot<Application>;
 
-                fn mutation_root() -> Self::MutationRoot {
-                    SomeOperationMutationRoot
+                fn mutation_root(
+                    runtime: ::std::sync::Arc<linera_sdk::ServiceRuntime<Application>>,
+                ) -> Self::MutationRoot {
+                    SomeOperationMutationRoot { runtime }
                 }
             }
         };

--- a/linera-sdk-derive/src/lib.rs
+++ b/linera-sdk-derive/src/lib.rs
@@ -46,13 +46,14 @@ fn generate_mutation_root_code(input: ItemEnum, crate_root: &str) -> TokenStream
                     field_names.push(name);
                 }
                 methods.push(quote! {
-                    async fn #function_name(&self, #(#fields,)*) -> Vec<u8> {
+                    async fn #function_name(&self, #(#fields,)*) -> [u8; 0] {
                         let operation = #enum_name::#variant_name {
                             #(#field_names,)*
                         };
 
                         self.runtime.schedule_operation(&operation);
-                        #crate_root::bcs::to_bytes(&operation).unwrap()
+
+                        []
                     }
                 });
             }
@@ -66,23 +67,25 @@ fn generate_mutation_root_code(input: ItemEnum, crate_root: &str) -> TokenStream
                     field_names.push(name);
                 }
                 methods.push(quote! {
-                    async fn #function_name(&self, #(#fields,)*) -> Vec<u8> {
+                    async fn #function_name(&self, #(#fields,)*) -> [u8; 0] {
                         let operation = #enum_name::#variant_name(
                             #(#field_names,)*
                         );
 
                         self.runtime.schedule_operation(&operation);
-                        #crate_root::bcs::to_bytes(&operation).unwrap()
+
+                        []
                     }
                 });
             }
             Fields::Unit => {
                 methods.push(quote! {
-                    async fn #function_name(&self) -> Vec<u8> {
+                    async fn #function_name(&self) -> [u8; 0] {
                         let operation = #enum_name::#variant_name;
 
                         self.runtime.schedule_operation(&operation);
-                        #crate_root::bcs::to_bytes(&operation).unwrap()
+
+                        []
                     }
                 });
             }
@@ -171,22 +174,22 @@ pub mod tests {
                 Application: linera_sdk::Service,
                 linera_sdk::ServiceRuntime<Application>: Send + Sync,
             {
-                async fn tuple_variant(&self, field0: String,) -> Vec<u8> {
+                async fn tuple_variant(&self, field0: String,) -> [u8; 0] {
                     let operation = SomeOperation::TupleVariant(field0,);
                     self.runtime.schedule_operation(&operation);
-                    linera_sdk::bcs::to_bytes(&operation).unwrap()
+                    []
                 }
 
-                async fn struct_variant(&self, a: u32, b: u64,) -> Vec<u8> {
+                async fn struct_variant(&self, a: u32, b: u64,) -> [u8; 0] {
                     let operation = SomeOperation::StructVariant { a, b, };
                     self.runtime.schedule_operation(&operation);
-                    linera_sdk::bcs::to_bytes(&operation).unwrap()
+                    []
                 }
 
-                async fn empty_variant(&self) -> Vec<u8> {
+                async fn empty_variant(&self) -> [u8; 0] {
                     let operation = SomeOperation::EmptyVariant;
                     self.runtime.schedule_operation(&operation);
-                    linera_sdk::bcs::to_bytes(&operation).unwrap()
+                    []
                 }
             }
 

--- a/linera-sdk/src/graphql.rs
+++ b/linera-sdk/src/graphql.rs
@@ -3,15 +3,22 @@
 
 //! GraphQL traits for generating interfaces into applications.
 
+use std::sync::Arc;
+
 /// Re-exports the derive macro for [`GraphQLMutationRoot`].
 pub use linera_sdk_derive::GraphQLMutationRoot;
 
+use crate::{Service, ServiceRuntime};
+
 /// An object associated with a GraphQL mutation root. Those are typically used to build
 /// an [`async_graphql::Schema`] object.
-pub trait GraphQLMutationRoot {
+pub trait GraphQLMutationRoot<Application>
+where
+    Application: Service,
+{
     /// The type of the mutation root.
     type MutationRoot: async_graphql::ObjectType;
 
     /// Returns the mutation root of the object.
-    fn mutation_root() -> Self::MutationRoot;
+    fn mutation_root(runtime: Arc<ServiceRuntime<Application>>) -> Self::MutationRoot;
 }

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -119,6 +119,13 @@ where
         })
     }
 
+    /// Schedules an operation to be included in the block being built.
+    ///
+    /// The operation is specified as an opaque blob of bytes.
+    pub fn schedule_raw_operation(&self, operation: Vec<u8>) {
+        wit::schedule_operation(&operation);
+    }
+
     /// Queries another application.
     pub fn query_application<A: ServiceAbi>(
         &self,

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -10,6 +10,7 @@ use linera_base::{
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{AccountOwner, ApplicationId, ChainId},
 };
+use serde::Serialize;
 
 use super::wit::service_system_api as wit;
 use crate::{DataBlobHash, KeyValueStore, Service, ViewStorageContext};
@@ -124,6 +125,15 @@ where
     /// The operation is specified as an opaque blob of bytes.
     pub fn schedule_raw_operation(&self, operation: Vec<u8>) {
         wit::schedule_operation(&operation);
+    }
+
+    /// Schedules an operation to be included in the block being built.
+    ///
+    /// The operation is serialized using BCS.
+    pub fn schedule_operation(&self, operation: &impl Serialize) {
+        let bytes = bcs::to_bytes(operation).expect("Failed to serialize application operation");
+
+        wit::schedule_operation(&bytes);
     }
 
     /// Queries another application.

--- a/linera-sdk/src/service/test_runtime.rs
+++ b/linera-sdk/src/service/test_runtime.rs
@@ -28,6 +28,7 @@ where
     query_application_handler: Mutex<Option<QueryApplicationHandler>>,
     url_blobs: Mutex<Option<HashMap<String, Vec<u8>>>>,
     blobs: Mutex<Option<HashMap<DataBlobHash, Vec<u8>>>>,
+    scheduled_operations: Mutex<Vec<Vec<u8>>>,
     key_value_store: KeyValueStore,
 }
 
@@ -57,6 +58,7 @@ where
             query_application_handler: Mutex::new(None),
             url_blobs: Mutex::new(None),
             blobs: Mutex::new(None),
+            scheduled_operations: Mutex::new(vec![]),
             key_value_store: KeyValueStore::mock(),
         }
     }
@@ -281,6 +283,13 @@ where
             .keys()
             .cloned()
             .collect()
+    }
+
+    /// Schedules an operation to be included in the block being built.
+    ///
+    /// The operation is specified as an opaque blob of bytes.
+    pub fn schedule_raw_operation(&self, operation: Vec<u8>) {
+        self.scheduled_operations.lock().unwrap().push(operation);
     }
 
     /// Configures the handler for application queries made during the test.

--- a/linera-sdk/src/service/test_runtime.rs
+++ b/linera-sdk/src/service/test_runtime.rs
@@ -10,6 +10,7 @@ use linera_base::{
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{AccountOwner, ApplicationId, ChainId},
 };
+use serde::Serialize;
 
 use crate::{DataBlobHash, KeyValueStore, Service, ViewStorageContext};
 
@@ -290,6 +291,15 @@ where
     /// The operation is specified as an opaque blob of bytes.
     pub fn schedule_raw_operation(&self, operation: Vec<u8>) {
         self.scheduled_operations.lock().unwrap().push(operation);
+    }
+
+    /// Schedules an operation to be included in the block being built.
+    ///
+    /// The operation is serialized using BCS.
+    pub fn schedule_operation(&self, operation: &impl Serialize) {
+        let bytes = bcs::to_bytes(operation).expect("Failed to serialize application operation");
+
+        self.schedule_raw_operation(bytes);
     }
 
     /// Configures the handler for application queries made during the test.

--- a/linera-sdk/src/service/test_runtime.rs
+++ b/linera-sdk/src/service/test_runtime.rs
@@ -3,7 +3,7 @@
 
 //! Runtime types to simulate interfacing with the host executing the service.
 
-use std::{collections::HashMap, sync::Mutex};
+use std::{collections::HashMap, mem, sync::Mutex};
 
 use linera_base::{
     abi::ServiceAbi,
@@ -300,6 +300,12 @@ where
         let bytes = bcs::to_bytes(operation).expect("Failed to serialize application operation");
 
         self.schedule_raw_operation(bytes);
+    }
+
+    /// Returns the list of operations scheduled since the last call to this method or
+    /// since the mock runtime was created.
+    pub fn raw_scheduled_operations(&self) -> Vec<Vec<u8>> {
+        mem::take(&mut self.scheduled_operations.lock().unwrap())
     }
 
     /// Configures the handler for application queries made during the test.

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -21,7 +21,7 @@ use linera_chain::{types::ConfirmedBlockCertificate, ChainError, ChainExecutionC
 use linera_core::{data_types::ChainInfoQuery, worker::WorkerError};
 use linera_execution::{
     system::{SystemExecutionError, SystemOperation, CREATE_APPLICATION_MESSAGE_INDEX},
-    ExecutionError, Query, Response,
+    ExecutionError, Query, QueryResponse,
 };
 use linera_storage::Storage as _;
 use serde::Serialize;
@@ -482,10 +482,12 @@ impl ActiveChain {
             .expect("Failed to query application");
 
         match response {
-            Response::User(bytes) => {
+            QueryResponse::User(bytes) => {
                 serde_json::from_slice(&bytes).expect("Failed to deserialize query response")
             }
-            Response::System(_) => unreachable!("User query returned a system response"),
+            QueryResponse::System(_) => {
+                unreachable!("User query returned a system response")
+            }
         }
     }
 

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -498,7 +498,7 @@ impl ActiveChain {
         &self,
         application_id: ApplicationId<Abi>,
         query: impl Into<async_graphql::Request>,
-    ) -> serde_json::Value
+    ) -> QueryOutcome<serde_json::Value>
     where
         Abi: ServiceAbi<Query = async_graphql::Request, QueryResponse = async_graphql::Response>,
     {
@@ -511,9 +511,13 @@ impl ActiveChain {
                 query_str, response.errors
             );
         }
-        response
+        let json_response = response
             .data
             .into_json()
-            .expect("Unexpected non-JSON query response")
+            .expect("Unexpected non-JSON query response");
+
+        QueryOutcome {
+            response: json_response,
+        }
     }
 }

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -21,7 +21,7 @@ use linera_chain::{types::ConfirmedBlockCertificate, ChainError, ChainExecutionC
 use linera_core::{data_types::ChainInfoQuery, worker::WorkerError};
 use linera_execution::{
     system::{SystemExecutionError, SystemOperation, CREATE_APPLICATION_MESSAGE_INDEX},
-    ExecutionError, Query, QueryResponse,
+    ExecutionError, Query, QueryOutcome, QueryResponse,
 };
 use linera_storage::Storage as _;
 use serde::Serialize;
@@ -468,7 +468,7 @@ impl ActiveChain {
     {
         let query_bytes = serde_json::to_vec(&query).expect("Failed to serialize query");
 
-        let response = self
+        let QueryOutcome { response } = self
             .validator
             .worker()
             .query_application(

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -468,7 +468,10 @@ impl ActiveChain {
     {
         let query_bytes = serde_json::to_vec(&query).expect("Failed to serialize query");
 
-        let QueryOutcome { response } = self
+        let QueryOutcome {
+            response,
+            operations,
+        } = self
             .validator
             .worker()
             .query_application(
@@ -492,6 +495,7 @@ impl ActiveChain {
 
         QueryOutcome {
             response: deserialized_response,
+            operations,
         }
     }
 
@@ -508,7 +512,10 @@ impl ActiveChain {
     {
         let query = query.into();
         let query_str = query.query.clone();
-        let QueryOutcome { response } = self.query(application_id, query).await;
+        let QueryOutcome {
+            response,
+            operations,
+        } = self.query(application_id, query).await;
         if !response.errors.is_empty() {
             panic!(
                 "GraphQL query:\n{}\nyielded errors:\n{:#?}",
@@ -522,6 +529,7 @@ impl ActiveChain {
 
         QueryOutcome {
             response: json_response,
+            operations,
         }
     }
 }

--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -19,7 +19,10 @@ mod mock_stubs;
 mod validator;
 
 #[cfg(with_integration_testing)]
-pub use linera_chain::data_types::{Medium, MessageAction};
+pub use {
+    linera_chain::data_types::{Medium, MessageAction},
+    linera_execution::QueryOutcome,
+};
 
 #[cfg(with_testing)]
 pub use self::mock_stubs::*;

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -11,6 +11,7 @@ interface service-system-api {
     read-system-timestamp: func() -> timestamp;
     read-owner-balances: func() -> list<tuple<account-owner, amount>>;
     read-balance-owners: func() -> list<account-owner>;
+    schedule-operation: func(operation: list<u8>);
     try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
     fetch-url: func(url: string) -> list<u8>;
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -44,7 +44,7 @@ use serde_json::json;
 use thiserror::Error as ThisError;
 use tokio::sync::OwnedRwLockReadGuard;
 use tower_http::cors::CorsLayer;
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, error, info, instrument, trace};
 
 use crate::util;
 
@@ -91,8 +91,6 @@ enum NodeServiceError {
     HeterogeneousOperations,
     #[error("failed to parse GraphQL query: {error}")]
     GraphQLParseError { error: String },
-    #[error("malformed application response")]
-    MalformedApplicationResponse,
     #[error("application service error: {errors:?}")]
     ApplicationServiceError { errors: Vec<String> },
     #[error("chain ID not found: {chain_id}")]
@@ -125,8 +123,7 @@ impl IntoResponse for NodeServiceError {
             NodeServiceError::JsonError(e) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, vec![e.to_string()])
             }
-            NodeServiceError::MalformedApplicationResponse
-            | NodeServiceError::UnexpectedOperationsFromQuery => {
+            NodeServiceError::UnexpectedOperationsFromQuery => {
                 (StatusCode::INTERNAL_SERVER_ERROR, vec![self.to_string()])
             }
             NodeServiceError::MissingOperation
@@ -861,36 +858,6 @@ fn operation_type(document: &ExecutableDocument) -> Result<OperationType, NodeSe
     }
 }
 
-/// Extracts the underlying byte vector from a serialized GraphQL response
-/// from an application.
-fn bytes_from_response(data: async_graphql::Value) -> Vec<Vec<u8>> {
-    if let async_graphql::Value::Object(map) = data {
-        map.values()
-            .filter_map(|value| {
-                if let async_graphql::Value::List(list) = value {
-                    bytes_from_list(list)
-                } else {
-                    None
-                }
-            })
-            .collect()
-    } else {
-        vec![]
-    }
-}
-
-fn bytes_from_list(list: &[async_graphql::Value]) -> Option<Vec<u8>> {
-    list.iter()
-        .map(|item| {
-            if let async_graphql::Value::Number(n) = item {
-                n.as_u64().map(|n| n as u8)
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
 /// The `NodeService` is a server that exposes a web-server to the client.
 /// The node service is primarily used to explore the state of a chain in GraphQL.
 pub struct NodeService<C>
@@ -1023,7 +990,7 @@ where
         debug!("Request: {:?}", &request);
         let QueryOutcome {
             response,
-            operations: _,
+            operations,
         } = self
             .query_user_application(application_id, request, chain_id)
             .await?;
@@ -1036,18 +1003,7 @@ where
                 .collect();
             return Err(NodeServiceError::ApplicationServiceError { errors });
         }
-        debug!("Response: {:?}", &graphql_response);
-        let bcs_bytes_list = bytes_from_response(graphql_response.data);
-        if bcs_bytes_list.is_empty() {
-            return Err(NodeServiceError::MalformedApplicationResponse);
-        }
-        let operations = bcs_bytes_list
-            .into_iter()
-            .map(|bytes| Operation::User {
-                application_id,
-                bytes,
-            })
-            .collect::<Vec<_>>();
+        trace!("Operations: {operations:?}");
 
         let client = self
             .context

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -34,7 +34,7 @@ use linera_core::{
 use linera_execution::{
     committee::{Committee, Epoch},
     system::{AdminOperation, Recipient, SystemChannel},
-    Operation, Query, Response, SystemOperation,
+    Operation, Query, QueryResponse, SystemOperation,
 };
 use linera_sdk::base::BlobContent;
 use linera_storage::Storage;
@@ -1009,8 +1009,10 @@ where
             })?;
         let response = client.query_application(query).await?;
         let user_response_bytes = match response {
-            Response::System(_) => unreachable!("cannot get a system response for a user query"),
-            Response::User(user) => user,
+            QueryResponse::System(_) => {
+                unreachable!("cannot get a system response for a user query")
+            }
+            QueryResponse::User(user) => user,
         };
         Ok(serde_json::from_slice(&user_response_bytes)?)
     }

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -34,7 +34,7 @@ use linera_core::{
 use linera_execution::{
     committee::{Committee, Epoch},
     system::{AdminOperation, Recipient, SystemChannel},
-    Operation, Query, QueryResponse, SystemOperation,
+    Operation, Query, QueryOutcome, QueryResponse, SystemOperation,
 };
 use linera_sdk::base::BlobContent;
 use linera_storage::Storage;
@@ -1007,7 +1007,7 @@ where
             .map_err(|_| NodeServiceError::UnknownChainId {
                 chain_id: chain_id.to_string(),
             })?;
-        let response = client.query_application(query).await?;
+        let QueryOutcome { response } = client.query_application(query).await?;
         let user_response_bytes = match response {
             QueryResponse::System(_) => {
                 unreachable!("cannot get a system response for a user query")

--- a/linera-service/template/service.rs.template
+++ b/linera-service/template/service.rs.template
@@ -2,6 +2,8 @@
 
 mod state;
 
+use std::sync::Arc;
+
 use async_graphql::{{EmptySubscription, Object, Schema}};
 use linera_sdk::{{
     base::WithServiceAbi, graphql::GraphQLMutationRoot, views::View, Service, ServiceRuntime,
@@ -13,7 +15,7 @@ use self::state::{project_name}State;
 
 pub struct {project_name}Service {{
     state: {project_name}State,
-    runtime: ServiceRuntime<Self>,
+    runtime: Arc<ServiceRuntime<Self>>,
 }}
 
 linera_sdk::service!({project_name}Service);
@@ -29,7 +31,10 @@ impl Service for {project_name}Service {{
         let state = {project_name}State::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
-        {project_name}Service {{ state, runtime }}
+        {project_name}Service {{
+            state,
+            runtime: Arc::new(runtime),
+        }}
     }}
 
     async fn handle_query(&self, query: Self::Query) -> Self::QueryResponse {{
@@ -37,7 +42,7 @@ impl Service for {project_name}Service {{
             QueryRoot {{
                 value: *self.state.value.get(),
             }},
-            Operation::mutation_root(),
+            Operation::mutation_root(self.runtime.clone()),
             EmptySubscription,
         )
         .finish()


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
Previously, services were required to use GraphQL in order to support creating blocks with operations. The design was that each mutation query would return a serialized operation as a vector of bytes. This is a constraint that's not really needed, and requires extra work by application developers.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Add a `schedule_operation` system API, which adds an operation to a list of scheduled operations. More than one operation can be scheduled to be added to the proposed block. The list is then returned back to the client (in the node service), which then uses it to build a block proposal and send it to the validators.

The SDK was updated to add `ServiceRuntime::schedule_raw_operation` to send the operation as a vector of bytes, and also add a `ServiceRuntime::schedule_operation` method which accepts any `Serialize` type and handles serialization for the application.

All examples were updated to use the new API, either manually if the mutation object is implemented manually or by the changes to the `GraphQLMutationRoot` derive macro. Unfortunately, `async_graphql` requires the methods to return _something_ that implements `OutputType`, so for now they return an empty array of bytes.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
CI should catch any regressions by the switch to use the new API.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Backporting is not possible but we may want to deploy a new `devnet` and release a new
      SDK soon.

In theory only the client is affected, but since the API is available to services, when running a contract the validators could query a service that runs as an oracle and the behavior would differ if this change is included in the validator or not. In both cases an error will be returned and the block rejected, but the errors would be different. To mitigate risk, this should be released together with validator upgrades.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
