### PR TITLE
docs: Remove duplicate word in game instructions

### DIFF
--- a/examples/hex-game/README.md
+++ b/examples/hex-game/README.md
@@ -136,7 +136,7 @@ Now the first player can make a move by navigating to the URL you get by running
 mutation { makeMove(x: 4, y: 4) }
 ```
 
-And the second player player at the URL you get by running `echo "http://localhost:8080/chains/$HEX_CHAIN/applications/$APP_ID"`:
+And the second player at the URL you get by running `echo "http://localhost:8080/chains/$HEX_CHAIN/applications/$APP_ID"`:
 
 ```gql,uri=http://localhost:8081/chains/$HEX_CHAIN/applications/$APP_ID
 mutation { makeMove(x: 4, y: 5) }


### PR DESCRIPTION
## Motivation

<img width="543" alt="Снимок экрана 2025-02-05 в 08 45 25" src="https://github.com/user-attachments/assets/49700d8b-221a-490d-b5c7-7a6e53009968" />


Noticed a  typo in the instructions: "player player" → "player".
This fixes it for clarity. No other changes.