### PR TITLE
make_benchmark_block_proposals now returns BlockProposals

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -843,7 +843,7 @@ where
         key_pairs: &HashMap<ChainId, KeyPair>,
         transactions_per_block: usize,
         fungible_application_id: Option<ApplicationId>,
-    ) -> Vec<RpcMessage> {
+    ) -> Vec<BlockProposal> {
         let mut proposals = Vec::new();
         let mut previous_chain_id = *key_pairs
             .iter()
@@ -887,7 +887,7 @@ where
                 block.clone(),
                 key_pair,
             );
-            proposals.push(RpcMessage::BlockProposal(Box::new(proposal)));
+            proposals.push(proposal);
             previous_chain_id = chain.chain_id;
         }
         proposals


### PR DESCRIPTION
## Motivation

This `RpcMessage` type is needed only when calling `mass_broadcast`, and it makes the code a bit more awkward because you have to check if it's a block proposal, when it'll always be

## Proposal

Return the actual `BlockProposal`s instead, and only convert them when needed.

## Test Plan

CI + ran locally

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
