### PR TITLE
Use newtype wrapper for `Account` keys and signatures.

### DIFF
--- a/linera-base/src/crypto/ed25519.rs
+++ b/linera-base/src/crypto/ed25519.rs
@@ -36,6 +36,8 @@ pub struct Ed25519Signature(pub dalek::Signature);
 impl Ed25519SecretKey {
     #[cfg(all(with_getrandom, with_testing))]
     /// Generates a new key pair.
+    ///
+    /// Uses `OsRng` for that. If you want control over the RNG, use `generate_from`[Ed25519SecretKey::generate_from].
     pub fn generate() -> Self {
         let mut rng = rand::rngs::OsRng;
         Self::generate_from(&mut rng)
@@ -68,6 +70,25 @@ impl Ed25519PublicKey {
     pub fn test_key(name: u8) -> Ed25519PublicKey {
         let addr = [name; dalek::PUBLIC_KEY_LENGTH];
         Ed25519PublicKey(addr)
+    }
+
+    /// Returns bytes of the public key.
+    pub fn as_bytes(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+
+    /// Parses bytes to a public key.
+    ///
+    /// Returns error if input bytes are not of the correct length.
+    pub fn from_slice(bytes: &[u8]) -> Result<Self, CryptoError> {
+        let key = bytes
+            .try_into()
+            .map_err(|_| CryptoError::IncorrectPublicKeySize {
+                scheme: ED25519_SCHEME_LABEL,
+                len: bytes.len(),
+                expected: dalek::PUBLIC_KEY_LENGTH,
+            })?;
+        Ok(Ed25519PublicKey(key))
     }
 }
 
@@ -269,6 +290,20 @@ impl Ed25519Signature {
         Ed25519Signature(signature)
     }
 
+    /// Parses bytes to a signature.
+    ///
+    /// Returns error if input slice is not 64 bytes.
+    pub fn from_slice(bytes: &[u8]) -> Result<Self, CryptoError> {
+        let sig = dalek::Signature::from_slice(bytes).map_err(|_| {
+            CryptoError::IncorrectSignatureBytes {
+                scheme: ED25519_SCHEME_LABEL,
+                len: bytes.len(),
+                expected: dalek::SIGNATURE_LENGTH,
+            }
+        })?;
+        Ok(Ed25519Signature(sig))
+    }
+
     fn check_internal<'de, T>(
         &self,
         value: &T,
@@ -317,6 +352,8 @@ impl Ed25519Signature {
     }
 
     /// Verifies a batch of signatures.
+    // NOTE: This is unused now since we don't use ed25519 in consensus layer.
+    #[allow(unused)]
     pub fn verify_batch<'a, 'de, T, I>(value: &'a T, votes: I) -> Result<(), CryptoError>
     where
         T: BcsSignable<'de>,

--- a/linera-base/src/crypto/ed25519.rs
+++ b/linera-base/src/crypto/ed25519.rs
@@ -35,9 +35,9 @@ pub struct Ed25519Signature(pub dalek::Signature);
 
 impl Ed25519SecretKey {
     #[cfg(all(with_getrandom, with_testing))]
-    /// Generates a new key pair.
+    /// Generates a new key pair using the operating system's RNG.
     ///
-    /// Uses `OsRng` for that. If you want control over the RNG, use `generate_from`[Ed25519SecretKey::generate_from].
+    /// If you want control over the RNG, use `generate_from`[Ed25519SecretKey::generate_from].
     pub fn generate() -> Self {
         let mut rng = rand::rngs::OsRng;
         Self::generate_from(&mut rng)

--- a/linera-base/src/crypto/mod.rs
+++ b/linera-base/src/crypto/mod.rs
@@ -75,7 +75,7 @@ impl AccountSecretKey {
         AccountPublicKey(self.0.public())
     }
 
-    /// Copy the secret key.
+    /// Copies the secret key.
     pub fn copy(&self) -> Self {
         AccountSecretKey(self.0.copy())
     }
@@ -141,7 +141,7 @@ impl FromStr for AccountPublicKey {
 
 impl Display for AccountPublicKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        self.0.fmt(f)
     }
 }
 

--- a/linera-base/src/crypto/mod.rs
+++ b/linera-base/src/crypto/mod.rs
@@ -8,12 +8,16 @@ mod ed25519;
 mod hash;
 #[allow(dead_code)]
 mod secp256k1;
-use std::{io, num::ParseIntError};
+use std::{fmt::Display, io, num::ParseIntError, str::FromStr};
 
 use alloy_primitives::FixedBytes;
+use custom_debug_derive::Debug;
 pub use hash::*;
+use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+use crate::identifiers::Owner;
 
 /// The public key of a validator.
 pub type ValidatorPublicKey = secp256k1::Secp256k1PublicKey;
@@ -27,11 +31,139 @@ pub type ValidatorKeypair = secp256k1::Secp256k1KeyPair;
 /// The public key of a chain owner.
 /// The corresponding private key is allowed to propose blocks
 /// on the chain and transfer account's tokens.
-pub type AccountPublicKey = ed25519::Ed25519PublicKey;
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Copy,
+    Clone,
+    Hash,
+    WitType,
+    WitLoad,
+    WitStore,
+)]
+pub struct AccountPublicKey(ed25519::Ed25519PublicKey);
+
 /// The private key of a chain owner.
-pub type AccountSecretKey = ed25519::Ed25519SecretKey;
+#[derive(Serialize, Deserialize)]
+pub struct AccountSecretKey(ed25519::Ed25519SecretKey);
+
 /// The signature of a chain owner.
-pub type AccountSignature = ed25519::Ed25519Signature;
+#[derive(Eq, PartialEq, Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct AccountSignature(ed25519::Ed25519Signature);
+
+impl AccountSecretKey {
+    #[cfg(all(with_getrandom, with_testing))]
+    /// Generates a new `AccountSecretKey`.
+    pub fn generate() -> Self {
+        Self(ed25519::Ed25519SecretKey::generate())
+    }
+
+    #[cfg(with_getrandom)]
+    /// Returns a new `AccountSecretKey` generated from the given `seed`.
+    pub fn generate_from<R: CryptoRng>(rng: &mut R) -> Self {
+        let secret_key = ed25519::Ed25519SecretKey::generate_from(rng);
+        AccountSecretKey(secret_key)
+    }
+
+    /// Returns the public key corresponding to this secret key.
+    pub fn public(&self) -> AccountPublicKey {
+        AccountPublicKey(self.0.public())
+    }
+
+    /// Copy the secret key.
+    pub fn copy(&self) -> Self {
+        AccountSecretKey(self.0.copy())
+    }
+}
+
+impl AccountPublicKey {
+    #[cfg(with_testing)]
+    /// Constructs a test key from a seed.
+    pub fn test_key(seed: u8) -> Self {
+        Self(ed25519::Ed25519PublicKey::test_key(seed))
+    }
+
+    /// Returns the byte representation of the public key.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.as_bytes()
+    }
+
+    /// Parses the byte representation of the public key.
+    ///
+    /// Returns error if the byte slice has incorrect length.
+    pub fn from_slice(bytes: &[u8]) -> Result<Self, CryptoError> {
+        Ok(Self(ed25519::Ed25519PublicKey::from_slice(bytes)?))
+    }
+}
+
+impl AccountSignature {
+    /// Creates a signature for the `value` using provided `secret`.
+    pub fn new<'de, T>(value: &T, secret: &AccountSecretKey) -> Self
+    where
+        T: BcsSignable<'de>,
+    {
+        let signature = ed25519::Ed25519Signature::new(value, &secret.0);
+        AccountSignature(signature)
+    }
+
+    /// Verifies the signature for the `value` using the provided `public_key`.
+    pub fn verify<'de, T>(&self, value: &T, author: AccountPublicKey) -> Result<(), CryptoError>
+    where
+        T: BcsSignable<'de> + std::fmt::Debug,
+    {
+        self.0.check(value, author.0)
+    }
+
+    /// Returns byte representation of the signatures.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0 .0.to_vec()
+    }
+
+    /// Parses the byte representation of the signature.
+    pub fn from_slice(_bytes: &[u8]) -> Result<Self, CryptoError> {
+        Ok(Self(ed25519::Ed25519Signature::from_slice(_bytes)?))
+    }
+}
+
+impl FromStr for AccountPublicKey {
+    type Err = CryptoError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let value = hex::decode(s)?;
+        Ok(AccountPublicKey((value.as_slice()).try_into()?))
+    }
+}
+
+impl Display for AccountPublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<AccountPublicKey> for Owner {
+    fn from(public_key: AccountPublicKey) -> Self {
+        public_key.0.into()
+    }
+}
+
+impl From<&AccountPublicKey> for Owner {
+    fn from(public_key: &AccountPublicKey) -> Self {
+        public_key.0.into()
+    }
+}
+
+impl TryFrom<&[u8]> for AccountSignature {
+    type Error = CryptoError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        AccountSignature::from_slice(bytes)
+    }
+}
 
 /// Error type for cryptographic errors.
 #[derive(Error, Debug)]
