### PR TITLE
Use linear buckets in some places

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -27,7 +27,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
 #[cfg(with_metrics)]
-use crate::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency};
+use crate::prometheus_util::{
+    exponential_bucket_latencies, register_histogram_vec, MeasureLatency,
+};
 use crate::{
     crypto::{BcsHashable, CryptoHash},
     doc_scalar, hex_debug, http,
@@ -1168,7 +1170,7 @@ static BYTECODE_COMPRESSION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "bytecode_compression_latency",
         "Bytecode compression latency",
         &[],
-        bucket_latencies(10.0),
+        exponential_bucket_latencies(10.0),
     )
 });
 
@@ -1179,7 +1181,7 @@ static BYTECODE_DECOMPRESSION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(||
         "bytecode_decompression_latency",
         "Bytecode decompression latency",
         &[],
-        bucket_latencies(10.0),
+        exponential_bucket_latencies(10.0),
     )
 });
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -60,8 +60,8 @@ mod chain_tests;
 #[cfg(with_metrics)]
 use {
     linera_base::prometheus_util::{
-        bucket_interval, bucket_latencies, register_histogram_vec, register_int_counter_vec,
-        MeasureLatency,
+        exponential_bucket_interval, exponential_bucket_latencies, register_histogram_vec,
+        register_int_counter_vec, MeasureLatency,
     },
     prometheus::{HistogramVec, IntCounterVec},
 };
@@ -77,7 +77,7 @@ static BLOCK_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "block_execution_latency",
         "Block execution latency",
         &[],
-        bucket_latencies(50.0),
+        exponential_bucket_latencies(50.0),
     )
 });
 
@@ -87,7 +87,7 @@ static MESSAGE_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "message_execution_latency",
         "Message execution latency",
         &[],
-        bucket_latencies(2.5),
+        exponential_bucket_latencies(2.5),
     )
 });
 
@@ -97,7 +97,7 @@ static OPERATION_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "operation_execution_latency",
         "Operation execution latency",
         &[],
-        bucket_latencies(2.5),
+        exponential_bucket_latencies(2.5),
     )
 });
 
@@ -107,7 +107,7 @@ static WASM_FUEL_USED_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
         "wasm_fuel_used_per_block",
         "Wasm fuel used per block",
         &[],
-        bucket_interval(10.0, 500_000.0),
+        exponential_bucket_interval(10.0, 500_000.0),
     )
 });
 
@@ -117,7 +117,7 @@ static WASM_NUM_READS_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
         "wasm_num_reads_per_block",
         "Wasm number of reads per block",
         &[],
-        bucket_interval(0.1, 100.0),
+        exponential_bucket_interval(0.1, 100.0),
     )
 });
 
@@ -127,7 +127,7 @@ static WASM_BYTES_READ_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
         "wasm_bytes_read_per_block",
         "Wasm number of bytes read per block",
         &[],
-        bucket_interval(0.1, 10_000_000.0),
+        exponential_bucket_interval(0.1, 10_000_000.0),
     )
 });
 
@@ -137,7 +137,7 @@ static WASM_BYTES_WRITTEN_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
         "wasm_bytes_written_per_block",
         "Wasm number of bytes written per block",
         &[],
-        bucket_interval(0.1, 10_000_000.0),
+        exponential_bucket_interval(0.1, 10_000_000.0),
     )
 });
 
@@ -147,7 +147,7 @@ static STATE_HASH_COMPUTATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(||
         "state_hash_computation_latency",
         "Time to recompute the state hash",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -94,7 +94,7 @@ mod client_tests;
 mod metrics {
     use std::sync::LazyLock;
 
-    use linera_base::prometheus_util::{bucket_latencies, register_histogram_vec};
+    use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
     use prometheus::HistogramVec;
 
     pub static PROCESS_INBOX_WITHOUT_PREPARE_LATENCY: LazyLock<HistogramVec> =
@@ -103,7 +103,7 @@ mod metrics {
                 "process_inbox_latency",
                 "process_inbox latency",
                 &[],
-                bucket_latencies(500.0),
+                exponential_bucket_latencies(500.0),
             )
         });
 
@@ -112,7 +112,7 @@ mod metrics {
             "prepare_chain_latency",
             "prepare_chain latency",
             &[],
-            bucket_latencies(500.0),
+            exponential_bucket_latencies(500.0),
         )
     });
 
@@ -121,7 +121,7 @@ mod metrics {
             "synchronize_chain_state_latency",
             "synchronize_chain_state latency",
             &[],
-            bucket_latencies(500.0),
+            exponential_bucket_latencies(500.0),
         )
     });
 
