### PR TITLE
Several corrections to `linera-execution` code.

### DIFF
--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet},
     mem, vec,
 };
 
@@ -289,7 +289,6 @@ where
                     .registry
                     .describe_applications_with_dependencies(
                         applications_to_describe.into_iter().collect(),
-                        &HashMap::new(),
                     )
                     .await?;
 

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -499,14 +499,14 @@ pub enum ExecutionRequest {
     CloseChain {
         application_id: UserApplicationId,
         #[debug(skip)]
-        callback: oneshot::Sender<Result<(), ExecutionError>>,
+        callback: Sender<Result<(), ExecutionError>>,
     },
 
     ChangeApplicationPermissions {
         application_id: UserApplicationId,
         application_permissions: ApplicationPermissions,
         #[debug(skip)]
-        callback: oneshot::Sender<Result<(), ExecutionError>>,
+        callback: Sender<Result<(), ExecutionError>>,
     },
 
     CreateApplication {
@@ -515,7 +515,7 @@ pub enum ExecutionRequest {
         parameters: Vec<u8>,
         required_application_ids: Vec<UserApplicationId>,
         #[debug(skip)]
-        callback: oneshot::Sender<Result<CreateApplicationResult, ExecutionError>>,
+        callback: Sender<Result<CreateApplicationResult, ExecutionError>>,
     },
 
     FetchUrl {
@@ -530,7 +530,7 @@ pub enum ExecutionRequest {
         #[debug(with = hex_debug)]
         payload: Vec<u8>,
         #[debug(skip)]
-        callback: oneshot::Sender<Vec<u8>>,
+        callback: Sender<Vec<u8>>,
     },
 
     ReadBlobContent {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1153,6 +1153,7 @@ impl Operation {
     }
 
     /// Creates a new user application operation following the `application_id`'s [`Abi`].
+    #[cfg(with_testing)]
     pub fn user<A: Abi>(
         application_id: UserApplicationId<A>,
         operation: &A::Operation,
@@ -1162,6 +1163,7 @@ impl Operation {
 
     /// Creates a new user application operation assuming that the `operation` is valid for the
     /// `application_id`.
+    #[cfg(with_testing)]
     pub fn user_without_abi(
         application_id: UserApplicationId<()>,
         operation: &impl Serialize,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -657,7 +657,7 @@ where
                 self.record_bytecode_blobs(blobs_to_register, txn_tracker)
                     .await?;
                 outcome.messages.push(message);
-                new_application = Some((app_id, instantiation_argument.clone()));
+                new_application = Some((app_id, instantiation_argument));
             }
             RequestApplication {
                 chain_id,
@@ -861,7 +861,7 @@ where
                     SystemExecutionError::InvalidCommitteeCreation
                 );
                 if epoch == chain_next_epoch {
-                    self.committees.get_mut().insert(epoch, committee.clone());
+                    self.committees.get_mut().insert(epoch, committee);
                     self.epoch.set(Some(epoch));
                 }
             }
@@ -872,9 +872,7 @@ where
                 for application in applications {
                     self.check_and_record_bytecode_blobs(&application.bytecode_id, txn_tracker)
                         .await?;
-                    self.registry
-                        .register_application(application.clone())
-                        .await?;
+                    self.registry.register_application(application).await?;
                 }
             }
             RequestApplication(application_id) => {
@@ -1048,7 +1046,7 @@ where
             }
         }
         self.registry
-            .register_new_application(id, parameters.clone(), required_application_ids.clone())
+            .register_new_application(id, parameters, required_application_ids)
             .await?;
         // Send a message to ourself to increment the message ID.
         let message = RawOutgoingMessage {

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -880,10 +880,7 @@ where
             RequestApplication(application_id) => {
                 let applications = self
                     .registry
-                    .describe_applications_with_dependencies(
-                        vec![application_id],
-                        &Default::default(),
-                    )
+                    .describe_applications_with_dependencies(vec![application_id])
                     .await?;
                 let message = RawOutgoingMessage {
                     destination: Destination::Recipient(context.message_id.chain_id),

--- a/linera-execution/src/unit_tests/applications_tests.rs
+++ b/linera-execution/src/unit_tests/applications_tests.rs
@@ -57,40 +57,15 @@ fn registry(graph: impl IntoIterator<Item = (u32, Vec<u32>)>) -> ApplicationRegi
 async fn test_topological_sort() {
     let mut view = ApplicationRegistryView::new().await;
     view.import(registry([(1, vec![2, 3])])).unwrap();
-    assert!(view
-        .find_dependencies(vec![app_id(1)], &Default::default())
-        .await
-        .is_err());
+    assert!(view.find_dependencies(vec![app_id(1)]).await.is_err());
     view.import(registry([(3, vec![2]), (2, vec![]), (0, vec![1])]))
         .unwrap();
-    let app_ids = view
-        .find_dependencies(vec![app_id(1)], &Default::default())
-        .await
-        .unwrap();
+    let app_ids = view.find_dependencies(vec![app_id(1)]).await.unwrap();
     assert_eq!(app_ids, Vec::from_iter([2, 3, 1].into_iter().map(app_id)));
-    let app_ids = view
-        .find_dependencies(vec![app_id(0)], &Default::default())
-        .await
-        .unwrap();
+    let app_ids = view.find_dependencies(vec![app_id(0)]).await.unwrap();
     assert_eq!(
         app_ids,
         Vec::from_iter([2, 3, 1, 0].into_iter().map(app_id))
-    );
-    let app_ids = view
-        .find_dependencies(
-            vec![app_id(0), app_id(5)],
-            &vec![
-                (app_id(5), app_description(5, vec![4])),
-                (app_id(4), app_description(5, vec![2])),
-            ]
-            .into_iter()
-            .collect(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(
-        app_ids,
-        Vec::from_iter([2, 4, 5, 3, 1, 0].into_iter().map(app_id))
     );
 }
 
@@ -104,15 +79,9 @@ async fn test_topological_sort_with_loop() {
         (0, vec![1]),
     ]))
     .unwrap();
-    let app_ids = view
-        .find_dependencies(vec![app_id(1)], &Default::default())
-        .await
-        .unwrap();
+    let app_ids = view.find_dependencies(vec![app_id(1)]).await.unwrap();
     assert_eq!(app_ids, Vec::from_iter([2, 3, 1].into_iter().map(app_id)));
-    let app_ids = view
-        .find_dependencies(vec![app_id(0)], &Default::default())
-        .await
-        .unwrap();
+    let app_ids = view.find_dependencies(vec![app_id(0)]).await.unwrap();
     assert_eq!(
         app_ids,
         Vec::from_iter([2, 3, 1, 0].into_iter().map(app_id))


### PR DESCRIPTION
## Motivation

The work on the integration of the EVM into the `linera-execution` led to code reading and so to identification of some ways to improve the code.

## Proposal

The following was done:
* The functions `user` and `user_without_abi` are only used for testing purposes and so marked as such.
* The functions `find_dependencies` and `describe_applications_with_dependencies` are always used with an empty last argument in the code. The code is thus simplified.
* Many `clone()` operations in `system.rs` are not needed even though clippy did not detect this.
* The use of `Sender` / `oneshot::Sender` is inconcistent in the code.

## Test Plan

The CI should detect it.

## Release Plan

Follow the normal release plan.

## Links

None.