### PR TITLE
Double worker count in benchmarks

### DIFF
--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -84,7 +84,7 @@ impl TestValidator {
             "Single validator node".to_string(),
             Some((validator_keypair.secret_key.copy(), account_secret.copy())),
             storage.clone(),
-            NonZeroUsize::new(20).expect("Chain worker limit should not be zero"),
+            NonZeroUsize::new(40).expect("Chain worker limit should not be zero"),
         );
 
         let validator = TestValidator {


### PR DESCRIPTION
## Motivation

After switching to `k256` for secp256k1 our `benchmarks` job stopped failing. Most likely it's caused by `k256` being much slower and this leads to worker cache being busy and unable to handle new requests - which leads to test failures.

## Proposal

Double worker count for now.

## Test Plan

CI

## Release Plan


- Nothing to do

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
