### PR TITLE
Don't forget pending blobs if retrying at the next height.

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -2,10 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeSet, HashSet},
-    fmt::Debug,
-};
+use std::{collections::BTreeSet, fmt::Debug};
 
 use async_graphql::SimpleObject;
 use linera_base::{
@@ -482,7 +479,7 @@ impl Block {
 
     /// Returns all the blob IDs required by this block.
     /// Either as oracle responses or as published blobs.
-    pub fn required_blob_ids(&self) -> HashSet<BlobId> {
+    pub fn required_blob_ids(&self) -> BTreeSet<BlobId> {
         let mut blob_ids = self.oracle_blob_ids();
         blob_ids.extend(self.published_blob_ids());
         blob_ids
@@ -512,8 +509,8 @@ impl Block {
     }
 
     /// Returns set of blob ids that were a result of an oracle call.
-    pub fn oracle_blob_ids(&self) -> HashSet<BlobId> {
-        let mut required_blob_ids = HashSet::new();
+    pub fn oracle_blob_ids(&self) -> BTreeSet<BlobId> {
+        let mut required_blob_ids = BTreeSet::new();
         for responses in &self.body.oracle_responses {
             for response in responses {
                 if let OracleResponse::Blob(blob_id) = response {

--- a/linera-chain/src/certificate/mod.rs
+++ b/linera-chain/src/certificate/mod.rs
@@ -8,7 +8,7 @@ mod lite;
 mod timeout;
 mod validated;
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 pub use generic::GenericCertificate;
 use linera_base::{
@@ -102,7 +102,7 @@ pub trait CertificateValue: Clone {
 
     fn height(&self) -> BlockHeight;
 
-    fn required_blob_ids(&self) -> HashSet<BlobId>;
+    fn required_blob_ids(&self) -> BTreeSet<BlobId>;
 }
 
 impl CertificateValue for Timeout {
@@ -120,8 +120,8 @@ impl CertificateValue for Timeout {
         self.height
     }
 
-    fn required_blob_ids(&self) -> HashSet<BlobId> {
-        HashSet::new()
+    fn required_blob_ids(&self) -> BTreeSet<BlobId> {
+        BTreeSet::new()
     }
 }
 
@@ -140,7 +140,7 @@ impl CertificateValue for ValidatedBlock {
         self.block().header.height
     }
 
-    fn required_blob_ids(&self) -> HashSet<BlobId> {
+    fn required_blob_ids(&self) -> BTreeSet<BlobId> {
         self.block().required_blob_ids()
     }
 }
@@ -160,7 +160,7 @@ impl CertificateValue for ConfirmedBlock {
         self.block().header.height
     }
 
-    fn required_blob_ids(&self) -> HashSet<BlobId> {
+    fn required_blob_ids(&self) -> BTreeSet<BlobId> {
         self.block().required_blob_ids()
     }
 }

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -187,7 +187,7 @@ pub enum ChainExecutionContext {
     Block,
 }
 
-trait ExecutionResultExt<T> {
+pub trait ExecutionResultExt<T> {
     fn with_execution_context(self, context: ChainExecutionContext) -> Result<T, ChainError>;
 }
 

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -3,17 +3,14 @@
 
 #[cfg(with_testing)]
 use std::num::NonZeroUsize;
-use std::{
-    collections::{BTreeMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashSet, sync::Arc};
 
 use async_trait::async_trait;
 use futures::Future;
 use linera_base::{
     crypto::KeyPair,
     data_types::{Blob, BlockHeight, Timestamp},
-    identifiers::{Account, BlobId, ChainId},
+    identifiers::{Account, ChainId},
     ownership::ChainOwnership,
     time::{Duration, Instant},
 };
@@ -273,7 +270,7 @@ where
             chain.timestamp,
             chain.next_block_height,
             chain.pending_block.clone(),
-            chain.pending_blobs.clone(),
+            chain.pending_blobs.iter().cloned(),
         );
         chain_client.options_mut().message_policy = MessagePolicy::new(
             self.blanket_message_policy,
@@ -326,7 +323,7 @@ where
         key_pair: Option<KeyPair>,
         timestamp: Timestamp,
     ) -> Result<(), Error> {
-        self.update_wallet_for_new_chain_internal(chain_id, key_pair, timestamp, BTreeMap::new())
+        self.update_wallet_for_new_chain_internal(chain_id, key_pair, timestamp, Vec::new())
             .await
     }
 
@@ -336,7 +333,7 @@ where
         chain_id: ChainId,
         key_pair: Option<KeyPair>,
         timestamp: Timestamp,
-        pending_blobs: BTreeMap<BlobId, Blob>,
+        pending_blobs: Vec<Blob>,
     ) -> Result<(), Error> {
         self.update_wallet_for_new_chain_internal(chain_id, key_pair, timestamp, pending_blobs)
             .await
@@ -347,7 +344,7 @@ where
         chain_id: ChainId,
         key_pair: Option<KeyPair>,
         timestamp: Timestamp,
-        pending_blobs: BTreeMap<BlobId, Blob>,
+        pending_blobs: Vec<Blob>,
     ) -> Result<(), Error> {
         if self.wallet.get(chain_id).is_none() {
             self.mutate_wallet(|w| {
@@ -644,7 +641,7 @@ where
                 .take(num_new_chains)
                 .collect();
             let certificate = chain_client
-                .execute_operations(operations)
+                .execute_operations(operations, vec![])
                 .await?
                 .expect("should execute block with OpenChain operations");
             let block = certificate.block();
@@ -713,7 +710,7 @@ where
         // Put at most 1000 fungible token operations in each block.
         for operations in operations.chunks(1000) {
             chain_client
-                .execute_operations(operations.to_vec())
+                .execute_operations(operations.to_vec(), vec![])
                 .await?
                 .expect("should execute block with OpenChain operations");
         }

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use futures::Future;
 use linera_base::{
     crypto::KeyPair,
-    data_types::{Blob, BlockHeight, Timestamp},
+    data_types::{BlockHeight, Timestamp},
     identifiers::{Account, ChainId},
     ownership::ChainOwnership,
     time::{Duration, Instant},
@@ -269,8 +269,7 @@ where
             chain.block_hash,
             chain.timestamp,
             chain.next_block_height,
-            chain.pending_block.clone(),
-            chain.pending_blobs.iter().cloned(),
+            chain.pending_proposal.clone(),
         );
         chain_client.options_mut().message_policy = MessagePolicy::new(
             self.blanket_message_policy,
@@ -323,19 +322,7 @@ where
         key_pair: Option<KeyPair>,
         timestamp: Timestamp,
     ) -> Result<(), Error> {
-        self.update_wallet_for_new_chain_internal(chain_id, key_pair, timestamp, Vec::new())
-            .await
-    }
-
-    #[cfg(test)]
-    pub async fn update_wallet_for_new_chain_with_pending_blobs(
-        &mut self,
-        chain_id: ChainId,
-        key_pair: Option<KeyPair>,
-        timestamp: Timestamp,
-        pending_blobs: Vec<Blob>,
-    ) -> Result<(), Error> {
-        self.update_wallet_for_new_chain_internal(chain_id, key_pair, timestamp, pending_blobs)
+        self.update_wallet_for_new_chain_internal(chain_id, key_pair, timestamp)
             .await
     }
 
@@ -344,7 +331,6 @@ where
         chain_id: ChainId,
         key_pair: Option<KeyPair>,
         timestamp: Timestamp,
-        pending_blobs: Vec<Blob>,
     ) -> Result<(), Error> {
         if self.wallet.get(chain_id).is_none() {
             self.mutate_wallet(|w| {
@@ -354,8 +340,7 @@ where
                     block_hash: None,
                     timestamp,
                     next_block_height: BlockHeight::ZERO,
-                    pending_block: None,
-                    pending_blobs,
+                    pending_proposal: None,
                 })
             })
             .await?;

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -70,8 +70,7 @@ impl chain_listener::ClientContext for ClientContext {
             chain.block_hash,
             chain.timestamp,
             chain.next_block_height,
-            chain.pending_block.clone(),
-            chain.pending_blobs.iter().cloned(),
+            chain.pending_proposal.clone(),
         ))
     }
 
@@ -88,8 +87,7 @@ impl chain_listener::ClientContext for ClientContext {
                 block_hash: None,
                 timestamp,
                 next_block_height: BlockHeight::ZERO,
-                pending_block: None,
-                pending_blobs: Vec::new(),
+                pending_proposal: None,
             });
         }
 

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::large_futures)]
 
-use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc, time::Duration};
+use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use futures::{lock::Mutex, FutureExt as _};
@@ -71,7 +71,7 @@ impl chain_listener::ClientContext for ClientContext {
             chain.timestamp,
             chain.next_block_height,
             chain.pending_block.clone(),
-            chain.pending_blobs.clone(),
+            chain.pending_blobs.iter().cloned(),
         ))
     }
 
@@ -89,7 +89,7 @@ impl chain_listener::ClientContext for ClientContext {
                 timestamp,
                 next_block_height: BlockHeight::ZERO,
                 pending_block: None,
-                pending_blobs: BTreeMap::new(),
+                pending_blobs: Vec::new(),
             });
         }
 

--- a/linera-client/src/unit_tests/wallet.rs
+++ b/linera-client/src/unit_tests/wallet.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
-
 use anyhow::anyhow;
 use linera_base::{
     crypto::KeyPair,
@@ -45,14 +43,12 @@ async fn test_save_wallet_with_pending_blobs() -> anyhow::Result<()> {
         WalletState::create_from_file(&wallet_path, Wallet::new(genesis_config, Some(37)))?;
     let mut context = ClientContext::new_test_client_context(storage, wallet);
     let blob = Blob::new_data(b"blob".to_vec());
-    let mut pending_blobs = BTreeMap::new();
-    pending_blobs.insert(blob.id(), blob);
     context
         .update_wallet_for_new_chain_with_pending_blobs(
             chain_id,
             Some(key_pair),
             clock.current_time(),
-            pending_blobs,
+            vec![blob],
         )
         .await?;
     context.save_wallet().await?;

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -179,7 +179,7 @@ impl Wallet {
                 next_block_height: state.next_block_height(),
                 timestamp: state.timestamp(),
                 pending_block: state.pending_proposal().clone(),
-                pending_blobs: state.pending_blobs().values().cloned().collect(),
+                pending_blobs: state.pending_blobs().clone(),
             },
         );
     }

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -10,7 +10,7 @@ use linera_base::{
     crypto::{CryptoHash, CryptoRng, KeyPair},
     data_types::{Blob, BlockHeight, Timestamp},
     ensure,
-    identifiers::{BlobId, ChainDescription, ChainId, Owner},
+    identifiers::{ChainDescription, ChainId, Owner},
 };
 use linera_chain::data_types::ProposedBlock;
 use linera_core::{client::ChainClient, node::ValidatorNodeProvider};
@@ -148,7 +148,7 @@ impl Wallet {
             timestamp,
             next_block_height: BlockHeight(0),
             pending_block: None,
-            pending_blobs: BTreeMap::new(),
+            pending_blobs: Vec::new(),
         };
         self.insert(user_chain);
         Ok(())
@@ -179,7 +179,7 @@ impl Wallet {
                 next_block_height: state.next_block_height(),
                 timestamp: state.timestamp(),
                 pending_block: state.pending_proposal().clone(),
-                pending_blobs: state.pending_blobs().clone(),
+                pending_blobs: state.pending_blobs().values().cloned().collect(),
             },
         );
     }
@@ -211,7 +211,7 @@ pub struct UserChain {
     pub timestamp: Timestamp,
     pub next_block_height: BlockHeight,
     pub pending_block: Option<ProposedBlock>,
-    pub pending_blobs: BTreeMap<BlobId, Blob>,
+    pub pending_blobs: Vec<Blob>,
 }
 
 impl UserChain {
@@ -229,7 +229,7 @@ impl UserChain {
             timestamp,
             next_block_height: BlockHeight::ZERO,
             pending_block: None,
-            pending_blobs: BTreeMap::new(),
+            pending_blobs: Vec::new(),
         }
     }
 
@@ -243,7 +243,7 @@ impl UserChain {
             timestamp,
             next_block_height: BlockHeight::ZERO,
             pending_block: None,
-            pending_blobs: BTreeMap::new(),
+            pending_blobs: Vec::new(),
         }
     }
 }

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -8,12 +8,14 @@ use std::{
 
 use linera_base::{
     crypto::{CryptoHash, CryptoRng, KeyPair},
-    data_types::{Blob, BlockHeight, Timestamp},
+    data_types::{BlockHeight, Timestamp},
     ensure,
     identifiers::{ChainDescription, ChainId, Owner},
 };
-use linera_chain::data_types::ProposedBlock;
-use linera_core::{client::ChainClient, node::ValidatorNodeProvider};
+use linera_core::{
+    client::{ChainClient, PendingProposal},
+    node::ValidatorNodeProvider,
+};
 use linera_storage::Storage;
 use rand::Rng as _;
 use serde::{Deserialize, Serialize};
@@ -147,8 +149,7 @@ impl Wallet {
             block_hash: None,
             timestamp,
             next_block_height: BlockHeight(0),
-            pending_block: None,
-            pending_blobs: Vec::new(),
+            pending_proposal: None,
         };
         self.insert(user_chain);
         Ok(())
@@ -178,8 +179,7 @@ impl Wallet {
                 block_hash: state.block_hash(),
                 next_block_height: state.next_block_height(),
                 timestamp: state.timestamp(),
-                pending_block: state.pending_proposal().clone(),
-                pending_blobs: state.pending_blobs().clone(),
+                pending_proposal: state.pending_proposal().clone(),
             },
         );
     }
