### PR TITLE
Stop updating the wallet during linera benchmark

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1634,7 +1634,7 @@ where
 
     /// Handles the certificate in the local node and the resulting notifications.
     #[instrument(level = "trace", skip(certificate))]
-    async fn process_certificate<T: ProcessableCertificate>(
+    pub async fn process_certificate<T: ProcessableCertificate>(
         &self,
         certificate: GenericCertificate<T>,
     ) -> Result<(), LocalNodeError> {

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -745,7 +745,9 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
     assert_eq!(client.load_wallet()?.num_chains(), 3);
     // Launch local benchmark using some additional chains.
     client.benchmark(4, 10, None).await?;
-    assert_eq!(client.load_wallet()?.num_chains(), 7);
+    // Number of chains should not change, as the chains created for the benchmark are not loaded
+    // in the wallet.
+    assert_eq!(client.load_wallet()?.num_chains(), 3);
 
     // Now we run the benchmark again, with the fungible token application instead of the
     // native token.


### PR DESCRIPTION
## Motivation

For the chains we're using during the benchmark, we were currently adding them to our wallet. However, that is not necessary.

## Proposal

Create chains for the benchmark, and don't add them to any wallet, just use them for the benchmark then close them.

## Test Plan

Ran locally, saw that things worked correctly

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
