### PR TITLE
Allow reading native balances in integration tests

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4238,6 +4238,7 @@ dependencies = [
  "linera-sdk",
  "native-fungible",
  "serde",
+ "test-log",
  "tokio",
 ]
 

--- a/examples/native-fungible/Cargo.toml
+++ b/examples/native-fungible/Cargo.toml
@@ -13,9 +13,12 @@ fungible.workspace = true
 linera-sdk.workspace = true
 serde.workspace = true
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-native-fungible = { workspace = true, features = ["test"] }
+[dev-dependencies]
 linera-sdk = { workspace = true, features = ["test", "wasmer"] }
+native-fungible = { workspace = true, features = ["test"] }
+test-log.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { workspace = true }
 
 [[bin]]

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -5,7 +5,7 @@
 
 //! Integration tests for Native Fungible Token transfers.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use fungible::{self, FungibleTokenAbi};
 use linera_sdk::{
@@ -137,8 +137,10 @@ async fn assert_balances(
     chain: &ActiveChain,
     expected_balances: impl IntoIterator<Item = (AccountOwner, Amount)>,
 ) {
-    let expected_balances = expected_balances.into_iter().collect::<HashMap<_, _>>();
-    let accounts = expected_balances.keys().copied();
+    let expected_balances = expected_balances.into_iter().collect::<BTreeMap<_, _>>();
+    let accounts = expected_balances.keys().copied().collect::<Vec<_>>();
+
+    assert_eq!(chain.accounts().await, accounts);
 
     let missing_accounts = ["missing1", "missing2"]
         .into_iter()
@@ -148,6 +150,7 @@ async fn assert_balances(
         .collect::<Vec<_>>();
 
     let accounts_to_query = accounts
+        .into_iter()
         .chain(missing_accounts.iter().copied())
         .collect::<Vec<_>>();
 

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -78,10 +78,7 @@ async fn transfer_to_owner() {
         })
         .await;
 
-    assert_eq!(
-        recipient_chain.owner_balance(&owner.into()).await,
-        Some(transfer_amount)
-    );
+    assert_balances(&recipient_chain, [(owner.into(), transfer_amount)]).await;
 }
 
 /// Tests if multiple accounts can receive tokens.

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -159,6 +159,15 @@ async fn assert_balances(
         .chain(missing_accounts.into_iter().map(|account| (account, None)))
         .collect::<HashMap<_, _>>();
 
+    for account in &accounts_to_query {
+        assert_eq!(
+            &chain.owner_balance(account).await,
+            expected_query_response
+                .get(account)
+                .expect("Missing balance amount for a test account")
+        );
+    }
+
     assert_eq!(
         chain.owner_balances(accounts_to_query).await,
         expected_query_response

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -7,7 +7,7 @@
 
 use fungible::{self, FungibleTokenAbi};
 use linera_sdk::{
-    linera_base_types::{Amount, ChainId},
+    linera_base_types::{Account, Amount, ChainId, CryptoHash, Owner},
     test::{Recipient, TestValidator},
 };
 
@@ -42,4 +42,42 @@ async fn chain_balance_transfers() {
         .await;
 
     assert_eq!(recipient_chain.chain_balance().await, transfer_amount);
+}
+
+/// Tests if an individual account can receive tokens.
+#[test_log::test(tokio::test)]
+async fn transfer_to_owner() {
+    let parameters = fungible::Parameters {
+        ticker_symbol: "NAT".to_owned(),
+    };
+    let initial_state = fungible::InitialStateBuilder::default().build();
+    let (validator, _application_id, recipient_chain) = TestValidator::with_current_application::<
+        FungibleTokenAbi,
+        _,
+        _,
+    >(parameters, initial_state)
+    .await;
+
+    let transfer_amount = Amount::from_tokens(2);
+    let funding_chain = validator.get_chain(&ChainId::root(0));
+    let owner = Owner(CryptoHash::test_hash("owner"));
+    let account = Account::owner(recipient_chain.id(), owner);
+    let recipient = Recipient::Account(account);
+
+    let transfer_certificate = funding_chain
+        .add_block(|block| {
+            block.with_native_token_transfer(None, recipient, transfer_amount);
+        })
+        .await;
+
+    recipient_chain
+        .add_block(|block| {
+            block.with_messages_from(&transfer_certificate);
+        })
+        .await;
+
+    assert_eq!(
+        recipient_chain.owner_balance(&owner.into()).await,
+        Some(transfer_amount)
+    );
 }

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -173,4 +173,8 @@ async fn assert_balances(
         chain.owner_balances(accounts_to_query).await,
         expected_query_response
     );
+    assert_eq!(
+        chain.all_owner_balances().await,
+        HashMap::from_iter(expected_balances)
+    );
 }

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -44,6 +44,7 @@ async fn chain_balance_transfers() {
         .await;
 
     assert_eq!(recipient_chain.chain_balance().await, transfer_amount);
+    assert_balances(&recipient_chain, []).await;
 }
 
 /// Tests if an individual account can receive tokens.

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(not(target_arch = "wasm32"))]
+
+//! Integration tests for Native Fungible Token transfers.
+
+use fungible::{self, FungibleTokenAbi};
+use linera_sdk::{
+    linera_base_types::{Amount, ChainId},
+    test::{Recipient, TestValidator},
+};
+
+/// Tests if tokens from the shared chain balance can be sent to a different chain.
+#[test_log::test(tokio::test)]
+async fn chain_balance_transfers() {
+    let parameters = fungible::Parameters {
+        ticker_symbol: "NAT".to_owned(),
+    };
+    let initial_state = fungible::InitialStateBuilder::default().build();
+    let (validator, _application_id, recipient_chain) = TestValidator::with_current_application::<
+        FungibleTokenAbi,
+        _,
+        _,
+    >(parameters, initial_state)
+    .await;
+
+    let transfer_amount = Amount::ONE;
+    let funding_chain = validator.get_chain(&ChainId::root(0));
+    let recipient = Recipient::chain(recipient_chain.id());
+
+    let transfer_certificate = funding_chain
+        .add_block(|block| {
+            block.with_native_token_transfer(None, recipient, transfer_amount);
+        })
+        .await;
+
+    recipient_chain
+        .add_block(|block| {
+            block.with_messages_from(&transfer_certificate);
+        })
+        .await;
+
+    assert_eq!(recipient_chain.chain_balance().await, transfer_amount);
+}

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -158,6 +158,24 @@ impl ActiveChain {
         balances
     }
 
+    /// Reads a list of [`AccountOwner`]s that have a non-zero balance on this microchain.
+    pub async fn accounts(&self) -> Vec<AccountOwner> {
+        let chain_state = self
+            .validator
+            .worker()
+            .chain_state_view(self.id())
+            .await
+            .expect("Failed to read chain state");
+
+        chain_state
+            .execution_state
+            .system
+            .balances
+            .indices()
+            .await
+            .expect("Failed to list accounts on the chain")
+    }
+
     /// Adds a block to this microchain.
     ///
     /// The `block_builder` parameter is a closure that should use the [`BlockBuilder`] parameter

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -127,6 +127,13 @@ impl ActiveChain {
         self.try_add_block_with_blobs(block_builder, vec![]).await
     }
 
+    /// Tries to add a block to this microchain, writing some `blobs` to storage if needed.
+    ///
+    /// The `block_builder` parameter is a closure that should use the [`BlockBuilder`] parameter
+    /// to provide the block's contents.
+    ///
+    /// The blobs are either all written to storage, if executing the block fails due to a missing
+    /// blob, or none are written to storage if executing the block succeeds without the blobs.
     async fn try_add_block_with_blobs(
         &self,
         block_builder: impl FnOnce(&mut BlockBuilder),

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -15,7 +15,7 @@ use cargo_toml::Manifest;
 use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey},
     data_types::{Amount, Blob, BlockHeight, Bytecode, CompressedBytecode},
-    identifiers::{ApplicationId, BytecodeId, ChainDescription, ChainId, MessageId},
+    identifiers::{AccountOwner, ApplicationId, BytecodeId, ChainDescription, ChainId, MessageId},
     vm::VmRuntime,
 };
 use linera_chain::{types::ConfirmedBlockCertificate, ChainError, ChainExecutionContext};
