### PR TITLE
Refactorings to make separation of execution from certificate handling easier.

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -11,7 +11,7 @@ use linera_base::{
     hashed::Hashed,
     identifiers::{BlobId, BlobType, ChainId, MessageId, Owner},
 };
-use linera_execution::{committee::Epoch, Operation, SystemOperation};
+use linera_execution::{committee::Epoch, BlobState, Operation, SystemOperation};
 use serde::{ser::SerializeStruct, Deserialize, Serialize};
 use thiserror::Error;
 
@@ -173,6 +173,16 @@ impl ConfirmedBlock {
             && *timestamp == self.block().header.timestamp
             && *authenticated_signer == self.block().header.authenticated_signer
             && *previous_block_hash == self.block().header.previous_block_hash
+    }
+
+    /// Returns a blob state that applies to all blobs used by this block.
+    pub fn to_blob_state(&self) -> BlobState {
+        BlobState {
+            last_used_by: self.0.hash(),
+            chain_id: self.chain_id(),
+            block_height: self.height(),
+            epoch: self.epoch(),
+        }
     }
 }
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -281,26 +281,29 @@ impl ChainTipState {
     }
 
     /// Checks if the measurement counters would be valid.
-    pub fn verify_counters(
-        &self,
+    pub fn update_counters(
+        &mut self,
         new_block: &ProposedBlock,
         outcome: &BlockExecutionOutcome,
     ) -> Result<(), ChainError> {
         let num_incoming_bundles = u32::try_from(new_block.incoming_bundles.len())
             .map_err(|_| ArithmeticError::Overflow)?;
-        self.num_incoming_bundles
+        self.num_incoming_bundles = self
+            .num_incoming_bundles
             .checked_add(num_incoming_bundles)
             .ok_or(ArithmeticError::Overflow)?;
 
         let num_operations =
             u32::try_from(new_block.operations.len()).map_err(|_| ArithmeticError::Overflow)?;
-        self.num_operations
+        self.num_operations = self
+            .num_operations
             .checked_add(num_operations)
             .ok_or(ArithmeticError::Overflow)?;
 
         let num_outgoing_messages =
             u32::try_from(outcome.messages.len()).map_err(|_| ArithmeticError::Overflow)?;
-        self.num_outgoing_messages
+        self.num_outgoing_messages = self
+            .num_outgoing_messages
             .checked_add(num_outgoing_messages)
             .ok_or(ArithmeticError::Overflow)?;
 
@@ -566,7 +569,7 @@ where
     }
 
     /// Verifies that the block's first message is `OpenChain`. Initializes the chain if necessary.
-    async fn execute_init_message_from(
+    pub async fn execute_init_message_from(
         &mut self,
         block: &ProposedBlock,
         local_time: Timestamp,
@@ -975,7 +978,7 @@ where
     }
 
     /// Returns whether this is a child chain.
-    fn is_child(&self) -> bool {
+    pub fn is_child(&self) -> bool {
         let Some(description) = self.execution_state.system.description.get() else {
             // Root chains are always initialized, so this must be a child chain.
             return true;

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -590,7 +590,7 @@ where
     }
 
     /// Initializes the chain using the given configuration.
-    pub async fn execute_init_message(
+    async fn execute_init_message(
         &mut self,
         message_id: MessageId,
         config: &OpenChainConfig,
@@ -709,11 +709,6 @@ where
         let _execution_latency = BLOCK_EXECUTION_LATENCY.measure_latency();
 
         assert_eq!(block.chain_id, self.chain_id());
-
-        // If this is the first block of a child chain, initialize the chain.
-        if block.height == BlockHeight::ZERO && self.is_child() {
-            self.execute_init_message_from(block, local_time).await?;
-        }
 
         ensure!(
             *self.execution_state.system.timestamp.get() <= block.timestamp,

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -9,7 +9,7 @@ use futures::future::Either;
 use linera_base::{
     data_types::{Blob, BlockHeight, Timestamp},
     ensure,
-    identifiers::{ChainId, MessageId},
+    identifiers::ChainId,
 };
 use linera_chain::{
     data_types::{
@@ -20,10 +20,7 @@ use linera_chain::{
     types::{ConfirmedBlockCertificate, TimeoutCertificate, ValidatedBlockCertificate},
     ChainExecutionContext, ChainStateView, ExecutionResultExt as _,
 };
-use linera_execution::{
-    committee::{Committee, Epoch, ValidatorName},
-    BlobState,
-};
+use linera_execution::committee::{Committee, Epoch, ValidatorName};
 use linera_storage::{Clock as _, Storage};
 use linera_views::{
     context::Context,
@@ -302,54 +299,39 @@ where
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         let executed_block: ExecutedBlock = certificate.block().clone().into();
-        let block_height = executed_block.block.height;
+        let block = &executed_block.block;
+        let height = block.height;
+        let chain_id = block.chain_id;
+
         // Check that the chain is active and ready for this confirmation.
         let tip = self.state.chain.tip_state.get().clone();
-        if tip.next_block_height < block_height {
+        if tip.next_block_height < height {
             return Err(WorkerError::MissingEarlierBlocks {
                 current_block_height: tip.next_block_height,
             });
         }
-        if tip.next_block_height > block_height {
+        if tip.next_block_height > height {
             // Block was already confirmed.
             let info = ChainInfoResponse::new(&self.state.chain, self.state.config.key_pair());
             let actions = self.state.create_network_actions().await?;
             return Ok((info, actions));
         }
+        let local_time = self.state.storage.clock().current_time();
         // TODO(#2351): This sets the committee and then checks that committee's signatures.
-        if tip.is_first_block() && !self.state.chain.is_active() {
-            if let Some((incoming_bundle, posted_message, config)) =
-                executed_block.block.starts_with_open_chain_message()
-            {
-                let message_id = MessageId {
-                    chain_id: incoming_bundle.origin.sender,
-                    height: incoming_bundle.bundle.height,
-                    index: posted_message.index,
-                };
-                let local_time = self.state.storage.clock().current_time();
-                self.state
-                    .chain
-                    .execute_init_message(
-                        message_id,
-                        config,
-                        incoming_bundle.bundle.timestamp,
-                        local_time,
-                    )
-                    .await?;
-            }
+        if tip.is_first_block() && self.state.chain.is_child() {
+            self.state
+                .chain
+                .execute_init_message_from(block, local_time)
+                .await?;
         }
         self.state.ensure_is_active()?;
         // Verify the certificate.
         let (epoch, committee) = self.state.chain.current_committee()?;
-        check_block_epoch(
-            epoch,
-            executed_block.block.chain_id,
-            executed_block.block.epoch,
-        )?;
+        check_block_epoch(epoch, chain_id, block.epoch)?;
         certificate.check(committee)?;
         // This should always be true for valid certificates.
         ensure!(
-            tip.block_hash == executed_block.block.previous_block_hash,
+            tip.block_hash == block.previous_block_hash,
             WorkerError::InvalidBlockChaining
         );
 
@@ -368,12 +350,7 @@ where
         }
 
         // Update the blob state with last used certificate hash.
-        let blob_state = BlobState {
-            last_used_by: certificate.hash(),
-            chain_id: executed_block.block.chain_id,
-            block_height,
-            epoch: executed_block.block.epoch,
-        };
+        let blob_state = certificate.value().inner().to_blob_state();
         let overwrite = blobs_result.is_ok(); // Overwrite only if we wrote the certificate.
         let blob_ids = required_blob_ids.into_iter().collect::<Vec<_>>();
         self.state
@@ -385,19 +362,14 @@ where
         // Execute the block and update inboxes.
         self.state
             .chain
-            .remove_bundles_from_inboxes(
-                executed_block.block.timestamp,
-                &executed_block.block.incoming_bundles,
-            )
+            .remove_bundles_from_inboxes(block.timestamp, &block.incoming_bundles)
             .await?;
-        let local_time = self.state.storage.clock().current_time();
-        let verified_outcome = Box::pin(self.state.chain.execute_block(
-            &executed_block.block,
-            local_time,
-            None,
-            Some(executed_block.outcome.oracle_responses.clone()),
-        ))
-        .await?;
+        let oracle_responses = Some(executed_block.outcome.oracle_responses.clone());
+        let verified_outcome = self
+            .state
+            .chain
+            .execute_block(block, local_time, None, oracle_responses)
+            .await?;
         // We should always agree on the messages and state hash.
         ensure!(
             executed_block.outcome == verified_outcome,
@@ -408,26 +380,17 @@ where
         );
         // Advance to next block height.
         let tip = self.state.chain.tip_state.get_mut();
-        tip.block_hash = Some(certificate.hash());
+        let hash = certificate.hash();
+        tip.block_hash = Some(hash);
         tip.next_block_height.try_add_assign_one()?;
-        tip.num_incoming_bundles += executed_block.block.incoming_bundles.len() as u32;
-        tip.num_operations += executed_block.block.operations.len() as u32;
-        tip.num_outgoing_messages += executed_block.outcome.messages.len() as u32;
-        self.state.chain.confirmed_log.push(certificate.hash());
-        let info = ChainInfoResponse::new(&self.state.chain, self.state.config.key_pair());
+        tip.update_counters(block, &executed_block.outcome)?;
+        self.state.chain.confirmed_log.push(hash);
         self.state.track_newly_created_chains(&executed_block);
         let mut actions = self.state.create_network_actions().await?;
-        trace!(
-            "Processed confirmed block {} on chain {:.8}",
-            block_height,
-            executed_block.block.chain_id
-        );
+        trace!("Processed confirmed block {height} on chain {chain_id:.8}");
         actions.notifications.push(Notification {
-            chain_id: executed_block.block.chain_id,
-            reason: Reason::NewBlock {
-                height: block_height,
-                hash: certificate.hash(),
-            },
+            chain_id,
+            reason: Reason::NewBlock { height, hash },
         });
         // Persist chain.
         self.save().await?;
@@ -436,8 +399,9 @@ where
             .block_values
             .insert(Cow::Owned(certificate.into_inner().into_inner()));
 
-        self.register_delivery_notifier(block_height, &actions, notify_when_messages_are_delivered)
+        self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
             .await;
+        let info = ChainInfoResponse::new(&self.state.chain, self.state.config.key_pair());
 
         Ok((info, actions))
     }

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -180,8 +180,8 @@ where
         // Check if the counters of tip_state would be valid.
         chain
             .tip_state
-            .get()
-            .verify_counters(block, &executed_block.outcome)?;
+            .get_mut()
+            .update_counters(block, &executed_block.outcome)?;
         // Verify that the resulting chain would have no unconfirmed incoming messages.
         chain.validate_incoming_bundles().await?;
         Ok(Some((executed_block.outcome, local_time)))


### PR DESCRIPTION
## Motivation

To make https://github.com/linera-io/linera-protocol/issues/2025 possible, we need to better separate the code that verifies a certificate and handles outboxes and inboxes from the block execution code.

## Proposal

Don't call `execute_init_message` from `execute_block` at all: That is already unnecessary because it is called from `process_confirmed_block` and `receive_message_bundle`.

Extract some functions from `execute_block` and `process_confirmed_block` to make them easier to read, and deduplicate some of the logic.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Related to #2025 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
