### PR TITLE
Implement the functionalities of listing the `ChainIds`.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -57,6 +57,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera storage initialize`↴](#linera-storage-initialize)
 * [`linera storage list_namespaces`↴](#linera-storage-list_namespaces)
 * [`linera storage list_blob_ids`↴](#linera-storage-list_blob_ids)
+* [`linera storage list_chain_ids`↴](#linera-storage-list_chain_ids)
 * [`linera storage list_root_keys`↴](#linera-storage-list_root_keys)
 
 ## `linera`
@@ -964,7 +965,8 @@ Operation on the storage
 * `check_absence` — Check absence of a namespace in the database
 * `initialize` — Initialize a namespace in the database
 * `list_namespaces` — List the namespaces of the database
-* `list_blob_ids` — List the blobs of the database
+* `list_blob_ids` — List the blob ids of the database
+* `list_chain_ids` — List the chain ids of the database
 * `list_root_keys` — List the root keys of the database
 
 
@@ -1043,9 +1045,21 @@ List the namespaces of the database
 
 ## `linera storage list_blob_ids`
 
-List the blobs of the database
+List the blob ids of the database
 
 **Usage:** `linera storage list_blob_ids --storage <STORAGE_CONFIG>`
+
+###### **Options:**
+
+* `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
+
+
+
+## `linera storage list_chain_ids`
+
+List the chain ids of the database
+
+**Usage:** `linera storage list_chain_ids --storage <STORAGE_CONFIG>`
 
 ###### **Options:**
 

