### PR TITLE
Make sure we include end_value in generated Prometheus buckets

### DIFF
--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -44,10 +44,14 @@ pub fn bucket_interval(start_value: f64, end_value: f64) -> Option<Vec<f64>> {
     let factor = 3.0_f64;
     let count_approx = quot.ln() / factor.ln();
     let count = count_approx.round() as usize;
-    Some(
-        exponential_buckets(start_value, factor, count)
-            .expect("Exponential buckets creation should not fail!"),
-    )
+    let mut buckets = exponential_buckets(start_value, factor, count)
+        .expect("Exponential buckets creation should not fail!");
+    if let Some(last) = buckets.last() {
+        if *last < end_value {
+            buckets.push(end_value);
+        }
+    }
+    Some(buckets)
 }
 
 /// Construct the latencies starting from 0.0001 and ending at the maximum latency


### PR DESCRIPTION
## Motivation

Right now we're generating the buckets, but it's not in an inclusive way, and it should be. For latency metrics, for example, you have `end_value` being 500ms, but one of the buckets is 159. Since we're using a multiplication factor of 3, the next bucket would go over 500ms, so we don't include it...

## Proposal

Make sure we always include the `end_value` bucket

## Test Plan

CI + start a network locally and see the correct buckets exported

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
