### PR TITLE
Move events and subscriptions out of `RawExecutionOutcome`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4408,7 +4408,6 @@ dependencies = [
  "cfg_aliases",
  "custom_debug_derive",
  "futures",
- "hex",
  "linera-base",
  "linera-chain",
  "linera-execution",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3536,7 +3536,6 @@ dependencies = [
  "cfg_aliases",
  "custom_debug_derive",
  "futures",
- "hex",
  "linera-base",
  "linera-execution",
  "linera-views",

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -376,6 +376,43 @@ pub struct ChannelName(
     Vec<u8>,
 );
 
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+/// A channel name together with its application ID.
+pub struct ChannelFullName {
+    /// The application owning the channel.
+    pub application_id: GenericApplicationId,
+    /// The name of the channel.
+    pub name: ChannelName,
+}
+
+impl fmt::Display for ChannelFullName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = hex::encode(&self.name);
+        match self.application_id {
+            GenericApplicationId::System => write!(f, "system channel {name}"),
+            GenericApplicationId::User(app_id) => write!(f, "user channel {name} for app {app_id}"),
+        }
+    }
+}
+
+impl ChannelFullName {
+    /// Creates a full system channel name.
+    pub fn system(name: ChannelName) -> Self {
+        Self {
+            application_id: GenericApplicationId::System,
+            name,
+        }
+    }
+
+    /// Creates a full user channel name.
+    pub fn user(name: ChannelName, application_id: ApplicationId) -> Self {
+        Self {
+            application_id: application_id.into(),
+            name,
+        }
+    }
+}
+
 /// The name of an event stream.
 #[derive(
     Clone,
@@ -1037,6 +1074,10 @@ doc_scalar!(Account, "An account");
 doc_scalar!(
     BlobId,
     "A content-addressed blob ID i.e. the hash of the `BlobContent`"
+);
+doc_scalar!(
+    ChannelFullName,
+    "A channel name together with its application ID."
 );
 
 #[cfg(test)]

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -22,7 +22,6 @@ async-graphql.workspace = true
 async-trait.workspace = true
 custom_debug_derive.workspace = true
 futures.workspace = true
-hex.workspace = true
 linera-base.workspace = true
 linera-execution.workspace = true
 linera-views.workspace = true

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeSet, fmt::Debug};
 use async_graphql::SimpleObject;
 use linera_base::{
     crypto::{BcsHashable, CryptoHash},
-    data_types::{BlockHeight, OracleResponse, Timestamp},
+    data_types::{BlockHeight, EventRecord, OracleResponse, Timestamp},
     hashed::Hashed,
     identifiers::{BlobId, BlobType, ChainId, MessageId, Owner},
 };
