### PR TITLE
Don't forget pending blobs if retrying at the next height.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -562,7 +562,7 @@ where
                 .take(num_new_chains)
                 .collect();
             let certificate = chain_client
-                .execute_without_prepare(operations)
+                .execute_without_prepare(operations, Vec::new())
                 .await?
                 .expect("should execute block with OpenChain operations");
             let executed_block = certificate
@@ -634,7 +634,7 @@ where
         // Put at most 1000 fungible token operations in each block.
         for operations in operations.chunks(1000) {
             chain_client
-                .execute_without_prepare(operations.to_vec())
+                .execute_without_prepare(operations.to_vec(), Vec::new())
                 .await?
                 .expect("should execute block with OpenChain operations");
         }

--- a/linera-core/src/client/chain_state.rs
+++ b/linera-core/src/client/chain_state.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
 };
 
@@ -99,10 +99,15 @@ impl ChainState {
         blobs: impl IntoIterator<Item = Blob>,
     ) {
         if block.height == self.next_block_height {
-            self.pending_block = Some(block);
+            self.pending_blobs.clear();
             for blob in blobs {
                 self.insert_pending_blob(blob);
             }
+            assert_eq!(
+                block.published_blob_ids(),
+                self.pending_blobs.keys().copied().collect::<HashSet<_>>()
+            );
+            self.pending_block = Some(block);
         } else {
             tracing::error!(
                 "Not setting pending block at height {}, because next_block_height is {}.",

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2823,13 +2823,6 @@ where
         self.publish_data_blobs(vec![bytes]).await
     }
 
-    /// Adds pending blobs
-    pub async fn add_pending_blobs(&self, pending_blobs: impl IntoIterator<Item = Blob>) {
-        for blob in pending_blobs {
-            self.state_mut().insert_pending_blob(blob);
-        }
-    }
-
     /// Creates an application by instantiating some bytecode.
     #[instrument(
         level = "trace",

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -881,7 +881,7 @@ where
 
     // Since blocks are free of charge on closed chains, empty blocks are not allowed.
     assert_matches!(
-        client1.execute_operations(vec![]).await,
+        client1.execute_operations(vec![], vec![]).await,
         Err(ChainClientError::LocalNodeError(
             LocalNodeError::WorkerError(WorkerError::ChainError(error))
         )) if matches!(*error, ChainError::ClosedChain)
@@ -1473,7 +1473,6 @@ where
     let blob1 = Blob::new_data(b"blob1".to_vec());
     let blob1_hash = blob1.id().hash;
 
-    client2_a.add_pending_blobs([blob1]).await;
     let blob_0_1_operations = vec![
         Operation::System(SystemOperation::ReadBlob { blob_id: blob0_id }),
         Operation::System(SystemOperation::PublishDataBlob {
@@ -1481,7 +1480,7 @@ where
         }),
     ];
     let b0_result = client2_a
-        .execute_operations(blob_0_1_operations.clone())
+        .execute_operations(blob_0_1_operations.clone(), vec![blob1])
         .await;
 
     assert!(b0_result.is_err());
@@ -1617,7 +1616,6 @@ where
     let blob1 = Blob::new_data(b"blob1".to_vec());
     let blob1_hash = blob1.id().hash;
 
-    client2_a.add_pending_blobs([blob1]).await;
     let blob_0_1_operations = vec![
         Operation::System(SystemOperation::ReadBlob { blob_id: blob0_id }),
         Operation::System(SystemOperation::PublishDataBlob {
@@ -1625,7 +1623,7 @@ where
         }),
     ];
     let b0_result = client2_a
-        .execute_operations(blob_0_1_operations.clone())
+        .execute_operations(blob_0_1_operations.clone(), vec![blob1])
         .await;
 
     assert!(b0_result.is_err());
@@ -1794,7 +1792,6 @@ where
     let blob1 = Blob::new_data(b"blob1".to_vec());
     let blob1_hash = blob1.id().hash;
 
-    client3_a.add_pending_blobs([blob1]).await;
     let blob_0_1_operations = vec![
         Operation::System(SystemOperation::ReadBlob { blob_id: blob0_id }),
         Operation::System(SystemOperation::PublishDataBlob {
@@ -1802,7 +1799,7 @@ where
         }),
     ];
     let b0_result = client3_a
-        .execute_operations(blob_0_1_operations.clone())
+        .execute_operations(blob_0_1_operations.clone(), vec![blob1])
         .await;
 
     assert!(b0_result.is_err());
@@ -1869,7 +1866,6 @@ where
     let blob3 = Blob::new_data(b"blob3".to_vec());
     let blob3_hash = blob3.id().hash;
 
-    client3_b.add_pending_blobs([blob3]).await;
     let blob_2_3_operations = vec![
         Operation::System(SystemOperation::ReadBlob { blob_id: blob2_id }),
         Operation::System(SystemOperation::PublishDataBlob {
@@ -1877,7 +1873,7 @@ where
         }),
     ];
     let b1_result = client3_b
-        .execute_operations(blob_2_3_operations.clone())
+        .execute_operations(blob_2_3_operations.clone(), vec![blob3])
         .await;
     assert!(b1_result.is_err());
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1926,8 +1926,10 @@ where
     builder.set_fault_type([0, 2, 3], FaultType::Honest).await;
 
     client3_c.synchronize_from_validators().await.unwrap();
+    let blob4_data = b"blob4".to_vec();
+    let blob4 = Blob::from(BlobContent::new_data(blob4_data.clone()));
     let bt_certificate = client3_c
-        .burn(None, Amount::from_tokens(1))
+        .publish_data_blob(blob4_data)
         .await
         .unwrap()
         .unwrap();
@@ -1943,10 +1945,8 @@ where
         .block()
         .unwrap()
         .operations
-        .contains(&Operation::System(SystemOperation::Transfer {
-            owner: None,
-            recipient: Recipient::Burn,
-            amount: Amount::from_tokens(1),
+        .contains(&Operation::System(SystemOperation::PublishDataBlob {
+            blob_hash: blob4.id().hash
         })));
 
     // Block before that should be b1

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -929,7 +929,10 @@ async fn test_memory_fuel_limit(wasm_runtime: WasmRuntime) -> anyhow::Result<()>
         .unwrap();
 
     assert!(publisher
-        .execute_operations(vec![Operation::user(application_id, &increment)?; 10])
+        .execute_operations(
+            vec![Operation::user(application_id, &increment)?; 10],
+            vec![]
+        )
         .await
         .is_err());
 

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -1063,7 +1063,10 @@ where
                 chain_id: chain_id.to_string(),
             })?;
         let hash = loop {
-            let timeout = match client.execute_operations(operations.clone()).await? {
+            let timeout = match client
+                .execute_operations(operations.clone(), Vec::new())
+                .await?
+            {
                 ClientOutcome::Committed(certificate) => break certificate.value.hash(),
                 ClientOutcome::WaitForTimeout(timeout) => timeout,
             };


### PR DESCRIPTION
## Motivation

When a conflicting block is committed, the pending blobs are cleared, so if the client retries at the next height, it cannot find them anymore.

## Proposal

Always set the pending blobs together with the pending block.

## Test Plan

`test_re_propose_locked_block_with_blobs` was modified to re-propose a `PublishDataBlob` operation. This fails for me without the fix.

An assertion was added that the pending blobs match the pending block. This would fail if the blobs were missing.

## Release Plan

- These changes should be ported to the latest `main` branch.
- It could be released in a new SDK patch version.

## Links

- Possibly related: #3029
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
