### PR TITLE
Add Secp256k1 keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4369,6 +4369,7 @@ dependencies = [
  "is-terminal",
  "linera-base",
  "linera-witty",
+ "once_cell",
  "port-selector",
  "prometheus",
  "proptest",

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -46,6 +46,7 @@ is-terminal.workspace = true
 linera-witty = { workspace = true, features = ["macros"] }
 prometheus = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true, features = ["alloc"] }
+once_cell = "1.20"
 rand.workspace = true
 secp256k1.workspace = true
 serde.workspace = true


### PR DESCRIPTION
## Motivation

N/A

## Proposal

Adds `Secp256k1SecretKey` and `Secp256k1PublicKey` structs. Creates a static `SECP256K1` context for reuse, instead of initializing new context for every operation. Note that the same effect could be used by using `global-context` feature of the `secp256k1` crate but that is mutually exclusive with other features (like `alloc`) that we might want to use in the future.

## Test Plan

N/A

## Release Plan

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
