### PR TITLE
Migrate from cargo-sort to Taplo (#3409)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -338,18 +338,18 @@ jobs:
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - name: Install cargo-sort
+    - name: Install taplo-sort
       run: |
-        RUSTFLAGS='' cargo install cargo-sort --git https://github.com/Twey/cargo-sort/ --tag linera
+        RUSTFLAGS='' cargo install taplo-cli --locked
     - name: Check if Cargo.toml files are sorted
       run: |
-        cargo sort --check --workspace --grouped
+        taplo fmt --check
     - name: Check if example Cargo.toml files are sorted
       run: |
         cd examples
-        cargo sort --check --workspace --grouped
+        taplo fmt --check
         cd agent
-        cargo sort --check
+        taplo fmt --check
 
   lint-check-for-outdated-readme:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -340,15 +340,9 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install taplo-sort
       run: |
-        RUSTFLAGS='' cargo install taplo-cli --locked
+        RUSTFLAGS='' cargo install taplo-cli@0.9.3 --locked
     - name: Check if Cargo.toml files are sorted
       run: |
-        taplo fmt --check
-    - name: Check if example Cargo.toml files are sorted
-      run: |
-        cd examples
-        taplo fmt --check
-        cd agent
         taplo fmt --check
 
   lint-check-for-outdated-readme:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -330,7 +330,7 @@ jobs:
 
   lint-cargo-sort:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
 
     steps:
     - uses: actions/checkout@v3

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,11 +1,11 @@
-include = ["Cargo.toml", "examples/**/Cargo.toml"]
+include = ["**/Cargo.toml", "examples/**/Cargo.toml"]
 
 [formatting]
 reorder_keys = false
 indent_string = "    "
 
 [[rule]]
-keys = ["workspace.dependencies"]
+keys = ["dependencies", "workspace.dependencies", "dev-dependencies"]
 
 [rule.formatting]
 reorder_keys = true

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,11 @@
+include = ["Cargo.toml"]
+
+[formatting]
+reorder_keys = false
+
+[[rule]]
+include = ["Cargo.toml"]
+keys = ["workspace.dependencies"]
+
+[rule.formatting]
+reorder_keys = true

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,10 +1,10 @@
-include = ["Cargo.toml"]
+include = ["Cargo.toml", "examples/**/Cargo.toml"]
 
 [formatting]
 reorder_keys = false
+indent_string = "    "
 
 [[rule]]
-include = ["Cargo.toml"]
 keys = ["workspace.dependencies"]
 
 [rule.formatting]

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,4 +1,4 @@
-include = ["**/Cargo.toml", "examples/**/Cargo.toml"]
+include = ["**/Cargo.toml"]
 
 [formatting]
 reorder_keys = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,32 +1,32 @@
 [workspace]
 members = [
-  "linera-base",
-  "linera-chain",
-  "linera-client",
-  "linera-core",
-  "linera-ethereum",
-  "linera-execution",
-  "linera-explorer",
-  "linera-faucet",
-  "linera-faucet/client",
-  "linera-faucet/server",
-  "linera-indexer/example",
-  "linera-indexer/graphql-client",
-  "linera-indexer/lib",
-  "linera-indexer/plugins",
-  "linera-rpc",
-  "linera-sdk",
-  "linera-sdk-derive",
-  "linera-service",
-  "linera-service-graphql-client",
-  "linera-storage",
-  "linera-storage-service",
-  "linera-summary",
-  "linera-views",
-  "linera-views-derive",
-  "linera-witty",
-  "linera-witty-macros",
-  "linera-witty/test-modules",
+    "linera-base",
+    "linera-chain",
+    "linera-client",
+    "linera-core",
+    "linera-ethereum",
+    "linera-execution",
+    "linera-explorer",
+    "linera-faucet",
+    "linera-faucet/client",
+    "linera-faucet/server",
+    "linera-indexer/example",
+    "linera-indexer/graphql-client",
+    "linera-indexer/lib",
+    "linera-indexer/plugins",
+    "linera-rpc",
+    "linera-sdk",
+    "linera-sdk-derive",
+    "linera-service",
+    "linera-service-graphql-client",
+    "linera-storage",
+    "linera-storage-service",
+    "linera-summary",
+    "linera-views",
+    "linera-views-derive",
+    "linera-witty",
+    "linera-witty-macros",
+    "linera-witty/test-modules",
 ]
 exclude = ["examples", "scripts"]
 resolver = "2"
@@ -42,7 +42,7 @@ edition = "2021"
 [workspace.dependencies]
 alloy = { version = "0.9.2", default-features = false }
 alloy-primitives = { version = "0.8.18", default-features = false, features = [
-  "serde",
+    "serde",
 ] }
 alloy-signer-local = "0.9.2"
 alloy-sol-types = "0.8.18"
@@ -80,10 +80,10 @@ derive_more = "1.0.0"
 dirs = "5.0.1"
 dyn-clone = "1.0.17"
 ed25519-dalek = { version = "2.1.1", default-features = false, features = [
-  "batch",
-  "fast",
-  "serde",
-  "zeroize",
+    "batch",
+    "fast",
+    "serde",
+    "zeroize",
 ] }
 either = "1.10.0"
 flarch = "0.7.0"
@@ -107,15 +107,13 @@ insta = "1.36.1"
 is-terminal = "0.4.12"
 js-sys = "0.3.70"
 k256 = { version = "0.13.4", default-features = false, features = [
-  "ecdsa",
-  "pem",
-  "sha256",
-  "serde",
-  "arithmetic",
+    "ecdsa",
+    "pem",
+    "sha256",
+    "serde",
+    "arithmetic",
 ] }
 k8s-openapi = { version = "0.21.1", features = ["v1_28"] }
-k8s-openapi = { version = "0.21.1", features = ["v1_28"] }
-kube = "0.88.1"
 kube = "0.88.1"
 linked-hash-map = "0.5.6"
 log = "0.4.21"
@@ -125,7 +123,6 @@ num-format = "0.4.4"
 num-traits = "0.2.18"
 octocrab = "0.42.1"
 oneshot = "0.1.6"
-pathdiff = "0.2.1"
 pathdiff = "0.2.1"
 port-selector = "0.1.6"
 prettyplease = "0.2.16"
@@ -140,7 +137,7 @@ rand_chacha = { version = "0.3.1", default-features = false }
 rand_distr = { version = "0.4.3", default-features = false }
 rcgen = "0.12.1"
 reqwest = { version = "0.11.24", default-features = false, features = [
-  "rustls-tls",
+    "rustls-tls",
 ] }
 revm = "19.4.0"
 revm-interpreter = { version = "15.1.0", features = ["serde"] }
@@ -148,12 +145,11 @@ revm-precompile = "16.0.0"
 revm-primitives = "15.1.0"
 rocksdb = "0.21.0"
 ruzstd = "0.7.1"
-ruzstd = "0.7.1"
 scylla = "0.15.1"
 secp256k1 = { version = "0.30.0", default-features = false, features = [
-  "alloc",
-  "rand",
-  "serde",
+    "alloc",
+    "rand",
+    "serde",
 ] }
 semver = "1.0.22"
 serde = { version = "1.0.197", features = ["derive"] }
@@ -163,8 +159,8 @@ serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11.14"
 serde_json = "1.0.114"
 serde_with = { version = "3", default-features = false, features = [
-  "alloc",
-  "macros",
+    "alloc",
+    "macros",
 ] }
 serde_yaml = "0.8.26"
 sha3 = "0.10.8"
@@ -175,7 +171,7 @@ syn = "2.0.52"
 tempfile = "3.10.1"
 test-case = "3.3.1"
 test-log = { version = "0.2.15", default-features = false, features = [
-  "trace",
+    "trace",
 ] }
 test-strategy = "0.3.1"
 thiserror = "1.0.65"
@@ -195,7 +191,7 @@ tower = "0.4.13"
 tower-http = "0.5.2"
 tracing = { version = "0.1.40", features = ["release_max_level_debug"] }
 tracing-subscriber = { version = "0.3.18", default-features = false, features = [
-  "env-filter",
+    "env-filter",
 ] }
 tracing-web = "0.1.3"
 trait-variant = "0.1.1"
@@ -208,15 +204,15 @@ wasm-instrument = "0.4.0"
 wasm_thread = "0.3.0"
 wasmer = { package = "linera-wasmer", version = "4.4.0-linera.6", default-features = false }
 wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", version = "4.4.0-linera.6", default-features = false, features = [
-  "std",
-  "unwind",
-  "avx",
+    "std",
+    "unwind",
+    "avx",
 ] }
 wasmparser = "0.101.1"
 wasmtime = { version = "25.0.0", default-features = false, features = [
-  "cranelift",
-  "runtime",
-  "std",
+    "cranelift",
+    "runtime",
+    "std",
 ] }
 wasmtimer = "0.2.0"
 web-sys = "0.3.69"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,32 +1,32 @@
 [workspace]
 members = [
-    "linera-base",
-    "linera-chain",
-    "linera-client",
-    "linera-core",
-    "linera-ethereum",
-    "linera-execution",
-    "linera-explorer",
-    "linera-faucet",
-    "linera-faucet/client",
-    "linera-faucet/server",
-    "linera-indexer/example",
-    "linera-indexer/graphql-client",
-    "linera-indexer/lib",
-    "linera-indexer/plugins",
-    "linera-rpc",
-    "linera-sdk",
-    "linera-sdk-derive",
-    "linera-service",
-    "linera-service-graphql-client",
-    "linera-storage",
-    "linera-storage-service",
-    "linera-summary",
-    "linera-views",
-    "linera-views-derive",
-    "linera-witty",
-    "linera-witty-macros",
-    "linera-witty/test-modules",
+  "linera-base",
+  "linera-chain",
+  "linera-client",
+  "linera-core",
+  "linera-ethereum",
+  "linera-execution",
+  "linera-explorer",
+  "linera-faucet",
+  "linera-faucet/client",
+  "linera-faucet/server",
+  "linera-indexer/example",
+  "linera-indexer/graphql-client",
+  "linera-indexer/lib",
+  "linera-indexer/plugins",
+  "linera-rpc",
+  "linera-sdk",
+  "linera-sdk-derive",
+  "linera-service",
+  "linera-service-graphql-client",
+  "linera-storage",
+  "linera-storage-service",
+  "linera-summary",
+  "linera-views",
+  "linera-views-derive",
+  "linera-witty",
+  "linera-witty-macros",
+  "linera-witty/test-modules",
 ]
 exclude = ["examples", "scripts"]
 resolver = "2"
