### PR TITLE
Introduce --with-faucet for net up using the default chain

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -932,7 +932,10 @@ Start a Local Linera Network
 * `--external-protocol <EXTERNAL_PROTOCOL>` — External protocol used, either `grpc` or `grpcs`
 
   Default value: `grpc`
-* `--with-faucet-chain <WITH_FAUCET_CHAIN>` — If present, a faucet is started using the given chain root number (0 for the admin chain, 1 for the first non-admin initial chain, etc)
+* `--with-faucet` — If present, a faucet is started using the chain provided by --faucet-chain, or `ChainId::root(1)` if not provided, as root 0 is usually the admin chain
+
+  Default value: `false`
+* `--faucet-chain <FAUCET_CHAIN>` — When using --with-faucet, this specifies the chain on which the faucet will be started. The chain is specified by its root number (0 for the admin chain, 1 for the first non-admin initial chain, etc)
 * `--faucet-port <FAUCET_PORT>` — The port on which to run the faucet server
 
   Default value: `8080`

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -1099,10 +1099,16 @@ pub enum NetCommand {
         #[arg(long, default_value = "grpc")]
         external_protocol: String,
 
-        /// If present, a faucet is started using the given chain root number (0 for the
-        /// admin chain, 1 for the first non-admin initial chain, etc).
+        /// If present, a faucet is started using the chain provided by --faucet-chain, or
+        /// `ChainId::root(1)` if not provided, as root 0 is usually the admin chain.
+        #[arg(long, default_value = "false")]
+        with_faucet: bool,
+
+        /// When using --with-faucet, this specifies the chain on which the faucet will be started.
+        /// The chain is specified by its root number (0 for the admin chain, 1 for the first
+        /// non-admin initial chain, etc).
         #[arg(long)]
-        with_faucet_chain: Option<u32>,
+        faucet_chain: Option<u32>,
 
         /// The port on which to run the faucet server
         #[arg(long, default_value = "8080")]

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1613,7 +1613,8 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                 path: _,
                 storage: _,
                 external_protocol: _,
-                with_faucet_chain,
+                with_faucet,
+                faucet_chain,
                 faucet_port,
                 faucet_amount,
             } => {
@@ -1628,7 +1629,8 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                     *no_build,
                     docker_image_name.clone(),
                     policy_config.into_policy(),
-                    *with_faucet_chain,
+                    *with_faucet,
+                    *faucet_chain,
                     *faucet_port,
                     *faucet_amount,
                 )
@@ -1648,7 +1650,8 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                 path,
                 storage,
                 external_protocol,
-                with_faucet_chain,
+                with_faucet,
+                faucet_chain,
                 faucet_port,
                 faucet_amount,
                 ..
@@ -1664,7 +1667,8 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                     path,
                     storage,
                     external_protocol.clone(),
-                    *with_faucet_chain,
+                    *with_faucet,
+                    *faucet_chain,
                     *faucet_port,
                     *faucet_amount,
                 )

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -664,7 +664,8 @@ async fn test_storage_service_linera_net_up_simple() -> Result<()> {
     command.args([
         "net",
         "up",
-        "--with-faucet-chain",
+        "--with-faucet",
+        "--faucet-chain",
         "1",
         "--faucet-port",
         &port.to_string(),


### PR DESCRIPTION
## Motivation

Right now we have a `--with-faucet-chain` option that both enables starting a faucet and also specifies what chain the faucet will be running on.
`linera faucet` however has a slightly different behavior, in which if you don't specify the chain, it just uses the default chain.

## Proposal

Introduce a `--with-faucet` option that controls whether a faucet will be started, which will by default start a faucet on the default chain, unless the `--faucet-chain` argument is provided.

## Test Plan

Run it locally, see the faucet being started using the default chain as expected, and previous behavior also works

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