@@ -52,6 +184,14 @@ pub enum CryptoError {
         "Byte slice has length {len} but a {scheme} `PublicKey` requires exactly {expected} bytes"
     )]
     IncorrectPublicKeySize {
+        scheme: &'static str,
+        len: usize,
+        expected: usize,
+    },
+    #[error(
+        "byte slice has length {len} but a {scheme} `Signature` requires exactly {expected} bytes"
+    )]
+    IncorrectSignatureBytes {
         scheme: &'static str,
         len: usize,
         expected: usize,

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -774,7 +774,7 @@ impl BlockProposal {
     }
 
     pub fn check_signature(&self) -> Result<(), CryptoError> {
-        self.signature.check(&self.content, self.public_key)
+        self.signature.verify(&self.content, self.public_key)
     }
 
     pub fn required_blob_ids(&self) -> impl Iterator<Item = BlobId> + '_ {

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -620,7 +620,7 @@ impl TryFrom<api::ChainId> for ChainId {
 impl From<AccountPublicKey> for api::AccountPublicKey {
     fn from(public_key: AccountPublicKey) -> Self {
         Self {
-            bytes: public_key.0.to_vec(),
+            bytes: public_key.to_bytes(),
         }
     }
 }
@@ -637,7 +637,7 @@ impl TryFrom<api::ValidatorPublicKey> for ValidatorPublicKey {
     type Error = GrpcProtoConversionError;
 
     fn try_from(public_key: api::ValidatorPublicKey) -> Result<Self, Self::Error> {
-        Ok(ValidatorPublicKey::from_bytes(public_key.bytes.as_slice())?)
+        Ok(Self::from_bytes(public_key.bytes.as_slice())?)
     }
 }
 
@@ -645,14 +645,14 @@ impl TryFrom<api::AccountPublicKey> for AccountPublicKey {
     type Error = GrpcProtoConversionError;
 
     fn try_from(public_key: api::AccountPublicKey) -> Result<Self, Self::Error> {
-        Ok(AccountPublicKey::try_from(public_key.bytes.as_slice())?)
+        Ok(Self::from_slice(public_key.bytes.as_slice())?)
     }
 }
 
 impl From<AccountSignature> for api::AccountSignature {
     fn from(signature: AccountSignature) -> Self {
         Self {
-            bytes: signature.0.to_vec(),
+            bytes: signature.to_bytes(),
         }
     }
 }
@@ -677,7 +677,7 @@ impl TryFrom<api::AccountSignature> for AccountSignature {
     type Error = GrpcProtoConversionError;
 
     fn try_from(signature: api::AccountSignature) -> Result<Self, Self::Error> {
-        Ok(Self(signature.bytes.as_slice().try_into()?))
+        Ok(Self::from_slice(signature.bytes.as_slice())?)
     }
 }
 

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -19,6 +19,12 @@ AccountOwner:
       Application:
         NEWTYPE:
           TYPENAME: ApplicationId
+AccountPublicKey:
+  NEWTYPESTRUCT:
+    TYPENAME: Ed25519PublicKey
+AccountSignature:
+  NEWTYPESTRUCT:
+    TYPENAME: Ed25519Signature
 AdminOperation:
   ENUM:
     0:
@@ -148,9 +154,9 @@ BlockProposal:
     - content:
         TYPENAME: ProposalContent
     - public_key:
-        TYPENAME: Ed25519PublicKey
+        TYPENAME: AccountPublicKey
     - signature:
-        TYPENAME: Ed25519Signature
+        TYPENAME: AccountSignature
     - validated_block_certificate:
         OPTION:
           TYPENAME: LiteCertificate
@@ -1196,7 +1202,7 @@ ValidatorState:
     - network_address: STR
     - votes: U64
     - account_public_key:
-        TYPENAME: Ed25519PublicKey
+        TYPENAME: AccountPublicKey
 VersionInfo:
   STRUCT:
     - crate_version:


### PR DESCRIPTION
## Motivation

In order to improve type-safety (and also in preparation for allowing for Ethereum keys as chain owners) we need to replace type alias with a struct.

## Proposal

Use newtype struct wrapper for `Ed25519` for now.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