@@ -40,7 +40,12 @@ license = "Apache-2.0"
 edition = "2021"
 
 [workspace.dependencies]
-heck = "0.4.1"
+alloy = { version = "0.9.2", default-features = false }
+alloy-primitives = { version = "0.8.18", default-features = false, features = [
+  "serde",
+] }
+alloy-signer-local = "0.9.2"
+alloy-sol-types = "0.8.18"
 anyhow = "1.0.80"
 assert_matches = "1.5.0"
 async-graphql = "=7.0.2"
@@ -75,10 +80,10 @@ derive_more = "1.0.0"
 dirs = "5.0.1"
 dyn-clone = "1.0.17"
 ed25519-dalek = { version = "2.1.1", default-features = false, features = [
-    "batch",
-    "fast",
-    "serde",
-    "zeroize",
+  "batch",
+  "fast",
+  "serde",
+  "zeroize",
 ] }
 either = "1.10.0"
 flarch = "0.7.0"
@@ -91,63 +96,77 @@ genawaiter = "0.99.1"
 generic-array = { version = "0.14.7", features = ["serde"] }
 getrandom = "0.2.12"
 git2 = "0.19.0"
+glob = "0.3.1"
+gloo-utils = "0.2.0"
+heck = "0.4.1"
 hex = "0.4.3"
 http = "1.1.0"
 humantime = "2.1.0"
