### PR TITLE
Write events to storage.

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -420,6 +420,29 @@ pub struct StreamId {
     pub stream_name: StreamName,
 }
 
+/// An event identifier.
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Clone,
+    Serialize,
+    Deserialize,
+    WitLoad,
+    WitStore,
+    WitType,
+    SimpleObject,
+)]
+pub struct EventId {
+    /// The ID of the chain that generated this event.
+    pub chain_id: ChainId,
+    /// The ID of the stream this event belongs to.
+    pub stream_id: StreamId,
+    /// The event key.
+    pub key: Vec<u8>,
+}
+
 /// The destination of a message, relative to a particular application.
 #[derive(
     Clone,

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -17,8 +17,8 @@ use linera_base::{
     hashed::Hashed,
     hex_debug,
     identifiers::{
-        Account, BlobId, BlobType, ChainId, ChannelName, Destination, GenericApplicationId,
-        MessageId, Owner, StreamId,
+        Account, BlobId, BlobType, ChainId, ChannelName, Destination, EventId,
+        GenericApplicationId, MessageId, Owner, StreamId,
     },
 };
 use linera_execution::{
@@ -429,6 +429,17 @@ pub struct EventRecord {
     #[debug(with = "hex_debug")]
     #[serde(with = "serde_bytes")]
     pub value: Vec<u8>,
+}
+
+impl EventRecord {
+    /// Returns the ID of this event record, given the publisher chain ID.
+    pub fn id(&self, chain_id: ChainId) -> EventId {
+        EventId {
+            chain_id,
+            stream_id: self.stream_id.clone(),
+            key: self.key.clone(),
+        }
+    }
 }
 
 impl<'de> BcsHashable<'de> for EventRecord {}

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -347,6 +347,13 @@ where
                 .storage
                 .write_blobs_and_certificate(blobs, &certificate)
                 .await?;
+            let events = executed_block
+                .outcome
+                .events
+                .iter()
+                .flatten()
+                .map(|event| (event.id(chain_id), &event.value[..]));
+            self.state.storage.write_events(events).await?;
         }
 
         // Update the blob state with last used certificate hash.

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -16,7 +16,7 @@ use linera_base::{
     data_types::{Amount, Blob, BlockHeight, TimeDelta, Timestamp, UserApplicationDescription},
     hashed::Hashed,
     identifiers::{
-        BlobId, ChainDescription, ChainId, GenericApplicationId, Owner, UserApplicationId,
+        BlobId, ChainDescription, ChainId, EventId, GenericApplicationId, Owner, UserApplicationId,
     },
     ownership::ChainOwnership,
 };
@@ -162,6 +162,15 @@ pub trait Storage: Sized {
         &self,
         hashes: I,
     ) -> Result<Vec<ConfirmedBlockCertificate>, ViewError>;
+
+    /// Reads the event with the given ID.
+    async fn read_event(&self, id: EventId) -> Result<Vec<u8>, ViewError>;
+
+    /// Writes a vector of events.
+    async fn write_events(
+        &self,
+        events: impl IntoIterator<Item = (EventId, &[u8])> + Send,
+    ) -> Result<(), ViewError>;
 
     /// Loads the view of a chain state and checks that it is active.
     ///


### PR DESCRIPTION
## Motivation

We want to use event streams for committee changes to address the admin chain's scalability issues. Ultimately we want to replace pub-sub channels with event streams entirely. (#365)

## Proposal

Write committed blocks' events to storage.

## Test Plan

This doesn't use them yet, and just ports parts of https://github.com/linera-io/linera-protocol/pull/2309 to `main`, so we don't have to rebase them again in the future. CI should catch any regressions, and the event functionality itself will be tested in upcoming PRs, when events are actually used.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Porting parts of #2309.
- Related to #365.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