--- a/CLI.md
+++ b/CLI.md
@@ -58,7 +58,6 @@ This document contains the help content for the `linera` command-line program.
 * [`linera storage list_namespaces`↴](#linera-storage-list_namespaces)
 * [`linera storage list_blob_ids`↴](#linera-storage-list_blob_ids)
 * [`linera storage list_chain_ids`↴](#linera-storage-list_chain_ids)
-* [`linera storage list_root_keys`↴](#linera-storage-list_root_keys)
 
 ## `linera`
 
@@ -967,7 +966,6 @@ Operation on the storage
 * `list_namespaces` — List the namespaces of the database
 * `list_blob_ids` — List the blob ids of the database
 * `list_chain_ids` — List the chain ids of the database
-* `list_root_keys` — List the root keys of the database
 
 
 
@@ -1060,18 +1058,6 @@ List the blob ids of the database
 List the chain ids of the database
 
 **Usage:** `linera storage list_chain_ids --storage <STORAGE_CONFIG>`
-
-###### **Options:**
-
-* `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
-
-
-
-## `linera storage list_root_keys`
-
-List the root keys of the database
-
-**Usage:** `linera storage list_root_keys --storage <STORAGE_CONFIG>`
 
 ###### **Options:**
 

--- a/CLI.md
+++ b/CLI.md
@@ -958,20 +958,20 @@ Operation on the storage
 
 ###### **Subcommands:**
 
-* `delete_all` — Delete all the namespaces of the database
+* `delete_all` — Delete all the namespaces in the database
 * `delete_namespace` — Delete a single namespace from the database
 * `check_existence` — Check existence of a namespace in the database
 * `check_absence` — Check absence of a namespace in the database
 * `initialize` — Initialize a namespace in the database
-* `list_namespaces` — List the namespaces of the database
-* `list_blob_ids` — List the blob IDs of the database
-* `list_chain_ids` — List the chain IDs of the database
+* `list_namespaces` — List the namespaces in the database
+* `list_blob_ids` — List the blob IDs in the database
+* `list_chain_ids` — List the chain IDs in the database
 
 
 
 ## `linera storage delete_all`
 
-Delete all the namespaces of the database
+Delete all the namespaces in the database
 
 **Usage:** `linera storage delete_all --storage <STORAGE_CONFIG>`
 
@@ -1031,7 +1031,7 @@ Initialize a namespace in the database
 
 ## `linera storage list_namespaces`
 
-List the namespaces of the database
+List the namespaces in the database
 
 **Usage:** `linera storage list_namespaces --storage <STORAGE_CONFIG>`
 
@@ -1043,7 +1043,7 @@ List the namespaces of the database
 
 ## `linera storage list_blob_ids`
 
-List the blob IDs of the database
+List the blob IDs in the database
 
 **Usage:** `linera storage list_blob_ids --storage <STORAGE_CONFIG>`
 
@@ -1055,7 +1055,7 @@ List the blob IDs of the database
 
 ## `linera storage list_chain_ids`
 
-List the chain IDs of the database
+List the chain IDs in the database
 
 **Usage:** `linera storage list_chain_ids --storage <STORAGE_CONFIG>`
 

--- a/CLI.md
+++ b/CLI.md
@@ -964,8 +964,8 @@ Operation on the storage
 * `check_absence` — Check absence of a namespace in the database
 * `initialize` — Initialize a namespace in the database
 * `list_namespaces` — List the namespaces of the database
-* `list_blob_ids` — List the blob ids of the database
-* `list_chain_ids` — List the chain ids of the database
+* `list_blob_ids` — List the blob IDs of the database
+* `list_chain_ids` — List the chain IDs of the database
 
 
 
@@ -1043,7 +1043,7 @@ List the namespaces of the database
 
 ## `linera storage list_blob_ids`
 
-List the blob ids of the database
+List the blob IDs of the database
 
 **Usage:** `linera storage list_blob_ids --storage <STORAGE_CONFIG>`
 
@@ -1055,7 +1055,7 @@ List the blob ids of the database
 
 ## `linera storage list_chain_ids`
 
-List the chain ids of the database
+List the chain IDs of the database
 
 **Usage:** `linera storage list_chain_ids --storage <STORAGE_CONFIG>`
 

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -518,7 +518,7 @@ impl Block {
         blob_ids
     }
 
-    /// Returns set of blob ids that were a result of an oracle call.
+    /// Returns set of blob IDs that were a result of an oracle call.
     pub fn oracle_blob_ids(&self) -> BTreeSet<BlobId> {
         let mut required_blob_ids = BTreeSet::new();
         for responses in &self.body.oracle_responses {

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -944,7 +944,7 @@ pub static DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS: &str = "3";
 
 #[derive(Clone, clap::Parser)]
 pub enum DatabaseToolCommand {
-    /// Delete all the namespaces of the database
+    /// Delete all the namespaces in the database
     #[command(name = "delete_all")]
     DeleteAll {
         /// Storage configuration for the blockchain history.
@@ -984,7 +984,7 @@ pub enum DatabaseToolCommand {
         storage_config: String,
     },
 
-    /// List the namespaces of the database
+    /// List the namespaces in the database
     #[command(name = "list_namespaces")]
     ListNamespaces {
         /// Storage configuration for the blockchain history.
@@ -992,7 +992,7 @@ pub enum DatabaseToolCommand {
         storage_config: String,
     },
 
-    /// List the blob IDs of the database
+    /// List the blob IDs in the database
     #[command(name = "list_blob_ids")]
     ListBlobIds {
         /// Storage configuration for the blockchain history.
@@ -1000,7 +1000,7 @@ pub enum DatabaseToolCommand {
         storage_config: String,
     },
 
-    /// List the chain IDs of the database
+    /// List the chain IDs in the database
     #[command(name = "list_chain_ids")]
     ListChainIds {
         /// Storage configuration for the blockchain history.

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -992,9 +992,17 @@ pub enum DatabaseToolCommand {
         storage_config: String,
     },
 
-    /// List the blobs of the database
+    /// List the blob ids of the database
     #[command(name = "list_blob_ids")]
     ListBlobIds {
+        /// Storage configuration for the blockchain history.
+        #[arg(long = "storage")]
+        storage_config: String,
+    },
+
+    /// List the chain ids of the database
+    #[command(name = "list_chain_ids")]
+    ListChainIds {
         /// Storage configuration for the blockchain history.
         #[arg(long = "storage")]
         storage_config: String,
@@ -1019,6 +1027,7 @@ impl DatabaseToolCommand {
             DatabaseToolCommand::Initialize { storage_config } => storage_config,
             DatabaseToolCommand::ListNamespaces { storage_config } => storage_config,
             DatabaseToolCommand::ListBlobIds { storage_config } => storage_config,
+            DatabaseToolCommand::ListChainIds { storage_config } => storage_config,
             DatabaseToolCommand::ListRootKeys { storage_config } => storage_config,
         };
         Ok(storage_config.parse::<StorageConfigNamespace>()?)

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -992,7 +992,7 @@ pub enum DatabaseToolCommand {
         storage_config: String,
     },
 
-    /// List the blob ids of the database
+    /// List the blob IDs of the database
     #[command(name = "list_blob_ids")]
     ListBlobIds {
         /// Storage configuration for the blockchain history.
@@ -1000,7 +1000,7 @@ pub enum DatabaseToolCommand {
         storage_config: String,
     },
 
-    /// List the chain ids of the database
+    /// List the chain IDs of the database
     #[command(name = "list_chain_ids")]
     ListChainIds {
         /// Storage configuration for the blockchain history.

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -1007,14 +1007,6 @@ pub enum DatabaseToolCommand {
         #[arg(long = "storage")]
         storage_config: String,
     },
-
-    /// List the root keys of the database
-    #[command(name = "list_root_keys")]
-    ListRootKeys {
-        /// Storage configuration for the blockchain history.
-        #[arg(long = "storage")]
-        storage_config: String,
-    },
 }
 
 impl DatabaseToolCommand {
@@ -1028,7 +1020,6 @@ impl DatabaseToolCommand {
             DatabaseToolCommand::ListNamespaces { storage_config } => storage_config,
             DatabaseToolCommand::ListBlobIds { storage_config } => storage_config,
             DatabaseToolCommand::ListChainIds { storage_config } => storage_config,
-            DatabaseToolCommand::ListRootKeys { storage_config } => storage_config,
         };
         Ok(storage_config.parse::<StorageConfigNamespace>()?)
     }

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -598,7 +598,7 @@ impl StoreConfig {
         match self {
             StoreConfig::Memory(_, _) => Err(ViewError::StoreError {
                 backend: "memory".to_string(),
-                error: "list_root_keys is not supported for the memory storage".to_string(),
+                error: "list_chain_ids is not supported for the memory storage".to_string(),
             }),
             #[cfg(feature = "storage-service")]
             StoreConfig::Service(config, namespace) => {
@@ -615,32 +615,6 @@ impl StoreConfig {
             #[cfg(feature = "scylladb")]
             StoreConfig::ScyllaDb(config, namespace) => {
                 Ok(list_all_chain_ids::<ScyllaDbStore>(&config, &namespace).await?)
-            }
-        }
-    }
-
-    /// Lists all root keys of the storage
-    pub async fn list_root_keys(self) -> Result<Vec<Vec<u8>>, ViewError> {
-        match self {
-            StoreConfig::Memory(_, _) => Err(ViewError::StoreError {
-                backend: "memory".to_string(),
-                error: "list_root_keys is not supported for the memory storage".to_string(),
-            }),
-            #[cfg(feature = "storage-service")]
-            StoreConfig::Service(config, namespace) => {
-                Ok(ServiceStoreClient::list_root_keys(&config, &namespace).await?)
-            }
-            #[cfg(feature = "rocksdb")]
-            StoreConfig::RocksDb(config, namespace) => {
-                Ok(RocksDbStore::list_root_keys(&config, &namespace).await?)
-            }
-            #[cfg(feature = "dynamodb")]
-            StoreConfig::DynamoDb(config, namespace) => {
-                Ok(DynamoDbStore::list_root_keys(&config, &namespace).await?)
-            }
-            #[cfg(feature = "scylladb")]
-            StoreConfig::ScyllaDb(config, namespace) => {
-                Ok(ScyllaDbStore::list_root_keys(&config, &namespace).await?)
             }
         }
     }

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -593,7 +593,7 @@ impl StoreConfig {
         }
     }
 
-    /// Lists all the chain ids of the storage
+    /// Lists all the chain IDs of the storage
     pub async fn list_chain_ids(self) -> Result<Vec<ChainId>, ViewError> {
         match self {
             StoreConfig::Memory(_, _) => Err(ViewError::StoreError {

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -593,32 +593,6 @@ impl StoreConfig {
         }
     }
 
-    /// Lists all root keys of the storage
-    pub async fn list_root_keys(self) -> Result<Vec<Vec<u8>>, ViewError> {
-        match self {
-            StoreConfig::Memory(_, _) => Err(ViewError::StoreError {
-                backend: "memory".to_string(),
-                error: "list_root_keys is not supported for the memory storage".to_string(),
-            }),
-            #[cfg(feature = "storage-service")]
-            StoreConfig::Service(config, namespace) => {
-                Ok(ServiceStoreClient::list_root_keys(&config, &namespace).await?)
-            }
-            #[cfg(feature = "rocksdb")]
-            StoreConfig::RocksDb(config, namespace) => {
-                Ok(RocksDbStore::list_root_keys(&config, &namespace).await?)
-            }
-            #[cfg(feature = "dynamodb")]
-            StoreConfig::DynamoDb(config, namespace) => {
-                Ok(DynamoDbStore::list_root_keys(&config, &namespace).await?)
-            }
-            #[cfg(feature = "scylladb")]
-            StoreConfig::ScyllaDb(config, namespace) => {
-                Ok(ScyllaDbStore::list_root_keys(&config, &namespace).await?)
-            }
-        }
-    }
-
     /// Lists all the chain ids of the storage
     pub async fn list_chain_ids(self) -> Result<Vec<ChainId>, ViewError> {
         match self {
@@ -641,6 +615,32 @@ impl StoreConfig {
             #[cfg(feature = "scylladb")]
             StoreConfig::ScyllaDb(config, namespace) => {
                 Ok(list_all_chain_ids::<ScyllaDbStore>(&config, &namespace).await?)
+            }
+        }
+    }
+
+    /// Lists all root keys of the storage
+    pub async fn list_root_keys(self) -> Result<Vec<Vec<u8>>, ViewError> {
+        match self {
+            StoreConfig::Memory(_, _) => Err(ViewError::StoreError {
+                backend: "memory".to_string(),
+                error: "list_root_keys is not supported for the memory storage".to_string(),
+            }),
+            #[cfg(feature = "storage-service")]
+            StoreConfig::Service(config, namespace) => {
+                Ok(ServiceStoreClient::list_root_keys(&config, &namespace).await?)
+            }
+            #[cfg(feature = "rocksdb")]
+            StoreConfig::RocksDb(config, namespace) => {
+                Ok(RocksDbStore::list_root_keys(&config, &namespace).await?)
+            }
+            #[cfg(feature = "dynamodb")]
+            StoreConfig::DynamoDb(config, namespace) => {
+                Ok(DynamoDbStore::list_root_keys(&config, &namespace).await?)
+            }
+            #[cfg(feature = "scylladb")]
+            StoreConfig::ScyllaDb(config, namespace) => {
+                Ok(ScyllaDbStore::list_root_keys(&config, &namespace).await?)
             }
         }
     }

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -136,7 +136,7 @@ pub trait ValidatorNode {
     /// Returns the hash of the `Certificate` that last used a blob.
     async fn blob_last_used_by(&self, blob_id: BlobId) -> Result<CryptoHash, NodeError>;
 
-    /// Returns the missing `Blob`s. by their ids.
+    /// Returns the missing `Blob`s. by their IDs.
     async fn missing_blob_ids(&self, blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError>;
 }
 

--- a/linera-execution/src/applications.rs
+++ b/linera-execution/src/applications.rs
@@ -53,7 +53,7 @@ where
         &mut self,
         application: UserApplicationDescription,
     ) -> Result<UserApplicationId, SystemExecutionError> {
-        // Make sure that referenced applications ids have been registered.
+        // Make sure that referenced applications IDs have been registered.
         for required_id in &application.required_application_ids {
             self.describe_application(*required_id).await?;
         }
@@ -69,7 +69,7 @@ where
         parameters: Vec<u8>,
         required_application_ids: Vec<UserApplicationId>,
     ) -> Result<(), SystemExecutionError> {
-        // Make sure that referenced applications ids have been registered.
+        // Make sure that referenced applications IDs have been registered.
         for required_id in &required_application_ids {
             self.describe_application(*required_id).await?;
         }

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -40,7 +40,7 @@ pub enum GrpcProtoConversionError {
     SignatureError(ed25519_dalek::SignatureError),
     #[error("Cryptographic error: {0}")]
     CryptoError(#[from] CryptoError),
-    #[error("Inconsistent outer/inner chain ids")]
+    #[error("Inconsistent outer/inner chain IDs")]
     InconsistentChainId,
     #[error("Unrecognized certificate type")]
     InvalidCertificateType,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1752,6 +1752,11 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                     info!("Blob IDs listed in {} ms", start_time.elapsed().as_millis());
                     println!("The list of blob IDs is {:?}", blob_ids);
                 }
+                DatabaseToolCommand::ListChainIds { .. } => {
+                    let chain_ids = Box::pin(full_storage_config.list_chain_ids()).await?;
+                    info!("Chain IDs listed in {} ms", start_time.elapsed().as_millis());
+                    println!("The list of chain IDs is {:?}", chain_ids);
+                }
                 DatabaseToolCommand::ListRootKeys { .. } => {
                     let root_keys = Box::pin(full_storage_config.list_root_keys()).await?;
                     info!(

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1754,7 +1754,10 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                 }
                 DatabaseToolCommand::ListChainIds { .. } => {
                     let chain_ids = Box::pin(full_storage_config.list_chain_ids()).await?;
-                    info!("Chain IDs listed in {} ms", start_time.elapsed().as_millis());
+                    info!(
+                        "Chain IDs listed in {} ms",
+                        start_time.elapsed().as_millis()
+                    );
                     println!("The list of chain IDs is {:?}", chain_ids);
                 }
                 DatabaseToolCommand::ListRootKeys { .. } => {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1760,14 +1760,6 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                     );
                     println!("The list of chain IDs is {:?}", chain_ids);
                 }
-                DatabaseToolCommand::ListRootKeys { .. } => {
-                    let root_keys = Box::pin(full_storage_config.list_root_keys()).await?;
-                    info!(
-                        "Root keys listed in {} ms",
-                        start_time.elapsed().as_millis()
-                    );
-                    println!("The list of root keys is {:?}", root_keys);
-                }
             }
             Ok(0)
         }

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -315,7 +315,7 @@ mod tests {
     }
 }
 
-/// Lists the blob ids of the storage.
+/// Lists the blob IDs of the storage.
 pub async fn list_all_blob_ids<S: KeyValueStore>(store: &S) -> Result<Vec<BlobId>, ViewError> {
     let prefix = &[INDEX_BLOB_ID];
     let keys = store.find_keys_by_prefix(prefix).await?;
@@ -329,7 +329,7 @@ pub async fn list_all_blob_ids<S: KeyValueStore>(store: &S) -> Result<Vec<BlobId
     Ok(blob_ids)
 }
 
-/// Lists the chain ids of the storage.
+/// Lists the chain IDs of the storage.
 pub async fn list_all_chain_ids<S: AdminKeyValueStore>(
     config: &S::Config,
     namespace: &str,

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -25,7 +25,7 @@ use linera_views::{
     backends::dual::{DualStoreRootKeyAssignment, StoreInUse},
     batch::Batch,
     context::ViewContext,
-    store::{KeyIterable as _, KeyValueStore},
+    store::{AdminKeyValueStore, KeyIterable as _, KeyValueStore},
     views::{View, ViewError},
 };
 use serde::{Deserialize, Serialize};
@@ -277,17 +277,19 @@ enum BaseKey {
     Event(EventId),
 }
 
-const INDEX_BLOB: u8 = 3;
-const BLOB_LENGTH: usize = std::mem::size_of::<BlobId>();
+const INDEX_CHAIN_ID: u8 = 0;
+const INDEX_BLOB_ID: u8 = 3;
+const CHAIN_ID_LENGTH: usize = std::mem::size_of::<ChainId>();
+const BLOB_ID_LENGTH: usize = std::mem::size_of::<BlobId>();
 
 #[cfg(test)]
 mod tests {
     use linera_base::{
         crypto::CryptoHash,
-        identifiers::{BlobId, BlobType},
+        identifiers::{BlobId, BlobType, ChainId},
     };
 
-    use crate::db_storage::{BaseKey, INDEX_BLOB};
+    use crate::db_storage::{BaseKey, BLOB_ID_LENGTH, CHAIN_ID_LENGTH, INDEX_BLOB_ID, INDEX_CHAIN_ID};
 
     #[test]
     fn test_base_key_serialization() {
@@ -296,22 +298,47 @@ mod tests {
         let blob_id = BlobId::new(hash, blob_type);
         let base_key = BaseKey::Blob(blob_id);
         let key = bcs::to_bytes(&base_key).expect("a key");
-        assert_eq!(key[0], INDEX_BLOB);
+        assert_eq!(key[0], INDEX_BLOB_ID);
+        assert_eq!(key.len(), 1 + BLOB_ID_LENGTH);
+    }
+
+    #[test]
+    fn test_chain_id_serialization() {
+        let hash = CryptoHash::default();
+        let chain_id = ChainId(hash);
+        let base_key = BaseKey::ChainState(chain_id);
+        let key = bcs::to_bytes(&base_key).expect("a key");
+        assert_eq!(key[0], INDEX_CHAIN_ID);
+        assert_eq!(key.len(), 1 + CHAIN_ID_LENGTH);
     }
 }
 
-/// Lists the blobs of the storage.
+/// Lists the blob ids of the storage.
 pub async fn list_all_blob_ids<S: KeyValueStore>(store: &S) -> Result<Vec<BlobId>, ViewError> {
-    let prefix = &[INDEX_BLOB];
+    let prefix = &[INDEX_BLOB_ID];
     let keys = store.find_keys_by_prefix(prefix).await?;
     let mut blob_ids = Vec::new();
     for key in keys.iterator() {
         let key = key?;
-        let key_red = &key[..BLOB_LENGTH];
+        let key_red = &key[..BLOB_ID_LENGTH];
         let blob_id = bcs::from_bytes(key_red)?;
         blob_ids.push(blob_id);
     }
     Ok(blob_ids)
+}
+
+/// Lists the chain ids of the storage.
+pub async fn list_all_chain_ids<S: AdminKeyValueStore>(config: &S::Config, namespace: &str) -> Result<Vec<ChainId>, ViewError> {
+    let root_keys = S::list_root_keys(config, namespace).await?;
+    let mut chain_ids = Vec::new();
+    for root_key in root_keys {
+        if root_key.len() == 1 + CHAIN_ID_LENGTH && root_key[0] == INDEX_CHAIN_ID {
+            let root_key_red = &root_key[1..1 + CHAIN_ID_LENGTH];
+            let chain_id = bcs::from_bytes(root_key_red)?;
+            chain_ids.push(chain_id);
+        }
+    }
+    Ok(chain_ids)
 }
 
 /// An implementation of [`DualStoreRootKeyAssignment`] that stores the

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -289,7 +289,9 @@ mod tests {
         identifiers::{BlobId, BlobType, ChainId},
     };
 
-    use crate::db_storage::{BaseKey, BLOB_ID_LENGTH, CHAIN_ID_LENGTH, INDEX_BLOB_ID, INDEX_CHAIN_ID};
+    use crate::db_storage::{
+        BaseKey, BLOB_ID_LENGTH, CHAIN_ID_LENGTH, INDEX_BLOB_ID, INDEX_CHAIN_ID,
+    };
 
     #[test]
     fn test_base_key_serialization() {
@@ -328,7 +330,10 @@ pub async fn list_all_blob_ids<S: KeyValueStore>(store: &S) -> Result<Vec<BlobId
 }
 
 /// Lists the chain ids of the storage.
-pub async fn list_all_chain_ids<S: AdminKeyValueStore>(config: &S::Config, namespace: &str) -> Result<Vec<ChainId>, ViewError> {
+pub async fn list_all_chain_ids<S: AdminKeyValueStore>(
+    config: &S::Config,
+    namespace: &str,
+) -> Result<Vec<ChainId>, ViewError> {
     let root_keys = S::list_root_keys(config, namespace).await?;
     let mut chain_ids = Vec::new();
     for root_key in root_keys {

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -40,7 +40,7 @@ use {
 
 #[cfg(with_testing)]
 pub use crate::db_storage::TestClock;
-pub use crate::db_storage::{list_all_blob_ids, ChainStatesFirstAssignment, DbStorage, WallClock};
+pub use crate::db_storage::{list_all_blob_ids, list_all_chain_ids, ChainStatesFirstAssignment, DbStorage, WallClock};
 #[cfg(with_metrics)]
 pub use crate::db_storage::{
     READ_CERTIFICATE_COUNTER, READ_HASHED_CONFIRMED_BLOCK_COUNTER, WRITE_CERTIFICATE_COUNTER,

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -40,7 +40,9 @@ use {
 
 #[cfg(with_testing)]
 pub use crate::db_storage::TestClock;
-pub use crate::db_storage::{list_all_blob_ids, list_all_chain_ids, ChainStatesFirstAssignment, DbStorage, WallClock};
+pub use crate::db_storage::{
+    list_all_blob_ids, list_all_chain_ids, ChainStatesFirstAssignment, DbStorage, WallClock,
+};
 #[cfg(with_metrics)]
 pub use crate::db_storage::{
     READ_CERTIFICATE_COUNTER, READ_HASHED_CONFIRMED_BLOCK_COUNTER, WRITE_CERTIFICATE_COUNTER,


### PR DESCRIPTION
## Motivation

We implement here the functionality of listing the Chain Ids from a storage.

## Proposal

The implementation follows the same path as from the implementation of the listing of the BlobIds by using the `list_root_keys`.

## Test Plan

The functionality was tested locally by running the non-fungible test and listing the ChainIds.

## Release Plan

Normal release schedule.

## Links

None.