### PR TITLE
Block Header and Merkle Proofs

### DIFF
--- a/linera-base/src/codec.rs
+++ b/linera-base/src/codec.rs
@@ -1,0 +1,172 @@
+//! Defines a universal consensus codec for Linera.
+
+use core::{error, fmt};
+use std::io::{self, Read, Write};
+
+use crate::{crypto::CryptoHash, data_types::BlockHeight, identifiers::ChainId};
+
+/// Error type for serialization related operations.
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to encode
+    SerializeError(String),
+    /// Failed to read
+    ReadError(io::Error),
+    /// Failed to decode
+    DeserializeError(String),
+    /// Failed to write
+    WriteError(io::Error),
+    /// Underflow -- not enough bytes
+    UnderflowError(String),
+    /// Overflow -- too big
+    OverflowError(String),
+    /// Array is too big
+    ArrayTooLong,
+    /// Generic error
+    GenericError(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::SerializeError(ref s) => fmt::Display::fmt(s, f),
+            Error::DeserializeError(ref s) => fmt::Display::fmt(s, f),
+            Error::ReadError(ref io) => fmt::Display::fmt(io, f),
+            Error::WriteError(ref io) => fmt::Display::fmt(io, f),
+            Error::UnderflowError(ref s) => fmt::Display::fmt(s, f),
+            Error::OverflowError(ref s) => fmt::Display::fmt(s, f),
+            Error::ArrayTooLong => write!(f, "Array too long"),
+            Error::GenericError(ref s) => fmt::Display::fmt(s, f),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            Error::SerializeError(ref _s) => None,
+            Error::ReadError(ref io) => Some(io),
+            Error::DeserializeError(ref _s) => None,
+            Error::WriteError(ref io) => Some(io),
+            Error::UnderflowError(ref _s) => None,
+            Error::OverflowError(ref _s) => None,
+            Error::ArrayTooLong => None,
+            Error::GenericError(ref _s) => None,
+        }
+    }
+}
+
+/// Types implementing a single, universally agreed consensus.
+/// Helps to make serialization and deserialization a single pipeline
+/// creating a confidence of compatibilty among all types implementing it.
+pub trait Codec {
+    /// Serialize directly into a writable file descriptor.
+    fn consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), Error>
+    where
+        Self: Sized;
+
+    /// Deserialize from a readable file descriptor
+    fn consensus_deserialize<R: Read>(fd: &mut R) -> Result<Self, Error>
+    where
+        Self: Sized;
+}
+
+/// Convenience function for the [`Codec`] trait.
+/// Just to make implementing the trait a bit more elegant.
+pub fn write_next<T: Codec, W: Write>(fd: &mut W, item: &T) -> Result<(), Error> {
+    item.consensus_serialize(fd)
+}
+
+/// Convenience function for the [`Codec`] trait.
+/// Just to make implementing the trait a bit more elegant.
+pub fn read_next<T: Codec, R: Read>(fd: &mut R) -> Result<T, Error> {
+    let item: T = T::consensus_deserialize(fd)?;
+    Ok(item)
+}
+
+crate::impl_byte_array_codec!(CryptoHash, 32);
+crate::impl_byte_array_codec!(ChainId, 32);
+
+crate::impl_codec_for_int!(u8; [0; 1]);
+crate::impl_codec_for_int!(u16; [0; 2]);
+crate::impl_codec_for_int!(u32; [0; 4]);
+crate::impl_codec_for_int!(u64; [0; 8]);
+crate::impl_codec_for_int!(i64; [0; 8]);
+
+crate::impl_codec_for_int_wrapper!(BlockHeight);
+
+/// Helper macro for redundant generic implementations of the [`Codec`] trait
+/// for primitive integer types.
+#[macro_export]
+macro_rules! impl_codec_for_int {
+    ($typ:ty; $array:expr) => {
+        impl $crate::codec::Codec for $typ {
+            fn consensus_serialize<W: Write>(
+                &self,
+                fd: &mut W,
+            ) -> Result<(), $crate::codec::Error> {
+                fd.write_all(&self.to_be_bytes())
+                    .map_err($crate::codec::Error::WriteError)
+            }
+
+            fn consensus_deserialize<R: Read>(fd: &mut R) -> Result<Self, $crate::codec::Error> {
+                let mut buf = $array;
+                fd.read_exact(&mut buf)
+                    .map_err($crate::codec::Error::ReadError)?;
+                Ok(<$typ>::from_be_bytes(buf))
+            }
+        }
+    };
+}
+
+/// Helper macro for redundant generic implementations of the [`Codec`] trait
+/// for types encompassing an array of bytes of variable lengths.
+#[macro_export]
+macro_rules! impl_byte_array_codec {
+    ($thing:ident, $len:expr) => {
+        impl $crate::codec::Codec for $thing {
+            fn consensus_serialize<W: std::io::Write>(
+                &self,
+                fd: &mut W,
+            ) -> Result<(), $crate::codec::Error> {
+                fd.write_all(self.as_bytes())
+                    .map_err($crate::codec::Error::WriteError)
+            }
+
+            fn consensus_deserialize<R: std::io::Read>(
+                fd: &mut R,
+            ) -> Result<$thing, $crate::codec::Error> {
+                let mut buf = [0u8; ($len as usize)];
+                fd.read_exact(&mut buf)
+                    .map_err($crate::codec::Error::ReadError)?;
+                let ret = $thing::try_from(&buf as &[u8])
+                    .map_err(|e| $crate::codec::Error::UnderflowError(e.to_string()))?;
+                Ok(ret)
+            }
+        }
+    };
+}
+
+/// Helper macro for redundant generic implementations of the [`Codec`] trait
+/// for types wrapping a primitive integer type.
+#[macro_export]
+macro_rules! impl_codec_for_int_wrapper {
+    ($thing:ident) => {
+        impl $crate::codec::Codec for $thing {
+            fn consensus_serialize<W: std::io::Write>(
+                &self,
+                fd: &mut W,
+            ) -> Result<(), $crate::codec::Error> {
+                write_next(fd, &self.0)?;
+                Ok(())
+            }
+
+            fn consensus_deserialize<R: std::io::Read>(
+                fd: &mut R,
+            ) -> Result<$thing, $crate::codec::Error> {
+                Ok(Self(read_next(fd)?))
+            }
+        }
+    };
+}
+

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -978,6 +978,11 @@ impl ChainId {
     pub fn child(id: MessageId) -> Self {
         Self(CryptoHash::new(&ChainDescription::Child(id)))
     }
+
+    /// Internal hash bytes of this [`ChainId`].
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0.as_bytes()[..]
+    }
 }
 
 impl<'de> BcsHashable<'de> for ChainDescription {}

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -30,6 +30,10 @@ pub mod port;
 pub mod prometheus_util;
 #[cfg(not(chain))]
 pub mod task;
+pub mod tree;
+pub mod codec;
+pub mod version;
+pub mod trie;
 #[cfg(not(chain))]
 pub use task::Blocking;
 pub mod time;

