### PR TITLE
Use .in_scope() in gRPC client

### DIFF
--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -331,11 +331,10 @@ impl ValidatorNode for GrpcClient {
                     retry_count = 0;
                     return future::Either::Left(future::ready(true));
                 };
-                let _enter_span = span.enter();
-                if !Self::is_retryable(status) || retry_count >= max_retries {
+
+                if !span.in_scope(|| Self::is_retryable(status)) || retry_count >= max_retries {
                     return future::Either::Left(future::ready(false));
                 }
-                drop(_enter_span);
                 let delay = retry_delay.saturating_mul(retry_count);
                 retry_count += 1;
                 future::Either::Right(async move {


### PR DESCRIPTION
## Motivation

This is an attempt to clean up https://github.com/linera-io/linera-protocol/pull/3313 a bit

## Proposal

Use `.in_scope()` as it seems cleaner

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
