### PR TITLE
Introduce random storage service problem in `storage-service`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4986,6 +4986,7 @@ dependencies = [
  "linera-views",
  "proptest",
  "prost",
+ "rand",
  "serde",
  "serde-reflection",
  "serde_yaml 0.8.26",

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -12,6 +12,8 @@ repository.workspace = true
 version.workspace = true
 
 [features]
+artificial_random_read_error = []
+artificial_random_write_error = []
 metrics = ["linera-views/metrics"]
 rocksdb = ["linera-views/rocksdb"]
 storage-service = []

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-artificial_random_read_error = []
-artificial_random_write_error = []
+artificial_random_read_error = ["dep:rand"]
+artificial_random_write_error = ["dep:rand"]
 metrics = ["linera-views/metrics"]
 rocksdb = ["linera-views/rocksdb"]
 storage-service = []
@@ -24,6 +24,7 @@ name = "linera-storage-server"
 path = "src/server.rs"
 
 [dependencies]
+rand = { workspace = true, optional = true, features = ["small_rng"] }
 anyhow.workspace = true
 async-lock.workspace = true
 bcs.workspace = true

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -11,6 +11,14 @@ use linera_views::{
 use thiserror::Error;
 use tonic::Status;
 
+#[cfg(feature = "artificial_random_read_error")]
+const READ_ERROR_FREQUENCY: usize = 10;
+
+#[cfg(feature = "artificial_random_write_error")]
+const WRITE_ERROR_FREQUENCY: usize = 100;
+
+
+
 // The maximal block size on GRPC is 4M.
 //
 // That size occurs in almost every use of GRPC and in particular the
@@ -60,6 +68,16 @@ pub enum ServiceStoreError {
     /// An error occurred during BCS serialization
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
+
+    #[cfg(feature = "artificial_random_read_error")]
+    /// An artificial read error occurred
+    #[error("An artificial read error occurred")]
+    ArtificialReadError,
+
+    #[cfg(feature = "artificial_random_write_error")]
+    /// An artificial write batch error occurred
+    #[error("An artificial write batch error occurred")]
+    ArtificialWriteBatchError,
 }
 
 impl KeyValueStoreError for ServiceStoreError {

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -11,14 +11,6 @@ use linera_views::{
 use thiserror::Error;
 use tonic::Status;
 
-#[cfg(feature = "artificial_random_read_error")]
-const READ_ERROR_FREQUENCY: usize = 10;
-
-#[cfg(feature = "artificial_random_write_error")]
-const WRITE_ERROR_FREQUENCY: usize = 100;
-
-
-
 // The maximal block size on GRPC is 4M.
 //
 // That size occurs in almost every use of GRPC and in particular the

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -85,7 +85,6 @@ pub mod metrics;
 mod graphql;
 
 /// Functions for random generation
-#[cfg(with_testing)]
 pub mod random;
 
 /// Helper types for tests.


### PR DESCRIPTION
## Motivation

We had some problem with `ScyllaDb` running on the storage. Being able to reproduce problem is useful for finding unexpected schemes of failure.

## Proposal

A scheme is introduced for adding random read and/or write errors in the running of the storage service client. There is a different probability for read and for writes. This is a deterministic error introduction scheme in order to be as deterministic as possible.

## Test Plan

The test did show some problems. Whether it is a true problem or some other errors remains to be determined.

The commands to get one problem is the following:
* Running the `storage-service`: ```cargo run --release -p linera-storage-service -- memory --endpoint $LINERA_STORAGE_SERVICE```

* Running the validators:
```
     cargo build --features artificial_random_read_error,storage-service,remote-net
     rm -rf /tmp/WORK && mkdir /tmp/WORK
     cargo run \
        --features artificial_random_read_error \
        --bin linera \
        -- net up \
        --storage service:tcp:localhost:1235:table \
        --policy-config devnet \
        --path /tmp/WORK \
        --validators 4 --shards 4
```
* Running the faucet:
```
     export LINERA_WALLET=/tmp/WORK/wallet_0.json
     export LINERA_STORAGE=rocksdb:/tmp/WORK/client_0.db
     cargo run --features artificial_random_read_error,storage-service,remote-net --bin linera -- faucet --amount 1000 --port 8079
```
* Running the tests:
```
     export LINERA_FAUCET_URL=http://localhost:8079
     cargo test test_wasm_end_to_end_amm::remote_net_grpc --features artificial_random_read_error,remote-net
```

For which we get the error
```
2025-02-12T13:33:31.404232Z ERROR linera: Error is Failed to close chain

Caused by:
    chain client error: Failed to communicate with a quorum of validators: Worker error: Storage operation error in service: An artificial read error occurred
```

## Release Plan

Follow the normal release plan.

## Links

None