@@ -210,8 +210,7 @@ pub struct UserChain {
     pub block_hash: Option<CryptoHash>,
     pub timestamp: Timestamp,
     pub next_block_height: BlockHeight,
-    pub pending_block: Option<ProposedBlock>,
-    pub pending_blobs: Vec<Blob>,
+    pub pending_proposal: Option<PendingProposal>,
 }
 
 impl UserChain {
@@ -228,8 +227,7 @@ impl UserChain {
             block_hash: None,
             timestamp,
             next_block_height: BlockHeight::ZERO,
-            pending_block: None,
-            pending_blobs: Vec::new(),
+            pending_proposal: None,
         }
     }
 
@@ -242,8 +240,7 @@ impl UserChain {
             block_hash: None,
             timestamp,
             next_block_height: BlockHeight::ZERO,
-            pending_block: None,
-            pending_blobs: Vec::new(),
+            pending_proposal: None,
         }
     }
 }

--- a/linera-core/src/client/chain_client_state.rs
+++ b/linera-core/src/client/chain_client_state.rs
@@ -70,6 +70,8 @@ impl ChainClientState {
         };
         if let Some(block) = pending_block {
             state.set_pending_proposal(block, pending_blobs);
+        } else {
+            assert!(pending_blobs.into_iter().next().is_none());
         }
         state
     }

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -206,6 +206,24 @@ where
         Ok(Some(blobs))
     }
 
