### PR TITLE
Stop using deprecated stuff in yaml configs

### DIFF
--- a/kubernetes/linera-validator/helmfile.yaml
+++ b/kubernetes/linera-validator/helmfile.yaml
@@ -31,7 +31,7 @@ releases:
       - writeToGrafanaCloud: {{ .Values.writeToGrafanaCloud }}
       - {{ env "LINERA_HELMFILE_VALUES_LINERA_CORE" | default "values-local.yaml.gotmpl" }}
     set:
-      - name: installCRDs
+      - name: crds.enabled
         value: "true"
   - name: scylla
     version: v1.13.0
@@ -67,6 +67,6 @@ releases:
     chart: jetstack/cert-manager
     timeout: 900
     set:
-      - name: installCRDs
+      - name: crds.enabled
         value: "true"
 

--- a/kubernetes/linera-validator/templates/ingress.yaml
+++ b/kubernetes/linera-validator/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.staticIpGcpName }}
     networking.gke.io/managed-certificates: managed-cert
-    kubernetes.io/ingress.class: "gce"
+    spec.ingressClassName: "gce"
 spec:
   defaultBackend:
     service:


### PR DESCRIPTION
## Motivation

Right now when deploying networks we see a few warnings because we're using deprecated stuff

## Proposal

Stop using the deprecated stuff

## Test Plan

Deployed a netowrk, didn't see the warnings anymore

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
