### PR TITLE
Introduce Evm support in Linera.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -198,6 +198,9 @@ jobs:
       run: |
         cargo test -p linera-ethereum --features ethereum
         cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum,storage-service,unstable-oracles
+    - name: Run REVM test
+      run: |
+        cargo test -p linera-execution test_fuel_for_counter_revm_application --features revm
 
   storage-service-tests:
     runs-on: ubuntu-latest-16-cores

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
+ "k256",
  "serde",
 ]
 
@@ -1083,6 +1084,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aurora-engine-modexp"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aef7712851e524f35fbbb74fa6599c5cd8692056a1c36f9ca0d2001b670e7e5"
+dependencies = [
+ "hex",
+ "num",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,6 +1606,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -1604,6 +1618,7 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
+ "serde",
  "tap",
  "wyz",
 ]
@@ -2794,6 +2809,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4247,6 +4273,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -4374,7 +4403,7 @@ dependencies = [
  "proptest",
  "rand",
  "ruzstd",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde-name",
  "serde_bytes",
@@ -4558,6 +4587,8 @@ dependencies = [
 name = "linera-execution"
 version = "0.14.0"
 dependencies = [
+ "alloy",
+ "alloy-sol-types",
  "anyhow",
  "assert_matches",
  "async-graphql",
@@ -4571,6 +4602,7 @@ dependencies = [
  "derive_more",
  "dyn-clone",
  "futures",
+ "hex",
  "js-sys",
  "linera-base",
  "linera-execution",
@@ -4584,9 +4616,12 @@ dependencies = [
  "prometheus",
  "proptest",
  "reqwest 0.11.27",
+ "revm",
+ "revm-primitives",
  "serde",
  "serde_bytes",
  "serde_json",
+ "tempfile",
  "test-case",
  "test-log",
  "test-strategy",
@@ -5594,12 +5629,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -5615,6 +5673,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -6624,6 +6704,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm"
+version = "19.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1538aea4d103a8044820eede9b1254e1b5a2a2abaf3f9a67bef19f8865cf1826"
+dependencies = [
+ "auto_impl",
+ "cfg-if",
+ "dyn-clone",
+ "revm-interpreter",
+ "revm-precompile",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f632e761f171fb2f6ace8d1552a5793e0350578d4acec3e79ade1489f4c2a6"
+dependencies = [
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6542fb37650dfdbf4b9186769e49c4a8bc1901a3280b2ebf32f915b6c8850f36"
+dependencies = [
+ "aurora-engine-modexp",
+ "blst",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "once_cell",
+ "revm-primitives",
+ "ripemd",
+ "secp256k1 0.29.1",
+ "sha2",
+ "substrate-bn",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48faea1ecf2c9f80d9b043bbde0db9da616431faed84c4cfa3dd7393005598e6"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives",
+ "auto_impl",
+ "bitflags 2.6.0",
+ "bitvec",
+ "c-kzg",
+ "cfg-if",
+ "dyn-clone",
+ "enumn",
+ "hex",
+ "serde",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6646,6 +6790,15 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -7047,6 +7200,16 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "rand",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
@@ -7247,6 +7410,7 @@ version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
+ "indexmap 2.7.0",
  "itoa",
  "memchr",
  "ryu",
@@ -7630,6 +7794,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.95",
+]
+
+[[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand",
+ "rustc-hex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,6 @@ ed25519-dalek = { version = "2.1.1", default-features = false, features = [
     "zeroize",
 ] }
 either = "1.10.0"
-ethers = { version = "2.0.14", features = ["solc"] }
 flarch = "0.7.0"
 frunk = "0.4.2"
 fs-err = "2.11.0"
@@ -103,6 +102,7 @@ gloo-utils = "0.2.0"
 indexed_db_futures = "0.4.1"
 insta = "1.36.1"
 is-terminal = "0.4.12"
+alloy-sol-types = "0.8.18"
 alloy = { version = "0.9.2", default-features = false }
 alloy-signer-local = "0.9.2"
 alloy-primitives = { version = "0.8.18", default-features = false, features = ["serde"] }
@@ -132,6 +132,10 @@ rcgen = "0.12.1"
 reqwest = { version = "0.11.24", default-features = false, features = [
     "rustls-tls",
 ] }
+revm = "19.4.0"
+revm-interpreter = { version = "15.1.0", features = [ "serde" ] }
+revm-precompile = "16.0.0"
+revm-primitives = "15.1.0"
 rocksdb = "0.21.0"
 secp256k1 = { version = "0.30.0", default-features = false, features = [ "alloc", "rand", "serde" ] }
 scylla = "0.15.1"

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -13,6 +13,14 @@ version.workspace = true
 
 [features]
 test = ["tokio/macros", "linera-base/test", "linera-views/test", "proptest"]
+revm = [
+    "dep:revm",
+    "dep:revm-primitives",
+    "dep:alloy",
+    "dep:alloy-sol-types",
+    "dep:hex",
+    "dep:tempfile",
+]
 fs = ["tokio/fs"]
 metrics = ["prometheus", "linera-views/metrics"]
 unstable-oracles = []
@@ -33,6 +41,8 @@ wasmtime = [
 web = ["linera-base/web", "linera-views/web", "js-sys"]
 
 [dependencies]
+alloy = { workspace = true, default-features = false, optional = true, features = [ "rpc-types-eth" ] }
+alloy-sol-types = { workspace = true, optional = true }
 anyhow.workspace = true
 async-graphql.workspace = true
 async-trait.workspace = true
@@ -44,6 +54,7 @@ dashmap.workspace = true
 derive_more = { workspace = true, features = ["display"] }
 dyn-clone.workspace = true
 futures.workspace = true
+hex = { workspace = true, optional = true }
 js-sys = { workspace = true, optional = true }
 linera-base.workspace = true
 linera-views.workspace = true
@@ -54,9 +65,12 @@ oneshot.workspace = true
 prometheus = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["blocking", "json"] }
+revm = { workspace = true, optional = true, features = ["serde"] }
+revm-primitives = { workspace = true, optional = true }
 serde.workspace = true
 serde_bytes.workspace = true
 serde_json.workspace = true
+tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
 tracing = { workspace = true, features = ["log"] }
 wasm-encoder = { workspace = true, optional = true }

--- a/linera-execution/build.rs
+++ b/linera-execution/build.rs
@@ -10,6 +10,7 @@ fn main() {
         with_testing: { any(test, feature = "test") },
         with_tokio_multi_thread: { not(target_arch = "wasm32") },
         with_wasmer: { feature = "wasmer" },
+        with_revm: { feature = "revm" },
         with_wasmtime: { all(not(target_arch = "wasm32"), feature = "wasmtime") },
 
         // If you change this, don't forget to update `WasmRuntime` and

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -187,8 +187,7 @@ where
             txn_tracker,
             resource_controller,
         )
-        .await?;
-        Ok(())
+        .await
     }
 
     #[expect(clippy::too_many_arguments)]

--- a/linera-execution/src/revm.rs
+++ b/linera-execution/src/revm.rs
@@ -1,0 +1,632 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Code specific to the usage of the [Revm](https://bluealloy.github.io/revm/) runtime.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use alloy::primitives::{Address, B256, U256};
+use linera_base::{data_types::Bytecode, ensure, identifiers::StreamName};
+use linera_views::common::from_bytes_option;
+use revm::{
+    db::AccountState,
+    primitives::{
+        keccak256,
+        state::{Account, AccountInfo},
+        Bytes,
+    },
+    Database, DatabaseCommit, DatabaseRef, Evm,
+};
+use revm_primitives::{ExecutionResult, HaltReason, Log, Output, TxKind};
+use thiserror::Error;
+#[cfg(with_metrics)]
+use {
+    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency as _},
+    prometheus::HistogramVec,
+    std::sync::LazyLock,
+};
+
+use crate::{
+    BaseRuntime, Batch, ContractRuntime, ContractSyncRuntimeHandle, EvmRuntime, ExecutionError,
+    FinalizeContext, MessageContext, OperationContext, QueryContext, ServiceRuntime,
+    ServiceSyncRuntimeHandle, UserContract, UserContractInstance, UserContractModule, UserService,
+    UserServiceInstance, UserServiceModule, ViewError,
+};
+
+const EXECUTE_MESSAGE_SELECTOR: &[u8] = &[173, 125, 234, 205];
+
+#[cfg(test)]
+mod tests {
+    use revm_primitives::keccak256;
+
+    use crate::revm::EXECUTE_MESSAGE_SELECTOR;
+
+    // The function keccak256 is not const so we cannot build the execute_message
+    // selector directly.
+    #[test]
+    fn check_execute_message_selector() {
+        let selector = &keccak256("execute_message(bytes)".as_bytes())[..4];
+        assert_eq!(selector, EXECUTE_MESSAGE_SELECTOR);
+    }
+}
+
+#[cfg(with_metrics)]
+static CONTRACT_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
+    register_histogram_vec(
+        "evm_contract_instantiation_latency",
+        "Evm contract instantiation latency",
+        &[],
+        bucket_latencies(1.0),
+    )
+});
+
+#[cfg(with_metrics)]
+static SERVICE_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
+    register_histogram_vec(
+        "evm_service_instantiation_latency",
+        "Evm service instantiation latency",
+        &[],
+        bucket_latencies(1.0),
+    )
+});
+
+#[derive(Debug, Error)]
+pub enum EvmExecutionError {
+    #[error("Failed to load contract EVM module: {_0}")]
+    LoadContractModule(#[source] anyhow::Error),
+    #[error("Failed to load service EVM module: {_0}")]
+    LoadServiceModule(#[source] anyhow::Error),
+    #[error("Commit error")]
+    CommitError(String),
+    #[error("It is illegal to call execute_message from an operation")]
+    OperationCallExecuteMessage,
+    #[error("The operation should contain the evm selector and so have length 4 or more")]
+    TooShortOperation,
+    #[error("Transact commit error")]
+    TransactCommitError(String),
+    #[error("The operation was reverted")]
+    Revert {
+        gas_used: u64,
+        output: alloy::primitives::Bytes,
+    },
+    #[error("The operation was halted")]
+    Halt { gas_used: u64, reason: HaltReason },
+}
+
+#[derive(Clone)]
+pub enum EvmContractModule {
+    #[cfg(with_revm)]
+    Revm { module: Vec<u8> },
+}
+
+impl EvmContractModule {
+    /// Creates a new [`EvmContractModule`] using the EVM module with the provided `contract_bytecode`.
+    pub async fn new(
+        contract_bytecode: Bytecode,
+        runtime: EvmRuntime,
+    ) -> Result<Self, EvmExecutionError> {
+        match runtime {
+            #[cfg(with_revm)]
+            EvmRuntime::Revm => Self::from_revm(contract_bytecode).await,
+        }
+    }
+
+    /// Creates a new [`EvmContractModule`] using the WebAssembly module in `contract_bytecode_file`.
+    #[cfg(with_fs)]
+    pub async fn from_file(
+        contract_bytecode_file: impl AsRef<std::path::Path>,
+        runtime: EvmRuntime,
+    ) -> Result<Self, EvmExecutionError> {
+        Self::new(
+            Bytecode::load_from_file(contract_bytecode_file)
+                .await
+                .map_err(anyhow::Error::from)
+                .map_err(EvmExecutionError::LoadContractModule)?,
+            runtime,
+        )
+        .await
+    }
+}
+
+impl UserContractModule for EvmContractModule {
+    fn instantiate(
+        &self,
+        runtime: ContractSyncRuntimeHandle,
+    ) -> Result<UserContractInstance, ExecutionError> {
+        #[cfg(with_metrics)]
+        let _instantiation_latency = CONTRACT_INSTANTIATION_LATENCY.measure_latency();
+
+        let instance: UserContractInstance = match self {
+            #[cfg(with_revm)]
+            EvmContractModule::Revm { module } => {
+                Box::new(RevmContractInstance::prepare(module.to_vec(), runtime))
+            }
+        };
+
+        Ok(instance)
+    }
+}
+
+impl EvmContractModule {
+    /// Creates a new [`EvmContractModule`] using Revm with the provided bytecodes.
+    pub async fn from_revm(contract_bytecode: Bytecode) -> Result<Self, EvmExecutionError> {
+        let module = contract_bytecode.bytes;
+        Ok(EvmContractModule::Revm { module })
+    }
+}
+
+/// A user service in a compiled EVM module.
+#[derive(Clone)]
+pub enum EvmServiceModule {
+    #[cfg(with_revm)]
+    Revm { module: Vec<u8> },
+}
+
+impl EvmServiceModule {
+    /// Creates a new [`EvmServiceModule`] using the EVM module with the provided bytecode.
+    pub async fn new(
+        service_bytecode: Bytecode,
+        runtime: EvmRuntime,
+    ) -> Result<Self, EvmExecutionError> {
+        match runtime {
+            #[cfg(with_revm)]
+            EvmRuntime::Revm => Self::from_revm(service_bytecode).await,
+        }
+    }
+
+    /// Creates a new [`EvmServiceModule`] using the EVM module in `service_bytecode_file`.
+    #[cfg(with_fs)]
+    pub async fn from_file(
+        service_bytecode_file: impl AsRef<std::path::Path>,
+        runtime: EvmRuntime,
+    ) -> Result<Self, EvmExecutionError> {
+        Self::new(
+            Bytecode::load_from_file(service_bytecode_file)
+                .await
+                .map_err(anyhow::Error::from)
+                .map_err(EvmExecutionError::LoadServiceModule)?,
+            runtime,
+        )
+        .await
+    }
+}
+
+impl UserServiceModule for EvmServiceModule {
+    fn instantiate(
+        &self,
+        runtime: ServiceSyncRuntimeHandle,
+    ) -> Result<UserServiceInstance, ExecutionError> {
+        #[cfg(with_metrics)]
+        let _instantiation_latency = SERVICE_INSTANTIATION_LATENCY.measure_latency();
+
+        let instance: UserServiceInstance = match self {
+            #[cfg(with_revm)]
+            EvmServiceModule::Revm { module } => {
+                Box::new(RevmServiceInstance::prepare(module.to_vec(), runtime))
+            }
+        };
+
+        Ok(instance)
+    }
+}
+
+impl EvmServiceModule {
+    /// Creates a new [`EvmServiceModule`] using Revm with the provided bytecodes.
+    pub async fn from_revm(contract_bytecode: Bytecode) -> Result<Self, EvmExecutionError> {
+        let module = contract_bytecode.bytes;
+        Ok(EvmServiceModule::Revm { module })
+    }
+}
+
+struct DatabaseRuntime<Runtime> {
+    contract_address: Address,
+    commit_error: Option<ExecutionError>,
+    runtime: Arc<Mutex<Runtime>>,
+}
+
+#[repr(u8)]
+pub enum KeyTag {
+    /// Key prefix for the storage of the zero contract.
+    ZeroContractAddress,
+    /// Key prefix for the storage of the contract address.
+    ContractAddress,
+}
+
+#[repr(u8)]
+pub enum KeyCategory {
+    AccountInfo,
+    AccountState,
+    Storage,
+}
+
+impl<Runtime> DatabaseRuntime<Runtime> {
+    fn get_uint256_key(val: u8, index: U256) -> Result<Vec<u8>, ExecutionError> {
+        let mut key = vec![val, KeyCategory::Storage as u8];
+        bcs::serialize_into(&mut key, &index)?;
+        Ok(key)
+    }
+
+    fn get_contract_address_key(&self, address: &Address) -> Option<u8> {
+        if address == &Address::ZERO {
+            return Some(KeyTag::ZeroContractAddress as u8);
+        }
+        if address == &self.contract_address {
+            return Some(KeyTag::ContractAddress as u8);
+        }
+        None
+    }
+
+    fn new(runtime: Runtime) -> Self {
+        let nonce = 0;
+        let contract_address = Address::ZERO.create(nonce);
+        Self {
+            contract_address,
+            commit_error: None,
+            runtime: Arc::new(Mutex::new(runtime)),
+        }
+    }
+
+    fn throw_error(&self) -> Result<(), ExecutionError> {
+        if let Some(error) = &self.commit_error {
+            let error = format!("{:?}", error);
+            let error = EvmExecutionError::CommitError(error);
+            return Err(ExecutionError::EvmError(error));
+        }
+        Ok(())
+    }
+}
+
+impl<Runtime> Database for DatabaseRuntime<Runtime>
+where
+    Runtime: BaseRuntime,
+{
+    type Error = ExecutionError;
+
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, ExecutionError> {
+        self.basic_ref(address)
+    }
+
+    fn code_by_hash(
+        &mut self,
+        _code_hash: B256,
+    ) -> Result<revm::primitives::Bytecode, ExecutionError> {
+        panic!("Functionality code_by_hash not implemented");
+    }
+
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, ExecutionError> {
+        self.storage_ref(address, index)
+    }
+
+    fn block_hash(&mut self, number: u64) -> Result<B256, ExecutionError> {
+        self.throw_error()?;
+        <Self as DatabaseRef>::block_hash_ref(self, number)
+    }
+}
+
+impl<Runtime> DatabaseCommit for DatabaseRuntime<Runtime>
+where
+    Runtime: ContractRuntime,
+{
+    fn commit(&mut self, changes: HashMap<Address, Account>) {
+        let result = self.commit_with_error(changes);
+        if let Err(error) = result {
+            self.commit_error = Some(error);
+        }
+    }
+}
+
+impl<Runtime> DatabaseRuntime<Runtime>
+where
+    Runtime: ContractRuntime,
+{
+    fn commit_with_error(
+        &mut self,
+        changes: HashMap<Address, Account>,
+    ) -> Result<(), ExecutionError> {
+        let mut runtime = self.runtime.lock().expect("The lock should be possible");
+        let mut batch = Batch::new();
+        let mut list_new_balances = Vec::new();
+        for (address, account) in changes {
+            if !account.is_touched() {
+                continue;
+            }
+            let val = self.get_contract_address_key(&address);
+            if let Some(val) = val {
+                let key_prefix = vec![val, KeyCategory::Storage as u8];
+                let key_info = vec![val, KeyCategory::AccountInfo as u8];
+                let key_state = vec![val, KeyCategory::AccountState as u8];
+                if account.is_selfdestructed() {
+                    batch.delete_key_prefix(key_prefix);
+                    batch.put_key_value(key_info, &AccountInfo::default())?;
+                    batch.put_key_value(key_state, &AccountState::NotExisting)?;
+                } else {
+                    let is_newly_created = account.is_created();
+                    batch.put_key_value(key_info, &account.info)?;
+
+                    let account_state = if is_newly_created {
+                        batch.delete_key_prefix(key_prefix);
+                        AccountState::StorageCleared
+                    } else {
+                        let promise = runtime.read_value_bytes_new(key_state.clone())?;
+                        let result = runtime.read_value_bytes_wait(&promise)?;
+                        let account_state = from_bytes_option::<AccountState, ViewError>(&result)?
+                            .unwrap_or_default();
+                        if account_state.is_storage_cleared() {
+                            AccountState::StorageCleared
+                        } else {
+                            AccountState::Touched
+                        }
+                    };
+                    batch.put_key_value(key_state, &account_state)?;
+                    for (index, value) in account.storage {
+                        let key = Self::get_uint256_key(val, index)?;
+                        batch.put_key_value(key, &value.present_value())?;
+                    }
+                }
+            } else {
+                if !account.storage.is_empty() {
+                    panic!("For user account, storage must be empty");
+                }
+                // The only allowed operations are the ones for the
+                // account balances.
+                let new_balance = (address, account.info.balance);
+                list_new_balances.push(new_balance);
+            }
+        }
+        runtime.write_batch(batch)?;
+        if !list_new_balances.is_empty() {
+            panic!("The conversion Ethereum address / Linera address is not yet implemented");
+        }
+        Ok(())
+    }
+}
+
+impl<Runtime> DatabaseRef for DatabaseRuntime<Runtime>
+where
+    Runtime: BaseRuntime,
+{
+    type Error = ExecutionError;
+
+    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, ExecutionError> {
+        self.throw_error()?;
+        let mut runtime = self.runtime.lock().expect("The lock should be possible");
+        let val = self.get_contract_address_key(&address);
+        if let Some(val) = val {
+            let key = vec![val, KeyCategory::AccountInfo as u8];
+            let promise = runtime.read_value_bytes_new(key)?;
+            let result = runtime.read_value_bytes_wait(&promise)?;
+            let account_info = from_bytes_option::<AccountInfo, ViewError>(&result)?;
+            return Ok(account_info);
+        }
+        panic!("only contract address are supported thus far address={address:?}");
+    }
+
+    fn code_by_hash_ref(
+        &self,
+        _code_hash: B256,
+    ) -> Result<revm::primitives::Bytecode, ExecutionError> {
+        panic!("Functionality code_by_hash_ref not implemented");
+    }
+
+    fn storage_ref(&self, address: Address, index: U256) -> Result<U256, ExecutionError> {
+        self.throw_error()?;
+        let val = self.get_contract_address_key(&address);
+        let Some(val) = val else {
+            panic!("There is no storage associated to Externally Owned Account");
+        };
+        let key = Self::get_uint256_key(val, index)?;
+        let result = {
+            let mut runtime = self.runtime.lock().expect("The lock should be possible");
+            let promise = runtime.read_value_bytes_new(key)?;
+            runtime.read_value_bytes_wait(&promise)
+        }?;
+        Ok(from_bytes_option::<U256, ViewError>(&result)?.unwrap_or_default())
+    }
+
+    fn block_hash_ref(&self, number: u64) -> Result<B256, ExecutionError> {
+        self.throw_error()?;
+        Ok(keccak256(number.to_string().as_bytes()))
+    }
+}
+
+pub struct RevmContractInstance<Runtime> {
+    module: Vec<u8>,
+    db: DatabaseRuntime<Runtime>,
+}
+
+enum Choice {
+    Create,
+    Call,
+}
+
+// The OperationContext / MessageContext / FinalizeContext are not used
+// in the wasmer / wasmtime. Should we used it? It seems
+impl<Runtime> UserContract for RevmContractInstance<Runtime>
+where
+    Runtime: ContractRuntime,
+{
+    fn instantiate(
+        &mut self,
+        _context: OperationContext,
+        argument: Vec<u8>,
+    ) -> Result<(), ExecutionError> {
+        let mut vec = self.module.clone();
+        vec.extend_from_slice(&argument);
+        let tx_data = Bytes::copy_from_slice(&vec);
+        let (output, logs) = self.transact_commit_tx_data(Choice::Create, tx_data)?;
+        let contract_address = self.db.contract_address;
+        self.write_logs(&contract_address, logs)?;
+        let Output::Create(_, Some(contract_address_used)) = output else {
+            unreachable!("It is impossible for a Choice::Create to lead to an Output::Call");
+        };
+        assert_eq!(contract_address_used, contract_address);
+        Ok(())
+    }
+
+    fn execute_operation(
+        &mut self,
+        _context: OperationContext,
+        operation: Vec<u8>,
+    ) -> Result<Vec<u8>, ExecutionError> {
+        ensure!(
+            operation.len() >= 4,
+            ExecutionError::EvmError(EvmExecutionError::TooShortOperation)
+        );
+        ensure!(
+            &operation[..4] != EXECUTE_MESSAGE_SELECTOR,
+            ExecutionError::EvmError(EvmExecutionError::OperationCallExecuteMessage)
+        );
+        let tx_data = Bytes::copy_from_slice(&operation);
+        let (output, logs) = self.transact_commit_tx_data(Choice::Call, tx_data)?;
+        let contract_address = self.db.contract_address;
+        self.write_logs(&contract_address, logs)?;
+        let Output::Call(output) = output else {
+            unreachable!("It is impossible for a Choice::Call to lead to an Output::Create");
+        };
+        let output = output.as_ref().to_vec();
+        Ok(output)
+    }
+
+    fn execute_message(
+        &mut self,
+        _context: MessageContext,
+        _message: Vec<u8>,
+    ) -> Result<(), ExecutionError> {
+        panic!("The execute_message part of the Ethereum smart contract has not yet been coded");
+    }
+
+    fn finalize(&mut self, _context: FinalizeContext) -> Result<(), ExecutionError> {
+        Ok(())
+    }
+}
+
+fn process_execution_result(result: ExecutionResult) -> Result<(Output, Vec<Log>), ExecutionError> {
+    match result {
+        ExecutionResult::Success {
+            reason: _,
+            gas_used: _,
+            gas_refunded: _,
+            logs,
+            output,
+        } => Ok((output, logs)),
+        ExecutionResult::Revert { gas_used, output } => {
+            let error = EvmExecutionError::Revert { gas_used, output };
+            Err(ExecutionError::EvmError(error))
+        }
+        ExecutionResult::Halt { gas_used, reason } => {
+            let error = EvmExecutionError::Halt { gas_used, reason };
+            Err(ExecutionError::EvmError(error))
+        }
+    }
+}
+
+impl<Runtime> RevmContractInstance<Runtime>
+where
+    Runtime: ContractRuntime,
+{
+    pub fn prepare(module: Vec<u8>, runtime: Runtime) -> Self {
+        let db = DatabaseRuntime::new(runtime);
+        Self { module, db }
+    }
+
+    fn transact_commit_tx_data(
+        &mut self,
+        ch: Choice,
+        tx_data: Bytes,
+    ) -> Result<(Output, Vec<Log>), ExecutionError> {
+        let kind = match ch {
+            Choice::Create => TxKind::Create,
+            Choice::Call => TxKind::Call(self.db.contract_address),
+        };
+        let mut evm: Evm<'_, (), _> = Evm::builder()
+            .with_ref_db(&mut self.db)
+            .modify_tx_env(|tx| {
+                tx.clear();
+                tx.transact_to = kind;
+                tx.data = tx_data;
+            })
+            .build();
+
+        let result = evm.transact_commit().map_err(|error| {
+            let error = format!("{:?}", error);
+            let error = EvmExecutionError::TransactCommitError(error);
+            ExecutionError::EvmError(error)
+        })?;
+        process_execution_result(result)
+    }
+
+    fn write_logs(
+        &mut self,
+        contract_address: &Address,
+        logs: Vec<Log>,
+    ) -> Result<(), ExecutionError> {
+        if !logs.is_empty() {
+            let mut runtime = self.db.runtime.lock().expect("The lock should be possible");
+            let stream_name = bcs::to_bytes("ethereum_event").unwrap();
+            let stream_name = StreamName(stream_name);
+            for (log, index) in logs.iter().enumerate() {
+                let mut key = bcs::to_bytes(&contract_address).unwrap();
+                bcs::serialize_into(&mut key, "deploy").unwrap();
+                bcs::serialize_into(&mut key, index).unwrap();
+                let value = bcs::to_bytes(&log).unwrap();
+                runtime.emit(stream_name.clone(), key, value)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct RevmServiceInstance<Runtime> {
+    db: DatabaseRuntime<Runtime>,
+}
+
+impl<Runtime> RevmServiceInstance<Runtime>
+where
+    Runtime: ServiceRuntime,
+{
+    pub fn prepare(_module: Vec<u8>, runtime: Runtime) -> Self {
+        let db = DatabaseRuntime::new(runtime);
+        Self { db }
+    }
+}
+
+impl<Runtime> UserService for RevmServiceInstance<Runtime>
+where
+    Runtime: ServiceRuntime,
+{
+    fn handle_query(
+        &mut self,
+        _context: QueryContext,
+        argument: Vec<u8>,
+    ) -> Result<Vec<u8>, ExecutionError> {
+        let tx_data = Bytes::copy_from_slice(&argument);
+        let address = self.db.contract_address;
+        let mut evm: Evm<'_, (), _> = Evm::builder()
+            .with_ref_db(&mut self.db)
+            .modify_tx_env(|tx| {
+                tx.clear();
+                tx.transact_to = TxKind::Call(address);
+                tx.data = tx_data;
+            })
+            .build();
+
+        let result = evm.transact();
+        let result_state = match result {
+            Ok(result_state) => result_state,
+            Err(error) => {
+                let error = format!("{:?}", error);
+                let error = EvmExecutionError::TransactCommitError(error);
+                return Err(ExecutionError::EvmError(error));
+            }
+        };
+        let (output, _logs) = process_execution_result(result_state.result)?;
+        // We drop the logs since the "eth_call" execution does not return any log.
+        let Output::Call(output) = output else {
+            unreachable!("It is impossible for a Choice::Call to lead to a Output::Create");
+        };
+        Ok(output.as_ref().to_vec())
+    }
+}

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -28,7 +28,7 @@ use wasmer::{WasmerContractInstance, WasmerServiceInstance};
 use wasmtime::{WasmtimeContractInstance, WasmtimeServiceInstance};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
+    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency as _},
     prometheus::HistogramVec,
     std::sync::LazyLock,
 };
@@ -46,8 +46,8 @@ use crate::{
 #[cfg(with_metrics)]
 static CONTRACT_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec(
-        "contract_instantiation_latency",
-        "Contract instantiation latency",
+        "wasm_contract_instantiation_latency",
+        "Wasm contract instantiation latency",
         &[],
         bucket_latencies(1.0),
     )
@@ -56,8 +56,8 @@ static CONTRACT_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(||
 #[cfg(with_metrics)]
 static SERVICE_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec(
-        "service_instantiation_latency",
-        "Service instantiation latency",
+        "wasm_service_instantiation_latency",
+        "Wasm service instantiation latency",
         &[],
         bucket_latencies(1.0),
     )
@@ -76,7 +76,7 @@ pub enum WasmContractModule {
 }
 
 impl WasmContractModule {
-    /// Creates a new [`WasmContractModule`] using the WebAssembly module with the provided bytecodes.
+    /// Creates a new [`WasmContractModule`] using the WebAssembly module with the provided bytecode.
     pub async fn new(
         contract_bytecode: Bytecode,
         runtime: WasmRuntime,
@@ -100,7 +100,7 @@ impl WasmContractModule {
         }
     }
 
-    /// Creates a new [`WasmContractModule`] using the WebAssembly module in `bytecode_file`.
+    /// Creates a new [`WasmContractModule`] using the WebAssembly module in `contract_bytecode_file`.
     #[cfg(with_fs)]
     pub async fn from_file(
         contract_bytecode_file: impl AsRef<std::path::Path>,
@@ -150,7 +150,7 @@ pub enum WasmServiceModule {
 }
 
 impl WasmServiceModule {
-    /// Creates a new [`WasmServiceModule`] using the WebAssembly module with the provided bytecodes.
+    /// Creates a new [`WasmServiceModule`] using the WebAssembly module with the provided bytecode.
     pub async fn new(
         service_bytecode: Bytecode,
         runtime: WasmRuntime,
@@ -167,7 +167,7 @@ impl WasmServiceModule {
         }
     }
 
-    /// Creates a new [`WasmServiceModule`] using the WebAssembly module in `bytecode_file`.
+    /// Creates a new [`WasmServiceModule`] using the WebAssembly module in `service_bytecode_file`.
     #[cfg(with_fs)]
     pub async fn from_file(
         service_bytecode_file: impl AsRef<std::path::Path>,
@@ -269,7 +269,6 @@ const _: () = {
 };
 
 /// Errors that can occur when executing a user application in a WebAssembly module.
-#[cfg(any(with_wasmer, with_wasmtime))]
 #[derive(Debug, Error)]
 pub enum WasmExecutionError {
     #[error("Failed to load contract Wasm module: {_0}")]

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -1,0 +1,245 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(with_revm)]
+
+use std::{
+    fs::File,
+    io::Write,
+    path::Path,
+    process::{Command, Stdio},
+    sync::Arc,
+};
+
+use alloy_sol_types::{sol, SolCall, SolValue};
+use anyhow::Context;
+use linera_base::{
+    data_types::{Amount, BlockHeight, Timestamp},
+    identifiers::{ChainDescription, ChainId},
+};
+use linera_execution::{
+    revm::{EvmContractModule, EvmServiceModule},
+    test_utils::{create_dummy_user_application_description, SystemExecutionState},
+    ExecutionRuntimeConfig, ExecutionRuntimeContext, Operation, OperationContext, Query,
+    QueryContext, QueryResponse, ResourceControlPolicy, ResourceController, ResourceTracker,
+    TransactionTracker,
+};
+use linera_views::{context::Context as _, views::View};
+use revm_primitives::U256;
+use tempfile::tempdir;
+
+fn write_compilation_json(path: &Path, file_name: &str) {
+    let mut source = File::create(path).unwrap();
+    writeln!(
+        source,
+        r#"
+{{
+  "language": "Solidity",
+  "sources": {{
+    "{file_name}": {{
+      "urls": ["./{file_name}"]
+    }}
+  }},
+  "settings": {{
+    "viaIR": true,
+    "outputSelection": {{
+      "*": {{
+        "*": ["evm.bytecode"]
+      }}
+    }}
+  }}
+}}
+"#
+    )
+    .unwrap();
+}
+
+fn get_bytecode_path(path: &Path, file_name: &str, contract_name: &str) -> anyhow::Result<Vec<u8>> {
+    let config_path = path.join("config.json");
+    write_compilation_json(&config_path, file_name);
+    let config_file = File::open(config_path)?;
+
+    let output_path = path.join("result.json");
+    let output_file = File::create(output_path.clone())?;
+
+    let status = Command::new("solc")
+        .current_dir(path)
+        .arg("--standard-json")
+        .stdin(Stdio::from(config_file))
+        .stdout(Stdio::from(output_file))
+        .status()?;
+    assert!(status.success());
+
+    let contents = std::fs::read_to_string(output_path)?;
+    let json_data: serde_json::Value = serde_json::from_str(&contents)?;
+    let contracts = json_data
+        .get("contracts")
+        .context("failed to get contracts")?;
+    let file_name_contract = contracts
+        .get(file_name)
+        .context("failed to get {file_name}")?;
+    let test_data = file_name_contract
+        .get(contract_name)
+        .context("failed to get contract_name={contract_name}")?;
+    let evm_data = test_data.get("evm").context("failed to get evm")?;
+    let bytecode = evm_data.get("bytecode").context("failed to get bytecode")?;
+    let object = bytecode.get("object").context("failed to get object")?;
+    let object = object.to_string();
+    let object = object.trim_matches(|c| c == '"').to_string();
+    Ok(hex::decode(&object)?)
+}
+
+fn get_bytecode(source_code: &str, contract_name: &str) -> anyhow::Result<Vec<u8>> {
+    let dir = tempdir().unwrap();
+    let path = dir.path();
+    let file_name = "test_code.sol";
+    let test_code_path = path.join(file_name);
+    let mut test_code_file = File::create(&test_code_path)?;
+    writeln!(test_code_file, "{}", source_code)?;
+    get_bytecode_path(path, file_name, contract_name)
+}
+
+#[tokio::test]
+async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
+    let source_code = r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ExampleCounter {
+  uint256 value;
+  constructor(uint256 start_value) {
+    value = start_value;
+  }
+
+  function increment(uint256 input) external returns (uint256) {
+    value = value + input;
+    return value;
+  }
+
+  function get_value() external view returns (uint256) {
+    return value;
+  }
+
+}
+"#
+    .to_string();
+    let module = get_bytecode(&source_code, "ExampleCounter")?;
+
+    sol! {
+        struct ConstructorArgs {
+            uint256 initial_value;
+        }
+        function increment(uint256 input);
+        function get_value();
+    }
+
+    let initial_value = U256::from(10000);
+    let mut value = initial_value;
+    let args = ConstructorArgs { initial_value };
+    let instantiation_argument: Vec<u8> = args.abi_encode();
+
+    let state = SystemExecutionState {
+        description: Some(ChainDescription::Root(0)),
+        ..Default::default()
+    };
+    let mut view = state
+        .into_view_with(ChainId::root(0), ExecutionRuntimeConfig::default())
+        .await;
+    let (app_desc, contract_blob, service_blob) = create_dummy_user_application_description(1);
+    let app_id = view
+        .system
+        .registry
+        .register_application(app_desc.clone())
+        .await?;
+
+    let contract = EvmContractModule::Revm {
+        module: module.clone(),
+    };
+    view.context()
+        .extra()
+        .user_contracts()
+        .insert(app_id, contract.clone().into());
+
+    let service = EvmServiceModule::Revm { module };
+    view.context()
+        .extra()
+        .user_services()
+        .insert(app_id, service.into());
+
+    view.simulate_instantiation(
+        contract.into(),
+        Timestamp::from(2),
+        app_desc,
+        instantiation_argument,
+        contract_blob,
+        service_blob,
+    )
+    .await?;
+
+    let operation_context = OperationContext {
+        chain_id: ChainId::root(0),
+        height: BlockHeight(0),
+        round: Some(0),
+        index: Some(0),
+        authenticated_signer: None,
+        authenticated_caller_id: None,
+    };
+
+    let query_context = QueryContext {
+        chain_id: ChainId::root(0),
+        next_block_height: BlockHeight(0),
+        local_time: Timestamp::from(0),
+    };
+
+    let increments = [
+        U256::from(2),
+        U256::from(9),
+        U256::from(7),
+        U256::from(1000),
+    ];
+    let policy = ResourceControlPolicy {
+        fuel_unit: Amount::from_attos(1),
+        ..ResourceControlPolicy::default()
+    };
+    let amount = Amount::from_tokens(1);
+    *view.system.balance.get_mut() = amount;
+    let mut controller = ResourceController {
+        policy: Arc::new(policy),
+        tracker: ResourceTracker::default(),
+        account: None,
+    };
+
+    for increment in &increments {
+        let mut txn_tracker = TransactionTracker::new(0, Some(Vec::new()));
+        value += increment;
+        let operation = incrementCall { input: *increment };
+        let bytes = operation.abi_encode();
+        let operation = Operation::User {
+            application_id: app_id,
+            bytes,
+        };
+        view.execute_operation(
+            operation_context,
+            Timestamp::from(0),
+            operation,
+            &mut txn_tracker,
+            &mut controller,
+        )
+        .await?;
+
+        let query = get_valueCall {};
+        let bytes = query.abi_encode();
+        let query = Query::User {
+            application_id: app_id,
+            bytes,
+        };
+
+        let result = view.query_application(query_context, query, None).await?;
+        let QueryResponse::User(result) = result.response else {
+            anyhow::bail!("Wrong QueryResponse result");
+        };
+        let result = U256::from_be_slice(&result);
+        assert_eq!(result, value);
+    }
+    Ok(())
+}

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -102,9 +102,7 @@ pub(crate) fn get_interval(key_prefix: Vec<u8>) -> (Bound<Vec<u8>>, Bound<Vec<u8
 }
 
 /// Deserializes an optional vector of `u8`
-pub(crate) fn from_bytes_option<V: DeserializeOwned, E>(
-    key_opt: &Option<Vec<u8>>,
-) -> Result<Option<V>, E>
+pub fn from_bytes_option<V: DeserializeOwned, E>(key_opt: &Option<Vec<u8>>) -> Result<Option<V>, E>
 where
     E: From<bcs::Error>,
 {


### PR DESCRIPTION
## Motivation

We want to make Linera a Multi VM blockchain. Here is the first step toward having EVM support.

## Proposal

We use the REVM implementation which is flexible enough for our purposes. The following decisions were made:
* Just like Linera smart contracts, Ethereum smart contracts can return some values when called. 
* The nonce is used for building the smart contract address. Here we limit ourselves to just one address build from `Address::ZERO` with a nonce of 0. Something else would have to be done for handling more than one contract.
* REVM allows to make cross application calls. But right now, we call only one contract.
* Ethereum addresses are quite different from Linera ones. So Transfer of Ethereum are not supported.
* The feature `revm` is used for enabling this.
* `Revm` is introduced in `EvmContractModule`. This is done in a way parallel to `WasmContractModule`.

Next steps for the core dev:
* Implement a matching mechanism between Ethereum address and Evm address. This would allow transfer from contract to users of Eths/Lineras.
* Implement a nonce mechanism so that a user can create multiple smart contracts or use CREATE2.
* In this PR, we have `WasmContractModule` / `EvmContractModule`. They should be integrated into a single enum that handle both.
* A matching for user addresses would extend to contract addressses. This would allow cross contract calls: Evm -> Evm, Evm -> Wasm, Wasm -> Evm. 

Next step for usability
* The Evm events have to be made into the Linera events and exploitable. Similarly, the result of execute operation should 
* Make the `execute_operation` return some value and this value should be accessible from outside.


## Test Plan

The test `test_fuel_for_counter_revm_application` is introduced for this purpose. It does not read the result of increment.

## Release Plan

Normal release plan.

## Links

See e.g. https://crates.io/crates/revm for how the REVM works.