@@ -130,7 +130,7 @@ mod metrics {
             "execute_block_latency",
             "execute_block latency",
             &[],
-            bucket_latencies(500.0),
+            exponential_bucket_latencies(500.0),
         )
     });
 
@@ -139,7 +139,7 @@ mod metrics {
             "find_received_certificates_latency",
             "find_received_certificates latency",
             &[],
-            bucket_latencies(500.0),
+            exponential_bucket_latencies(500.0),
         )
     });
 }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -42,7 +42,7 @@ use tracing::{error, instrument, trace, warn, Instrument as _};
 #[cfg(with_metrics)]
 use {
     linera_base::prometheus_util::{
-        bucket_interval, register_histogram_vec, register_int_counter_vec,
+        exponential_bucket_interval, register_histogram_vec, register_int_counter_vec,
     },
     prometheus::{HistogramVec, IntCounterVec},
     std::sync::LazyLock,
@@ -66,7 +66,7 @@ static NUM_ROUNDS_IN_CERTIFICATE: LazyLock<HistogramVec> = LazyLock::new(|| {
         "num_rounds_in_certificate",
         "Number of rounds in certificate",
         &["certificate_value", "round_type"],
-        bucket_interval(0.1, 50.0),
+        exponential_bucket_interval(0.1, 50.0),
     )
 });
 
@@ -76,7 +76,7 @@ static NUM_ROUNDS_IN_BLOCK_PROPOSAL: LazyLock<HistogramVec> = LazyLock::new(|| {
         "num_rounds_in_block_proposal",
         "Number of rounds in block proposal",
         &["round_type"],
-        bucket_interval(0.1, 50.0),
+        exponential_bucket_interval(0.1, 50.0),
     )
 });
 

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -9,7 +9,9 @@ use std::sync::LazyLock;
 use custom_debug_derive::Debug;
 use futures::channel::mpsc;
 #[cfg(with_metrics)]
-use linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency as _};
+use linera_base::prometheus_util::{
+    exponential_bucket_latencies, register_histogram_vec, MeasureLatency as _,
+};
 use linera_base::{
     data_types::{Amount, ApplicationPermissions, BlobContent, Timestamp},
     hex_debug, hex_vec_debug, http,
@@ -37,7 +39,7 @@ static LOAD_CONTRACT_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "load_contract_latency",
         "Load contract latency",
         &[],
-        bucket_latencies(250.0),
+        exponential_bucket_latencies(250.0),
     )
 });
 
@@ -48,7 +50,7 @@ static LOAD_SERVICE_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "load_service_latency",
         "Load service latency",
         &[],
-        bucket_latencies(250.0),
+        exponential_bucket_latencies(250.0),
     )
 });
 

--- a/linera-execution/src/revm.rs
+++ b/linera-execution/src/revm.rs
@@ -24,7 +24,9 @@ use revm_primitives::{ExecutionResult, HaltReason, Log, Output, TxKind};
 use thiserror::Error;
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency as _},
+    linera_base::prometheus_util::{
+        exponential_bucket_latencies, register_histogram_vec, MeasureLatency as _,
+    },
     prometheus::HistogramVec,
     std::sync::LazyLock,
 };
@@ -59,7 +61,7 @@ static CONTRACT_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(||
         "evm_contract_instantiation_latency",
         "Evm contract instantiation latency",
         &[],
-        bucket_latencies(1.0),
+        exponential_bucket_latencies(1.0),
     )
 });
 
@@ -69,7 +71,7 @@ static SERVICE_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| 
         "evm_service_instantiation_latency",
         "Evm service instantiation latency",
         &[],
-        bucket_latencies(1.0),
+        exponential_bucket_latencies(1.0),
     )
 });
 

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -28,7 +28,9 @@ use wasmer::{WasmerContractInstance, WasmerServiceInstance};
 use wasmtime::{WasmtimeContractInstance, WasmtimeServiceInstance};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency as _},
+    linera_base::prometheus_util::{
+        exponential_bucket_latencies, register_histogram_vec, MeasureLatency as _,
+    },
     prometheus::HistogramVec,
     std::sync::LazyLock,
 };
@@ -49,7 +51,7 @@ static CONTRACT_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(||
         "wasm_contract_instantiation_latency",
         "Wasm contract instantiation latency",
         &[],
-        bucket_latencies(1.0),
+        exponential_bucket_latencies(1.0),
     )
 });
 
@@ -59,7 +61,7 @@ static SERVICE_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| 
         "wasm_service_instantiation_latency",
         "Wasm service instantiation latency",
         &[],
