### PR TITLE
Global state for non-fungible tokens.

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -100,6 +100,38 @@ impl FromStr for Account {
     }
 }
 
+/// The mint associated with this asset.
+#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Copy, Clone, Serialize, Deserialize, WitLoad, WitStore, WitType)]
+pub struct NftMint(pub CryptoHash);
+
+/// Handy elegant Alias
+pub type Mint = NftMint;
+
+/// Necessary minimal data associated with a minted asset.
+#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Serialize, Deserialize, WitLoad, WitStore, WitType)]
+pub struct NftMetadata {
+    /// The mint associated with this asset.
+    pub mint: Mint,
+    /// Link to the asset's data and metadata json file.
+    pub uri: String,
+    /// A name for the asset.
+    pub name: String,
+    /// A samll description of the asset.
+    pub description: String,
+}
+
+/// Handy elegant Alias
+pub type Metadata = NftMetadata;
+
+/// Just for convinience
+pub fn hash_bytes(bytes: &[u8]) -> CryptoHash {
+    use sha3::digest::Digest;
+
+    let mut hasher = sha3::Sha3_256::new();
+    hasher.update(bytes);
+    hasher.finalize()[..].try_into().unwrap()
+}
+
 /// How to create a chain.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
 pub enum ChainDescription {

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -22,6 +22,7 @@ use linera_chain::{
     ChainStateView,
 };
 use linera_execution::{
+    global_state::GlobalContext,
     committee::{Epoch, ValidatorName},
     Query, QueryContext, QueryOutcome, ServiceRuntimeEndpoint, ServiceSyncRuntime,
 };
@@ -181,6 +182,7 @@ where
     pub async fn load(
         config: ChainWorkerConfig,
         storage: StorageClient,
+        global_context: GlobalContext,
         executed_block_cache: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
         tracked_chains: Option<Arc<RwLock<HashSet<ChainId>>>>,
         delivery_notifier: DeliveryNotifier,
@@ -198,6 +200,7 @@ where
         let worker = ChainWorkerState::load(
             config,
             storage,
+            global_context,
             executed_block_cache,
             tracked_chains,
             delivery_notifier,

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -393,6 +393,7 @@ where
         let local_time = self.state.storage.clock().current_time();
         let verified_outcome = Box::pin(self.state.chain.execute_block(
             &executed_block.block,
+            &self.state.global_context,
             local_time,
             None,
             Some(executed_block.outcome.oracle_responses.clone()),

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -28,6 +28,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Epoch, ValidatorName},
+    global_state::GlobalContext,
     Message, Query, QueryContext, QueryOutcome, ServiceRuntimeEndpoint, SystemMessage,
 };
 use linera_storage::{Clock as _, Storage};
@@ -54,6 +55,7 @@ where
 {
     config: ChainWorkerConfig,
     storage: StorageClient,
+    global_context: GlobalContext,
     chain: ChainStateView<StorageClient::Context>,
     shared_chain_view: Option<Arc<RwLock<ChainStateView<StorageClient::Context>>>>,
     service_runtime_endpoint: Option<ServiceRuntimeEndpoint>,
@@ -72,6 +74,7 @@ where
     pub async fn load(
         config: ChainWorkerConfig,
         storage: StorageClient,
+        global_context: GlobalContext,
         block_values: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
         tracked_chains: Option<Arc<sync::RwLock<HashSet<ChainId>>>>,
         delivery_notifier: DeliveryNotifier,
@@ -83,6 +86,7 @@ where
         Ok(ChainWorkerState {
             config,
             storage,
+            global_context,
             chain,
             shared_chain_view: None,
             service_runtime_endpoint,

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -100,7 +100,12 @@ where
         let outcome = self
             .0
             .chain
-            .query_application(local_time, query, self.0.service_runtime_endpoint.as_mut())
+            .query_application(
+                local_time,
+                query,
+                &self.0.global_context,
+                self.0.service_runtime_endpoint.as_mut()
+            )
             .await?;
         Ok(outcome)
     }
@@ -124,7 +129,13 @@ where
         let local_time = self.0.storage.clock().current_time();
         let signer = block.authenticated_signer;
 
-        let executed_block = Box::pin(self.0.chain.execute_block(&block, local_time, round, None))
+        let executed_block = Box::pin(self.0.chain.execute_block(
+                &block,
+                &self.0.global_context,
+                local_time,
+                round,
+                None,
+            ))
             .await?
             .with(block);
 
@@ -169,7 +180,14 @@ where
         let outcome = if let Some(outcome) = outcome {
             outcome.clone()
         } else {
-            Box::pin(chain.execute_block(block, local_time, round.multi_leader(), None)).await?
+            Box::pin(chain.execute_block(
+                    block,
+                    &self.0.global_context,
+                    local_time,
+                    round.multi_leader(),
+                    None,
+                ))
+                .await?
         };
 
         let executed_block = outcome.with(block.clone());

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -35,6 +35,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Epoch, ValidatorName},
+    global_state::GlobalContext,
     ExecutionError, Query, QueryOutcome,
 };
 use linera_storage::Storage;
@@ -271,6 +272,9 @@ where
     /// Configuration options for the [`ChainWorker`]s.
     chain_worker_config: ChainWorkerConfig,
     executed_block_cache: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
+    /// Reference to the global state
+    /// persisted in the storage views
+    global_context: GlobalContext,
     /// Chain IDs that should be tracked by a worker.
     tracked_chains: Option<Arc<RwLock<HashSet<ChainId>>>>,
     /// One-shot channels to notify callers when messages of a particular chain have been
@@ -304,6 +308,7 @@ where
             storage,
             chain_worker_config: ChainWorkerConfig::default().with_key_pair(key_pair),
             executed_block_cache: Arc::new(ValueCache::default()),
+            global_context: GlobalContext::new(),
             tracked_chains: None,
             delivery_notifiers: Arc::default(),
             chain_worker_tasks: Arc::default(),
@@ -323,6 +328,7 @@ where
             storage,
             chain_worker_config: ChainWorkerConfig::default(),
             executed_block_cache: Arc::new(ValueCache::default()),
+            global_context: GlobalContext::new(),
             tracked_chains: Some(tracked_chains),
             delivery_notifiers: Arc::default(),
             chain_worker_tasks: Arc::default(),
@@ -702,6 +708,7 @@ where
             let actor = ChainWorkerActor::load(
                 self.chain_worker_config.clone(),
                 self.storage.clone(),
+                self.global_context.clone(),
                 self.executed_block_cache.clone(),
                 self.tracked_chains.clone(),
                 delivery_notifier,

--- a/linera-execution/src/global_state.rs
+++ b/linera-execution/src/global_state.rs
@@ -1,0 +1,45 @@
+use std::{fmt::Debug, sync::Arc};
+
+use linera_base::identifiers::{hash_bytes, Account, Metadata};
+use tokio::sync::{Mutex, MutexGuard};
+
+/// can be cheaply cloned.
+#[derive(Debug, Clone)]
+pub struct GlobalContext {
+    pub assets: Arc<dyn Trie>,
+}
+
+type Lock = Mutex<()>; // Just for now.
+type Guard<'a> = MutexGuard<'a, ()>;
+type Key = [u8; 32];
+
+/// Placeholder trait
+pub trait Trie: Send + Sync + Debug {
+    // Since this will be a very throughput intesnive memory location, it has to
+    // be made into a lock-free data structure. Something like Solana's Concurrent Tree.
+    fn lock<'a>(&'a self) -> Guard<'a>;
+
+    fn contains(&self, key: &Key) -> bool;
+
+    fn write(&self, key: &Key, value: Metadata, owner: Account) -> bool;
+
+    fn update(&self, key: &Key, owner: Account) -> bool;
+
+    fn read(&self, key: &Key) -> Option<(Account, Metadata)>;
+}
+
+pub fn get_asset_key(key: &[u8]) -> Key {
+    let key  = hash_bytes(key);
+    <[u8; 32]>::try_from(&key.as_bytes()[..]).unwrap()
+}
+
+impl GlobalContext {
+    pub fn new() -> Self {
+        todo!()
+    }
+
+    pub fn persist(&mut self) {
+        // TODO Manually serialize and make a view out of it
+        todo!()
+    }
+}

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -21,6 +21,7 @@ pub mod test_utils;
 mod transaction_tracker;
 mod util;
 mod wasm;
+pub mod global_state;
 
 use std::{any::Any, fmt, str::FromStr, sync::Arc};
 
@@ -41,8 +42,8 @@ use linera_base::{
     },
     doc_scalar, hex_debug,
     identifiers::{
-        Account, AccountOwner, ApplicationId, BlobId, BytecodeId, ChainId, ChannelName,
-        Destination, GenericApplicationId, MessageId, Owner, StreamName, UserApplicationId,
+        Account, AccountOwner, ApplicationId, BlobId, BytecodeId, ChainId, ChannelName, Destination,
+        GenericApplicationId, MessageId, Metadata, Mint, Owner, StreamName, UserApplicationId
     },
     ownership::ChainOwnership,
     task,
@@ -493,6 +494,10 @@ pub trait BaseRuntime {
     /// Reads the current ownership configuration for this chain.
     fn chain_ownership(&mut self) -> Result<ChainOwnership, ExecutionError>;
 
+    fn nft_get_owner(&mut self, mint: Mint) -> Result<Option<Account>, ExecutionError>;
+
+    fn nft_get_metadata(&mut self, mint: Mint) -> Result<Option<Metadata>, ExecutionError>;
+
     /// Tests whether a key exists in the key-value store
     #[cfg(feature = "test")]
     fn contains_key(&mut self, key: Vec<u8>) -> Result<bool, ExecutionError> {
@@ -691,6 +696,12 @@ pub trait ContractRuntime: BaseRuntime {
         destination: Account,
         amount: Amount,
     ) -> Result<(), ExecutionError>;
+
+    fn nft_mint(&mut self, metadata: Metadata, recipient: Account) -> Result<bool, ExecutionError>;
+
+    fn nft_transfer(&mut self, mint: Mint, recipient: Account) -> Result<bool, ExecutionError>;
+
+    fn nft_burn(&mut self, mint: Mint) -> Result<bool, ExecutionError>;
 
     /// Calls another application. Forwarded sessions will now be visible to
     /// `callee_id` (but not to the caller any more).

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -7,7 +7,8 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, ApplicationPermissions, BlockHeight, SendMessageRequest, Timestamp},
     identifiers::{
-        Account, AccountOwner, ApplicationId, ChainId, ChannelName, MessageId, Owner, StreamName,
+        Account, AccountOwner, ApplicationId, ChainId, ChannelName,
+        MessageId, Mint, Metadata, Owner, StreamName
     },
     ownership::{ChainOwnership, ChangeApplicationPermissionsError, CloseChainError},
 };
@@ -262,6 +263,59 @@ where
             .user_data_mut()
             .runtime
             .claim(source, destination, amount)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
+    /// Attempts to mint an non-fungible asset to the `recipient` account.
+    fn nft_mint(
+        caller: &mut Caller,
+        metadata: Metadata,
+        recipient: Account,
+    ) -> Result<bool, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .nft_mint(metadata, recipient)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
+    /// Returns the current owner of an asset associated with a `mint`, if it exists.
+    fn nft_get_owner(caller: &mut Caller, mint: Mint) -> Result<Option<Account>, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .nft_get_owner(mint)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
+    /// Attempts to transfer an asset from the current owner to the `recipient`.
+    fn nft_transfer(
+        caller: &mut Caller,
+        mint: Mint,
+        recipient: Account,
+    ) -> Result<bool, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .nft_transfer(mint, recipient)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
+    /// Returns the [`Metadata`] asscociated with this `mint`.
+    fn nft_get_metadata(caller: &mut Caller, mint: Mint) -> Result<Option<Metadata>, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .nft_get_metadata(mint)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
+    /// Attempt to burn an asset by its owner.
+    fn nft_burn(caller: &mut Caller, mint: Mint) -> Result<bool, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .nft_burn(mint)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
@@ -556,6 +610,24 @@ where
             .user_data_mut()
             .runtime
             .read_balance_owners()
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
+    /// Returns the current owner of an asset associated with a `mint`, if it exists.
+    fn nft_get_owner(caller: &mut Caller, mint: Mint) -> Result<Option<Account>, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .nft_get_owner(mint)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
+    /// Returns the [`Metadata`] asscociated with this `mint`.
+    fn nft_get_metadata(caller: &mut Caller, mint: Mint) -> Result<Option<Metadata>, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .nft_get_metadata(mint)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -6,7 +6,7 @@
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
-    identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
+    identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Metadata, Mint, Owner},
     ownership::{
         ChainOwnership, ChangeApplicationPermissionsError, CloseChainError, TimeoutConfig,
     },
@@ -82,6 +82,23 @@ impl From<wit_system_api::CryptoHash> for CryptoHash {
 impl From<wit_system_api::Owner> for Owner {
     fn from(owner: wit_system_api::Owner) -> Self {
         Owner(owner.inner0.into())
+    }
+}
+
+impl From<wit_system_api::Mint> for Mint {
+    fn from(mint: wit_system_api::Mint) -> Self {
+        Self(mint.inner0.into())
+    }
+}
+
+impl From<wit_system_api::Metadata> for Metadata {
+    fn from(metadata: wit_system_api::Metadata) -> Self {
+        Self {
+            mint: metadata.mint.into(),
+            uri: metadata.uri,
+            name: metadata.name,
+            description: metadata.description,
+        }
     }
 }
 

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -10,8 +10,7 @@ use linera_base::{
         Timestamp,
     },
     identifiers::{
-        Account, AccountOwner, ApplicationId, BytecodeId, ChainId, ChannelName, Destination,
-        MessageId, Owner, StreamName,
+        Account, AccountOwner, ApplicationId, BytecodeId, ChainId, ChannelName, Destination, MessageId, Metadata, Mint, Owner, StreamName
     },
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -85,6 +84,26 @@ impl From<ChainId> for wit_system_api::ChainId {
     fn from(chain_id: ChainId) -> Self {
         wit_system_api::ChainId {
             inner0: chain_id.0.into(),
+        }
+    }
+}
+
+
+impl From<Mint> for wit_system_api::Mint {
+    fn from(mint: Mint) -> Self {
+        wit_system_api::Mint {
+            inner0: mint.0.into(),
+        }
+    }
+}
+
+impl From<Metadata> for wit_system_api::Metadata {
+    fn from(metadata: Metadata) -> Self {
+        wit_system_api::Metadata {
+            mint: metadata.mint.into(),
+            uri: metadata.uri,
+            name: metadata.name,
+            description: metadata.description,
         }
     }
 }

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -10,7 +10,7 @@ use linera_base::{
     },
     identifiers::{
         Account, AccountOwner, ApplicationId, BytecodeId, ChainId, ChannelName, Destination,
-        MessageId, Owner, StreamName,
+        MessageId, Owner, StreamName, Mint, Metadata,
     },
     ownership::{ChainOwnership, ChangeApplicationPermissionsError, CloseChainError},
 };
@@ -196,6 +196,33 @@ where
     /// Claims an `amount` of native tokens from a `source` account to a `destination` account.
     pub fn claim(&mut self, source: Account, destination: Account, amount: Amount) {
         wit::claim(source.into(), destination.into(), amount.into())
+    }
+
+    /// Mints a globaly unique asset.
+    pub fn nft_mint(&mut self, metadata: Metadata, recipient: Account) -> bool {
+        wit::nft_mint(metadata.into(), recipient())
+    }
+
+    /// Current on of a globaly unique asset.
+    pub fn nft_get_owner(&self, mint: Mint) -> Option<Account> {
+        wit::nft_get_owner(mint.into()).map(|account| account.into())
+    }
+
+    /// Tranfers the ownership rights of an asset to the recipient.
+    /// The ritual of tranfer of the ownership rights can only be performed by the current possessor.
+    pub fn nft_transfer(&mut self, mint: Mint, recipient: Account) -> bool {
+        wit::nft_transfer(mint.into(), recipient.into())
+    }
+
+    /// Fetches the metadata about an asset.
+    pub fn nft_get_metadata(&mut self, mint: Mint) -> Option<Metadata> {
+        wit::nft_get_metadata(mint.into()).map(|metadata| metadata.into())
+    }
+
+    /// Burns an asset.
+    /// Forever, for the rest of the eternity.
+    pub fn nft_burn(&mut self, mint: Mint) -> bool {
+        wit::nft_burn(mint.into())
     }
 
     /// Retrieves the owner configuration for the current chain.

--- a/linera-sdk/src/service/conversions_from_wit.rs
+++ b/linera-sdk/src/service/conversions_from_wit.rs
@@ -6,7 +6,7 @@
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::{AccountOwner, ApplicationId, BytecodeId, ChainId, MessageId, Owner},
+    identifiers::{Account, AccountOwner, ApplicationId, BytecodeId, ChainId, MessageId, Metadata, Mint, Owner},
 };
 
 use super::wit::service_system_api as wit_system_api;
@@ -14,6 +14,15 @@ use super::wit::service_system_api as wit_system_api;
 impl From<wit_system_api::CryptoHash> for ChainId {
     fn from(hash_value: wit_system_api::CryptoHash) -> Self {
         ChainId(hash_value.into())
+    }
+}
+
+impl From<wit_system_api::Account> for Account {
+    fn from(account: wit_system_api::Account) -> Self {
+        Self {
+            chain_id: account.chain_id.into(),
+            owner: account.owner.map(|owner| owner.into()),
+        }
     }
 }
 
@@ -62,6 +71,23 @@ impl From<wit_system_api::CryptoHash> for CryptoHash {
             hash_value.part3,
             hash_value.part4,
         ])
+    }
+}
+
+impl From<wit_system_api::Mint> for Mint {
+    fn from(mint: wit_system_api::Mint) -> Self {
+        Self(mint.inner0.into())
+    }
+}
+
+impl From<wit_system_api::Metadata> for Metadata {
+    fn from(metadata: wit_system_api::Metadata) -> Self {
+        Self {
+            mint: metadata.mint.into(),
+            uri: format!("{:?}", metadata.uri),
+            name: format!("{:?}", metadata.name),
+            description: format!("{:?}", metadata.description),
+        }
     }
 }
 

