### PR TITLE
Adjust latency metrics buckets

### DIFF
--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -63,7 +63,7 @@ static SERVER_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "server_request_latency",
         "Server request latency",
         &[],
-        bucket_interval(0.1, 50.0),
+        bucket_interval(1.0, 200.0),
     )
 });
 
@@ -95,7 +95,7 @@ static SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE: LazyLock<HistogramVec> = LazyLoc
         "server_request_latency_per_request_type",
         "Server request latency per request type",
         &["method_name"],
-        bucket_interval(0.1, 50.0),
+        bucket_interval(1.0, 200.0),
     )
 });
 

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -57,7 +57,7 @@ use tracing::{debug, info, instrument, Instrument as _, Level};
 #[cfg(with_metrics)]
 use {
     linera_base::prometheus_util::{
-        bucket_latencies, register_histogram_vec, register_int_counter_vec,
+        bucket_interval, register_histogram_vec, register_int_counter_vec,
     },
     prometheus::{HistogramVec, IntCounterVec},
 };
@@ -71,7 +71,7 @@ static PROXY_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "proxy_request_latency",
         "Proxy request latency",
         &[],
-        bucket_latencies(500.0),
+        bucket_interval(1.0, 500.0),
     )
 });
 


### PR DESCRIPTION
## Motivation

We don't need to track latencies below 1ms IMHO. Also, for the server latency, I noticed it would very often just shoot to 50ms and stay there the whole time. If you're using few shards (1, like me, for example), shard latency can actually be fairly high.

## Proposal

Adjust things

## Test Plan

Check the changes on a local network

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
