### PR TITLE
End value fix for linear_bucket_interval

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,6 +80,17 @@ jobs:
       run: |
         cargo test --locked -p linera-execution --features wasmtime
 
+  metrics-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: Run metrics tests
+      run: |
+        cargo test --locked -p linera-base --features metrics
+
   wasm-application-test:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -62,11 +62,11 @@ pub fn exponential_bucket_latencies(max_latency: f64) -> Option<Vec<f64>> {
 /// Construct the bucket interval linearly starting from a value and an ending value.
 pub fn linear_bucket_interval(start_value: f64, width: f64, end_value: f64) -> Option<Vec<f64>> {
     let count = (end_value - start_value) / width;
-    let count = count.ceil() as usize;
-    Some(
-        linear_buckets(start_value, width, count)
-            .expect("Linear buckets creation should not fail!"),
-    )
+    let count = count.round() as usize;
+    let mut buckets = linear_buckets(start_value, width, count)
+        .expect("Linear buckets creation should not fail!");
+    buckets.push(end_value);
+    Some(buckets)
 }
 
 /// Construct the latencies linearly starting from 1 and ending at the maximum latency
@@ -142,5 +142,50 @@ impl MeasureLatency for HistogramVec {
 
     fn finish_measurement(&self, milliseconds: f64) {
         self.with_label_values(&[]).observe(milliseconds);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper function for approximate floating point comparison
+    fn assert_float_vec_eq(left: &[f64], right: &[f64]) {
+        const EPSILON: f64 = 1e-10;
+
+        assert_eq!(left.len(), right.len(), "Vectors have different lengths");
+        for (i, (l, r)) in left.iter().zip(right.iter()).enumerate() {
+            assert!(
+                (l - r).abs() < EPSILON,
+                "Vectors differ at index {}: {} != {}",
+                i,
+                l,
+                r
+            );
+        }
+    }
+
+    #[test]
+    fn test_linear_bucket_interval() {
+        // Case 1: Width divides range evenly - small values
+        let buckets = linear_bucket_interval(0.05, 0.01, 0.1).unwrap();
+        assert_float_vec_eq(&buckets, &[0.05, 0.06, 0.07, 0.08, 0.09, 0.1]);
+
+        // Case 2: Width divides range evenly - large values
+        let buckets = linear_bucket_interval(100.0, 50.0, 500.0).unwrap();
+        assert_float_vec_eq(
+            &buckets,
+            &[
+                100.0, 150.0, 200.0, 250.0, 300.0, 350.0, 400.0, 450.0, 500.0,
+            ],
+        );
+
+        // Case 3: Width doesn't divide range evenly - small values
+        let buckets = linear_bucket_interval(0.05, 0.12, 0.5).unwrap();
+        assert_float_vec_eq(&buckets, &[0.05, 0.17, 0.29, 0.41, 0.5]);
+
+        // Case 4: Width doesn't divide range evenly - large values
+        let buckets = linear_bucket_interval(100.0, 150.0, 500.0).unwrap();
+        assert_float_vec_eq(&buckets, &[100.0, 250.0, 400.0, 500.0]);
     }
 }


### PR DESCRIPTION
## Motivation

So I was under the impression that getting the ceiling there would make us always include the end value, but I was wrong :)

## Proposal

Doing the same fix here for the end value that we did for the exponential buckets

## Test Plan

Deployed a local network, saw that we actually see 500 as the max value now for example for proxy latency

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
