### PR TITLE
Actually use the correct docker image when docker_image_name is used

### DIFF
--- a/linera-service/src/cli_wrappers/helmfile.rs
+++ b/linera-service/src/cli_wrappers/helmfile.rs
@@ -16,6 +16,7 @@ impl HelmFile {
         github_root: &Path,
         num_shards: usize,
         cluster_id: u32,
+        docker_image_name: String,
     ) -> Result<()> {
         let chart_dir = format!("{}/kubernetes/linera-validator", github_root.display());
 
@@ -29,6 +30,7 @@ impl HelmFile {
                 format!("working/server_{server_config_id}.json"),
             )
             .env("LINERA_HELMFILE_SET_NUM_SHARDS", num_shards.to_string())
+            .env("LINERA_HELMFILE_LINERA_IMAGE", docker_image_name)
             .arg("sync")
             .arg("--wait")
             .args(["--kube-context", &format!("kind-{}", cluster_id)])

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -446,7 +446,7 @@ impl LocalKubernetesNet {
                     base_dir.join(&server_config_filename),
                 )?;
 
-                HelmFile::sync(i, &github_root, num_shards, cluster_id).await?;
+                HelmFile::sync(i, &github_root, num_shards, cluster_id, docker_image_name).await?;
 
                 let mut kubectl_instance = kubectl_instance.lock().await;
                 let output = kubectl_instance.get_pods(cluster_id).await?;


### PR DESCRIPTION
## Motivation

The docker image name is not actually getting propagated to the helmfile

## Proposal

Properly propagate the docker image name down to the helmfime, so the specified image is actaully used

## Test Plan

Ran with a custom image, and it worked.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
