### PR TITLE
Add option to not close chains on benchmark

### DIFF
--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -52,6 +52,7 @@ where
         blocks_infos: Vec<(ChainId, Vec<Operation>, AccountSecretKey)>,
         committee: Committee,
         local_node: LocalNodeClient<S>,
+        keep_chains_open: bool,
     ) -> Result<(), Error> {
         let shutdown_notifier = CancellationToken::new();
         tokio::spawn(listen_for_shutdown_signals(shutdown_notifier.clone()));
@@ -143,6 +144,7 @@ where
                             sender,
                             committee,
                             local_node,
+                            keep_chains_open,
                         )
                         .await?;
 
@@ -179,6 +181,7 @@ where
         sender: crossbeam_channel::Sender<()>,
         committee: Committee,
         local_node: LocalNodeClient<S>,
+        keep_chains_open: bool,
     ) -> Result<(), Error> {
         let chain_id = chain_client.chain_id();
         info!(
@@ -237,7 +240,9 @@ where
             }
         }
 
-        Self::close_benchmark_chain(chain_client).await?;
+        if !keep_chains_open {
+            Self::close_benchmark_chain(chain_client).await?;
+        }
         info!("Exiting task...");
         Ok(())
     }

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -612,6 +612,11 @@ pub enum ClientCommand {
         /// provided fixed BPS rate.
         #[arg(long)]
         bps: Option<usize>,
+
+        /// If provided, will not close the chains after the benchmark is finished. This is useful
+        /// when running with many chains, as closing them all might take a while.
+        #[arg(long)]
+        keep_chains_open: bool,
     },
 
     /// Create genesis configuration for a Linera deployment.

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -737,6 +737,7 @@ impl Runnable for Job {
                 transactions_per_block,
                 fungible_application_id,
                 bps,
+                keep_chains_open,
             } => {
                 assert!(num_chains > 0, "Number of chains must be greater than 0");
                 assert!(
@@ -769,6 +770,7 @@ impl Runnable for Job {
                     blocks_infos,
                     committee,
                     context.client.local_node().clone(),
+                    keep_chains_open,
                 )
                 .await?;
             }


### PR DESCRIPTION
## Motivation

Closing chains actually takes a surprisingly long time. The client will actually return fairly quickly, but the validators will be executing stuff for a while after the `CloseChain` operation is done. Also latency spikes while the validator is doing that.
It's probably something to be investigated as well, tbh.

## Proposal

For now, add an option to the benchmark to just not close the chains that are created for the benchmark (don't close them at the end), so that iteration with a lot of chains is faster.

## Test Plan

Run it with the option, see that we exit quicker and the validators are not doing a bunch of stuff after the benchmark is exited.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
