### PR TITLE
Remove `mut` from `ServiceRuntime::http_request`

### DIFF
--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -160,7 +160,7 @@ where
     ///
     /// Cannot be used in fast blocks: A block using this call should be proposed by a regular
     /// owner, not a super owner.
-    pub fn http_request(&mut self, request: http::Request) -> http::Response {
+    pub fn http_request(&self, request: http::Request) -> http::Response {
         wit::perform_http_request(&request.into()).into()
     }
 


### PR DESCRIPTION
Allow it to be used in a shared reference to the runtime.

## Motivation

PR #2631 updated the runtime APIs to perform HTTP requests, but unfortunately the `ServiceRuntime::http_request` method had an unnecessary `&mut self` receiver. This makes it different from all other `ServiceRuntime` methods.

## Proposal

Change the receiver to be `&self`, and do the same in the `MockServiceRuntime`.

## Test Plan

CI should catch any regressions by this refactor.

## Release Plan

- Nothing to do / These changes follow the usual release cycle, because this fixes an issue with a feature that hasn't yet been released.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
