### PR TITLE
Fix dangling endpoint to chain worker actor that failed to start

### DIFF
--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -176,8 +176,8 @@ impl<StorageClient> ChainWorkerActor<StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
 {
-    /// Spawns a new task to run the [`ChainWorkerActor`], returning an endpoint for sending
-    /// requests to the worker.
+    /// Creates a [`ChainWorkerActor`], loading it with the chain state for the requested
+    /// [`ChainId`].
     pub async fn load(
         config: ChainWorkerConfig,
         storage: StorageClient,

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -246,7 +246,7 @@ where
         skip_all,
         fields(chain_id = format!("{:.8}", self.worker.chain_id())),
     )]
-    pub async fn run(
+    pub async fn handle_requests(
         mut self,
         mut incoming_requests: mpsc::UnboundedReceiver<ChainWorkerRequest<StorageClient::Context>>,
     ) {

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -27,7 +27,7 @@ use linera_execution::{
 };
 use linera_storage::Storage;
 use tokio::sync::{mpsc, oneshot, OwnedRwLockReadGuard};
-use tracing::{instrument, trace, warn};
+use tracing::{debug, instrument, trace, warn};
 
 use super::{config::ChainWorkerConfig, state::ChainWorkerState, DeliveryNotifier};
 use crate::{
@@ -372,6 +372,71 @@ where
         }
 
         trace!("`ChainWorkerActor` finished");
+    }
+}
+
+impl<Context> ChainWorkerRequest<Context>
+where
+    Context: linera_views::context::Context + Clone + Send + Sync + 'static,
+{
+    /// Responds to this request with an `error`.
+    pub fn send_error(self, error: WorkerError) {
+        debug!("Immediately sending error to chain worker request {self:?}");
+
+        let responded = match self {
+            #[cfg(with_testing)]
+            ChainWorkerRequest::ReadCertificate { callback, .. } => {
+                callback.send(Err(error)).is_ok()
+            }
+            #[cfg(with_testing)]
+            ChainWorkerRequest::FindBundleInInbox { callback, .. } => {
+                callback.send(Err(error)).is_ok()
+            }
+            ChainWorkerRequest::GetChainStateView { callback } => callback.send(Err(error)).is_ok(),
+            ChainWorkerRequest::QueryApplication { callback, .. } => {
+                callback.send(Err(error)).is_ok()
+            }
+            ChainWorkerRequest::DescribeApplication { callback, .. } => {
+                callback.send(Err(error)).is_ok()
+            }
+            ChainWorkerRequest::StageBlockExecution { callback, .. } => {
+                callback.send(Err(error)).is_ok()
+            }
+            ChainWorkerRequest::ProcessTimeout { callback, .. } => {
+                callback.send(Err(error)).is_ok()
+            }
+            ChainWorkerRequest::HandleBlockProposal { callback, .. } => {
+                callback.send(Err(error)).is_ok()
+            }
+            ChainWorkerRequest::ProcessValidatedBlock { callback, .. } => {
+                callback.send(Err(error)).is_ok()
+            }
+            ChainWorkerRequest::ProcessConfirmedBlock { callback, .. } => {
+                callback.send(Err(error)).is_ok()
+            }
+            ChainWorkerRequest::ProcessCrossChainUpdate { callback, .. } => {
+                callback.send(Err(error)).is_ok()
+            }
+            ChainWorkerRequest::ConfirmUpdatedRecipient { callback, .. } => {
+                callback.send(Err(error)).is_ok()
+            }
+            ChainWorkerRequest::HandleChainInfoQuery { callback, .. } => {
+                callback.send(Err(error)).is_ok()
+            }
+            ChainWorkerRequest::DownloadPendingBlob { callback, .. } => {
+                callback.send(Err(error)).is_ok()
+            }
+            ChainWorkerRequest::HandlePendingBlob { callback, .. } => {
+                callback.send(Err(error)).is_ok()
+            }
+            ChainWorkerRequest::UpdateReceivedCertificateTrackers { callback, .. } => {
+                callback.send(Err(error)).is_ok()
+            }
+        };
+
+        if !responded {
+            warn!("Callback for `ChainWorkerActor` was dropped before a response was sent");
+        }
     }
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -697,20 +697,20 @@ where
                 .or_default()
                 .clone();
 
-            let actor = ChainWorkerActor::load(
+            let actor_task = ChainWorkerActor::run(
                 self.chain_worker_config.clone(),
                 self.storage.clone(),
                 self.executed_block_cache.clone(),
                 self.tracked_chains.clone(),
                 delivery_notifier,
                 chain_id,
-            )
-            .await?;
+                receiver,
+            );
 
             self.chain_worker_tasks
                 .lock()
                 .unwrap()
-                .spawn_task(actor.run(receiver).in_current_span());
+                .spawn_task(actor_task.in_current_span());
         }
 
         Ok(sender)

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -530,7 +530,7 @@ impl Runnable for Job {
                 for chain_id in chains {
                     let chain = context.make_chain_client(chain_id)?;
 
-                    chain.sync_validator(validator.clone()).await?;
+                    Box::pin(chain.sync_validator(validator.clone())).await?;
                 }
             }
 


### PR DESCRIPTION
## Motivation

Testnet is currently experiencing some panics when an attempt is made to send a request to a chain worker actor. The panic message says that the endpoint is closed. One possible cause is #3295, where a storage error could cause an endpoint to be added to the chain worker cache but its respective actor task wouldn't start.

## Proposal

Refactor the `ChainWorkerActor` so that it has a `run` method that loads the chain state from storage and then handles the incoming requests. If loading the state fails, then the error is reported to the next requester, and loading will be reattempted while the actor is running and receiving requests.

## Test Plan

CI should catch any regressions caused by this refactor.

#3299 tracks having a regression test for the issue.

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

This needs to be hotfixed because it may fix a bug that's in production.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Closes #3295 
