### PR TITLE
Use secp256k1 features depending on the target arch.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3546,6 +3562,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -7051,6 +7076,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
+ "bitcoin_hashes",
  "rand",
  "secp256k1-sys",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ reqwest = { version = "0.11.24", default-features = false, features = [
     "rustls-tls",
 ] }
 rocksdb = "0.21.0"
-secp256k1 = { version = "0.30.0", default-features = false, features = [ "alloc", "rand", "serde" ] }
+secp256k1 = { version = "0.30.0", default-features = false }
 scylla = "0.15.1"
 semver = "1.0.22"
 serde = { version = "1.0.197", features = ["derive"] }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1139,6 +1139,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,6 +2990,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -5420,6 +5445,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
+ "bitcoin_hashes",
  "rand",
  "secp256k1-sys",
  "serde",

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -47,7 +47,6 @@ linera-witty = { workspace = true, features = ["macros"] }
 prometheus = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true, features = ["alloc"] }
 rand.workspace = true
-secp256k1.workspace = true
 serde.workspace = true
 serde-name.workspace = true
 serde_bytes.workspace = true
@@ -67,11 +66,13 @@ web-time = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 ruzstd.workspace = true
+secp256k1 = { workspace = true, features = [ "alloc", "rand", "serde" ] }
 tracing-web = { optional = true, workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono.workspace = true
 rand = { workspace = true, features = ["getrandom", "std", "std_rng"] }
+secp256k1 = { workspace = true, features = [ "std", "rand", "serde" ] }
 tokio = { workspace = true, features = ["process", "rt-multi-thread", "signal", "macros"] }
 tokio-util.workspace = true
 prometheus.workspace = true


### PR DESCRIPTION
## Motivation

We want to have `thread::rng` in `std` environments but `Secp256k1` constructor feature-gates its usage based on the target arch which does NOT randomize the secp256k1 context if `feature = "std"` is not enabled.
```rust
#[cfg(all(
                not(target_arch = "wasm32"),
                feature = "rand",
                feature = "std",
                not(feature = "global-context-less-secure")
            ))]
            {
                ctx.randomize(&mut rand::thread_rng());
            }
```

To get around the compilation of `linera-base` in wasm32 environments (like indexer or examples) I used `alloc` feature instead of `std` but that means secp256k1 context was NOT randomized properly which could have lead to some cryptography-related problems.

## Proposal

Enable `secp256k1` features conditionally - depending on the target architecture for which it is being compiled.

## Test Plan

N/A

## Release Plan


- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
