### PR TITLE
[testnet] Manually adjust proxy/server buckets for latencies

### DIFF
--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -59,7 +59,7 @@ static SERVER_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "server_request_latency",
         "Server request latency",
         &[],
-        Some(vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0]),
+        Some(vec![1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 150.0, 200.0]),
     )
     .expect("Counter creation should not fail")
 });
@@ -96,7 +96,7 @@ static SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE: LazyLock<HistogramVec> = LazyLoc
         "server_request_latency_per_request_type",
         "Server request latency per request type",
         &["method_name"],
-        Some(vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0]),
+        Some(vec![1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 150.0, 200.0]),
     )
     .expect("Counter creation should not fail")
 });

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -69,8 +69,8 @@ static PROXY_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         "Proxy request latency",
         &[],
         Some(vec![
-            0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0,
-            50.0, 100.0, 200.0, 300.0, 400.0,
+            1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 150.0, 200.0, 250.0, 300.0, 350.0, 400.0,
+            450.0, 500.0,
         ]),
     )
     .expect("Counter creation should not fail")


### PR DESCRIPTION
## Motivation

A lot of changes happened in this prometheus code that we didn't backport (mainly [#2878](https://github.com/linera-io/linera-protocol/pull/2878)). Backporting it would be a huge pain, so I'm just gonna change the buckets manually for now, and when we cut a new testnet we'll have the proper stuff in

## Proposal

Manually adjust buckets

## Test Plan

CI

