### PR TITLE
`linera-service`: move `assign_new_chain_to_key` to `linera-client`

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -464,7 +464,7 @@ where
         if !config.ownership.verify_owner(&owner) {
             tracing::error!(
                 "The chain with the ID returned by the faucet is not owned by you. \
-            Please make sure you are connecting to a genuine faucet."
+                Please make sure you are connecting to a genuine faucet."
             );
             return Err(error::Inner::ChainOwnership.into());
         }

--- a/linera-client/src/error.rs
+++ b/linera-client/src/error.rs
@@ -26,6 +26,14 @@ pub(crate) enum Inner {
     LocalNode(#[from] linera_core::local_node::LocalNodeError),
     #[error("remote node operation failed: {0}")]
     RemoteNode(#[from] linera_core::node::NodeError),
+    #[error("chain info response missing latest committee")]
+    ChainInfoResponseMissingCommittee,
+    #[error("arithmetic error: {0}")]
+    Arithmetic(#[from] linera_base::data_types::ArithmeticError),
+    #[error("invalid open message")]
+    InvalidOpenMessage(Option<linera_execution::Message>),
+    #[error("incorrect chain ownership")]
+    ChainOwnership,
     #[cfg(feature = "benchmark")]
     #[error("failed to send message: {0}")]
     SendError(#[from] crossbeam_channel::SendError<()>),


### PR DESCRIPTION
## Motivation

I'd like to also use this function from `linera-web`.

## Proposal

Move it into `linera-client`, and give it its own non-`anyhow` errors.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