+    /// Looks for the specified blobs in the local chain manager's pending blobs.
+    /// Returns `Ok(None)` if any of the blobs is not found.
+    pub async fn get_pending_blobs(
+        &self,
+        blob_ids: &[BlobId],
+        chain_id: ChainId,
+    ) -> Result<Option<Vec<Blob>>, LocalNodeError> {
+        let chain = self.chain_state_view(chain_id).await?;
+        let mut blobs = Vec::new();
+        for blob_id in blob_ids {
+            match chain.manager.pending_blob(blob_id).await? {
+                None => return Ok(None),
+                Some(blob) => blobs.push(blob),
+            }
+        }
+        Ok(Some(blobs))
+    }
+
     /// Writes the given blobs to storage if there is an appropriate blob state.
     pub async fn store_blobs(&self, blobs: &[Blob]) -> Result<(), LocalNodeError> {
         let storage = self.storage_client();

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -192,7 +192,7 @@ where
     /// Returns `Ok(None)` if any of the blobs is not found.
     pub async fn get_locking_blobs(
         &self,
-        blob_ids: &[BlobId],
+        blob_ids: impl IntoIterator<Item = &BlobId>,
         chain_id: ChainId,
     ) -> Result<Option<Vec<Blob>>, LocalNodeError> {
         let chain = self.chain_state_view(chain_id).await?;

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2311,12 +2311,11 @@ where
         ))
     );
 
