### PR TITLE
generalize --with-wallet N to --with-wallet ALPHANUM

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -109,7 +109,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 
 * `--wallet <WALLET_STATE_PATH>` — Sets the file storing the private state of user chains (an empty one will be created if missing)
 * `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
-* `-w`, `--with-wallet <WITH_WALLET>` — Given an integer value `N`, read the wallet state and the wallet storage config from the environment variables `LINERA_WALLET_{N}` and `LINERA_STORAGE_{N}` instead of `LINERA_WALLET` and `LINERA_STORAGE`
+* `-w`, `--with-wallet <WITH_WALLET>` — Given an ASCII alphanumeric parameter `X`, read the wallet state and the wallet storage config from the environment variables `LINERA_WALLET_{X}` and `LINERA_STORAGE_{X}` instead of `LINERA_WALLET` and `LINERA_STORAGE`
 * `--send-timeout-ms <SEND_TIMEOUT>` — Timeout for sending queries (milliseconds)
 
   Default value: `4000`

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -78,11 +78,12 @@ pub struct ClientOptions {
     #[arg(long = "storage")]
     pub storage_config: Option<String>,
 
-    /// Given an integer value `N`, read the wallet state and the wallet storage config from the
-    /// environment variables `LINERA_WALLET_{N}` and `LINERA_STORAGE_{N}` instead of
-    /// `LINERA_WALLET` and `LINERA_STORAGE`.
-    #[arg(long, short = 'w')]
-    pub with_wallet: Option<u32>,
+    /// Given an ASCII alphanumeric parameter `X`, read the wallet state and the wallet
+    /// storage config from the environment variables `LINERA_WALLET_{X}` and
+    /// `LINERA_STORAGE_{X}` instead of `LINERA_WALLET` and
+    /// `LINERA_STORAGE`.
+    #[arg(long, short = 'w', value_parser = util::parse_ascii_alphanumeric_string)]
+    pub with_wallet: Option<String>,
 
     /// Timeout for sending queries (milliseconds)
     #[arg(long = "send-timeout-ms", default_value = "4000", value_parser = util::parse_millis)]
@@ -174,7 +175,8 @@ impl ClientOptions {
         let mut options = <ClientOptions as clap::Parser>::parse();
         let suffix = options
             .with_wallet
-            .map(|n| format!("_{}", n))
+            .as_ref()
+            .map(|x| format!("_{}", x))
             .unwrap_or_default();
         let wallet_env_var = env::var(format!("LINERA_WALLET{suffix}")).ok();
         let storage_env_var = env::var(format!("LINERA_STORAGE{suffix}")).ok();

--- a/linera-client/src/util.rs
+++ b/linera-client/src/util.rs
@@ -32,6 +32,14 @@ pub fn parse_chain_set(s: &str) -> Result<HashSet<ChainId>, CryptoError> {
     }
 }
 
+pub fn parse_ascii_alphanumeric_string(s: &str) -> Result<String, &'static str> {
+    if s.chars().all(|x| x.is_ascii_alphanumeric()) {
+        Ok(s.to_string())
+    } else {
+        Err("Expecting ASCII alphanumeric characters")
+    }
+}
+
 /// Returns after the specified time or if we receive a notification that a new round has started.
 pub async fn wait_for_next_round(stream: &mut NotificationStream, timeout: RoundTimeout) {
     let mut stream = stream.filter(|notification| match &notification.reason {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1353,7 +1353,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     let span = tracing::info_span!("linera::main");
-    if let Some(wallet_id) = options.with_wallet {
+    if let Some(wallet_id) = &options.with_wallet {
         span.record("wallet_id", wallet_id);
     }
 


### PR DESCRIPTION
## Motivation

After #3393, wallet names do not need to be numbers

## Proposal

Support alphanumerical wallet names

## Test Plan

CI