@@ -17,7 +17,7 @@ use thiserror::Error;
 
 use crate::{
     data_types::{
-        BlockExecutionOutcome, EventRecord, ExecutedBlock, IncomingBundle, Medium, MessageBundle,
+        BlockExecutionOutcome, ExecutedBlock, IncomingBundle, Medium, MessageBundle,
         OutgoingMessage, ProposedBlock,
     },
     types::CertificateValue,

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -6,11 +6,11 @@
 use linera_base::{
     data_types::{ArithmeticError, Timestamp, UserApplicationDescription},
     ensure,
-    identifiers::{AccountOwner, GenericApplicationId, UserApplicationId},
+    identifiers::{AccountOwner, ChannelFullName, GenericApplicationId, UserApplicationId},
 };
 use linera_chain::data_types::{
-    BlockExecutionOutcome, ChannelFullName, ExecutedBlock, IncomingBundle, Medium, MessageAction,
-    ProposalContent, ProposedBlock,
+    BlockExecutionOutcome, ExecutedBlock, IncomingBundle, Medium, MessageAction, ProposalContent,
+    ProposedBlock,
 };
 use linera_execution::{ChannelSubscription, Query, QueryOutcome};
 use linera_storage::{Clock as _, Storage};

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -19,12 +19,12 @@ use assert_matches::assert_matches;
 use async_graphql::Request;
 use counter::CounterAbi;
 use linera_base::{
-    data_types::{Amount, Bytecode, OracleResponse, UserApplicationDescription},
+    data_types::{Amount, Bytecode, EventRecord, OracleResponse, UserApplicationDescription},
     identifiers::{AccountOwner, ApplicationId, Destination, Owner, StreamId, StreamName},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
-    data_types::{EventRecord, MessageAction, OutgoingMessage},
+    data_types::{MessageAction, OutgoingMessage},
     ChainError, ChainExecutionContext,
 };
 use linera_execution::{

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -21,16 +21,16 @@ use linera_base::{
     data_types::*,
     hashed::Hashed,
     identifiers::{
-        Account, AccountOwner, ChainDescription, ChainId, ChannelName, Destination,
-        GenericApplicationId, MessageId, Owner,
+        Account, AccountOwner, ChainDescription, ChainId, ChannelFullName, ChannelName,
+        Destination, GenericApplicationId, MessageId, Owner,
     },
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
     data_types::{
-        BlockExecutionOutcome, BlockProposal, ChainAndHeight, ChannelFullName, ExecutedBlock,
-        IncomingBundle, LiteValue, LiteVote, Medium, MessageAction, MessageBundle, Origin,
-        OutgoingMessage, PostedMessage, ProposedBlock, SignatureAggregator,
+        BlockExecutionOutcome, BlockProposal, ChainAndHeight, ExecutedBlock, IncomingBundle,
+        LiteValue, LiteVote, Medium, MessageAction, MessageBundle, Origin, OutgoingMessage,
+        PostedMessage, ProposedBlock, SignatureAggregator,
     },
     manager::LockingBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -76,7 +76,7 @@ pub use crate::{
         SystemExecutionError, SystemExecutionStateView, SystemMessage, SystemOperation,
         SystemQuery, SystemResponse,
     },
-    transaction_tracker::TransactionTracker,
+    transaction_tracker::{TransactionOutcome, TransactionTracker},
 };
 
 /// The maximum length of an event key in bytes.
@@ -907,12 +907,6 @@ pub struct RawExecutionOutcome<Message, Grant = Resources> {
     /// Sends messages to the given destinations, possibly forwarding the authenticated
     /// signer and including grant with the refund policy described above.
     pub messages: Vec<RawOutgoingMessage<Message, Grant>>,
-    /// Events recorded by contracts' `emit` calls.
-    pub events: Vec<(StreamName, Vec<u8>, Vec<u8>)>,
-    /// Subscribe chains to channels.
-    pub subscribe: Vec<(ChannelName, ChainId)>,
-    /// Unsubscribe chains to channels.
-    pub unsubscribe: Vec<(ChannelName, ChainId)>,
 }
 
 /// The identifier of a channel, relative to a particular application.
@@ -975,9 +969,6 @@ impl<Message, Grant> Default for RawExecutionOutcome<Message, Grant> {
             authenticated_signer: None,
             refund_grant_to: None,
             messages: Vec::new(),
-            events: Vec::new(),
-            subscribe: Vec::new(),
-            unsubscribe: Vec::new(),
         }
     }
 }
@@ -1013,9 +1004,6 @@ impl<Message> RawExecutionOutcome<Message, Resources> {
             authenticated_signer,
             refund_grant_to,
             messages,
-            events,
-            subscribe,
-            unsubscribe,
         } = self;
         let messages = messages
             .into_iter()
