### PR TITLE
Fix Grammar and Clarity in Documentation and Error Messages

### DIFF
--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -73,7 +73,7 @@ pub struct ChainInfoQuery {
     /// Query the current committees.
     #[debug(skip_if = Not::not)]
     pub request_committees: bool,
-    /// Query the received messages that are waiting be picked in the next block.
+    /// Query the received messages that are waiting to be picked in the next block.
     #[debug(skip_if = Not::not)]
     pub request_pending_message_bundles: bool,
     /// Query a range of certificate hashes sent from the chain.
@@ -322,7 +322,7 @@ impl<'de> BcsSignable<'de> for ChainInfo {}
 pub enum ClientOutcome<T> {
     /// The operations were committed successfully.
     Committed(T),
-    /// We are not the round leader and cannot do anything. Try again at the specified time or
+    /// We are not the round leader and cannot do anything. Try again at the specified time
     /// or whenever the round or block height changes.
     WaitForTimeout(RoundTimeout),
 }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -148,7 +148,7 @@ pub enum Reason {
     },
 }
 
-/// Error type for worker operations..
+/// Error type for worker operations.
 #[derive(Debug, Error)]
 pub enum WorkerError {
     #[error(transparent)]
@@ -190,7 +190,7 @@ pub enum WorkerError {
     // Other server-side errors
     #[error("Invalid cross-chain request")]
     InvalidCrossChainRequest,
-    #[error("The block does contain the hash that we expected for the previous block")]
+    #[error("The block does not contain the hash that we expected for the previous block")]
     InvalidBlockChaining,
     #[error(
         "


### PR DESCRIPTION

Changes:

1. linera-core/src/data_types.rs:
- waiting be picked
+ waiting to be picked
Reason: Added missing "to" preposition for grammatical correctness

2. linera-core/src/data_types.rs:
- time or or whenever
+ time or whenever  
Reason: Removed duplicate "or" to fix redundancy

3. linera-core/src/worker.rs:
- does contain
+ does not contain
Reason: Added missing "not" to correctly express error condition

These changes improve documentation clarity and error message accuracy.
