### PR TITLE
remove CLI option "linera net up --extra-wallets"

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -936,8 +936,7 @@ Start a Local Linera Network
 
 ###### **Options:**
 
-* `--extra-wallets <EXTRA_WALLETS>` — The number of extra wallets and user chains to initialize. Default is 0
-* `--other-initial-chains <OTHER_INITIAL_CHAINS>` — The number of initial "root" chains created in the genesis config on top of the default "admin" chain. All initial chains belong to the first "admin" wallet
+* `--other-initial-chains <OTHER_INITIAL_CHAINS>` — The number of initial "root" chains created in the genesis config on top of the default "admin" chain. All initial chains belong to the first "admin" wallet. It is recommended to use at least one other initial chain for the faucet
 
   Default value: `2`
 * `--initial-amount <INITIAL_AMOUNT>` — The initial amount of native tokens credited in the initial "root" chains, including the default "admin" chain

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -1028,13 +1028,10 @@ impl DatabaseToolCommand {
 pub enum NetCommand {
     /// Start a Local Linera Network
     Up {
-        /// The number of extra wallets and user chains to initialize. Default is 0.
-        #[arg(long)]
-        extra_wallets: Option<usize>,
-
         /// The number of initial "root" chains created in the genesis config on top of
         /// the default "admin" chain. All initial chains belong to the first "admin"
-        /// wallet.
+        /// wallet. It is recommended to use at least one other initial chain for the
+        /// faucet.
         #[arg(long, default_value = "2")]
         other_initial_chains: u32,
 

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1595,7 +1595,6 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
         ClientCommand::Net(net_command) => match net_command {
             #[cfg(feature = "kubernetes")]
             NetCommand::Up {
-                extra_wallets,
                 other_initial_chains,
                 initial_amount,
                 validators,
@@ -1615,7 +1614,6 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                 faucet_amount,
             } => {
                 net_up_utils::handle_net_up_kubernetes(
-                    *extra_wallets,
                     *other_initial_chains,
                     *initial_amount,
                     *validators,
@@ -1636,7 +1634,6 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
             }
 
             NetCommand::Up {
-                extra_wallets,
                 other_initial_chains,
                 initial_amount,
                 validators,
@@ -1653,7 +1650,6 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                 ..
             } => {
                 net_up_utils::handle_net_up_service(
-                    *extra_wallets,
                     *other_initial_chains,
                     *initial_amount,
                     *validators,


### PR DESCRIPTION
## Motivation

This option is no longer needed after #3388.

## Proposal

Remove CLI option "linera net up --extra-wallets"

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
