### PR TITLE
Introduce the tombstone for `RocksDb`

### DIFF
--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -25,8 +25,6 @@ use linera_execution::{
 };
 use linera_views::{
     context::{Context as _, MemoryContext},
-    memory::TEST_MEMORY_MAX_STREAM_QUERIES,
-    random::generate_test_namespace,
     views::{View, ViewError},
 };
 
@@ -47,14 +45,7 @@ where
     pub async fn new(chain_id: ChainId) -> Self {
         let exec_runtime_context =
             TestExecutionRuntimeContext::new(chain_id, ExecutionRuntimeConfig::default());
-        let namespace = generate_test_namespace();
-        let root_key = &[];
-        let context = MemoryContext::new_for_testing(
-            TEST_MEMORY_MAX_STREAM_QUERIES,
-            &namespace,
-            root_key,
-            exec_runtime_context,
-        );
+        let context = MemoryContext::new_for_testing(exec_runtime_context);
         Self::load(context)
             .await
             .expect("Loading from memory should work")

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -16,7 +16,6 @@ use linera_base::{
 };
 use linera_views::{
     context::{Context, MemoryContext},
-    memory::TEST_MEMORY_MAX_STREAM_QUERIES,
     random::generate_test_namespace,
     views::{CryptoHashView, View, ViewError},
 };
@@ -128,14 +127,7 @@ impl SystemExecutionState {
             extra.user_services().insert(id, mock_application.into());
         }
 
-        let namespace = generate_test_namespace();
-        let root_key = &[];
-        let context = MemoryContext::new_for_testing(
-            TEST_MEMORY_MAX_STREAM_QUERIES,
-            &namespace,
-            root_key,
-            extra,
-        );
+        let context = MemoryContext::new_for_testing(extra);
         let mut view = ExecutionStateView::load(context)
             .await
             .expect("Loading from memory should work");

--- a/linera-storage-service/benches/store.rs
+++ b/linera-storage-service/benches/store.rs
@@ -3,7 +3,7 @@
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use linera_storage_service::client::ServiceStoreClient;
-use linera_views::{store::TestKeyValueStore as _, test_utils::performance};
+use linera_views::test_utils::performance;
 use tokio::runtime::Runtime;
 
 fn bench_storage_service(criterion: &mut Criterion) {
@@ -11,8 +11,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = ServiceStoreClient::new_test_store().await.unwrap();
-                performance::contains_key(store, iterations, black_box).await
+                performance::contains_key::<ServiceStoreClient, _>(iterations, black_box).await
             })
     });
 
@@ -20,8 +19,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = ServiceStoreClient::new_test_store().await.unwrap();
-                performance::contains_keys(store, iterations, black_box).await
+                performance::contains_keys::<ServiceStoreClient, _>(iterations, black_box).await
             })
     });
 
@@ -29,8 +27,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = ServiceStoreClient::new_test_store().await.unwrap();
-                performance::find_keys_by_prefix(store, iterations, black_box).await
+                performance::find_keys_by_prefix::<ServiceStoreClient, _>(iterations, black_box).await
             })
     });
 
@@ -40,8 +37,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
             bencher
                 .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
                 .iter_custom(|iterations| async move {
-                    let store = ServiceStoreClient::new_test_store().await.unwrap();
-                    performance::find_key_values_by_prefix(store, iterations, black_box).await
+                    performance::find_key_values_by_prefix::<ServiceStoreClient, _>(iterations, black_box).await
                 })
         },
     );
@@ -50,8 +46,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = ServiceStoreClient::new_test_store().await.unwrap();
-                performance::read_value_bytes(store, iterations, black_box).await
+                performance::read_value_bytes::<ServiceStoreClient, _>(iterations, black_box).await
             })
     });
 
@@ -59,8 +54,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = ServiceStoreClient::new_test_store().await.unwrap();
-                performance::read_multi_values_bytes(store, iterations, black_box).await
+                performance::read_multi_values_bytes::<ServiceStoreClient, _>(iterations, black_box).await
             })
     });
 
@@ -68,8 +62,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = ServiceStoreClient::new_test_store().await.unwrap();
-                performance::write_batch(store, iterations).await
+                performance::write_batch::<ServiceStoreClient>(iterations).await
             })
     });
 }

--- a/linera-storage-service/benches/store.rs
+++ b/linera-storage-service/benches/store.rs
@@ -27,7 +27,8 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::find_keys_by_prefix::<ServiceStoreClient, _>(iterations, black_box).await
+                performance::find_keys_by_prefix::<ServiceStoreClient, _>(iterations, black_box)
+                    .await
             })
     });
 
@@ -37,7 +38,10 @@ fn bench_storage_service(criterion: &mut Criterion) {
             bencher
                 .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
                 .iter_custom(|iterations| async move {
-                    performance::find_key_values_by_prefix::<ServiceStoreClient, _>(iterations, black_box).await
+                    performance::find_key_values_by_prefix::<ServiceStoreClient, _>(
+                        iterations, black_box,
+                    )
+                    .await
                 })
         },
     );
