### PR TITLE
`linera-faucet-client`: remove `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4678,19 +4678,22 @@ version = "0.14.0"
 dependencies = [
  "async-graphql",
  "linera-base",
+ "serde",
 ]
 
 [[package]]
 name = "linera-faucet-client"
 version = "0.14.0"
 dependencies = [
- "anyhow",
  "linera-base",
  "linera-client",
  "linera-faucet",
  "linera-version",
  "reqwest 0.11.27",
+ "serde",
  "serde_json",
+ "thiserror 1.0.69",
+ "thiserror-context",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,6 +2582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -4679,6 +4680,7 @@ dependencies = [
  "async-graphql",
  "linera-base",
  "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -7458,6 +7460,36 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.7.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,6 @@ async-trait = "0.1.77"
 async-tungstenite = { version = "0.22", features = ["tokio-runtime"] }
 aws-config = "1.1.7"
 aws-sdk-dynamodb = "1.60.0"
-aws-sdk-s3 = "1.17.0"
-aws-smithy-http = "0.60.6"
-aws-types = "1.1.7"
 aws-smithy-types = "1.1.7"
 axum = "0.7.4"
 base64 = "0.22.0"
@@ -98,7 +95,6 @@ hex = "0.4.3"
 http = "1.1.0"
 humantime = "2.1.0"
 glob = "0.3.1"
-gloo-storage = "0.3.0"
 gloo-utils = "0.2.0"
 indexed_db_futures = "0.4.1"
 insta = "1.36.1"
@@ -200,7 +196,6 @@ wasmtime = { version = "25.0.0", default-features = false, features = [
     "std",
 ] }
 wasmtimer = "0.2.0"
-webassembly-test = "0.1.0"
 web-sys = "0.3.69"
 js-sys = "0.3.70"
 web-time = "1.1.0"
@@ -228,7 +223,6 @@ linera-views = { version = "0.14.0", path = "./linera-views", default-features =
 linera-views-derive = { version = "0.14.0", path = "./linera-views-derive" }
 linera-witty = { version = "0.14.0", path = "./linera-witty" }
 linera-witty-macros = { version = "0.14.0", path = "./linera-witty-macros" }
-linera-witty-test-modules = { version = "0.14.0", path = "./linera-witty/test-modules" }
 linera-sdk-derive = { version = "0.14.0", path = "./linera-sdk-derive" }
 linera-service = { version = "0.14.0", path = "./linera-service", default-features = false }
 linera-service-graphql-client = { version = "0.14.0", path = "./linera-service-graphql-client" }

--- a/linera-faucet/Cargo.toml
+++ b/linera-faucet/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 
 [dependencies]
 linera-base.workspace = true
+serde.workspace = true
 
 [dependencies.async-graphql]
 workspace = true

--- a/linera-faucet/Cargo.toml
+++ b/linera-faucet/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 [dependencies]
 linera-base.workspace = true
 serde.workspace = true
+serde_with = "3.12.0"
 
 [dependencies.async-graphql]
 workspace = true

--- a/linera-faucet/client/Cargo.toml
+++ b/linera-faucet/client/Cargo.toml
@@ -8,10 +8,12 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 linera-base.workspace = true
 linera-client.workspace = true
 linera-faucet = { version = "0.14.0", path = ".." }
 linera-version.workspace = true
 reqwest.workspace = true
+serde.workspace = true
 serde_json.workspace = true
+thiserror.workspace = true
+thiserror-context.workspace = true

--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -3,35 +3,37 @@
 
 //! The client component of the Linera faucet.
 
-use anyhow::{bail, Context, Result};
-use linera_base::{crypto::ValidatorPublicKey, identifiers::Owner};
+// TODO(3362): generate this code
+
+use linera_base::crypto::ValidatorPublicKey;
 use linera_client::config::GenesisConfig;
 use linera_faucet::ClaimOutcome;
 use linera_version::VersionInfo;
-use serde_json::{json, Value};
+use thiserror_context::Context;
 
-fn truncate_query_output(input: &str) -> String {
-    let max_len = 200;
-    if input.len() < max_len {
-        input.to_string()
-    } else {
-        format!("{} ...", input.get(..max_len).unwrap())
-    }
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ErrorInner {
+    #[error("JSON parsing error: {0:?}")]
+    Json(#[from] serde_json::Error),
+    #[error("GraphQL error: {0:?}")]
+    GraphQl(Vec<serde_json::Value>),
+    #[error("HTTP error: {0:?}")]
+    Http(#[from] reqwest::Error),
 }
 
-fn reqwest_client() -> reqwest::Client {
-    let builder = reqwest::ClientBuilder::new();
-
-    #[cfg(not(target_arch = "wasm32"))]
-    let builder = builder.timeout(std::time::Duration::from_secs(30));
-
-    builder.build().unwrap()
-}
+thiserror_context::impl_context!(Error(ErrorInner));
 
 /// A faucet instance that can be queried.
 #[derive(Debug, Clone)]
 pub struct Faucet {
     url: String,
+}
+
+#[derive(serde::Deserialize)]
+struct GraphQlResponse<T> {
+    data: Option<T>,
+    errors: Option<Vec<serde_json::Value>>,
 }
 
 impl Faucet {
@@ -43,170 +45,107 @@ impl Faucet {
         &self.url
     }
 
-    pub async fn genesis_config(&self) -> Result<GenesisConfig> {
-        let query = "query { genesisConfig }";
-        let client = reqwest_client();
-        let response = client
+    async fn query<Response: serde::de::DeserializeOwned>(
+        &self,
+        query: &str,
+    ) -> Result<Response, Error> {
+        let builder = reqwest::ClientBuilder::new();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let builder = builder.timeout(std::time::Duration::from_secs(30));
+
+        let response: GraphQlResponse<Response> = builder
+            .build()
+            .unwrap()
             .post(&self.url)
-            .json(&json!({ "query": query }))
+            .json(&serde_json::json!({
+                "query": query,
+            }))
             .send()
             .await
-            .context("genesis_config: failed to post query")?;
-        anyhow::ensure!(
-            response.status().is_success(),
-            "Query \"{}\" failed: {}",
-            query,
-            response
-                .text()
-                .await
-                .unwrap_or_else(|error| format!("Could not get response text: {error}"))
-        );
-        let mut value: Value = response.json().await.context("invalid JSON")?;
-        if let Some(errors) = value.get("errors") {
-            bail!("Query \"{}\" failed: {}", query, errors);
+            .with_context(|| format!("executing query {query:?}"))?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        if let Some(errors) = response.errors {
+            Err(ErrorInner::GraphQl(errors).into())
+        } else {
+            Ok(response
+                .data
+                .expect("no errors present but no data returned"))
         }
-        serde_json::from_value(value["data"]["genesisConfig"].take())
-            .context("could not parse genesis config")
     }
 
-    pub async fn version_info(&self) -> Result<VersionInfo> {
-        let query =
-            "query { version { crateVersion gitCommit gitDirty rpcHash graphqlHash witHash } }";
-        let client = reqwest_client();
-        let response = client
-            .post(&self.url)
-            .json(&json!({ "query": query }))
-            .send()
-            .await
-            .context("version_info: failed to post query")?;
-        anyhow::ensure!(
-            response.status().is_success(),
-            "Query \"{}\" failed: {}",
-            query,
-            response
-                .text()
-                .await
-                .unwrap_or_else(|error| format!("Could not get response text: {error}"))
-        );
-        let mut value: Value = response.json().await.context("invalid JSON")?;
-        if let Some(errors) = value.get("errors") {
-            bail!("Query \"{}\" failed: {}", query, errors);
+    pub async fn genesis_config(&self) -> Result<GenesisConfig, Error> {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Response {
+            genesis_config: GenesisConfig,
         }
-        let crate_version = serde_json::from_value(value["data"]["version"]["crateVersion"].take())
-            .context("could not parse crate version")?;
-        let git_commit = serde_json::from_value(value["data"]["version"]["gitCommit"].take())
-            .context("could not parse git commit")?;
-        let git_dirty = serde_json::from_value(value["data"]["version"]["gitDirty"].take())
-            .context("could not parse git dirty")?;
-        let rpc_hash = serde_json::from_value(value["data"]["version"]["rpcHash"].take())
-            .context("could not parse rpc hash")?;
-        let graphql_hash = serde_json::from_value(value["data"]["version"]["graphqlHash"].take())
-            .context("could not parse graphql hash")?;
-        let wit_hash = serde_json::from_value(value["data"]["version"]["witHash"].take())
-            .context("could not parse wit hash")?;
-        Ok(VersionInfo {
-            crate_version,
-            git_commit,
-            git_dirty,
-            rpc_hash,
-            graphql_hash,
-            wit_hash,
-        })
+
+        Ok(self
+            .query::<Response>("query { genesisConfig }")
+            .await?
+            .genesis_config)
     }
 
-    pub async fn claim(&self, owner: &Owner) -> Result<ClaimOutcome> {
+    pub async fn version_info(&self) -> Result<VersionInfo, Error> {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Response {
+            version: VersionInfo,
+        }
+
+        Ok(self
+            .query::<Response>(
+                "query { version { crateVersion gitCommit gitDirty rpcHash graphqlHash witHash } }",
+            )
+            .await?
+            .version)
+    }
+
+    pub async fn claim(
+        &self,
+        owner: &linera_base::identifiers::Owner,
+    ) -> Result<ClaimOutcome, Error> {
         let query = format!(
             "mutation {{ claim(owner: \"{owner}\") {{ \
                 messageId chainId certificateHash \
             }} }}"
         );
-        let client = reqwest_client();
-        let response = client
-            .post(&self.url)
-            .json(&json!({ "query": &query }))
-            .send()
-            .await
-            .with_context(|| {
-                format!(
-                    "claim: failed to post query={}",
-                    truncate_query_output(&query)
-                )
-            })?;
-        anyhow::ensure!(
-            response.status().is_success(),
-            "Query \"{}\" failed: {}",
-            query,
-            response
-                .text()
-                .await
-                .unwrap_or_else(|error| format!("Could not get response text: {error}"))
-        );
-        let value: Value = response.json().await.context("invalid JSON")?;
-        if let Some(errors) = value.get("errors") {
-            bail!("Query \"{}\" failed: {}", query, errors);
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Response {
+            claim: ClaimOutcome,
         }
-        let data = &value["data"]["claim"];
-        let message_id = data["messageId"]
-            .as_str()
-            .context("message ID not found")?
-            .parse()
-            .context("could not parse message ID")?;
-        let chain_id = data["chainId"]
-            .as_str()
-            .context("chain ID not found")?
-            .parse()
-            .context("could not parse chain ID")?;
-        let certificate_hash = data["certificateHash"]
-            .as_str()
-            .context("Certificate hash not found")?
-            .parse()
-            .context("could not parse certificate hash")?;
-        let outcome = ClaimOutcome {
-            message_id,
-            chain_id,
-            certificate_hash,
-        };
-        Ok(outcome)
+
+        Ok(self.query::<Response>(&query).await?.claim)
     }
 
-    pub async fn current_validators(&self) -> Result<Vec<(ValidatorPublicKey, String)>> {
+    pub async fn current_validators(&self) -> Result<Vec<(ValidatorPublicKey, String)>, Error> {
         let query = "query { currentValidators { publicKey networkAddress } }";
-        let client = reqwest_client();
-        let response = client
-            .post(&self.url)
-            .json(&json!({ "query": query }))
-            .send()
-            .await
-            .context("current_validators: failed to post query")?;
-        anyhow::ensure!(
-            response.status().is_success(),
-            "Query \"{}\" failed: {}",
-            query,
-            response
-                .text()
-                .await
-                .unwrap_or_else(|error| format!("Could not get response text: {error}"))
-        );
-        let mut value: Value = response.json().await.context("invalid JSON")?;
-        if let Some(errors) = value.get("errors") {
-            bail!("Query \"{}\" failed: {}", query, errors);
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Validator {
+            public_key: ValidatorPublicKey,
+            network_address: String,
         }
-        let validators = match value["data"]["currentValidators"].take() {
-            serde_json::Value::Array(validators) => validators,
-            validators => bail!("{validators} is not an array"),
-        };
-        validators
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Response {
+            current_validators: Vec<Validator>,
+        }
+
+        Ok(self
+            .query::<Response>(&query)
+            .await?
+            .current_validators
             .into_iter()
-            .map(|mut validator| {
-                let name =
-                    serde_json::from_value::<ValidatorPublicKey>(validator["publicKey"].take())
-                        .context("could not parse current validators: invalid name")?;
-                let addr = validator["networkAddress"]
-                    .as_str()
-                    .context("could not parse current validators: invalid address")?
-                    .to_string();
-                Ok((name, addr))
-            })
-            .collect()
+            .map(|validator| (validator.public_key, validator.network_address))
+            .collect())
     }
 }

--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -30,12 +30,6 @@ pub struct Faucet {
     url: String,
 }
 
-#[derive(serde::Deserialize)]
-struct GraphQlResponse<T> {
-    data: Option<T>,
-    errors: Option<Vec<serde_json::Value>>,
-}
-
 impl Faucet {
     pub fn new(url: String) -> Self {
         Self { url }
@@ -49,6 +43,12 @@ impl Faucet {
         &self,
         query: &str,
     ) -> Result<Response, Error> {
+        #[derive(serde::Deserialize)]
+        struct GraphQlResponse<T> {
+            data: Option<T>,
+            errors: Option<Vec<serde_json::Value>>,
+        }
+
         let builder = reqwest::ClientBuilder::new();
 
         #[cfg(not(target_arch = "wasm32"))]
@@ -125,8 +125,6 @@ impl Faucet {
     }
 
     pub async fn current_validators(&self) -> Result<Vec<(ValidatorPublicKey, String)>, Error> {
-        let query = "query { currentValidators { publicKey networkAddress } }";
-
         #[derive(serde::Deserialize)]
         #[serde(rename_all = "camelCase")]
         struct Validator {
@@ -141,7 +139,7 @@ impl Faucet {
         }
 
         Ok(self
-            .query::<Response>(&query)
+            .query::<Response>("query { currentValidators { publicKey networkAddress } }")
             .await?
             .current_validators
             .into_iter()

--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -3,7 +3,7 @@
 
 //! The client component of the Linera faucet.
 
-// TODO(3362): generate this code
+// TODO(#3362): generate this code
 
 use linera_base::crypto::ValidatorPublicKey;
 use linera_client::config::GenesisConfig;
@@ -92,17 +92,11 @@ impl Faucet {
 
     pub async fn version_info(&self) -> Result<VersionInfo, Error> {
         #[derive(serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
         struct Response {
             version: VersionInfo,
         }
 
-        Ok(self
-            .query::<Response>(
-                "query { version { crateVersion gitCommit gitDirty rpcHash graphqlHash witHash } }",
-            )
-            .await?
-            .version)
+        Ok(self.query::<Response>("query { version }").await?.version)
     }
 
     pub async fn claim(
@@ -116,7 +110,6 @@ impl Faucet {
         );
 
         #[derive(serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
         struct Response {
             claim: ClaimOutcome,
         }

--- a/linera-faucet/src/lib.rs
+++ b/linera-faucet/src/lib.rs
@@ -12,6 +12,7 @@ use linera_base::{
 
 /// The result of a successful `claim` mutation.
 #[cfg_attr(feature = "async-graphql", derive(async_graphql::SimpleObject))]
+#[derive(serde::Deserialize)]
 pub struct ClaimOutcome {
     /// The ID of the message that created the new chain.
     pub message_id: MessageId,

--- a/linera-faucet/src/lib.rs
+++ b/linera-faucet/src/lib.rs
@@ -12,12 +12,15 @@ use linera_base::{
 
 /// The result of a successful `claim` mutation.
 #[cfg_attr(feature = "async-graphql", derive(async_graphql::SimpleObject))]
+#[serde_with::serde_as]
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClaimOutcome {
     /// The ID of the message that created the new chain.
+    #[serde_as(as = "serde_with::DisplayFromStr")]
     pub message_id: MessageId,
     /// The ID of the new chain.
+    #[serde_as(as = "serde_with::DisplayFromStr")]
     pub chain_id: ChainId,
     /// The hash of the parent chain's certificate containing the `OpenChain` operation.
     pub certificate_hash: CryptoHash,

--- a/linera-faucet/src/lib.rs
+++ b/linera-faucet/src/lib.rs
@@ -13,6 +13,7 @@ use linera_base::{
 /// The result of a successful `claim` mutation.
 #[cfg_attr(feature = "async-graphql", derive(async_graphql::SimpleObject))]
 #[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ClaimOutcome {
     /// The ID of the message that created the new chain.
     pub message_id: MessageId,

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -424,11 +424,6 @@ type ConfirmedBlock {
 }
 
 """
-The version of the Linera crates used in this build
-"""
-scalar CrateVersion
-
-"""
 A Keccak256 value
 """
 scalar CryptoHash
@@ -1185,35 +1180,7 @@ Description of the necessary information to run a user application
 """
 scalar UserApplicationDescription
 
-"""
-The version info of a build of Linera.
-"""
-type VersionInfo {
-	"""
-	The crate version
-	"""
-	crateVersion: CrateVersion!
-	"""
-	The git commit hash
-	"""
-	gitCommit: String!
-	"""
-	Whether the git checkout was dirty
-	"""
-	gitDirty: Boolean!
-	"""
-	A hash of the RPC API
-	"""
-	rpcHash: String!
-	"""
-	A hash of the GraphQL API
-	"""
-	graphqlHash: String!
-	"""
-	A hash of the WIT API
-	"""
-	witHash: String!
-}
+scalar VersionInfo
 
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/linera-version/src/version_info/type.rs
+++ b/linera-version/src/version_info/type.rs
@@ -45,9 +45,11 @@ impl From<CrateVersion> for semver::Version {
 
 pub type Hash = std::borrow::Cow<'static, str>;
 
+// camelCase rename to align with the `SimpleObject` implementation.
 #[cfg_attr(
     linera_version_building,
-    derive(async_graphql::SimpleObject, serde::Deserialize, serde::Serialize)
+    derive(async_graphql::SimpleObject, serde::Deserialize, serde::Serialize),
+    serde(rename_all = "camelCase"),
 )]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 /// The version info of a build of Linera.

--- a/linera-version/src/version_info/type.rs
+++ b/linera-version/src/version_info/type.rs
@@ -45,12 +45,7 @@ impl From<CrateVersion> for semver::Version {
 
 pub type Hash = std::borrow::Cow<'static, str>;
 
-// camelCase rename to align with the `SimpleObject` implementation.
-#[cfg_attr(
-    linera_version_building,
-    derive(async_graphql::SimpleObject, serde::Deserialize, serde::Serialize),
-    serde(rename_all = "camelCase"),
-)]
+#[cfg_attr(linera_version_building, derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 /// The version info of a build of Linera.
 pub struct VersionInfo {
@@ -67,6 +62,9 @@ pub struct VersionInfo {
     /// A hash of the WIT API
     pub wit_hash: Hash,
 }
+
+#[cfg(linera_version_building)]
+async_graphql::scalar!(VersionInfo);
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {


### PR DESCRIPTION
## Motivation

`anyhow::Error` doesn't implement `std::error::Error`, and therefore can't be converted to a JavaScript error (`wasm_bindgen::JsError`).

## Proposal

Give `linera-faucet-client` a dedicated error type, with help from `thiserror` and `thiserror-context`.

## Test Plan

Refactor: should be tested by CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
