### PR TITLE
Fix variable naming inconsistency in timeout handling

### DIFF
--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -96,7 +96,7 @@ where
             ));
         }
         let old_round = self.state.chain.manager.current_round();
-        let timeout_chainid = certificate.inner().chain_id;
+        let timeout_chain_id = certificate.inner().chain_id;
         let timeout_height = certificate.inner().height;
         self.state
             .chain
@@ -105,7 +105,7 @@ where
         let round = self.state.chain.manager.current_round();
         if round > old_round {
             actions.notifications.push(Notification {
-                chain_id: timeout_chainid,
+                chain_id: timeout_chain_id,
                 reason: Reason::NewRound {
                     height: timeout_height,
                     round,


### PR DESCRIPTION
Fix inconsistent variable naming in process_timeout function by renaming timeout_chainid to timeout_chain_id to maintain consistent naming conventions throughout the codebase.