@@ -54,7 +58,8 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::read_multi_values_bytes::<ServiceStoreClient, _>(iterations, black_box).await
+                performance::read_multi_values_bytes::<ServiceStoreClient, _>(iterations, black_box)
+                    .await
             })
     });
 

--- a/linera-views/benches/stores.rs
+++ b/linera-views/benches/stores.rs
@@ -127,7 +127,8 @@ fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::find_key_values_by_prefix::<MemoryStore, _>(iterations, black_box).await
+                performance::find_key_values_by_prefix::<MemoryStore, _>(iterations, black_box)
+                    .await
             })
     });
 
@@ -136,7 +137,8 @@ fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::find_key_values_by_prefix::<RocksDbStore, _>(iterations, black_box).await
+                performance::find_key_values_by_prefix::<RocksDbStore, _>(iterations, black_box)
+                    .await
             })
     });
 
@@ -145,7 +147,8 @@ fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::find_key_values_by_prefix::<DynamoDbStore, _>(iterations, black_box).await
+                performance::find_key_values_by_prefix::<DynamoDbStore, _>(iterations, black_box)
+                    .await
             })
     });
 
@@ -154,7 +157,8 @@ fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::find_key_values_by_prefix::<ScyllaDbStore, _>(iterations, black_box).await
+                performance::find_key_values_by_prefix::<ScyllaDbStore, _>(iterations, black_box)
+                    .await
             })
     });
 }
@@ -219,7 +223,8 @@ fn bench_read_multi_values_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::read_multi_values_bytes::<DynamoDbStore, _>(iterations, black_box).await
+                performance::read_multi_values_bytes::<DynamoDbStore, _>(iterations, black_box)
+                    .await
             })
     });
 
@@ -228,7 +233,8 @@ fn bench_read_multi_values_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::read_multi_values_bytes::<ScyllaDbStore,_>(iterations, black_box).await
+                performance::read_multi_values_bytes::<ScyllaDbStore, _>(iterations, black_box)
+                    .await
             })
     });
 }

--- a/linera-views/benches/stores.rs
+++ b/linera-views/benches/stores.rs
@@ -8,7 +8,7 @@ use linera_views::dynamo_db::DynamoDbStore;
 use linera_views::rocks_db::RocksDbStore;
 #[cfg(with_scylladb)]
 use linera_views::scylla_db::ScyllaDbStore;
-use linera_views::{memory::MemoryStore, store::TestKeyValueStore as _, test_utils::performance};
+use linera_views::{memory::MemoryStore, test_utils::performance};
 use tokio::runtime::Runtime;
 
 fn bench_contains_key(criterion: &mut Criterion) {
@@ -16,8 +16,7 @@ fn bench_contains_key(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = MemoryStore::new_test_store().await.unwrap();
-                performance::contains_key(store, iterations, black_box).await
+                performance::contains_key::<MemoryStore, _>(iterations, black_box).await
             })
     });
 
@@ -26,8 +25,7 @@ fn bench_contains_key(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = RocksDbStore::new_test_store().await.unwrap();
-                performance::contains_key(store, iterations, black_box).await
+                performance::contains_key::<RocksDbStore, _>(iterations, black_box).await
             })
     });
 
@@ -36,8 +34,7 @@ fn bench_contains_key(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = DynamoDbStore::new_test_store().await.unwrap();
-                performance::contains_key(store, iterations, black_box).await
+                performance::contains_key::<DynamoDbStore, _>(iterations, black_box).await
             })
     });
 
@@ -46,8 +43,7 @@ fn bench_contains_key(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = ScyllaDbStore::new_test_store().await.unwrap();
-                performance::contains_key(store, iterations, black_box).await
+                performance::contains_key::<ScyllaDbStore, _>(iterations, black_box).await
             })
     });
 }
@@ -57,8 +53,7 @@ fn bench_contains_keys(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = MemoryStore::new_test_store().await.unwrap();
-                performance::contains_keys(store, iterations, black_box).await
+                performance::contains_keys::<MemoryStore, _>(iterations, black_box).await
             })
     });
 
@@ -67,8 +62,7 @@ fn bench_contains_keys(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = RocksDbStore::new_test_store().await.unwrap();
-                performance::contains_keys(store, iterations, black_box).await
+                performance::contains_keys::<RocksDbStore, _>(iterations, black_box).await
             })
     });
 
@@ -77,8 +71,7 @@ fn bench_contains_keys(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = DynamoDbStore::new_test_store().await.unwrap();
-                performance::contains_keys(store, iterations, black_box).await
+                performance::contains_keys::<DynamoDbStore, _>(iterations, black_box).await
             })
     });
 
