### PR TITLE
Rename `EventRecord` → `Event`.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1158,7 +1158,7 @@ impl<'a> Deserialize<'a> for Blob {
 
 /// An event recorded in an executed block.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
-pub struct EventRecord {
+pub struct Event {
     /// The ID of the stream this event belongs to.
     pub stream_id: StreamId,
     /// The event key.
@@ -1171,7 +1171,7 @@ pub struct EventRecord {
     pub value: Vec<u8>,
 }
 
-impl EventRecord {
+impl Event {
     /// Returns the ID of this event record, given the publisher chain ID.
     pub fn id(&self, chain_id: ChainId) -> EventId {
         EventId {
@@ -1182,7 +1182,7 @@ impl EventRecord {
     }
 }
 
-impl<'de> BcsHashable<'de> for EventRecord {}
+impl<'de> BcsHashable<'de> for Event {}
 
 doc_scalar!(Bytecode, "A WebAssembly module's bytecode");
 doc_scalar!(Amount, "A non-negative amount of tokens.");

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeSet, fmt::Debug};
 use async_graphql::SimpleObject;
 use linera_base::{
     crypto::{BcsHashable, CryptoHash},
-    data_types::{BlockHeight, EventRecord, OracleResponse, Timestamp},
+    data_types::{BlockHeight, Event, OracleResponse, Timestamp},
     hashed::Hashed,
     identifiers::{BlobId, BlobType, ChainId, MessageId, Owner},
 };
@@ -359,7 +359,7 @@ pub struct BlockBody {
     /// The record of oracle responses for each transaction.
     pub oracle_responses: Vec<Vec<OracleResponse>>,
     /// The list of events produced by each transaction.
-    pub events: Vec<Vec<EventRecord>>,
+    pub events: Vec<Vec<Event>>,
 }
 
 impl Block {

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -12,7 +12,7 @@ use custom_debug_derive::Debug;
 use linera_base::{
     bcs,
     crypto::{BcsHashable, BcsSignable, CryptoError, CryptoHash, KeyPair, PublicKey, Signature},
-    data_types::{Amount, BlockHeight, EventRecord, OracleResponse, Round, Timestamp},
+    data_types::{Amount, BlockHeight, Event, OracleResponse, Round, Timestamp},
     doc_scalar, ensure,
     hashed::Hashed,
     identifiers::{
@@ -392,7 +392,7 @@ pub struct BlockExecutionOutcome {
     /// The record of oracle responses for each transaction.
     pub oracle_responses: Vec<Vec<OracleResponse>>,
     /// The list of events produced by each transaction.
-    pub events: Vec<Vec<EventRecord>>,
+    pub events: Vec<Vec<Event>>,
 }
 
 /// The hash and chain ID of a `CertificateValue`.

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -19,7 +19,7 @@ use assert_matches::assert_matches;
 use async_graphql::Request;
 use counter::CounterAbi;
 use linera_base::{
-    data_types::{Amount, Bytecode, EventRecord, OracleResponse, UserApplicationDescription},
+    data_types::{Amount, Bytecode, Event, OracleResponse, UserApplicationDescription},
     identifiers::{AccountOwner, ApplicationId, Destination, Owner, StreamId, StreamName},
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -335,7 +335,7 @@ where
         certificate.block().body.events,
         vec![
             Vec::new(),
-            vec![EventRecord {
+            vec![Event {
                 stream_id: StreamId {
                     application_id: application_id2.forget_abi().into(),
                     stream_name: StreamName(b"announcements".to_vec()),

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -5,7 +5,7 @@ use std::vec;
 
 use custom_debug_derive::Debug;
 use linera_base::{
-    data_types::{Amount, ArithmeticError, EventRecord, OracleResponse},
+    data_types::{Amount, ArithmeticError, Event, OracleResponse},
     ensure,
     identifiers::{ApplicationId, ChainId, ChannelFullName, StreamId},
 };
@@ -26,7 +26,7 @@ pub struct TransactionTracker {
     outcomes: Vec<ExecutionOutcome>,
     next_message_index: u32,
     /// Events recorded by contracts' `emit` calls.
-    events: Vec<EventRecord>,
+    events: Vec<Event>,
     /// Subscribe chains to channels.
     subscribe: Vec<(ChannelFullName, ChainId)>,
     /// Unsubscribe chains from channels.
@@ -42,7 +42,7 @@ pub struct TransactionOutcome {
     pub outcomes: Vec<ExecutionOutcome>,
     pub next_message_index: u32,
     /// Events recorded by contracts' `emit` calls.
-    pub events: Vec<EventRecord>,
+    pub events: Vec<Event>,
     /// Subscribe chains to channels.
     pub subscribe: Vec<(ChannelFullName, ChainId)>,
     /// Unsubscribe chains from channels.
@@ -99,7 +99,7 @@ impl TransactionTracker {
     }
 
     pub fn add_event(&mut self, stream_id: StreamId, key: Vec<u8>, value: Vec<u8>) {
-        self.events.push(EventRecord {
+        self.events.push(Event {
             stream_id,
             key,
             value,

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -100,7 +100,7 @@ BlockBody:
     - events:
         SEQ:
           SEQ:
-            TYPENAME: EventRecord
+            TYPENAME: Event
 BlockExecutionOutcome:
   STRUCT:
     - messages:
@@ -116,7 +116,7 @@ BlockExecutionOutcome:
     - events:
         SEQ:
           SEQ:
-            TYPENAME: EventRecord
+            TYPENAME: Event
 BlockHeader:
   STRUCT:
     - chain_id:
@@ -409,7 +409,7 @@ Destination:
           TYPENAME: ChannelName
 Epoch:
   NEWTYPESTRUCT: U32
-EventRecord:
+Event:
   STRUCT:
     - stream_id:
         TYPENAME: StreamId

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -102,7 +102,7 @@ type BlockBody {
 	"""
 	The list of events produced by each transaction.
 	"""
-	events: [[EventRecord!]!]!
+	events: [[Event!]!]!
 }
 
 """
@@ -507,7 +507,7 @@ scalar Epoch
 """
 An event recorded in an executed block.
 """
-type EventRecord {
+type Event {
 	"""
 	The ID of the stream this event belongs to.
 	"""

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -133,7 +133,7 @@ pub struct Transfer;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod from {
-    use linera_base::{data_types::EventRecord, hashed::Hashed, identifiers::StreamId};
+    use linera_base::{data_types::Event, hashed::Hashed, identifiers::StreamId};
     use linera_chain::{
         block::{Block, BlockBody, BlockHeader},
         data_types::{
@@ -285,9 +285,9 @@ mod from {
         }
     }
 
-    impl From<block::BlockBlockValueBlockBodyEvents> for EventRecord {
+    impl From<block::BlockBlockValueBlockBodyEvents> for Event {
         fn from(event: block::BlockBlockValueBlockBodyEvents) -> Self {
-            EventRecord {
+            Event {
                 stream_id: event.stream_id.into(),
                 key: event.key.into_iter().map(|byte| byte as u8).collect(),
                 value: event.value.into_iter().map(|byte| byte as u8).collect(),


### PR DESCRIPTION
## Motivation

`EventRecord` has its name because back then there was still another `Event` type. That is not the case anymore.

## Proposal

Rename `EventRecord` to `Event`.

## Test Plan

Only renaming; CI would catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
