### PR TITLE
Improve CLI for owners in bash tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,15 @@ export LINERA_STORAGE="rocksdb:$LINERA_TMP_DIR/client.db"
 linera wallet init --faucet $FAUCET_URL
 
 # Request chains.
-CHAIN1=$(linera wallet request-chain --faucet $FAUCET_URL | head -n 1)
-CHAIN2=$(linera wallet request-chain --faucet $FAUCET_URL | head -n 1)
+INFO1=($(linera wallet request-chain --faucet $FAUCET_URL))
+INFO2=($(linera wallet request-chain --faucet $FAUCET_URL))
+CHAIN1="${INFO1[0]}"
+ACCOUNT1="User:${INFO1[3]}"
+CHAIN2="${INFO2[0]}"
+ACCOUNT2="User:${INFO2[3]}"
+
+# Show the different chains tracked by the wallet.
+linera wallet show
 
 # Query the chain balance of some of the chains.
 linera query-balance "$CHAIN1"
@@ -107,6 +114,16 @@ linera transfer 5 --from "$CHAIN2" --to "$CHAIN1"
 # Query balances again.
 linera query-balance "$CHAIN1"
 linera query-balance "$CHAIN2"
+
+# Now let's fund the user balances.
+linera transfer 5 --from "$CHAIN1" --to "$CHAIN1:$ACCOUNT1"
+linera transfer 2 --from "$CHAIN1:$ACCOUNT1" --to "$CHAIN2:$ACCOUNT2"
+
+# Query user balances again.
+linera query-balance "$CHAIN1:$ACCOUNT1"
+linera query-balance "$CHAIN2:$ACCOUNT2"
+
+# TODO(#1713): The syntax `User:$OWNER` for user accounts will change in the future.
 ```
 
 More complex examples may be found in our [developer manual](https://linera.dev) as well

--- a/examples/amm/README.md
+++ b/examples/amm/README.md
@@ -29,7 +29,7 @@ It supports the following operations. All operations need to be executed remotel
 
 Before getting started, make sure that the binary tools `linera*` corresponding to
 your version of `linera-sdk` are in your PATH. For scripting purposes, we also assume
-that the BASH function `linera_spawn_and_read_wallet_variables` is defined.
+that the BASH function `linera_spawn` is defined.
 
 From the root of Linera repository, this can be achieved as follows:
 
@@ -38,22 +38,35 @@ export PATH="$PWD/target/debug:$PATH"
 source /dev/stdin <<<"$(linera net helper 2>/dev/null)"
 ```
 
-To start the local Linera network:
+Next, start the local Linera network and run a faucet:
 
 ```bash
-linera_spawn_and_read_wallet_variables linera net up --testing-prng-seed 37
+FAUCET_PORT=8079
+FAUCET_URL=http://localhost:$FAUCET_PORT
+linera_spawn linera net up --with-faucet --faucet-port $FAUCET_PORT
+
+# If you're using a testnet, run this instead:
+#   LINERA_TMP_DIR=$(mktemp -d)
+#   FAUCET_URL=https://faucet.testnet-XXX.linera.net  # for some value XXX
 ```
 
-We use the test-only CLI option `--testing-prng-seed` to make keys deterministic and simplify our
-explanation.
+Create the user wallet and add chains to it:
 
 ```bash
-OWNER_1=789dcf5afb0afb9c5c473568bab33c68b83005bf7b964dc2a93e5d4368a9da1f
-OWNER_2=38e7f6b6d1887b0ea1511e04a08382577aaf551bb440ee6011966d73d19b8150
-CHAIN_1=678e9f66507069d38955b593e93ddf192a23a4087225fd307eadad44e5544ae3
-CHAIN_2=a3edc33d8e951a1139333be8a4b56646b5598a8f51216e86592d881808972b07
-CHAIN_AMM=aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8
-OWNER_AMM=de166237331a2966d8cf6778e81a8c007b4084be80dc1e0409d51f216c1deaa1
+export LINERA_WALLET="$LINERA_TMP_DIR/wallet.json"
+export LINERA_STORAGE="rocksdb:$LINERA_TMP_DIR/client.db"
+
+linera wallet init --faucet $FAUCET_URL
+
+INFO_1=($(linera wallet request-chain --faucet $FAUCET_URL))
+INFO_2=($(linera wallet request-chain --faucet $FAUCET_URL))
+INFO_AMM=($(linera wallet request-chain --faucet $FAUCET_URL))
+CHAIN_1="${INFO_1[0]}"
+CHAIN_2="${INFO_2[0]}"
+CHAIN_AMM="${INFO_AMM[0]}"
+OWNER_1="${INFO_1[3]}"
+OWNER_2="${INFO_2[3]}"
+OWNER_AMM="${INFO_AMM[3]}"
 ```
 
 Now we have to publish and create the fungible applications. The flag `--wait-for-outgoing-messages` waits until a quorum of validators has confirmed that all sent cross-chain messages have been delivered.

