### PR TITLE
Correcting the Typo in `entrypoint2`

### DIFF
--- a/linera-indexer/plugins/src/template.rs
+++ b/linera-indexer/plugins/src/template.rs
@@ -37,7 +37,7 @@ impl Template<C> {
     }
 
     pub async fn entrypoint2(&self, key: u32) -> Result<String, IndexerError> {
-        Ok(self.view1.get(&key).await?)
+        Ok(self.view2.get(&key).await?)
     }
 
     // Other functions are derived to fill the `linera_indexer::plugin::Plugin` trait.


### PR DESCRIPTION
There’s a small typo in `entrypoint2`: replace `Ok(self.view1.get(&key).await?)` with `Ok(self.view2.get(&key).await?)` because `view2` is the MapView that requires a key.