--- a/linera-sdk/src/service/conversions_to_wit.rs
+++ b/linera-sdk/src/service/conversions_to_wit.rs
@@ -6,7 +6,7 @@
 use linera_base::{
     crypto::CryptoHash,
     data_types::BlockHeight,
-    identifiers::{AccountOwner, ApplicationId, BytecodeId, ChainId, MessageId, Owner},
+    identifiers::{AccountOwner, ApplicationId, BytecodeId, ChainId, MessageId, Mint, Owner},
 };
 
 use super::wit::service_system_api as wit_system_api;
@@ -67,6 +67,14 @@ impl From<ChainId> for wit_system_api::ChainId {
     fn from(chain_id: ChainId) -> Self {
         wit_system_api::ChainId {
             inner0: chain_id.0.into(),
+        }
+    }
+}
+
+impl From<Mint> for wit_system_api::Mint {
+    fn from(mint: Mint) -> Self {
+        wit_system_api::Mint {
+            inner0: mint.0.into(),
         }
     }
 }

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -8,7 +8,7 @@ use std::sync::Mutex;
 use linera_base::{
     abi::ServiceAbi,
     data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::{AccountOwner, ApplicationId, ChainId},
+    identifiers::{AccountOwner, ApplicationId, ChainId, Mint, Metadata},
 };
 use serde::Serialize;
 