-    let result = client1.publish_data_blob(large_blob_bytes).await;
     assert_matches!(
-        result,
-        Err(ChainClientError::LocalNodeError(
-            LocalNodeError::WorkerError(WorkerError::BlobTooLarge)
-        ))
+        client1.publish_data_blob(large_blob_bytes).await,
+        Err(ChainClientError::ChainError(ChainError::ExecutionError(
+            error, ChainExecutionContext::Block
+        ))) if matches!(*error, ExecutionError::BlobTooLarge)
     );
 
     Ok(())

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1782,8 +1782,10 @@ where
     builder.set_fault_type([0, 2, 3], FaultType::Honest).await;
 
     client3_c.synchronize_from_validators().await.unwrap();
+    let blob4_data = b"blob4".to_vec();
+    let blob4 = Blob::new(BlobContent::new_data(blob4_data.clone()));
     let bt_certificate = client3_c
-        .burn(None, Amount::from_tokens(1))
+        .publish_data_blob(blob4_data)
         .await
         .unwrap()
         .unwrap();
@@ -1799,10 +1801,8 @@ where
         .block()
         .body
         .operations
-        .contains(&Operation::System(SystemOperation::Transfer {
-            owner: None,
-            recipient: Recipient::Burn,
-            amount: Amount::from_tokens(1),
+        .contains(&Operation::System(SystemOperation::PublishDataBlob {
+            blob_hash: blob4.id().hash
         })));
 
     // Block before that should be b1

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -797,7 +797,7 @@ where
 
     // Since blocks are free of charge on closed chains, empty blocks are not allowed.
     assert_matches!(
-        client1.execute_operations(vec![]).await,
+        client1.execute_operations(vec![], vec![]).await,
         Err(ChainClientError::LocalNodeError(
             LocalNodeError::WorkerError(WorkerError::ChainError(error))
         )) if matches!(*error, ChainError::ClosedChain)
@@ -1353,7 +1353,6 @@ where
     let blob1 = Blob::new_data(b"blob1".to_vec());
     let blob1_hash = blob1.id().hash;
 
-    client2_a.add_pending_blobs([blob1.clone()]).await;
     let blob_0_1_operations = vec![
         Operation::System(SystemOperation::ReadBlob { blob_id: blob0_id }),
         Operation::System(SystemOperation::PublishDataBlob {
@@ -1361,7 +1360,7 @@ where
         }),
     ];
     let b0_result = client2_a
-        .execute_operations(blob_0_1_operations.clone())
+        .execute_operations(blob_0_1_operations.clone(), vec![blob1.clone()])
         .await;
 
     assert!(b0_result.is_err());
@@ -1502,7 +1501,6 @@ where
     let blob1 = Blob::new_data(b"blob1".to_vec());
     let blob1_hash = blob1.id().hash;
 
-    client2_a.add_pending_blobs([blob1]).await;
     let blob_0_1_operations = vec![
         Operation::System(SystemOperation::ReadBlob { blob_id: blob0_id }),
         Operation::System(SystemOperation::PublishDataBlob {
@@ -1510,7 +1508,7 @@ where
         }),
     ];
     let b0_result = client2_a
-        .execute_operations(blob_0_1_operations.clone())
+        .execute_operations(blob_0_1_operations.clone(), vec![blob1])
         .await;
 
     assert!(b0_result.is_err());
@@ -1658,7 +1656,6 @@ where
     let blob1 = Blob::new_data(b"blob1".to_vec());
     let blob1_hash = blob1.id().hash;
 
-    client3_a.add_pending_blobs([blob1.clone()]).await;
     let blob_0_1_operations = vec![
         Operation::System(SystemOperation::ReadBlob { blob_id: blob0_id }),
         Operation::System(SystemOperation::PublishDataBlob {
@@ -1666,7 +1663,7 @@ where
         }),
     ];
     let b0_result = client3_a
-        .execute_operations(blob_0_1_operations.clone())
+        .execute_operations(blob_0_1_operations.clone(), vec![blob1.clone()])
         .await;
 
     assert!(b0_result.is_err());
@@ -1727,7 +1724,6 @@ where
     let blob3 = Blob::new_data(b"blob3".to_vec());
     let blob3_hash = blob3.id().hash;
 
-    client3_b.add_pending_blobs([blob3.clone()]).await;
     let blob_2_3_operations = vec![
         Operation::System(SystemOperation::ReadBlob { blob_id: blob2_id }),
         Operation::System(SystemOperation::PublishDataBlob {
@@ -1735,7 +1731,7 @@ where
         }),
     ];
     let b1_result = client3_b
-        .execute_operations(blob_2_3_operations.clone())
+        .execute_operations(blob_2_3_operations.clone(), vec![blob3.clone()])
         .await;
     assert!(b1_result.is_err());
 

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -915,7 +915,6 @@ where
             Timestamp::from(0),
             block_height,
             None,
-            vec![],
         ))
     }
 

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -915,7 +915,7 @@ where
             Timestamp::from(0),
             block_height,
             None,
