### PR TITLE
Export linera_execution::system::Recipient to application tests

### DIFF
--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -21,7 +21,7 @@ mod validator;
 #[cfg(with_integration_testing)]
 pub use {
     linera_chain::data_types::{Medium, MessageAction},
-    linera_execution::QueryOutcome,
+    linera_execution::{system::Recipient, QueryOutcome},
 };
 
 #[cfg(with_testing)]


### PR DESCRIPTION
## Motivation

Let application unit tests be able to call `block.with_native_token_transfer` which need `Recipient`.

## Proposal

Export `linera_execution::system::Recipient` in `linera-sdk/src/test` crate.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