@@ -87,8 +80,7 @@ fn bench_contains_keys(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = ScyllaDbStore::new_test_store().await.unwrap();
-                performance::contains_keys(store, iterations, black_box).await
+                performance::contains_keys::<ScyllaDbStore, _>(iterations, black_box).await
             })
     });
 }
@@ -98,8 +90,7 @@ fn bench_find_keys_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = MemoryStore::new_test_store().await.unwrap();
-                performance::find_keys_by_prefix(store, iterations, black_box).await
+                performance::find_keys_by_prefix::<MemoryStore, _>(iterations, black_box).await
             })
     });
 
@@ -108,8 +99,7 @@ fn bench_find_keys_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = RocksDbStore::new_test_store().await.unwrap();
-                performance::find_keys_by_prefix(store, iterations, black_box).await
+                performance::find_keys_by_prefix::<RocksDbStore, _>(iterations, black_box).await
             })
     });
 
@@ -118,8 +108,7 @@ fn bench_find_keys_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = DynamoDbStore::new_test_store().await.unwrap();
-                performance::find_keys_by_prefix(store, iterations, black_box).await
+                performance::find_keys_by_prefix::<DynamoDbStore, _>(iterations, black_box).await
             })
     });
 
@@ -128,8 +117,7 @@ fn bench_find_keys_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = ScyllaDbStore::new_test_store().await.unwrap();
-                performance::find_keys_by_prefix(store, iterations, black_box).await
+                performance::find_keys_by_prefix::<ScyllaDbStore, _>(iterations, black_box).await
             })
     });
 }
@@ -139,8 +127,7 @@ fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = MemoryStore::new_test_store().await.unwrap();
-                performance::find_key_values_by_prefix(store, iterations, black_box).await
+                performance::find_key_values_by_prefix::<MemoryStore, _>(iterations, black_box).await
             })
     });
 
@@ -149,8 +136,7 @@ fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = RocksDbStore::new_test_store().await.unwrap();
-                performance::find_key_values_by_prefix(store, iterations, black_box).await
+                performance::find_key_values_by_prefix::<RocksDbStore, _>(iterations, black_box).await
             })
     });
 
@@ -159,8 +145,7 @@ fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = DynamoDbStore::new_test_store().await.unwrap();
-                performance::find_key_values_by_prefix(store, iterations, black_box).await
+                performance::find_key_values_by_prefix::<DynamoDbStore, _>(iterations, black_box).await
             })
     });
 
@@ -169,8 +154,7 @@ fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = ScyllaDbStore::new_test_store().await.unwrap();
-                performance::find_key_values_by_prefix(store, iterations, black_box).await
+                performance::find_key_values_by_prefix::<ScyllaDbStore, _>(iterations, black_box).await
             })
     });
 }
@@ -180,8 +164,7 @@ fn bench_read_value_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = MemoryStore::new_test_store().await.unwrap();
-                performance::read_value_bytes(store, iterations, black_box).await
+                performance::read_value_bytes::<MemoryStore, _>(iterations, black_box).await
             })
     });
 
@@ -190,8 +173,7 @@ fn bench_read_value_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = RocksDbStore::new_test_store().await.unwrap();
-                performance::read_value_bytes(store, iterations, black_box).await
+                performance::read_value_bytes::<RocksDbStore, _>(iterations, black_box).await
             })
     });
 
@@ -200,8 +182,7 @@ fn bench_read_value_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = DynamoDbStore::new_test_store().await.unwrap();
-                performance::read_value_bytes(store, iterations, black_box).await
+                performance::read_value_bytes::<DynamoDbStore, _>(iterations, black_box).await
             })
     });
 
@@ -210,8 +191,7 @@ fn bench_read_value_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = ScyllaDbStore::new_test_store().await.unwrap();
-                performance::read_value_bytes(store, iterations, black_box).await
+                performance::read_value_bytes::<ScyllaDbStore, _>(iterations, black_box).await
             })
     });
 }
@@ -221,8 +201,7 @@ fn bench_read_multi_values_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = MemoryStore::new_test_store().await.unwrap();
-                performance::read_multi_values_bytes(store, iterations, black_box).await
+                performance::read_multi_values_bytes::<MemoryStore, _>(iterations, black_box).await
             })
     });
 
@@ -231,8 +210,7 @@ fn bench_read_multi_values_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = RocksDbStore::new_test_store().await.unwrap();
-                performance::read_multi_values_bytes(store, iterations, black_box).await
+                performance::read_multi_values_bytes::<RocksDbStore, _>(iterations, black_box).await
             })
     });
 
@@ -241,8 +219,7 @@ fn bench_read_multi_values_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = DynamoDbStore::new_test_store().await.unwrap();
-                performance::read_multi_values_bytes(store, iterations, black_box).await
+                performance::read_multi_values_bytes::<DynamoDbStore, _>(iterations, black_box).await
             })
     });
 