@@ -134,6 +134,16 @@ where
         let bytes = bcs::to_bytes(operation).expect("Failed to serialize application operation");
 
         wit::schedule_operation(&bytes);
+    }
+
+    /// Current owner of a globaly unique asset.
+    pub fn nft_get_owner(&self, mint: Mint) -> Option<Account> {
+        wit::nft_get_owner(mint.into()).map(|account| account.into())
+    }
+
+    /// Fetches the metadata about an asset.
+    pub fn nft_get_metadata(&mut self, mint: Mint) -> Option<Metadata> {
+        wit::nft_get_metadata(mint.into()).map(|metadata| metadata.into())
     }
 
     /// Queries another application.

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -18,6 +18,15 @@ interface contract-system-api {
     unsubscribe: func(chain: chain-id, channel: channel-name);
     transfer: func(source: option<account-owner>, destination: account, amount: amount);
     claim: func(source: account, destination: account, amount: amount);
+    nft-mint: func(metadata: metadata, recipient: account) -> bool;
+    nft-get-owner: func(mint: mint) -> option<account>;
+    nft-transfer: func(mint: mint, recipient: account) -> bool;
+    // maybe this can be stored in the contract itself, rather than on the world tree.
+    // can be retrieved by contract call to application.
+    // Something like runtime enforced trait like functionality 
+    // that nft contracts must implement and abide by.
+    nft-get-metadata: func(mint: mint) -> option<metadata>;
+    nft-burn: func(mint: mint) -> bool;
     get-chain-ownership: func() -> chain-ownership;
     open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: amount) -> tuple<message-id, chain-id>;
     close-chain: func() -> result<tuple<>, close-chain-error>;