--- a/linera-base/src/tree.rs
+++ b/linera-base/src/tree.rs
@@ -1,0 +1,91 @@
+//! Binary Merkle Tree for Linera transactions and various other objects
+//! for efficient zero-knowledge validity proofs of inclusion.
+
+use std::{fmt::Debug, marker::PhantomData};
+
+use serde::{Deserialize, Serialize};
+
+use crate::crypto::{BcsHashable, CryptoHash};
+
+/// Intermediate node for a binary merkle Tree
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Node {
+    /// Hash of this intermediate node.
+    /// Computed as the hash of its children from left to right.
+    pub hash: CryptoHash,
+}
+
+/// Just a simple binary merkle tree
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct Tree<T> {
+    /// All the nodes contained by this Tree.
+    /// Nodes are stored in Breadth-First / Level order.
+    /// If the number of nodes at any level is odd then
+    /// only the last node is duplicated only at that level, so
+    /// that the Tree only contains minimum number of nodes required.
+    /// The rest of information can be computed on-the-fly dynamically.
+    pub elements: Vec<Node>,
+
+    /// Number of leaves, cached only for convenience purposes.
+    pub number_of_leaves: u32,
+
+    /// Type bound indenity for a Tree.
+    pub _phantom_leaves: PhantomData<T>,
+}
+
+fn hash_node_pair(left: &Node, right: &Node) -> CryptoHash {
+    use sha3::digest::Digest;
+
+    let mut hasher = sha3::Sha3_256::default();
+    hasher.update(left.hash.as_bytes());
+    hasher.update(right.hash.as_bytes());
+    hasher.finalize()[..].try_into().expect("not possible")
+}
+
+fn build_tree(nodes: &mut Vec<Node>, hashed_leaves: &mut Vec<Node>) {
+    if hashed_leaves.len() == 1 {
+        nodes.push(hashed_leaves.last().expect("not possible").clone());
+        return;
+    }
+
+    if hashed_leaves.len() % 2 == 1 {
+        hashed_leaves.push(hashed_leaves.last().expect("not possible").clone());
+    }
+
+    let mut hashed_nodes = Vec::new();
+    for pair in hashed_leaves.chunks(2) {
+        hashed_nodes.push(Node { hash: hash_node_pair(&pair[0], &pair[1]) });
+    }
+    build_tree(nodes, &mut hashed_nodes);
+    nodes.append(hashed_leaves);
+}
+
+// base methods
+// other methods can be implemented at module or crate level
+impl<T> Tree<T>
+where
+    T: Debug + Clone + for<'de> BcsHashable<'de>
+{
+    /// Constructs a simple binary merkle tree from the provided values.
+    pub fn from_values(values: &[T]) -> Self {
+        if values.len() == 0 {
+            return Self { elements: Vec::new(), _phantom_leaves: PhantomData, number_of_leaves: 0u32 }
+        }
+
+        let mut hashed_leaves = Vec::new();
+        let mut nodes = Vec::new();
+
+        for value in values {
+            hashed_leaves.push(Node { hash: CryptoHash::new(value) });
+        }
+
+        build_tree(&mut nodes, &mut hashed_leaves);
+
+        Self { elements: nodes, _phantom_leaves: PhantomData, number_of_leaves: values.len() as u32 }
+    }
+
+    /// Takes a shared reference of the root the tree.
+    pub fn root(&self) -> Option<&CryptoHash> {
+        self.elements.first().map(|node| &node.hash)
+    }
+}

--- a/linera-base/src/trie.rs
+++ b/linera-base/src/trie.rs
@@ -1,0 +1,50 @@
+//! Defines a common trie functionality for various Linera Tries
+
+use std::fmt::Debug;
+
+/// Trie node definition.
+pub trait TrieNode: Debug {
+    /// Key upto this point.
+    fn path(&self) -> &[u8];
+
+    /// Does this node contains a child at this character.
+    fn contains(&self, chr: u8) -> bool;
+
+    /// Get a reference to the children of this node.
+    fn daughters(&self) -> &[Option<Box<dyn TrieNode>>];
+
+    /// Follow a path character to a child pointer.
+    fn walk(&self, chr: u8) -> Option<&dyn TrieNode>;
+
+    /// Does this node contains a value.
+    fn value(&self) -> Option<&dyn TrieValue>;
+
+    /// Takes a exclusive reference to value contained by this node.
+    fn value_as_mut(&mut self) -> Option<&mut dyn TrieValue>;
+
+    /// Are all the slots of this node filled.
+    fn is_filled(&self) -> bool;
+
+    /// Inserts a Leaf at this character path.
+    fn insert(&mut self, chr: u8, path: &[u8], value: Box<dyn TrieValue>, should_overwrite: bool) -> bool;
+}
+
+
+/// What defines a Trie.
+pub trait Trie {
+    /// Takes a shared reference of the root of this trie.
+    fn root(&self) -> &dyn TrieNode;
+
+    /// Insert a node at this character.
+    fn insert(&mut self, key: &str, value: Box<dyn TrieValue>) -> bool;
+
+    /// Remove a value at this path
+    fn remove(&mut self, key: &str) -> Box<dyn TrieValue>;
+
+    /// Does this trie contains a node at this path.
+    fn contains(&self, key: &str) -> bool;
+}
+
+
+/// Generic trait bound for a trie value.
+pub trait TrieValue: Debug {}

--- a/linera-base/src/version.rs
+++ b/linera-base/src/version.rs
@@ -1,0 +1,39 @@
+//! Linera Protocol version.
+
+use serde::{Deserialize, Serialize};
+
+use crate::codec::Error;
+
+/// Single Byte to distinguish between different
+/// Linera Protocol version.
+/// Currently seperates Mainnet and Testnet.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, Hash, Serialize, Deserialize)]
+pub enum Protocol {
+    /// Tetstnet byte set to 255
+    Testnet = 0xFF,
+
+    /// Mainnet is represented as 01
+    Mainnet = 0x01,
+}
+
+impl TryFrom<u8> for Protocol {
+    type Error = Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0xFF => Ok(Self::Testnet),
+            0x01 => Ok(Self::Mainnet),
+            _ => Err(Error::SerializeError(format!("Protcol version corresponding to value: {value} is not part of the curerent consensus"))),
+        }
+    }
+}
+
+impl From<Protocol> for u8 {
+    fn from(value: Protocol) -> Self {
+        match value {
+            Protocol::Testnet => 0xFF,
+            Protocol::Mainnet => 0x01,
+        }
+    }
+}

