### PR TITLE
Return an error if a pending blob is not needed by any pending block.

### DIFF
--- a/linera-chain/src/pending_blobs.rs
+++ b/linera-chain/src/pending_blobs.rs
@@ -44,14 +44,16 @@ where
         Ok(self.pending_blobs.get(blob_id).await?.flatten())
     }
 
-    pub async fn maybe_insert(&mut self, blob: &Blob) -> Result<(), ViewError> {
+    /// Inserts the blob. Returns whether the blob was required by the pending block.
+    pub async fn maybe_insert(&mut self, blob: &Blob) -> Result<bool, ViewError> {
         let blob_id = blob.id();
-        if let Some(maybe_blob) = self.pending_blobs.get_mut(&blob_id).await? {
-            if maybe_blob.is_none() {
-                *maybe_blob = Some(blob.clone());
-            }
+        let Some(maybe_blob) = self.pending_blobs.get_mut(&blob_id).await? else {
+            return Ok(false);
+        };
+        if maybe_blob.is_none() {
+            *maybe_blob = Some(blob.clone());
         }
-        Ok(())
+        Ok(true)
     }
 
     pub async fn update(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -221,6 +221,8 @@ pub enum WorkerError {
     JoinError,
     #[error("Blob exceeds size limit")]
     BlobTooLarge,
+    #[error("Blob was not required by any pending block")]
+    UnexpectedBlob,
     #[error("Bytecode exceeds size limit")]
     BytecodeTooLarge,
     #[error("Number of published blobs per block must not exceed {0}")]


### PR DESCRIPTION
## Motivation

We currently don't detect if the blob in `HandlePendingBlob` was needed at all.
(See [this discussion](https://github.com/linera-io/linera-protocol/pull/3204#discussion_r1939274824))

## Proposal

Return an error if no pending block needed it.

## Test Plan

CI should catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Discussion: https://github.com/linera-io/linera-protocol/pull/3204#discussion_r1939274824
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