@@ -108,6 +108,24 @@ impl ActiveChain {
         };
 
         balance
+    }
+
+    /// Reads the current account balance on this microchain of an [`AccountOwner`].
+    pub async fn owner_balance(&self, owner: &AccountOwner) -> Option<Amount> {
+        let chain_state = self
+            .validator
+            .worker()
+            .chain_state_view(self.id())
+            .await
+            .expect("Failed to read chain state");
+
+        chain_state
+            .execution_state
+            .system
+            .balances
+            .get(owner)
+            .await
+            .expect("Failed to read owner balance")
     }
 
     /// Adds a block to this microchain.

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -176,6 +176,20 @@ impl ActiveChain {
             .expect("Failed to list accounts on the chain")
     }
 
+    /// Reads all the non-zero account balances on this microchain.
+    pub async fn all_owner_balances(&self) -> HashMap<AccountOwner, Amount> {
+        self.owner_balances(self.accounts().await)
+            .await
+            .into_iter()
+            .map(|(owner, balance)| {
+                (
+                    owner,
+                    balance.expect("`accounts` should only return accounts with non-zero balance"),
+                )
+            })
+            .collect()
+    }
+
     /// Adds a block to this microchain.
     ///
     /// The `block_builder` parameter is a closure that should use the [`BlockBuilder`] parameter


### PR DESCRIPTION
## Motivation

When writing applications that use native tokens, it helps to write integration tests if there's an easy way to query the on-chain native token balances.

## Proposal

Add a few helper methods to read the native account balances on an `ActiveChain`.

## Test Plan

Integration tests that use the new helpers were added to the Native Fungible Token application example.

## Release Plan

- Nothing to do / These changes follow the usual release cycle, because this introduces a new backwards compatible feature.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Closes #3417 
