### PR TITLE
Add missing faucet entries to packages.txt.

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -18,5 +18,7 @@ linera-sdk
 linera-rpc
 linera-client
 linera-faucet
+linera-faucet-client
+linera-faucet-server
 linera-service
 linera-service-graphql-client


### PR DESCRIPTION
## Motivation

Publishing the documentation fails on `main`.

## Proposal

Add the missing entries to `packages.txt`.

## Test Plan

I reproduced the problem locally with `test_publish.sh`. The change fixes it.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