-glob = "0.3.1"
-gloo-utils = "0.2.0"
 indexed_db_futures = "0.4.1"
 insta = "1.36.1"
 is-terminal = "0.4.12"
-alloy-sol-types = "0.8.18"
-alloy = { version = "0.9.2", default-features = false }
-alloy-signer-local = "0.9.2"
-alloy-primitives = { version = "0.8.18", default-features = false, features = ["serde"] }
+js-sys = "0.3.70"
+k256 = { version = "0.13.4", default-features = false, features = [
+  "ecdsa",
+  "pem",
+  "sha256",
+  "serde",
+  "arithmetic",
+] }
+k8s-openapi = { version = "0.21.1", features = ["v1_28"] }
+k8s-openapi = { version = "0.21.1", features = ["v1_28"] }
+kube = "0.88.1"
+kube = "0.88.1"
+linked-hash-map = "0.5.6"
 log = "0.4.21"
 lru = "0.12.3"
-linked-hash-map = "0.5.6"
 num-bigint = "0.4.3"
 num-format = "0.4.4"
 num-traits = "0.2.18"
 octocrab = "0.42.1"
 oneshot = "0.1.6"
+pathdiff = "0.2.1"
+pathdiff = "0.2.1"
 port-selector = "0.1.6"
 prettyplease = "0.2.16"
-prometheus = "0.13.3"
 proc-macro-error = "1.0.4"
 proc-macro2 = "1.0"
