### PR TITLE
 Discrepancies in Comments

### DIFF
--- a/linera-views/src/test_utils/performance.rs
+++ b/linera-views/src/test_utils/performance.rs
@@ -12,7 +12,7 @@ use crate::{
     test_utils::{add_prefix, get_random_key_values2},
 };
 
-// We generate about 2000 keys of length 11 with a key of length 10000
+// We generate about 200 keys of length 10 with a value of length 10000
 // The keys are of the form 0,x_1, ..., x_n with 0 <= x_i < 4 and n=10.
 
 /// A value to use for the keys


### PR DESCRIPTION
There's a mismatch in the second doc comment: it references `find_keys_by_prefix` 
but the function is actually named `find_key_values_by_prefix`.
Also, the top comment mentions generating about 2000 keys of length 11, 
whereas the code sets NUM_ENTRIES to 200 and LEN_KEY to 10.