-        bucket_latencies(1.0),
+        exponential_bucket_latencies(1.0),
     )
 });
 

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -31,7 +31,7 @@ use tracing::{debug, error, info, instrument, trace, warn};
 #[cfg(with_metrics)]
 use {
     linera_base::prometheus_util::{
-        bucket_interval, register_histogram_vec, register_int_counter_vec,
+        linear_bucket_interval, register_histogram_vec, register_int_counter_vec,
     },
     prometheus::{HistogramVec, IntCounterVec},
 };
@@ -63,7 +63,7 @@ static SERVER_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "server_request_latency",
         "Server request latency",
         &[],
-        bucket_interval(1.0, 200.0),
+        linear_bucket_interval(1.0, 25.0, 200.0),
     )
 });
 
@@ -95,7 +95,7 @@ static SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE: LazyLock<HistogramVec> = LazyLoc
         "server_request_latency_per_request_type",
         "Server request latency per request type",
         &["method_name"],
-        bucket_interval(1.0, 200.0),
+        linear_bucket_interval(1.0, 25.0, 200.0),
     )
 });
 

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -57,7 +57,7 @@ use tracing::{debug, info, instrument, Instrument as _, Level};
 #[cfg(with_metrics)]
 use {
     linera_base::prometheus_util::{
-        bucket_interval, register_histogram_vec, register_int_counter_vec,
+        linear_bucket_interval, register_histogram_vec, register_int_counter_vec,
     },
     prometheus::{HistogramVec, IntCounterVec},
 };
@@ -71,7 +71,7 @@ static PROXY_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "proxy_request_latency",
         "Proxy request latency",
         &[],
-        bucket_interval(1.0, 500.0),
+        linear_bucket_interval(1.0, 50.0, 500.0),
     )
 });
 

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -38,7 +38,8 @@ use {
 #[cfg(with_metrics)]
 use {
     linera_base::prometheus_util::{
-        bucket_latencies, register_histogram_vec, register_int_counter_vec, MeasureLatency,
+        exponential_bucket_latencies, register_histogram_vec, register_int_counter_vec,
+        MeasureLatency,
     },
     prometheus::{HistogramVec, IntCounterVec},
 };
@@ -181,7 +182,7 @@ pub static LOAD_CHAIN_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "load_chain_latency",
         "The latency to load a chain state",
         &[],
-        bucket_latencies(1.0),
+        exponential_bucket_latencies(1.0),
     )
 });
 

--- a/linera-views/src/metrics.rs
+++ b/linera-views/src/metrics.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 
 // Re-export for macros.
 #[doc(hidden)]
-pub use linera_base::prometheus_util::{self, bucket_latencies};
+pub use linera_base::prometheus_util::{self, exponential_bucket_latencies};
 use prometheus::IntCounterVec;
 
 /// Increments the metrics counter with the given name, with the struct and base key as labels.
@@ -22,7 +22,7 @@ pub static LOAD_VIEW_LATENCY: LazyLock<prometheus::HistogramVec> = LazyLock::new
         "load_view_latency",
         "Load view latency",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -9,7 +9,9 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
+    linera_base::prometheus_util::{
+        exponential_bucket_latencies, register_histogram_vec, MeasureLatency,
+    },
     prometheus::HistogramVec,
 };
 
@@ -28,7 +30,7 @@ static BUCKET_QUEUE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(||
         "bucket_queue_view_hash_runtime",
         "BucketQueueView hash runtime",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -16,7 +16,9 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
+    linera_base::prometheus_util::{
+        exponential_bucket_latencies, register_histogram_vec, MeasureLatency,
+    },
     prometheus::HistogramVec,
 };
 
@@ -36,7 +38,7 @@ static COLLECTION_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
         "collection_view_hash_runtime",
         "CollectionView hash runtime",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -22,7 +22,9 @@ use linera_base::{data_types::ArithmeticError, ensure};
 use serde::{Deserialize, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
+    linera_base::prometheus_util::{
+        exponential_bucket_latencies, register_histogram_vec, MeasureLatency,
+    },
     prometheus::HistogramVec,
 };
 
@@ -45,7 +47,7 @@ static KEY_VALUE_STORE_VIEW_HASH_LATENCY: LazyLock<HistogramVec> = LazyLock::new
         "key_value_store_view_hash_latency",
         "KeyValueStoreView hash latency",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 