+prometheus = "0.13.3"
 proptest = { version = "1.6.0", default-features = false, features = ["alloc"] }
 prost = "0.13.2"
 quote = "1.0"
 rand = { version = "0.8.5", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
 rand_distr = { version = "0.4.3", default-features = false }
-ruzstd = "0.7.1"
-k256 = { version = "0.13.4", default-features = false, features = [ 
-    "ecdsa", "pem", "sha256", "serde", "arithmetic" 
-] }
-k8s-openapi = { version = "0.21.1", features = ["v1_28"] }
-pathdiff = "0.2.1"
-kube = "0.88.1"
 rcgen = "0.12.1"
 reqwest = { version = "0.11.24", default-features = false, features = [
-    "rustls-tls",
+  "rustls-tls",
 ] }
 revm = "19.4.0"
-revm-interpreter = { version = "15.1.0", features = [ "serde" ] }
+revm-interpreter = { version = "15.1.0", features = ["serde"] }
 revm-precompile = "16.0.0"
 revm-primitives = "15.1.0"
 rocksdb = "0.21.0"
+ruzstd = "0.7.1"
+ruzstd = "0.7.1"
 scylla = "0.15.1"
+secp256k1 = { version = "0.30.0", default-features = false, features = [
+  "alloc",
+  "rand",
+  "serde",
+] }
 semver = "1.0.22"
 serde = { version = "1.0.197", features = ["derive"] }
-serde_bytes = "0.11.14"
-serde_json = "1.0.114"
-serde_yaml = "0.8.26"
 serde-name = "0.2.1"
 serde-reflection = "0.3.6"
 serde-wasm-bindgen = "0.6.5"
-serde_with = { version = "3", default-features = false, features = ["alloc", "macros"] }
+serde_bytes = "0.11.14"
+serde_json = "1.0.114"
+serde_with = { version = "3", default-features = false, features = [
+  "alloc",
+  "macros",
+] }
+serde_yaml = "0.8.26"
 sha3 = "0.10.8"
 similar-asserts = "1.5.0"
 static_assertions = "1.1.0"
@@ -156,27 +175,27 @@ syn = "2.0.52"
 tempfile = "3.10.1"
 test-case = "3.3.1"
 test-log = { version = "0.2.15", default-features = false, features = [
-    "trace",
+  "trace",
 ] }
 test-strategy = "0.3.1"
 thiserror = "1.0.65"
 thiserror-context = "0.1.1"
+tokio = "1.36.0"
+tokio-stream = "0.1.14"
+tokio-test = "0.4.3"
+tokio-util = "0.7.10"
+toml = "0.8.10"
 tonic = { version = "0.12.3", default-features = false }
 tonic-build = { version = "0.12.3", default-features = false }
 tonic-health = "0.12"
 tonic-reflection = "0.12"
 tonic-web = "0.12"
 tonic-web-wasm-client = "0.6.0"
-tokio = "1.36.0"
-tokio-stream = "0.1.14"
-tokio-test = "0.4.3"
-tokio-util = "0.7.10"
-toml = "0.8.10"
-tower-http = "0.5.2"
 tower = "0.4.13"
+tower-http = "0.5.2"
 tracing = { version = "0.1.40", features = ["release_max_level_debug"] }
 tracing-subscriber = { version = "0.3.18", default-features = false, features = [
-    "env-filter",
+  "env-filter",
 ] }
 tracing-web = "0.1.3"
 trait-variant = "0.1.1"
@@ -189,19 +208,18 @@ wasm-instrument = "0.4.0"
 wasm_thread = "0.3.0"
 wasmer = { package = "linera-wasmer", version = "4.4.0-linera.6", default-features = false }
 wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", version = "4.4.0-linera.6", default-features = false, features = [
-    "std",
-    "unwind",
-    "avx",
+  "std",
+  "unwind",
+  "avx",
 ] }
 wasmparser = "0.101.1"
 wasmtime = { version = "25.0.0", default-features = false, features = [
-    "cranelift",
-    "runtime",
-    "std",
+  "cranelift",
+  "runtime",
+  "std",
 ] }
 wasmtimer = "0.2.0"
 web-sys = "0.3.69"
-js-sys = "0.3.70"
 web-time = "1.1.0"
 wit-bindgen = "0.24.0"
 zstd = "0.13.2"
