### PR TITLE
Print validator public key on shard start-up.

### DIFF
--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -60,6 +60,7 @@ impl ServerContext {
     {
         let shard = self.server_config.internal_network.shard(shard_id);
         info!("Shard booted on {}", shard.host);
+        info!("Public key: {}", self.server_config.key.public());
         let state = WorkerState::new(
             format!("Shard {} @ {}:{}", shard_id, local_ip_addr, shard.port),
             Some(self.server_config.key.copy()),


### PR DESCRIPTION
## Motivation

There is currently no way of telling what a validator's public key is without trying to read volume mounted config files.

## Proposal

Shards now log the validator public key on start-up.

## Test Plan

Tested manually:

```
2025-01-31T12:46:23.411398Z  INFO linera_storage_server: Starting linera_storage_service on endpoint=127.0.0.1:35445
2025-01-31T12:46:24.424004Z  INFO linera_server: Wrote server config server_0.json
2025-01-31T12:46:24.424121Z  INFO linera_server: Wrote committee config committee.json
2025-01-31T12:46:24.445542Z DEBUG linera::main: linera_client::config: Persisted user chains
2025-01-31T12:46:24.462538Z  INFO linera::main: linera: Genesis config created in 18 ms
2025-01-31T12:46:24.517358Z  INFO GrpcProxy::run{public_address=0.0.0.0:9000 internal_address=0.0.0.0:10000 metrics_address=0.0.0.0:11000}: linera_proxy::grpc: Starting gRPC server
2025-01-31T12:46:24.613915Z  INFO linera::main: linera_service::cli_wrappers::local_net: Successfully started validator proxy 0
2025-01-31T12:46:24.626143Z  INFO linera_version::version_info: Linera protocol: v0.14.0
2025-01-31T12:46:24.626168Z  INFO linera_version::version_info: RPC API hash: SfdxbfPoJwbzbnVcCbO+i2Mww3NZzaOOYwPYLKU8CFU
2025-01-31T12:46:24.626172Z  INFO linera_version::version_info: GraphQL API hash: 3houdm/AVAsa8tku0ER8R4yVpguVQ8Ejh5o0wASDGSg
2025-01-31T12:46:24.626175Z  INFO linera_version::version_info: WIT API hash: AwzZ4HncyIJomU6NAAScV/4RkD8lXvsgJEyziLOSOK0
2025-01-31T12:46:24.626179Z  INFO linera_version::version_info: Source code: https://github.com/linera-io/linera-protocol/tree/452e5cd80b (dirty)
2025-01-31T12:46:24.627578Z  INFO linera_server: Running shard number 0
2025-01-31T12:46:24.627588Z  INFO linera_server: Shard booted on localhost
2025-01-31T12:46:24.627593Z  INFO linera_server: Public key: da11c38d60803580f759396090c8118a228f9af4fa203f2f7c27b549df11b86a
2025-01-31T12:46:24.627687Z  INFO linera_rpc::grpc::server: spawning gRPC server on 0.0.0.0:9001 for shard 0
2025-01-31T12:46:24.627701Z  INFO linera_rpc::grpc::server: spawning cross-chain queries thread on 0.0.0.0 for shard 0 nickname="Shard 0 @ 0.0.0.0:9001"
2025-01-31T12:46:24.627749Z  INFO linera_rpc::grpc::server: spawning notifications thread on 0.0.0.0 for shard 0 nickname="Shard 0 @ 0.0.0.0:9001"
```

## Release Plan
- These changes should be backported to the latest `devnet` branch, then
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.
