### PR TITLE
Export `unstable-oracles` feature from `linera-service`

### DIFF
--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -31,7 +31,7 @@ rocksdb = ["linera-views/rocksdb"]
 dynamodb = ["linera-views/dynamodb"]
 scylladb = ["linera-views/scylladb"]
 storage-service = ["linera-storage-service"]
-unstable-oracles = []
+unstable-oracles = ["linera-execution/unstable-oracles"]
 metrics = [
     "prometheus",
     "linera-base/metrics",

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 [features]
 ethereum = []
 default = ["wasmer", "rocksdb", "storage-service"]
+unstable-oracles = ["linera-core/unstable-oracles"]
 test = [
     "linera-base/test",
     "linera-execution/test",


### PR DESCRIPTION
## Motivation

The `unstable-oracles` feature currently has to be enabled manually for the `linera-core` and `linera-execution` crates. This makes it hard to rebuild the binaries while enabling the feature with a single command.

## Proposal

Link `linera-core` and `linera-execution`, so that if the feature is enabled in `linera-core`, it will also get enabled in `linera-execution`.

Add a new `unstable-oracles` feature to `linera-service`, and enable `linera-core`'s feature if it's enabled.

## Test Plan

Manually tested with the following steps using the [`atoma-demo` repository](https://github.com/linera-io/atoma-demo).

```bash
export TEST_REV=9cdac7723e
cargo install linera-service --git https://github.com/jvff/linera-protocol-archive.git --rev "$TEST_REV" --features unstable-oracles
cargo install linera-storage-service --git https://github.com/jvff/linera-protocol-archive.git --rev "$TEST_REV"

linera net up &
export LINERA_WALLET=...
export LINERA_STORAGE=...

export CHAIN_ID="$(linera wallet show --short | tail -n 1)"
export APP_ID="$(linera project publish-and-create)"
export ATOMA_API_ID=...

linera service &
curl 127.0.0.1:8080/chains/$CHAIN_ID/applications/$APP_ID -d "{\"query\": \"mutation { chat(apiToken: \\\"${ATOMA_API_TOKEN}\\\", message: { content: \\\"What is the capital of France\\\", role: \\\"user\\\" }) }\"}"
```

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
