### PR TITLE
The validator label should always apply on local runs, even when not using GrafanaCloud

### DIFF
--- a/kubernetes/linera-validator/values-local.yaml.gotmpl
+++ b/kubernetes/linera-validator/values-local.yaml.gotmpl
@@ -57,9 +57,9 @@ kube-prometheus-stack:
               action: drop
             - regex: endpoint|instance|namespace|pod|prometheus|prometheus_replica|service|name|resource|id
               action: labeldrop
+      {{- end }}
       externalLabels:
         validator: {{ .Values.validatorLabel }}
-      {{- end }}
       retention: 2d
       retentionSize: 1GB
       storageSpec:


### PR DESCRIPTION
## Motivation

Right now this is just for Grafana Cloud for absolutely no reason. This will be useful for everyone, so let's just enable it everywhere.

## Proposal

Enable it always

## Test Plan

Run a cluster, see the validator label in the metrics

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