@@ -251,8 +228,7 @@ fn bench_read_multi_values_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = ScyllaDbStore::new_test_store().await.unwrap();
-                performance::read_multi_values_bytes(store, iterations, black_box).await
+                performance::read_multi_values_bytes::<ScyllaDbStore,_>(iterations, black_box).await
             })
     });
 }
@@ -262,8 +238,7 @@ fn bench_write_batch(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = MemoryStore::new_test_store().await.unwrap();
-                performance::write_batch(store, iterations).await
+                performance::write_batch::<MemoryStore>(iterations).await
             })
     });
 
@@ -272,8 +247,7 @@ fn bench_write_batch(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = RocksDbStore::new_test_store().await.unwrap();
-                performance::write_batch(store, iterations).await
+                performance::write_batch::<RocksDbStore>(iterations).await
             })
     });
 
@@ -282,8 +256,7 @@ fn bench_write_batch(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = DynamoDbStore::new_test_store().await.unwrap();
-                performance::write_batch(store, iterations).await
+                performance::write_batch::<DynamoDbStore>(iterations).await
             })
     });
 
@@ -292,8 +265,7 @@ fn bench_write_batch(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let store = ScyllaDbStore::new_test_store().await.unwrap();
-                performance::write_batch(store, iterations).await
+                performance::write_batch::<ScyllaDbStore>(iterations).await
             })
     });
 }

