### PR TITLE
Rename `WasmExecutionError`.

### DIFF
--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -60,7 +60,7 @@ pub use crate::wasm::test as wasm_test;
 #[cfg(with_wasm_runtime)]
 pub use crate::wasm::{
     ContractEntrypoints, ContractSystemApi, ServiceEntrypoints, ServiceSystemApi, SystemApiData,
-    ViewSystemApi, WasmContractModule, WasmExecutionError, WasmServiceModule,
+    ViewSystemApi, WasmContractModule, VmExecutionError, WasmServiceModule,
 };
 pub use crate::{
     applications::ApplicationRegistryView,
@@ -199,7 +199,7 @@ pub enum ExecutionError {
     UserError(String),
     #[cfg(any(with_wasmer, with_wasmtime))]
     #[error(transparent)]
-    WasmError(#[from] WasmExecutionError),
+    WasmError(#[from] VmExecutionError),
     #[error(transparent)]
     DecompressionError(#[from] DecompressionError),
     #[error("The given promise is invalid or was polled once already")]

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -80,11 +80,11 @@ impl WasmContractModule {
     pub async fn new(
         contract_bytecode: Bytecode,
         runtime: WasmRuntime,
-    ) -> Result<Self, WasmExecutionError> {
+    ) -> Result<Self, VmExecutionError> {
         let contract_bytecode = if runtime.needs_sanitizer() {
             // Ensure bytecode normalization whenever wasmer and wasmtime are possibly
             // compared.
-            sanitize(contract_bytecode).map_err(WasmExecutionError::LoadContractModule)?
+            sanitize(contract_bytecode).map_err(VmExecutionError::LoadContractModule)?
         } else {
             contract_bytecode
         };
@@ -105,12 +105,12 @@ impl WasmContractModule {
     pub async fn from_file(
         contract_bytecode_file: impl AsRef<std::path::Path>,
         runtime: WasmRuntime,
-    ) -> Result<Self, WasmExecutionError> {
+    ) -> Result<Self, VmExecutionError> {
         Self::new(
             Bytecode::load_from_file(contract_bytecode_file)
                 .await
                 .map_err(anyhow::Error::from)
-                .map_err(WasmExecutionError::LoadContractModule)?,
+                .map_err(VmExecutionError::LoadContractModule)?,
             runtime,
         )
         .await
@@ -154,7 +154,7 @@ impl WasmServiceModule {
     pub async fn new(
         service_bytecode: Bytecode,
         runtime: WasmRuntime,
-    ) -> Result<Self, WasmExecutionError> {
+    ) -> Result<Self, VmExecutionError> {
         match runtime {
             #[cfg(with_wasmer)]
             WasmRuntime::Wasmer | WasmRuntime::WasmerWithSanitizer => {
@@ -172,12 +172,12 @@ impl WasmServiceModule {
     pub async fn from_file(
         service_bytecode_file: impl AsRef<std::path::Path>,
         runtime: WasmRuntime,
-    ) -> Result<Self, WasmExecutionError> {
+    ) -> Result<Self, VmExecutionError> {
         Self::new(
             Bytecode::load_from_file(service_bytecode_file)
                 .await
                 .map_err(anyhow::Error::from)
-                .map_err(WasmExecutionError::LoadServiceModule)?,
+                .map_err(VmExecutionError::LoadServiceModule)?,
             runtime,
         )
         .await
@@ -271,7 +271,7 @@ const _: () = {
 /// Errors that can occur when executing a user application in a WebAssembly module.
 #[cfg(any(with_wasmer, with_wasmtime))]
 #[derive(Debug, Error)]
-pub enum WasmExecutionError {
+pub enum VmExecutionError {
     #[error("Failed to load contract Wasm module: {_0}")]
     LoadContractModule(#[source] anyhow::Error),
     #[error("Failed to load service Wasm module: {_0}")]
@@ -299,9 +299,9 @@ pub enum WasmExecutionError {
 }
 
 #[cfg(with_wasmer)]
-impl From<::wasmer::InstantiationError> for WasmExecutionError {
+impl From<::wasmer::InstantiationError> for VmExecutionError {
     fn from(instantiation_error: ::wasmer::InstantiationError) -> Self {
-        WasmExecutionError::InstantiateModuleWithWasmer(Box::new(instantiation_error))
+        VmExecutionError::InstantiateModuleWithWasmer(Box::new(instantiation_error))
     }
 }
 

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -15,10 +15,9 @@ use linera_views::batch::{Batch, WriteOperation};
 use linera_witty::{wit_export, Instance, RuntimeError};
 use tracing::log;
 
-use super::VmExecutionError;
 use crate::{
     BaseRuntime, BytecodeId, ContractRuntime, ContractSyncRuntimeHandle, ExecutionError,
-    ServiceRuntime, ServiceSyncRuntimeHandle,
+    ServiceRuntime, ServiceSyncRuntimeHandle, VmExecutionError,
 };
 
 /// Common host data used as the `UserData` of the system API implementations.

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -15,7 +15,7 @@ use linera_views::batch::{Batch, WriteOperation};
 use linera_witty::{wit_export, Instance, RuntimeError};
 use tracing::log;
 
-use super::WasmExecutionError;
+use super::VmExecutionError;
 use crate::{
     BaseRuntime, BytecodeId, ContractRuntime, ContractSyncRuntimeHandle, ExecutionError,
     ServiceRuntime, ServiceSyncRuntimeHandle,
@@ -65,12 +65,12 @@ impl<Runtime> SystemApiData<Runtime> {
         let type_erased_promise = self
             .active_promises
             .remove(&promise_id)
-            .ok_or_else(|| RuntimeError::Custom(WasmExecutionError::UnknownPromise.into()))?;
+            .ok_or_else(|| RuntimeError::Custom(VmExecutionError::UnknownPromise.into()))?;
 
         type_erased_promise
             .downcast()
             .map(|boxed_promise| *boxed_promise)
-            .map_err(|_| RuntimeError::Custom(WasmExecutionError::IncorrectPromise.into()))
+            .map_err(|_| RuntimeError::Custom(VmExecutionError::IncorrectPromise.into()))
     }
 }
 

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -16,12 +16,12 @@ use wasm_instrument::{gas_metering, parity_wasm};
 use super::{
     module_cache::ModuleCache,
     system_api::{ContractSystemApi, ServiceSystemApi, SystemApiData, ViewSystemApi, WriteBatch},
-    ContractEntrypoints, ServiceEntrypoints, VmExecutionError,
+    ContractEntrypoints, ServiceEntrypoints,
 };
 use crate::{
     wasm::{WasmContractModule, WasmServiceModule},
     ContractRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext,
-    QueryContext, ServiceRuntime,
+    QueryContext, ServiceRuntime, VmExecutionError,
 };
 
 /// An [`Engine`] instance configured to run application services.
@@ -192,7 +192,7 @@ impl From<wasmer::RuntimeError> for ExecutionError {
         error
             .downcast::<ExecutionError>()
             .unwrap_or_else(|unknown_error| {
-                ExecutionError::WasmError(VmExecutionError::ExecuteModuleInWasmer(unknown_error))
+                ExecutionError::VmError(VmExecutionError::ExecuteModuleInWasmer(unknown_error))
             })
     }
 }

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -13,12 +13,12 @@ use wasmtime::{AsContextMut, Config, Engine, Linker, Module, Store};
 use super::{
     module_cache::ModuleCache,
     system_api::{ContractSystemApi, ServiceSystemApi, SystemApiData, ViewSystemApi, WriteBatch},
-    ContractEntrypoints, ServiceEntrypoints, VmExecutionError,
+    ContractEntrypoints, ServiceEntrypoints,
 };
 use crate::{
     wasm::{WasmContractModule, WasmServiceModule},
     ContractRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext,
-    QueryContext, ServiceRuntime,
+    QueryContext, ServiceRuntime, VmExecutionError,
 };
 
 /// An [`Engine`] instance configured to run application contracts.


### PR DESCRIPTION
## Motivation

Subsequent to https://github.com/linera-io/linera-protocol/pull/3327 it was requested that the renaming done in a separate PR. This is done here.

## Proposal

Following changes are done:
* Rename `WasmExecutionError` as `VmExecutionError`.
* Rename `WasmError` as `VmError`.
* Move the `VmExecutionError` and `{CONTRACT,SERVICE}_INSTANTIATION_LATENCY` to `linera_execution/src/lib.rs`

## Test Plan

No change to CI as it is simply a renaming.

## Release Plan

Normal release schedule.

## Links

None.