--- a/linera-chain/src/block_header.rs
+++ b/linera-chain/src/block_header.rs
@@ -1,0 +1,95 @@
+
+use linera_base::{codec::{self, read_next, write_next, Codec}, crypto::CryptoHash, data_types::{BlockHeight, Timestamp}, identifiers::ChainId, version::Protocol};
+use linera_execution::committee::Epoch;
+
+use crate::{data_types::Block, ChainError};
+
+
+/// A block-header
+/// is to be derived from the block proposal
+/// doesnt need to be propogated
+#[derive(Clone, Debug, Hash)]
+pub struct BlockHeader {
+    /// Protocol mode
+    pub version: Protocol,
+    /// The chain to which this block belongs.
+    pub chain_id: ChainId,
+    /// The number identifying the current configuration.
+    pub epoch: Epoch,
+    /// The block height.
+    pub height: BlockHeight,
+    /// The timestamp when this block was created. This must be later than all messages received
+    /// in this block, but no later than the current time.
+    pub timestamp: Timestamp,
+
+    /// Merkle tree root of Messages.
+    pub messages_root: CryptoHash,
+    // Merkle tree root of operations.
+    pub operations_root: CryptoHash,
+
+    /// Merkle root of Outcomes, Logs and Emissions after the execution of the transactions.
+    pub outcomes_root: CryptoHash,
+    /// Hash of the current execution state after the execution of this block.
+    pub execution_state_hash: CryptoHash,
+
+    /// Parallel block header hash.
+    pub parent_block_header_hash: CryptoHash,
+    /// Ancestor state index root
+    /// Derived from merklized skip list
+    /// Canonical block header hash.
+    pub parent_block_header_root: CryptoHash,
+}
+
+
+impl Codec for BlockHeader {
+    fn consensus_serialize<W: std::io::Write>(&self, fd: &mut W) -> Result<(), codec::Error> {
+        write_next(fd, &(self.version as u8))?;
+        write_next(fd, &self.chain_id)?;
+        write_next(fd, &self.epoch)?;
+        write_next(fd, &self.height)?;
+        write_next(fd, &self.timestamp)?;
+        write_next(fd, &self.messages_root)?;
+        write_next(fd, &self.operations_root)?;
+        write_next(fd, &self.outcomes_root)?;
+        write_next(fd, &self.execution_state_hash)?;
+        write_next(fd, &self.parent_block_header_hash)?;
+        write_next(fd, &self.parent_block_header_root)?;
+        Ok(())
+    }
+
+    fn consensus_deserialize<R: std::io::Read>(fd: &mut R) -> Result<Self, codec::Error> {
+        let version: Protocol = read_next::<u8, R>(fd)?.try_into()?;
+        let chain_id: ChainId = read_next(fd)?;
+        let epoch: Epoch = read_next(fd)?;
+        let height: BlockHeight = read_next(fd)?;
+        let timestamp: Timestamp = read_next(fd)?;
+
+        let messages_root: CryptoHash = read_next(fd)?;
+        let operations_root: CryptoHash = read_next(fd)?;
+
+        let outcomes_root: CryptoHash = read_next(fd)?;
+        let execution_state_hash: CryptoHash = read_next(fd)?;
+        let parent_block_header_hash: CryptoHash = read_next(fd)?;
+        let parent_block_header_root: CryptoHash = read_next(fd)?;
+
+        Ok(Self {
+            version,
+            chain_id,
+            epoch,
+            height,
+            timestamp,
+            messages_root,
+            operations_root,
+            outcomes_root,
+            execution_state_hash,
+            parent_block_header_hash,
+            parent_block_header_root,
+        })
+    }
+}
+
+impl BlockHeader {
+    pub fn try_append_to_chain<'a>(chain: impl Iterator<Item = &'a BlockHeader>, block: &Block) -> Result<Self, ChainError> {
+        todo!()
+    }
+}

--- a/linera-chain/src/index/merkle_forest.rs
+++ b/linera-chain/src/index/merkle_forest.rs
@@ -1,0 +1,17 @@
+use linera_base::{crypto::CryptoHash, tree::Tree};
+
+use crate::{block_header::BlockHeader, transaction::{Transaction, TransactionOutcome}};
+
+use super::trie::Trie;
+
+
+type WorldTree = Trie;
+
+pub struct Forest {
+    pub world_tree: WorldTree,
+    pub message_forest: Vec<Tree<Transaction>>,
+    pub operation_forest: Vec<Tree<Transaction>>,
+    pub receipts_forest: Vec<Tree<TransactionOutcome>>,
+    pub block_headers: Vec<(BlockHeader, CryptoHash)>, // inverse mapping (header_hash -> height) can be inserted in the world tree
+}
+

--- a/linera-chain/src/index/mod.rs
+++ b/linera-chain/src/index/mod.rs
@@ -1,0 +1,5 @@
+pub mod proofs;
+pub mod trie;
+pub mod node;
+pub mod merkle_forest;
+pub mod walker;

