### PR TITLE
Grammar and Clarity Fixes

### DIFF
--- a/examples/counter/tests/single_chain.rs
+++ b/examples/counter/tests/single_chain.rs
@@ -9,7 +9,7 @@ use linera_sdk::test::{QueryOutcome, TestValidator};
 
 /// Test setting a counter and testing its coherency across microchains.
 ///
-/// Creates the application on a `chain`, initializing it with a 42 then add 15 and obtain 57.
+/// Creates the application on a `chain`, initializing it with a 42 then adds 15 and obtains 57.
 /// which is then checked.
 #[tokio::test(flavor = "multi_thread")]
 async fn single_chain_test() {

--- a/examples/crowd-funding/src/state.rs
+++ b/examples/crowd-funding/src/state.rs
@@ -31,7 +31,7 @@ pub struct CrowdFundingState {
     pub status: RegisterView<Status>,
     /// The map of pledges that will be collected if the campaign succeeds.
     pub pledges: MapView<AccountOwner, Amount>,
-    /// The instantiation data that determine the details of the campaign.
+    /// The instantiation data that determines the details of the campaign.
     pub instantiation_argument: RegisterView<Option<InstantiationArgument>>,
 }
 

--- a/examples/crowd-funding/src/state.rs
+++ b/examples/crowd-funding/src/state.rs
@@ -31,7 +31,7 @@ pub struct CrowdFundingState {
     pub status: RegisterView<Status>,
     /// The map of pledges that will be collected if the campaign succeeds.
     pub pledges: MapView<AccountOwner, Amount>,
-    /// The instantiation data that determine the details the campaign.
+    /// The instantiation data that determine the details of the campaign.
     pub instantiation_argument: RegisterView<Option<InstantiationArgument>>,
 }
 


### PR DESCRIPTION
Comment on chain application initialization:

Old: Creates the application on a 'chain', initializing it with a 42 then add 15 and obtain 57.
New: Creates the application on a 'chain', initializing it with a 42 then adds 15 and obtains 57.
Reason: Fixed verb tense for consistency.
Comment on instantiation data:

Old: The instantiation data that determine the details the campaign.
New: The instantiation data that determine the details of the campaign.
Reason: Added missing preposition "of" for clarity.
