### PR TITLE
Remove max_in_flight from linera benchmark

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -140,7 +140,7 @@ jobs:
 
   benchmark-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v3

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -585,10 +585,6 @@ pub enum ClientCommand {
     /// Send one transfer per chain in bulk mode
     #[cfg(feature = "benchmark")]
     Benchmark {
-        /// Maximum number of blocks in flight
-        #[arg(long, default_value = "200")]
-        max_in_flight: usize,
-
         /// How many chains to use for the benchmark
         #[arg(long, default_value = "10")]
         num_chains: usize,

--- a/linera-rpc/src/mass_client.rs
+++ b/linera-rpc/src/mass_client.rs
@@ -20,9 +20,5 @@ pub enum MassClientError {
 
 #[async_trait]
 pub trait MassClient {
-    async fn send(
-        &self,
-        requests: Vec<RpcMessage>,
-        max_in_flight: usize,
-    ) -> Result<Vec<RpcMessage>, MassClientError>;
+    async fn send(&self, requests: Vec<RpcMessage>) -> Result<Vec<RpcMessage>, MassClientError>;
 }

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -259,7 +259,6 @@ impl mass_client::MassClient for SimpleMassClient {
     async fn send(
         &self,
         requests: Vec<RpcMessage>,
-        max_in_flight: usize,
     ) -> Result<Vec<RpcMessage>, mass_client::MassClientError> {
         let address = format!("{}:{}", self.network.host, self.network.port);
         let mut stream = self.network.protocol.connect(address).await?;
@@ -268,7 +267,7 @@ impl mass_client::MassClient for SimpleMassClient {
         let mut responses = Vec::new();
 
         loop {
-            while in_flight < max_in_flight {
+            loop {
                 let request = match requests.next() {
                     None => {
                         if in_flight == 0 {

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -679,7 +679,6 @@ impl ClientWrapper {
     #[cfg(feature = "benchmark")]
     pub async fn benchmark(
         &self,
-        max_in_flight: usize,
         num_chains: usize,
         transactions_per_block: usize,
         fungible_application_id: Option<
@@ -689,7 +688,6 @@ impl ClientWrapper {
         let mut command = self.command().await?;
         command
             .arg("benchmark")
-            .args(["--max-in-flight", &max_in_flight.to_string()])
             .args(["--num-chains", &num_chains.to_string()])
             .args([
                 "--transactions-per-block",

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -759,7 +759,6 @@ impl Runnable for Job {
 
             #[cfg(feature = "benchmark")]
             Benchmark {
-                max_in_flight,
                 num_chains,
                 tokens_per_chain,
                 transactions_per_block,
@@ -775,9 +774,7 @@ impl Runnable for Job {
                     .await?;
 
                 if let Some(id) = fungible_application_id {
-                    context
-                        .supply_fungible_tokens(&key_pairs, id, max_in_flight)
-                        .await?;
+                    context.supply_fungible_tokens(&key_pairs, id).await?;
                 }
 
                 // For this command, we create proposals and gather certificates without using
@@ -801,9 +798,7 @@ impl Runnable for Job {
                     }
                 }
 
-                let responses = context
-                    .mass_broadcast("block proposals", max_in_flight, proposals)
-                    .await;
+                let responses = context.mass_broadcast("block proposals", proposals).await;
                 let votes = responses
                     .into_iter()
                     .filter_map(|message| {
@@ -833,9 +828,7 @@ impl Runnable for Job {
                         ))
                     })
                     .collect();
-                let responses = context
-                    .mass_broadcast("certificates", max_in_flight, messages)
-                    .await;
+                let responses = context.mass_broadcast("certificates", messages).await;
                 let mut confirmed = HashSet::new();
                 let num_valid = responses.into_iter().fold(0, |acc, message| {
                     match deserialize_response(message) {

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -819,7 +819,7 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
 
     assert_eq!(client.load_wallet()?.num_chains(), 3);
     // Launch local benchmark using some additional chains.
-    client.benchmark(2, 4, 10, None).await?;
+    client.benchmark(4, 10, None).await?;
     assert_eq!(client.load_wallet()?.num_chains(), 7);
 
     // Now we run the benchmark again, with the fungible token application instead of the
@@ -839,7 +839,7 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
             None,
         )
         .await?;
-    client.benchmark(2, 5, 10, Some(application_id)).await?;
+    client.benchmark(5, 10, Some(application_id)).await?;
 
     net.ensure_is_running().await?;
     net.terminate().await?;


### PR DESCRIPTION
## Motivation

We're gonna slowly change the design of this. Limiting the amount of in flight requests goes against our goal of stress testing a network with this

## Proposal

Remove that constraint

## Test Plan

Ran `linera benchmark` with a few parameter variations

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
