### PR TITLE
nit: fix wallet name in example README

### DIFF
--- a/examples/hex-game/README.md
+++ b/examples/hex-game/README.md
@@ -53,19 +53,19 @@ export LINERA_STORAGE_0="rocksdb:$LINERA_TMP_DIR/client_0.db"
 export LINERA_WALLET_1="$LINERA_TMP_DIR/wallet_1.json"
 export LINERA_STORAGE_1="rocksdb:$LINERA_TMP_DIR/client_1.db"
 
-linera --with-wallet 0 wallet init --faucet $FAUCET_URL
 linera --with-wallet 1 wallet init --faucet $FAUCET_URL
+linera --with-wallet 2 wallet init --faucet $FAUCET_URL
 
-INFO_1=($(linera --with-wallet 0 wallet request-chain --faucet $FAUCET_URL))
-INFO_2=($(linera --with-wallet 1 wallet request-chain --faucet $FAUCET_URL))
+INFO_1=($(linera --with-wallet 1 wallet request-chain --faucet $FAUCET_URL))
+INFO_2=($(linera --with-wallet 2 wallet request-chain --faucet $FAUCET_URL))
 CHAIN_1="${INFO_1[0]}"
 CHAIN_2="${INFO_2[0]}"
 OWNER_1="${INFO_1[3]}"
 OWNER_2="${INFO_2[3]}"
 ```
 
-Note that `linera -with-wallet 0` or `linera -w0` is equivalent to `linera --wallet
-"$LINERA_WALLET_0" --storage "$LINERA_STORAGE_0"`.
+Note that `linera -with-wallet 1` or `linera -w1` is equivalent to `linera --wallet
+"$LINERA_WALLET_1" --storage "$LINERA_STORAGE_1"`.
 
 ### Creating the Game Chain
 
@@ -73,7 +73,7 @@ We open a new chain owned by both `$OWNER_1` and `$OWNER_2`, create the applicat
 start the node service.
 
 ```bash
-APP_ID=$(linera -w0 --wait-for-outgoing-messages \
+APP_ID=$(linera -w1 --wait-for-outgoing-messages \
   project publish-and-create examples/hex-game hex_game $CHAIN_1 \
     --json-argument "{
         \"startTime\": 600000000,
@@ -81,10 +81,10 @@ APP_ID=$(linera -w0 --wait-for-outgoing-messages \
         \"blockDelay\": 100000000
     }")
 
-OWNER_1=$(linera -w0 keygen)
-OWNER_2=$(linera -w1 keygen)
+OWNER_1=$(linera -w1 keygen)
+OWNER_2=$(linera -w2 keygen)
 
-linera -w0 service --port 8080 &
+linera -w1 service --port 8080 &
 sleep 1
 ```
 
@@ -140,11 +140,11 @@ kill %% && sleep 1    # Kill the service so we can use CLI commands for wallet 0
 HEX_CHAIN=$(echo "$QUERY_RESULT" | jq -r '.gameChains.entry.value[0].chainId')
 MESSAGE_ID=$(echo "$QUERY_RESULT" | jq -r '.gameChains.entry.value[0].messageId')
 
-linera -w0 assign --owner $OWNER_1 --message-id $MESSAGE_ID
-linera -w1 assign --owner $OWNER_2 --message-id $MESSAGE_ID
+linera -w1 assign --owner $OWNER_1 --message-id $MESSAGE_ID
+linera -w2 assign --owner $OWNER_2 --message-id $MESSAGE_ID
 
-linera -w0 service --port 8080 &
-linera -w1 service --port 8081 &
+linera -w1 service --port 8080 &
+linera -w2 service --port 8081 &
 sleep 1
 ```
 

--- a/examples/social/README.md
+++ b/examples/social/README.md
@@ -58,19 +58,19 @@ export LINERA_STORAGE_0="rocksdb:$LINERA_TMP_DIR/client_0.db"
 export LINERA_WALLET_1="$LINERA_TMP_DIR/wallet_1.json"
 export LINERA_STORAGE_1="rocksdb:$LINERA_TMP_DIR/client_1.db"
 
-linera --with-wallet 0 wallet init --faucet $FAUCET_URL
 linera --with-wallet 1 wallet init --faucet $FAUCET_URL
+linera --with-wallet 2 wallet init --faucet $FAUCET_URL
 
-INFO_1=($(linera --with-wallet 0 wallet request-chain --faucet $FAUCET_URL))
-INFO_2=($(linera --with-wallet 1 wallet request-chain --faucet $FAUCET_URL))
+INFO_1=($(linera --with-wallet 1 wallet request-chain --faucet $FAUCET_URL))
+INFO_2=($(linera --with-wallet 2 wallet request-chain --faucet $FAUCET_URL))
 CHAIN_1="${INFO_1[0]}"
 CHAIN_2="${INFO_2[0]}"
 OWNER_1="${INFO_1[3]}"
 OWNER_2="${INFO_2[3]}"
 ```
 
-Note that `linera --with-wallet 0` is equivalent to `linera --wallet "$LINERA_WALLET_0"
---storage "$LINERA_STORAGE_0"`.
+Note that `linera --with-wallet 1` is equivalent to `linera --wallet "$LINERA_WALLET_1"
+--storage "$LINERA_STORAGE_1"`.
 
 Compile the `social` example and create an application with it:
 


### PR DESCRIPTION
## Motivation

After #3393, wallet 0 no longer has to be used.

## Proposal

Be consistent in the name of wallets w.r.t. BASH variables

## Test Plan

CI