--- a/linera-chain/src/index/node.rs
+++ b/linera-chain/src/index/node.rs
@@ -1,0 +1,636 @@
+use linera_base::trie::{TrieNode, TrieValue};
+
+
+// for a node X
+//
+// path field refers to a
+// maybe compressed path
+// to be lazily expanded
+// most paths are likely to be compressed
+//
+// value field can be used for literary anything
+
+pub trait AdaptiveRadixTrieNode: TrieNode {
+    fn id(&self) -> NodeId;
+
+    fn adapt(&mut self, adapt_at: u8, adaption: Adaption);
+
+    fn promote(&mut self) -> Box<dyn AdaptiveRadixTrieNode>;
+
+    fn walk(&mut self, chr: u8) -> Option<&mut dyn AdaptiveRadixTrieNode>;
+}
+
+pub enum Adaption {
+    Promote,
+    Splice((Vec<u8>, u8)),
+}
+
+#[derive(Debug)]
+pub struct Node256 {
+    pub path: Vec<u8>,
+    pub value: Option<Box<dyn TrieValue>>,
+    pub count: u8,
+    pub pointers: [Option<Box<dyn AdaptiveRadixTrieNode>>; 256],
+}
+
+#[derive(Debug)]
+pub struct Node4 {
+    pub path: Vec<u8>,
+    pub value: Option<Box<dyn TrieValue>>,
+    pub keys: [u8; 4],
+    pub count: u8,
+    pub pointers: [Option<Box<dyn AdaptiveRadixTrieNode>>; 4],
+}
+
+#[derive(Debug)]
+pub struct Node16 {
+    pub path: Vec<u8>,
+    pub value: Option<Box<dyn TrieValue>>,
+    pub keys: [u8; 16],
+    pub count: u8,
+    pub pointers: [Option<Box<dyn AdaptiveRadixTrieNode>>; 16],
+}
+
+#[derive(Debug)]
+pub struct Node48 {
+    pub path: Vec<u8>,
+    pub value: Option<Box<dyn TrieValue>>,
+    pub indexes: [i8; 256],
+    pub count: u8,
+    pub pointers: [Option<Box<dyn AdaptiveRadixTrieNode>>; 48],
+}
+
+#[derive(Debug)]
+pub struct Leaf {
+    pub path: Vec<u8>,
+    pub value: Option<Box<dyn TrieValue>>,  // leaves always contain some value
+}
+
+pub enum NodeId {
+    Empty,
+    Leaf,
+    Node4,
+    Node16,
+    Node48,
+    Node256,
+}
+
+impl Leaf {
+    pub fn new(path: &[u8], value: Box<dyn TrieValue>) -> Self {
+        Leaf {
+            path: path.to_vec(),
+            value: Some(value),
+        }
+    }
+}
+
+impl TrieNode for Leaf {
+    fn path(&self) -> &[u8] {
+        todo!()
+    }
+
+    fn contains(&self, _chr: u8) -> bool {
+        false
+    }
+
+    fn daughters(&self) -> &[Option<Box<dyn TrieNode>>] {
+        &[]
+    }
+
+    fn walk(&self, _chr: u8) -> Option<&dyn TrieNode> {
+        None
+    }
+
+    fn value(&self) -> Option<&dyn TrieValue> {
+        todo!()
+    }
+
+    fn value_as_mut(&mut self) -> Option<&mut dyn TrieValue> {
+        todo!()
+    }
+
+    fn is_filled(&self) -> bool {
+        true
+    }
+
+    fn insert(&mut self, _chr: u8, _path: &[u8], value: Box<dyn TrieValue>, should_overwrite: bool) -> bool {
+        if !should_overwrite {
+            return false
+        }
+
+        let _ = self.value.replace(value);
+        true
+    }
+}
+
+impl AdaptiveRadixTrieNode for Leaf {
+    fn id(&self) -> NodeId {
+        NodeId::Leaf
+    }
+
+    fn adapt(&mut self, _adapt_at: u8, adaption: Adaption) {
+        match adaption {
+            Adaption::Promote => panic!("Leaves are the ends of the world. No point in promotion."),
+            Adaption::Splice(_) => panic!("Leaves are the ends of the world. No sense in slicing."),
+        }
+    }
+
+    fn promote(&mut self) -> Box<dyn AdaptiveRadixTrieNode> {
+        panic!("Leaves are the ends of the world. No point in promotion.")
+    }
+
+    fn walk(&mut self, _chr: u8) -> Option<&mut dyn AdaptiveRadixTrieNode> {
+        None
+    }
+}
+
+impl Default for Node4 {
+    fn default() -> Self {
+        Self {
+            path: Vec::new(),
+            value: None,
+            keys: [0u8; 4],
+            count: 0,
+            pointers: [const { None }; 4],
+        }
+    }
+}
+
+impl TrieNode for Node4 {
+    fn insert(&mut self, chr: u8, path: &[u8], value: Box<dyn TrieValue>, should_overwrite: bool) -> bool {
+        let mut i = 0;
+
+        loop {
+            if i == self.count as usize {
+                self.count += 1;
+                break;
+            }
+
+            if chr != self.keys[i] {
+                i += 1;
+                continue;
+            }
+
+            if !should_overwrite {
+                return false;
+            }
+
+            break;
+        }
+
+        self.keys[i] = chr;
+        self.pointers[i] = Some(Box::new(Leaf::new(path, value)));
+
+        true
+    }
+
+    fn path(&self) -> &[u8] {
+        todo!()
+    }
+
+    fn contains(&self, chr: u8) -> bool {
+        let mut i = 0;
+
+        loop {
+            if self.count == i as u8 {
+                return false;
+            }
+
+            if chr != self.keys[i] {
+                i += 1;
+                continue;
+            }
+
+            if self.pointers[i].is_none() {
+                return false;
+            }
+
+            break;
+        }
+
+        true
+    }
+
+    fn daughters(&self) -> &[Option<Box<dyn TrieNode>>] {
+        todo!()
+    }
+
+    fn walk(&self, chr: u8) -> Option<&dyn TrieNode> {
+        todo!()
+    }
+
+    fn value(&self) -> Option<&dyn TrieValue> {
+        todo!()
+    }
+
+    fn value_as_mut(&mut self) -> Option<&mut dyn TrieValue> {
+        todo!()
+    }
+
+    fn is_filled(&self) -> bool {
+        // use count
+        todo!()
+    }
+}
+
+impl AdaptiveRadixTrieNode for Node4 {
+    fn id(&self) -> NodeId {
+        NodeId::Node4
+    }
+
+    fn walk(&mut self, chr: u8) -> Option<&mut dyn AdaptiveRadixTrieNode> {
+        todo!()
+    }
+
+    fn adapt(&mut self, adapt_at: u8, adaption: Adaption) {
+        match adaption {
+            Adaption::Promote => {
+                let node = <Self as AdaptiveRadixTrieNode>::walk(self, adapt_at).unwrap();
+                let new_node = node.promote();
+
+                for i in 0..4 {
+                    if adapt_at == self.keys[i] {
+                        self.pointers[i] = Some(new_node);
+                        break;
+                    }
+                }
+            },
+
+            Adaption::Splice((suffixed_path, suffix_at)) => {
+                let mut node = Node4::default();
+                node.path = suffixed_path;
+                node.keys[0] = suffix_at;
+                node.count = 1;
+
+                for i in 0..4 {
+                    if adapt_at == self.keys[i] {
+
+                        node.pointers[0] = self.pointers[i].take();
+                        let _ = self.pointers[i].replace(Box::new(node));
+                        break;
+                    }
+                }
+            },
+        }
+    }
+
+    fn promote(&mut self) -> Box<dyn AdaptiveRadixTrieNode> {
+        let path = self.path.clone();
+        let value = self.value.take();
+
+        let mut keys = [0u8; 16];
+        for i in 0..4 {
+            keys[i] = self.keys[i];
+        }
+
+        let count = self.count;
+
+        let mut pointers = [const { None }; 16];
+        for i in 0..4 {
+            pointers[i] = self.pointers[i].take();
+        }
+
+        let node = Node16 {
+            path,
+            value,
+            keys,
+            count,
+            pointers,
+        };
+
+        Box::new(node)
+    }
+}
+
+impl TrieNode for Node16 {
+    fn path(&self) -> &[u8] {
+        todo!()
+    }
+
+    fn contains(&self, chr: u8) -> bool {
+        let mut i = 0;
+
+        loop {
+            if self.count == i as u8 {
+                return false;
+            }
+
+            if chr != self.keys[i] {
+                i += 1;
+                continue;
+            }
+
+            if self.pointers[i].is_none() {
+                return false;
+            }
+
+            break;
+        }
+
+        true
+    }
+
+    fn daughters(&self) -> &[Option<Box<dyn TrieNode>>] {
+        todo!()
+    }
+
+    fn walk(&self, chr: u8) -> Option<&dyn TrieNode> {
+        todo!()
+    }
+
+    fn value(&self) -> Option<&dyn TrieValue> {
+        todo!()
+    }
+
+    fn value_as_mut(&mut self) -> Option <&mut dyn TrieValue> {
+        todo!()
+    }
+
+    fn is_filled(&self) -> bool {
+        todo!()
+    }
+
+    fn insert(&mut self, chr: u8, path: &[u8], value: Box<dyn TrieValue>, should_overwrite: bool) -> bool {
+        let mut i = 0;
+
+        loop {
+            if i == self.count as usize {
+                self.count += 1;
+                break;
+            }
+
+            if chr != self.keys[i] {
+                i += 1;
+                continue;
+            }
+
+            if !should_overwrite {
+                return false;
+            }
+
+            break;
+        }
+
+        self.keys[i] = chr;
+        self.pointers[i] = Some(Box::new(Leaf::new(path, value)));
+
+        true
+    }
+}
+
+impl AdaptiveRadixTrieNode for Node16 {
+    fn id(&self) -> NodeId {
+        todo!()
+    }
+
+    fn adapt(&mut self, adapt_at: u8, adaption: Adaption) {
+        match adaption {
+            Adaption::Promote => {
+                let node = <Self as AdaptiveRadixTrieNode>::walk(self, adapt_at).unwrap();
+                let new_node = node.promote();
+
+                for i in 0..16 {
+                    if adapt_at == self.keys[i] {
+                        self.pointers[i] = Some(new_node);
+                        break;
+                    }
+                }
+            },
+
+            Adaption::Splice((suffixed_path, suffix_at)) => {
+                let mut node = Node4::default();
+                node.path = suffixed_path;
+                node.keys[0] = suffix_at;
+                node.count = 1;
+
+                for i in 0..16 {
+                    if adapt_at == self.keys[i] {
+
+                        node.pointers[0] = self.pointers[i].take();
+                        let _ = self.pointers[i].replace(Box::new(node));
+                        break;
+                    }
+                }
+            },
+        }
+    }
+
+    fn promote(&mut self) -> Box<dyn AdaptiveRadixTrieNode> {
+        let path = self.path.clone();
+        let value = self.value.take();
+
+        let mut indexes = [-1; 256];
+        for i in 0..16 {
+            indexes[self.keys[i as usize] as usize] = i;
+        }
+
+        let count = self.count;
+
+        let mut pointers = [const { None }; 48];
+        for i in 0..16 {
+            pointers[i] = self.pointers[i].take();
+        }
+
+        let node = Node48 {
+            path,
+            value,
+            indexes,
+            count,
+            pointers,
+        };
+
+        Box::new(node)
+    }
+
+    fn walk(&mut self, chr: u8) -> Option<&mut dyn AdaptiveRadixTrieNode> {
+        todo!()
+    }
+}
+
+impl TrieNode for Node48 {
+    fn path(&self) -> &[u8] {
+        todo!()
+    }
+
+    fn contains(&self, chr: u8) -> bool {
+        if -1 == self.indexes[chr as usize] {
+            return false
+        }
+
+        true
+    }
+
+    fn daughters(&self) -> &[Option<Box<dyn TrieNode>>] {
+        todo!()
+    }
+
+    fn walk(&self, chr: u8) -> Option<&dyn TrieNode> {
+        todo!()
+    }
+
+    fn value(&self) -> Option<&dyn TrieValue> {
+        todo!()
+    }
+
+    fn value_as_mut(&mut self) -> Option<&mut dyn TrieValue> {
+        todo!()
+    }
+
+    fn is_filled(&self) -> bool {
+        todo!()
+    }
+
+    fn insert(&mut self, chr: u8, path: &[u8], value: Box<dyn TrieValue>, should_overwrite: bool) -> bool {
+        if !should_overwrite
+            &&
+            -1 != self.indexes[chr as usize]
+        {
+            return false
+        }
+
+        let leaf = Leaf::new(path, value);
+
+        self.pointers[self.count as usize] = Some(Box::new(leaf));
+        self.indexes[chr as usize] = self.count as i8;
+        self.count += 1;
+
+        true
+    }
+}
+
+impl AdaptiveRadixTrieNode for Node48 {
+    fn id(&self) -> NodeId {
+        todo!()
+    }
+
+    fn adapt(&mut self, adapt_at: u8, adaption: Adaption) {
+        match adaption {
+            Adaption::Promote => {
+                let node = <Self as AdaptiveRadixTrieNode>::walk(self, adapt_at).unwrap();
+                let new_node = node.promote();
+
+                let index = self.indexes[adapt_at as usize].unsigned_abs(); // little hacky
+                let _ = self.pointers[index as usize].replace(new_node);
+            },
+
+            Adaption::Splice((suffixed_path, suffix_at)) => {
+                let mut node = Node4::default();
+                node.path = suffixed_path;
+                node.keys[0] = suffix_at;
+                node.count = 1;
+
+                let index = self.indexes[adapt_at as usize].unsigned_abs() as usize;
+                node.pointers[0] = self.pointers[index].take();
+                let _ = self.pointers[index].replace(Box::new(node));
+            },
+        }
+    }
+
+    fn promote(&mut self) -> Box<dyn AdaptiveRadixTrieNode> {
+        let path = self.path.clone();
+        let value = self.value.take();
+        let count = self.count;
+
+        let mut pointers = [const { None }; 256];
+        for chr in 0..256 {
+            match self.indexes[chr] {
+                -1 => continue,
+                index => pointers[chr] = self.pointers[index.unsigned_abs() as usize].take(),
+            }
+        }
+
+        let node = Node256 {
+            path,
+            value,
+            count,
+            pointers,
+        };
+
+        Box::new(node)
+    }
+
+    fn walk(&mut self, chr: u8) -> Option<&mut dyn AdaptiveRadixTrieNode> {
+        todo!()
+    }
+}
+
+impl TrieNode for Node256 {
+    fn path(&self) -> &[u8] {
+        todo!()
+    }
+
+    fn contains(&self, chr: u8) -> bool {
+        self.pointers[chr as usize].is_some()
+    }
+
+    fn daughters(&self) -> &[Option<Box<dyn TrieNode>>] {
+        todo!()
+    }
+
+    fn walk(&self, chr: u8) -> Option<&dyn TrieNode> {
+        todo!()
+    }
+
+    fn value(&self) -> Option<&dyn TrieValue> {
+        todo!()
+    }
+
+    fn value_as_mut(&mut self) -> Option<&mut dyn TrieValue> {
+        todo!()
+    }
+
+    fn is_filled(&self) -> bool {
+        false
+    }
+
+    fn insert(&mut self, chr: u8, path: &[u8], value: Box<dyn TrieValue>, should_overwrite: bool) -> bool {
+        if !should_overwrite
+            &&
+            self.contains(chr)
+        {
+            return false
+        }
+
+        let leaf = Leaf::new(path, value);
+
+        self.pointers[self.count as usize] = Some(Box::new(leaf));
+        self.count += 1;
+
+        true
+    }
+}
+
+impl AdaptiveRadixTrieNode for Node256 {
+    fn id(&self) -> NodeId {
+        todo!()
+    }
+
+    fn adapt(&mut self, adapt_at: u8, adaption: Adaption) {
+        match adaption {
+            Adaption::Promote => {
+                let node = <Self as AdaptiveRadixTrieNode>::walk(self, adapt_at).unwrap();
+                let new_node = node.promote();
+
+                let _ = self.pointers[adapt_at as usize].replace(new_node);
+            },
+
+            Adaption::Splice((suffixed_path, suffix_at)) => {
+                let mut node = Node4::default();
+                node.path = suffixed_path;
+                node.keys[0] = suffix_at;
+                node.count = 1;
+
+                node.pointers[0] = self.pointers[adapt_at as usize].take();
+                let _ = self.pointers[adapt_at as usize].replace(Box::new(node));
+            },
+        }
+    }
+
+    fn promote(&mut self) -> Box<dyn AdaptiveRadixTrieNode> {
+        panic!("Node256 is the whole world. Nothing exists beyond it.")
+    }
+
+    fn walk(&mut self, chr: u8) -> Option<&mut dyn AdaptiveRadixTrieNode> {
+        todo!()
+    }
+}