@@ -220,6 +238,9 @@ linera-indexer-graphql-client = { version = "0.14.0", path = "./linera-indexer/g
 linera-indexer-plugins = { version = "0.14.0", path = "./linera-indexer/plugins" }
 linera-rpc = { version = "0.14.0", path = "./linera-rpc" }
 linera-sdk = { version = "0.14.0", path = "./linera-sdk" }
+linera-sdk-derive = { version = "0.14.0", path = "./linera-sdk-derive" }
+linera-service = { version = "0.14.0", path = "./linera-service", default-features = false }
+linera-service-graphql-client = { version = "0.14.0", path = "./linera-service-graphql-client" }
 linera-storage = { version = "0.14.0", path = "./linera-storage", default-features = false }
 linera-storage-service = { version = "0.14.0", path = "./linera-storage-service", default-features = false }
 linera-version = { version = "0.14.0", path = "./linera-version" }
@@ -227,20 +248,17 @@ linera-views = { version = "0.14.0", path = "./linera-views", default-features =
 linera-views-derive = { version = "0.14.0", path = "./linera-views-derive" }
 linera-witty = { version = "0.14.0", path = "./linera-witty" }
 linera-witty-macros = { version = "0.14.0", path = "./linera-witty-macros" }
-linera-sdk-derive = { version = "0.14.0", path = "./linera-sdk-derive" }
-linera-service = { version = "0.14.0", path = "./linera-service", default-features = false }
-linera-service-graphql-client = { version = "0.14.0", path = "./linera-service-graphql-client" }
 
+amm = { path = "./examples/amm" }
 counter = { path = "./examples/counter" }
-meta-counter = { path = "./examples/meta-counter" }
+crowd-funding = { path = "./examples/crowd-funding" }
 ethereum-tracker = { path = "./examples/ethereum-tracker" }
 fungible = { path = "./examples/fungible" }
+matching-engine = { path = "./examples/matching-engine" }
+meta-counter = { path = "./examples/meta-counter" }
 native-fungible = { path = "./examples/native-fungible" }
 non-fungible = { path = "./examples/non-fungible" }
-crowd-funding = { path = "./examples/crowd-funding" }
-matching-engine = { path = "./examples/matching-engine" }
 social = { path = "./examples/social" }
-amm = { path = "./examples/amm" }
 
 [profile.release]
 lto = "thin"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@
 
 * `brew install jq`
 * `cargo install cargo-rdme`
-* `cargo install cargo-sort`
+* `cargo install taplo-cli`
 * `cargo install cargo-all-features`
 * `cargo install cargo-machete`
 
@@ -51,7 +51,7 @@ Alternatively, we have added experimental Nix support (see `flake.nix`).
 
 * `sudo apt-get install jq`
 * `cargo install cargo-rdme`
-* `cargo install cargo-sort`
+* `cargo install taplo-cli`
 * `cargo install cargo-all-features`
 * `cargo install cargo-machete`
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,20 +1,20 @@
 [workspace]
 resolver = "2"
 members = [
-  "amm",
-  "counter",
-  "crowd-funding",
-  "ethereum-tracker",
-  "fungible",
-  "gen-nft",
-  "hex-game",
-  "llm",
-  "matching-engine",
-  "meta-counter",
-  "native-fungible",
-  "non-fungible",
-  "rfq",
-  "social",
+    "amm",
+    "counter",
+    "crowd-funding",
+    "ethereum-tracker",
+    "fungible",
+    "gen-nft",
+    "hex-game",
+    "llm",
+    "matching-engine",
+    "meta-counter",
+    "native-fungible",
+    "non-fungible",
+    "rfq",
+    "social",
 ]
 
 [workspace.dependencies]
@@ -28,7 +28,7 @@ candle-transformers = "0.4.1"
 futures = "0.3.24"
 futures-util = "0.3.26"
 getrandom = { version = "0.2.12", default-features = false, features = [
-  "custom",
+    "custom",
 ] }
 hex = "0.4.3"
 linera-sdk = { path = "../linera-sdk" }
@@ -41,10 +41,10 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 sha3 = "0.10.8"
 test-log = { version = "0.2.15", default-features = false, features = [
-  "trace",
+    "trace",
 ] }
 tokenizers = { git = "https://github.com/christos-h/tokenizers", default-features = false, features = [
-  "unstable_wasm",
+    "unstable_wasm",
 ] }
 tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread"] }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,23 +1,24 @@
 [workspace]
 resolver = "2"
 members = [
-    "amm",
-    "counter",
-    "crowd-funding",
-    "ethereum-tracker",
-    "fungible",
-    "gen-nft",
-    "hex-game",
-    "llm",
-    "matching-engine",
-    "meta-counter",
-    "native-fungible",
-    "non-fungible",
-    "rfq",
-    "social",
+  "amm",
+  "counter",
+  "crowd-funding",
+  "ethereum-tracker",
+  "fungible",
+  "gen-nft",
+  "hex-game",
+  "llm",
+  "matching-engine",
+  "meta-counter",
+  "native-fungible",
+  "non-fungible",
+  "rfq",
+  "social",
 ]
 
 [workspace.dependencies]
+alloy = { version = "0.9.2", default-features = false }
 assert_matches = "1.5.0"
 async-graphql = { version = "=7.0.2", default-features = false }
 base64 = "0.22.0"
@@ -26,9 +27,10 @@ candle-core = "0.4.1"
 candle-transformers = "0.4.1"
 futures = "0.3.24"
 futures-util = "0.3.26"
-getrandom = { version = "0.2.12", default-features = false, features = ["custom"] }
+getrandom = { version = "0.2.12", default-features = false, features = [
+  "custom",
+] }
 hex = "0.4.3"
-alloy = { version = "0.9.2", default-features = false }
 linera-sdk = { path = "../linera-sdk" }
 linera-views = { path = "../linera-views", default-features = false }
 log = "0.4.20"
@@ -38,18 +40,22 @@ rand = "0.8.5"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 sha3 = "0.10.8"
-test-log = { version = "0.2.15", default-features = false, features = ["trace"] }
-tokenizers = { git = "https://github.com/christos-h/tokenizers", default-features = false, features = ["unstable_wasm"] }
+test-log = { version = "0.2.15", default-features = false, features = [
+  "trace",
+] }
+tokenizers = { git = "https://github.com/christos-h/tokenizers", default-features = false, features = [
+  "unstable_wasm",
+] }
 tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread"] }
 
+amm = { path = "./amm" }
 counter = { path = "./counter" }
 crowd-funding = { path = "./crowd-funding" }
 ethereum-tracker = { path = "./ethereum-tracker", features = ["ethereum"] }
 fungible = { path = "./fungible" }
+matching-engine = { path = "./matching-engine" }
 native-fungible = { path = "./native-fungible" }
 non-fungible = { path = "./non-fungible" }
-amm = { path = "./amm" }
-matching-engine = { path = "./matching-engine" }
 
 [profile.release]
 debug = true

--- a/examples/agent/Cargo.toml
+++ b/examples/agent/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 anyhow = "1.0.95"
 clap = { version = "4.5.26", features = ["derive"] }
 reqwest = { version = "0.11.24", default-features = false, features = [
-    "rustls-tls",
+  "rustls-tls",
 ] }
 rig-core = "0.8.0"
 serde = { version = "1.0.152", features = ["derive"] }

--- a/examples/agent/Cargo.toml
+++ b/examples/agent/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 anyhow = "1.0.95"
 clap = { version = "4.5.26", features = ["derive"] }
 reqwest = { version = "0.11.24", default-features = false, features = [
-  "rustls-tls",
+    "rustls-tls",
 ] }
 rig-core = "0.8.0"
 serde = { version = "1.0.152", features = ["derive"] }

--- a/examples/ethereum-tracker/Cargo.toml
+++ b/examples/ethereum-tracker/Cargo.toml
@@ -5,9 +5,11 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dependencies]
-alloy = { workspace = true, default-features = false, features = ["rpc-types-eth"] }
+alloy = { workspace = true, default-features = false, features = [
+    "rpc-types-eth",
+] }
 async-graphql.workspace = true
-linera-sdk = { workspace = true, features = [ "ethereum" ] }
+linera-sdk = { workspace = true, features = ["ethereum"] }
 serde.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -76,7 +76,12 @@ tracing-web = { optional = true, workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono.workspace = true
 rand = { workspace = true, features = ["getrandom", "std", "std_rng"] }
-tokio = { workspace = true, features = ["process", "rt-multi-thread", "signal", "macros"] }
+tokio = { workspace = true, features = [
+    "process",
+    "rt-multi-thread",
+    "signal",
+    "macros",
+] }
 tokio-util.workspace = true
 prometheus.workspace = true
 port-selector.workspace = true

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -102,7 +102,9 @@ test-case.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = { workspace = true, default-features = true, features = ["async_tokio"] }
+criterion = { workspace = true, default-features = true, features = [
+    "async_tokio",
+] }
 
 [package.metadata.cargo-machete]
 ignored = ["async-graphql", "proptest"]

--- a/linera-ethereum/Cargo.toml
+++ b/linera-ethereum/Cargo.toml
@@ -29,13 +29,23 @@ serde_json = { workspace = true, features = ["raw_value"] }
 thiserror.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-alloy = { workspace = true, default-features = false, features = [ "rpc-types-eth", "provider-http", "json-rpc", "node-bindings", "network", "signers", "contract" ] }
+alloy = { workspace = true, default-features = false, features = [
+    "rpc-types-eth",
+    "provider-http",
+    "json-rpc",
+    "node-bindings",
+    "network",
+    "signers",
+    "contract",
+] }
 alloy-signer-local = { workspace = true }
 url.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-alloy = { workspace = true, default-features = false, features = [ "rpc-types-eth" ] }
+alloy = { workspace = true, default-features = false, features = [
+    "rpc-types-eth",
+] }
 
 [build-dependencies]
 cfg_aliases.workspace = true

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -41,7 +41,9 @@ wasmtime = [
 web = ["linera-base/web", "linera-views/web", "js-sys"]
 
 [dependencies]
-alloy = { workspace = true, default-features = false, optional = true, features = [ "rpc-types-eth" ] }
+alloy = { workspace = true, default-features = false, optional = true, features = [
+    "rpc-types-eth",
+] }
 alloy-sol-types = { workspace = true, optional = true }
 anyhow.workspace = true
 async-graphql.workspace = true
@@ -80,7 +82,10 @@ wasmtime = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-wasmer = { workspace = true, optional = true, features = ["cranelift", "singlepass"] }
+wasmer = { workspace = true, optional = true, features = [
+    "cranelift",
+    "singlepass",
+] }
 wasmer-compiler-singlepass.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -92,7 +97,10 @@ anyhow.workspace = true
 assert_matches.workspace = true
 bcs.workspace = true
 linera-base = { workspace = true, features = ["test"] }
-linera-execution = { path = ".", default-features = false, features = ["fs", "test"] }
+linera-execution = { path = ".", default-features = false, features = [
+    "fs",
+    "test",
+] }
 linera-witty = { workspace = true, features = ["log", "macros", "test"] }
 proptest.workspace = true
 test-case.workspace = true

--- a/linera-explorer/Cargo.toml
+++ b/linera-explorer/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 anyhow.workspace = true
 console_error_panic_hook = "0.1"
 futures.workspace = true
-graphql_client = { version = "0.13", features = [ "reqwest-rustls" ] }
+graphql_client = { version = "0.13", features = ["reqwest-rustls"] }
 hex.workspace = true
 js-sys = "0.3"
 linera-base.workspace = true
@@ -24,12 +24,18 @@ linera-indexer-graphql-client.workspace = true
 linera-service-graphql-client.workspace = true
 once_cell = "1.19.0"
 reqwest.workspace = true
-serde = { workspace = true, features = [ "derive" ] }
+serde = { workspace = true, features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 serde_json.workspace = true
 url = "2.5"
-uuid = { version = "1.7", features = [ "v3" ] }
+uuid = { version = "1.7", features = ["v3"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3", features = [ "console", "Window", "History", "Storage", "Location" ] }
+web-sys = { version = "0.3", features = [
+    "console",
+    "Window",
+    "History",
+    "Storage",
+    "Location",
+] }
 ws_stream_wasm = "0.7"

--- a/linera-faucet/Cargo.toml
+++ b/linera-faucet/Cargo.toml
@@ -13,5 +13,5 @@ serde.workspace = true
 serde_with = "3.12.0"
 
 [dependencies.async-graphql]
-workspace = true
 optional = true
+workspace = true

--- a/linera-faucet/server/Cargo.toml
+++ b/linera-faucet/server/Cargo.toml
@@ -27,6 +27,6 @@ tracing.workspace = true
 [dev-dependencies]
 async-trait.workspace = true
 linera-views.workspace = true
-  [dev-dependencies.linera-core]
-  workspace = true
-  features = ["test"]
+[dev-dependencies.linera-core]
+features = ["test"]
+workspace = true

--- a/linera-indexer/example/Cargo.toml
+++ b/linera-indexer/example/Cargo.toml
@@ -17,7 +17,10 @@ benchmark = ["linera-base/test", "linera-indexer/benchmark"]
 rocksdb = ["linera-indexer/rocksdb", "linera-indexer-plugins/rocksdb"]
 dynamodb = ["linera-indexer/dynamodb", "linera-indexer-plugins/dynamodb"]
 scylladb = ["linera-indexer/scylladb", "linera-indexer-plugins/scylladb"]
-storage-service = ["linera-indexer/storage-service", "linera-service/storage-service"]
+storage-service = [
+    "linera-indexer/storage-service",
+    "linera-service/storage-service",
+]
 wasmer = ["linera-indexer-plugins/wasmer"]
 wasmtime = ["linera-indexer-plugins/wasmtime"]
 test = ["linera-service/test"]

--- a/linera-indexer/graphql-client/Cargo.toml
+++ b/linera-indexer/graphql-client/Cargo.toml
@@ -12,9 +12,9 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-graphql_client = { version = "0.13", features = [ "reqwest-rustls" ] }
+graphql_client = { version = "0.13", features = ["reqwest-rustls"] }
 linera-base.workspace = true
-serde = { workspace = true, features = [ "derive" ] }
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/linera-indexer/lib/Cargo.toml
+++ b/linera-indexer/lib/Cargo.toml
@@ -29,7 +29,7 @@ bcs.workspace = true
 clap.workspace = true
 futures.workspace = true
 graphql-ws-client = { version = "0.5", features = ["client-graphql-client"] }
-graphql_client = { version = "0.13", features = [ "reqwest-rustls" ] }
+graphql_client = { version = "0.13", features = ["reqwest-rustls"] }
 hyper = "0.14"
 linera-base.workspace = true
 linera-chain.workspace = true

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -77,7 +77,13 @@ serde-reflection.workspace = true
 test-strategy.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tonic = { workspace = true, features = ["tls", "tls-webpki-roots", "prost", "codegen", "transport"] }
+tonic = { workspace = true, features = [
+    "tls",
+    "tls-webpki-roots",
+    "prost",
+    "codegen",
+    "transport",
+] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tonic = { workspace = true, features = ["codegen", "prost"] }

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -24,7 +24,10 @@ ignored = ["base64ct"]
 
 [features]
 ethereum = ["async-trait", "linera-ethereum"]
-unstable-oracles = ["linera-core/unstable-oracles", "linera-execution/unstable-oracles"]
+unstable-oracles = [
+    "linera-core/unstable-oracles",
+    "linera-execution/unstable-oracles",
+]
 wasmer = [
     "linera-core/wasmer",
     "linera-execution/wasmer",

--- a/linera-service-graphql-client/Cargo.toml
+++ b/linera-service-graphql-client/Cargo.toml
@@ -19,10 +19,10 @@ scylladb = ["linera-service/scylladb"]
 storage-service = ["linera-service/storage-service"]
 
 [dependencies]
-graphql_client = { version = "0.13", features = [ "reqwest-rustls" ] }
+graphql_client = { version = "0.13", features = ["reqwest-rustls"] }
 linera-base.workspace = true
 reqwest.workspace = true
-serde = { workspace = true, features = [ "derive" ] }
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
 

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -27,7 +27,11 @@ benchmark = [
     "linera-client/benchmark",
     "linera-chain/benchmark",
 ]
-wasmer = ["linera-client/wasmer", "linera-execution/wasmer", "linera-storage/wasmer"]
+wasmer = [
+    "linera-client/wasmer",
+    "linera-execution/wasmer",
+    "linera-storage/wasmer",
+]
 wasmtime = [
     "linera-client/wasmtime",
     "linera-execution/wasmtime",
@@ -126,7 +130,9 @@ tracing.workspace = true
 cfg_aliases.workspace = true
 
 [dev-dependencies]
-alloy = { workspace = true, default-features = false, features = [ "rpc-types-eth" ] }
+alloy = { workspace = true, default-features = false, features = [
+    "rpc-types-eth",
+] }
 amm.workspace = true
 base64.workspace = true
 counter.workspace = true

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -40,7 +40,9 @@ tracing-subscriber = { workspace = true, features = ["fmt"] }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
-linera-storage-service = { path = ".", default-features = false, features = ["test"] }
+linera-storage-service = { path = ".", default-features = false, features = [
+    "test",
+] }
 proptest = { workspace = true, features = ["alloc"] }
 serde-reflection.workspace = true
 serde_yaml.workspace = true

--- a/linera-version/Cargo.toml
+++ b/linera-version/Cargo.toml
@@ -42,4 +42,6 @@ thiserror.workspace = true
 ignored = ["async-graphql-derive"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(linera_version_building)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(linera_version_building)',
+] }

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -43,7 +43,10 @@ features = ["singlepass"]
 [dev-dependencies]
 assert_matches.workspace = true
 insta.workspace = true
-linera-witty = { path = ".", default-features = false, features = ["macros", "test"] }
+linera-witty = { path = ".", default-features = false, features = [
+    "macros",
+    "test",
+] }
 test-case.workspace = true
 tracing.workspace = true
 


### PR DESCRIPTION
## Motivation

A fork of cargo-sort used in CI to normalize Cargo.toml files as the project is on life support. #3409

## Proposal

Migrate from cargo-sort to [Taplo](https://taplo.tamasfe.dev/), while current lint step should verify the order of dependencies alongside schema validation. 

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- https://taplo.tamasfe.dev/cli/usage/validation.html