@@ -1025,9 +1013,6 @@ impl<Message> RawExecutionOutcome<Message, Resources> {
             authenticated_signer,
             refund_grant_to,
             messages,
-            events,
-            subscribe,
-            unsubscribe,
         })
     }
 }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -23,8 +23,8 @@ use linera_base::{
     },
     ensure, hex_debug,
     identifiers::{
-        Account, AccountOwner, BlobId, BlobType, BytecodeId, ChainDescription, ChainId, MessageId,
-        Owner,
+        Account, AccountOwner, BlobId, BlobType, BytecodeId, ChainDescription, ChainId,
+        ChannelFullName, MessageId, Owner,
     },
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -280,6 +280,11 @@ impl SystemChannel {
         bcs::to_bytes(self)
             .expect("`SystemChannel` can be serialized")
             .into()
+    }
+
+    /// The [`ChannelFullName`] of this [`SystemChannel`].
+    pub fn full_name(&self) -> ChannelFullName {
+        ChannelFullName::system(self.name())
     }
 }
 

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -5,9 +5,9 @@ use std::vec;
 
 use custom_debug_derive::Debug;
 use linera_base::{
-    data_types::{Amount, ArithmeticError, OracleResponse},
+    data_types::{Amount, ArithmeticError, EventRecord, OracleResponse},
     ensure,
-    identifiers::ApplicationId,
+    identifiers::{ApplicationId, ChainId, ChannelFullName, StreamId},
 };
 
 use crate::{
@@ -25,6 +25,28 @@ pub struct TransactionTracker {
     #[debug(skip_if = Vec::is_empty)]
     outcomes: Vec<ExecutionOutcome>,
     next_message_index: u32,
+    /// Events recorded by contracts' `emit` calls.
+    events: Vec<EventRecord>,
+    /// Subscribe chains to channels.
+    subscribe: Vec<(ChannelFullName, ChainId)>,
+    /// Unsubscribe chains from channels.
+    unsubscribe: Vec<(ChannelFullName, ChainId)>,
+}
+
+/// The [`TransactionTracker`] contents after a transaction has finished.
+#[derive(Debug, Default)]
+pub struct TransactionOutcome {
+    #[debug(skip_if = Vec::is_empty)]
+    pub oracle_responses: Vec<OracleResponse>,
+    #[debug(skip_if = Vec::is_empty)]
+    pub outcomes: Vec<ExecutionOutcome>,
+    pub next_message_index: u32,
+    /// Events recorded by contracts' `emit` calls.
+    pub events: Vec<EventRecord>,
+    /// Subscribe chains to channels.
+    pub subscribe: Vec<(ChannelFullName, ChainId)>,
+    /// Unsubscribe chains from channels.
+    pub unsubscribe: Vec<(ChannelFullName, ChainId)>,
 }
 
 impl TransactionTracker {
@@ -32,8 +54,7 @@ impl TransactionTracker {
         TransactionTracker {
             replaying_oracle_responses: oracle_responses.map(Vec::into_iter),
             next_message_index,
-            oracle_responses: Vec::new(),
-            outcomes: Vec::new(),
+            ..Self::default()
         }
     }
 
@@ -77,6 +98,22 @@ impl TransactionTracker {
         Ok(())
     }
 
+    pub fn add_event(&mut self, stream_id: StreamId, key: Vec<u8>, value: Vec<u8>) {
+        self.events.push(EventRecord {
+            stream_id,
+            key,
+            value,
+        });
+    }
+
+    pub fn subscribe(&mut self, name: ChannelFullName, subscriber: ChainId) {
+        self.subscribe.push((name, subscriber));
+    }
+
+    pub fn unsubscribe(&mut self, name: ChannelFullName, subscriber: ChainId) {
+        self.unsubscribe.push((name, subscriber));
+    }
+
     pub fn add_oracle_response(&mut self, oracle_response: OracleResponse) {
         self.oracle_responses.push(oracle_response);
     }
@@ -112,14 +149,15 @@ impl TransactionTracker {
         Ok(Some(response))
     }
 
-    pub fn destructure(
-        self,
-    ) -> Result<(Vec<ExecutionOutcome>, Vec<OracleResponse>, u32), ExecutionError> {
+    pub fn into_outcome(self) -> Result<TransactionOutcome, ExecutionError> {
         let TransactionTracker {
             replaying_oracle_responses,
             oracle_responses,
             outcomes,
             next_message_index,
+            events,
+            subscribe,
+            unsubscribe,
         } = self;
         if let Some(mut responses) = replaying_oracle_responses {
             ensure!(
@@ -127,7 +165,14 @@ impl TransactionTracker {
                 ExecutionError::UnexpectedOracleResponse
             );
         }
-        Ok((outcomes, oracle_responses, next_message_index))
+        Ok(TransactionOutcome {
+            outcomes,
+            oracle_responses,
+            next_message_index,
+            events,
+            subscribe,
+            unsubscribe,
+        })
     }
 
     pub(crate) fn outcomes_mut(&mut self) -> &mut Vec<ExecutionOutcome> {

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -60,7 +60,8 @@ async fn application_message_index() -> anyhow::Result<()> {
         .system
         .execute_operation(context, operation, &mut txn_tracker)
         .await?;
-    let [ExecutionOutcome::System(result)] = &txn_tracker.destructure()?.0[..] else {
+    let [ExecutionOutcome::System(result)] = &txn_tracker.into_outcome().unwrap().outcomes[..]
+    else {
         panic!("Unexpected outcome");
     };
     assert_eq!(
@@ -105,7 +106,8 @@ async fn open_chain_message_index() {
         .await
         .unwrap();
     assert_eq!(new_application, None);
-    let [ExecutionOutcome::System(result)] = &txn_tracker.destructure().unwrap().0[..] else {
+    let [ExecutionOutcome::System(result)] = &txn_tracker.into_outcome().unwrap().outcomes[..]
+    else {
         panic!("Unexpected outcome");
     };
     assert_eq!(

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -28,7 +28,7 @@ use linera_execution::{
     },
     BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome, Message, MessageContext,
     Operation, OperationContext, ResourceController, SystemExecutionError,
-    SystemExecutionStateView, TestExecutionRuntimeContext, TransactionTracker,
+    SystemExecutionStateView, TestExecutionRuntimeContext, TransactionOutcome, TransactionTracker,
 };
 use linera_views::context::MemoryContext;
 use test_case::test_matrix;
@@ -90,7 +90,12 @@ async fn test_transfer_system_api(
     )
     .await?;
 
-    let (outcomes, oracle_responses, next_message_index) = tracker.destructure()?;
+    let TransactionOutcome {
+        outcomes,
+        oracle_responses,
+        next_message_index,
+        ..
+    } = tracker.into_outcome()?;
     assert_eq!(outcomes.len(), 3);
     assert!(oracle_responses.is_empty());
     assert_eq!(next_message_index, 1);
@@ -259,7 +264,12 @@ async fn test_claim_system_api(
         )
         .await?;
 
-    let (outcomes, oracle_responses, next_message_index) = tracker.destructure()?;
+    let TransactionOutcome {
+        outcomes,
+        oracle_responses,
+        next_message_index,
+        ..
+    } = tracker.into_outcome()?;
     assert_eq!(outcomes.len(), 3);
     assert!(oracle_responses.is_empty());
     assert_eq!(next_message_index, 1);
@@ -294,7 +304,12 @@ async fn test_claim_system_api(
         })
         .await?;
 
-    let (outcomes, oracle_responses, next_message_index) = tracker.destructure()?;
+    let TransactionOutcome {
+        outcomes,
+        oracle_responses,
+        next_message_index,
+        ..
+    } = tracker.into_outcome()?;
     assert_eq!(outcomes.len(), 1);
     assert!(oracle_responses.is_empty());
     assert_eq!(next_message_index, 1);

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -214,9 +214,9 @@ async fn test_fee_consumption(
     )
     .await?;
 
-    let (outcomes, _, _) = txn_tracker.destructure()?;
+    let txn_outcome = txn_tracker.into_outcome()?;
     assert_eq!(
-        outcomes,
+        txn_outcome.outcomes,
         vec![
             ExecutionOutcome::User(
                 application_id,

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -157,9 +157,9 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         chain_id: ChainId::root(0),
         owner: Some(AccountOwner::User(owner)),
     };
-    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
+    let txn_outcome = txn_tracker.into_outcome().unwrap();
     assert_eq!(
-        outcomes,
+        txn_outcome.outcomes,
         vec![
             ExecutionOutcome::User(
                 target_id,
@@ -336,9 +336,9 @@ async fn test_simulated_session() -> anyhow::Result<()> {
         chain_id: ChainId::root(0),
         owner: None,
     };
-    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
+    let txn_outcome = txn_tracker.into_outcome().unwrap();
     assert_eq!(
-        outcomes,
+        txn_outcome.outcomes,
         vec![
             ExecutionOutcome::User(
                 target_id,
@@ -656,9 +656,9 @@ async fn test_sending_message_from_finalize() -> anyhow::Result<()> {
         owner: None,
     };
 
-    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
+    let txn_outcome = txn_tracker.into_outcome().unwrap();
     assert_eq!(
-        outcomes,
+        txn_outcome.outcomes,
         vec![
             ExecutionOutcome::System(
                 RawExecutionOutcome::default().with_message(registration_message)
@@ -978,9 +978,9 @@ async fn test_simple_message() -> anyhow::Result<()> {
         owner: None,
     };
 
-    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
+    let txn_outcome = txn_tracker.into_outcome().unwrap();
     assert_eq!(
-        outcomes,
+        txn_outcome.outcomes,
         &[
             ExecutionOutcome::System(
                 RawExecutionOutcome::default().with_message(registration_message)
@@ -1074,9 +1074,9 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
         owner: None,
     };
 
-    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
+    let txn_outcome = txn_tracker.into_outcome().unwrap();
     assert_eq!(
-        outcomes,
+        txn_outcome.outcomes,
         &[
             ExecutionOutcome::System(
                 RawExecutionOutcome::default().with_message(registration_message)
@@ -1185,9 +1185,9 @@ async fn test_message_from_deeper_call() -> anyhow::Result<()> {
         chain_id: ChainId::root(0),
         owner: None,
     };
-    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
+    let txn_outcome = txn_tracker.into_outcome().unwrap();
     assert_eq!(
-        outcomes,
+        txn_outcome.outcomes,
         &[
             ExecutionOutcome::System(
                 RawExecutionOutcome::default().with_message(registration_message)
@@ -1365,9 +1365,9 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
     };
 
     // Return to checking the user application outcomes
-    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
+    let txn_outcome = txn_tracker.into_outcome().unwrap();
     assert_eq!(
-        outcomes,
+        txn_outcome.outcomes,
         &[
             ExecutionOutcome::System(
                 RawExecutionOutcome::default()
@@ -1473,8 +1473,9 @@ async fn test_open_chain() -> anyhow::Result<()> {
     .await?;
 
     assert_eq!(*view.system.balance.get(), Amount::from_tokens(3));
-    let (outcomes, _, _) = txn_tracker.destructure()?;
-    let message = outcomes
+    let txn_outcome = txn_tracker.into_outcome().unwrap();
+    let message = txn_outcome
+        .outcomes
         .iter()
         .flat_map(|outcome| match outcome {
             ExecutionOutcome::System(outcome) => &outcome.messages,

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -59,9 +59,9 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         chain_id: ChainId::root(0),
         owner: Some(AccountOwner::User(owner)),
     };
-    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
+    let txn_outcome = txn_tracker.into_outcome().unwrap();
     assert_eq!(
-        outcomes,
+        txn_outcome.outcomes,
         vec![ExecutionOutcome::System(
             RawExecutionOutcome::default()
                 .with_authenticated_signer(Some(owner))
@@ -108,9 +108,9 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
     .await
     .unwrap();
     assert_eq!(view.system.balance.get(), &Amount::from_tokens(4));
-    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
+    let txn_outcome = txn_tracker.into_outcome().unwrap();
     assert_eq!(
-        outcomes,
+        txn_outcome.outcomes,
         vec![ExecutionOutcome::System(RawExecutionOutcome::default())]
     );
     Ok(())

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -101,9 +101,9 @@ async fn test_fuel_for_counter_wasm_application(
             &mut controller,
         )
         .await?;
-        let (outcomes, _, _) = txn_tracker.destructure().unwrap();
+        let txn_outcome = txn_tracker.into_outcome().unwrap();
         assert_eq!(
-            outcomes,
+            txn_outcome.outcomes,
             vec![
                 ExecutionOutcome::User(
                     app_id.forget_abi(),

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -8,13 +8,13 @@
 use linera_base::{
     data_types::{Amount, ApplicationPermissions, Round, Timestamp},
     hashed::Hashed,
-    identifiers::{ApplicationId, ChainId, GenericApplicationId, Owner},
+    identifiers::{ApplicationId, ChainId, ChannelFullName, GenericApplicationId, Owner},
     ownership::TimeoutConfig,
 };
 use linera_chain::{
     data_types::{
-        ChannelFullName, IncomingBundle, LiteValue, LiteVote, Medium, MessageAction, Origin,
-        ProposedBlock, SignatureAggregator,
+        IncomingBundle, LiteValue, LiteVote, Medium, MessageAction, Origin, ProposedBlock,
+        SignatureAggregator,
     },
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
 };

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -93,7 +93,7 @@ query Chain(
   $chainId: ChainId!,
   $inboxesInput: MapInput_Origin_742d451b,
   $outboxesInput: MapInput_Target_7aac1e1c,
-  $channelsInput: MapInput_ChannelFullName_3b59bf69,
+  $channelsInput: MapInput_ChannelFullName_7b67e184,
 ) {
   chain(chainId: $chainId) {
     chainId

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -320,7 +320,7 @@ type ChainStateExtendedView {
 	"""
 	Channels able to multicast messages to subscribers.
 	"""
-	channels: ReentrantCollectionView_ChannelFullName_ChannelStateView_629706216!
+	channels: ReentrantCollectionView_ChannelFullName_ChannelStateView_3660287053!
 }
 
 """
@@ -470,7 +470,7 @@ type Entry_BlobId_Blob_9f0b41f3 {
 """
 A GraphQL-visible map item, complete with key.
 """
-type Entry_ChannelFullName_ChannelStateView_ef52a064 {
+type Entry_ChannelFullName_ChannelStateView_bd1de7ae {
 	key: ChannelFullName!
 	value: ChannelStateView!
 }
@@ -616,7 +616,7 @@ input MapFilters_BlobId_4d2a0555 {
 	keys: [BlobId!]
 }
 
-input MapFilters_ChannelFullName_3b59bf69 {
+input MapFilters_ChannelFullName_7b67e184 {
 	keys: [ChannelFullName!]
 }
 
@@ -640,8 +640,8 @@ input MapInput_BlobId_4d2a0555 {
 	filters: MapFilters_BlobId_4d2a0555
 }
 
-input MapInput_ChannelFullName_3b59bf69 {
-	filters: MapFilters_ChannelFullName_3b59bf69
+input MapInput_ChannelFullName_7b67e184 {
+	filters: MapFilters_ChannelFullName_7b67e184
 }
 
 input MapInput_Origin_742d451b {
@@ -995,10 +995,10 @@ The recipient of a transfer
 """
 scalar Recipient
 
-type ReentrantCollectionView_ChannelFullName_ChannelStateView_629706216 {
+type ReentrantCollectionView_ChannelFullName_ChannelStateView_3660287053 {
 	keys: [ChannelFullName!]!
-	entry(key: ChannelFullName!): Entry_ChannelFullName_ChannelStateView_ef52a064!
-	entries(input: MapInput_ChannelFullName_3b59bf69): [Entry_ChannelFullName_ChannelStateView_ef52a064!]!
+	entry(key: ChannelFullName!): Entry_ChannelFullName_ChannelStateView_bd1de7ae!
+	entries(input: MapInput_ChannelFullName_7b67e184): [Entry_ChannelFullName_ChannelStateView_bd1de7ae!]!
 }
 
 type ReentrantCollectionView_Origin_InboxStateView_3699835794 {

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -60,9 +60,12 @@ mod types {
 
 #[cfg(not(target_arch = "wasm32"))]
 mod types {
-    pub use linera_base::{data_types::UserApplicationDescription, ownership::ChainOwnership};
+    pub use linera_base::{
+        data_types::UserApplicationDescription, identifiers::ChannelFullName,
+        ownership::ChainOwnership,
+    };
     pub use linera_chain::{
-        data_types::{ChannelFullName, MessageAction, MessageBundle, Origin, Target},
+        data_types::{MessageAction, MessageBundle, Origin, Target},
         manager::ChainManager,
     };
     pub use linera_core::worker::{Notification, Reason};
@@ -130,12 +133,11 @@ pub struct Transfer;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod from {
-    use linera_base::{hashed::Hashed, identifiers::StreamId};
+    use linera_base::{data_types::EventRecord, hashed::Hashed, identifiers::StreamId};
     use linera_chain::{
         block::{Block, BlockBody, BlockHeader},
         data_types::{
-            EventRecord, ExecutedBlock, IncomingBundle, MessageBundle, OutgoingMessage,
-            PostedMessage,
+            ExecutedBlock, IncomingBundle, MessageBundle, OutgoingMessage, PostedMessage,
         },
         types::ConfirmedBlock,
     };

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -15,13 +15,10 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, Blob, BlockHeight, TimeDelta, Timestamp, UserApplicationDescription},
     hashed::Hashed,
-    identifiers::{
-        BlobId, ChainDescription, ChainId, EventId, GenericApplicationId, Owner, UserApplicationId,
-    },
+    identifiers::{BlobId, ChainDescription, ChainId, EventId, Owner, UserApplicationId},
     ownership::ChainOwnership,
 };
 use linera_chain::{
-    data_types::ChannelFullName,
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
     ChainError, ChainStateView,
 };
@@ -244,10 +241,7 @@ pub trait Storage: Sized {
                 name: SystemChannel::Admin.name(),
             })?;
             let mut admin_chain = self.load_chain(admin_id).await?;
-            let full_name = ChannelFullName {
-                application_id: GenericApplicationId::System,
-                name: SystemChannel::Admin.name(),
-            };
+            let full_name = SystemChannel::Admin.full_name();
             {
                 let mut channel = admin_chain.channels.try_load_entry_mut(&full_name).await?;
                 channel.subscribers.insert(&id)?;


### PR DESCRIPTION
## Motivation

The fact that events are in `RawExecutionOutcome` makes #365 more complicated. They also conceptually don't need to be in the structure whose purpose is mainly to associate messages with the correct application ID and authenticated signer.

## Proposal

Remove `events` from `RawExecutionOutcome`. Also remove `subscribe` and `unsubscribe`; the same argument applies to them.

## Test Plan

Refactoring; CI should catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Related to #365
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