--- a/linera-chain/src/index/proofs.rs
+++ b/linera-chain/src/index/proofs.rs
@@ -1,0 +1,50 @@
+use linera_base::tree::Tree;
+use serde::{Deserialize, Serialize};
+
+
+/// simple proof chache for binary merkle tree
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Proof {
+    pub hashes: Vec<u32>,
+    pub index: u32,
+}
+
+/// extrention for tree-like data structures
+pub trait MerkleProof {
+    type Proof;
+
+    fn build_proof(&self, index: u32) -> Result<Self::Proof, String>;
+}
+
+impl<T> MerkleProof for Tree<T> {
+    type Proof = Proof;
+
+    fn build_proof(&self, index: u32) -> Result<Proof, String> {
+        let number_of_leaves = self.number_of_leaves;
+        if number_of_leaves < index + 1 {
+            return Err(format!("index: {index} not found in the tree"));
+        }
+
+        let mut hashes = Vec::new();
+
+        let virtual_leaves_size= number_of_leaves.next_power_of_two();
+        let virtual_tree_size = 2 * virtual_leaves_size - 1;
+        let phantom_leaves_size = (virtual_leaves_size - number_of_leaves).next_power_of_two() / 2;
+        let phantom_subtree_size = (2 * phantom_leaves_size).saturating_sub(2);
+        let mut phantom_partition = phantom_subtree_size - phantom_leaves_size;
+
+        let mut cursor = virtual_leaves_size + index - 1;
+        while 0 != cursor {
+            let mut virtual_cursor = cursor + phantom_partition;
+            hashes.push(virtual_cursor ^ 1);
+            virtual_cursor = ((virtual_cursor + (1 & virtual_cursor)) >> 1) - 1;
+            cursor = virtual_cursor - ((phantom_partition + (0 != phantom_partition) as u32 * 2) >> 1);
+            phantom_partition = phantom_partition.saturating_sub(phantom_partition + 2 >> 1);
+        }
+
+        Ok(Proof { hashes, index })
+    }
+}
+
+// TODO
+mod tests {}

