### PR TITLE
Remove Owner from BlockProposal.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -288,7 +288,6 @@ pub enum Medium {
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 pub struct BlockProposal {
     pub content: ProposalContent,
-    pub owner: Owner,
     pub public_key: AccountPublicKey,
     pub signature: AccountSignature,
     #[debug(skip_if = Option::is_none)]
@@ -747,7 +746,6 @@ impl BlockProposal {
         Self {
             content,
             public_key: secret.public(),
-            owner: secret.public().into(),
             signature,
             validated_block_certificate: None,
         }
@@ -770,7 +768,6 @@ impl BlockProposal {
         Self {
             content,
             public_key: secret.public(),
-            owner: secret.public().into(),
             signature,
             validated_block_certificate: Some(lite_cert),
         }
@@ -792,10 +789,6 @@ impl BlockProposal {
     /// Checks that the public key matches the owner and that the optional certificate matches
     /// the outcome.
     pub fn check_invariants(&self) -> Result<(), &'static str> {
-        ensure!(
-            self.owner == Owner::from(&self.public_key),
-            "Public key does not match owner"
-        );
         match (&self.validated_block_certificate, &self.content.outcome) {
             (None, None) => {}
             (None, Some(_)) | (Some(_), None) => {

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -309,7 +309,7 @@ where
                 // If the fast round has not timed out yet, only a super owner is allowed to open
                 // a later round by making a proposal.
                 ensure!(
-                    self.is_super(&proposal.owner) || !current_round.is_fast(),
+                    self.is_super(&proposal.public_key.into()) || !current_round.is_fast(),
                     ChainError::WrongRound(current_round)
                 );
                 // After the fast round, proposals older than the current round are obsolete.
@@ -582,7 +582,7 @@ where
     /// Returns whether the signer is a valid owner and allowed to propose a block in the
     /// proposal's round.
     pub fn verify_owner(&self, proposal: &BlockProposal) -> bool {
-        let owner = &proposal.owner;
+        let owner = &proposal.public_key.into();
         if self.ownership.get().super_owners.contains(owner) {
             return true;
         }

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -9,7 +9,7 @@ use futures::future::Either;
 use linera_base::{
     data_types::{Blob, BlockHeight, Timestamp},
     ensure,
-    identifiers::ChainId,
+    identifiers::{ChainId, Owner},
 };
 use linera_chain::{
     data_types::{
@@ -128,12 +128,12 @@ where
                     round,
                     outcome: _,
                 },
-            public_key: _,
-            owner,
+            public_key,
             validated_block_certificate,
             signature: _,
         } = proposal;
 
+        let owner: Owner = public_key.into();
         let chain = &self.state.chain;
         // Check the epoch.
         let (epoch, committee) = chain.current_committee()?;
@@ -150,7 +150,7 @@ where
             lite_certificate.check(committee)?;
         } else if let Some(signer) = block.authenticated_signer {
             // Check the authentication of the operations in the new block.
-            ensure!(signer == *owner, WorkerError::InvalidSigner(signer));
+            ensure!(signer == owner, WorkerError::InvalidSigner(signer));
         }
         // Check if the chain is ready for this new block proposal.
         chain.tip_state.get().verify_block_chaining(block)?;
@@ -170,7 +170,7 @@ where
             }
             chain
                 .pending_proposed_blobs
-                .try_load_entry_mut(owner)
+                .try_load_entry_mut(&owner)
                 .await?
                 .update(*round, validated_block_certificate.is_some(), maybe_blobs)
                 .await?;

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1778,7 +1778,7 @@ where
             }
         }
         for proposal in proposals {
-            let owner = proposal.owner;
+            let owner: Owner = proposal.public_key.into();
             if let Err(mut err) = self
                 .client
                 .local_node

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -197,7 +197,7 @@ impl TryFrom<BlockProposal> for api::BlockProposal {
             chain_id: Some(block_proposal.content.block.chain_id.into()),
             content: bincode::serialize(&block_proposal.content)?,
             public_key: Some(block_proposal.public_key.into()),
-            owner: Some(block_proposal.owner.into()),
+            owner: Some(Owner::from(block_proposal.public_key).into()),
             signature: Some(block_proposal.signature.into()),
             validated_block_certificate: block_proposal
                 .validated_block_certificate
@@ -219,7 +219,6 @@ impl TryFrom<api::BlockProposal> for BlockProposal {
         Ok(Self {
             content,
             public_key: try_proto_convert(block_proposal.public_key)?,
-            owner: try_proto_convert(block_proposal.owner)?,
             signature: try_proto_convert(block_proposal.signature)?,
             validated_block_certificate: block_proposal
                 .validated_block_certificate
@@ -1222,7 +1221,6 @@ pub mod tests {
                 round: Round::SingleLeader(4),
                 outcome: Some(outcome),
             },
-            owner: Owner::from(key_pair.public()),
             public_key: key_pair.public(),
             signature: AccountSignature::new(&Foo("test".into()), &key_pair),
             validated_block_certificate: Some(cert),

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -147,8 +147,6 @@ BlockProposal:
   STRUCT:
     - content:
         TYPENAME: ProposalContent
-    - owner:
-        TYPENAME: Owner
     - public_key:
         TYPENAME: Ed25519PublicKey
     - signature:


### PR DESCRIPTION
## Motivation

`Owner` in `BlockProposal` is redundant information (derived from public key that's already part of the `BlockProposal`).

## Proposal

Remove `owner` field from `BlockProposal`.

## Test Plan

CI.

## Release Plan


- Nothing to do / These changes follow the usual release cycle.

## Links


- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
