### PR TITLE
Pin the version of the `base64ct` indirect dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4858,6 +4858,7 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "async-trait",
+ "base64ct",
  "bcs",
  "cargo_toml",
  "cfg_aliases",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3663,6 +3663,7 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "async-trait",
+ "base64ct",
  "bcs",
  "cargo_toml",
  "cfg_aliases",

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -18,6 +18,10 @@ development = ["linera-sdk"]
 features = ["test", "wasmer"]
 targets = ["wasm32-unknown-unknown", "x86_64-unknown-linux-gnu"]
 
+[package.metadata.cargo-machete]
+# TODO(#3421): Remove the pinned version once the `linera-*` crates move to Rust Edition 2024
+ignored = ["base64ct"]
+
 [features]
 ethereum = ["async-trait", "linera-ethereum"]
 unstable-oracles = ["linera-core/unstable-oracles", "linera-execution/unstable-oracles"]
@@ -55,6 +59,9 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 wit-bindgen.workspace = true
+
+# TODO(#3421): Remove the pinned version once the `linera-*` crates move to Rust Edition 2024
+base64ct = "=1.6.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-graphql.workspace = true


### PR DESCRIPTION
## Motivation

Version 1.7.0 breaks semver compatibility by requiring the usage of a new Rust edition. More information is available in https://github.com/RustCrypto/formats/issues/1684.

## Proposal

We should pin it to the last version that we still support at least until we manage to update to the new Rust edition.

## Test Plan

CI should catch any regressions.

## Release Plan

We may have to make a new SDK release with a new patch version.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