--- a/linera-chain/src/index/trie.rs
+++ b/linera-chain/src/index/trie.rs
@@ -1,0 +1,62 @@
+
+use linera_base::{codec::Codec, crypto::CryptoHash};
+
+use super::node::Node256;
+
+
+#[derive(Debug)]
+pub struct Trie {
+    pub root: Node256,
+    pub blocks: Vec<TrieBlock>,
+}
+
+
+/// In a TrieBlock, the values at the leaves point to the
+/// WorldTree leaves, maybe by a raw pointer.
+/// So a TrieBlock is just a indexed reference to all the values in that block
+/// which resides in the WorldTee.
+#[derive(Debug)]
+pub struct TrieBlock {
+    pub root: PhantomNode,
+    pub hash: CryptoHash, // merkle skip list
+    pub nodes: Vec<[u8; 32]>, // keys of leaves
+}
+
+type PhantomNode = Node256;
+
+
+/// Its a TODO
+/// When persisting a WorldTree in the views, the Tree
+/// itself need not be of concern.
+/// The leaves of TrieBlocks would have to be serialized
+/// in their respective vectors with a 1-1 mapping of keys, and not
+/// the intermediate nodes themselves.
+/// Then all the Tries, inclusive of the World, can be dynamically constructed
+/// by inserting those key - value leaves block by block.
+impl Codec for TrieBlock {
+    fn consensus_serialize<W: std::io::Write>(&self, fd: &mut W) -> Result<(), linera_base::codec::Error>
+    where
+        Self: Sized {
+        todo!()
+    }
+
+    fn consensus_deserialize<R: std::io::Read>(fd: &mut R) -> Result<Self, linera_base::codec::Error>
+    where
+        Self: Sized {
+        todo!()
+    }
+}
+
+impl Codec for Trie {
+    fn consensus_serialize<W: std::io::Write>(&self, fd: &mut W) -> Result<(), linera_base::codec::Error>
+    where
+        Self: Sized {
+        todo!()
+    }
+
+    fn consensus_deserialize<R: std::io::Read>(fd: &mut R) -> Result<Self, linera_base::codec::Error>
+    where
+        Self: Sized {
+        todo!()
+    }
+}

