### PR TITLE
(Port of #3363) Make sure we include end_value in generated Prometheus buckets

### DIFF
--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -4,8 +4,8 @@
 //! This module defines util functions for interacting with Prometheus (logging metrics, etc)
 
 use prometheus::{
-    histogram_opts, register_histogram_vec, register_int_counter_vec, Error, HistogramVec,
-    IntCounterVec, Opts,
+    exponential_buckets, histogram_opts, register_histogram_vec, register_int_counter_vec, Error,
+    HistogramVec, IntCounterVec, Opts,
 };
 
 use crate::time::Instant;
@@ -36,6 +36,27 @@ pub fn register_histogram_vec(
     };
 
     register_histogram_vec!(histogram_opts, label_names)
+}
+
+/// Construct the bucket interval starting from a value and an ending value.
+pub fn bucket_interval(start_value: f64, end_value: f64) -> Option<Vec<f64>> {
+    let quot = end_value / start_value;
+    let factor = 3.0_f64;
+    let count_approx = quot.ln() / factor.ln();
+    let count = count_approx.round() as usize;
+    let mut buckets = exponential_buckets(start_value, factor, count)
+        .expect("Exponential buckets creation should not fail!");
+    if let Some(last) = buckets.last() {
+        if *last < end_value {
+            buckets.push(end_value);
+        }
+    }
+    Some(buckets)
+}
+
+/// Construct the latencies starting from 0.0001 and ending at the maximum latency
+pub fn bucket_latencies(max_latency: f64) -> Option<Vec<f64>> {
+    bucket_interval(0.0001_f64, max_latency)
 }
 
 /// A guard for an active latency measurement.


### PR DESCRIPTION
## Motivation

Right now we're generating the buckets, but it's not in an inclusive way, and it should be. For latency metrics, for example, you have `end_value` being 500ms, but one of the buckets is 159. Since we're using a multiplication factor of 3, the next bucket would go over 500ms, so we don't include it...

## Proposal

Make sure we always include the `end_value` bucket

## Test Plan

CI + start a network locally and see the correct buckets exported

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
