### PR TITLE
Add .cursor to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 .vscode
 /.direnv
 
+# Cursor
+.cursor
+
 # Helm
 kubernetes/linera-validator/working/*
 node_modules


### PR DESCRIPTION
## Motivation

For people using Cursor, we don't want their config files getting committed

## Proposal

Add `.cursor` to `.gitignore`

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
