### PR TITLE
Make `query_service` contract-only.

### DIFF
--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -602,13 +602,6 @@ pub trait BaseRuntime {
         promise: &Self::FindKeyValuesByPrefix,
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ExecutionError>;
 
-    /// Queries a service.
-    fn query_service(
-        &mut self,
-        application_id: ApplicationId,
-        query: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError>;
-
     /// Makes a POST request to the given URL and returns the answer, if any.
     fn http_post(
         &mut self,
@@ -708,6 +701,13 @@ pub trait ContractRuntime: BaseRuntime {
         key: Vec<u8>,
         value: Vec<u8>,
     ) -> Result<(), ExecutionError>;
+
+    /// Queries a service.
+    fn query_service(
+        &mut self,
+        application_id: ApplicationId,
+        query: Vec<u8>,
+    ) -> Result<Vec<u8>, ExecutionError>;
 
     /// Opens a new chain.
     fn open_chain(

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1349,9 +1349,9 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
     }
 
     fn query_service(
-            &mut self,
-            application_id: ApplicationId,
-            query: Vec<u8>,
+        &mut self,
+        application_id: ApplicationId,
+        query: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
         ensure!(
             cfg!(feature = "unstable-oracles"),

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -697,14 +697,6 @@ impl<UserInstance> BaseRuntime for SyncRuntimeHandle<UserInstance> {
         self.inner().find_key_values_by_prefix_wait(promise)
     }
 
-    fn query_service(
-        &mut self,
-        application_id: ApplicationId,
-        query: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError> {
-        self.inner().query_service(application_id, query)
-    }
-
     fn http_post(
         &mut self,
         url: &str,
@@ -952,42 +944,6 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         self.resource_controller
             .track_bytes_read(read_size as u64)?;
         Ok(key_values)
-    }
-
-    fn query_service(
-        &mut self,
-        application_id: ApplicationId,
-        query: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError> {
-        ensure!(
-            cfg!(feature = "unstable-oracles"),
-            ExecutionError::UnstableOracle
-        );
-        let response =
-            if let Some(response) = self.transaction_tracker.next_replayed_oracle_response()? {
-                match response {
-                    OracleResponse::Service(bytes) => bytes,
-                    _ => return Err(ExecutionError::OracleResponseMismatch),
-                }
-            } else {
-                let context = QueryContext {
-                    chain_id: self.chain_id,
-                    next_block_height: self.height,
-                    local_time: self.local_time,
-                };
-                let sender = self.execution_state_sender.clone();
-
-                let QueryOutcome {
-                    response,
-                    operations,
-                } = ServiceSyncRuntime::new(sender, context).run_query(application_id, query)?;
-
-                self.scheduled_operations.extend(operations);
-                response
-            };
-        self.transaction_tracker
-            .add_oracle_response(OracleResponse::Service(response.clone()));
-        Ok(response)
     }
 
     fn http_post(
@@ -1390,6 +1346,46 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         let application = this.current_application_mut();
         application.outcome.events.push((name, key, value));
         Ok(())
+    }
+
+    fn query_service(
+            &mut self,
+            application_id: ApplicationId,
+            query: Vec<u8>,
+    ) -> Result<Vec<u8>, ExecutionError> {
+        ensure!(
+            cfg!(feature = "unstable-oracles"),
+            ExecutionError::UnstableOracle
+        );
+
+        let mut this = self.inner();
+        let response =
+            if let Some(response) = this.transaction_tracker.next_replayed_oracle_response()? {
+                match response {
+                    OracleResponse::Service(bytes) => bytes,
+                    _ => return Err(ExecutionError::OracleResponseMismatch),
+                }
+            } else {
+                let context = QueryContext {
+                    chain_id: this.chain_id,
+                    next_block_height: this.height,
+                    local_time: this.local_time,
+                };
+                let sender = this.execution_state_sender.clone();
+
+                let QueryOutcome {
+                    response,
+                    operations,
+                } = ServiceSyncRuntime::new(sender, context).run_query(application_id, query)?;
+
+                this.scheduled_operations.extend(operations);
+                response
+            };
+
+        this.transaction_tracker
+            .add_oracle_response(OracleResponse::Service(response.clone()));
+
+        Ok(response)
     }
 
     fn open_chain(

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -590,19 +590,6 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
-    /// Queries a service and returns the response.
-    fn query_service(
-        caller: &mut Caller,
-        application_id: ApplicationId,
-        query: Vec<u8>,
-    ) -> Result<Vec<u8>, RuntimeError> {
-        caller
-            .user_data_mut()
-            .runtime
-            .query_service(application_id, query)
-            .map_err(|error| RuntimeError::Custom(error.into()))
-    }
-
     /// Makes a POST request to the given URL and returns the response body.
     fn http_post(
         caller: &mut Caller,

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -14,7 +14,6 @@ interface service-system-api {
     schedule-operation: func(operation: list<u8>);
     try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
     fetch-url: func(url: string) -> list<u8>;
-    query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
     read-data-blob: func(hash: crypto-hash) -> list<u8>;
     assert-data-blob-exists: func(hash: crypto-hash);


### PR DESCRIPTION
Removed query service from the BaseRuntime and moved it to the ContractRuntime as the ServiceRuntime doesn't need it.