### PR TITLE
Start shards in parallel

### DIFF
--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -21,6 +21,7 @@ metadata:
 spec:
   serviceName: "shards"
   replicas: {{ .Values.numShards }}
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       app: shards


### PR DESCRIPTION
## Motivation

Right now we start all shards one by one. That doesn't seem necessary, and when starting a large number of shards (like 100 or more), it can take a long time.

## Proposal

Change the pod management policy to start all shards at once, in parallel

## Test Plan

Deployed a local kind network with 80 shards, saw all of them getting initialized in parallel, much faster

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