--- a/linera-views/src/context.rs
+++ b/linera-views/src/context.rs
@@ -276,26 +276,19 @@ pub type MemoryContext<E> = ViewContext<E, MemoryStore>;
 /// Provides a `MemoryContext<()>` that can be used for tests.
 #[cfg(with_testing)]
 pub fn create_test_memory_context() -> MemoryContext<()> {
-    let namespace = crate::random::generate_test_namespace();
-    let root_key = &[];
-    MemoryContext::new_for_testing(
-        crate::memory::TEST_MEMORY_MAX_STREAM_QUERIES,
-        &namespace,
-        root_key,
-        (),
-    )
+    MemoryContext::new_for_testing(())
 }
 
 impl<E> MemoryContext<E> {
     /// Creates a [`Context`] instance in memory for testing.
     #[cfg(with_testing)]
     pub fn new_for_testing(
-        max_stream_queries: usize,
-        namespace: &str,
-        root_key: &[u8],
         extra: E,
     ) -> Self {
-        let store = MemoryStore::new_for_testing(max_stream_queries, namespace, root_key).unwrap();
+        let max_stream_queries = crate::memory::TEST_MEMORY_MAX_STREAM_QUERIES;
+        let namespace = crate::random::generate_test_namespace();
+        let root_key = &[];
+        let store = MemoryStore::new_for_testing(max_stream_queries, &namespace, root_key).unwrap();
         let base_key = Vec::new();
         Self {
             store,

--- a/linera-views/src/context.rs
+++ b/linera-views/src/context.rs
@@ -282,9 +282,7 @@ pub fn create_test_memory_context() -> MemoryContext<()> {
 impl<E> MemoryContext<E> {
     /// Creates a [`Context`] instance in memory for testing.
     #[cfg(with_testing)]
-    pub fn new_for_testing(
-        extra: E,
-    ) -> Self {
+    pub fn new_for_testing(extra: E) -> Self {
         let max_stream_queries = crate::memory::TEST_MEMORY_MAX_STREAM_QUERIES;
         let namespace = crate::random::generate_test_namespace();
         let root_key = &[];

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -7,10 +7,7 @@ pub mod test_views;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod performance;
 
-use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
-    fmt::Debug,
-};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use rand::{seq::SliceRandom, Rng};
 
@@ -683,10 +680,7 @@ pub async fn run_writes_from_state<C: LocalRestrictedKeyValueStore>(key_value_st
 async fn namespaces_with_prefix<S: LocalKeyValueStore>(
     config: &S::Config,
     prefix: &str,
-) -> BTreeSet<String>
-where
-    S::Error: Debug,
-{
+) -> BTreeSet<String> {
     let namespaces = S::list_all(config).await.expect("namespaces");
     namespaces
         .into_iter()
@@ -697,10 +691,7 @@ where
 /// Exercises the namespace functionalities of the `AdminKeyValueStore`.
 /// This tests everything except the `delete_all` which would
 /// interact with other namespaces.
-pub async fn namespace_admin_test<S: TestKeyValueStore>()
-where
-    S::Error: Debug,
-{
+pub async fn namespace_admin_test<S: TestKeyValueStore>() {
     let config = S::new_test_config().await.expect("config");
     let prefix = generate_test_namespace();
     let namespaces = namespaces_with_prefix::<S>(&config, &prefix).await;
@@ -761,10 +752,7 @@ where
 }
 
 /// Tests listing the root keys.
-pub async fn root_key_admin_test<S: TestKeyValueStore>()
-where
-    S::Error: Debug,
-{
+pub async fn root_key_admin_test<S: TestKeyValueStore>() {
     let config = S::new_test_config().await.expect("config");
     let namespace = generate_test_namespace();
     let mut root_keys = Vec::new();

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -522,12 +522,12 @@ pub async fn tombstone_triggering_test<C: LocalRestrictedKeyValueStore>(key_valu
         let t1 = Instant::now();
         let key_values = read_key_values_prefix(&key_value_store, &key_prefix).await;
         assert_eq!(key_values, remaining_key_values);
-        println!("iter={} read_key_values_prefix in {} ms", t1.elapsed().as_millis());
+        println!("iter={} read_key_values_prefix in {} ms", iter, t1.elapsed().as_millis());
 
         let t1 = Instant::now();
         let keys = read_keys_prefix(&key_value_store, &key_prefix).await;
         assert_eq!(keys, remaining_keys);
-        println!("iter={} read_keys_prefix after {} ms", t1.elapsed().as_millis());
+        println!("iter={} read_keys_prefix after {} ms", iter, t1.elapsed().as_millis());
     }
 }
 

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -367,6 +367,25 @@ fn realize_batch(batch: &Batch) -> BTreeMap<Vec<u8>, Vec<u8>> {
     kv_state
 }
 
+async fn read_keys_prefix<C: LocalRestrictedKeyValueStore>(
+    key_value_store: &C,
+    key_prefix: &[u8],
+) -> BTreeSet<Vec<u8>> {
+    let mut keys = BTreeSet::new();
+    for key in key_value_store
+        .find_keys_by_prefix(key_prefix)
+        .await
+        .unwrap()
+        .iterator()
+    {
+        let key_suffix = key.unwrap();
+        let mut key = key_prefix.to_vec();
+        key.extend(key_suffix);
+        keys.insert(key);
+    }
+    keys
+}
+
 async fn read_key_values_prefix<C: LocalRestrictedKeyValueStore>(
     key_value_store: &C,
     key_prefix: &[u8],
@@ -461,6 +480,8 @@ pub async fn big_read_multi_values<C: LocalKeyValueStore>(
 /// selection, Scylla is forced to introduce around 100000 tombstones
 /// which triggers the crash with the default settings.
 pub async fn tombstone_triggering_test<C: LocalRestrictedKeyValueStore>(key_value_store: C) {
+    use std::time::Instant;
+    let t1 = Instant::now();
     let mut rng = make_deterministic_rng();
     let value_size = 100;
     let n_entry = 200000;
@@ -469,6 +490,7 @@ pub async fn tombstone_triggering_test<C: LocalRestrictedKeyValueStore>(key_valu
     let key_prefix = vec![0];
     let mut batch_delete = Batch::new();
     let mut remaining_key_values = BTreeMap::new();
+    let mut remaining_keys = BTreeSet::new();
     for i in 0..n_entry {
         let mut key = key_prefix.clone();
         bcs::serialize_into(&mut key, &i).unwrap();
@@ -476,17 +498,37 @@ pub async fn tombstone_triggering_test<C: LocalRestrictedKeyValueStore>(key_valu
         batch_insert.put_key_value_bytes(key.clone(), value.clone());
         let to_delete = rng.gen::<bool>();
         if to_delete {
-            batch_delete.delete_key(key);
+            batch_delete.delete_key_prefix(key);
+//            batch_delete.delete_key(key);
         } else {
+            remaining_keys.insert(key.clone());
             remaining_key_values.insert(key, value);
         }
     }
+    println!("Set up in {} ms", t1.elapsed().as_millis());
+
+    let t1 = Instant::now();
     run_test_batch_from_blank(&key_value_store, key_prefix.clone(), batch_insert).await;
+    println!("run_test_batch in {} ms", t1.elapsed().as_millis());
+
+
     // Deleting them all
+    let t1 = Instant::now();
     key_value_store.write_batch(batch_delete).await.unwrap();
-    // Reading everything and seeing that it is now cleaned.
-    let key_values = read_key_values_prefix(&key_value_store, &key_prefix).await;
-    assert_eq!(key_values, remaining_key_values);
+    println!("batch_delete in {} ms", t1.elapsed().as_millis());
+
+    for iter in 0..5 {
+        // Reading everything and seeing that it is now cleaned.
+        let t1 = Instant::now();
+        let key_values = read_key_values_prefix(&key_value_store, &key_prefix).await;
+        assert_eq!(key_values, remaining_key_values);
+        println!("iter={} read_key_values_prefix in {} ms", t1.elapsed().as_millis());
+
+        let t1 = Instant::now();
+        let keys = read_keys_prefix(&key_value_store, &key_prefix).await;
+        assert_eq!(keys, remaining_keys);
+        println!("iter={} read_keys_prefix after {} ms", t1.elapsed().as_millis());
+    }
 }
 
 /// DynamoDb has limits at 1M (for pagination), 4M (for write)

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -499,7 +499,7 @@ pub async fn tombstone_triggering_test<C: LocalRestrictedKeyValueStore>(key_valu
         let to_delete = rng.gen::<bool>();
         if to_delete {
             batch_delete.delete_key_prefix(key);
-//            batch_delete.delete_key(key);
+        //            batch_delete.delete_key(key);
         } else {
             remaining_keys.insert(key.clone());
             remaining_key_values.insert(key, value);
@@ -511,7 +511,6 @@ pub async fn tombstone_triggering_test<C: LocalRestrictedKeyValueStore>(key_valu
     run_test_batch_from_blank(&key_value_store, key_prefix.clone(), batch_insert).await;
     println!("run_test_batch in {} ms", t1.elapsed().as_millis());
 
-
     // Deleting them all
     let t1 = Instant::now();
     key_value_store.write_batch(batch_delete).await.unwrap();
@@ -522,12 +521,20 @@ pub async fn tombstone_triggering_test<C: LocalRestrictedKeyValueStore>(key_valu
         let t1 = Instant::now();
         let key_values = read_key_values_prefix(&key_value_store, &key_prefix).await;
         assert_eq!(key_values, remaining_key_values);
-        println!("iter={} read_key_values_prefix in {} ms", iter, t1.elapsed().as_millis());
+        println!(
+            "iter={} read_key_values_prefix in {} ms",
+            iter,
+            t1.elapsed().as_millis()
+        );
 
         let t1 = Instant::now();
         let keys = read_keys_prefix(&key_value_store, &key_prefix).await;
         assert_eq!(keys, remaining_keys);
-        println!("iter={} read_keys_prefix after {} ms", iter, t1.elapsed().as_millis());
+        println!(
+            "iter={} read_keys_prefix after {} ms",
+            iter,
+            t1.elapsed().as_millis()
+        );
     }
 }
 

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -495,8 +495,7 @@ pub async fn tombstone_triggering_test<C: LocalRestrictedKeyValueStore>(key_valu
         batch_insert.put_key_value_bytes(key.clone(), value.clone());
         let to_delete = rng.gen::<bool>();
         if to_delete {
-            batch_delete.delete_key_prefix(key);
-        //            batch_delete.delete_key(key);
+            batch_delete.delete_key(key);
         } else {
             remaining_keys.insert(key.clone());
             remaining_key_values.insert(key, value);

--- a/linera-views/src/test_utils/performance.rs
+++ b/linera-views/src/test_utils/performance.rs
@@ -104,10 +104,7 @@ where
 }
 
 /// Benchmarks the `find_keys_by_prefix` operation.
-pub async fn find_keys_by_prefix<S: TestKeyValueStore, F>(
-    iterations: u64,
-    f: F,
-) -> Duration
+pub async fn find_keys_by_prefix<S: TestKeyValueStore, F>(iterations: u64, f: F) -> Duration
 where
     S::Error: Debug,
     F: Fn(S::Keys) -> S::Keys,
@@ -136,10 +133,7 @@ where
 }
 
 /// Benchmarks the `find_keys_by_prefix` operation.
-pub async fn find_key_values_by_prefix<S: TestKeyValueStore, F>(
-    iterations: u64,
-    f: F,
-) -> Duration
+pub async fn find_key_values_by_prefix<S: TestKeyValueStore, F>(iterations: u64, f: F) -> Duration
 where
     S::Error: Debug,
     F: Fn(S::KeyValues) -> S::KeyValues,
@@ -202,10 +196,7 @@ where
 }
 
 /// Benchmarks the `read_multi_values_bytes` operation.
-pub async fn read_multi_values_bytes<S: TestKeyValueStore, F>(
-    iterations: u64,
-    f: F,
-) -> Duration
+pub async fn read_multi_values_bytes<S: TestKeyValueStore, F>(iterations: u64, f: F) -> Duration
 where
     S::Error: Debug,
     F: Fn(Vec<Option<Vec<u8>>>) -> Vec<Option<Vec<u8>>>,

--- a/linera-views/src/test_utils/performance.rs
+++ b/linera-views/src/test_utils/performance.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    fmt::Debug,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use crate::{
     batch::Batch,
@@ -42,7 +39,6 @@ async fn clear_store<S: LocalKeyValueStore>(store: &S) {
 /// Benchmarks the `contains_key` operation.
 pub async fn contains_key<S: TestKeyValueStore, F>(iterations: u64, f: F) -> Duration
 where
-    S::Error: Debug,
     F: Fn(bool) -> bool,
 {
     let store = S::new_test_store().await.unwrap();
@@ -73,7 +69,6 @@ where
 /// Benchmarks the `contains_keys` operation.
 pub async fn contains_keys<S: TestKeyValueStore, F>(iterations: u64, f: F) -> Duration
 where
-    S::Error: Debug,
     F: Fn(Vec<bool>) -> Vec<bool>,
 {
     let store = S::new_test_store().await.unwrap();
@@ -106,7 +101,6 @@ where
 /// Benchmarks the `find_keys_by_prefix` operation.
 pub async fn find_keys_by_prefix<S: TestKeyValueStore, F>(iterations: u64, f: F) -> Duration
 where
-    S::Error: Debug,
     F: Fn(S::Keys) -> S::Keys,
 {
     let store = S::new_test_store().await.unwrap();
@@ -135,7 +129,6 @@ where
 /// Benchmarks the `find_keys_by_prefix` operation.
 pub async fn find_key_values_by_prefix<S: TestKeyValueStore, F>(iterations: u64, f: F) -> Duration
 where
-    S::Error: Debug,
     F: Fn(S::KeyValues) -> S::KeyValues,
 {
     let store = S::new_test_store().await.unwrap();
@@ -167,7 +160,6 @@ where
 /// Benchmarks the `read_value_bytes` operation.
 pub async fn read_value_bytes<S: TestKeyValueStore, F>(iterations: u64, f: F) -> Duration
 where
-    S::Error: Debug,
     F: Fn(Option<Vec<u8>>) -> Option<Vec<u8>>,
 {
     let store = S::new_test_store().await.unwrap();
@@ -198,7 +190,6 @@ where
 /// Benchmarks the `read_multi_values_bytes` operation.
 pub async fn read_multi_values_bytes<S: TestKeyValueStore, F>(iterations: u64, f: F) -> Duration
 where
-    S::Error: Debug,
     F: Fn(Vec<Option<Vec<u8>>>) -> Vec<Option<Vec<u8>>>,
 {
     let store = S::new_test_store().await.unwrap();
@@ -229,10 +220,7 @@ where
 }
 
 /// Benchmarks the `write_batch` operation.
-pub async fn write_batch<S: TestKeyValueStore>(iterations: u64) -> Duration
-where
-    S::Error: Debug,
-{
+pub async fn write_batch<S: TestKeyValueStore>(iterations: u64) -> Duration {
     let store = S::new_test_store().await.unwrap();
     let mut total_time = Duration::ZERO;
     for _ in 0..iterations {

--- a/linera-views/src/test_utils/performance.rs
+++ b/linera-views/src/test_utils/performance.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{
     batch::Batch,
-    store::LocalKeyValueStore,
+    store::{LocalKeyValueStore, TestKeyValueStore},
     test_utils::{add_prefix, get_random_key_values2},
 };
 
@@ -40,11 +40,12 @@ async fn clear_store<S: LocalKeyValueStore>(store: &S) {
 }
 
 /// Benchmarks the `contains_key` operation.
-pub async fn contains_key<S: LocalKeyValueStore, F>(store: S, iterations: u64, f: F) -> Duration
+pub async fn contains_key<S: TestKeyValueStore, F>(iterations: u64, f: F) -> Duration
 where
     S::Error: Debug,
     F: Fn(bool) -> bool,
 {
+    let store = S::new_test_store().await.unwrap();
     let mut total_time = Duration::ZERO;
     for _ in 0..iterations {
         let key_values = add_prefix(
@@ -70,11 +71,12 @@ where
 }
 
 /// Benchmarks the `contains_keys` operation.
-pub async fn contains_keys<S: LocalKeyValueStore, F>(store: S, iterations: u64, f: F) -> Duration
+pub async fn contains_keys<S: TestKeyValueStore, F>(iterations: u64, f: F) -> Duration
 where
     S::Error: Debug,
     F: Fn(Vec<bool>) -> Vec<bool>,
 {
+    let store = S::new_test_store().await.unwrap();
     let mut total_time = Duration::ZERO;
     for _ in 0..iterations {
         let key_values = add_prefix(
@@ -102,8 +104,7 @@ where
 }
 
 /// Benchmarks the `find_keys_by_prefix` operation.
-pub async fn find_keys_by_prefix<S: LocalKeyValueStore, F>(
-    store: S,
+pub async fn find_keys_by_prefix<S: TestKeyValueStore, F>(
     iterations: u64,
     f: F,
 ) -> Duration
@@ -111,6 +112,7 @@ where
     S::Error: Debug,
     F: Fn(S::Keys) -> S::Keys,
 {
+    let store = S::new_test_store().await.unwrap();
     let mut total_time = Duration::ZERO;
     for _ in 0..iterations {
         let key_values = add_prefix(
@@ -134,8 +136,7 @@ where
 }
 
 /// Benchmarks the `find_keys_by_prefix` operation.
-pub async fn find_key_values_by_prefix<S: LocalKeyValueStore, F>(
-    store: S,
+pub async fn find_key_values_by_prefix<S: TestKeyValueStore, F>(
     iterations: u64,
     f: F,
 ) -> Duration
@@ -143,6 +144,7 @@ where
     S::Error: Debug,
     F: Fn(S::KeyValues) -> S::KeyValues,
 {
+    let store = S::new_test_store().await.unwrap();
     let mut total_time = Duration::ZERO;
     for _ in 0..iterations {
         let key_values = add_prefix(
@@ -169,11 +171,12 @@ where
 }
 
 /// Benchmarks the `read_value_bytes` operation.
-pub async fn read_value_bytes<S: LocalKeyValueStore, F>(store: S, iterations: u64, f: F) -> Duration
+pub async fn read_value_bytes<S: TestKeyValueStore, F>(iterations: u64, f: F) -> Duration
 where
     S::Error: Debug,
     F: Fn(Option<Vec<u8>>) -> Option<Vec<u8>>,
 {
+    let store = S::new_test_store().await.unwrap();
     let mut total_time = Duration::ZERO;
     for _ in 0..iterations {
         let key_values = add_prefix(
@@ -199,8 +202,7 @@ where
 }
 
 /// Benchmarks the `read_multi_values_bytes` operation.
-pub async fn read_multi_values_bytes<S: LocalKeyValueStore, F>(
-    store: S,
+pub async fn read_multi_values_bytes<S: TestKeyValueStore, F>(
     iterations: u64,
     f: F,
 ) -> Duration
@@ -208,6 +210,7 @@ where
     S::Error: Debug,
     F: Fn(Vec<Option<Vec<u8>>>) -> Vec<Option<Vec<u8>>>,
 {
+    let store = S::new_test_store().await.unwrap();
     let mut total_time = Duration::ZERO;
     for _ in 0..iterations {
         let key_values = add_prefix(
@@ -235,10 +238,11 @@ where
 }
 
 /// Benchmarks the `write_batch` operation.
-pub async fn write_batch<S: LocalKeyValueStore>(store: S, iterations: u64) -> Duration
+pub async fn write_batch<S: TestKeyValueStore>(iterations: u64) -> Duration
 where
     S::Error: Debug,
 {
+    let store = S::new_test_store().await.unwrap();
     let mut total_time = Duration::ZERO;
     for _ in 0..iterations {
         let key_values = add_prefix(

--- a/linera-views/tests/admin_tests.rs
+++ b/linera-views/tests/admin_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fmt::Debug, marker::PhantomData};
+use std::marker::PhantomData;
 
 #[cfg(with_dynamodb)]
 use linera_views::dynamo_db::DynamoDbStore;
@@ -21,11 +21,7 @@ use test_case::test_case;
 #[cfg_attr(with_dynamodb, test_case(PhantomData::<DynamoDbStore>; "DynamoDbStore"))]
 #[cfg_attr(with_scylladb, test_case(PhantomData::<ScyllaDbStore>; "ScyllaDbStore"))]
 #[tokio::test]
-async fn namespace_admin_test_cases<K>(_view_type: PhantomData<K>)
-where
-    K: TestKeyValueStore,
-    K::Error: Debug,
-{
+async fn namespace_admin_test_cases<K: TestKeyValueStore>(_view_type: PhantomData<K>) {
     namespace_admin_test::<K>().await;
 }
 
@@ -34,10 +30,6 @@ where
 #[cfg_attr(with_dynamodb, test_case(PhantomData::<DynamoDbStore>; "DynamoDbStore"))]
 #[cfg_attr(with_scylladb, test_case(PhantomData::<ScyllaDbStore>; "ScyllaDbStore"))]
 #[tokio::test]
-async fn root_key_admin_test_cases<K>(_view_type: PhantomData<K>)
-where
-    K: TestKeyValueStore,
-    K::Error: Debug,
-{
+async fn root_key_admin_test_cases<K: TestKeyValueStore>(_view_type: PhantomData<K>) {
     root_key_admin_test::<K>().await;
 }

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -206,6 +206,15 @@ async fn scylla_db_tombstone_triggering_test() {
     linera_views::test_utils::tombstone_triggering_test(store).await;
 }
 
+#[cfg(with_rocksdb)]
+#[tokio::test]
+async fn rocks_db_tombstone_triggering_test() {
+    let store = linera_views::rocks_db::RocksDbStore::new_test_store()
+        .await
+        .unwrap();
+    linera_views::test_utils::tombstone_triggering_test(store).await;
+}
+
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_big_write_read() {


### PR DESCRIPTION
## Motivation

The tombstone problem has emerged as a problem for `RocksDb`. We therefore introduce the test here for this store. We also do some corrections and simplification to the testing framework.

## Proposal

We propose the following changes:
* Add the testing of read keys from the store as test.
* Iterate the reading of the keys from the store to see the evolution of the performance.
* Introduce the test for RocksDb.

Besides, there are a number of changes for the tests:
* Simplification of the `MemoryContext::new_for_testing` function since the calls always took the same arguments.
* Elimination of requirement for `Debug` in the error type since it was not used.
* Put the creation of the testing store in the benchmark code.


## Test Plan

The CI is the object of those changes.

## Release Plan

Not relevant to TestNet / DevNet.

## Links

None.