### PR TITLE
Remove `Display` and `FromStr` for `OracleResponse`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4357,7 +4357,6 @@ dependencies = [
  "async-graphql",
  "async-graphql-derive",
  "async-trait",
- "base64 0.22.1",
  "bcs",
  "cfg-if",
  "cfg_aliases",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3498,7 +3498,6 @@ dependencies = [
  "async-graphql",
  "async-graphql-derive",
  "async-trait",
- "base64 0.22.1",
  "bcs",
  "cfg-if",
  "cfg_aliases",

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -34,7 +34,6 @@ anyhow.workspace = true
 async-graphql.workspace = true
 async-graphql-derive.workspace = true
 async-trait.workspace = true
-base64.workspace = true
 bcs.workspace = true
 cfg-if.workspace = true
 chrono.workspace = true

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -18,9 +18,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::Context as _;
 use async_graphql::{InputObject, SimpleObject};
-use base64::engine::{general_purpose::STANDARD_NO_PAD, Engine as _};
 use custom_debug_derive::Debug;
 use linera_witty::{WitLoad, WitStore, WitType};
 #[cfg(with_metrics)]
@@ -784,46 +782,6 @@ pub enum OracleResponse {
     Assert,
     /// The block's validation round.
     Round(Option<u32>),
-}
-
-impl Display for OracleResponse {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            OracleResponse::Service(bytes) => {
-                write!(f, "Service:{}", STANDARD_NO_PAD.encode(bytes))?
-            }
-            OracleResponse::Post(bytes) => write!(f, "Post:{}", STANDARD_NO_PAD.encode(bytes))?,
-            OracleResponse::Blob(blob_id) => write!(f, "Blob:{}", blob_id)?,
-            OracleResponse::Assert => write!(f, "Assert")?,
-            OracleResponse::Round(Some(round)) => write!(f, "Round:{round}")?,
-            OracleResponse::Round(None) => write!(f, "Round:None")?,
-        };
-
-        Ok(())
-    }
-}
-
-impl FromStr for OracleResponse {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Some(string) = s.strip_prefix("Service:") {
-            return Ok(OracleResponse::Service(
-                STANDARD_NO_PAD.decode(string).context("Invalid base64")?,
-            ));
-        }
-        if let Some(string) = s.strip_prefix("Post:") {
-            return Ok(OracleResponse::Post(
-                STANDARD_NO_PAD.decode(string).context("Invalid base64")?,
-            ));
-        }
-        if let Some(string) = s.strip_prefix("Blob:") {
-            return Ok(OracleResponse::Blob(
-                BlobId::from_str(string).context("Invalid BlobId")?,
-            ));
-        }
-        Err(anyhow::anyhow!("Invalid enum! Enum: {}", s))
-    }
 }
 
 impl<'de> BcsHashable<'de> for OracleResponse {}


### PR DESCRIPTION
## Motivation

The `FromStr` and `Display` implementations for `OracleResponse` are not used anywhere, and make it a lot more complicated to add new oracle variants, especially if they involve complex types. We will soon have to add one for events.

## Proposal

Remove `FromStr` and `Display`.

## Test Plan

CI will tell us if it was used after all!

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
