### PR TITLE
Limit network actions per batch

### DIFF
--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -27,6 +27,8 @@ pub struct ChainWorkerConfig {
     /// Blocks with a timestamp this far in the future will still be accepted, but the validator
     /// will wait until that timestamp before voting.
     pub grace_period: Duration,
+    /// The maximum number of network actions to include in a single batch.
+    pub network_actions_batch_limit: Option<usize>,
 }
 
 impl ChainWorkerConfig {

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -423,6 +423,11 @@ where
     async fn create_network_actions(&self) -> Result<NetworkActions, WorkerError> {
         let mut heights_by_recipient = BTreeMap::<_, BTreeMap<_, _>>::new();
         let mut targets = self.chain.outboxes.indices().await?;
+
+        if let Some(limit) = self.config.network_actions_batch_limit {
+            targets.truncate(limit);
+        }
+
         if let Some(tracked_chains) = self.tracked_chains.as_ref() {
             let publishers = self
                 .chain

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -364,6 +364,13 @@ where
         self
     }
 
+    /// Returns an instance with a limit on the number of network actions created per batch.
+    #[instrument(level = "trace", skip(self))]
+    pub fn with_network_actions_batch_limit(mut self, limit: usize) -> Self {
+        self.chain_worker_config.network_actions_batch_limit = Some(limit);
+        self
+    }
+
     #[instrument(level = "trace", skip(self))]
     pub fn nickname(&self) -> &str {
         &self.nickname

--- a/linera-rpc/src/config.rs
+++ b/linera-rpc/src/config.rs
@@ -11,7 +11,7 @@ use crate::simple;
 pub struct CrossChainConfig {
     /// Number of cross-chain messages allowed before dropping them.
     #[arg(long = "cross-chain-queue-size", default_value = "1000")]
-    pub(crate) queue_size: usize,
+    pub queue_size: usize,
 
     /// Maximum number of retries for a cross-chain message.
     #[arg(long = "cross-chain-max-retries", default_value = "10")]

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -76,7 +76,8 @@ impl ServerContext {
         )
         .with_allow_inactive_chains(false)
         .with_allow_messages_from_deprecated_epochs(false)
-        .with_grace_period(self.grace_period);
+        .with_grace_period(self.grace_period)
+        .with_network_actions_batch_limit(self.cross_chain_config.queue_size);
         (state, shard_id, shard.clone())
     }
 


### PR DESCRIPTION
## Motivation

There's a risk of `O(n^2)` behavior in the chain worker, because when network actions are created (for cross-chain messages) **all** outboxes are inspected in order to figure out which actions should be created. However, the outboxes are only emptied after a confirmation of the receipt from the receiver. This means that until that confirmation is received, the same network actions might be created again and again, stressing the cross-chain channels.

## Proposal

Limit the number of outboxes inspected to create the network actions. The limit is configured on server shards to be equal to the cross-shard communication channel queue size. If the limit is reached, random outboxes are skipped when creating a new batch of network actions.

## Test Plan

CI should catch any regressions.
TODO: should we add a stress test for this scenario?

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

Because this could be related to a performance issue the testnet is running into.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
