### PR TITLE
fix: broken links in README files

### DIFF
--- a/linera-indexer/graphql-client/README.md
+++ b/linera-indexer/graphql-client/README.md
@@ -20,8 +20,8 @@ cargo run --bin linera-indexer schema operations > linera-indexer/graphql-client
 
 ## Contributing
 
-See the [CONTRIBUTING](../CONTRIBUTING.md) file for how to help out.
+See the [CONTRIBUTING](../../CONTRIBUTING.md) file for how to help out.
 
 ## License
 
-This project is available under the terms of the [Apache 2.0 license](../LICENSE).
+This project is available under the terms of the [Apache 2.0 license](../../LICENSE).

--- a/linera-sdk/wit/README.md
+++ b/linera-sdk/wit/README.md
@@ -3,7 +3,7 @@
 These [WIT files](https://component-model.bytecodealliance.org/design/wit.html) define the
 interface that Linera applications compiled to [WebAssembly (Wasm)](https://webassembly.org) must
 adhere to. Application contracts should implement the [`contract.wit`](./contract.wit) interfaces,
-application services should implement the [`service.wit`](./service.wit) interfaces.
+and application services should implement the [`service.wit`](./service.wit) interfaces.
 
 ## Generation of the WIT files
 

--- a/linera-sdk/wit/README.md
+++ b/linera-sdk/wit/README.md
@@ -3,8 +3,7 @@
 These [WIT files](https://component-model.bytecodealliance.org/design/wit.html) define the
 interface that Linera applications compiled to [WebAssembly (Wasm)](https://webassembly.org) must
 adhere to. Application contracts should implement the [`contract.wit`](./contract.wit) interfaces,
-application services should implement the [`service.wit`](./service.wit) interfaces and unit tests
-compiled to Wasm should implement the [`unit-tests.wit`](./unit-tests.wit) interfaces. 
+application services should implement the [`service.wit`](./service.wit) interfaces.
 
 ## Generation of the WIT files
 


### PR DESCRIPTION
## Motivation

HI! This PR fixes incorrect relative links in `README.md` files to ensure proper navigation and avoid broken references.

## Proposal

- Updated the relative path to `CONTRIBUTING.md` and `LICENSE` in `linera-indexer/graphql-client/README.md`
- Removed redundant description in `linera-sdk/wit/README.md` to maintain clarity and accuracy
#1974
