### PR TITLE
Move listen_for_shutdown_signals to linera-base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4383,6 +4383,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "tracing-web",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3521,6 +3521,7 @@ dependencies = [
  "thiserror 1.0.65",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "zstd",

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -71,7 +71,8 @@ tracing-web = { optional = true, workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono.workspace = true
 rand = { workspace = true, features = ["getrandom", "std", "std_rng"] }
-tokio = { workspace = true, features = ["process", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["process", "rt-multi-thread", "signal", "macros"] }
+tokio-util.workspace = true
 prometheus.workspace = true
 port-selector.workspace = true
 zstd.workspace = true

--- a/linera-service/src/linera/net_up_utils.rs
+++ b/linera-service/src/linera/net_up_utils.rs
@@ -4,16 +4,14 @@
 use std::{num::NonZeroU16, str::FromStr};
 
 use colored::Colorize as _;
-use linera_base::{data_types::Amount, identifiers::ChainId, time::Duration};
+use linera_base::{
+    data_types::Amount, identifiers::ChainId, listen_for_shutdown_signals, time::Duration,
+};
 use linera_client::storage::{StorageConfig, StorageConfigNamespace};
 use linera_execution::ResourceControlPolicy;
-use linera_service::{
-    cli_wrappers::{
-        local_net::{Database, LocalNetConfig, PathProvider, StorageConfigBuilder},
-        ClientWrapper, FaucetOption, FaucetService, LineraNet, LineraNetConfig, Network,
-        NetworkConfig,
-    },
-    util::listen_for_shutdown_signals,
+use linera_service::cli_wrappers::{
+    local_net::{Database, LocalNetConfig, PathProvider, StorageConfigBuilder},
+    ClientWrapper, FaucetOption, FaucetService, LineraNet, LineraNetConfig, Network, NetworkConfig,
 };
 #[cfg(feature = "storage-service")]
 use linera_storage_service::{

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -8,6 +8,7 @@ use std::{net::SocketAddr, path::PathBuf, time::Duration};
 use anyhow::{bail, ensure, Result};
 use async_trait::async_trait;
 use futures::{FutureExt as _, SinkExt, StreamExt};
+use linera_base::listen_for_shutdown_signals;
 use linera_client::{
     config::{GenesisConfig, ValidatorServerConfig},
     storage::{run_with_storage, Runnable, StorageConfigNamespace},
@@ -118,7 +119,7 @@ impl Runnable for ProxyContext {
         S: Storage + Clone + Send + Sync + 'static,
     {
         let shutdown_notifier = CancellationToken::new();
-        tokio::spawn(util::listen_for_shutdown_signals(shutdown_notifier.clone()));
+        tokio::spawn(listen_for_shutdown_signals(shutdown_notifier.clone()));
         let proxy = Proxy::from_context(self, storage)?;
         match proxy {
             Proxy::Simple(simple_proxy) => simple_proxy.run(shutdown_notifier).await,

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -14,7 +14,10 @@ use std::{
 use anyhow::{bail, Context};
 use async_trait::async_trait;
 use futures::{stream::FuturesUnordered, FutureExt as _, StreamExt, TryFutureExt as _};
-use linera_base::crypto::{CryptoRng, KeyPair};
+use linera_base::{
+    crypto::{CryptoRng, KeyPair},
+    listen_for_shutdown_signals,
+};
 use linera_client::{
     config::{CommitteeConfig, GenesisConfig, ValidatorConfig, ValidatorServerConfig},
     persistent::{self, Persist},
@@ -193,7 +196,7 @@ impl Runnable for ServerContext {
         let shutdown_notifier = CancellationToken::new();
         let listen_address = self.get_listen_address();
 
-        tokio::spawn(util::listen_for_shutdown_signals(shutdown_notifier.clone()));
+        tokio::spawn(listen_for_shutdown_signals(shutdown_notifier.clone()));
 
         // Run the server
         let states = match self.shard {

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -16,8 +16,6 @@ use http::Uri;
 use linera_base::command::parse_version_message;
 use linera_base::data_types::TimeDelta;
 pub use linera_client::util::*;
-use tokio::signal::unix;
-use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 /// Extension trait for [`tokio::process::Child`].
@@ -36,25 +34,6 @@ impl ChildExt for tokio::process::Child {
         }
         debug!("Child process {:?} is running as expected.", self);
         Ok(())
-    }
-}
-
-/// Listens for shutdown signals, and notifies the [`CancellationToken`] if one is
-/// received.
-pub async fn listen_for_shutdown_signals(shutdown_sender: CancellationToken) {
-    let _shutdown_guard = shutdown_sender.drop_guard();
-
-    let mut sigint =
-        unix::signal(unix::SignalKind::interrupt()).expect("Failed to set up SIGINT handler");
-    let mut sigterm =
-        unix::signal(unix::SignalKind::terminate()).expect("Failed to set up SIGTERM handler");
-    let mut sighup =
-        unix::signal(unix::SignalKind::hangup()).expect("Failed to set up SIGHUP handler");
-
-    tokio::select! {
-        _ = sigint.recv() => debug!("Received SIGINT"),
-        _ = sigterm.recv() => debug!("Received SIGTERM"),
-        _ = sighup.recv() => debug!("Received SIGHUP"),
     }
 }
 


### PR DESCRIPTION
## Motivation

This is a pretty useful function in general to be used by different binaries. It makes sense to have it be in a location that will avoid circular dependencies.

## Proposal

Move it to `linera-base`

## Test Plan

CI + will use this from the client in the next PR

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