--- a/linera-chain/src/index/walker.rs
+++ b/linera-chain/src/index/walker.rs
@@ -1,0 +1,144 @@
+use linera_base::trie::TrieValue;
+use thiserror::Error;
+
+use super::node::{Adaption, AdaptiveRadixTrieNode};
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("leaves' path must be 32 bytes")]
+    InvalidLeafPath,
+
+    #[error("leaf at the path to be inserted is already occupied")]
+    LeafAlreadyExists,
+
+    #[error("cannot insert leaf somehow")]
+    LeafInsertError,
+}
+
+// its quite clumsy and inefficient right now;
+// TODO implement multi-threading
+// for a Concurrent Trie. Should be
+// quite simple.
+struct Walker<'a> {
+    root: Option<&'a mut dyn AdaptiveRadixTrieNode>,
+    path: &'a [u8],                     // the path to walk
+    index: usize,                       // absolute index into the path
+    phantom_index: usize,               // index into the currently-visited node's compressed path
+    value: Option<Box<dyn TrieValue>>,
+    walked: bool,
+    should_overwrite: bool,
+    result: bool,
+}
+
+impl<'a> Walker<'a> {
+    pub fn new(root: &'a mut dyn AdaptiveRadixTrieNode) -> Self {
+        Walker {
+            root: Some(root),
+            path: &[],
+            index: 0,
+            phantom_index: 0,
+            value: None,
+            walked: false,
+            should_overwrite: false,
+            result: false,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.path = &[];
+        self.index = 0;
+        self.phantom_index = 0;
+        self.value = None;
+        self.walked = false;
+        self.should_overwrite = false;
+        self.result = false;
+    }
+
+    pub fn insert(
+        &mut self,
+        key: &'a [u8],
+        value: Box<dyn TrieValue>,
+        should_overwrite: bool,
+    ) -> Result<(), Error> {
+
+        if 32 != key.len() {
+            return Err(Error::InvalidLeafPath)
+        }
+
+        self.path = key;
+        self.value = Some(value);
+
+        let mut root = self.root.take().unwrap();
+
+        root = self.recursive_insert(root);
+
+        self.root.replace(root);
+
+        let result = match (should_overwrite, self.result) {
+            (true, false) => Err(Error::LeafInsertError),
+            (false, false) => Err(Error::LeafAlreadyExists),
+            (_, true) => Ok(()),
+        };
+
+        self.reset();
+        result
+    }
+
+    // TODO
+    // Get back to the root of trie
+    // hashing the intermediate nodes along the way.
+    fn recursive_insert<'b>(&mut self, root: &'b mut dyn AdaptiveRadixTrieNode) -> &'b mut dyn AdaptiveRadixTrieNode {
+        if 32 == self.phantom_index {
+            self.walked = true;
+            self.result = root.insert(self.path[self.phantom_index - 1], &self.path, self.value.take().unwrap(), self.should_overwrite);
+            return root;
+        }
+
+        // check for splicing
+        let mut should_splice = None;
+        if let Some(node) = root.walk(self.path[self.phantom_index]) {
+            let node_path = node.path();
+            for i in 0..node_path.len() {
+                if node_path[i] != self.path[i] {
+                    should_splice = Some((node_path[0..i].to_vec(), node_path[i]));
+                    break;
+                }
+            }
+        }
+
+        if let Some(splicing_data) = should_splice {
+            root.adapt(self.path[self.phantom_index], Adaption::Splice(splicing_data))
+        }
+
+        // check if next node needs to be promoted
+        let mut next_is_filled = false;
+        if let Some(node) = root.walk(self.path[self.phantom_index]) {
+            let phantom_index = node.path().len();
+            if 32 != phantom_index    // if not leaf; leaves are only spliced not promoted
+                && !node.contains(self.path[phantom_index])
+                && node.is_filled()
+            {
+                next_is_filled = true;
+            }
+
+        }
+
+        if next_is_filled {
+            root.adapt(self.path[root.path().len()], Adaption::Promote);
+        }
+
+        if let Some(node) = root.walk(self.path[self.phantom_index]) {
+            self.phantom_index = node.path().len();
+            self.index += 1;
+            let _ = self.recursive_insert(node);
+        }
+
+        if !self.walked {
+            self.result = root.insert(self.path[self.phantom_index], &self.path, self.value.take().unwrap(), self.should_overwrite);
+            self.walked = true;
+        }
+
+        root
+    }
+}
+

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -7,6 +7,9 @@
 
 mod block;
 mod certificate;
