### PR TITLE
spelling and grammar issues in comments

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -1182,7 +1182,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
         .await?
         .contains(&nft2_id));
 
-    // Transferring to another chain, maitaining the owner
+    // Transferring to another chain, maintaining the owner
     app2.transfer(
         &account_owner2,
         &nft2_id,

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -41,7 +41,7 @@ use crate::{
 const MAX_KEY_SIZE: usize = 1000000;
 
 // The shared store client.
-// * Interior mutability is required for client because
+// * Interior mutability is required for the client because
 // accessing requires mutability while the KeyValueStore
 // does not allow it.
 // * The semaphore and max_stream_queries work as other


### PR DESCRIPTION
maitaining - maintaining 

for client - for the client