### PR TITLE
Use events for adding and removing committees.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1002,6 +1002,11 @@ impl BlobContent {
         BlobContent::new(BlobType::ApplicationDescription, bytes)
     }
 
+    /// Creates a new committee [`BlobContent`] from the provided serialized committee.
+    pub fn new_committee(committee: impl Into<Box<[u8]>>) -> Self {
+        BlobContent::new(BlobType::Committee, committee)
+    }
+
     /// Gets a reference to the blob's bytes.
     pub fn bytes(&self) -> &[u8] {
         &self.bytes

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -780,6 +780,8 @@ pub enum OracleResponse {
     Assert,
     /// The block's validation round.
     Round(Option<u32>),
+    /// An event was read.
+    Event(EventId, Vec<u8>),
 }
 
 impl<'de> BcsHashable<'de> for OracleResponse {}

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -166,6 +166,8 @@ pub enum BlobType {
     ServiceBytecode,
     /// A blob containing an application description.
     ApplicationDescription,
+    /// A blob containing a committee of validators.
+    Committee,
 }
 
 impl Display for BlobType {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -439,6 +439,15 @@ pub struct StreamName(
     pub Vec<u8>,
 );
 
+impl<T> From<T> for StreamName
+where
+    T: Into<Vec<u8>>,
+{
+    fn from(name: T) -> Self {
+        StreamName(name.into())
+    }
+}
+
 /// An event stream ID.
 #[derive(
     Clone,
@@ -460,6 +469,16 @@ pub struct StreamId {
     pub application_id: GenericApplicationId,
     /// The name of this stream: an application can have multiple streams with different names.
     pub stream_name: StreamName,
+}
+
+impl StreamId {
+    /// Creates a system stream ID with the given name.
+    pub fn system(name: impl Into<StreamName>) -> Self {
+        StreamId {
+            application_id: GenericApplicationId::System,
+            stream_name: name.into(),
+        }
+    }
 }
 
 /// An event identifier.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -3053,8 +3053,6 @@ where
         #[cfg(with_metrics)]
         let _latency = metrics::PROCESS_INBOX_WITHOUT_PREPARE_LATENCY.measure_latency();
 
-        self.synchronize_chain_state(self.admin_id).await?;
-
         let (mut min_epoch, mut next_epoch) = {
             let query = ChainInfoQuery::new(self.chain_id).with_committees();
             let info = *self

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -3074,7 +3074,7 @@ where
     }
 
     /// Returns operations to process all pending epoch changes: first the new epochs, in order,
-    /// then the revoked epochs, in order.
+    /// then the removed epochs, in order.
     async fn collect_epoch_changes(&self) -> Result<Vec<Operation>, ChainClientError> {
         let (mut min_epoch, mut next_epoch) = {
             let query = ChainInfoQuery::new(self.chain_id).with_committees();

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1105,7 +1105,7 @@ where
     // Create a new committee.
     let committee = Committee::new(validators, ResourceControlPolicy::only_fuel());
     admin.stage_new_committee(committee).await.unwrap();
-    assert_eq!(admin.next_block_height(), BlockHeight::from(3));
+    assert_eq!(admin.next_block_height(), BlockHeight::from(5));
     assert!(admin.pending_proposal().is_none());
     assert!(admin.key_pair().await.is_ok());
     assert_eq!(admin.epoch().await.unwrap(), Epoch::from(2));

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -478,20 +478,11 @@ where
         .unwrap()
         .unwrap();
 
-    // Regression test for #2869.
-    let sub_message_id = MessageId {
-        index: message_id.index + 1,
-        ..message_id
-    };
-    assert_matches!(
-        certificate.block().messages()[0][sub_message_id.index as usize].message,
-        Message::System(SystemMessage::Subscribe { .. })
-    );
     assert_eq!(
         sender
             .client
             .local_node()
-            .certificate_for(&sub_message_id)
+            .certificate_for(&message_id)
             .await
             .unwrap(),
         certificate
@@ -1111,18 +1102,6 @@ where
     user.process_inbox().await.unwrap();
     assert_eq!(user.epoch().await.unwrap(), Epoch::from(1));
 
-    // Stop listening for new committees.
-    let cert = user
-        .unsubscribe_from_new_committees()
-        .await
-        .unwrap()
-        .unwrap();
-    admin
-        .receive_certificate_and_update_validators(cert)
-        .await
-        .unwrap();
-    admin.process_inbox().await.unwrap();
-
     // Create a new committee.
     let committee = Committee::new(validators, ResourceControlPolicy::only_fuel());
     admin.stage_new_committee(committee).await.unwrap();
@@ -1156,20 +1135,8 @@ where
     assert_eq!(user.epoch().await.unwrap(), Epoch::from(1));
     user.synchronize_from_validators().await.unwrap();
 
-    // User is unsubscribed, so the migration message is not even in the inbox yet.
     user.process_inbox().await.unwrap();
-    assert_eq!(user.epoch().await.unwrap(), Epoch::from(1));
-
-    // Now subscribe explicitly to migrations.
-    let cert = user.subscribe_to_new_committees().await.unwrap().unwrap();
-    admin
-        .receive_certificate_and_update_validators(cert)
-        .await
-        .unwrap();
-    builder
-        .check_that_validators_have_empty_outboxes(admin.chain_id())
-        .await;
-    admin.process_inbox().await.unwrap();
+    assert_eq!(user.epoch().await.unwrap(), Epoch::from(2));
 
     // Have the admin chain deprecate the previous epoch.
     admin.finalize_committee().await.unwrap();
@@ -1184,18 +1151,10 @@ where
         .await
         .unwrap()
         .unwrap();
-    assert_matches!(
-        admin.receive_certificate_and_update_validators(cert).await,
-        Err(ChainClientError::CommitteeDeprecationError)
-    );
-    // Transfer is blocked because the epoch #0 has been retired by admin.
-    admin.synchronize_from_validators().await.unwrap();
-    admin.process_inbox().await.unwrap();
-    assert_eq!(admin.local_balance().await.unwrap(), Amount::ZERO);
-
-    // Have the user receive the notification to migrate to epoch #2.
-    user.synchronize_from_validators().await.unwrap();
-    user.process_inbox().await.unwrap();
+    admin
+        .receive_certificate_and_update_validators(cert)
+        .await
+        .unwrap();
     assert_eq!(user.epoch().await.unwrap(), Epoch::from(2));
 
     // Try again to make a transfer back to the admin chain.

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -46,7 +46,7 @@ use linera_execution::{
     committee::{Committee, Epoch},
     system::{
         AdminOperation, OpenChainConfig, Recipient, SystemMessage, SystemOperation,
-        EPOCH_STREAM_NAME, REMOVED_EPOCH_STREAM_NAME,
+        EPOCH_STREAM_NAME as NEW_EPOCH_STREAM_NAME, REMOVED_EPOCH_STREAM_NAME,
     },
     test_utils::{ExpectedCall, RegisterMockApplication, SystemExecutionState},
     ExecutionError, Message, MessageKind, OutgoingMessage, Query, QueryContext, QueryOutcome,
@@ -2423,7 +2423,7 @@ where
                 events: vec![
                     vec![Event {
                         value: bcs::to_bytes(&committee).unwrap(),
-                        stream_id: StreamId::system(EPOCH_STREAM_NAME),
+                        stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
                         key: bcs::to_bytes(&Epoch::from(1)).unwrap(),
                     }],
                     Vec::new(),
@@ -2517,7 +2517,7 @@ where
                     vec![OracleResponse::Event(
                         EventId {
                             chain_id: admin_id,
-                            stream_id: StreamId::system(EPOCH_STREAM_NAME),
+                            stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
                             key: bcs::to_bytes(&Epoch::from(1)).unwrap(),
                         },
                         bcs::to_bytes(&committee).unwrap(),
@@ -2656,7 +2656,7 @@ where
                 messages: vec![vec![]],
                 events: vec![vec![Event {
                     value: bcs::to_bytes(&committee).unwrap(),
-                    stream_id: StreamId::system(EPOCH_STREAM_NAME),
+                    stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
                     key: bcs::to_bytes(&Epoch::from(1)).unwrap(),
                 }]],
                 blobs: vec![Vec::new()],
@@ -2786,7 +2786,7 @@ where
                 events: vec![
                     vec![Event {
                         value: bcs::to_bytes(&committee).unwrap(),
-                        stream_id: StreamId::system(EPOCH_STREAM_NAME),
+                        stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
                         key: bcs::to_bytes(&Epoch::from(1)).unwrap(),
                     }],
                     vec![Event {

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -563,7 +563,7 @@ pub enum ExecutionRequest {
         next_message_id: MessageId,
         application_permissions: ApplicationPermissions,
         #[debug(skip)]
-        callback: Sender<[RawOutgoingMessage<SystemMessage, Amount>; 2]>,
+        callback: Sender<RawOutgoingMessage<SystemMessage, Amount>>,
     },
 
     CloseChain {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1174,6 +1174,9 @@ impl Operation {
             Operation::System(SystemOperation::PublishDataBlob { blob_hash }) => {
                 vec![BlobId::new(*blob_hash, BlobType::Data)]
             }
+            Operation::System(SystemOperation::PublishCommitteeBlob { blob_hash }) => {
+                vec![BlobId::new(*blob_hash, BlobType::Committee)]
+            }
             Operation::System(SystemOperation::PublishModule { module_id }) => vec![
                 BlobId::new(module_id.contract_blob_hash, BlobType::ContractBytecode),
                 BlobId::new(module_id.service_blob_hash, BlobType::ServiceBytecode),

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -290,7 +290,7 @@ impl ResourceControlPolicy {
                     ExecutionError::BytecodeTooLarge
                 );
             }
-            BlobType::Data | BlobType::ApplicationDescription => {}
+            BlobType::Data | BlobType::ApplicationDescription | BlobType::Committee => {}
         }
         Ok(())
     }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1374,7 +1374,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             index: this.transaction_tracker.next_message_index(),
         };
         let chain_id = ChainId::child(message_id);
-        let [open_chain_message, subscribe_message] = this
+        let open_chain_message = this
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::OpenChain {
                 ownership,
@@ -1384,9 +1384,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
                 callback,
             })?
             .recv_response()?;
-        let outcome = RawExecutionOutcome::default()
-            .with_message(open_chain_message)
-            .with_message(subscribe_message);
+        let outcome = RawExecutionOutcome::default().with_message(open_chain_message);
         this.transaction_tracker.add_system_outcome(outcome)?;
         Ok((message_id, chain_id))
     }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -200,8 +200,8 @@ pub enum AdminOperation {
     /// Registers a new committee. Other chains can then migrate to the new epoch by executing
     /// [`SystemOperation::ProcessNewEpoch`].
     CreateCommittee { epoch: Epoch, blob_hash: CryptoHash },
-    /// Removes a committee. Other chains should execute [`SystemOperation::RemoveCommittee`], so
-    /// that blocks from the retired epoch will not be accepted until they are followed (hence
+    /// Removes a committee. Other chains should execute [`SystemOperation::ProcessRemovedEpoch`],
+    /// so that blocks from the retired epoch will not be accepted until they are followed (hence
     /// re-certified) by a block certified by a recent committee.
     RemoveCommittee { epoch: Epoch },
 }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -197,12 +197,11 @@ pub enum SystemOperation {
 /// Operations that are only allowed on the admin chain.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub enum AdminOperation {
-    /// Registers a new committee. This will notify the subscribers of the admin chain so that they
-    /// can migrate to the new epoch by accepting the resulting `CreateCommittee` as an incoming
-    /// message in a block.
+    /// Registers a new committee. Other chains can then migrate to the new epoch by executing
+    /// [`SystemOperation::ProcessNewEpoch`].
     CreateCommittee { epoch: Epoch, blob_hash: CryptoHash },
-    /// Removes a committee. Once the resulting `RemoveCommittee` message is accepted by a chain,
-    /// blocks from the retired epoch will not be accepted until they are followed (hence
+    /// Removes a committee. Other chains should execute [`SystemOperation::RemoveCommittee`], so
+    /// that blocks from the retired epoch will not be accepted until they are followed (hence
     /// re-certified) by a block certified by a recent committee.
     RemoveCommittee { epoch: Epoch },
 }

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -56,20 +56,10 @@ pub struct SystemExecutionState {
 
 impl SystemExecutionState {
     pub fn new(epoch: Epoch, description: ChainDescription, admin_id: impl Into<ChainId>) -> Self {
-        let admin_id = admin_id.into();
-        let subscriptions = if ChainId::from(description) == admin_id {
-            BTreeSet::new()
-        } else {
-            BTreeSet::from([ChannelSubscription {
-                chain_id: admin_id,
-                name: SystemChannel::Admin.name(),
-            }])
-        };
         SystemExecutionState {
             epoch: Some(epoch),
             description: Some(description),
-            admin_id: Some(admin_id),
-            subscriptions,
+            admin_id: Some(admin_id.into()),
             ..SystemExecutionState::default()
         }
     }

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -192,6 +192,13 @@ impl TransactionTracker {
         Ok(replaying)
     }
 
+    /// If in replay mode, returns the next oracle response, or an error if it is missing.
+    ///
+    /// If not in replay mode, `None` is returned, and the caller must execute the actual oracle
+    /// to obtain the value.
+    ///
+    /// In both cases, the value (returned or obtained from the oracle) must be recorded using
+    /// `add_oracle_response`.
     pub fn next_replayed_oracle_response(
         &mut self,
     ) -> Result<Option<OracleResponse>, SystemExecutionError> {

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -46,8 +46,8 @@ AdminOperation:
         STRUCT:
           - epoch:
               TYPENAME: Epoch
-          - committee:
-              TYPENAME: Committee
+          - blob_hash:
+              TYPENAME: CryptoHash
     1:
       RemoveCommittee:
         STRUCT:
@@ -97,6 +97,8 @@ BlobType:
       ServiceBytecode: UNIT
     3:
       ApplicationDescription: UNIT
+    4:
+      Committee: UNIT
 Block:
   STRUCT:
     - header:
@@ -1131,16 +1133,21 @@ SystemOperation:
           - module_id:
               TYPENAME: ModuleId
     9:
-      PublishDataBlob:
+      PublishCommitteeBlob:
         STRUCT:
           - blob_hash:
               TYPENAME: CryptoHash
     10:
+      PublishDataBlob:
+        STRUCT:
+          - blob_hash:
+              TYPENAME: CryptoHash
+    11:
       ReadBlob:
         STRUCT:
           - blob_id:
               TYPENAME: BlobId
-    11:
+    12:
       CreateApplication:
         STRUCT:
           - module_id:
@@ -1150,15 +1157,15 @@ SystemOperation:
           - required_application_ids:
               SEQ:
                 TYPENAME: ApplicationId
-    12:
+    13:
       Admin:
         NEWTYPE:
           TYPENAME: AdminOperation
-    13:
+    14:
       ProcessNewEpoch:
         NEWTYPE:
           TYPENAME: Epoch
-    14:
+    15:
       ProcessRemovedEpoch:
         NEWTYPE:
           TYPENAME: Epoch

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -447,6 +447,14 @@ Event:
         TYPENAME: StreamId
     - key: BYTES
     - value: BYTES
+EventId:
+  STRUCT:
+    - chain_id:
+        TYPENAME: ChainId
+    - stream_id:
+        TYPENAME: StreamId
+    - key:
+        SEQ: U8
 GenericApplicationId:
   ENUM:
     0:
@@ -731,6 +739,11 @@ OracleResponse:
       Round:
         NEWTYPE:
           OPTION: U32
+    5:
+      Event:
+        TUPLE:
+          - TYPENAME: EventId
+          - SEQ: U8
 Origin:
   STRUCT:
     - sender:
@@ -1035,32 +1048,20 @@ SystemMessage:
         NEWTYPE:
           TYPENAME: OpenChainConfig
     3:
-      CreateCommittee:
-        STRUCT:
-          - epoch:
-              TYPENAME: Epoch
-          - committee:
-              TYPENAME: Committee
-    4:
-      RemoveCommittee:
-        STRUCT:
-          - epoch:
-              TYPENAME: Epoch
-    5:
       Subscribe:
         STRUCT:
           - id:
               TYPENAME: ChainId
           - subscription:
               TYPENAME: ChannelSubscription
-    6:
+    4:
       Unsubscribe:
         STRUCT:
           - id:
               TYPENAME: ChainId
           - subscription:
               TYPENAME: ChannelSubscription
-    7:
+    5:
       ApplicationCreated: UNIT
 SystemOperation:
   ENUM:
@@ -1153,6 +1154,14 @@ SystemOperation:
       Admin:
         NEWTYPE:
           TYPENAME: AdminOperation
+    13:
+      ProcessNewEpoch:
+        NEWTYPE:
+          TYPENAME: Epoch
+    14:
+      ProcessRemovedEpoch:
+        NEWTYPE:
+          TYPENAME: Epoch
 TimeDelta:
   NEWTYPESTRUCT: U64
 Timeout:

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -28,9 +28,8 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Committee, Epoch},
-    system::SystemChannel,
-    BlobState, ChannelSubscription, ExecutionError, ExecutionRuntimeConfig,
-    ExecutionRuntimeContext, UserContractCode, UserServiceCode, WasmRuntime,
+    BlobState, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, UserContractCode,
+    UserServiceCode, WasmRuntime,
 };
 #[cfg(with_revm)]
 use linera_execution::{
@@ -241,21 +240,6 @@ pub trait Storage: Sized {
         system_state.ownership.set(ChainOwnership::single(owner));
         system_state.balance.set(balance);
         system_state.timestamp.set(timestamp);
-
-        if id != admin_id {
-            // Add the new subscriber to the admin chain.
-            system_state.subscriptions.insert(&ChannelSubscription {
-                chain_id: admin_id,
-                name: SystemChannel::Admin.name(),
-            })?;
-            let mut admin_chain = self.load_chain(admin_id).await?;
-            let full_name = SystemChannel::Admin.full_name();
-            {
-                let mut channel = admin_chain.channels.try_load_entry_mut(&full_name).await?;
-                channel.subscribers.insert(&id)?;
-            } // Make channel go out of scope, so we can call save.
-            admin_chain.save().await?;
-        }
 
         let state_hash = chain.execution_state.crypto_hash().await?;
         chain.execution_state_hash.set(Some(state_hash));


### PR DESCRIPTION
## Motivation

To make epoch changes scalable, we want to use events instead of messages (https://github.com/linera-io/linera-protocol/issues/365).

## Proposal

Remove the committee messages and add add `ProcessNewEpoch` and `ProcessRemovedEpoch` system _operations_ instead. The committee change operations on the admin change create events now, and the two new operations consume those events, i.e. verify that they exist, change the epoch and committees on the local chain, and create an `OracleResponse::Event` entry in the execution outcome.

Clients get notified about new epochs because they always follow/synchronize the admin chain and thus store the epoch change events locally. They will then run `process_inbox` which, in addition to incoming messages, looks for epoch change events, and includes the new operations in the proposal accordingly.

## Test Plan

Several existing tests verify that reconfigurations are processed correctly. These check the new mechanism now instead of the message-based one.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Part of #365.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