--- a/examples/gen-nft/README.md
+++ b/examples/gen-nft/README.md
@@ -26,16 +26,46 @@ For more details on the application's contract and how it manages multiple diffe
 
 ### Setting Up
 
-Most of this can be referred to the [fungible app README](https://github.com/linera-io/linera-protocol/blob/main/examples/fungible/README.md#setting-up), except for at the end when compiling and publishing the bytecode, what you'll need to do will be slightly different.
+Before getting started, make sure that the binary tools `linera*` corresponding to
+your version of `linera-sdk` are in your PATH. For scripting purposes, we also assume
+that the BASH function `linera_spawn` is defined.
+
+From the root of Linera repository, this can be achieved as follows:
 
 ```bash
 export PATH="$PWD/target/debug:$PATH"
 source /dev/stdin <<<"$(linera net helper 2>/dev/null)"
-
-linera_spawn_and_read_wallet_variables linera net up --testing-prng-seed 37
 ```
 
-Compile the `non-fungible` application WebAssembly binaries, and publish them as an application bytecode:
+Next, start the local Linera network and run a faucet:
+
+```bash
+FAUCET_PORT=8079
+FAUCET_URL=http://localhost:$FAUCET_PORT
+linera_spawn linera net up --with-faucet --faucet-port $FAUCET_PORT
+
+# If you're using a testnet, run this instead:
+#   LINERA_TMP_DIR=$(mktemp -d)
+#   FAUCET_URL=https://faucet.testnet-XXX.linera.net  # for some value XXX
+```
+
+Create the user wallet and add chains to it:
+
+```bash
+export LINERA_WALLET="$LINERA_TMP_DIR/wallet.json"
+export LINERA_STORAGE="rocksdb:$LINERA_TMP_DIR/client.db"
+
+linera wallet init --faucet $FAUCET_URL
+
+INFO_1=($(linera wallet request-chain --faucet $FAUCET_URL))
+INFO_2=($(linera wallet request-chain --faucet $FAUCET_URL))
+CHAIN_1="${INFO_1[0]}"
+CHAIN_2="${INFO_2[0]}"
+OWNER_1="${INFO_1[3]}"
+OWNER_2="${INFO_2[3]}"
+```
+
+Next, compile the `non-fungible` application WebAssembly binaries, and publish them as an application bytecode:
 
 ```bash
 (cd examples/gen-nft && cargo build --release --target wasm32-unknown-unknown)
@@ -51,15 +81,6 @@ Here, we stored the new bytecode ID in a variable `BYTECODE_ID` to be reused lat
 Unlike fungible tokens, each NFT is unique and identified by a unique token ID. Also unlike fungible tokens, when creating the NFT application you don't need to specify an initial state or parameters. NFTs will be minted later.
 
 Refer to the [fungible app README](https://github.com/linera-io/linera-protocol/blob/main/examples/fungible/README.md#creating-a-token) to figure out how to list the chains created for the test in the default wallet, as well as defining some variables corresponding to these values.
-
-```bash
-linera wallet show
-
-CHAIN_1=aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8  # default chain for the wallet
-OWNER_1=de166237331a2966d8cf6778e81a8c007b4084be80dc1e0409d51f216c1deaa1  # owner of chain 1
-CHAIN_2=63620ea465af9e9e0e8e4dd8d21593cc3a719feac5f096df8440f90738f4dbd8  # another chain in the wallet
-OWNER_2=598d18f67709fe76ed6a36b75a7c9889012d30b896800dfd027ee10e1afd49a3  # owner of chain 2
-```
 
 To create the NFT application, run the command below:
 

--- a/examples/hex-game/README.md
+++ b/examples/hex-game/README.md
@@ -25,27 +25,47 @@ does not have to wait for any other chain owner to accept any message.
 Make sure you have the `linera` binary in your `PATH`, and that it is compatible with your
 `linera-sdk` version.
 
-For scripting purposes, we also assume that the BASH function
-`linera_spawn_and_read_wallet_variables` is defined. From the root of Linera repository, this can
-be achieved as follows:
+For scripting purposes, we also assume that the BASH function `linera_spawn` is defined.
+From the root of Linera repository, this can be achieved as follows:
 
 ```bash
 export PATH="$PWD/target/debug:$PATH"
 source /dev/stdin <<<"$(linera net helper 2>/dev/null)"
 ```
 
-To start the local Linera network and create two wallets:
+Start the local Linera network and run a faucet:
 
 ```bash
-linera_spawn_and_read_wallet_variables linera net up --testing-prng-seed 37 --extra-wallets 1
+FAUCET_PORT=8079
+FAUCET_URL=http://localhost:$FAUCET_PORT
+linera_spawn linera net up --with-faucet --faucet-port $FAUCET_PORT
+
+# If you're using a testnet, run this instead:
+#   LINERA_TMP_DIR=$(mktemp -d)
+#   FAUCET_URL=https://faucet.testnet-XXX.linera.net  # for some value XXX
 ```
 
-We use the test-only CLI option `--testing-prng-seed` to make keys deterministic and simplify our
-explanation.
+Create the user wallets and add chains to them:
 
 ```bash
-CHAIN_1=aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8
+export LINERA_WALLET_0="$LINERA_TMP_DIR/wallet_0.json"
+export LINERA_STORAGE_0="rocksdb:$LINERA_TMP_DIR/client_0.db"
+export LINERA_WALLET_1="$LINERA_TMP_DIR/wallet_1.json"
+export LINERA_STORAGE_1="rocksdb:$LINERA_TMP_DIR/client_1.db"
+
+linera --with-wallet 0 wallet init --faucet $FAUCET_URL
+linera --with-wallet 1 wallet init --faucet $FAUCET_URL
+
+INFO_1=($(linera --with-wallet 0 wallet request-chain --faucet $FAUCET_URL))
+INFO_2=($(linera --with-wallet 1 wallet request-chain --faucet $FAUCET_URL))
+CHAIN_1="${INFO_1[0]}"
+CHAIN_2="${INFO_2[0]}"
+OWNER_1="${INFO_1[3]}"
+OWNER_2="${INFO_2[3]}"
 ```
+
+Note that `linera -with-wallet 0` or `linera -w0` is equivalent to `linera --wallet
+"$LINERA_WALLET_0" --storage "$LINERA_STORAGE_0"`.
 
 ### Creating the Game Chain
 

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -29,16 +29,41 @@ to the GGUF format where it can be used for inference.
 
 ## Usage
 
-We're assuming that a local wallet is set up and connected to a running test network
-(local or otherwise).
+Before getting started, make sure that the binary tools `linera*` corresponding to
+your version of `linera-sdk` are in your PATH. For scripting purposes, we also assume
+that the BASH function `linera_spawn` is defined.
 
-If you use `linera net up`, the value of the default chain ID is:
+From the root of Linera repository, this can be achieved as follows:
+
 ```bash
-CHAIN=aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8
+export PATH="$PWD/target/debug:$PATH"
+source /dev/stdin <<<"$(linera net helper 2>/dev/null)"
 ```
 
-See the file `linera-protocol/examples/fungible/README.md` or the [online developer
-manual](https://linera.dev) for instructions.
+Next, start the local Linera network and run a faucet:
+
+```bash
+FAUCET_PORT=8079
+FAUCET_URL=http://localhost:$FAUCET_PORT
+linera_spawn linera net up --with-faucet --faucet-port $FAUCET_PORT
+
+# If you're using a testnet, run this instead:
+#   LINERA_TMP_DIR=$(mktemp -d)
+#   FAUCET_URL=https://faucet.testnet-XXX.linera.net  # for some value XXX
+```
+
+Create the user wallet and add chains to it:
+
+```bash
+export LINERA_WALLET="$LINERA_TMP_DIR/wallet.json"
+export LINERA_STORAGE="rocksdb:$LINERA_TMP_DIR/client.db"
+
+linera wallet init --faucet $FAUCET_URL
+
+INFO=($(linera wallet request-chain --faucet $FAUCET_URL))
+CHAIN="${INFO[0]}"
+OWNER="${INFO[3]}"
+```
 
 ### Using the LLM Application
 

--- a/examples/non-fungible/README.md
+++ b/examples/non-fungible/README.md
@@ -26,16 +26,44 @@ NFTs can be transferred to various destinations, including:
 
 ### Setting Up
 
-Most of this can be referred to the [fungible app README](https://github.com/linera-io/linera-protocol/blob/main/examples/fungible/README.md#setting-up), except for at the end when compiling and publishing the bytecode, what you'll need to do will be slightly different.
+Before getting started, make sure that the binary tools `linera*` corresponding to
+your version of `linera-sdk` are in your PATH. For scripting purposes, we also assume
+that the BASH function `linera_spawn` is defined.
+
+From the root of Linera repository, this can be achieved as follows:
 
 ```bash
 export PATH="$PWD/target/debug:$PATH"
 source /dev/stdin <<<"$(linera net helper 2>/dev/null)"
-
-linera_spawn_and_read_wallet_variables linera net up --testing-prng-seed 37
 ```
 
-Compile the `non-fungible` application WebAssembly binaries, and publish them as an application bytecode:
+Next, start the local Linera network and run a faucet:
+
+```bash
+FAUCET_PORT=8079
+FAUCET_URL=http://localhost:$FAUCET_PORT
+linera_spawn linera net up --with-faucet --faucet-port $FAUCET_PORT
+
+# If you're using a testnet, run this instead:
+#   LINERA_TMP_DIR=$(mktemp -d)
+#   FAUCET_URL=https://faucet.testnet-XXX.linera.net  # for some value XXX
+```
+
+Create the user wallet and add chains to it:
+
+```bash
+export LINERA_WALLET="$LINERA_TMP_DIR/wallet.json"
+export LINERA_STORAGE="rocksdb:$LINERA_TMP_DIR/client.db"
+
+linera wallet init --faucet $FAUCET_URL
+
+INFO_1=($(linera wallet request-chain --faucet $FAUCET_URL))
+INFO_2=($(linera wallet request-chain --faucet $FAUCET_URL))
+CHAIN_1="${INFO_1[0]}"
+CHAIN_2="${INFO_2[0]}"
+OWNER_1="${INFO_1[3]}"
+OWNER_2="${INFO_2[3]}"
+```
 
 ```bash
 (cd examples/non-fungible && cargo build --release --target wasm32-unknown-unknown)
@@ -51,15 +79,6 @@ Here, we stored the new bytecode ID in a variable `BYTECODE_ID` to be reused lat
 Unlike fungible tokens, each NFT is unique and identified by a unique token ID. Also unlike fungible tokens, when creating the NFT application you don't need to specify an initial state or parameters. NFTs will be minted later.
 
 Refer to the [fungible app README](https://github.com/linera-io/linera-protocol/blob/main/examples/fungible/README.md#creating-a-token) to figure out how to list the chains created for the test in the default wallet, as well as defining some variables corresponding to these values.
-
-```bash
-linera wallet show
-
-CHAIN_1=aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8  # default chain for the wallet
-OWNER_1=de166237331a2966d8cf6778e81a8c007b4084be80dc1e0409d51f216c1deaa1  # owner of chain 1
-CHAIN_2=63620ea465af9e9e0e8e4dd8d21593cc3a719feac5f096df8440f90738f4dbd8  # another chain in the wallet
-OWNER_2=598d18f67709fe76ed6a36b75a7c9889012d30b896800dfd027ee10e1afd49a3  # owner of chain 2
-```
 
 To create the NFT application, run the command below:
 

--- a/examples/social/README.md
+++ b/examples/social/README.md
@@ -30,46 +30,52 @@ TODO the following documentation involves `sleep`ing to avoid some race conditio
 
 ## Usage
 
-Set up the path and the helper function.
+Set up the path and the helper function. From the root of Linera repository, this can be
+achieved as follows:
 
 ```bash
-PATH=$PWD/target/debug:$PATH
+export PATH="$PWD/target/debug:$PATH"
 source /dev/stdin <<<"$(linera net helper 2>/dev/null)"
 ```
 
-Then, using the helper function defined by `linera net helper`, set up a local network
-with two wallets and define variables holding their wallet paths (`$LINERA_WALLET_0`,
-`$LINERA_WALLET_1`) and storage paths (`$LINERA_STORAGE_0`, `$LINERA_STORAGE_1`).
+Start the local Linera network and run a faucet:
 
 ```bash
-linera_spawn_and_read_wallet_variables \
-    linera net up \
-        --extra-wallets 1
+FAUCET_PORT=8079
+FAUCET_URL=http://localhost:$FAUCET_PORT
+linera_spawn linera net up --with-faucet --faucet-port $FAUCET_PORT
+
+# If you're using a testnet, run this instead:
+#   LINERA_TMP_DIR=$(mktemp -d)
+#   FAUCET_URL=https://faucet.testnet-XXX.linera.net  # for some value XXX
 ```
+
+Create the user wallets and add chains to them:
+
+```bash
+export LINERA_WALLET_0="$LINERA_TMP_DIR/wallet_0.json"
+export LINERA_STORAGE_0="rocksdb:$LINERA_TMP_DIR/client_0.db"
+export LINERA_WALLET_1="$LINERA_TMP_DIR/wallet_1.json"
+export LINERA_STORAGE_1="rocksdb:$LINERA_TMP_DIR/client_1.db"
+
+linera --with-wallet 0 wallet init --faucet $FAUCET_URL
+linera --with-wallet 1 wallet init --faucet $FAUCET_URL
+
+INFO_1=($(linera --with-wallet 0 wallet request-chain --faucet $FAUCET_URL))
+INFO_2=($(linera --with-wallet 1 wallet request-chain --faucet $FAUCET_URL))
+CHAIN_1="${INFO_1[0]}"
+CHAIN_2="${INFO_2[0]}"
+OWNER_1="${INFO_1[3]}"
+OWNER_2="${INFO_2[3]}"
+```
+
+Note that `linera --with-wallet 0` is equivalent to `linera --wallet "$LINERA_WALLET_0"
+--storage "$LINERA_STORAGE_0"`.
 
 Compile the `social` example and create an application with it:
 
 ```bash
 APP_ID=$(linera --with-wallet 0 project publish-and-create examples/social)
-```
-
-This will output the new application ID, e.g.:
-
-```rust
-20dc1ed01670501414eb59defe71f9a7b817fe2da18fcdd5e704bbac32f5bd97a020afcb645167bcaacd1d8cee9083605f42a95de24e056f3a958c7ca91f9f728ac320aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8020000000000000000000000
-```
-
-With the `wallet show` command you can find the ID of the application creator's chain:
-
-```bash
-linera --with-wallet 0 wallet show
-
-CHAIN_1=582843bc9322ed1928239ce3f6a855f6cd9ea94c8690907f113d6d7a8296a119
-CHAIN_2=aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8
-```
-
-```rust
-aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8
 ```
 
 Now start a node service for each wallet, using two different ports:

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -316,7 +316,7 @@ impl ClientWrapper {
         &self,
         chain_ids: &[ChainId],
         faucet: FaucetOption<'_>,
-    ) -> Result<Option<ClaimOutcome>> {
+    ) -> Result<Option<(ClaimOutcome, Owner)>> {
         let mut command = self.command().await?;
         command.args(["wallet", "init"]);
         match faucet {
@@ -350,14 +350,23 @@ impl ClientWrapper {
                     .parse()
                     .context("invalid certificate hash")?,
             };
-            Ok(Some(outcome))
+            let owner = lines
+                .next()
+                .context("missing chain owner")?
+                .parse()
+                .context("invalid chain owner")?;
+            Ok(Some((outcome, owner)))
         } else {
             Ok(None)
         }
     }
 
     /// Runs `linera wallet request-chain`.
-    pub async fn request_chain(&self, faucet: &Faucet, set_default: bool) -> Result<ClaimOutcome> {
+    pub async fn request_chain(
+        &self,
+        faucet: &Faucet,
+        set_default: bool,
+    ) -> Result<(ClaimOutcome, Owner)> {
         let mut command = self.command().await?;
         command.args(["wallet", "request-chain", "--faucet", faucet.url()]);
         if set_default {
@@ -375,7 +384,12 @@ impl ClientWrapper {
                 .parse()
                 .context("invalid certificate hash")?,
         };
-        Ok(outcome)
+        let owner = lines
+            .next()
+            .context("missing chain owner")?
+            .parse()
+            .context("invalid chain owner")?;
+        Ok((outcome, owner))
     }
 
     /// Runs `linera wallet publish-and-create`.

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1119,6 +1119,7 @@ impl Runnable for Job {
                 println!("{}", outcome.chain_id);
                 println!("{}", outcome.message_id);
                 println!("{}", outcome.certificate_hash);
+                println!("{}", owner);
                 Self::assign_new_chain_to_key(
                     outcome.chain_id,
                     outcome.message_id,
@@ -1163,6 +1164,7 @@ impl Runnable for Job {
                 println!("{}", outcome.chain_id);
                 println!("{}", outcome.message_id);
                 println!("{}", outcome.certificate_hash);
+                println!("{}", owner);
                 Self::assign_new_chain_to_key(
                     outcome.chain_id,
                     outcome.message_id,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1676,7 +1676,7 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
             NetCommand::Helper => {
                 info!("You may append the following script to your `~/.bash_profile` or `source` it when needed.");
                 info!(
-                    "This will install a function `linera_spawn_and_read_wallet_variables` to facilitate \
+                    "This will install several functions to facilitate \
                        testing with a local Linera network"
                 );
                 println!("{}", include_str!("../../template/linera_net_helper.sh"));

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -164,9 +164,10 @@ impl Runnable for Job {
                     time_total.as_millis()
                 );
                 debug!("{:?}", certificate);
-                // Print the new chain ID and message ID on stdout for scripting purposes.
+                // Print the new chain ID, message ID, and owner on stdout for scripting purposes.
                 println!("{}", message_id);
                 println!("{}", ChainId::child(message_id));
+                println!("{}", new_owner);
             }
 
             OpenMultiOwnerChain {

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2815,18 +2815,18 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
     // Use the faucet directly to initialize client 3.
     let client3 = net.make_client().await;
     client3.wallet_init(&[], FaucetOption::None).await?;
-    let outcome = client3.request_chain(&faucet, false).await?;
+    let (outcome, _) = client3.request_chain(&faucet, false).await?;
     assert_eq!(
         outcome.chain_id,
         client3.load_wallet()?.default_chain().unwrap()
     );
 
-    let outcome = client3.request_chain(&faucet, false).await?;
+    let (outcome, _) = client3.request_chain(&faucet, false).await?;
     assert!(outcome.chain_id != client3.load_wallet()?.default_chain().unwrap());
     client3.forget_chain(outcome.chain_id).await?;
     client3.follow_chain(outcome.chain_id).await?;
 
-    let outcome = client3.request_chain(&faucet, true).await?;
+    let (outcome, _) = client3.request_chain(&faucet, true).await?;
     assert_eq!(
         outcome.chain_id,
         client3.load_wallet()?.default_chain().unwrap()
@@ -2899,11 +2899,12 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
 
     // Create a new wallet using the faucet
     let client = net.make_client().await;
-    let outcome = client
+    let (outcome, _) = client
         .wallet_init(&[], FaucetOption::NewChain(&faucet))
-        .await?;
+        .await?
+        .unwrap();
 
-    let chain = outcome.unwrap().chain_id;
+    let chain = outcome.chain_id;
     assert_eq!(chain, client.load_wallet()?.default_chain().unwrap());
 
     let initial_balance = client.query_balance(Account::chain(chain)).await?;

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2568,7 +2568,7 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) -> Resul
     let owner2 = client2.keygen().await?;
 
     // Open chain on behalf of Client 2.
-    let (message_id, chain2) = client1
+    let (message_id, chain2, _) = client1
         .open_chain(chain1, Some(owner2), Amount::ZERO)
         .await?;
 
@@ -2722,11 +2722,11 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     let owner2 = client2.keygen().await?;
 
     // Open a great-grandchild chain on behalf of client 2.
-    let (_, grandparent) = client1
+    let (_, grandparent, _) = client1
         .open_chain(chain1, None, Amount::from_tokens(2))
         .await?;
-    let (_, parent) = client1.open_chain(grandparent, None, Amount::ONE).await?;
-    let (message_id, chain2) = client1
+    let (_, parent, _) = client1.open_chain(grandparent, None, Amount::ONE).await?;
+    let (message_id, chain2, _) = client1
         .open_chain(parent, Some(owner2), Amount::ZERO)
         .await?;
     client2.assign(owner2, message_id).await?;
@@ -2887,7 +2887,7 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
 
     // Use the faucet directly to initialize many chains
     for _ in 0..chain_count {
-        let (_, new_chain_id) = faucet_client
+        let (_, new_chain_id, _) = faucet_client
             .open_chain(faucet_chain, None, Amount::ONE)
             .await?;
         faucet_client.forget_chain(new_chain_id).await?;

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -799,7 +799,7 @@ async fn test_sync_validator(config: LocalNetConfig) -> Result<()> {
 
     // Create some blocks
     let sender_chain = client.default_chain().expect("Client has no default chain");
-    let (_, receiver_chain) = client
+    let (_, receiver_chain, _) = client
         .open_chain(sender_chain, None, Amount::from_tokens(1_000))
         .await?;
 

--- a/linera-service/tests/readme_test.rs
+++ b/linera-service/tests/readme_test.rs
@@ -26,6 +26,7 @@ use tokio::process::Command;
 #[test_case::test_case("../examples/fungible" ; "fungible")]
 #[test_case::test_case("../examples/gen-nft" ; "gen-nft")]
 #[test_case::test_case("../examples/hex-game" ; "hex-game")]
+#[test_case::test_case("../examples/lmm" ; "lmm")]
 #[test_case::test_case("../examples/native-fungible" ; "native-fungible")]
 #[test_case::test_case("../examples/non-fungible" ; "non-fungible")]
 #[test_case::test_case("../examples/matching-engine" ; "matching engine")]

--- a/linera-service/tests/readme_test.rs
+++ b/linera-service/tests/readme_test.rs
@@ -33,7 +33,7 @@ use tokio::process::Command;
 #[test_case::test_case("../examples/rfq" ; "requests for quotes")]
 #[test_case::test_case("../examples/social" ; "social")]
 #[test_log::test(tokio::test)]
-async fn test_script_in_readme_with_storage_service(path: &str) -> std::io::Result<()> {
+async fn test_script_in_readme(path: &str) -> std::io::Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {} for path {}", test_name!(), path);
 


### PR DESCRIPTION
## Motivation

Allow removing the hard-coded OWNER variables from README tests

## Proposal

Make sure to return the owner on stdout every time the CLI generates a key pair.

## Test Plan

I modified the main README file.

## Links

Continues #3385