+pub mod block_header;
+pub mod index;
+pub mod transaction;
 
 pub mod types {
     pub use super::{block::*, certificate::*};

--- a/linera-chain/src/transaction.rs
+++ b/linera-chain/src/transaction.rs
@@ -1,0 +1,206 @@
+use linera_base::{codec::{read_next, write_next, Codec}, crypto::CryptoHash, data_types::{BlockHeight, OracleResponse}, identifiers::ChainId, version::Protocol};
+use serde::{Deserialize, Serialize};
+use linera_base::bcs;
+use crate::data_types::{EventRecord, IncomingBundle, OutgoingMessage};
+
+type TransactionVersion = Protocol;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum TransactionPayload {
+    Message(Message),
+    Operation(Operation),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Message {
+    pub index: u32, // within block message index
+    pub nonce: u64, // between blocks message index
+    pub message: IncomingBundle,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Operation {
+    pub index: u32,
+    pub nonce: u64,
+    pub operation: linera_execution::Operation,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Transaction {
+    pub version: TransactionVersion,
+    pub chain_id: ChainId,
+    pub height: BlockHeight,
+    pub index: u32, // local index
+    pub nonce: u64, // global index
+    pub payload: TransactionPayload,
+}
+
+impl Codec for Transaction {
+    fn consensus_serialize<W: std::io::Write>(&self, fd: &mut W) -> Result<(), linera_base::codec::Error>
+    where
+        Self: Sized {
+        write_next(fd, &(self.version as u8))?;
+        write_next(fd, &self.chain_id)?;
+        write_next(fd, &self.height)?;
+        write_next(fd, &self.index)?;
+        write_next(fd, &self.nonce)?;
+        write_next(fd, &self.payload)?;
+        Ok(())
+    }
+
+    fn consensus_deserialize<R: std::io::Read>(fd: &mut R) -> Result<Self, linera_base::codec::Error>
+    where
+        Self: Sized {
+        let version: Protocol = read_next::<u8, R>(fd)?.try_into()?;
+        let chain_id: ChainId = read_next(fd)?;
+        let height: BlockHeight = read_next(fd)?;
+        let index: u32 = read_next(fd)?;
+        let nonce: u64 = read_next(fd)?;
+        let payload: TransactionPayload = read_next(fd)?;
+
+        Ok(Self {
+            version,
+            chain_id,
+            height,
+            index,
+            nonce,
+            payload,
+        })
+    }
+}
+
+impl Codec for TransactionPayload {
+    fn consensus_serialize<W: std::io::Write>(&self, fd: &mut W) -> Result<(), linera_base::codec::Error>
+    where
+        Self: Sized
+    {
+        match self {
+            TransactionPayload::Message(message) => {
+                write_next(fd, &0u8)?;
+                write_next(fd, &message.index)?;
+                write_next(fd, &message.nonce)?;
+                write_next(fd, &message.message)?;
+            },
+
+            TransactionPayload::Operation(operation) => {
+                write_next(fd, &1u8)?;
+                write_next(fd, &operation.index)?;
+                write_next(fd, &operation.nonce)?;
+                write_next(fd, &operation.operation)?;
+            },
+        }
+
+        Ok(())
+    }
+
+    fn consensus_deserialize<R: std::io::Read>(fd: &mut R) -> Result<Self, linera_base::codec::Error>
+    where
+        Self: Sized
+    {
+        let variant: u8 = read_next(fd)?;
+        let index: u32 = read_next(fd)?;
+        let nonce: u64 = read_next(fd)?;
+
+        if 0 == variant {
+            Ok(Self::Message(
+                Message { index, nonce, message: read_next::<IncomingBundle, R>(fd)? }
+            ))
+        } else if 1 == variant {
+            Ok(Self::Operation(
+                Operation { index, nonce, operation: read_next::<linera_execution::Operation, R>(fd)? }
+            ))
+        } else {
+            panic!("not implemented")
+        }
+    }
+}
+
+impl Codec for IncomingBundle {
+    fn consensus_serialize<W: std::io::Write>(&self, fd: &mut W) -> Result<(), linera_base::codec::Error>
+    where
+        Self: Sized
+    {
+        bcs::serialize_into(fd, self)
+            .map_err(|e| e.to_string())
+            .map_err(linera_base::codec::Error::GenericError)
+    }
+
+    fn consensus_deserialize<R: std::io::Read>(fd: &mut R) -> Result<Self, linera_base::codec::Error>
+    where
+        Self: Sized
+    {
+        bcs::from_reader(fd)
+            .map_err(|e| e.to_string())
+            .map_err(linera_base::codec::Error::GenericError)
+    }
+}
+
+#[derive(Debug, Hash, Serialize, Deserialize)]
+pub struct TransactionOutcome {
+    pub version: Protocol,
+    pub chain_id: ChainId,
+    pub block_height: u64,
+    pub transaction_hash: CryptoHash,
+    pub transaction_index: u32,
+    pub kind: OutcomeKind,
+}
+
+#[derive(Debug, Hash, Serialize, Deserialize)]
+pub enum OutcomeKind {
+    OracleResponse(OracleResponse),
+    Message(OutgoingMessage),
+    EventRecord(EventRecord),
+}
+
+impl Codec for OutcomeKind {
+    fn consensus_serialize<W: std::io::Write>(&self, fd: &mut W) -> Result<(), linera_base::codec::Error>
+    where
+        Self: Sized {
+        bcs::serialize_into(fd, self)
+            .map_err(|e| e.to_string())
+            .map_err(linera_base::codec::Error::GenericError)
+    }
+
+    fn consensus_deserialize<R: std::io::Read>(fd: &mut R) -> Result<Self, linera_base::codec::Error>
+    where
+        Self: Sized {
+        bcs::from_reader(fd)
+            .map_err(|e| e.to_string())
+            .map_err(linera_base::codec::Error::GenericError)
+    }
+}
+
+impl Codec for TransactionOutcome {
+    fn consensus_serialize<W: std::io::Write>(&self, fd: &mut W) -> Result<(), linera_base::codec::Error>
+    where
+        Self: Sized {
+        write_next(fd, &(self.version as u8))?;
+        write_next(fd, &self.chain_id)?;
+        write_next(fd, &self.block_height)?;
+        write_next(fd, &self.transaction_hash)?;
+        write_next(fd, &self.transaction_index)?;
+        write_next(fd, &self.kind)?;
+        Ok(())
+    }
+
+    fn consensus_deserialize<R: std::io::Read>(fd: &mut R) -> Result<Self, linera_base::codec::Error>
+    where
+        Self: Sized {
+        let version: Protocol = read_next::<u8, R>(fd)?.try_into()?;
+        let chain_id: ChainId = read_next(fd)?;
+        let block_height: u64 = read_next(fd)?;
+        let transaction_hash: CryptoHash = read_next(fd)?;
+        let transaction_index: u32 = read_next(fd)?;
+        let kind: OutcomeKind = read_next(fd)?;
+
+        Ok(Self {
+            version,
+            chain_id,
+            block_height,
+            transaction_hash,
+            transaction_index,
+            kind,
+        })
+    }
+}
+

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -6,8 +6,7 @@ use std::{borrow::Cow, collections::BTreeMap, str::FromStr};
 
 use async_graphql::InputObject;
 use linera_base::{
-    crypto::{CryptoError, PublicKey},
-    data_types::ArithmeticError,
+    codec::{self, read_next, write_next, Codec}, crypto::{CryptoError, PublicKey}, data_types::ArithmeticError
 };
 use serde::{Deserialize, Serialize};
 
@@ -16,6 +15,16 @@ use crate::policy::ResourceControlPolicy;
 /// A number identifying the configuration of the chain (aka the committee).
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug)]
 pub struct Epoch(pub u32);
+
+impl Codec for Epoch {
+    fn consensus_serialize<W: std::io::Write>(&self, fd: &mut W) -> Result<(), codec::Error> {
+        write_next(fd, &self.0)
+    }
+
+    fn consensus_deserialize<R: std::io::Read>(fd: &mut R) -> Result<Self, codec::Error> {
+        Ok(Self(read_next(fd)?))
+    }
+}
 
 impl Epoch {
     pub const ZERO: Epoch = Epoch(0);


### PR DESCRIPTION
For this pr, I define:
- Client - A normal node peer storing, if wished, the entire chain of concern. For example, a desktop client node.
- Light Client - Node peers with limited and constrained resources which are only required to store the Block-Headers. For example, a web or mobile wallet.
- Stateless Client - For example, a smart contract in a chain in the outside world. They only need a single good known trusted hash to verify the zero knowledge proofs till that point in time. 
<br/>
A proper Block-Header is a single point of consensus, among all peers, which acts as a snapshot of the entire history of the respective blockchain state, up until the corresponding block height, in a compressed form. 

It should be:
- A unique identity for a block.
- Compact, Precise and Elegant as it will be the face of the blockchain for the outside world.
- Simple and easy to develop around protocols as it will act as a bridge between the outside world.
- Able to verify the entire history of the chain state with minimal amount of resources possible in at most sub-linear complexity for both the time and the space.
- Able to allow the light clients to prune the chain state.

Other than these, the surrounding blockchain should support quick, generation of validity proofs, adding a new block with its header to the chainstate in sub-linear time, small proof sizes, etc.
<br/>
Fortunately, unlike other blockchains, the way linera is, we don't have to send the blockheader to other peers. It can be derived at the either ends, saving the block space, as its not part of the consensus(yet, there is a small space where it can be, for the better).
And also improving on the recent implementation, we don't have to send the block execution outcomes, as they are deterministic and dependent on the inputs, greatly saving the precious block space.
But, what's the incentive for the clients to cryptographically commit to the block-headers?
The state of the chain can be check-pointed, a snapshot, and the history of the chain before that point can be safely pruned.
<br/>
Further, to maintain those, likely to be millions of, transaction hashes, a index data structure is needed. After careful considerations, a merkle trie is a most likely candidate. A trie like data structure is used by every major blockchain, Ethereum uses a modified merkle patricia tree, Solana uses a form of concurrent tree, etc. And we require a trie data structure at many places anyway, like in linera-views, and in future to manage Accounts and chain ids.
<br/>
For our purposes, a best fit would an Adaptive Radix Merkle Trie (ART). Details about it can be found in the original paper<sup>[[1]](https://db.in.tum.de/~leis/papers/ART.pdf)</sup> below.
Adding a new block to the index require minimal samples 
![x](https://github.com/user-attachments/assets/5aa409d2-a359-4fa6-b950-e0934dd6116a)
Reads are O(1) 
Writes are O(1)
Adding a new block is O(logn)
Generating a proof is O(logn)
Verifying a proof is O(logn)
Proof size is O(logn)
<br/>

Lastly, a merkle skip list is used to calculate the canonical block hash, which is the concatenation of the current root hash with the consensus hashes N - 1, N - 2, N - 4, N - 8 ... and so on.
The benefits to this can be many due to the magical nature of numbers and cryptrography, but two main reasons are 
- Early detection of forks and malicious peers at the point of fork.
- Possibility of Existence of stateless clients.
## Links
- [1] https://db.in.tum.de/~leis/papers/ART.pdf