-            BTreeMap::new(),
+            vec![],
         ))
     }
 

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -908,7 +908,10 @@ async fn test_memory_fuel_limit(wasm_runtime: WasmRuntime) -> anyhow::Result<()>
         .unwrap();
 
     assert!(publisher
-        .execute_operations(vec![Operation::user(application_id, &increment)?; 10])
+        .execute_operations(
+            vec![Operation::user(application_id, &increment)?; 10],
+            vec![]
+        )
         .await
         .is_err());
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -219,12 +219,8 @@ pub enum WorkerError {
     FullChainWorkerCache,
     #[error("Failed to join spawned worker task")]
     JoinError,
-    #[error("Blob exceeds size limit")]
-    BlobTooLarge,
     #[error("Blob was not required by any pending block")]
     UnexpectedBlob,
-    #[error("Bytecode exceeds size limit")]
-    BytecodeTooLarge,
     #[error("Number of published blobs per block must not exceed {0}")]
     TooManyPublishedBlobs(u64),
     #[error(transparent)]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -261,6 +261,10 @@ pub enum ExecutionError {
     EventKeyTooLong,
     #[error("Stream names can be at most {MAX_STREAM_NAME_LEN} bytes.")]
     StreamNameTooLong,
+    #[error("Blob exceeds size limit")]
+    BlobTooLarge,
+    #[error("Bytecode exceeds size limit")]
+    BytecodeTooLarge,
     // TODO(#2127): Remove this error and the unstable-oracles feature once there are fees
     // and enforced limits for all oracles.
     #[error("Unstable oracles are disabled on this network.")]

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -1014,7 +1014,10 @@ where
                 chain_id: chain_id.to_string(),
             })?;
         let hash = loop {
-            let timeout = match client.execute_operations(operations.clone()).await? {
+            let timeout = match client
+                .execute_operations(operations.clone(), vec![])
+                .await?
+            {
                 ClientOutcome::Committed(certificate) => break certificate.hash(),
                 ClientOutcome::WaitForTimeout(timeout) => timeout,
             };


### PR DESCRIPTION
## Motivation

This is a port of #3238 to the main branch.

## Proposal

Always set the pending blobs together with the pending block.

Also simplify some more blob-related client code.

## Test Plan

`test_re_propose_locked_block_with_blobs` was modified to re-propose a `PublishDataBlob` operation. This fails without the fix.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Original PR: #3238 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
