### PR TITLE
Refactor: Separate authority and chain owner keys.

### DIFF
--- a/examples/hex-game/tests/hex_game.rs
+++ b/examples/hex-game/tests/hex_game.rs
@@ -7,14 +7,14 @@
 
 use hex_game::{HexAbi, Operation, Timeouts};
 use linera_sdk::{
-    base::{Amount, ChainDescription, SigningKey, TimeDelta},
+    base::{AccountPrivateKey, Amount, ChainDescription, TimeDelta},
     test::{ActiveChain, QueryOutcome, TestValidator},
 };
 
 #[test_log::test(tokio::test)]
 async fn hex_game() {
-    let key_pair1 = SigningKey::generate();
-    let key_pair2 = SigningKey::generate();
+    let key_pair1 = AccountPrivateKey::generate();
+    let key_pair2 = AccountPrivateKey::generate();
 
     let (validator, app_id, creation_chain) =
         TestValidator::with_current_application::<HexAbi, _, _>((), Timeouts::default()).await;
@@ -74,8 +74,8 @@ async fn hex_game() {
 
 #[tokio::test]
 async fn hex_game_clock() {
-    let key_pair1 = SigningKey::generate();
-    let key_pair2 = SigningKey::generate();
+    let key_pair1 = AccountPrivateKey::generate();
+    let key_pair2 = AccountPrivateKey::generate();
 
     let timeouts = Timeouts {
         start_time: TimeDelta::from_secs(60),

--- a/examples/hex-game/tests/hex_game.rs
+++ b/examples/hex-game/tests/hex_game.rs
@@ -7,14 +7,14 @@
 
 use hex_game::{HexAbi, Operation, Timeouts};
 use linera_sdk::{
-    base::{AccountPrivateKey, Amount, ChainDescription, TimeDelta},
+    base::{AccountSecretKey, Amount, ChainDescription, TimeDelta},
     test::{ActiveChain, QueryOutcome, TestValidator},
 };
 
 #[test_log::test(tokio::test)]
 async fn hex_game() {
-    let key_pair1 = AccountPrivateKey::generate();
-    let key_pair2 = AccountPrivateKey::generate();
+    let key_pair1 = AccountSecretKey::generate();
+    let key_pair2 = AccountSecretKey::generate();
 
     let (validator, app_id, creation_chain) =
         TestValidator::with_current_application::<HexAbi, _, _>((), Timeouts::default()).await;
@@ -74,8 +74,8 @@ async fn hex_game() {
 
 #[tokio::test]
 async fn hex_game_clock() {
-    let key_pair1 = AccountPrivateKey::generate();
-    let key_pair2 = AccountPrivateKey::generate();
+    let key_pair1 = AccountSecretKey::generate();
+    let key_pair2 = AccountSecretKey::generate();
 
     let timeouts = Timeouts {
         start_time: TimeDelta::from_secs(60),

--- a/linera-base/src/crypto/mod.rs
+++ b/linera-base/src/crypto/mod.rs
@@ -16,12 +16,12 @@ pub use hash::*;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// The public key of an authority.
-pub type AuthorityPublicKey = ed25519::Ed25519PublicKey;
-/// The private key of an authority.
-pub type AuthorityPrivateKey = ed25519::Ed25519SecretKey;
-/// The signature of an authority.
-pub type AuthoritySignature = ed25519::Ed25519Signature;
+/// The public key of a validator.
+pub type ValidatorPublicKey = ed25519::Ed25519PublicKey;
+/// The private key of a validator.
+pub type ValidatorPrivateKey = ed25519::Ed25519SecretKey;
+/// The signature of a validator.
+pub type ValidatorSignature = ed25519::Ed25519Signature;
 
 /// The public key of a chain owner.
 /// Corresponding private key is allowed to propose blocks

--- a/linera-base/src/crypto/mod.rs
+++ b/linera-base/src/crypto/mod.rs
@@ -11,13 +11,26 @@ mod secp256k1;
 use std::{io, num::ParseIntError};
 
 use alloy_primitives::FixedBytes;
-pub use ed25519::{
-    Ed25519PublicKey as PublicKey, Ed25519SecretKey as SigningKey, Ed25519Signature as Signature,
-};
 use ed25519_dalek::{self as dalek};
 pub use hash::*;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+/// The public key of an authority.
+pub type AuthorityPublicKey = ed25519::Ed25519PublicKey;
+/// The private key of an authority.
+pub type AuthorityPrivateKey = ed25519::Ed25519SecretKey;
+/// The signature of an authority.
+pub type AuthoritySignature = ed25519::Ed25519Signature;
+
+/// The public key of a chain owner.
+/// Corresponding private key is allowed to propose blocks
+/// on the chain and transfer account's tokens.
+pub type AccountPublicKey = ed25519::Ed25519PublicKey;
+/// The private key of a chain owner.
+pub type AccountPrivateKey = ed25519::Ed25519SecretKey;
+/// The signature of a chain owner.
+pub type AccountSignature = ed25519::Ed25519Signature;
 
 /// Error type for cryptographic errors.
 #[derive(Error, Debug)]

--- a/linera-base/src/crypto/mod.rs
+++ b/linera-base/src/crypto/mod.rs
@@ -24,7 +24,7 @@ pub type ValidatorPrivateKey = ed25519::Ed25519SecretKey;
 pub type ValidatorSignature = ed25519::Ed25519Signature;
 
 /// The public key of a chain owner.
-/// Corresponding private key is allowed to propose blocks
+/// The corresponding private key is allowed to propose blocks
 /// on the chain and transfer account's tokens.
 pub type AccountPublicKey = ed25519::Ed25519PublicKey;
 /// The private key of a chain owner.

--- a/linera-base/src/crypto/mod.rs
+++ b/linera-base/src/crypto/mod.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 /// The public key of a validator.
 pub type ValidatorPublicKey = ed25519::Ed25519PublicKey;
 /// The private key of a validator.
-pub type ValidatorPrivateKey = ed25519::Ed25519SecretKey;
+pub type ValidatorSecretKey = ed25519::Ed25519SecretKey;
 /// The signature of a validator.
 pub type ValidatorSignature = ed25519::Ed25519Signature;
 
@@ -28,7 +28,7 @@ pub type ValidatorSignature = ed25519::Ed25519Signature;
 /// on the chain and transfer account's tokens.
 pub type AccountPublicKey = ed25519::Ed25519PublicKey;
 /// The private key of a chain owner.
-pub type AccountPrivateKey = ed25519::Ed25519SecretKey;
+pub type AccountSecretKey = ed25519::Ed25519SecretKey;
 /// The signature of a chain owner.
 pub type AccountSignature = ed25519::Ed25519Signature;
 

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -198,13 +198,13 @@ pub enum ChangeApplicationPermissionsError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crypto::SigningKey;
+    use crate::crypto::AccountPrivateKey;
 
     #[test]
     fn test_ownership_round_timeouts() {
-        let super_pub_key = SigningKey::generate().public();
+        let super_pub_key = AccountPrivateKey::generate().public();
         let super_owner = Owner::from(super_pub_key);
-        let pub_key = SigningKey::generate().public();
+        let pub_key = AccountPrivateKey::generate().public();
         let owner = Owner::from(pub_key);
 
         let ownership = ChainOwnership {

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -198,13 +198,13 @@ pub enum ChangeApplicationPermissionsError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crypto::AccountPrivateKey;
+    use crate::crypto::AccountSecretKey;
 
     #[test]
     fn test_ownership_round_timeouts() {
-        let super_pub_key = AccountPrivateKey::generate().public();
+        let super_pub_key = AccountSecretKey::generate().public();
         let super_owner = Owner::from(super_pub_key);
-        let pub_key = AccountPrivateKey::generate().public();
+        let pub_key = AccountSecretKey::generate().public();
         let owner = Owner::from(pub_key);
 
         let ownership = ChainOwnership {

--- a/linera-base/src/unit_tests.rs
+++ b/linera-base/src/unit_tests.rs
@@ -9,7 +9,7 @@ use linera_witty::{Layout, WitLoad, WitStore};
 use test_case::test_case;
 
 use crate::{
-    crypto::{CryptoHash, PublicKey},
+    crypto::{AccountPublicKey, CryptoHash},
     data_types::{Amount, BlockHeight, Resources, SendMessageRequest, TimeDelta, Timestamp},
     identifiers::{
         Account, AccountOwner, ApplicationId, BytecodeId, ChainId, ChannelName, Destination,
@@ -20,7 +20,7 @@ use crate::{
 
 /// Test roundtrip of types used in the WIT interface.
 #[test_case(CryptoHash::test_hash("hash"); "of_crypto_hash")]
-#[test_case(PublicKey::test_key(255); "of_public_key")]
+#[test_case(AccountPublicKey::test_key(255); "of_public_key")]
 #[test_case(Amount::from_tokens(500); "of_amount")]
 #[test_case(BlockHeight(1095); "of_block_height")]
 #[test_case(Timestamp::from(6_400_003); "of_timestamp")]

--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_base::{
-    crypto::Signature,
+    crypto::AuthoritySignature,
     data_types::Round,
     hashed::Hashed,
     identifiers::{BlobId, ChainId, MessageId},
@@ -92,7 +92,7 @@ impl<'de> Deserialize<'de> for GenericCertificate<ConfirmedBlock> {
         struct Helper {
             value: Hashed<ConfirmedBlock>,
             round: Round,
-            signatures: Vec<(ValidatorName, Signature)>,
+            signatures: Vec<(ValidatorName, AuthoritySignature)>,
         }
 
         let helper = Helper::deserialize(deserializer)?;

--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_base::{
-    crypto::AuthoritySignature,
+    crypto::ValidatorSignature,
     data_types::Round,
     hashed::Hashed,
     identifiers::{BlobId, ChainId, MessageId},
@@ -92,7 +92,7 @@ impl<'de> Deserialize<'de> for GenericCertificate<ConfirmedBlock> {
         struct Helper {
             value: Hashed<ConfirmedBlock>,
             round: Round,
-            signatures: Vec<(ValidatorName, AuthoritySignature)>,
+            signatures: Vec<(ValidatorName, ValidatorSignature)>,
         }
 
         let helper = Helper::deserialize(deserializer)?;

--- a/linera-chain/src/certificate/generic.rs
+++ b/linera-chain/src/certificate/generic.rs
@@ -4,7 +4,7 @@
 
 use custom_debug_derive::Debug;
 use linera_base::{
-    crypto::{AuthoritySignature, CryptoHash},
+    crypto::{CryptoHash, ValidatorSignature},
     data_types::Round,
     hashed::Hashed,
 };
@@ -18,14 +18,14 @@ use crate::{data_types::LiteValue, ChainError};
 pub struct GenericCertificate<T> {
     value: Hashed<T>,
     pub round: Round,
-    signatures: Vec<(ValidatorName, AuthoritySignature)>,
+    signatures: Vec<(ValidatorName, ValidatorSignature)>,
 }
 
 impl<T> GenericCertificate<T> {
     pub fn new(
         value: Hashed<T>,
         round: Round,
-        mut signatures: Vec<(ValidatorName, AuthoritySignature)>,
+        mut signatures: Vec<(ValidatorName, ValidatorSignature)>,
     ) -> Self {
         signatures.sort_by_key(|&(validator_name, _)| validator_name);
 
@@ -61,16 +61,16 @@ impl<T> GenericCertificate<T> {
         self.value.hash()
     }
 
-    pub fn destructure(self) -> (Hashed<T>, Round, Vec<(ValidatorName, AuthoritySignature)>) {
+    pub fn destructure(self) -> (Hashed<T>, Round, Vec<(ValidatorName, ValidatorSignature)>) {
         (self.value, self.round, self.signatures)
     }
 
-    pub fn signatures(&self) -> &Vec<(ValidatorName, AuthoritySignature)> {
+    pub fn signatures(&self) -> &Vec<(ValidatorName, ValidatorSignature)> {
         &self.signatures
     }
 
     #[cfg(with_testing)]
-    pub fn signatures_mut(&mut self) -> &mut Vec<(ValidatorName, AuthoritySignature)> {
+    pub fn signatures_mut(&mut self) -> &mut Vec<(ValidatorName, ValidatorSignature)> {
         &mut self.signatures
     }
 
@@ -78,8 +78,8 @@ impl<T> GenericCertificate<T> {
     /// It's the responsibility of the caller to not insert duplicates
     pub fn add_signature(
         &mut self,
-        signature: (ValidatorName, AuthoritySignature),
-    ) -> &Vec<(ValidatorName, AuthoritySignature)> {
+        signature: (ValidatorName, ValidatorSignature),
+    ) -> &Vec<(ValidatorName, ValidatorSignature)> {
         let index = self
             .signatures
             .binary_search_by(|(name, _)| name.cmp(&signature.0))

--- a/linera-chain/src/certificate/generic.rs
+++ b/linera-chain/src/certificate/generic.rs
@@ -4,7 +4,7 @@
 
 use custom_debug_derive::Debug;
 use linera_base::{
-    crypto::{CryptoHash, Signature},
+    crypto::{AuthoritySignature, CryptoHash},
     data_types::Round,
     hashed::Hashed,
 };
@@ -18,14 +18,14 @@ use crate::{data_types::LiteValue, ChainError};
 pub struct GenericCertificate<T> {
     value: Hashed<T>,
     pub round: Round,
-    signatures: Vec<(ValidatorName, Signature)>,
+    signatures: Vec<(ValidatorName, AuthoritySignature)>,
 }
 
 impl<T> GenericCertificate<T> {
     pub fn new(
         value: Hashed<T>,
         round: Round,
-        mut signatures: Vec<(ValidatorName, Signature)>,
+        mut signatures: Vec<(ValidatorName, AuthoritySignature)>,
     ) -> Self {
         signatures.sort_by_key(|&(validator_name, _)| validator_name);
 
@@ -61,16 +61,16 @@ impl<T> GenericCertificate<T> {
         self.value.hash()
     }
 
-    pub fn destructure(self) -> (Hashed<T>, Round, Vec<(ValidatorName, Signature)>) {
+    pub fn destructure(self) -> (Hashed<T>, Round, Vec<(ValidatorName, AuthoritySignature)>) {
         (self.value, self.round, self.signatures)
     }
 
-    pub fn signatures(&self) -> &Vec<(ValidatorName, Signature)> {
+    pub fn signatures(&self) -> &Vec<(ValidatorName, AuthoritySignature)> {
         &self.signatures
     }
 
     #[cfg(with_testing)]
-    pub fn signatures_mut(&mut self) -> &mut Vec<(ValidatorName, Signature)> {
+    pub fn signatures_mut(&mut self) -> &mut Vec<(ValidatorName, AuthoritySignature)> {
         &mut self.signatures
     }
 
@@ -78,8 +78,8 @@ impl<T> GenericCertificate<T> {
     /// It's the responsibility of the caller to not insert duplicates
     pub fn add_signature(
         &mut self,
-        signature: (ValidatorName, Signature),
-    ) -> &Vec<(ValidatorName, Signature)> {
+        signature: (ValidatorName, AuthoritySignature),
+    ) -> &Vec<(ValidatorName, AuthoritySignature)> {
         let index = self
             .signatures
             .binary_search_by(|(name, _)| name.cmp(&signature.0))

--- a/linera-chain/src/certificate/lite.rs
+++ b/linera-chain/src/certificate/lite.rs
@@ -4,7 +4,7 @@
 
 use std::borrow::Cow;
 
-use linera_base::{crypto::AuthoritySignature, data_types::Round, hashed::Hashed};
+use linera_base::{crypto::ValidatorSignature, data_types::Round, hashed::Hashed};
 use linera_execution::committee::{Committee, ValidatorName};
 use serde::{Deserialize, Serialize};
 
@@ -23,14 +23,14 @@ pub struct LiteCertificate<'a> {
     /// The round in which the value was certified.
     pub round: Round,
     /// Signatures on the value.
-    pub signatures: Cow<'a, [(ValidatorName, AuthoritySignature)]>,
+    pub signatures: Cow<'a, [(ValidatorName, ValidatorSignature)]>,
 }
 
 impl<'a> LiteCertificate<'a> {
     pub fn new(
         value: LiteValue,
         round: Round,
-        mut signatures: Vec<(ValidatorName, AuthoritySignature)>,
+        mut signatures: Vec<(ValidatorName, ValidatorSignature)>,
     ) -> Self {
         signatures.sort_by_key(|&(validator_name, _)| validator_name);
 

--- a/linera-chain/src/certificate/lite.rs
+++ b/linera-chain/src/certificate/lite.rs
@@ -4,7 +4,7 @@
 
 use std::borrow::Cow;
 
-use linera_base::{crypto::Signature, data_types::Round, hashed::Hashed};
+use linera_base::{crypto::AuthoritySignature, data_types::Round, hashed::Hashed};
 use linera_execution::committee::{Committee, ValidatorName};
 use serde::{Deserialize, Serialize};
 
@@ -23,14 +23,14 @@ pub struct LiteCertificate<'a> {
     /// The round in which the value was certified.
     pub round: Round,
     /// Signatures on the value.
-    pub signatures: Cow<'a, [(ValidatorName, Signature)]>,
+    pub signatures: Cow<'a, [(ValidatorName, AuthoritySignature)]>,
 }
 
 impl<'a> LiteCertificate<'a> {
     pub fn new(
         value: LiteValue,
         round: Round,
-        mut signatures: Vec<(ValidatorName, Signature)>,
+        mut signatures: Vec<(ValidatorName, AuthoritySignature)>,
     ) -> Self {
         signatures.sort_by_key(|&(validator_name, _)| validator_name);
 

--- a/linera-chain/src/certificate/mod.rs
+++ b/linera-chain/src/certificate/mod.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeSet;
 
 pub use generic::GenericCertificate;
 use linera_base::{
-    crypto::AuthoritySignature,
+    crypto::ValidatorSignature,
     data_types::{BlockHeight, Round},
     identifiers::{BlobId, ChainId},
 };
@@ -76,7 +76,7 @@ impl Certificate {
         }
     }
 
-    pub fn signatures(&self) -> &Vec<(ValidatorName, AuthoritySignature)> {
+    pub fn signatures(&self) -> &Vec<(ValidatorName, ValidatorSignature)> {
         match self {
             Certificate::Validated(cert) => cert.signatures(),
             Certificate::Confirmed(cert) => cert.signatures(),

--- a/linera-chain/src/certificate/mod.rs
+++ b/linera-chain/src/certificate/mod.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeSet;
 
 pub use generic::GenericCertificate;
 use linera_base::{
-    crypto::Signature,
+    crypto::AuthoritySignature,
     data_types::{BlockHeight, Round},
     identifiers::{BlobId, ChainId},
 };
@@ -76,7 +76,7 @@ impl Certificate {
         }
     }
 
-    pub fn signatures(&self) -> &Vec<(ValidatorName, Signature)> {
+    pub fn signatures(&self) -> &Vec<(ValidatorName, AuthoritySignature)> {
         match self {
             Certificate::Validated(cert) => cert.signatures(),
             Certificate::Confirmed(cert) => cert.signatures(),

--- a/linera-chain/src/certificate/timeout.rs
+++ b/linera-chain/src/certificate/timeout.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_base::{crypto::AuthoritySignature, data_types::Round, hashed::Hashed};
+use linera_base::{crypto::ValidatorSignature, data_types::Round, hashed::Hashed};
 use linera_execution::committee::ValidatorName;
 use serde::{
     ser::{Serialize, SerializeStruct, Serializer},
@@ -49,7 +49,7 @@ impl<'de> Deserialize<'de> for GenericCertificate<Timeout> {
         struct Inner {
             value: Hashed<Timeout>,
             round: Round,
-            signatures: Vec<(ValidatorName, AuthoritySignature)>,
+            signatures: Vec<(ValidatorName, ValidatorSignature)>,
         }
         let inner = Inner::deserialize(deserializer)?;
         if !crate::data_types::is_strictly_ordered(&inner.signatures) {

--- a/linera-chain/src/certificate/timeout.rs
+++ b/linera-chain/src/certificate/timeout.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_base::{crypto::Signature, data_types::Round, hashed::Hashed};
+use linera_base::{crypto::AuthoritySignature, data_types::Round, hashed::Hashed};
 use linera_execution::committee::ValidatorName;
 use serde::{
     ser::{Serialize, SerializeStruct, Serializer},
@@ -49,7 +49,7 @@ impl<'de> Deserialize<'de> for GenericCertificate<Timeout> {
         struct Inner {
             value: Hashed<Timeout>,
             round: Round,
-            signatures: Vec<(ValidatorName, Signature)>,
+            signatures: Vec<(ValidatorName, AuthoritySignature)>,
         }
         let inner = Inner::deserialize(deserializer)?;
         if !crate::data_types::is_strictly_ordered(&inner.signatures) {

--- a/linera-chain/src/certificate/validated.rs
+++ b/linera-chain/src/certificate/validated.rs
@@ -2,7 +2,9 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_base::{crypto::Signature, data_types::Round, hashed::Hashed, identifiers::BlobId};
+use linera_base::{
+    crypto::AuthoritySignature, data_types::Round, hashed::Hashed, identifiers::BlobId,
+};
 use linera_execution::committee::ValidatorName;
 use serde::{
     ser::{Serialize, SerializeStruct, Serializer},
@@ -65,7 +67,7 @@ impl<'de> Deserialize<'de> for GenericCertificate<ValidatedBlock> {
         struct Inner {
             value: Hashed<ValidatedBlock>,
             round: Round,
-            signatures: Vec<(ValidatorName, Signature)>,
+            signatures: Vec<(ValidatorName, AuthoritySignature)>,
         }
         let inner = Inner::deserialize(deserializer)?;
         if !crate::data_types::is_strictly_ordered(&inner.signatures) {

--- a/linera-chain/src/certificate/validated.rs
+++ b/linera-chain/src/certificate/validated.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_base::{
-    crypto::AuthoritySignature, data_types::Round, hashed::Hashed, identifiers::BlobId,
+    crypto::ValidatorSignature, data_types::Round, hashed::Hashed, identifiers::BlobId,
 };
 use linera_execution::committee::ValidatorName;
 use serde::{
@@ -67,7 +67,7 @@ impl<'de> Deserialize<'de> for GenericCertificate<ValidatedBlock> {
         struct Inner {
             value: Hashed<ValidatedBlock>,
             round: Round,
-            signatures: Vec<(ValidatorName, AuthoritySignature)>,
+            signatures: Vec<(ValidatorName, ValidatorSignature)>,
         }
         let inner = Inner::deserialize(deserializer)?;
         if !crate::data_types::is_strictly_ordered(&inner.signatures) {

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -288,6 +288,7 @@ pub enum Medium {
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 pub struct BlockProposal {
     pub content: ProposalContent,
+    pub owner: Owner,
     pub public_key: AccountPublicKey,
     pub signature: AccountSignature,
     #[debug(skip_if = Option::is_none)]
@@ -746,6 +747,7 @@ impl BlockProposal {
         Self {
             content,
             public_key: secret.public(),
+            owner: secret.public().into(),
             signature,
             validated_block_certificate: None,
         }
@@ -768,6 +770,7 @@ impl BlockProposal {
         Self {
             content,
             public_key: secret.public(),
+            owner: secret.public().into(),
             signature,
             validated_block_certificate: Some(lite_cert),
         }
@@ -789,6 +792,10 @@ impl BlockProposal {
     /// Checks that the public key matches the owner and that the optional certificate matches
     /// the outcome.
     pub fn check_invariants(&self) -> Result<(), &'static str> {
+        ensure!(
+            self.owner == Owner::from(&self.public_key),
+            "Public key does not match owner"
+        );
         match (&self.validated_block_certificate, &self.content.outcome) {
             (None, None) => {}
             (None, Some(_)) | (Some(_), None) => {

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -12,8 +12,8 @@ use custom_debug_derive::Debug;
 use linera_base::{
     bcs,
     crypto::{
-        AccountPrivateKey, AccountPublicKey, AccountSignature, BcsHashable, BcsSignable,
-        CryptoError, CryptoHash, ValidatorPrivateKey, ValidatorSignature,
+        AccountPublicKey, AccountSecretKey, AccountSignature, BcsHashable, BcsSignable,
+        CryptoError, CryptoHash, ValidatorSecretKey, ValidatorSignature,
     },
     data_types::{Amount, BlockHeight, Event, OracleResponse, Round, Timestamp},
     doc_scalar, ensure,
@@ -430,7 +430,7 @@ pub struct Vote<T> {
 
 impl<T> Vote<T> {
     /// Use signing key to create a signed object.
-    pub fn new(value: Hashed<T>, round: Round, key_pair: &ValidatorPrivateKey) -> Self
+    pub fn new(value: Hashed<T>, round: Round, key_pair: &ValidatorSecretKey) -> Self
     where
         T: CertificateValue,
     {
@@ -736,7 +736,7 @@ pub struct ProposalContent {
 }
 
 impl BlockProposal {
-    pub fn new_initial(round: Round, block: ProposedBlock, secret: &AccountPrivateKey) -> Self {
+    pub fn new_initial(round: Round, block: ProposedBlock, secret: &AccountSecretKey) -> Self {
         let content = ProposalContent {
             round,
             block,
@@ -754,7 +754,7 @@ impl BlockProposal {
     pub fn new_retry(
         round: Round,
         validated_block_certificate: ValidatedBlockCertificate,
-        secret: &AccountPrivateKey,
+        secret: &AccountSecretKey,
     ) -> Self {
         let lite_cert = validated_block_certificate.lite_certificate().cloned();
         let block = validated_block_certificate.into_inner().into_inner();
@@ -810,7 +810,7 @@ impl BlockProposal {
 
 impl LiteVote {
     /// Uses the signing key to create a signed object.
-    pub fn new(value: LiteValue, round: Round, key_pair: &ValidatorPrivateKey) -> Self {
+    pub fn new(value: LiteValue, round: Round, key_pair: &ValidatorSecretKey) -> Self {
         let hash_and_round = VoteValue(value.value_hash, round, value.kind);
         let signature = ValidatorSignature::new(&hash_and_round, key_pair);
         Self {

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -285,7 +285,6 @@ pub enum Medium {
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 pub struct BlockProposal {
     pub content: ProposalContent,
-    pub owner: Owner,
     pub public_key: PublicKey,
     pub signature: Signature,
     #[debug(skip_if = Option::is_none)]
@@ -744,7 +743,6 @@ impl BlockProposal {
         Self {
             content,
             public_key: secret.public(),
-            owner: secret.public().into(),
             signature,
             validated_block_certificate: None,
         }
@@ -767,7 +765,6 @@ impl BlockProposal {
         Self {
             content,
             public_key: secret.public(),
-            owner: secret.public().into(),
             signature,
             validated_block_certificate: Some(lite_cert),
         }
@@ -789,10 +786,6 @@ impl BlockProposal {
     /// Checks that the public key matches the owner and that the optional certificate matches
     /// the outcome.
     pub fn check_invariants(&self) -> Result<(), &'static str> {
-        ensure!(
-            self.owner == Owner::from(&self.public_key),
-            "Public key does not match owner"
-        );
         match (&self.validated_block_certificate, &self.content.outcome) {
             (None, None) => {}
             (None, Some(_)) | (Some(_), None) => {

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -309,7 +309,7 @@ where
                 // If the fast round has not timed out yet, only a super owner is allowed to open
                 // a later round by making a proposal.
                 ensure!(
-                    self.is_super(&proposal.public_key.into()) || !current_round.is_fast(),
+                    self.is_super(&proposal.owner) || !current_round.is_fast(),
                     ChainError::WrongRound(current_round)
                 );
                 // After the fast round, proposals older than the current round are obsolete.
@@ -582,7 +582,7 @@ where
     /// Returns whether the signer is a valid owner and allowed to propose a block in the
     /// proposal's round.
     pub fn verify_owner(&self, proposal: &BlockProposal) -> bool {
-        let owner = &proposal.public_key.into();
+        let owner = &proposal.owner;
         if self.ownership.get().super_owners.contains(owner) {
             return true;
         }

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -74,7 +74,7 @@ use async_graphql::{ComplexObject, SimpleObject};
 use custom_debug_derive::Debug;
 use futures::future::Either;
 use linera_base::{
-    crypto::{AccountPublicKey, AuthorityPrivateKey},
+    crypto::{AccountPublicKey, ValidatorPrivateKey},
     data_types::{Blob, BlockHeight, Round, Timestamp},
     ensure,
     hashed::Hashed,
@@ -361,7 +361,7 @@ where
         chain_id: ChainId,
         height: BlockHeight,
         epoch: Epoch,
-        key_pair: Option<&AuthorityPrivateKey>,
+        key_pair: Option<&ValidatorPrivateKey>,
         local_time: Timestamp,
     ) -> bool {
         let Some(key_pair) = key_pair else {
@@ -394,7 +394,7 @@ where
         chain_id: ChainId,
         height: BlockHeight,
         epoch: Epoch,
-        key_pair: Option<&AuthorityPrivateKey>,
+        key_pair: Option<&ValidatorPrivateKey>,
     ) -> bool {
         let Some(key_pair) = key_pair else {
             return false; // We are not a validator.
@@ -446,7 +446,7 @@ where
         &mut self,
         proposal: BlockProposal,
         executed_block: ExecutedBlock,
-        key_pair: Option<&AuthorityPrivateKey>,
+        key_pair: Option<&ValidatorPrivateKey>,
         local_time: Timestamp,
         blobs: BTreeMap<BlobId, Blob>,
     ) -> Result<Option<ValidatedOrConfirmedVote>, ChainError> {
@@ -500,7 +500,7 @@ where
     pub fn create_final_vote(
         &mut self,
         validated: ValidatedBlockCertificate,
-        key_pair: Option<&AuthorityPrivateKey>,
+        key_pair: Option<&ValidatorPrivateKey>,
         local_time: Timestamp,
         blobs: BTreeMap<BlobId, Blob>,
     ) -> Result<(), ViewError> {

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -74,7 +74,7 @@ use async_graphql::{ComplexObject, SimpleObject};
 use custom_debug_derive::Debug;
 use futures::future::Either;
 use linera_base::{
-    crypto::{AccountPublicKey, ValidatorPrivateKey},
+    crypto::{AccountPublicKey, ValidatorSecretKey},
     data_types::{Blob, BlockHeight, Round, Timestamp},
     ensure,
     hashed::Hashed,
@@ -361,7 +361,7 @@ where
         chain_id: ChainId,
         height: BlockHeight,
         epoch: Epoch,
-        key_pair: Option<&ValidatorPrivateKey>,
+        key_pair: Option<&ValidatorSecretKey>,
         local_time: Timestamp,
     ) -> bool {
         let Some(key_pair) = key_pair else {
@@ -394,7 +394,7 @@ where
         chain_id: ChainId,
         height: BlockHeight,
         epoch: Epoch,
-        key_pair: Option<&ValidatorPrivateKey>,
+        key_pair: Option<&ValidatorSecretKey>,
     ) -> bool {
         let Some(key_pair) = key_pair else {
             return false; // We are not a validator.
@@ -446,7 +446,7 @@ where
         &mut self,
         proposal: BlockProposal,
         executed_block: ExecutedBlock,
-        key_pair: Option<&ValidatorPrivateKey>,
+        key_pair: Option<&ValidatorSecretKey>,
         local_time: Timestamp,
         blobs: BTreeMap<BlobId, Blob>,
     ) -> Result<Option<ValidatedOrConfirmedVote>, ChainError> {
@@ -500,7 +500,7 @@ where
     pub fn create_final_vote(
         &mut self,
         validated: ValidatedBlockCertificate,
-        key_pair: Option<&ValidatorPrivateKey>,
+        key_pair: Option<&ValidatorSecretKey>,
         local_time: Timestamp,
         blobs: BTreeMap<BlobId, Blob>,
     ) -> Result<(), ViewError> {

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -309,7 +309,7 @@ where
                 // If the fast round has not timed out yet, only a super owner is allowed to open
                 // a later round by making a proposal.
                 ensure!(
-                    self.is_super(&proposal.owner) || !current_round.is_fast(),
+                    self.is_super(&proposal.public_key.into()) || !current_round.is_fast(),
                     ChainError::WrongRound(current_round)
                 );
                 // After the fast round, proposals older than the current round are obsolete.
@@ -582,7 +582,7 @@ where
     /// Returns whether the signer is a valid owner and allowed to propose a block in the
     /// proposal's round.
     pub fn verify_owner(&self, proposal: &BlockProposal) -> bool {
-        let owner = &proposal.owner;
+        let owner = &proposal.public_key.into();
         if self.ownership.get().super_owners.contains(owner) {
             return true;
         }

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -74,7 +74,7 @@ use async_graphql::{ComplexObject, SimpleObject};
 use custom_debug_derive::Debug;
 use futures::future::Either;
 use linera_base::{
-    crypto::{PublicKey, SigningKey},
+    crypto::{AccountPublicKey, AuthorityPrivateKey},
     data_types::{Blob, BlockHeight, Round, Timestamp},
     ensure,
     hashed::Hashed,
@@ -223,7 +223,7 @@ where
         ownership: ChainOwnership,
         height: BlockHeight,
         local_time: Timestamp,
-        fallback_owners: impl Iterator<Item = (PublicKey, u64)> + 'a,
+        fallback_owners: impl Iterator<Item = (AccountPublicKey, u64)> + 'a,
     ) -> Result<(), ChainError> {
         let distribution = if !ownership.owners.is_empty() {
             let weights = ownership.owners.values().copied().collect();
@@ -361,7 +361,7 @@ where
         chain_id: ChainId,
         height: BlockHeight,
         epoch: Epoch,
-        key_pair: Option<&SigningKey>,
+        key_pair: Option<&AuthorityPrivateKey>,
         local_time: Timestamp,
     ) -> bool {
         let Some(key_pair) = key_pair else {
@@ -394,7 +394,7 @@ where
         chain_id: ChainId,
         height: BlockHeight,
         epoch: Epoch,
-        key_pair: Option<&SigningKey>,
+        key_pair: Option<&AuthorityPrivateKey>,
     ) -> bool {
         let Some(key_pair) = key_pair else {
             return false; // We are not a validator.
@@ -446,7 +446,7 @@ where
         &mut self,
         proposal: BlockProposal,
         executed_block: ExecutedBlock,
-        key_pair: Option<&SigningKey>,
+        key_pair: Option<&AuthorityPrivateKey>,
         local_time: Timestamp,
         blobs: BTreeMap<BlobId, Blob>,
     ) -> Result<Option<ValidatedOrConfirmedVote>, ChainError> {
@@ -500,7 +500,7 @@ where
     pub fn create_final_vote(
         &mut self,
         validated: ValidatedBlockCertificate,
-        key_pair: Option<&SigningKey>,
+        key_pair: Option<&AuthorityPrivateKey>,
         local_time: Timestamp,
         blobs: BTreeMap<BlobId, Blob>,
     ) -> Result<(), ViewError> {

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -4,7 +4,7 @@
 //! Test utilities
 
 use linera_base::{
-    crypto::SigningKey,
+    crypto::AccountPrivateKey,
     data_types::{Amount, BlockHeight, Round, Timestamp},
     hashed::Hashed,
     identifiers::{ChainId, Owner},
@@ -78,12 +78,12 @@ pub trait BlockTestExt: Sized {
 
     /// Returns a block proposal in the first round in a default ownership configuration
     /// (`Round::MultiLeader(0)`) without any hashed certificate values or validated block.
-    fn into_first_proposal(self, key_pair: &SigningKey) -> BlockProposal {
+    fn into_first_proposal(self, key_pair: &AccountPrivateKey) -> BlockProposal {
         self.into_proposal_with_round(key_pair, Round::MultiLeader(0))
     }
 
     /// Returns a block proposal without any hashed certificate values or validated block.
-    fn into_proposal_with_round(self, key_pair: &SigningKey, round: Round) -> BlockProposal;
+    fn into_proposal_with_round(self, key_pair: &AccountPrivateKey, round: Round) -> BlockProposal;
 }
 
 impl BlockTestExt for ProposedBlock {
@@ -124,7 +124,7 @@ impl BlockTestExt for ProposedBlock {
         self
     }
 
-    fn into_proposal_with_round(self, key_pair: &SigningKey, round: Round) -> BlockProposal {
+    fn into_proposal_with_round(self, key_pair: &AccountPrivateKey, round: Round) -> BlockProposal {
         BlockProposal::new_initial(round, self, key_pair)
     }
 }

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -4,7 +4,7 @@
 //! Test utilities
 
 use linera_base::{
-    crypto::AccountPrivateKey,
+    crypto::AccountSecretKey,
     data_types::{Amount, BlockHeight, Round, Timestamp},
     hashed::Hashed,
     identifiers::{ChainId, Owner},
@@ -78,12 +78,12 @@ pub trait BlockTestExt: Sized {
 
     /// Returns a block proposal in the first round in a default ownership configuration
     /// (`Round::MultiLeader(0)`) without any hashed certificate values or validated block.
-    fn into_first_proposal(self, key_pair: &AccountPrivateKey) -> BlockProposal {
+    fn into_first_proposal(self, key_pair: &AccountSecretKey) -> BlockProposal {
         self.into_proposal_with_round(key_pair, Round::MultiLeader(0))
     }
 
     /// Returns a block proposal without any hashed certificate values or validated block.
-    fn into_proposal_with_round(self, key_pair: &AccountPrivateKey, round: Round) -> BlockProposal;
+    fn into_proposal_with_round(self, key_pair: &AccountSecretKey, round: Round) -> BlockProposal;
 }
 
 impl BlockTestExt for ProposedBlock {
@@ -124,7 +124,7 @@ impl BlockTestExt for ProposedBlock {
         self
     }
 
-    fn into_proposal_with_round(self, key_pair: &AccountPrivateKey, round: Round) -> BlockProposal {
+    fn into_proposal_with_round(self, key_pair: &AccountSecretKey, round: Round) -> BlockProposal {
         BlockProposal::new_initial(round, self, key_pair)
     }
 }

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeMap, iter};
 
 use assert_matches::assert_matches;
 use linera_base::{
-    crypto::{CryptoHash, ValidatorPublicKey},
+    crypto::{AccountPublicKey, CryptoHash, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationPermissions, Blob, BlockHeight, Bytecode, Timestamp,
         UserApplicationDescription,
@@ -95,7 +95,7 @@ fn make_admin_message_id(height: BlockHeight) -> MessageId {
 fn make_open_chain_config() -> OpenChainConfig {
     let committee = Committee::make_simple(vec![ValidatorPublicKey::test_key(1).into()]);
     OpenChainConfig {
-        ownership: ChainOwnership::single(ValidatorPublicKey::test_key(0).into()),
+        ownership: ChainOwnership::single(AccountPublicKey::test_key(0).into()),
         admin_id: admin_id(),
         epoch: Epoch::ZERO,
         committees: iter::once((Epoch::ZERO, committee)).collect(),

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeMap, iter};
 
 use assert_matches::assert_matches;
 use linera_base::{
-    crypto::{AuthorityPublicKey, CryptoHash},
+    crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationPermissions, Blob, BlockHeight, Bytecode, Timestamp,
         UserApplicationDescription,
@@ -93,9 +93,9 @@ fn make_admin_message_id(height: BlockHeight) -> MessageId {
 }
 
 fn make_open_chain_config() -> OpenChainConfig {
-    let committee = Committee::make_simple(vec![AuthorityPublicKey::test_key(1).into()]);
+    let committee = Committee::make_simple(vec![ValidatorPublicKey::test_key(1).into()]);
     OpenChainConfig {
-        ownership: ChainOwnership::single(AuthorityPublicKey::test_key(0).into()),
+        ownership: ChainOwnership::single(ValidatorPublicKey::test_key(0).into()),
         admin_id: admin_id(),
         epoch: Epoch::ZERO,
         committees: iter::once((Epoch::ZERO, committee)).collect(),
@@ -120,9 +120,9 @@ async fn test_block_size_limit() {
         Epoch(0),
         Committee::new(
             BTreeMap::from([(
-                ValidatorName(AuthorityPublicKey::test_key(1)),
+                ValidatorName(ValidatorPublicKey::test_key(1)),
                 ValidatorState {
-                    network_address: AuthorityPublicKey::test_key(1).to_string(),
+                    network_address: ValidatorPublicKey::test_key(1).to_string(),
                     votes: 1,
                 },
             )]),

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeMap, iter};
 
 use assert_matches::assert_matches;
 use linera_base::{
-    crypto::{CryptoHash, PublicKey},
+    crypto::{AuthorityPublicKey, CryptoHash},
     data_types::{
         Amount, ApplicationPermissions, Blob, BlockHeight, Bytecode, Timestamp,
         UserApplicationDescription,
@@ -93,9 +93,9 @@ fn make_admin_message_id(height: BlockHeight) -> MessageId {
 }
 
 fn make_open_chain_config() -> OpenChainConfig {
-    let committee = Committee::make_simple(vec![PublicKey::test_key(1).into()]);
+    let committee = Committee::make_simple(vec![AuthorityPublicKey::test_key(1).into()]);
     OpenChainConfig {
-        ownership: ChainOwnership::single(PublicKey::test_key(0).into()),
+        ownership: ChainOwnership::single(AuthorityPublicKey::test_key(0).into()),
         admin_id: admin_id(),
         epoch: Epoch::ZERO,
         committees: iter::once((Epoch::ZERO, committee)).collect(),
@@ -120,9 +120,9 @@ async fn test_block_size_limit() {
         Epoch(0),
         Committee::new(
             BTreeMap::from([(
-                ValidatorName(PublicKey::test_key(1)),
+                ValidatorName(AuthorityPublicKey::test_key(1)),
                 ValidatorState {
-                    network_address: PublicKey::test_key(1).to_string(),
+                    network_address: AuthorityPublicKey::test_key(1).to_string(),
                     votes: 1,
                 },
             )]),

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -12,8 +12,8 @@ use crate::{
 
 #[test]
 fn test_signed_values() {
-    let key1 = ValidatorPrivateKey::generate();
-    let key2 = ValidatorPrivateKey::generate();
+    let key1 = ValidatorSecretKey::generate();
+    let key2 = ValidatorSecretKey::generate();
     let name1 = ValidatorName(key1.public());
 
     let block =
@@ -81,9 +81,9 @@ fn test_hashes() {
 
 #[test]
 fn test_certificates() {
-    let key1 = ValidatorPrivateKey::generate();
-    let key2 = ValidatorPrivateKey::generate();
-    let key3 = ValidatorPrivateKey::generate();
+    let key1 = ValidatorSecretKey::generate();
+    let key2 = ValidatorSecretKey::generate();
+    let key3 = ValidatorSecretKey::generate();
     let name1 = ValidatorName(key1.public());
     let name2 = ValidatorName(key2.public());
 

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -12,8 +12,8 @@ use crate::{
 
 #[test]
 fn test_signed_values() {
-    let key1 = AuthorityPrivateKey::generate();
-    let key2 = AuthorityPrivateKey::generate();
+    let key1 = ValidatorPrivateKey::generate();
+    let key2 = ValidatorPrivateKey::generate();
     let name1 = ValidatorName(key1.public());
 
     let block =
@@ -81,9 +81,9 @@ fn test_hashes() {
 
 #[test]
 fn test_certificates() {
-    let key1 = AuthorityPrivateKey::generate();
-    let key2 = AuthorityPrivateKey::generate();
-    let key3 = AuthorityPrivateKey::generate();
+    let key1 = ValidatorPrivateKey::generate();
+    let key2 = ValidatorPrivateKey::generate();
+    let key3 = ValidatorPrivateKey::generate();
     let name1 = ValidatorName(key1.public());
     let name2 = ValidatorName(key2.public());
 

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -12,8 +12,8 @@ use crate::{
 
 #[test]
 fn test_signed_values() {
-    let key1 = SigningKey::generate();
-    let key2 = SigningKey::generate();
+    let key1 = AuthorityPrivateKey::generate();
+    let key2 = AuthorityPrivateKey::generate();
     let name1 = ValidatorName(key1.public());
 
     let block =
@@ -81,9 +81,9 @@ fn test_hashes() {
 
 #[test]
 fn test_certificates() {
-    let key1 = SigningKey::generate();
-    let key2 = SigningKey::generate();
-    let key3 = SigningKey::generate();
+    let key1 = AuthorityPrivateKey::generate();
+    let key2 = AuthorityPrivateKey::generate();
+    let key3 = AuthorityPrivateKey::generate();
     let name1 = ValidatorName(key1.public());
     let name2 = ValidatorName(key2.public());
 

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -10,7 +10,7 @@ use futures::{
     StreamExt,
 };
 use linera_base::{
-    crypto::AccountPrivateKey,
+    crypto::AccountSecretKey,
     data_types::Timestamp,
     identifiers::{ChainId, Destination},
 };
@@ -69,7 +69,7 @@ pub trait ClientContext: 'static {
     async fn update_wallet_for_new_chain(
         &mut self,
         chain_id: ChainId,
-        key_pair: Option<AccountPrivateKey>,
+        key_pair: Option<AccountSecretKey>,
         timestamp: Timestamp,
     ) -> Result<(), Error>;
 

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -10,7 +10,7 @@ use futures::{
     StreamExt,
 };
 use linera_base::{
-    crypto::SigningKey,
+    crypto::AccountPrivateKey,
     data_types::Timestamp,
     identifiers::{ChainId, Destination},
 };
@@ -69,7 +69,7 @@ pub trait ClientContext: 'static {
     async fn update_wallet_for_new_chain(
         &mut self,
         chain_id: ChainId,
-        key_pair: Option<SigningKey>,
+        key_pair: Option<AccountPrivateKey>,
         timestamp: Timestamp,
     ) -> Result<(), Error>;
 

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -8,7 +8,7 @@ use std::{collections::HashSet, sync::Arc};
 use async_trait::async_trait;
 use futures::Future;
 use linera_base::{
-    crypto::AccountPrivateKey,
+    crypto::AccountSecretKey,
     data_types::{BlockHeight, Timestamp},
     identifiers::{Account, ChainId},
     ownership::ChainOwnership,
@@ -111,7 +111,7 @@ where
     async fn update_wallet_for_new_chain(
         &mut self,
         chain_id: ChainId,
-        key_pair: Option<AccountPrivateKey>,
+        key_pair: Option<AccountSecretKey>,
         timestamp: Timestamp,
     ) -> Result<(), Error> {
         self.update_wallet_for_new_chain(chain_id, key_pair, timestamp)
@@ -319,7 +319,7 @@ where
     pub async fn update_wallet_for_new_chain(
         &mut self,
         chain_id: ChainId,
-        key_pair: Option<AccountPrivateKey>,
+        key_pair: Option<AccountSecretKey>,
         timestamp: Timestamp,
     ) -> Result<(), Error> {
         self.update_wallet_for_new_chain_internal(chain_id, key_pair, timestamp)
@@ -329,7 +329,7 @@ where
     async fn update_wallet_for_new_chain_internal(
         &mut self,
         chain_id: ChainId,
-        key_pair: Option<AccountPrivateKey>,
+        key_pair: Option<AccountSecretKey>,
         timestamp: Timestamp,
     ) -> Result<(), Error> {
         if self.wallet.get(chain_id).is_none() {
@@ -568,7 +568,7 @@ where
     pub async fn run_benchmark(
         &mut self,
         bps: Option<usize>,
-        blocks_infos_iter: impl Iterator<Item = &(ChainId, Vec<Operation>, AccountPrivateKey)>,
+        blocks_infos_iter: impl Iterator<Item = &(ChainId, Vec<Operation>, AccountSecretKey)>,
         clients: Vec<linera_rpc::Client>,
         transactions_per_block: usize,
         epoch: Epoch,
@@ -734,7 +734,7 @@ where
         &mut self,
         num_chains: usize,
         balance: Amount,
-    ) -> Result<HashMap<ChainId, AccountPrivateKey>, Error> {
+    ) -> Result<HashMap<ChainId, AccountSecretKey>, Error> {
         let mut benchmark_chains = HashMap::new();
         let start = Instant::now();
         for chain_id in self.wallet.owned_chain_ids() {
@@ -844,7 +844,7 @@ where
         num_new_chains: usize,
         chain_client: &ChainClient<NodeProvider, S>,
         balance: Amount,
-        key_pair: &AccountPrivateKey,
+        key_pair: &AccountSecretKey,
         admin_id: ChainId,
     ) -> Result<ConfirmedBlockCertificate, Error> {
         let chain_id = chain_client.chain_id();
@@ -871,7 +871,7 @@ where
     /// Supplies fungible tokens to the chains.
     pub async fn supply_fungible_tokens(
         &mut self,
-        key_pairs: &HashMap<ChainId, AccountPrivateKey>,
+        key_pairs: &HashMap<ChainId, AccountSecretKey>,
         application_id: ApplicationId,
     ) -> Result<(), Error> {
         let default_chain_id = self
@@ -961,10 +961,10 @@ where
     /// Generates information related to one block per chain, up to `num_chains` blocks.
     pub fn make_benchmark_block_info(
         &mut self,
-        key_pairs: HashMap<ChainId, AccountPrivateKey>,
+        key_pairs: HashMap<ChainId, AccountSecretKey>,
         transactions_per_block: usize,
         fungible_application_id: Option<ApplicationId>,
-    ) -> Vec<(ChainId, Vec<Operation>, AccountPrivateKey)> {
+    ) -> Vec<(ChainId, Vec<Operation>, AccountSecretKey)> {
         let mut blocks_infos = Vec::new();
         let mut previous_chain_id = *key_pairs
             .iter()

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -8,7 +8,10 @@ use std::{
 };
 
 use linera_base::{
-    crypto::{BcsSignable, CryptoHash, CryptoRng, PublicKey, SigningKey},
+    crypto::{
+        AccountPrivateKey, AccountPublicKey, AuthorityPrivateKey, BcsSignable, CryptoHash,
+        CryptoRng,
+    },
     data_types::{Amount, Timestamp},
     identifiers::{ChainDescription, ChainId},
 };
@@ -54,7 +57,7 @@ pub struct ValidatorConfig {
 #[derive(Serialize, Deserialize)]
 pub struct ValidatorServerConfig {
     pub validator: ValidatorConfig,
-    pub key: SigningKey,
+    pub key: AuthorityPrivateKey,
     pub internal_network: ValidatorInternalNetworkConfig,
 }
 
@@ -174,8 +177,8 @@ impl<W: Deref<Target = Wallet>> WalletState<W> {
         }
     }
 
-    pub fn generate_key_pair(&mut self) -> SigningKey {
-        SigningKey::generate_from(&mut self.prng)
+    pub fn generate_key_pair(&mut self) -> AccountPrivateKey {
+        AccountPrivateKey::generate_from(&mut self.prng)
     }
 }
 
@@ -184,7 +187,7 @@ pub struct GenesisConfig {
     pub committee: CommitteeConfig,
     pub admin_id: ChainId,
     pub timestamp: Timestamp,
-    pub chains: Vec<(PublicKey, Amount)>,
+    pub chains: Vec<(AccountPublicKey, Amount)>,
     pub policy: ResourceControlPolicy,
     pub network_name: String,
 }

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -9,8 +9,7 @@ use std::{
 
 use linera_base::{
     crypto::{
-        AccountPrivateKey, AccountPublicKey, BcsSignable, CryptoHash, CryptoRng,
-        ValidatorPrivateKey,
+        AccountPublicKey, AccountSecretKey, BcsSignable, CryptoHash, CryptoRng, ValidatorSecretKey,
     },
     data_types::{Amount, Timestamp},
     identifiers::{ChainDescription, ChainId},
@@ -57,7 +56,7 @@ pub struct ValidatorConfig {
 #[derive(Serialize, Deserialize)]
 pub struct ValidatorServerConfig {
     pub validator: ValidatorConfig,
-    pub key: ValidatorPrivateKey,
+    pub key: ValidatorSecretKey,
     pub internal_network: ValidatorInternalNetworkConfig,
 }
 
@@ -177,8 +176,8 @@ impl<W: Deref<Target = Wallet>> WalletState<W> {
         }
     }
 
-    pub fn generate_key_pair(&mut self) -> AccountPrivateKey {
-        AccountPrivateKey::generate_from(&mut self.prng)
+    pub fn generate_key_pair(&mut self) -> AccountSecretKey {
+        AccountSecretKey::generate_from(&mut self.prng)
     }
 }
 

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -9,8 +9,8 @@ use std::{
 
 use linera_base::{
     crypto::{
-        AccountPrivateKey, AccountPublicKey, AuthorityPrivateKey, BcsSignable, CryptoHash,
-        CryptoRng,
+        AccountPrivateKey, AccountPublicKey, BcsSignable, CryptoHash, CryptoRng,
+        ValidatorPrivateKey,
     },
     data_types::{Amount, Timestamp},
     identifiers::{ChainDescription, ChainId},
@@ -57,7 +57,7 @@ pub struct ValidatorConfig {
 #[derive(Serialize, Deserialize)]
 pub struct ValidatorServerConfig {
     pub validator: ValidatorConfig,
-    pub key: AuthorityPrivateKey,
+    pub key: ValidatorPrivateKey,
     pub internal_network: ValidatorInternalNetworkConfig,
 }
 

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -8,7 +8,7 @@ use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use futures::{lock::Mutex, FutureExt as _};
 use linera_base::{
-    crypto::{AccountPrivateKey, AccountPublicKey},
+    crypto::{AccountPublicKey, AccountSecretKey},
     data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
     identifiers::ChainId,
     ownership::{ChainOwnership, TimeoutConfig},
@@ -77,7 +77,7 @@ impl chain_listener::ClientContext for ClientContext {
     async fn update_wallet_for_new_chain(
         &mut self,
         chain_id: ChainId,
-        key_pair: Option<AccountPrivateKey>,
+        key_pair: Option<AccountSecretKey>,
         timestamp: Timestamp,
     ) -> Result<(), Error> {
         if self.wallet.get(chain_id).is_none() {
@@ -136,7 +136,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
             Duration::from_secs(1),
         )),
     };
-    let key_pair = AccountPrivateKey::generate_from(&mut rng);
+    let key_pair = AccountSecretKey::generate_from(&mut rng);
     let owner = key_pair.public().into();
     context
         .update_wallet_for_new_chain(chain_id0, Some(key_pair), clock.current_time())

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -8,7 +8,7 @@ use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use futures::{lock::Mutex, FutureExt as _};
 use linera_base::{
-    crypto::{PublicKey, SigningKey},
+    crypto::{AccountPrivateKey, AccountPublicKey},
     data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
     identifiers::ChainId,
     ownership::{ChainOwnership, TimeoutConfig},
@@ -77,7 +77,7 @@ impl chain_listener::ClientContext for ClientContext {
     async fn update_wallet_for_new_chain(
         &mut self,
         chain_id: ChainId,
-        key_pair: Option<SigningKey>,
+        key_pair: Option<AccountPrivateKey>,
         timestamp: Timestamp,
     ) -> Result<(), Error> {
         if self.wallet.get(chain_id).is_none() {
@@ -136,7 +136,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
             Duration::from_secs(1),
         )),
     };
-    let key_pair = SigningKey::generate_from(&mut rng);
+    let key_pair = AccountPrivateKey::generate_from(&mut rng);
     let owner = key_pair.public().into();
     context
         .update_wallet_for_new_chain(chain_id0, Some(key_pair), clock.current_time())
@@ -147,7 +147,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
 
     // Transfer ownership of chain 0 to the chain listener and some other key. The listener will
     // be leader in ~10% of the rounds.
-    let owners = [(owner, 1), (PublicKey::test_key(1).into(), 9)];
+    let owners = [(owner, 1), (AccountPublicKey::test_key(1).into(), 9)];
     let timeout_config = TimeoutConfig {
         base_timeout: TimeDelta::from_secs(1),
         timeout_increment: TimeDelta::ZERO,

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use linera_base::{
-    crypto::{CryptoHash, CryptoRng, SigningKey},
+    crypto::{AccountPrivateKey, CryptoHash, CryptoRng},
     data_types::{BlockHeight, Timestamp},
     ensure,
     identifiers::{ChainDescription, ChainId, Owner},
@@ -25,7 +25,7 @@ use crate::{config::GenesisConfig, error, Error};
 #[derive(Serialize, Deserialize)]
 pub struct Wallet {
     pub chains: BTreeMap<ChainId, UserChain>,
-    pub unassigned_key_pairs: HashMap<Owner, SigningKey>,
+    pub unassigned_key_pairs: HashMap<Owner, AccountPrivateKey>,
     pub default: Option<ChainId>,
     pub genesis_config: GenesisConfig,
     pub testing_prng_seed: Option<u64>,
@@ -68,7 +68,7 @@ impl Wallet {
         self.chains.insert(chain.chain_id, chain);
     }
 
-    pub fn forget_keys(&mut self, chain_id: &ChainId) -> Result<SigningKey, Error> {
+    pub fn forget_keys(&mut self, chain_id: &ChainId) -> Result<AccountPrivateKey, Error> {
         let chain = self
             .chains
             .get_mut(chain_id)
@@ -113,12 +113,12 @@ impl Wallet {
         self.chains.values_mut()
     }
 
-    pub fn add_unassigned_key_pair(&mut self, key_pair: SigningKey) {
+    pub fn add_unassigned_key_pair(&mut self, key_pair: AccountPrivateKey) {
         let owner = key_pair.public().into();
         self.unassigned_key_pairs.insert(owner, key_pair);
     }
 
-    pub fn key_pair_for_owner(&self, owner: &Owner) -> Option<SigningKey> {
+    pub fn key_pair_for_owner(&self, owner: &Owner) -> Option<AccountPrivateKey> {
         if let Some(key_pair) = self
             .unassigned_key_pairs
             .get(owner)
@@ -206,7 +206,7 @@ impl Wallet {
 #[derive(Serialize, Deserialize)]
 pub struct UserChain {
     pub chain_id: ChainId,
-    pub key_pair: Option<SigningKey>,
+    pub key_pair: Option<AccountPrivateKey>,
     pub block_hash: Option<CryptoHash>,
     pub timestamp: Timestamp,
     pub next_block_height: BlockHeight,
@@ -220,7 +220,7 @@ impl UserChain {
         description: ChainDescription,
         timestamp: Timestamp,
     ) -> Self {
-        let key_pair = SigningKey::generate_from(rng);
+        let key_pair = AccountPrivateKey::generate_from(rng);
         Self {
             chain_id: description.into(),
             key_pair: Some(key_pair),

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use linera_base::{
-    crypto::{AccountPrivateKey, CryptoHash, CryptoRng},
+    crypto::{AccountSecretKey, CryptoHash, CryptoRng},
     data_types::{BlockHeight, Timestamp},
     ensure,
     identifiers::{ChainDescription, ChainId, Owner},
@@ -25,7 +25,7 @@ use crate::{config::GenesisConfig, error, Error};
 #[derive(Serialize, Deserialize)]
 pub struct Wallet {
     pub chains: BTreeMap<ChainId, UserChain>,
-    pub unassigned_key_pairs: HashMap<Owner, AccountPrivateKey>,
+    pub unassigned_key_pairs: HashMap<Owner, AccountSecretKey>,
     pub default: Option<ChainId>,
     pub genesis_config: GenesisConfig,
     pub testing_prng_seed: Option<u64>,
@@ -68,7 +68,7 @@ impl Wallet {
         self.chains.insert(chain.chain_id, chain);
     }
 
-    pub fn forget_keys(&mut self, chain_id: &ChainId) -> Result<AccountPrivateKey, Error> {
+    pub fn forget_keys(&mut self, chain_id: &ChainId) -> Result<AccountSecretKey, Error> {
         let chain = self
             .chains
             .get_mut(chain_id)
@@ -113,12 +113,12 @@ impl Wallet {
         self.chains.values_mut()
     }
 
-    pub fn add_unassigned_key_pair(&mut self, key_pair: AccountPrivateKey) {
+    pub fn add_unassigned_key_pair(&mut self, key_pair: AccountSecretKey) {
         let owner = key_pair.public().into();
         self.unassigned_key_pairs.insert(owner, key_pair);
     }
 
-    pub fn key_pair_for_owner(&self, owner: &Owner) -> Option<AccountPrivateKey> {
+    pub fn key_pair_for_owner(&self, owner: &Owner) -> Option<AccountSecretKey> {
         if let Some(key_pair) = self
             .unassigned_key_pairs
             .get(owner)
@@ -206,7 +206,7 @@ impl Wallet {
 #[derive(Serialize, Deserialize)]
 pub struct UserChain {
     pub chain_id: ChainId,
-    pub key_pair: Option<AccountPrivateKey>,
+    pub key_pair: Option<AccountSecretKey>,
     pub block_hash: Option<CryptoHash>,
     pub timestamp: Timestamp,
     pub next_block_height: BlockHeight,
@@ -220,7 +220,7 @@ impl UserChain {
         description: ChainDescription,
         timestamp: Timestamp,
     ) -> Self {
-        let key_pair = AccountPrivateKey::generate_from(rng);
+        let key_pair = AccountSecretKey::generate_from(rng);
         Self {
             chain_id: description.into(),
             key_pair: Some(key_pair),

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -5,14 +5,14 @@
 
 use std::sync::Arc;
 
-use linera_base::{crypto::AuthorityPrivateKey, time::Duration};
+use linera_base::{crypto::ValidatorPrivateKey, time::Duration};
 
 /// Configuration parameters for the [`ChainWorkerState`][`super::state::ChainWorkerState`].
 #[derive(Clone, Default)]
 pub struct ChainWorkerConfig {
     /// The signature key pair of the validator. The key may be missing for replicas
     /// without voting rights (possibly with a partial view of chains).
-    pub key_pair: Option<Arc<AuthorityPrivateKey>>,
+    pub key_pair: Option<Arc<ValidatorPrivateKey>>,
     /// Whether inactive chains are allowed in storage.
     pub allow_inactive_chains: bool,
     /// Whether new messages from deprecated epochs are allowed.
@@ -26,13 +26,13 @@ pub struct ChainWorkerConfig {
 
 impl ChainWorkerConfig {
     /// Configures the `key_pair` in this [`ChainWorkerConfig`].
-    pub fn with_key_pair(mut self, key_pair: impl Into<Option<AuthorityPrivateKey>>) -> Self {
+    pub fn with_key_pair(mut self, key_pair: impl Into<Option<ValidatorPrivateKey>>) -> Self {
         self.key_pair = key_pair.into().map(Arc::new);
         self
     }
 
-    /// Gets a reference to the [`AuthorityPrivateKey`], if available.
-    pub fn key_pair(&self) -> Option<&AuthorityPrivateKey> {
+    /// Gets a reference to the [`ValidatorPrivateKey`], if available.
+    pub fn key_pair(&self) -> Option<&ValidatorPrivateKey> {
         self.key_pair.as_ref().map(Arc::as_ref)
     }
 }

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -5,14 +5,14 @@
 
 use std::sync::Arc;
 
-use linera_base::{crypto::ValidatorPrivateKey, time::Duration};
+use linera_base::{crypto::ValidatorSecretKey, time::Duration};
 
 /// Configuration parameters for the [`ChainWorkerState`][`super::state::ChainWorkerState`].
 #[derive(Clone, Default)]
 pub struct ChainWorkerConfig {
     /// The signature key pair of the validator. The key may be missing for replicas
     /// without voting rights (possibly with a partial view of chains).
-    pub key_pair: Option<Arc<ValidatorPrivateKey>>,
+    pub key_pair: Option<Arc<ValidatorSecretKey>>,
     /// Whether inactive chains are allowed in storage.
     pub allow_inactive_chains: bool,
     /// Whether new messages from deprecated epochs are allowed.
@@ -26,13 +26,13 @@ pub struct ChainWorkerConfig {
 
 impl ChainWorkerConfig {
     /// Configures the `key_pair` in this [`ChainWorkerConfig`].
-    pub fn with_key_pair(mut self, key_pair: impl Into<Option<ValidatorPrivateKey>>) -> Self {
+    pub fn with_key_pair(mut self, key_pair: impl Into<Option<ValidatorSecretKey>>) -> Self {
         self.key_pair = key_pair.into().map(Arc::new);
         self
     }
 
-    /// Gets a reference to the [`ValidatorPrivateKey`], if available.
-    pub fn key_pair(&self) -> Option<&ValidatorPrivateKey> {
+    /// Gets a reference to the [`ValidatorSecretKey`], if available.
+    pub fn key_pair(&self) -> Option<&ValidatorSecretKey> {
         self.key_pair.as_ref().map(Arc::as_ref)
     }
 }

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -5,14 +5,14 @@
 
 use std::sync::Arc;
 
-use linera_base::{crypto::SigningKey, time::Duration};
+use linera_base::{crypto::AuthorityPrivateKey, time::Duration};
 
 /// Configuration parameters for the [`ChainWorkerState`][`super::state::ChainWorkerState`].
 #[derive(Clone, Default)]
 pub struct ChainWorkerConfig {
     /// The signature key pair of the validator. The key may be missing for replicas
     /// without voting rights (possibly with a partial view of chains).
-    pub key_pair: Option<Arc<SigningKey>>,
+    pub key_pair: Option<Arc<AuthorityPrivateKey>>,
     /// Whether inactive chains are allowed in storage.
     pub allow_inactive_chains: bool,
     /// Whether new messages from deprecated epochs are allowed.
@@ -26,13 +26,13 @@ pub struct ChainWorkerConfig {
 
 impl ChainWorkerConfig {
     /// Configures the `key_pair` in this [`ChainWorkerConfig`].
-    pub fn with_key_pair(mut self, key_pair: impl Into<Option<SigningKey>>) -> Self {
+    pub fn with_key_pair(mut self, key_pair: impl Into<Option<AuthorityPrivateKey>>) -> Self {
         self.key_pair = key_pair.into().map(Arc::new);
         self
     }
 
-    /// Gets a reference to the [`SigningKey`], if available.
-    pub fn key_pair(&self) -> Option<&SigningKey> {
+    /// Gets a reference to the [`AuthorityPrivateKey`], if available.
+    pub fn key_pair(&self) -> Option<&AuthorityPrivateKey> {
         self.key_pair.as_ref().map(Arc::as_ref)
     }
 }

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -9,7 +9,7 @@ use futures::future::Either;
 use linera_base::{
     data_types::{Blob, BlockHeight, Timestamp},
     ensure,
-    identifiers::ChainId,
+    identifiers::{ChainId, Owner},
 };
 use linera_chain::{
     data_types::{
@@ -128,12 +128,12 @@ where
                     round,
                     outcome: _,
                 },
-            public_key: _,
-            owner,
+            public_key,
             validated_block_certificate,
             signature: _,
         } = proposal;
 
+        let owner: Owner = public_key.into();
         let chain = &self.state.chain;
         // Check the epoch.
         let (epoch, committee) = chain.current_committee()?;
@@ -150,7 +150,7 @@ where
             lite_certificate.check(committee)?;
         } else if let Some(signer) = block.authenticated_signer {
             // Check the authentication of the operations in the new block.
-            ensure!(signer == *owner, WorkerError::InvalidSigner(signer));
+            ensure!(signer == owner, WorkerError::InvalidSigner(signer));
         }
         // Check if the chain is ready for this new block proposal.
         chain.tip_state.get().verify_block_chaining(block)?;
@@ -170,7 +170,7 @@ where
             }
             chain
                 .pending_proposed_blobs
-                .try_load_entry_mut(owner)
+                .try_load_entry_mut(&owner)
                 .await?
                 .update(*round, validated_block_certificate.is_some(), maybe_blobs)
                 .await?;

--- a/linera-core/src/client/chain_client_state.rs
+++ b/linera-core/src/client/chain_client_state.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use linera_base::{
-    crypto::{AccountPrivateKey, AccountPublicKey, CryptoHash},
+    crypto::{AccountPublicKey, AccountSecretKey, CryptoHash},
     data_types::{Blob, BlockHeight, Timestamp},
     ensure,
     identifiers::Owner,
@@ -35,7 +35,7 @@ pub struct ChainClientState {
     /// This is always at the same height as `next_block_height`.
     pending_proposal: Option<PendingProposal>,
     /// Known key pairs from present and past identities.
-    known_key_pairs: BTreeMap<Owner, AccountPrivateKey>,
+    known_key_pairs: BTreeMap<Owner, AccountSecretKey>,
 
     /// A mutex that is held whilst we are performing operations that should not be
     /// attempted by multiple clients at the same time.
@@ -44,7 +44,7 @@ pub struct ChainClientState {
 
 impl ChainClientState {
     pub fn new(
-        known_key_pairs: Vec<AccountPrivateKey>,
+        known_key_pairs: Vec<AccountSecretKey>,
         block_hash: Option<CryptoHash>,
         timestamp: Timestamp,
         next_block_height: BlockHeight,
@@ -97,7 +97,7 @@ impl ChainClientState {
         }
     }
 
-    pub fn known_key_pairs(&self) -> &BTreeMap<Owner, AccountPrivateKey> {
+    pub fn known_key_pairs(&self) -> &BTreeMap<Owner, AccountSecretKey> {
         &self.known_key_pairs
     }
 
@@ -108,10 +108,7 @@ impl ChainClientState {
             .any(|owner| !self.known_key_pairs.contains_key(owner))
     }
 
-    pub(super) fn insert_known_key_pair(
-        &mut self,
-        key_pair: AccountPrivateKey,
-    ) -> AccountPublicKey {
+    pub(super) fn insert_known_key_pair(&mut self, key_pair: AccountSecretKey) -> AccountPublicKey {
         let new_public_key = key_pair.public();
         self.known_key_pairs.insert(new_public_key.into(), key_pair);
         new_public_key

--- a/linera-core/src/client/chain_client_state.rs
+++ b/linera-core/src/client/chain_client_state.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use linera_base::{
-    crypto::{CryptoHash, PublicKey, SigningKey},
+    crypto::{AccountPrivateKey, AccountPublicKey, CryptoHash},
     data_types::{Blob, BlockHeight, Timestamp},
     ensure,
     identifiers::Owner,
@@ -35,7 +35,7 @@ pub struct ChainClientState {
     /// This is always at the same height as `next_block_height`.
     pending_proposal: Option<PendingProposal>,
     /// Known key pairs from present and past identities.
-    known_key_pairs: BTreeMap<Owner, SigningKey>,
+    known_key_pairs: BTreeMap<Owner, AccountPrivateKey>,
 
     /// A mutex that is held whilst we are performing operations that should not be
     /// attempted by multiple clients at the same time.
@@ -44,7 +44,7 @@ pub struct ChainClientState {
 
 impl ChainClientState {
     pub fn new(
-        known_key_pairs: Vec<SigningKey>,
+        known_key_pairs: Vec<AccountPrivateKey>,
         block_hash: Option<CryptoHash>,
         timestamp: Timestamp,
         next_block_height: BlockHeight,
@@ -97,7 +97,7 @@ impl ChainClientState {
         }
     }
 
-    pub fn known_key_pairs(&self) -> &BTreeMap<Owner, SigningKey> {
+    pub fn known_key_pairs(&self) -> &BTreeMap<Owner, AccountPrivateKey> {
         &self.known_key_pairs
     }
 
@@ -108,7 +108,10 @@ impl ChainClientState {
             .any(|owner| !self.known_key_pairs.contains_key(owner))
     }
 
-    pub(super) fn insert_known_key_pair(&mut self, key_pair: SigningKey) -> PublicKey {
+    pub(super) fn insert_known_key_pair(
+        &mut self,
+        key_pair: AccountPrivateKey,
+    ) -> AccountPublicKey {
         let new_public_key = key_pair.public();
         self.known_key_pairs.insert(new_public_key.into(), key_pair);
         new_public_key

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -28,7 +28,7 @@ use linera_base::data_types::Bytecode;
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     abi::Abi,
-    crypto::{CryptoHash, PublicKey, SigningKey},
+    crypto::{AuthorityPrivateKey, AuthorityPublicKey, CryptoHash},
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Round, Timestamp,
     },
@@ -285,7 +285,7 @@ impl<P, S: Storage + Clone> Client<P, S> {
     pub fn create_chain_client(
         self: &Arc<Self>,
         chain_id: ChainId,
-        known_key_pairs: Vec<SigningKey>,
+        known_key_pairs: Vec<AuthorityPrivateKey>,
         admin_id: ChainId,
         block_hash: Option<CryptoHash>,
         timestamp: Timestamp,
@@ -976,7 +976,7 @@ where
 
     /// Obtains the key pair associated to the current identity.
     #[instrument(level = "trace")]
-    pub async fn key_pair(&self) -> Result<SigningKey, ChainClientError> {
+    pub async fn key_pair(&self) -> Result<AuthorityPrivateKey, ChainClientError> {
         let id = self.identity().await?;
         Ok(self
             .state()
@@ -988,7 +988,7 @@ where
 
     /// Obtains the public key associated to the current identity.
     #[instrument(level = "trace")]
-    pub async fn public_key(&self) -> Result<PublicKey, ChainClientError> {
+    pub async fn public_key(&self) -> Result<AuthorityPublicKey, ChainClientError> {
         Ok(self.key_pair().await?.public())
     }
 
@@ -2690,7 +2690,7 @@ where
     #[instrument(level = "trace", skip(key_pair))]
     pub async fn rotate_key_pair(
         &self,
-        key_pair: SigningKey,
+        key_pair: AuthorityPrivateKey,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
         let new_public_key = self.state_mut().insert_known_key_pair(key_pair);
         self.transfer_ownership(new_public_key.into()).await

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1778,7 +1778,7 @@ where
             }
         }
         for proposal in proposals {
-            let owner = proposal.owner;
+            let owner: Owner = proposal.public_key.into();
             if let Err(mut err) = self
                 .client
                 .local_node

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1778,7 +1778,7 @@ where
             }
         }
         for proposal in proposals {
-            let owner: Owner = proposal.public_key.into();
+            let owner = proposal.owner;
             if let Err(mut err) = self
                 .client
                 .local_node

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -28,7 +28,7 @@ use linera_base::data_types::Bytecode;
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     abi::Abi,
-    crypto::{AuthorityPrivateKey, AuthorityPublicKey, CryptoHash},
+    crypto::{CryptoHash, ValidatorPrivateKey, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Round, Timestamp,
     },
@@ -285,7 +285,7 @@ impl<P, S: Storage + Clone> Client<P, S> {
     pub fn create_chain_client(
         self: &Arc<Self>,
         chain_id: ChainId,
-        known_key_pairs: Vec<AuthorityPrivateKey>,
+        known_key_pairs: Vec<ValidatorPrivateKey>,
         admin_id: ChainId,
         block_hash: Option<CryptoHash>,
         timestamp: Timestamp,
@@ -976,7 +976,7 @@ where
 
     /// Obtains the key pair associated to the current identity.
     #[instrument(level = "trace")]
-    pub async fn key_pair(&self) -> Result<AuthorityPrivateKey, ChainClientError> {
+    pub async fn key_pair(&self) -> Result<ValidatorPrivateKey, ChainClientError> {
         let id = self.identity().await?;
         Ok(self
             .state()
@@ -988,7 +988,7 @@ where
 
     /// Obtains the public key associated to the current identity.
     #[instrument(level = "trace")]
-    pub async fn public_key(&self) -> Result<AuthorityPublicKey, ChainClientError> {
+    pub async fn public_key(&self) -> Result<ValidatorPublicKey, ChainClientError> {
         Ok(self.key_pair().await?.public())
     }
 
@@ -2690,7 +2690,7 @@ where
     #[instrument(level = "trace", skip(key_pair))]
     pub async fn rotate_key_pair(
         &self,
-        key_pair: AuthorityPrivateKey,
+        key_pair: ValidatorPrivateKey,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
         let new_public_key = self.state_mut().insert_known_key_pair(key_pair);
         self.transfer_ownership(new_public_key.into()).await

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -28,7 +28,7 @@ use linera_base::data_types::Bytecode;
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     abi::Abi,
-    crypto::{CryptoHash, ValidatorPrivateKey, ValidatorPublicKey},
+    crypto::{CryptoHash, ValidatorPublicKey, ValidatorSecretKey},
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Round, Timestamp,
     },
@@ -285,7 +285,7 @@ impl<P, S: Storage + Clone> Client<P, S> {
     pub fn create_chain_client(
         self: &Arc<Self>,
         chain_id: ChainId,
-        known_key_pairs: Vec<ValidatorPrivateKey>,
+        known_key_pairs: Vec<ValidatorSecretKey>,
         admin_id: ChainId,
         block_hash: Option<CryptoHash>,
         timestamp: Timestamp,
@@ -976,7 +976,7 @@ where
 
     /// Obtains the key pair associated to the current identity.
     #[instrument(level = "trace")]
-    pub async fn key_pair(&self) -> Result<ValidatorPrivateKey, ChainClientError> {
+    pub async fn key_pair(&self) -> Result<ValidatorSecretKey, ChainClientError> {
         let id = self.identity().await?;
         Ok(self
             .state()
@@ -2690,7 +2690,7 @@ where
     #[instrument(level = "trace", skip(key_pair))]
     pub async fn rotate_key_pair(
         &self,
-        key_pair: ValidatorPrivateKey,
+        key_pair: ValidatorSecretKey,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
         let new_public_key = self.state_mut().insert_known_key_pair(key_pair);
         self.transfer_ownership(new_public_key.into()).await

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -6,7 +6,7 @@ use std::{collections::BTreeMap, ops::Not};
 
 use custom_debug_derive::Debug;
 use linera_base::{
-    crypto::{BcsSignable, CryptoError, CryptoHash, Signature, SigningKey},
+    crypto::{AuthorityPrivateKey, AuthoritySignature, BcsSignable, CryptoError, CryptoHash},
     data_types::{Amount, BlockHeight, Round, Timestamp},
     identifiers::{AccountOwner, ChainDescription, ChainId},
 };
@@ -217,7 +217,7 @@ impl ChainInfo {
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 pub struct ChainInfoResponse {
     pub info: Box<ChainInfo>,
-    pub signature: Option<Signature>,
+    pub signature: Option<AuthoritySignature>,
 }
 
 /// An internal request between chains within a validator.
@@ -292,20 +292,20 @@ where
 }
 
 impl ChainInfoResponse {
-    pub fn new(info: impl Into<ChainInfo>, key_pair: Option<&SigningKey>) -> Self {
+    pub fn new(info: impl Into<ChainInfo>, key_pair: Option<&AuthorityPrivateKey>) -> Self {
         let info = Box::new(info.into());
-        let signature = key_pair.map(|kp| Signature::new(&*info, kp));
+        let signature = key_pair.map(|kp| AuthoritySignature::new(&*info, kp));
         Self { info, signature }
     }
 
     /// Signs the [`ChainInfo`] stored inside this [`ChainInfoResponse`] with the provided
-    /// [`SigningKey`].
-    pub fn sign(&mut self, key_pair: &SigningKey) {
-        self.signature = Some(Signature::new(&*self.info, key_pair));
+    /// [`AuthorityPrivateKey`].
+    pub fn sign(&mut self, key_pair: &AuthorityPrivateKey) {
+        self.signature = Some(AuthoritySignature::new(&*self.info, key_pair));
     }
 
     pub fn check(&self, name: &ValidatorName) -> Result<(), CryptoError> {
-        Signature::check_optional_signature(self.signature.as_ref(), &*self.info, &name.0)
+        AuthoritySignature::check_optional_signature(self.signature.as_ref(), &*self.info, &name.0)
     }
 
     /// Returns the committee in the latest epoch.

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -6,7 +6,7 @@ use std::{collections::BTreeMap, ops::Not};
 
 use custom_debug_derive::Debug;
 use linera_base::{
-    crypto::{AuthorityPrivateKey, AuthoritySignature, BcsSignable, CryptoError, CryptoHash},
+    crypto::{BcsSignable, CryptoError, CryptoHash, ValidatorPrivateKey, ValidatorSignature},
     data_types::{Amount, BlockHeight, Round, Timestamp},
     identifiers::{AccountOwner, ChainDescription, ChainId},
 };
@@ -217,7 +217,7 @@ impl ChainInfo {
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 pub struct ChainInfoResponse {
     pub info: Box<ChainInfo>,
-    pub signature: Option<AuthoritySignature>,
+    pub signature: Option<ValidatorSignature>,
 }
 
 /// An internal request between chains within a validator.
@@ -292,20 +292,20 @@ where
 }
 
 impl ChainInfoResponse {
-    pub fn new(info: impl Into<ChainInfo>, key_pair: Option<&AuthorityPrivateKey>) -> Self {
+    pub fn new(info: impl Into<ChainInfo>, key_pair: Option<&ValidatorPrivateKey>) -> Self {
         let info = Box::new(info.into());
-        let signature = key_pair.map(|kp| AuthoritySignature::new(&*info, kp));
+        let signature = key_pair.map(|kp| ValidatorSignature::new(&*info, kp));
         Self { info, signature }
     }
 
     /// Signs the [`ChainInfo`] stored inside this [`ChainInfoResponse`] with the provided
-    /// [`AuthorityPrivateKey`].
-    pub fn sign(&mut self, key_pair: &AuthorityPrivateKey) {
-        self.signature = Some(AuthoritySignature::new(&*self.info, key_pair));
+    /// [`ValidatorPrivateKey`].
+    pub fn sign(&mut self, key_pair: &ValidatorPrivateKey) {
+        self.signature = Some(ValidatorSignature::new(&*self.info, key_pair));
     }
 
     pub fn check(&self, name: &ValidatorName) -> Result<(), CryptoError> {
-        AuthoritySignature::check_optional_signature(self.signature.as_ref(), &*self.info, &name.0)
+        ValidatorSignature::check_optional_signature(self.signature.as_ref(), &*self.info, &name.0)
     }
 
     /// Returns the committee in the latest epoch.

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -6,7 +6,7 @@ use std::{collections::BTreeMap, ops::Not};
 
 use custom_debug_derive::Debug;
 use linera_base::{
-    crypto::{BcsSignable, CryptoError, CryptoHash, ValidatorPrivateKey, ValidatorSignature},
+    crypto::{BcsSignable, CryptoError, CryptoHash, ValidatorSecretKey, ValidatorSignature},
     data_types::{Amount, BlockHeight, Round, Timestamp},
     identifiers::{AccountOwner, ChainDescription, ChainId},
 };
@@ -292,15 +292,15 @@ where
 }
 
 impl ChainInfoResponse {
-    pub fn new(info: impl Into<ChainInfo>, key_pair: Option<&ValidatorPrivateKey>) -> Self {
+    pub fn new(info: impl Into<ChainInfo>, key_pair: Option<&ValidatorSecretKey>) -> Self {
         let info = Box::new(info.into());
         let signature = key_pair.map(|kp| ValidatorSignature::new(&*info, kp));
         Self { info, signature }
     }
 
     /// Signs the [`ChainInfo`] stored inside this [`ChainInfoResponse`] with the provided
-    /// [`ValidatorPrivateKey`].
-    pub fn sign(&mut self, key_pair: &ValidatorPrivateKey) {
+    /// [`ValidatorSecretKey`].
+    pub fn sign(&mut self, key_pair: &ValidatorSecretKey) {
         self.signature = Some(ValidatorSignature::new(&*self.info, key_pair));
     }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -8,7 +8,7 @@ mod wasm;
 use assert_matches::assert_matches;
 use futures::StreamExt;
 use linera_base::{
-    crypto::AccountPrivateKey,
+    crypto::AccountSecretKey,
     data_types::*,
     identifiers::{Account, AccountOwner, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
@@ -273,7 +273,7 @@ where
         .await?
         .with_policy(ResourceControlPolicy::fuel_and_block());
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
-    let new_key_pair = AccountPrivateKey::generate();
+    let new_key_pair = AccountSecretKey::generate();
     let new_owner = Owner::from(new_key_pair.public());
     let certificate = sender.rotate_key_pair(new_key_pair).await.unwrap().unwrap();
     assert_eq!(sender.next_block_height(), BlockHeight::from(1));
@@ -311,7 +311,7 @@ where
         .with_policy(ResourceControlPolicy::fuel_and_block());
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
 
-    let new_owner = AccountPrivateKey::generate().public().into();
+    let new_owner = AccountSecretKey::generate().public().into();
     let certificate = sender.transfer_ownership(new_owner).await.unwrap().unwrap();
     assert_eq!(sender.next_block_height(), BlockHeight::from(1));
     assert!(sender.pending_proposal().is_none());
@@ -319,7 +319,7 @@ where
         sender
             .key_pair()
             .await
-            .map(|kp| AccountPrivateKey::public(&kp)), // AccountPrivateKey isn't Debug; using PublicKey.
+            .map(|kp| AccountSecretKey::public(&kp)), // AccountSecretKey isn't Debug; using PublicKey.
         Err(ChainClientError::CannotFindKeyForChain(_))
     );
     assert_eq!(
@@ -354,7 +354,7 @@ where
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 0).await?;
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
-    let new_key_pair = AccountPrivateKey::generate();
+    let new_key_pair = AccountSecretKey::generate();
     let new_owner = new_key_pair.public().into();
     let certificate = sender
         .share_ownership(new_owner, 100)
@@ -461,7 +461,7 @@ where
     // New chains use the admin chain to verify their creation certificate.
     let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
-    let new_key_pair = AccountPrivateKey::generate();
+    let new_key_pair = AccountSecretKey::generate();
     // Open the new chain.
     let (message_id, certificate) = sender
         .open_chain(
@@ -524,7 +524,7 @@ where
     let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let parent = builder.add_root_chain(2, Amount::ZERO).await?;
-    let new_key_pair = AccountPrivateKey::generate();
+    let new_key_pair = AccountSecretKey::generate();
     let new_id = ChainId::child(MessageId {
         chain_id: parent.chain_id(),
         height: BlockHeight::ZERO,
@@ -604,7 +604,7 @@ where
     // New chains use the admin chain to verify their creation certificate.
     let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
-    let new_key_pair = AccountPrivateKey::generate();
+    let new_key_pair = AccountSecretKey::generate();
     let new_id = ChainId::child(MessageId {
         chain_id: sender.chain_id(),
         height: BlockHeight::from(1),
@@ -678,7 +678,7 @@ where
     // New chains use the admin chain to verify their creation certificate.
     let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
-    let new_key_pair = AccountPrivateKey::generate();
+    let new_key_pair = AccountSecretKey::generate();
     // Open the new chain. We are both regular and super owner.
     let ownership = ChainOwnership::single(new_key_pair.public().into())
         .with_regular_owner(new_key_pair.public().into(), 100);
@@ -1269,7 +1269,7 @@ where
     let client1_a = builder.add_root_chain(1, Amount::ZERO).await?;
     let chain_id1 = client1_a.chain_id();
     let owner1_a = client1_a.public_key().await.unwrap().into();
-    let key_pair1_b = AccountPrivateKey::generate();
+    let key_pair1_b = AccountSecretKey::generate();
     let owner1_b = key_pair1_b.public().into();
 
     let owners = [(owner1_a, 50), (owner1_b, 50)];
@@ -1288,7 +1288,7 @@ where
     let client2_a = builder.add_root_chain(2, Amount::from_tokens(10)).await?;
     let chain_id2 = client2_a.chain_id();
     let owner2_a = client2_a.public_key().await.unwrap().into();
-    let key_pair2_b = AccountPrivateKey::generate();
+    let key_pair2_b = AccountSecretKey::generate();
     let owner2_b = key_pair2_b.public().into();
 
     let owners = [(owner2_a, 50), (owner2_b, 50)];
@@ -1460,7 +1460,7 @@ where
     let client2_a = builder.add_root_chain(2, Amount::from_tokens(10)).await?;
     let chain_id2 = client2_a.chain_id();
     let owner2_a = Owner::from(client2_a.public_key().await.unwrap());
-    let key_pair2_b = AccountPrivateKey::generate();
+    let key_pair2_b = AccountSecretKey::generate();
     let owner2_b = Owner::from(key_pair2_b.public());
     let owner_change_op = Operation::System(SystemOperation::ChangeOwnership {
         super_owners: Vec::new(),
@@ -1589,9 +1589,9 @@ where
     let client3_a = builder.add_root_chain(3, Amount::from_tokens(10)).await?;
     let chain_id3 = client3_a.chain_id();
     let owner3_a = Owner::from(client3_a.public_key().await.unwrap());
-    let key_pair3_b = AccountPrivateKey::generate();
+    let key_pair3_b = AccountSecretKey::generate();
     let owner3_b = Owner::from(key_pair3_b.public());
-    let key_pair3_c = AccountPrivateKey::generate();
+    let key_pair3_c = AccountSecretKey::generate();
     let owner3_c = Owner::from(key_pair3_c.public());
     let owner_change_op = Operation::System(SystemOperation::ChangeOwnership {
         super_owners: Vec::new(),
@@ -1835,7 +1835,7 @@ where
     let client = builder.add_root_chain(1, Amount::from_tokens(3)).await?;
     let chain_id = client.chain_id();
     let owner0 = client.public_key().await.unwrap().into();
-    let owner1 = AccountPrivateKey::generate().public().into();
+    let owner1 = AccountSecretKey::generate().public().into();
 
     let owners = [(owner0, 100), (owner1, 100)];
     let ownership = ChainOwnership::multiple(owners, 0, TimeoutConfig::default());
@@ -1949,7 +1949,7 @@ where
     let client0 = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
     let chain_id = client0.chain_id();
     let owner0 = client0.public_key().await.unwrap().into();
-    let key_pair1 = AccountPrivateKey::generate();
+    let key_pair1 = AccountSecretKey::generate();
     let owner1 = key_pair1.public().into();
 
     let owners = [(owner0, 100), (owner1, 100)];
@@ -2088,7 +2088,7 @@ where
     let client0 = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
     let chain_id = client0.chain_id();
     let owner0 = client0.public_key().await.unwrap().into();
-    let key_pair1 = AccountPrivateKey::generate();
+    let key_pair1 = AccountSecretKey::generate();
     let owner1 = key_pair1.public().into();
 
     let owners = [(owner0, 100), (owner1, 100)];

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -16,7 +16,7 @@ use futures::{
     Future,
 };
 use linera_base::{
-    crypto::{AccountPrivateKey, AccountPublicKey, AuthorityPrivateKey, CryptoHash},
+    crypto::{AccountPrivateKey, AccountPublicKey, CryptoHash, ValidatorPrivateKey},
     data_types::*,
     identifiers::{BlobId, ChainDescription, ChainId},
 };
@@ -733,7 +733,7 @@ where
         let mut key_pairs = Vec::new();
         let mut validators = Vec::new();
         for _ in 0..count {
-            let key_pair = AuthorityPrivateKey::generate();
+            let key_pair = ValidatorPrivateKey::generate();
             let name = ValidatorName(key_pair.public());
             validators.push(name);
             key_pairs.push(key_pair);
@@ -891,7 +891,7 @@ where
     pub async fn make_client(
         &mut self,
         chain_id: ChainId,
-        key_pair: AuthorityPrivateKey,
+        key_pair: ValidatorPrivateKey,
         block_hash: Option<CryptoHash>,
         block_height: BlockHeight,
     ) -> Result<ChainClient<NodeProvider<B::Storage>, B::Storage>, anyhow::Error> {

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -16,7 +16,7 @@ use futures::{
     Future,
 };
 use linera_base::{
-    crypto::{CryptoHash, PublicKey, SigningKey},
+    crypto::{AccountPrivateKey, AccountPublicKey, AuthorityPrivateKey, CryptoHash},
     data_types::*,
     identifiers::{BlobId, ChainDescription, ChainId},
 };
@@ -682,12 +682,17 @@ struct GenesisStorageBuilder {
 
 struct GenesisAccount {
     description: ChainDescription,
-    public_key: PublicKey,
+    public_key: AccountPublicKey,
     balance: Amount,
 }
 
 impl GenesisStorageBuilder {
-    fn add(&mut self, description: ChainDescription, public_key: PublicKey, balance: Amount) {
+    fn add(
+        &mut self,
+        description: ChainDescription,
+        public_key: AccountPublicKey,
+        balance: Amount,
+    ) {
         self.accounts.push(GenesisAccount {
             description,
             public_key,
@@ -728,7 +733,7 @@ where
         let mut key_pairs = Vec::new();
         let mut validators = Vec::new();
         for _ in 0..count {
-            let key_pair = SigningKey::generate();
+            let key_pair = AuthorityPrivateKey::generate();
             let name = ValidatorName(key_pair.public());
             validators.push(name);
             key_pairs.push(key_pair);
@@ -798,7 +803,7 @@ where
         balance: Amount,
     ) -> Result<ChainClient<NodeProvider<B::Storage>, B::Storage>, anyhow::Error> {
         let description = ChainDescription::Root(index);
-        let key_pair = SigningKey::generate();
+        let key_pair = AccountPrivateKey::generate();
         let public_key = key_pair.public();
         // Remember what's in the genesis store for future clients to join.
         self.genesis_storage_builder
@@ -848,7 +853,7 @@ where
             .await
     }
 
-    pub fn genesis_chains(&self) -> Vec<(PublicKey, Amount)> {
+    pub fn genesis_chains(&self) -> Vec<(AccountPublicKey, Amount)> {
         let mut result = Vec::new();
         for (i, genesis_account) in self.genesis_storage_builder.accounts.iter().enumerate() {
             assert_eq!(
@@ -886,7 +891,7 @@ where
     pub async fn make_client(
         &mut self,
         chain_id: ChainId,
-        key_pair: SigningKey,
+        key_pair: AuthorityPrivateKey,
         block_hash: Option<CryptoHash>,
         block_height: BlockHeight,
     ) -> Result<ChainClient<NodeProvider<B::Storage>, B::Storage>, anyhow::Error> {

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -16,7 +16,7 @@ use futures::{
     Future,
 };
 use linera_base::{
-    crypto::{AccountPrivateKey, AccountPublicKey, CryptoHash, ValidatorPrivateKey},
+    crypto::{AccountPublicKey, AccountSecretKey, CryptoHash, ValidatorSecretKey},
     data_types::*,
     identifiers::{BlobId, ChainDescription, ChainId},
 };
@@ -733,7 +733,7 @@ where
         let mut key_pairs = Vec::new();
         let mut validators = Vec::new();
         for _ in 0..count {
-            let key_pair = ValidatorPrivateKey::generate();
+            let key_pair = ValidatorSecretKey::generate();
             let name = ValidatorName(key_pair.public());
             validators.push(name);
             key_pairs.push(key_pair);
@@ -803,7 +803,7 @@ where
         balance: Amount,
     ) -> Result<ChainClient<NodeProvider<B::Storage>, B::Storage>, anyhow::Error> {
         let description = ChainDescription::Root(index);
-        let key_pair = AccountPrivateKey::generate();
+        let key_pair = AccountSecretKey::generate();
         let public_key = key_pair.public();
         // Remember what's in the genesis store for future clients to join.
         self.genesis_storage_builder
@@ -891,7 +891,7 @@ where
     pub async fn make_client(
         &mut self,
         chain_id: ChainId,
-        key_pair: ValidatorPrivateKey,
+        key_pair: ValidatorSecretKey,
         block_hash: Option<CryptoHash>,
         block_height: BlockHeight,
     ) -> Result<ChainClient<NodeProvider<B::Storage>, B::Storage>, anyhow::Error> {

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -14,7 +14,7 @@ use std::collections::BTreeSet;
 
 use assert_matches::assert_matches;
 use linera_base::{
-    crypto::AccountPrivateKey,
+    crypto::AccountSecretKey,
     data_types::{
         Amount, Blob, BlockHeight, Bytecode, OracleResponse, Timestamp, UserApplicationDescription,
     },
@@ -100,9 +100,9 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let admin_id = ChainDescription::Root(0);
-    let publisher_owner = AccountPrivateKey::generate().public().into();
+    let publisher_owner = AccountSecretKey::generate().public().into();
     let publisher_chain = ChainDescription::Root(1);
-    let creator_owner = AccountPrivateKey::generate().public().into();
+    let creator_owner = AccountSecretKey::generate().public().into();
     let creator_chain = ChainDescription::Root(2);
     let (committee, worker) = init_worker_with_chains(
         storage.clone(),

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -14,7 +14,7 @@ use std::collections::BTreeSet;
 
 use assert_matches::assert_matches;
 use linera_base::{
-    crypto::SigningKey,
+    crypto::AccountPrivateKey,
     data_types::{
         Amount, Blob, BlockHeight, Bytecode, OracleResponse, Timestamp, UserApplicationDescription,
     },
@@ -100,9 +100,9 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let admin_id = ChainDescription::Root(0);
-    let publisher_owner = SigningKey::generate().public().into();
+    let publisher_owner = AccountPrivateKey::generate().public().into();
     let publisher_chain = ChainDescription::Root(1);
-    let creator_owner = SigningKey::generate().public().into();
+    let creator_owner = AccountPrivateKey::generate().public().into();
     let creator_chain = ChainDescription::Root(2);
     let (committee, worker) = init_worker_with_chains(
         storage.clone(),

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -17,7 +17,7 @@ use std::{
 
 use assert_matches::assert_matches;
 use linera_base::{
-    crypto::{CryptoHash, PublicKey, SigningKey},
+    crypto::{AccountPrivateKey, AccountPublicKey, AuthorityPrivateKey, CryptoHash},
     data_types::*,
     hashed::Hashed,
     identifiers::{
@@ -89,7 +89,7 @@ fn init_worker<S>(
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    let key_pair = SigningKey::generate();
+    let key_pair = AuthorityPrivateKey::generate();
     let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
     let worker = WorkerState::new(
         "Single validator node".to_string(),
@@ -180,7 +180,7 @@ where
 #[expect(clippy::too_many_arguments)]
 async fn make_simple_transfer_certificate<S>(
     chain_description: ChainDescription,
-    key_pair: &SigningKey,
+    key_pair: &AccountPrivateKey,
     target_id: ChainId,
     amount: Amount,
     incoming_bundles: Vec<IncomingBundle>,
@@ -213,7 +213,7 @@ where
 #[expect(clippy::too_many_arguments)]
 async fn make_transfer_certificate<S>(
     chain_description: ChainDescription,
-    key_pair: &SigningKey,
+    key_pair: &AccountPrivateKey,
     source: Option<Owner>,
     recipient: Recipient,
     amount: Amount,
@@ -248,7 +248,7 @@ where
 #[expect(clippy::too_many_arguments)]
 async fn make_transfer_certificate_for_epoch<S>(
     chain_description: ChainDescription,
-    key_pair: &SigningKey,
+    key_pair: &AccountPrivateKey,
     authenticated_signer: Option<Owner>,
     source: Option<Owner>,
     recipient: Recipient,
@@ -392,8 +392,8 @@ fn direct_credit_message(recipient: ChainId, amount: Amount) -> OutgoingMessage 
 }
 
 /// Creates `count` key pairs and returns them, sorted by the `Owner` created from their public key.
-fn generate_key_pairs(count: usize) -> Vec<SigningKey> {
-    let mut key_pairs = iter::repeat_with(SigningKey::generate)
+fn generate_key_pairs(count: usize) -> Vec<AccountPrivateKey> {
+    let mut key_pairs = iter::repeat_with(AccountPrivateKey::generate)
         .take(count)
         .collect::<Vec<_>>();
     key_pairs.sort_by_key(|key_pair| Owner::from(key_pair.public()));
@@ -423,7 +423,7 @@ async fn test_handle_block_proposal_bad_signature<B>(mut storage_builder: B) -> 
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -434,7 +434,7 @@ where
             ),
             (
                 ChainDescription::Root(2),
-                PublicKey::test_key(2).into(),
+                AccountPublicKey::test_key(2).into(),
                 Amount::ZERO,
             ),
         ],
@@ -443,10 +443,10 @@ where
     let block_proposal = make_first_block(ChainId::root(1))
         .with_simple_transfer(ChainId::root(2), Amount::from_tokens(5))
         .into_first_proposal(&sender_key_pair);
-    let unknown_key_pair = SigningKey::generate();
+    let unknown_key_pair = AccountPrivateKey::generate();
     let mut bad_signature_block_proposal = block_proposal.clone();
     bad_signature_block_proposal.signature =
-        linera_base::crypto::Signature::new(&block_proposal.content, &unknown_key_pair);
+        linera_base::crypto::AccountSignature::new(&block_proposal.content, &unknown_key_pair);
     assert_matches!(
         worker
             .handle_block_proposal(bad_signature_block_proposal)
@@ -469,7 +469,7 @@ async fn test_handle_block_proposal_zero_amount<B>(mut storage_builder: B) -> an
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -480,7 +480,7 @@ where
             ),
             (
                 ChainDescription::Root(2),
-                PublicKey::test_key(2).into(),
+                AccountPublicKey::test_key(2).into(),
                 Amount::ZERO,
             ),
         ],
@@ -521,7 +521,7 @@ where
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
-    let key_pair = SigningKey::generate();
+    let key_pair = AccountPrivateKey::generate();
     let balance = Amount::from_tokens(5);
     let balances = vec![(ChainDescription::Root(1), key_pair.public().into(), balance)];
     let epoch = Epoch::ZERO;
@@ -589,7 +589,7 @@ async fn test_handle_block_proposal_unknown_sender<B>(mut storage_builder: B) ->
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -600,13 +600,13 @@ where
             ),
             (
                 ChainDescription::Root(2),
-                PublicKey::test_key(2).into(),
+                AccountPublicKey::test_key(2).into(),
                 Amount::ZERO,
             ),
         ],
     )
     .await;
-    let unknown_key = SigningKey::generate();
+    let unknown_key = AccountPrivateKey::generate();
     let unknown_sender_block_proposal = make_first_block(ChainId::root(1))
         .with_simple_transfer(ChainId::root(2), Amount::from_tokens(5))
         .into_first_proposal(&unknown_key);
@@ -632,7 +632,7 @@ async fn test_handle_block_proposal_with_chaining<B>(mut storage_builder: B) -> 
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let (committee, worker) = init_worker_with_chain(
         storage_builder.build().await?,
         ChainDescription::Root(1),
@@ -766,8 +766,8 @@ async fn test_handle_block_proposal_with_incoming_bundles<B>(
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
-    let recipient_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
+    let recipient_key_pair = AccountPrivateKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -1123,7 +1123,7 @@ async fn test_handle_block_proposal_exceed_balance<B>(mut storage_builder: B) ->
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -1134,7 +1134,7 @@ where
             ),
             (
                 ChainDescription::Root(2),
-                PublicKey::test_key(2).into(),
+                AccountPublicKey::test_key(2).into(),
                 Amount::ZERO,
             ),
         ],
@@ -1170,7 +1170,7 @@ async fn test_handle_block_proposal<B>(mut storage_builder: B) -> anyhow::Result
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
@@ -1222,7 +1222,7 @@ async fn test_handle_block_proposal_replay<B>(mut storage_builder: B) -> anyhow:
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -1233,7 +1233,7 @@ where
             ),
             (
                 ChainDescription::Root(2),
-                PublicKey::test_key(2).into(),
+                AccountPublicKey::test_key(2).into(),
                 Amount::ZERO,
             ),
         ],
@@ -1264,12 +1264,12 @@ async fn test_handle_certificate_unknown_sender<B>(mut storage_builder: B) -> an
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
             ChainDescription::Root(2),
-            PublicKey::test_key(2).into(),
+            AccountPublicKey::test_key(2).into(),
             Amount::ZERO,
         )],
     )
@@ -1304,12 +1304,12 @@ async fn test_handle_certificate_with_open_chain<B>(mut storage_builder: B) -> a
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
             ChainDescription::Root(2),
-            PublicKey::test_key(2).into(),
+            AccountPublicKey::test_key(2).into(),
             Amount::ZERO,
         )],
     )
@@ -1382,8 +1382,8 @@ async fn test_handle_certificate_wrong_owner<B>(mut storage_builder: B) -> anyho
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
-    let chain_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
+    let chain_key_pair = AccountPrivateKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
@@ -1429,7 +1429,7 @@ async fn test_handle_certificate_bad_block_height<B>(mut storage_builder: B) -> 
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -1440,7 +1440,7 @@ where
             ),
             (
                 ChainDescription::Root(2),
-                PublicKey::test_key(2).into(),
+                AccountPublicKey::test_key(2).into(),
                 Amount::ZERO,
             ),
         ],
@@ -1479,7 +1479,7 @@ async fn test_handle_certificate_with_anticipated_incoming_bundle<B>(
 where
     B: StorageBuilder,
 {
-    let key_pair = SigningKey::generate();
+    let key_pair = AccountPrivateKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -1490,7 +1490,7 @@ where
             ),
             (
                 ChainDescription::Root(2),
-                PublicKey::test_key(2).into(),
+                AccountPublicKey::test_key(2).into(),
                 Amount::ZERO,
             ),
         ],
@@ -1580,7 +1580,7 @@ async fn test_handle_certificate_receiver_balance_overflow<B>(
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -1591,7 +1591,7 @@ where
             ),
             (
                 ChainDescription::Root(2),
-                PublicKey::test_key(2).into(),
+                AccountPublicKey::test_key(2).into(),
                 Amount::MAX,
             ),
         ],
@@ -1649,7 +1649,7 @@ where
     B: StorageBuilder,
 {
     let storage = storage_builder.build().await?;
-    let key_pair = SigningKey::generate();
+    let key_pair = AccountPrivateKey::generate();
     let owner = key_pair.public().into();
     let (committee, worker) =
         init_worker_with_chain(storage, ChainDescription::Root(1), owner, Amount::ONE).await;
@@ -1717,11 +1717,11 @@ async fn test_handle_cross_chain_request<B>(mut storage_builder: B) -> anyhow::R
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let (committee, worker) = init_worker_with_chain(
         storage_builder.build().await?,
         ChainDescription::Root(2),
-        PublicKey::test_key(2).into(),
+        AccountPublicKey::test_key(2).into(),
         Amount::ONE,
     )
     .await;
@@ -1796,7 +1796,7 @@ where
     B: StorageBuilder,
 {
     let storage = storage_builder.build().await?;
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let (committee, worker) = init_worker(
         storage, /* is_client */ false, /* has_long_lived_services */ false,
     );
@@ -1835,7 +1835,7 @@ where
     B: StorageBuilder,
 {
     let storage = storage_builder.build().await?;
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let (committee, worker) = init_worker(
         storage, /* is_client */ true, /* has_long_lived_services */ false,
     );
@@ -1885,8 +1885,8 @@ async fn test_handle_certificate_to_active_recipient<B>(
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
-    let recipient_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
+    let recipient_key_pair = AccountPrivateKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -2050,7 +2050,7 @@ async fn test_handle_certificate_to_inactive_recipient<B>(
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let (committee, worker) = init_worker_with_chain(
         storage_builder.build().await?,
         ChainDescription::Root(1),
@@ -2094,14 +2094,14 @@ async fn test_handle_certificate_with_rejected_transfer<B>(
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = SigningKey::generate();
+    let sender_key_pair = AccountPrivateKey::generate();
     let sender = Owner::from(sender_key_pair.public());
     let sender_account = Account {
         chain_id: ChainId::root(1),
         owner: Some(AccountOwner::User(sender)),
     };
 
-    let recipient_key_pair = SigningKey::generate();
+    let recipient_key_pair = AccountPrivateKey::generate();
     let recipient = Owner::from(sender_key_pair.public());
     let recipient_account = Account {
         chain_id: ChainId::root(2),
@@ -2338,7 +2338,7 @@ async fn run_test_chain_creation_with_committee_creation<B>(
 where
     B: StorageBuilder,
 {
-    let key_pair = SigningKey::generate();
+    let key_pair = AccountPrivateKey::generate();
     let (committee, worker) = init_worker_with_chain(
         storage_builder.build().await?,
         ChainDescription::Root(0),
@@ -2690,8 +2690,8 @@ async fn test_transfers_and_committee_creation<B>(mut storage_builder: B) -> any
 where
     B: StorageBuilder,
 {
-    let owner0 = SigningKey::generate().public().into();
-    let owner1 = SigningKey::generate().public().into();
+    let owner0 = AccountPrivateKey::generate().public().into();
+    let owner1 = AccountPrivateKey::generate().public().into();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -2821,8 +2821,8 @@ async fn test_transfers_and_committee_removal<B>(mut storage_builder: B) -> anyh
 where
     B: StorageBuilder,
 {
-    let owner0 = SigningKey::generate().public().into();
-    let owner1 = SigningKey::generate().public().into();
+    let owner0 = AccountPrivateKey::generate().public().into();
+    let owner1 = AccountPrivateKey::generate().public().into();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -3013,7 +3013,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let (committee, worker) = init_worker(store, true, false);
     let committees = BTreeMap::from_iter([(Epoch::from(1), committee.clone())]);
 
-    let key_pair0 = SigningKey::generate();
+    let key_pair0 = AccountPrivateKey::generate();
     let id0 = ChainId::root(0);
     let id1 = ChainId::root(1);
 
@@ -3518,7 +3518,7 @@ where
 {
     let storage = storage_builder.build().await?;
     let chain_id = ChainId::root(0);
-    let key_pair = SigningKey::generate();
+    let key_pair = AccountPrivateKey::generate();
     let owner = key_pair.public().into();
     let description = ChainDescription::Root(0);
     let (committee, worker) =
@@ -3550,7 +3550,7 @@ where
     // But non-owners are not allowed to transfer the chain's funds.
     let proposal = make_child_block(&change_ownership_value)
         .with_transfer(None, Recipient::Burn, Amount::from_tokens(1))
-        .into_proposal_with_round(&SigningKey::generate(), Round::MultiLeader(0));
+        .into_proposal_with_round(&AccountPrivateKey::generate(), Round::MultiLeader(0));
     let result = worker.handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::ChainError(error)) if matches!(&*error,
         ChainError::ExecutionError(error, _) if matches!(&**error,
@@ -3559,7 +3559,7 @@ where
 
     // Without the transfer, a random key pair can propose a block.
     let proposal = make_child_block(&change_ownership_value)
-        .into_proposal_with_round(&SigningKey::generate(), Round::MultiLeader(0));
+        .into_proposal_with_round(&AccountPrivateKey::generate(), Round::MultiLeader(0));
     let (executed_block, _) = worker
         .stage_block_execution(proposal.content.block.clone(), None)
         .await?;
@@ -3694,7 +3694,7 @@ where
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
     let chain_id = ChainId::root(1);
-    let key_pair = SigningKey::generate();
+    let key_pair = AccountPrivateKey::generate();
     let balance = Amount::from_tokens(5);
     let balances = vec![(ChainDescription::Root(1), key_pair.public().into(), balance)];
     let (committee, worker) = init_worker_with_chains(storage, balances).await;
@@ -3768,7 +3768,7 @@ where
     let clock = storage_builder.clock();
     let chain_description = ChainDescription::Root(1);
     let chain_id = ChainId::from(chain_description);
-    let key_pair = SigningKey::generate();
+    let key_pair = AccountPrivateKey::generate();
     let balance = Amount::ZERO;
 
     let (committee, worker) = init_worker(
@@ -3857,7 +3857,7 @@ where
     let clock = storage_builder.clock();
     let chain_description = ChainDescription::Root(1);
     let chain_id = ChainId::from(chain_description);
-    let key_pair = SigningKey::generate();
+    let key_pair = AccountPrivateKey::generate();
     let balance = Amount::ZERO;
 
     let (committee, worker) = init_worker(

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -17,7 +17,7 @@ use std::{
 
 use assert_matches::assert_matches;
 use linera_base::{
-    crypto::{AccountPrivateKey, AccountPublicKey, AuthorityPrivateKey, CryptoHash},
+    crypto::{AccountPrivateKey, AccountPublicKey, CryptoHash, ValidatorPrivateKey},
     data_types::*,
     hashed::Hashed,
     identifiers::{
@@ -89,7 +89,7 @@ fn init_worker<S>(
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    let key_pair = AuthorityPrivateKey::generate();
+    let key_pair = ValidatorPrivateKey::generate();
     let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
     let worker = WorkerState::new(
         "Single validator node".to_string(),

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -17,7 +17,7 @@ use std::{
 
 use assert_matches::assert_matches;
 use linera_base::{
-    crypto::{AccountPrivateKey, AccountPublicKey, CryptoHash, ValidatorPrivateKey},
+    crypto::{AccountPublicKey, AccountSecretKey, CryptoHash, ValidatorSecretKey},
     data_types::*,
     hashed::Hashed,
     identifiers::{
@@ -89,7 +89,7 @@ fn init_worker<S>(
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    let key_pair = ValidatorPrivateKey::generate();
+    let key_pair = ValidatorSecretKey::generate();
     let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
     let worker = WorkerState::new(
         "Single validator node".to_string(),
@@ -180,7 +180,7 @@ where
 #[expect(clippy::too_many_arguments)]
 async fn make_simple_transfer_certificate<S>(
     chain_description: ChainDescription,
-    key_pair: &AccountPrivateKey,
+    key_pair: &AccountSecretKey,
     target_id: ChainId,
     amount: Amount,
     incoming_bundles: Vec<IncomingBundle>,
@@ -213,7 +213,7 @@ where
 #[expect(clippy::too_many_arguments)]
 async fn make_transfer_certificate<S>(
     chain_description: ChainDescription,
-    key_pair: &AccountPrivateKey,
+    key_pair: &AccountSecretKey,
     source: Option<Owner>,
     recipient: Recipient,
     amount: Amount,
@@ -248,7 +248,7 @@ where
 #[expect(clippy::too_many_arguments)]
 async fn make_transfer_certificate_for_epoch<S>(
     chain_description: ChainDescription,
-    key_pair: &AccountPrivateKey,
+    key_pair: &AccountSecretKey,
     authenticated_signer: Option<Owner>,
     source: Option<Owner>,
     recipient: Recipient,
@@ -392,8 +392,8 @@ fn direct_credit_message(recipient: ChainId, amount: Amount) -> OutgoingMessage 
 }
 
 /// Creates `count` key pairs and returns them, sorted by the `Owner` created from their public key.
-fn generate_key_pairs(count: usize) -> Vec<AccountPrivateKey> {
-    let mut key_pairs = iter::repeat_with(AccountPrivateKey::generate)
+fn generate_key_pairs(count: usize) -> Vec<AccountSecretKey> {
+    let mut key_pairs = iter::repeat_with(AccountSecretKey::generate)
         .take(count)
         .collect::<Vec<_>>();
     key_pairs.sort_by_key(|key_pair| Owner::from(key_pair.public()));
@@ -423,7 +423,7 @@ async fn test_handle_block_proposal_bad_signature<B>(mut storage_builder: B) -> 
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -443,7 +443,7 @@ where
     let block_proposal = make_first_block(ChainId::root(1))
         .with_simple_transfer(ChainId::root(2), Amount::from_tokens(5))
         .into_first_proposal(&sender_key_pair);
-    let unknown_key_pair = AccountPrivateKey::generate();
+    let unknown_key_pair = AccountSecretKey::generate();
     let mut bad_signature_block_proposal = block_proposal.clone();
     bad_signature_block_proposal.signature =
         linera_base::crypto::AccountSignature::new(&block_proposal.content, &unknown_key_pair);
@@ -469,7 +469,7 @@ async fn test_handle_block_proposal_zero_amount<B>(mut storage_builder: B) -> an
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -521,7 +521,7 @@ where
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
-    let key_pair = AccountPrivateKey::generate();
+    let key_pair = AccountSecretKey::generate();
     let balance = Amount::from_tokens(5);
     let balances = vec![(ChainDescription::Root(1), key_pair.public().into(), balance)];
     let epoch = Epoch::ZERO;
@@ -589,7 +589,7 @@ async fn test_handle_block_proposal_unknown_sender<B>(mut storage_builder: B) ->
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -606,7 +606,7 @@ where
         ],
     )
     .await;
-    let unknown_key = AccountPrivateKey::generate();
+    let unknown_key = AccountSecretKey::generate();
     let unknown_sender_block_proposal = make_first_block(ChainId::root(1))
         .with_simple_transfer(ChainId::root(2), Amount::from_tokens(5))
         .into_first_proposal(&unknown_key);
@@ -632,7 +632,7 @@ async fn test_handle_block_proposal_with_chaining<B>(mut storage_builder: B) -> 
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let (committee, worker) = init_worker_with_chain(
         storage_builder.build().await?,
         ChainDescription::Root(1),
@@ -766,8 +766,8 @@ async fn test_handle_block_proposal_with_incoming_bundles<B>(
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
-    let recipient_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
+    let recipient_key_pair = AccountSecretKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -1123,7 +1123,7 @@ async fn test_handle_block_proposal_exceed_balance<B>(mut storage_builder: B) ->
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -1170,7 +1170,7 @@ async fn test_handle_block_proposal<B>(mut storage_builder: B) -> anyhow::Result
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
@@ -1222,7 +1222,7 @@ async fn test_handle_block_proposal_replay<B>(mut storage_builder: B) -> anyhow:
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -1264,7 +1264,7 @@ async fn test_handle_certificate_unknown_sender<B>(mut storage_builder: B) -> an
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
@@ -1304,7 +1304,7 @@ async fn test_handle_certificate_with_open_chain<B>(mut storage_builder: B) -> a
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
@@ -1382,8 +1382,8 @@ async fn test_handle_certificate_wrong_owner<B>(mut storage_builder: B) -> anyho
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
-    let chain_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
+    let chain_key_pair = AccountSecretKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
@@ -1429,7 +1429,7 @@ async fn test_handle_certificate_bad_block_height<B>(mut storage_builder: B) -> 
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -1479,7 +1479,7 @@ async fn test_handle_certificate_with_anticipated_incoming_bundle<B>(
 where
     B: StorageBuilder,
 {
-    let key_pair = AccountPrivateKey::generate();
+    let key_pair = AccountSecretKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -1580,7 +1580,7 @@ async fn test_handle_certificate_receiver_balance_overflow<B>(
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -1649,7 +1649,7 @@ where
     B: StorageBuilder,
 {
     let storage = storage_builder.build().await?;
-    let key_pair = AccountPrivateKey::generate();
+    let key_pair = AccountSecretKey::generate();
     let owner = key_pair.public().into();
     let (committee, worker) =
         init_worker_with_chain(storage, ChainDescription::Root(1), owner, Amount::ONE).await;
@@ -1717,7 +1717,7 @@ async fn test_handle_cross_chain_request<B>(mut storage_builder: B) -> anyhow::R
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let (committee, worker) = init_worker_with_chain(
         storage_builder.build().await?,
         ChainDescription::Root(2),
@@ -1796,7 +1796,7 @@ where
     B: StorageBuilder,
 {
     let storage = storage_builder.build().await?;
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let (committee, worker) = init_worker(
         storage, /* is_client */ false, /* has_long_lived_services */ false,
     );
@@ -1835,7 +1835,7 @@ where
     B: StorageBuilder,
 {
     let storage = storage_builder.build().await?;
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let (committee, worker) = init_worker(
         storage, /* is_client */ true, /* has_long_lived_services */ false,
     );
@@ -1885,8 +1885,8 @@ async fn test_handle_certificate_to_active_recipient<B>(
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
-    let recipient_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
+    let recipient_key_pair = AccountSecretKey::generate();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -2050,7 +2050,7 @@ async fn test_handle_certificate_to_inactive_recipient<B>(
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let (committee, worker) = init_worker_with_chain(
         storage_builder.build().await?,
         ChainDescription::Root(1),
@@ -2094,14 +2094,14 @@ async fn test_handle_certificate_with_rejected_transfer<B>(
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountPrivateKey::generate();
+    let sender_key_pair = AccountSecretKey::generate();
     let sender = Owner::from(sender_key_pair.public());
     let sender_account = Account {
         chain_id: ChainId::root(1),
         owner: Some(AccountOwner::User(sender)),
     };
 
-    let recipient_key_pair = AccountPrivateKey::generate();
+    let recipient_key_pair = AccountSecretKey::generate();
     let recipient = Owner::from(sender_key_pair.public());
     let recipient_account = Account {
         chain_id: ChainId::root(2),
@@ -2338,7 +2338,7 @@ async fn run_test_chain_creation_with_committee_creation<B>(
 where
     B: StorageBuilder,
 {
-    let key_pair = AccountPrivateKey::generate();
+    let key_pair = AccountSecretKey::generate();
     let (committee, worker) = init_worker_with_chain(
         storage_builder.build().await?,
         ChainDescription::Root(0),
@@ -2690,8 +2690,8 @@ async fn test_transfers_and_committee_creation<B>(mut storage_builder: B) -> any
 where
     B: StorageBuilder,
 {
-    let owner0 = AccountPrivateKey::generate().public().into();
-    let owner1 = AccountPrivateKey::generate().public().into();
+    let owner0 = AccountSecretKey::generate().public().into();
+    let owner1 = AccountSecretKey::generate().public().into();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -2821,8 +2821,8 @@ async fn test_transfers_and_committee_removal<B>(mut storage_builder: B) -> anyh
 where
     B: StorageBuilder,
 {
-    let owner0 = AccountPrivateKey::generate().public().into();
-    let owner1 = AccountPrivateKey::generate().public().into();
+    let owner0 = AccountSecretKey::generate().public().into();
+    let owner1 = AccountSecretKey::generate().public().into();
     let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
@@ -3013,7 +3013,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let (committee, worker) = init_worker(store, true, false);
     let committees = BTreeMap::from_iter([(Epoch::from(1), committee.clone())]);
 
-    let key_pair0 = AccountPrivateKey::generate();
+    let key_pair0 = AccountSecretKey::generate();
     let id0 = ChainId::root(0);
     let id1 = ChainId::root(1);
 
@@ -3518,7 +3518,7 @@ where
 {
     let storage = storage_builder.build().await?;
     let chain_id = ChainId::root(0);
-    let key_pair = AccountPrivateKey::generate();
+    let key_pair = AccountSecretKey::generate();
     let owner = key_pair.public().into();
     let description = ChainDescription::Root(0);
     let (committee, worker) =
@@ -3550,7 +3550,7 @@ where
     // But non-owners are not allowed to transfer the chain's funds.
     let proposal = make_child_block(&change_ownership_value)
         .with_transfer(None, Recipient::Burn, Amount::from_tokens(1))
-        .into_proposal_with_round(&AccountPrivateKey::generate(), Round::MultiLeader(0));
+        .into_proposal_with_round(&AccountSecretKey::generate(), Round::MultiLeader(0));
     let result = worker.handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::ChainError(error)) if matches!(&*error,
         ChainError::ExecutionError(error, _) if matches!(&**error,
@@ -3559,7 +3559,7 @@ where
 
     // Without the transfer, a random key pair can propose a block.
     let proposal = make_child_block(&change_ownership_value)
-        .into_proposal_with_round(&AccountPrivateKey::generate(), Round::MultiLeader(0));
+        .into_proposal_with_round(&AccountSecretKey::generate(), Round::MultiLeader(0));
     let (executed_block, _) = worker
         .stage_block_execution(proposal.content.block.clone(), None)
         .await?;
@@ -3694,7 +3694,7 @@ where
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
     let chain_id = ChainId::root(1);
-    let key_pair = AccountPrivateKey::generate();
+    let key_pair = AccountSecretKey::generate();
     let balance = Amount::from_tokens(5);
     let balances = vec![(ChainDescription::Root(1), key_pair.public().into(), balance)];
     let (committee, worker) = init_worker_with_chains(storage, balances).await;
@@ -3768,7 +3768,7 @@ where
     let clock = storage_builder.clock();
     let chain_description = ChainDescription::Root(1);
     let chain_id = ChainId::from(chain_description);
-    let key_pair = AccountPrivateKey::generate();
+    let key_pair = AccountSecretKey::generate();
     let balance = Amount::ZERO;
 
     let (committee, worker) = init_worker(
@@ -3857,7 +3857,7 @@ where
     let clock = storage_builder.clock();
     let chain_description = ChainDescription::Root(1);
     let chain_id = ChainId::from(chain_description);
-    let key_pair = AccountPrivateKey::generate();
+    let key_pair = AccountSecretKey::generate();
     let balance = Amount::ZERO;
 
     let (committee, worker) = init_worker(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -11,9 +11,9 @@ use std::{
 
 use futures::future::Either;
 #[cfg(with_testing)]
-use linera_base::crypto::AuthorityPublicKey;
+use linera_base::crypto::ValidatorPublicKey;
 use linera_base::{
-    crypto::{AuthorityPrivateKey, CryptoError, CryptoHash},
+    crypto::{CryptoError, CryptoHash, ValidatorPrivateKey},
     data_types::{
         ArithmeticError, Blob, BlockHeight, DecompressionError, Round, UserApplicationDescription,
     },
@@ -293,7 +293,7 @@ where
     #[instrument(level = "trace", skip(nickname, key_pair, storage))]
     pub fn new(
         nickname: String,
-        key_pair: Option<AuthorityPrivateKey>,
+        key_pair: Option<ValidatorPrivateKey>,
         storage: StorageClient,
         chain_worker_limit: NonZeroUsize,
     ) -> Self {
@@ -391,7 +391,7 @@ where
     #[cfg(test)]
     pub(crate) async fn with_key_pair(
         mut self,
-        key_pair: Option<Arc<AuthorityPrivateKey>>,
+        key_pair: Option<Arc<ValidatorPrivateKey>>,
     ) -> Self {
         self.chain_worker_config.key_pair = key_pair;
         self.chain_workers.lock().unwrap().clear();
@@ -1058,13 +1058,13 @@ impl<StorageClient> WorkerState<StorageClient>
 where
     StorageClient: Storage,
 {
-    /// Gets a reference to the validator's [`AuthorityPublicKey`].
+    /// Gets a reference to the validator's [`ValidatorPublicKey`].
     ///
     /// # Panics
     ///
     /// If the validator doesn't have a key pair assigned to it.
     #[instrument(level = "trace", skip(self))]
-    pub fn public_key(&self) -> AuthorityPublicKey {
+    pub fn public_key(&self) -> ValidatorPublicKey {
         self.chain_worker_config
             .key_pair()
             .expect(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -11,9 +11,9 @@ use std::{
 
 use futures::future::Either;
 #[cfg(with_testing)]
-use linera_base::crypto::PublicKey;
+use linera_base::crypto::AuthorityPublicKey;
 use linera_base::{
-    crypto::{CryptoError, CryptoHash, SigningKey},
+    crypto::{AuthorityPrivateKey, CryptoError, CryptoHash},
     data_types::{
         ArithmeticError, Blob, BlockHeight, DecompressionError, Round, UserApplicationDescription,
     },
@@ -293,7 +293,7 @@ where
     #[instrument(level = "trace", skip(nickname, key_pair, storage))]
     pub fn new(
         nickname: String,
-        key_pair: Option<SigningKey>,
+        key_pair: Option<AuthorityPrivateKey>,
         storage: StorageClient,
         chain_worker_limit: NonZeroUsize,
     ) -> Self {
@@ -389,7 +389,10 @@ where
 
     #[instrument(level = "trace", skip(self, key_pair))]
     #[cfg(test)]
-    pub(crate) async fn with_key_pair(mut self, key_pair: Option<Arc<SigningKey>>) -> Self {
+    pub(crate) async fn with_key_pair(
+        mut self,
+        key_pair: Option<Arc<AuthorityPrivateKey>>,
+    ) -> Self {
         self.chain_worker_config.key_pair = key_pair;
         self.chain_workers.lock().unwrap().clear();
         self
@@ -1055,13 +1058,13 @@ impl<StorageClient> WorkerState<StorageClient>
 where
     StorageClient: Storage,
 {
-    /// Gets a reference to the validator's [`PublicKey`].
+    /// Gets a reference to the validator's [`AuthorityPublicKey`].
     ///
     /// # Panics
     ///
     /// If the validator doesn't have a key pair assigned to it.
     #[instrument(level = "trace", skip(self))]
-    pub fn public_key(&self) -> PublicKey {
+    pub fn public_key(&self) -> AuthorityPublicKey {
         self.chain_worker_config
             .key_pair()
             .expect(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -13,7 +13,7 @@ use futures::future::Either;
 #[cfg(with_testing)]
 use linera_base::crypto::ValidatorPublicKey;
 use linera_base::{
-    crypto::{CryptoError, CryptoHash, ValidatorPrivateKey},
+    crypto::{CryptoError, CryptoHash, ValidatorSecretKey},
     data_types::{
         ArithmeticError, Blob, BlockHeight, DecompressionError, Round, UserApplicationDescription,
     },
@@ -293,7 +293,7 @@ where
     #[instrument(level = "trace", skip(nickname, key_pair, storage))]
     pub fn new(
         nickname: String,
-        key_pair: Option<ValidatorPrivateKey>,
+        key_pair: Option<ValidatorSecretKey>,
         storage: StorageClient,
         chain_worker_limit: NonZeroUsize,
     ) -> Self {
@@ -389,10 +389,7 @@ where
 
     #[instrument(level = "trace", skip(self, key_pair))]
     #[cfg(test)]
-    pub(crate) async fn with_key_pair(
-        mut self,
-        key_pair: Option<Arc<ValidatorPrivateKey>>,
-    ) -> Self {
+    pub(crate) async fn with_key_pair(mut self, key_pair: Option<Arc<ValidatorSecretKey>>) -> Self {
         self.chain_worker_config.key_pair = key_pair;
         self.chain_workers.lock().unwrap().clear();
         self

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -6,7 +6,7 @@ use std::{borrow::Cow, collections::BTreeMap, str::FromStr};
 
 use async_graphql::InputObject;
 use linera_base::{
-    crypto::{CryptoError, PublicKey},
+    crypto::{AuthorityPublicKey, CryptoError},
     data_types::ArithmeticError,
 };
 use serde::{Deserialize, Serialize};
@@ -55,7 +55,7 @@ impl<'de> Deserialize<'de> for Epoch {
 
 /// The identity of a validator.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug)]
-pub struct ValidatorName(pub PublicKey);
+pub struct ValidatorName(pub AuthorityPublicKey);
 
 impl Serialize for ValidatorName {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -82,7 +82,7 @@ impl<'de> Deserialize<'de> for ValidatorName {
         } else {
             #[derive(Deserialize)]
             #[serde(rename = "ValidatorName")]
-            struct ValidatorNameDerived(PublicKey);
+            struct ValidatorNameDerived(AuthorityPublicKey);
 
             let value = ValidatorNameDerived::deserialize(deserializer)?;
             Ok(Self(value.0))
@@ -244,7 +244,7 @@ impl std::str::FromStr for ValidatorName {
     type Err = CryptoError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(ValidatorName(PublicKey::from_str(s)?))
+        Ok(ValidatorName(AuthorityPublicKey::from_str(s)?))
     }
 }
 
@@ -268,8 +268,8 @@ impl From<u32> for Epoch {
     }
 }
 
-impl From<PublicKey> for ValidatorName {
-    fn from(value: PublicKey) -> Self {
+impl From<AuthorityPublicKey> for ValidatorName {
+    fn from(value: AuthorityPublicKey) -> Self {
         Self(value)
     }
 }
@@ -334,7 +334,7 @@ impl Committee {
         }
     }
 
-    pub fn keys_and_weights(&self) -> impl Iterator<Item = (PublicKey, u64)> + '_ {
+    pub fn keys_and_weights(&self) -> impl Iterator<Item = (AuthorityPublicKey, u64)> + '_ {
         self.validators
             .iter()
             .map(|(name, validator)| (name.0, validator.votes))

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -6,7 +6,7 @@ use std::{borrow::Cow, collections::BTreeMap, str::FromStr};
 
 use async_graphql::InputObject;
 use linera_base::{
-    crypto::{AuthorityPublicKey, CryptoError},
+    crypto::{CryptoError, ValidatorPublicKey},
     data_types::ArithmeticError,
 };
 use serde::{Deserialize, Serialize};
@@ -55,7 +55,7 @@ impl<'de> Deserialize<'de> for Epoch {
 
 /// The identity of a validator.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug)]
-pub struct ValidatorName(pub AuthorityPublicKey);
+pub struct ValidatorName(pub ValidatorPublicKey);
 
 impl Serialize for ValidatorName {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -82,7 +82,7 @@ impl<'de> Deserialize<'de> for ValidatorName {
         } else {
             #[derive(Deserialize)]
             #[serde(rename = "ValidatorName")]
-            struct ValidatorNameDerived(AuthorityPublicKey);
+            struct ValidatorNameDerived(ValidatorPublicKey);
 
             let value = ValidatorNameDerived::deserialize(deserializer)?;
             Ok(Self(value.0))
@@ -244,7 +244,7 @@ impl std::str::FromStr for ValidatorName {
     type Err = CryptoError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(ValidatorName(AuthorityPublicKey::from_str(s)?))
+        Ok(ValidatorName(ValidatorPublicKey::from_str(s)?))
     }
 }
 
@@ -268,8 +268,8 @@ impl From<u32> for Epoch {
     }
 }
 
-impl From<AuthorityPublicKey> for ValidatorName {
-    fn from(value: AuthorityPublicKey) -> Self {
+impl From<ValidatorPublicKey> for ValidatorName {
+    fn from(value: ValidatorPublicKey) -> Self {
         Self(value)
     }
 }
@@ -334,7 +334,7 @@ impl Committee {
         }
     }
 
-    pub fn keys_and_weights(&self) -> impl Iterator<Item = (AuthorityPublicKey, u64)> + '_ {
+    pub fn keys_and_weights(&self) -> impl Iterator<Item = (ValidatorPublicKey, u64)> + '_ {
         self.validators
             .iter()
             .map(|(name, validator)| (name.0, validator.votes))

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -88,7 +88,7 @@ async fn open_chain_message_index() {
     let epoch = view.system.epoch.get().unwrap();
     let admin_id = view.system.admin_id.get().unwrap();
     let committees = view.system.committees.get().clone();
-    let owner = linera_base::crypto::PublicKey::test_key(0).into();
+    let owner = linera_base::crypto::AccountPublicKey::test_key(0).into();
     let ownership = ChainOwnership::single(owner);
     let config = OpenChainConfig {
         ownership,

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -8,7 +8,7 @@
 use std::{sync::Arc, vec};
 
 use linera_base::{
-    crypto::{CryptoHash, PublicKey},
+    crypto::{AccountPublicKey, CryptoHash},
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, AccountOwner, ChainDescription, ChainId, MessageId, Owner},
 };
@@ -124,7 +124,7 @@ async fn test_fee_consumption(
     let (application_id, application) = state.register_mock_application().await?;
     let mut view = state.into_view().await;
 
-    let signer = Owner::from(PublicKey::test_key(0));
+    let signer = Owner::from(AccountPublicKey::test_key(0));
     let owner = AccountOwner::User(signer);
     view.system.balance.set(chain_balance);
     if let Some(owner_balance) = owner_balance {

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -9,7 +9,7 @@ use anyhow::Context as _;
 use assert_matches::assert_matches;
 use futures::{stream, StreamExt, TryStreamExt};
 use linera_base::{
-    crypto::{AccountPublicKey, AuthorityPublicKey},
+    crypto::{AccountPublicKey, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, Timestamp,
     },
@@ -1412,7 +1412,7 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
 /// Tests the system API calls `open_chain` and `chain_ownership`.
 #[tokio::test]
 async fn test_open_chain() -> anyhow::Result<()> {
-    let committee = Committee::make_simple(vec![AuthorityPublicKey::test_key(0).into()]);
+    let committee = Committee::make_simple(vec![ValidatorPublicKey::test_key(0).into()]);
     let committees = BTreeMap::from([(Epoch::ZERO, committee)]);
     let chain_key = AccountPublicKey::test_key(1);
     let ownership = ChainOwnership::single(chain_key.into());
@@ -1517,7 +1517,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
 /// Tests the system API call `close_chain``.
 #[tokio::test]
 async fn test_close_chain() -> anyhow::Result<()> {
-    let committee = Committee::make_simple(vec![AuthorityPublicKey::test_key(0).into()]);
+    let committee = Committee::make_simple(vec![ValidatorPublicKey::test_key(0).into()]);
     let committees = BTreeMap::from([(Epoch::ZERO, committee)]);
     let ownership = ChainOwnership::single(AccountPublicKey::test_key(1).into());
     let state = SystemExecutionState {

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -9,7 +9,7 @@ use anyhow::Context as _;
 use assert_matches::assert_matches;
 use futures::{stream, StreamExt, TryStreamExt};
 use linera_base::{
-    crypto::PublicKey,
+    crypto::{AccountPublicKey, AuthorityPublicKey},
     data_types::{
         Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, Timestamp,
     },
@@ -79,7 +79,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
     let (caller_id, caller_application) = view.register_mock_application().await?;
     let (target_id, target_application) = view.register_mock_application().await?;
 
-    let owner = Owner::from(PublicKey::test_key(0));
+    let owner = Owner::from(AccountPublicKey::test_key(0));
     let state_key = vec![];
     let dummy_operation = vec![1];
 
@@ -1412,11 +1412,11 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
 /// Tests the system API calls `open_chain` and `chain_ownership`.
 #[tokio::test]
 async fn test_open_chain() -> anyhow::Result<()> {
-    let committee = Committee::make_simple(vec![PublicKey::test_key(0).into()]);
+    let committee = Committee::make_simple(vec![AuthorityPublicKey::test_key(0).into()]);
     let committees = BTreeMap::from([(Epoch::ZERO, committee)]);
-    let chain_key = PublicKey::test_key(1);
+    let chain_key = AccountPublicKey::test_key(1);
     let ownership = ChainOwnership::single(chain_key.into());
-    let child_ownership = ChainOwnership::single(PublicKey::test_key(2).into());
+    let child_ownership = ChainOwnership::single(AccountPublicKey::test_key(2).into());
     let state = SystemExecutionState {
         committees: committees.clone(),
         ownership: ownership.clone(),
@@ -1517,9 +1517,9 @@ async fn test_open_chain() -> anyhow::Result<()> {
 /// Tests the system API call `close_chain``.
 #[tokio::test]
 async fn test_close_chain() -> anyhow::Result<()> {
-    let committee = Committee::make_simple(vec![PublicKey::test_key(0).into()]);
+    let committee = Committee::make_simple(vec![AuthorityPublicKey::test_key(0).into()]);
     let committees = BTreeMap::from([(Epoch::ZERO, committee)]);
-    let ownership = ChainOwnership::single(PublicKey::test_key(1).into());
+    let ownership = ChainOwnership::single(AccountPublicKey::test_key(1).into());
     let state = SystemExecutionState {
         committees: committees.clone(),
         ownership: ownership.clone(),
@@ -1597,19 +1597,19 @@ async fn test_close_chain() -> anyhow::Result<()> {
 /// Tests an application attempting to transfer the tokens in the chain's balance while executing
 /// messages.
 #[test_case(
-    Some(PublicKey::test_key(1).into()), Some(PublicKey::test_key(1).into())
+    Some(AccountPublicKey::test_key(1).into()), Some(AccountPublicKey::test_key(1).into())
     => matches Ok(Ok(()));
     "works if sender is a receiving chain owner"
 )]
 #[test_case(
-    Some(PublicKey::test_key(1).into()), Some(PublicKey::test_key(2).into())
+    Some(AccountPublicKey::test_key(1).into()), Some(AccountPublicKey::test_key(2).into())
     => matches Ok(Err(
         ExecutionError::SystemError(SystemExecutionError::UnauthenticatedTransferOwner)
     ));
     "fails if sender is not a receiving chain owner"
 )]
 #[test_case(
-    Some(PublicKey::test_key(1).into()), None
+    Some(AccountPublicKey::test_key(1).into()), None
     => matches Ok(Err(
         ExecutionError::SystemError(SystemExecutionError::UnauthenticatedTransferOwner)
     ));
@@ -1623,7 +1623,7 @@ async fn test_close_chain() -> anyhow::Result<()> {
     "fails if unauthenticated and receiving chain has no owners"
 )]
 #[test_case(
-    None, Some(PublicKey::test_key(1).into())
+    None, Some(AccountPublicKey::test_key(1).into())
     => matches Ok(Err(
         ExecutionError::SystemError(SystemExecutionError::UnauthenticatedTransferOwner)
     ));

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::field_reassign_with_default)]
 
 use linera_base::{
-    crypto::{CryptoHash, SigningKey},
+    crypto::{AccountPrivateKey, CryptoHash},
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, AccountOwner, ChainDescription, ChainId, MessageId, Owner},
     ownership::ChainOwnership,
@@ -18,7 +18,7 @@ use linera_execution::{
 
 #[tokio::test]
 async fn test_simple_system_operation() -> anyhow::Result<()> {
-    let owner_key_pair = SigningKey::generate();
+    let owner_key_pair = AccountPrivateKey::generate();
     let owner = Owner::from(owner_key_pair.public());
     let state = SystemExecutionState {
         description: Some(ChainDescription::Root(0)),

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::field_reassign_with_default)]
 
 use linera_base::{
-    crypto::{AccountPrivateKey, CryptoHash},
+    crypto::{AccountSecretKey, CryptoHash},
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, AccountOwner, ChainDescription, ChainId, MessageId, Owner},
     ownership::ChainOwnership,
@@ -18,7 +18,7 @@ use linera_execution::{
 
 #[tokio::test]
 async fn test_simple_system_operation() -> anyhow::Result<()> {
-    let owner_key_pair = AccountPrivateKey::generate();
+    let owner_key_pair = AccountSecretKey::generate();
     let owner = Owner::from(owner_key_pair.public());
     let state = SystemExecutionState {
         description: Some(ChainDescription::Root(0)),

--- a/linera-faucet/server/src/tests.rs
+++ b/linera-faucet/server/src/tests.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::lock::Mutex;
 use linera_base::{
-    crypto::{PublicKey, SigningKey},
+    crypto::{AccountPrivateKey, AccountPublicKey},
     data_types::{Amount, Timestamp},
     identifiers::ChainId,
 };
@@ -50,7 +50,7 @@ impl chain_listener::ClientContext for ClientContext {
     async fn update_wallet_for_new_chain(
         &mut self,
         _: ChainId,
-        _: Option<SigningKey>,
+        _: Option<AccountPrivateKey>,
         _: Timestamp,
     ) -> Result<(), linera_client::Error> {
         self.update_calls += 1;
@@ -93,18 +93,39 @@ async fn test_faucet_rate_limiting() {
     // The faucet is releasing one token every 1000 microseconds. So at 1000 one claim should
     // succeed. At 3000, two more should have been unlocked.
     clock.set(Timestamp::from(999));
-    assert!(root.do_claim(PublicKey::test_key(0).into()).await.is_err());
+    assert!(root
+        .do_claim(AccountPublicKey::test_key(0).into())
+        .await
+        .is_err());
     clock.set(Timestamp::from(1000));
-    assert!(root.do_claim(PublicKey::test_key(1).into()).await.is_ok());
-    assert!(root.do_claim(PublicKey::test_key(2).into()).await.is_err());
+    assert!(root
+        .do_claim(AccountPublicKey::test_key(1).into())
+        .await
+        .is_ok());
+    assert!(root
+        .do_claim(AccountPublicKey::test_key(2).into())
+        .await
+        .is_err());
     clock.set(Timestamp::from(3000));
-    assert!(root.do_claim(PublicKey::test_key(3).into()).await.is_ok());
-    assert!(root.do_claim(PublicKey::test_key(4).into()).await.is_ok());
-    assert!(root.do_claim(PublicKey::test_key(5).into()).await.is_err());
+    assert!(root
+        .do_claim(AccountPublicKey::test_key(3).into())
+        .await
+        .is_ok());
+    assert!(root
+        .do_claim(AccountPublicKey::test_key(4).into())
+        .await
+        .is_ok());
+    assert!(root
+        .do_claim(AccountPublicKey::test_key(5).into())
+        .await
+        .is_err());
     // If a validator is offline, it will create a pending block and then fail.
     clock.set(Timestamp::from(6000));
     builder.set_fault_type([0, 1], FaultType::Offline).await;
-    assert!(root.do_claim(PublicKey::test_key(6).into()).await.is_err());
+    assert!(root
+        .do_claim(AccountPublicKey::test_key(6).into())
+        .await
+        .is_err());
     assert_eq!(context.lock().await.update_calls, 4); // Also called in the last error case.
 }
 

--- a/linera-faucet/server/src/tests.rs
+++ b/linera-faucet/server/src/tests.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::lock::Mutex;
 use linera_base::{
-    crypto::{AccountPrivateKey, AccountPublicKey},
+    crypto::{AccountPublicKey, AccountSecretKey},
     data_types::{Amount, Timestamp},
     identifiers::ChainId,
 };
@@ -50,7 +50,7 @@ impl chain_listener::ClientContext for ClientContext {
     async fn update_wallet_for_new_chain(
         &mut self,
         _: ChainId,
-        _: Option<AccountPrivateKey>,
+        _: Option<AccountSecretKey>,
         _: Timestamp,
     ) -> Result<(), linera_client::Error> {
         self.update_calls += 1;

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -197,7 +197,7 @@ impl TryFrom<BlockProposal> for api::BlockProposal {
             chain_id: Some(block_proposal.content.block.chain_id.into()),
             content: bincode::serialize(&block_proposal.content)?,
             public_key: Some(block_proposal.public_key.into()),
-            owner: Some(block_proposal.owner.into()),
+            owner: Some(Owner::from(block_proposal.public_key).into()),
             signature: Some(block_proposal.signature.into()),
             validated_block_certificate: block_proposal
                 .validated_block_certificate
@@ -219,7 +219,6 @@ impl TryFrom<api::BlockProposal> for BlockProposal {
         Ok(Self {
             content,
             public_key: try_proto_convert(block_proposal.public_key)?,
-            owner: try_proto_convert(block_proposal.owner)?,
             signature: try_proto_convert(block_proposal.signature)?,
             validated_block_certificate: block_proposal
                 .validated_block_certificate
@@ -1219,7 +1218,6 @@ pub mod tests {
                 round: Round::SingleLeader(4),
                 outcome: Some(outcome),
             },
-            owner: Owner::from(public_key),
             public_key,
             signature: Signature::new(&Foo("test".into()), &SigningKey::generate()),
             validated_block_certificate: Some(cert),

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -197,7 +197,7 @@ impl TryFrom<BlockProposal> for api::BlockProposal {
             chain_id: Some(block_proposal.content.block.chain_id.into()),
             content: bincode::serialize(&block_proposal.content)?,
             public_key: Some(block_proposal.public_key.into()),
-            owner: Some(Owner::from(block_proposal.public_key).into()),
+            owner: Some(block_proposal.owner.into()),
             signature: Some(block_proposal.signature.into()),
             validated_block_certificate: block_proposal
                 .validated_block_certificate
@@ -219,6 +219,7 @@ impl TryFrom<api::BlockProposal> for BlockProposal {
         Ok(Self {
             content,
             public_key: try_proto_convert(block_proposal.public_key)?,
+            owner: try_proto_convert(block_proposal.owner)?,
             signature: try_proto_convert(block_proposal.signature)?,
             validated_block_certificate: block_proposal
                 .validated_block_certificate
@@ -1221,6 +1222,7 @@ pub mod tests {
                 round: Round::SingleLeader(4),
                 outcome: Some(outcome),
             },
+            owner: Owner::from(key_pair.public()),
             public_key: key_pair.public(),
             signature: AccountSignature::new(&Foo("test".into()), &key_pair),
             validated_block_certificate: Some(cert),

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -969,7 +969,7 @@ pub mod tests {
     use std::{borrow::Cow, fmt::Debug};
 
     use linera_base::{
-        crypto::{AccountPrivateKey, BcsSignable, CryptoHash, ValidatorPrivateKey},
+        crypto::{AccountSecretKey, BcsSignable, CryptoHash, ValidatorSecretKey},
         data_types::{Amount, Blob, Round, Timestamp},
     };
     use linera_chain::{
@@ -1006,20 +1006,20 @@ pub mod tests {
 
     #[test]
     pub fn test_public_key() {
-        let public_key = ValidatorPrivateKey::generate().public();
+        let public_key = ValidatorSecretKey::generate().public();
         round_trip_check::<_, api::PublicKey>(public_key);
     }
 
     #[test]
     pub fn test_signature() {
-        let key_pair = ValidatorPrivateKey::generate();
+        let key_pair = ValidatorSecretKey::generate();
         let signature = ValidatorSignature::new(&Foo("test".into()), &key_pair);
         round_trip_check::<_, api::Signature>(signature);
     }
 
     #[test]
     pub fn test_owner() {
-        let key_pair = AccountPrivateKey::generate();
+        let key_pair = AccountSecretKey::generate();
         let owner = Owner::from(key_pair.public());
         round_trip_check::<_, api::Owner>(owner);
     }
@@ -1032,7 +1032,7 @@ pub mod tests {
 
     #[test]
     pub fn validator_name() {
-        let validator_name = ValidatorName::from(ValidatorPrivateKey::generate().public());
+        let validator_name = ValidatorName::from(ValidatorSecretKey::generate().public());
         // This is a correct comparison - `ValidatorNameRpc` does not exist in our
         // proto definitions.
         round_trip_check::<_, api::PublicKey>(validator_name);
@@ -1076,7 +1076,7 @@ pub mod tests {
             info: chain_info,
             signature: Some(ValidatorSignature::new(
                 &Foo("test".into()),
-                &ValidatorPrivateKey::generate(),
+                &ValidatorSecretKey::generate(),
             )),
         };
         round_trip_check::<_, api::ChainInfoResponse>(chain_info_response_some);
@@ -1131,7 +1131,7 @@ pub mod tests {
 
     #[test]
     pub fn test_lite_certificate() {
-        let key_pair = ValidatorPrivateKey::generate();
+        let key_pair = ValidatorSecretKey::generate();
         let certificate = LiteCertificate {
             value: LiteValue {
                 value_hash: CryptoHash::new(&Foo("value".into())),
@@ -1154,7 +1154,7 @@ pub mod tests {
 
     #[test]
     pub fn test_certificate() {
-        let key_pair = ValidatorPrivateKey::generate();
+        let key_pair = ValidatorSecretKey::generate();
         let certificate = ValidatedBlockCertificate::new(
             Hashed::new(ValidatedBlock::new(
                 BlockExecutionOutcome {
@@ -1199,7 +1199,7 @@ pub mod tests {
 
     #[test]
     pub fn test_block_proposal() {
-        let key_pair = ValidatorPrivateKey::generate();
+        let key_pair = ValidatorSecretKey::generate();
         let outcome = BlockExecutionOutcome {
             state_hash: CryptoHash::new(&Foo("validated".into())),
             ..BlockExecutionOutcome::default()
@@ -1214,7 +1214,7 @@ pub mod tests {
         )
         .lite_certificate()
         .cloned();
-        let key_pair = AccountPrivateKey::generate();
+        let key_pair = AccountSecretKey::generate();
         let block_proposal = BlockProposal {
             content: ProposalContent {
                 block: get_block(),

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -147,8 +147,6 @@ BlockProposal:
   STRUCT:
     - content:
         TYPENAME: ProposalContent
-    - owner:
-        TYPENAME: Owner
     - public_key:
         TYPENAME: Ed25519PublicKey
     - signature:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -147,6 +147,8 @@ BlockProposal:
   STRUCT:
     - content:
         TYPENAME: ProposalContent
+    - owner:
+        TYPENAME: Owner
     - public_key:
         TYPENAME: Ed25519PublicKey
     - signature:

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -13,7 +13,7 @@ use std::{
 
 use cargo_toml::Manifest;
 use linera_base::{
-    crypto::{AccountPrivateKey, AccountPublicKey},
+    crypto::{AccountPublicKey, AccountSecretKey},
     data_types::{Blob, BlockHeight, Bytecode, CompressedBytecode},
     identifiers::{ApplicationId, BytecodeId, ChainDescription, ChainId, MessageId},
 };
@@ -32,7 +32,7 @@ use crate::{ContractAbi, ServiceAbi};
 
 /// A reference to a single microchain inside a [`TestValidator`].
 pub struct ActiveChain {
-    key_pair: AccountPrivateKey,
+    key_pair: AccountSecretKey,
     description: ChainDescription,
     tip: Arc<Mutex<Option<ConfirmedBlockCertificate>>>,
     validator: TestValidator,
@@ -56,7 +56,7 @@ impl ActiveChain {
     /// The microchain has a single owner that uses the `key_pair` to produce blocks. The
     /// `description` is used as the identifier of the microchain.
     pub fn new(
-        key_pair: AccountPrivateKey,
+        key_pair: AccountSecretKey,
         description: ChainDescription,
         validator: TestValidator,
     ) -> Self {
@@ -78,13 +78,13 @@ impl ActiveChain {
         self.key_pair.public()
     }
 
-    /// Returns the [`AccountPrivateKey`] of the active owner of this microchain.
-    pub fn key_pair(&self) -> &AccountPrivateKey {
+    /// Returns the [`AccountSecretKey`] of the active owner of this microchain.
+    pub fn key_pair(&self) -> &AccountSecretKey {
         &self.key_pair
     }
 
-    /// Sets the [`AccountPrivateKey`] to use for signing new blocks.
-    pub fn set_key_pair(&mut self, key_pair: AccountPrivateKey) {
+    /// Sets the [`AccountSecretKey`] to use for signing new blocks.
+    pub fn set_key_pair(&mut self, key_pair: AccountSecretKey) {
         self.key_pair = key_pair
     }
 

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -13,7 +13,7 @@ use std::{
 
 use cargo_toml::Manifest;
 use linera_base::{
-    crypto::{PublicKey, SigningKey},
+    crypto::{AccountPrivateKey, AccountPublicKey},
     data_types::{Blob, BlockHeight, Bytecode, CompressedBytecode},
     identifiers::{ApplicationId, BytecodeId, ChainDescription, ChainId, MessageId},
 };
@@ -32,7 +32,7 @@ use crate::{ContractAbi, ServiceAbi};
 
 /// A reference to a single microchain inside a [`TestValidator`].
 pub struct ActiveChain {
-    key_pair: SigningKey,
+    key_pair: AccountPrivateKey,
     description: ChainDescription,
     tip: Arc<Mutex<Option<ConfirmedBlockCertificate>>>,
     validator: TestValidator,
@@ -56,7 +56,7 @@ impl ActiveChain {
     /// The microchain has a single owner that uses the `key_pair` to produce blocks. The
     /// `description` is used as the identifier of the microchain.
     pub fn new(
-        key_pair: SigningKey,
+        key_pair: AccountPrivateKey,
         description: ChainDescription,
         validator: TestValidator,
     ) -> Self {
@@ -73,18 +73,18 @@ impl ActiveChain {
         self.description.into()
     }
 
-    /// Returns the [`PublicKey`] of the active owner of this microchain.
-    pub fn public_key(&self) -> PublicKey {
+    /// Returns the [`AccountPublicKey`] of the active owner of this microchain.
+    pub fn public_key(&self) -> AccountPublicKey {
         self.key_pair.public()
     }
 
-    /// Returns the [`SigningKey`] of the active owner of this microchain.
-    pub fn key_pair(&self) -> &SigningKey {
+    /// Returns the [`AccountPrivateKey`] of the active owner of this microchain.
+    pub fn key_pair(&self) -> &AccountPrivateKey {
         &self.key_pair
     }
 
-    /// Sets the [`SigningKey`] to use for signing new blocks.
-    pub fn set_key_pair(&mut self, key_pair: SigningKey) {
+    /// Sets the [`AccountPrivateKey`] to use for signing new blocks.
+    pub fn set_key_pair(&mut self, key_pair: AccountPrivateKey) {
         self.key_pair = key_pair
     }
 

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -11,7 +11,7 @@ use std::{num::NonZeroUsize, sync::Arc};
 use dashmap::DashMap;
 use futures::FutureExt as _;
 use linera_base::{
-    crypto::{AccountPrivateKey, AuthorityPrivateKey},
+    crypto::{AccountPrivateKey, ValidatorPrivateKey},
     data_types::{Amount, ApplicationPermissions, Timestamp},
     identifiers::{ApplicationId, BytecodeId, ChainDescription, ChainId, MessageId, Owner},
     ownership::ChainOwnership,
@@ -43,7 +43,7 @@ use crate::ContractAbi;
 /// # });
 /// ```
 pub struct TestValidator {
-    key_pair: AuthorityPrivateKey,
+    key_pair: ValidatorPrivateKey,
     committee: Committee,
     storage: DbStorage<MemoryStore, TestClock>,
     worker: WorkerState<DbStorage<MemoryStore, TestClock>>,

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -11,7 +11,7 @@ use std::{num::NonZeroUsize, sync::Arc};
 use dashmap::DashMap;
 use futures::FutureExt as _;
 use linera_base::{
-    crypto::{AccountPrivateKey, ValidatorPrivateKey},
+    crypto::{AccountSecretKey, ValidatorSecretKey},
     data_types::{Amount, ApplicationPermissions, Timestamp},
     identifiers::{ApplicationId, BytecodeId, ChainDescription, ChainId, MessageId, Owner},
     ownership::ChainOwnership,
@@ -43,7 +43,7 @@ use crate::ContractAbi;
 /// # });
 /// ```
 pub struct TestValidator {
-    key_pair: ValidatorPrivateKey,
+    key_pair: ValidatorSecretKey,
     committee: Committee,
     storage: DbStorage<MemoryStore, TestClock>,
     worker: WorkerState<DbStorage<MemoryStore, TestClock>>,
@@ -67,7 +67,7 @@ impl Clone for TestValidator {
 impl TestValidator {
     /// Creates a new [`TestValidator`].
     pub async fn new() -> Self {
-        let key_pair = AccountPrivateKey::generate();
+        let key_pair = AccountSecretKey::generate();
         let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
         let wasm_runtime = Some(WasmRuntime::default());
         let storage = DbStorage::<MemoryStore, _>::make_test_storage(wasm_runtime)
@@ -155,7 +155,7 @@ impl TestValidator {
     }
 
     /// Returns the keys this test validator uses for signing certificates.
-    pub fn key_pair(&self) -> &AccountPrivateKey {
+    pub fn key_pair(&self) -> &AccountSecretKey {
         &self.key_pair
     }
 
@@ -169,7 +169,7 @@ impl TestValidator {
     /// Creates a new microchain and returns the [`ActiveChain`] that can be used to add blocks to
     /// it.
     pub async fn new_chain(&self) -> ActiveChain {
-        let key_pair = AccountPrivateKey::generate();
+        let key_pair = AccountSecretKey::generate();
         let description = self
             .request_new_chain_from_admin_chain(key_pair.public().into())
             .await;
@@ -224,7 +224,7 @@ impl TestValidator {
 
     /// Creates the root admin microchain and returns the [`ActiveChain`] map with it.
     async fn create_admin_chain(&self) {
-        let key_pair = AccountPrivateKey::generate();
+        let key_pair = AccountSecretKey::generate();
         let description = ChainDescription::Root(0);
 
         self.worker()

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -11,7 +11,7 @@ use std::{num::NonZeroUsize, sync::Arc};
 use dashmap::DashMap;
 use futures::FutureExt as _;
 use linera_base::{
-    crypto::SigningKey,
+    crypto::{AccountPrivateKey, AuthorityPrivateKey},
     data_types::{Amount, ApplicationPermissions, Timestamp},
     identifiers::{ApplicationId, BytecodeId, ChainDescription, ChainId, MessageId, Owner},
     ownership::ChainOwnership,
@@ -43,7 +43,7 @@ use crate::ContractAbi;
 /// # });
 /// ```
 pub struct TestValidator {
-    key_pair: SigningKey,
+    key_pair: AuthorityPrivateKey,
     committee: Committee,
     storage: DbStorage<MemoryStore, TestClock>,
     worker: WorkerState<DbStorage<MemoryStore, TestClock>>,
@@ -67,7 +67,7 @@ impl Clone for TestValidator {
 impl TestValidator {
     /// Creates a new [`TestValidator`].
     pub async fn new() -> Self {
-        let key_pair = SigningKey::generate();
+        let key_pair = AccountPrivateKey::generate();
         let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
         let wasm_runtime = Some(WasmRuntime::default());
         let storage = DbStorage::<MemoryStore, _>::make_test_storage(wasm_runtime)
@@ -155,7 +155,7 @@ impl TestValidator {
     }
 
     /// Returns the keys this test validator uses for signing certificates.
-    pub fn key_pair(&self) -> &SigningKey {
+    pub fn key_pair(&self) -> &AccountPrivateKey {
         &self.key_pair
     }
 
@@ -169,7 +169,7 @@ impl TestValidator {
     /// Creates a new microchain and returns the [`ActiveChain`] that can be used to add blocks to
     /// it.
     pub async fn new_chain(&self) -> ActiveChain {
-        let key_pair = SigningKey::generate();
+        let key_pair = AccountPrivateKey::generate();
         let description = self
             .request_new_chain_from_admin_chain(key_pair.public().into())
             .await;
@@ -224,7 +224,7 @@ impl TestValidator {
 
     /// Creates the root admin microchain and returns the [`ActiveChain`] map with it.
     async fn create_admin_chain(&self) {
-        let key_pair = SigningKey::generate();
+        let key_pair = AccountPrivateKey::generate();
         let description = ChainDescription::Root(0);
 
         self.worker()

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -67,7 +67,7 @@ impl Clone for TestValidator {
 impl TestValidator {
     /// Creates a new [`TestValidator`].
     pub async fn new() -> Self {
-        let key_pair = AccountSecretKey::generate();
+        let key_pair = ValidatorSecretKey::generate();
         let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
         let wasm_runtime = Some(WasmRuntime::default());
         let storage = DbStorage::<MemoryStore, _>::make_test_storage(wasm_runtime)

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -693,23 +693,20 @@ impl<T> GrpcMessageLimiter<T> {
 
 #[cfg(test)]
 mod proto_message_cap {
-    use linera_base::{
-        crypto::{Signature, SigningKey},
-        hashed::Hashed,
-    };
+    use linera_base::hashed::Hashed;
     use linera_chain::{
         data_types::{BlockExecutionOutcome, ExecutedBlock},
         types::{Certificate, ConfirmedBlock, ConfirmedBlockCertificate},
     };
     use linera_execution::committee::ValidatorName;
-    use linera_sdk::base::{ChainId, TestString};
+    use linera_sdk::base::{AuthorityPrivateKey, AuthoritySignature, ChainId, TestString};
 
     use super::{CertificatesBatchResponse, GrpcMessageLimiter};
 
     fn test_certificate() -> Certificate {
-        let keypair = SigningKey::generate();
+        let keypair = AuthorityPrivateKey::generate();
         let validator = ValidatorName(keypair.public());
-        let signature = Signature::new(&TestString::new("Test"), &keypair);
+        let signature = AuthoritySignature::new(&TestString::new("Test"), &keypair);
         let executed_block = ExecutedBlock {
             block: linera_chain::test::make_first_block(ChainId::root(0)),
             outcome: BlockExecutionOutcome::default(),

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -699,12 +699,12 @@ mod proto_message_cap {
         types::{Certificate, ConfirmedBlock, ConfirmedBlockCertificate},
     };
     use linera_execution::committee::ValidatorName;
-    use linera_sdk::base::{ChainId, TestString, ValidatorPrivateKey, ValidatorSignature};
+    use linera_sdk::base::{ChainId, TestString, ValidatorSecretKey, ValidatorSignature};
 
     use super::{CertificatesBatchResponse, GrpcMessageLimiter};
 
     fn test_certificate() -> Certificate {
-        let keypair = ValidatorPrivateKey::generate();
+        let keypair = ValidatorSecretKey::generate();
         let validator = ValidatorName(keypair.public());
         let signature = ValidatorSignature::new(&TestString::new("Test"), &keypair);
         let executed_block = ExecutedBlock {

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -699,14 +699,14 @@ mod proto_message_cap {
         types::{Certificate, ConfirmedBlock, ConfirmedBlockCertificate},
     };
     use linera_execution::committee::ValidatorName;
-    use linera_sdk::base::{AuthorityPrivateKey, AuthoritySignature, ChainId, TestString};
+    use linera_sdk::base::{ChainId, TestString, ValidatorPrivateKey, ValidatorSignature};
 
     use super::{CertificatesBatchResponse, GrpcMessageLimiter};
 
     fn test_certificate() -> Certificate {
-        let keypair = AuthorityPrivateKey::generate();
+        let keypair = ValidatorPrivateKey::generate();
         let validator = ValidatorName(keypair.public());
-        let signature = AuthoritySignature::new(&TestString::new("Test"), &keypair);
+        let signature = ValidatorSignature::new(&TestString::new("Test"), &keypair);
         let executed_block = ExecutedBlock {
             block: linera_chain::test::make_first_block(ChainId::root(0)),
             outcome: BlockExecutionOutcome::default(),

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -3,7 +3,7 @@
 
 use async_trait::async_trait;
 use linera_base::{
-    crypto::{AccountPrivateKey, CryptoHash},
+    crypto::{AccountSecretKey, CryptoHash},
     data_types::{BlobContent, Timestamp},
     identifiers::{BlobId, ChainId},
 };
@@ -185,7 +185,7 @@ impl<P: ValidatorNodeProvider + Send, S: Storage + Clone + Send + Sync + 'static
     async fn update_wallet_for_new_chain(
         &mut self,
         _: ChainId,
-        _: Option<AccountPrivateKey>,
+        _: Option<AccountSecretKey>,
         _: Timestamp,
     ) -> Result<(), Error> {
         Ok(())

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -3,7 +3,7 @@
 
 use async_trait::async_trait;
 use linera_base::{
-    crypto::{CryptoHash, SigningKey},
+    crypto::{AccountPrivateKey, CryptoHash},
     data_types::{BlobContent, Timestamp},
     identifiers::{BlobId, ChainId},
 };
@@ -185,7 +185,7 @@ impl<P: ValidatorNodeProvider + Send, S: Storage + Clone + Send + Sync + 'static
     async fn update_wallet_for_new_chain(
         &mut self,
         _: ChainId,
-        _: Option<SigningKey>,
+        _: Option<AccountPrivateKey>,
         _: Timestamp,
     ) -> Result<(), Error> {
         Ok(())

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -15,7 +15,7 @@ use anyhow::{bail, Context};
 use async_trait::async_trait;
 use futures::{stream::FuturesUnordered, FutureExt as _, StreamExt, TryFutureExt as _};
 use linera_base::{
-    crypto::{CryptoRng, ValidatorPrivateKey},
+    crypto::{CryptoRng, ValidatorSecretKey},
     listen_for_shutdown_signals,
 };
 use linera_client::{
@@ -283,7 +283,7 @@ fn make_server_config<R: CryptoRng>(
     rng: &mut R,
     options: ValidatorOptions,
 ) -> anyhow::Result<persistent::File<ValidatorServerConfig>> {
-    let key = ValidatorPrivateKey::generate_from(rng);
+    let key = ValidatorSecretKey::generate_from(rng);
     let name = ValidatorName(key.public());
     let network = ValidatorPublicNetworkConfig {
         protocol: options.external_protocol,

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -15,7 +15,7 @@ use anyhow::{bail, Context};
 use async_trait::async_trait;
 use futures::{stream::FuturesUnordered, FutureExt as _, StreamExt, TryFutureExt as _};
 use linera_base::{
-    crypto::{AuthorityPrivateKey, CryptoRng},
+    crypto::{CryptoRng, ValidatorPrivateKey},
     listen_for_shutdown_signals,
 };
 use linera_client::{
@@ -283,7 +283,7 @@ fn make_server_config<R: CryptoRng>(
     rng: &mut R,
     options: ValidatorOptions,
 ) -> anyhow::Result<persistent::File<ValidatorServerConfig>> {
-    let key = AuthorityPrivateKey::generate_from(rng);
+    let key = ValidatorPrivateKey::generate_from(rng);
     let name = ValidatorName(key.public());
     let network = ValidatorPublicNetworkConfig {
         protocol: options.external_protocol,

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -15,7 +15,7 @@ use anyhow::{bail, Context};
 use async_trait::async_trait;
 use futures::{stream::FuturesUnordered, FutureExt as _, StreamExt, TryFutureExt as _};
 use linera_base::{
-    crypto::{CryptoRng, SigningKey},
+    crypto::{AuthorityPrivateKey, CryptoRng},
     listen_for_shutdown_signals,
 };
 use linera_client::{
@@ -283,7 +283,7 @@ fn make_server_config<R: CryptoRng>(
     rng: &mut R,
     options: ValidatorOptions,
 ) -> anyhow::Result<persistent::File<ValidatorServerConfig>> {
-    let key = SigningKey::generate_from(rng);
+    let key = AuthorityPrivateKey::generate_from(rng);
     let name = ValidatorName(key.public());
     let network = ValidatorPublicNetworkConfig {
         protocol: options.external_protocol,

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2667,7 +2667,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) ->
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Result<()> {
-    use linera_base::crypto::PublicKey;
+    use linera_base::crypto::AccountPublicKey;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -2680,7 +2680,7 @@ async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Resul
         let user_chain = wallet.get(chain).unwrap();
         user_chain.key_pair.as_ref().unwrap().public().into()
     };
-    let owner2 = PublicKey::test_key(2).into();
+    let owner2 = AccountPublicKey::test_key(2).into();
 
     // Make both keys owners.
     client

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -21,7 +21,7 @@ use linera_base::{
 };
 use linera_core::{data_types::ChainInfoQuery, node::ValidatorNode};
 use linera_faucet::ClaimOutcome;
-use linera_sdk::base::AccountPrivateKey;
+use linera_sdk::base::AccountSecretKey;
 use linera_service::{
     cli_wrappers::{
         local_net::{get_node_port, Database, LocalNet, LocalNetConfig, ProcessInbox},
@@ -165,7 +165,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
         net.remove_validator(i)?;
     }
 
-    let recipient = AccountOwner::User(Owner::from(AccountPrivateKey::generate().public()));
+    let recipient = AccountOwner::User(Owner::from(AccountSecretKey::generate().public()));
     client
         .transfer_with_accounts(
             Amount::from_tokens(5),

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -21,6 +21,7 @@ use linera_base::{
 };
 use linera_core::{data_types::ChainInfoQuery, node::ValidatorNode};
 use linera_faucet::ClaimOutcome;
+use linera_sdk::base::AccountPrivateKey;
 use linera_service::{
     cli_wrappers::{
         local_net::{get_node_port, Database, LocalNet, LocalNetConfig, ProcessInbox},
@@ -50,8 +51,8 @@ fn get_fungible_account_owner(client: &ClientWrapper) -> AccountOwner {
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Udp) ; "aws_udp"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
-    use linera_base::{crypto::SigningKey, identifiers::Owner};
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+    use linera_base::identifiers::Owner;
+    let _guard: tokio::sync::MutexGuard<'_, ()> = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let network = config.network.external;
@@ -164,7 +165,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
         net.remove_validator(i)?;
     }
 
-    let recipient = AccountOwner::User(Owner::from(SigningKey::generate().public()));
+    let recipient = AccountOwner::User(Owner::from(AccountPrivateKey::generate().public()));
     client
         .transfer_with_accounts(
             Amount::from_tokens(5),


### PR DESCRIPTION
## Motivation

In order to sign blocks with secp256k1 signatures (while keeping ed25519 for chain owners/block proposals) we need to be able to differentiate between different type of keys. At the moment we have two types of actors in the system: validators and chain owners. Fact that both use the same public-key cryptography (ed25519) is orthoganal and will change soon. Authorities (validators) will need to be able to act as chain owners in the cases where they become _fallback_ chain owners. They will also receive rewards for their work so they need to be able to transfer these tokens.

## Proposal

Use type aliases `Authority*` and `Account*` (`*PrivateKey`, `*PublicKey`, `*Signature`) for validators and chain owners respectively. Right now it's a type alias (without a newtype wrapper) as these types will become enums in the near future.

## Test Plan

CI should catch any regressions (but there should not be any, it's just a rename).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.


## Links
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
