### PR TITLE
Include validator address in gRPC status log.

### DIFF
--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -253,6 +253,7 @@ impl ValidatorNode for GrpcClient {
         })
         .flatten();
 
+        let span = tracing::info_span!("notification stream");
         // The stream of `Notification`s that inserts increasing delays after retriable errors, and
         // terminates after unexpected or fatal errors.
         let notification_stream = endlessly_retrying_notification_stream
@@ -267,9 +268,11 @@ impl ValidatorNode for GrpcClient {
                     retry_count = 0;
                     return future::Either::Left(future::ready(true));
                 };
+                let _enter_span = span.enter();
                 if !Self::is_retryable(status) || retry_count >= max_retries {
                     return future::Either::Left(future::ready(false));
                 }
+                drop(_enter_span);
                 let delay = retry_delay.saturating_mul(retry_count);
                 retry_count += 1;
                 future::Either::Right(async move {


### PR DESCRIPTION
## Motivation

The gRPC status log currently does not show which validator connection it is about.

## Proposal

Include the validator address in the log.

## Test Plan

CI

Example log:
`2025-02-12T16:56:00.764092Z ERROR linera::main:node_service{port=8080}:subscribe{address="https://linera-testnet.contributiondao.com:443"}:notification stream: linera_rpc::grpc::client: Unexpected gRPC status: status: Internal, message: "h2 protocol error: error reading a body from connection", details: [], metadata: MetadataMap { headers: {} }`

## Release Plan

- These changes should released in a new SDK.
- They should be ported to the `main` branch.

## Links

- Related to #3300
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)