### PR TITLE
Adjust dashboards to show 1m metrics

### DIFF
--- a/docker/dashboards/linera-general.json
+++ b/docker/dashboards/linera-general.json
@@ -120,14 +120,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(sum(rate(linera_proxy_request_error[1h])) / (sum(rate(linera_proxy_request_success[1h])) + sum(rate(linera_proxy_request_error[1h])))) * 100",
+          "expr": "(sum(rate(linera_proxy_request_error[1m])) / (sum(rate(linera_proxy_request_success[1m])) + sum(rate(linera_proxy_request_error[1m])))) * 100",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Proxy Error rate (hourly)",
+      "title": "Proxy Error rate (1m)",
       "type": "timeseries"
     },
     {
@@ -216,14 +216,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(linera_proxy_request_latency_bucket[1h])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_proxy_request_latency_bucket[1m])) by (le))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Proxy p99 latency ms (hourly)",
+      "title": "Proxy p99 latency ms (1m)",
       "type": "timeseries"
     },
     {
@@ -312,14 +312,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(rate(linera_proxy_request_latency_bucket[1h])) by (le))",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_proxy_request_latency_bucket[1m])) by (le))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Proxy p90 latency ms (hourly)",
+      "title": "Proxy p90 latency ms (1m)",
       "type": "timeseries"
     },
     {
@@ -408,14 +408,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_proxy_request_latency_bucket[1h])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_proxy_request_latency_bucket[1m])) by (le))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Proxy p50 latency ms (hourly)",
+      "title": "Proxy p50 latency ms (1m)",
       "type": "timeseries"
     },
     {
@@ -518,7 +518,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "(sum(rate(linera_server_request_error[1h])) / (sum(rate(linera_server_request_success[1h])) + sum(rate(linera_server_request_error[1h])))) * 100",
+          "expr": "(sum(rate(linera_server_request_error[1m])) / (sum(rate(linera_server_request_success[1m])) + sum(rate(linera_server_request_error[1m])))) * 100",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -528,7 +528,7 @@
           "useBackend": false
         }
       ],
-      "title": "Server Error rate (hourly)",
+      "title": "Server Error rate (1m)",
       "type": "timeseries"
     },
     {
@@ -618,7 +618,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(linera_server_request_latency_bucket[1h])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_server_request_latency_bucket[1m])) by (le))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -628,7 +628,7 @@
           "useBackend": false
         }
       ],
-      "title": "Server p99 latency ms (hourly)",
+      "title": "Server p99 latency ms (1m)",
       "type": "timeseries"
     },
     {
@@ -717,14 +717,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(rate(linera_server_request_latency_bucket[1h])) by (le))",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_server_request_latency_bucket[1m])) by (le))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Server p90 latency ms (hourly)",
+      "title": "Server p90 latency ms (1m)",
       "type": "timeseries"
     },
     {
@@ -813,14 +813,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_server_request_latency_bucket[1h])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_server_request_latency_bucket[1m])) by (le))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Server p50 latency ms (hourly)",
+      "title": "Server p50 latency ms (1m)",
       "type": "timeseries"
     },
     {

--- a/kubernetes/linera-validator/grafana-dashboards/linera-general.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera-general.json
@@ -118,14 +118,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(sum(rate(linera_proxy_request_error[1h])) / (sum(rate(linera_proxy_request_success[1h])) + sum(rate(linera_proxy_request_error[1h])))) * 100",
+          "expr": "(sum(rate(linera_proxy_request_error[1m])) / (sum(rate(linera_proxy_request_success[1m])) + sum(rate(linera_proxy_request_error[1m])))) * 100",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Proxy Error rate (hourly)",
+      "title": "Proxy Error rate (1m)",
       "type": "timeseries"
     },
     {
@@ -212,14 +212,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(linera_proxy_request_latency_bucket[1h])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_proxy_request_latency_bucket[1m])) by (le))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Proxy p99 latency ms (hourly)",
+      "title": "Proxy p99 latency ms (1m)",
       "type": "timeseries"
     },
     {
@@ -306,14 +306,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(rate(linera_proxy_request_latency_bucket[1h])) by (le))",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_proxy_request_latency_bucket[1m])) by (le))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Proxy p90 latency ms (hourly)",
+      "title": "Proxy p90 latency ms (1m)",
       "type": "timeseries"
     },
     {
@@ -400,14 +400,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_proxy_request_latency_bucket[1h])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_proxy_request_latency_bucket[1m])) by (le))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Proxy p50 latency ms (hourly)",
+      "title": "Proxy p50 latency ms (1m)",
       "type": "timeseries"
     },
     {
@@ -508,7 +508,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "(sum(rate(linera_server_request_error[1h])) / (sum(rate(linera_server_request_success[1h])) + sum(rate(linera_server_request_error[1h])))) * 100",
+          "expr": "(sum(rate(linera_server_request_error[1m])) / (sum(rate(linera_server_request_success[1m])) + sum(rate(linera_server_request_error[1m])))) * 100",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -518,7 +518,7 @@
           "useBackend": false
         }
       ],
-      "title": "Server Error rate (hourly)",
+      "title": "Server Error rate (1m)",
       "type": "timeseries"
     },
     {
@@ -606,7 +606,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(linera_server_request_latency_bucket[1h])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_server_request_latency_bucket[1m])) by (le))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -616,7 +616,7 @@
           "useBackend": false
         }
       ],
-      "title": "Server p99 latency ms (hourly)",
+      "title": "Server p99 latency ms (1m)",
       "type": "timeseries"
     },
     {
@@ -703,14 +703,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(rate(linera_server_request_latency_bucket[1h])) by (le))",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_server_request_latency_bucket[1m])) by (le))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Server p90 latency ms (hourly)",
+      "title": "Server p90 latency ms (1m)",
       "type": "timeseries"
     },
     {
@@ -797,14 +797,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_server_request_latency_bucket[1h])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_server_request_latency_bucket[1m])) by (le))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Server p50 latency ms (hourly)",
+      "title": "Server p50 latency ms (1m)",
       "type": "timeseries"
     },
     {

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -63,7 +63,7 @@ static SERVER_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "server_request_latency",
         "Server request latency",
         &[],
-        bucket_interval(0.1, 50.0),
+        bucket_interval(1.0, 200.0),
     )
 });
 
@@ -95,7 +95,7 @@ static SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE: LazyLock<HistogramVec> = LazyLoc
         "server_request_latency_per_request_type",
         "Server request latency per request type",
         &["method_name"],
-        bucket_interval(0.1, 50.0),
+        bucket_interval(1.0, 200.0),
     )
 });
 

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -57,7 +57,7 @@ use tracing::{debug, info, instrument, Instrument as _, Level};
 #[cfg(with_metrics)]
 use {
     linera_base::prometheus_util::{
-        bucket_latencies, register_histogram_vec, register_int_counter_vec,
+        bucket_interval, register_histogram_vec, register_int_counter_vec,
     },
     prometheus::{HistogramVec, IntCounterVec},
 };
@@ -71,7 +71,7 @@ static PROXY_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "proxy_request_latency",
         "Proxy request latency",
         &[],
-        bucket_latencies(500.0),
+        bucket_interval(1.0, 500.0),
     )
 });
 


### PR DESCRIPTION
## Motivation

`1h` metrics honestly don't make much sense, because p99 for example could take forever to go down, even though the network is fine.

## Proposal

`1m` seems more reasonable.

## Test Plan

Deploy a local network and check

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
