### PR TITLE
[benchmark] Respect current Epoch and Committee on block proposal creation

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -569,13 +569,14 @@ where
         blocks_infos_iter: impl Iterator<Item = &(ChainId, Vec<Operation>, KeyPair)>,
         clients: Vec<linera_rpc::Client>,
         transactions_per_block: usize,
+        epoch: Epoch,
     ) -> Result<(), Error> {
         let mut num_sent_proposals = 0;
         let mut start = Instant::now();
         for (chain_id, operations, key_pair) in blocks_infos_iter {
             let chain = self.wallet.get(*chain_id).expect("should have chain");
             let block = ProposedBlock {
-                epoch: Epoch::ZERO,
+                epoch,
                 chain_id: *chain_id,
                 incoming_bundles: Vec::new(),
                 operations: operations.clone(),


### PR DESCRIPTION
## Motivation

Right now we don't respect the current Epoch when creating block proposals for the benchmark, as well as not getting the committee for the current epoch (we always just build a committee from the genesis config)

## Proposal

Send block proposals to committee of the current epoch, and build block proposals taking current epoch into consideration

## Test Plan

CI + ran benchmark locally

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
