### PR TITLE
`linera-client`: make sure to use `linera_base::time`

### DIFF
--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -6,7 +6,6 @@ use std::{
     env, fmt, iter,
     num::{NonZeroU16, NonZeroUsize},
     path::PathBuf,
-    time::Duration,
 };
 
 use chrono::{DateTime, Utc};
@@ -17,6 +16,7 @@ use linera_base::{
         Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner, UserApplicationId,
     },
     ownership::{ChainOwnership, TimeoutConfig},
+    time::Duration,
 };
 use linera_core::{client::BlanketMessagePolicy, DEFAULT_GRACE_PERIOD};
 use linera_execution::{


### PR DESCRIPTION
## Motivation

`std::time` will panic if used on `wasm32-unknown-unknown`, since without making additional assumptions about the execution environment no clock syscalls can be used.  A `std::time::Duration` is used in `linera_client::client_options`.

<!--
Briefly describe the goal(s) of this PR.
-->

## Proposal

We have time primitives exported from `linera_base::time` that are Web-safe (using `web-time` on the Web).  Replace `std::time::Duration` with `linera_base::time::Duration` in `linera-client`. 

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
