### PR TITLE
compose.sh uses docker so precompiled binaries are not required.

### DIFF
--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -57,13 +57,32 @@ set -xe
 # Create configuration files.
 # * Private server states are stored in `server.json`.
 # * `committee.json` is the public description of the Linera committee.
-linera-server generate --validators "$CONF_DIR/validator.toml" --committee committee.json --testing-prng-seed 1
+docker run \
+    -v $CONF_DIR:/config  \
+    -v $PWD:/working \
+    -w /working \
+    --platform linux/amd64 \
+    -it linera /linera-server \
+    generate \
+    --validators /config/validator.toml \
+    --committee /working/committee.json \
+    --testing-prng-seed 1
 
 # Create configuration files for 10 user chains.
 # * Private chain states are stored in one local wallet `wallet.json`.
 # * `genesis.json` will contain the initial balances of chains as well as the initial committee.
-
-linera --wallet wallet.json --storage rocksdb:linera.db create-genesis-config 10 --genesis genesis.json --initial-funding 10 --committee committee.json --testing-prng-seed 2
+docker run \
+    -v $PWD:/working \
+    -w /working \
+    --platform linux/amd64 \
+    -it linera /linera \
+    --wallet wallet.json \
+    --storage rocksdb:linera.db \
+    create-genesis-config 10 \
+    --genesis genesis.json \
+    --initial-funding 10 \
+    --committee committee.json \
+    --testing-prng-seed 2
 
 if [ "${DOCKER_COMPOSE_WAIT:-false}" = "true" ]; then
     docker compose up --wait


### PR DESCRIPTION
## Motivation

`compose.sh` has an unnecessary dependency on pre-built binaries.

## Proposal

Use the existing Docker image.

## Test Plan

CI will catch any regressions.
