### PR TITLE
Fix Grammar and Clarity in Documentation Comments

### DIFF
--- a/linera-witty/src/primitive_types/simple_type.rs
+++ b/linera-witty/src/primitive_types/simple_type.rs
@@ -11,7 +11,7 @@
 
 use super::FlatType;
 
-/// Marker trait to prevent [`SimpleType`] to be implemented for other types.
+/// Marker trait to prevent [`SimpleType`] from being implemented for other types.
 pub trait Sealed {}
 
 /// Primitive fundamental WIT types.

--- a/linera-witty/src/runtime/borrowed_instance.rs
+++ b/linera-witty/src/runtime/borrowed_instance.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Implementations of Wasm instance related traits to mutable borrows of instances.
+//! Implementations of Wasm instance-related traits for mutable borrows of instances.
 //!
 //! This allows using the same traits without having to move the type implementation around, for
 //! example as parameters in reentrant functions.


### PR DESCRIPTION


Before: /// Marker trait to prevent [SimpleType] to be implemented for other types.
After: /// Marker trait to prevent [SimpleType] from being implemented for other types.
Reason: Corrects improper English usage—"prevent from being implemented" is the correct form.
Fixed incorrect phrasing in instance.rs

Before: //! Implementations of Wasm instance related traits to mutable borrows of instances.
After: //! Implementations of Wasm instance-related traits for mutable borrows of instances.
Reason: Adds a hyphen in "instance-related" (compound adjective) and replaces "to" with "for" for accuracy.