### PR TITLE
update install for MacOS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,8 @@
 * Rust
     - `brew install rustup-init`
     - `rustup target add wasm32-unknown-unknown`
+* Clang/LLVM
+    - `brew install llvm@18` then make sure to update your `PATH` as instructed.
 * Protoc
     - `brew install protobuf`
 


### PR DESCRIPTION
## Motivation

Fix install after #3345.

## Proposal

Apple clang doesn't compile for Wasm. After #3345, clang is needed. However, LLVM v19 is an issue (to be discussed separately).

## Test Plan

run `brew install llvm@18` locally and it solved the issue