### PR TITLE
fix: 404 links in README.md files

### DIFF
--- a/linera-faucet/client/README.md
+++ b/linera-faucet/client/README.md
@@ -6,8 +6,8 @@ This module provides the executables needed to operate a Linera service, includi
 
 ## Contributing
 
-See the [CONTRIBUTING](../CONTRIBUTING.md) file for how to help out.
+See the [CONTRIBUTING](../../CONTRIBUTING.md) file for how to help out.
 
 ## License
 
-This project is available under the terms of the [Apache 2.0 license](../LICENSE).
+This project is available under the terms of the [Apache 2.0 license](../../LICENSE).

--- a/linera-faucet/server/README.md
+++ b/linera-faucet/server/README.md
@@ -6,8 +6,8 @@ This module provides the executables needed to operate a Linera service, includi
 
 ## Contributing
 
-See the [CONTRIBUTING](../CONTRIBUTING.md) file for how to help out.
+See the [CONTRIBUTING](../../CONTRIBUTING.md) file for how to help out.
 
 ## License
 
-This project is available under the terms of the [Apache 2.0 license](../LICENSE).
+This project is available under the terms of the [Apache 2.0 license](../../LICENSE).


### PR DESCRIPTION
## Motivation

The `README.md` files in the `linera-faucet/client` and `linera-faucet/server` directories contained broken links to the `CONTRIBUTING.md` and `LICENSE` files. This PR fixes these links to ensure users can access the correct resources.

## Proposal

Updated the paths in the `README.md` files:
1. Changed `../CONTRIBUTING.md` to `../../CONTRIBUTING.md`.
2. Changed `../LICENSE` to `../../LICENSE`.

These changes ensure the links point to the correct files in the repository.
