### PR TITLE
Gracefully shutdown benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4478,6 +4478,7 @@ dependencies = [
  "thiserror-context",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "trait-variant",
  "wasm-bindgen-futures",

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -13,7 +13,7 @@ version.workspace = true
 
 [features]
 test = ["linera-views/test", "linera-execution/test"]
-benchmark = ["linera-base/test", "dep:linera-sdk"]
+benchmark = ["linera-base/test", "dep:linera-sdk", "dep:tokio-util"]
 wasmer = [
     "linera-core/wasmer",
     "linera-execution/wasmer",
@@ -75,6 +75,7 @@ thiserror.workspace = true
 thiserror-context.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
+tokio-util = { workspace = true, optional = true }
 tracing.workspace = true
 trait-variant.workspace = true
 


### PR DESCRIPTION
## Motivation

Right now if you interrupt the benchmark, it might leave you in a state where the local node is inconsistent with the validators, the wallet hasn't been saved... etc

## Proposal

Gracefully shutdown the benchmark on interruption signals, making sure we never exit in the middle of sending a block proposal, and only saving the wallet on program exit.

## Test Plan

Ran the benchmark locally, did Ctrl+C and saw it gracefully exit.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
