### PR TITLE
Pin `cargo-machete`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -289,7 +289,7 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install cargo-machete
       run: |
-        cargo install cargo-machete --locked
+        cargo install cargo-machete@0.7.0 --locked
     - name: Check for unused dependencies
       run: |
         cargo machete


### PR DESCRIPTION
## Motivation

`cargo machete` 0.8 is incompatible with our codebase, until we can upgrade to Rust 2024.

## Proposal

Pin it to 0.7.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
