### PR TITLE
Limit waiting for a single node when downloading blobs.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -149,6 +149,9 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `--grace-period <GRACE_PERIOD>` — An additional delay, after reaching a quorum, to wait for additional validator signatures, as a fraction of time taken to reach quorum
 
   Default value: `0.2`
+* `--blob-download-timeout-ms <BLOB_DOWNLOAD_TIMEOUT>` — The delay when downloading a blob, after which we try a second validator, in milliseconds
+
+  Default value: `1000`
 
 
 

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -177,6 +177,7 @@ where
             name,
             options.max_loaded_chains,
             options.grace_period,
+            options.blob_download_timeout,
         );
 
         ClientContext {
@@ -224,6 +225,7 @@ where
             name,
             NonZeroUsize::new(20).expect("Chain worker limit should not be zero"),
             DEFAULT_GRACE_PERIOD,
+            Duration::from_secs(1),
         );
 
         ClientContext {

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -161,6 +161,14 @@ pub struct ClientOptions {
     /// as a fraction of time taken to reach quorum.
     #[arg(long, default_value_t = DEFAULT_GRACE_PERIOD)]
     pub grace_period: f64,
+
+    /// The delay when downloading a blob, after which we try a second validator, in milliseconds.
+    #[arg(
+        long = "blob-download-timeout-ms",
+        default_value = "1000",
+        value_parser = util::parse_millis
+    )]
+    pub blob_download_timeout: Duration,
 }
 
 impl ClientOptions {

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::large_futures)]
 
-use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc};
+use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use futures::{lock::Mutex, FutureExt as _};
@@ -135,6 +135,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
             format!("Client node for {:.8}", chain_id0),
             NonZeroUsize::new(20).expect("Chain worker LRU cache size must be non-zero"),
             DEFAULT_GRACE_PERIOD,
+            Duration::from_secs(1),
         )),
     };
     let key_pair = KeyPair::generate_from(&mut rng);

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -5,6 +5,7 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     num::NonZeroUsize,
     sync::Arc,
+    time::Duration,
     vec,
 };
 
@@ -904,6 +905,7 @@ where
             format!("Client node for {:.8}", chain_id),
             NonZeroUsize::new(20).expect("Chain worker limit should not be zero"),
             DEFAULT_GRACE_PERIOD,
+            Duration::from_secs(1),
         ));
         Ok(builder.create_chain_client(
             chain_id,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -6,8 +6,14 @@
 #![deny(clippy::large_futures)]
 
 use std::{
-    borrow::Cow, collections::HashMap, env, num::NonZeroUsize, path::PathBuf, process, sync::Arc,
-    time::Instant,
+    borrow::Cow,
+    collections::HashMap,
+    env,
+    num::NonZeroUsize,
+    path::PathBuf,
+    process,
+    sync::Arc,
+    time::{Duration, Instant},
 };
 
 use anyhow::{anyhow, bail, ensure, Context};
@@ -1251,6 +1257,7 @@ impl Job {
             "Temporary client for fetching the parent chain",
             NonZeroUsize::new(20).expect("Chain worker limit should not be zero"),
             DEFAULT_GRACE_PERIOD,
+            Duration::from_secs(1),
         );
 
         // Take the latest committee we know of.


### PR DESCRIPTION
## Motivation

When trying to download a blob sequentially from each validator, a single unresponsive validator can considerably slow down the client. (Even worse if they maliciously respond, after a delay, with a gRPC error code that makes the client retry the request.)

## Proposal

After 1s (configurable) try a second, after 4s try a third validator in parallel, after 9s etc.

## Test Plan

CI should catch any regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