@@ -56,7 +58,7 @@ static KEY_VALUE_STORE_VIEW_GET_LATENCY: LazyLock<HistogramVec> = LazyLock::new(
         "key_value_store_view_get_latency",
         "KeyValueStoreView get latency",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 
@@ -67,7 +69,7 @@ static KEY_VALUE_STORE_VIEW_MULTI_GET_LATENCY: LazyLock<HistogramVec> = LazyLock
         "key_value_store_view_multi_get_latency",
         "KeyValueStoreView multi get latency",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 
@@ -78,7 +80,7 @@ static KEY_VALUE_STORE_VIEW_CONTAINS_KEY_LATENCY: LazyLock<HistogramVec> = LazyL
         "key_value_store_view_contains_key_latency",
         "KeyValueStoreView contains key latency",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 
@@ -89,7 +91,7 @@ static KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_LATENCY: LazyLock<HistogramVec> = Lazy
         "key_value_store_view_contains_keys_latency",
         "KeyValueStoreView contains keys latency",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 
@@ -101,7 +103,7 @@ static KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_LATENCY: LazyLock<HistogramVec> 
             "key_value_store_view_find_keys_by_prefix_latency",
             "KeyValueStoreView find keys by prefix latency",
             &[],
-            bucket_latencies(5.0),
+            exponential_bucket_latencies(5.0),
         )
     });
 
@@ -113,7 +115,7 @@ static KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_LATENCY: LazyLock<Histogra
             "key_value_store_view_find_key_values_by_prefix_latency",
             "KeyValueStoreView find key values by prefix latency",
             &[],
-            bucket_latencies(5.0),
+            exponential_bucket_latencies(5.0),
         )
     });
 
@@ -124,7 +126,7 @@ static KEY_VALUE_STORE_VIEW_WRITE_BATCH_LATENCY: LazyLock<HistogramVec> = LazyLo
         "key_value_store_view_write_batch_latency",
         "KeyValueStoreView write batch latency",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -9,7 +9,9 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
+    linera_base::prometheus_util::{
+        exponential_bucket_latencies, register_histogram_vec, MeasureLatency,
+    },
     prometheus::HistogramVec,
 };
 
@@ -28,7 +30,7 @@ static LOG_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
         "log_view_hash_runtime",
         "LogView hash runtime",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -21,7 +21,9 @@ use std::sync::LazyLock;
 
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
+    linera_base::prometheus_util::{
+        exponential_bucket_latencies, register_histogram_vec, MeasureLatency,
+    },
     prometheus::HistogramVec,
 };
 
@@ -32,7 +34,7 @@ static MAP_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
         "map_view_hash_runtime",
         "MapView hash runtime",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -12,7 +12,9 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
+    linera_base::prometheus_util::{
+        exponential_bucket_latencies, register_histogram_vec, MeasureLatency,
+    },
     prometheus::HistogramVec,
 };
 
@@ -31,7 +33,7 @@ static QUEUE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
         "queue_view_hash_runtime",
         "QueueView hash runtime",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -17,7 +17,9 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
+    linera_base::prometheus_util::{
+        exponential_bucket_latencies, register_histogram_vec, MeasureLatency,
+    },
     prometheus::HistogramVec,
 };
 
@@ -37,7 +39,7 @@ static REENTRANT_COLLECTION_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock
         "reentrant_collection_view_hash_runtime",
         "ReentrantCollectionView hash runtime",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -8,7 +8,9 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
+    linera_base::prometheus_util::{
+        exponential_bucket_latencies, register_histogram_vec, MeasureLatency,
+    },
     prometheus::HistogramVec,
 };
 
@@ -27,7 +29,7 @@ static REGISTER_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
         "register_view_hash_runtime",
         "RegisterView hash runtime",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 

--- a/linera-views/src/views/set_view.rs
+++ b/linera-views/src/views/set_view.rs
@@ -9,7 +9,9 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 #[cfg(with_metrics)]
 use {
-    linera_base::prometheus_util::{bucket_latencies, register_histogram_vec, MeasureLatency},
+    linera_base::prometheus_util::{
+        exponential_bucket_latencies, register_histogram_vec, MeasureLatency,
+    },
     prometheus::HistogramVec,
 };
 
@@ -29,7 +31,7 @@ static SET_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
         "set_view_hash_runtime",
         "SetView hash runtime",
         &[],
-        bucket_latencies(5.0),
+        exponential_bucket_latencies(5.0),
     )
 });
 


### PR DESCRIPTION
## Motivation

We currently use exponential buckets everywhere. As much as they're good in the sense that they generate less buckets, and can be cheaper on Grafana Cloud, etc, they make our buckets super wide, which makes our Prometheus data less accurate.

## Proposal

I need to spend some time later looking at the `testnet` data for these different metrics to adjust the buckets, but for not just changing proxy/server latencies to use linear buckets instead.
I also changed the default starting value to 0.001 as 1 microsecond should be enough for most of what we're measuring, and will take at least one bucket away from metrics using this.

## Test Plan

Run a validator locally, see the metrics exported with the new buckets

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