@@ -103,6 +112,19 @@ interface contract-system-api {
     variant destination {
         recipient(chain-id),
         subscribers(channel-name),
+    }
+
+    record metadata {
+        mint: mint,
+        uri: string,
+        name: string,
+        description: string,
+    }
+
+    // this can be the DataBlobHash
+    // i.e. hash of the actual entity that is to be non fungibly tokenized
+    record mint {
+        inner0: crypto-hash,
     }
 
     enum log-level {

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -11,6 +11,8 @@ interface service-system-api {
     read-system-timestamp: func() -> timestamp;
     read-owner-balances: func() -> list<tuple<account-owner, amount>>;
     read-balance-owners: func() -> list<account-owner>;
+    nft-get-owner: func(mint: mint) -> option<account>;
+    nft-get-metadata: func(mint: mint) -> option<metadata>;
     schedule-operation: func(operation: list<u8>);
     try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
     fetch-url: func(url: string) -> list<u8>;
@@ -20,6 +22,11 @@ interface service-system-api {
     assert-data-blob-exists: func(hash: crypto-hash);
     assert-before: func(timestamp: timestamp);
     log: func(message: string, level: log-level);
+
+    record account {
+        chain-id: chain-id,
+        owner: option<account-owner>,
+    }
 
     variant account-owner {
         user(owner),
@@ -45,6 +52,17 @@ interface service-system-api {
     }
 
     record chain-id {
+        inner0: crypto-hash,
+    }
+
+    record metadata {
+        mint: mint,
+        name: list<u8>,
+        description: list<u8>,
+        uri: list<u8>,
+    }
+
+    record mint {
         inner0: crypto-hash,
     }
 


### PR DESCRIPTION
## Motivation
Global state of linera is difficult to realize. That's because its quite an inherent drawback of the the linera's microchain nature and
about the actor model like systems altogether.
For example, currently, there is no standard definition of what a non fungible token is unlike other blockchains. There should be a common behaviour standard, functionality and uniqueness of all kinds tokens in linera like Ethereum's ERC 721 or Stacks blockchain's SIP009 or SIP010 for fungibles.
Also, currently, anyone is able to mint a same token twice without any consequences, as there can be same contract bytcodes with same behaviours on different chains, further decreasing the ability to canonicalize the originality. 
Solana solves this problem quite beautifully, with its separate and unique token accounts, metadata accounts and mint accounts.
But that's more of a workaround, rather than a solution, to their stateless nature smart contracts. And that would be overkill for linera.

## Todo
- Implement the standard for fungible tokens.
- Discuss for the semi fungible tokens.

