### PR TITLE
Restore CI job to check WIT files

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -252,6 +252,15 @@ jobs:
         cd linera-views
         WASM_BINDGEN_TEST_TIMEOUT=300 wasm-pack test --chrome --headless -- --features web-default
 
+  check-wit-files:
+    runs-on: ubuntu-latest-16-cores
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: Check WIT files
+      run: |
+        cargo run --bin wit-generator -- -c
+
   lint-unexpected-chain-load-operations:
     runs-on: ubuntu-latest
     timeout-minutes: 2

--- a/linera-sdk/wit/base-runtime-api.wit
+++ b/linera-sdk/wit/base-runtime-api.wit
@@ -5,19 +5,18 @@ interface base-runtime-api {
     get-block-height: func() -> block-height;
     get-application-id: func() -> application-id;
     get-application-creator-chain-id: func() -> chain-id;
-    get-chain-ownership: func() -> chain-ownership;
     application-parameters: func() -> list<u8>;
+    get-chain-ownership: func() -> chain-ownership;
+    read-system-timestamp: func() -> timestamp;
     read-chain-balance: func() -> amount;
     read-owner-balance: func(owner: account-owner) -> amount;
-    read-system-timestamp: func() -> timestamp;
     read-owner-balances: func() -> list<tuple<account-owner, amount>>;
     read-balance-owners: func() -> list<account-owner>;
     perform-http-request: func(request: http-request) -> http-response;
+    assert-before: func(timestamp: timestamp);
     read-data-blob: func(hash: crypto-hash) -> list<u8>;
     assert-data-blob-exists: func(hash: crypto-hash);
-    assert-before: func(timestamp: timestamp);
     log: func(message: string, level: log-level);
-
     contains-key-new: func(key: list<u8>) -> u32;
     contains-key-wait: func(promise-id: u32) -> bool;
     contains-keys-new: func(keys: list<list<u8>>) -> u32;
@@ -31,38 +30,22 @@ interface base-runtime-api {
     find-key-values-new: func(key-prefix: list<u8>) -> u32;
     find-key-values-wait: func(promise-id: u32) -> list<tuple<list<u8>, list<u8>>>;
 
-    record block-height {
-        inner0: u64,
-    }
-
-    record crypto-hash {
-        part1: u64,
-        part2: u64,
-        part3: u64,
-        part4: u64,
-    }
-
-    record owner {
-        inner0: crypto-hash,
-    }
-
-    record chain-id {
-        inner0: crypto-hash,
+    variant account-owner {
+        user(owner),
+        application(application-id),
     }
 
     record amount {
         inner0: u128,
     }
 
-    variant account-owner {
-        user(owner),
-        application(application-id),
+    record application-id {
+        bytecode-id: bytecode-id,
+        creation: message-id,
     }
 
-    record message-id {
-        chain-id: chain-id,
-        height: block-height,
-        index: u32,
+    record block-height {
+        inner0: u64,
     }
 
     record bytecode-id {
@@ -71,24 +54,8 @@ interface base-runtime-api {
         vm-runtime: vm-runtime,
     }
 
-    record application-id {
-        bytecode-id: bytecode-id,
-        creation: message-id,
-    }
-
-    record timestamp {
-        inner0: u64,
-    }
-
-    record time-delta {
-        inner0: u64,
-    }
-
-    record timeout-config {
-        fast-round-duration: option<time-delta>,
-        base-timeout: time-delta,
-        timeout-increment: time-delta,
-        fallback-duration: time-delta,
+    record chain-id {
+        inner0: crypto-hash,
     }
 
     record chain-ownership {
@@ -97,6 +64,13 @@ interface base-runtime-api {
         multi-leader-rounds: u32,
         open-multi-leader-rounds: bool,
         timeout-config: timeout-config,
+    }
+
+    record crypto-hash {
+        part1: u64,
+        part2: u64,
+        part3: u64,
+        part4: u64,
     }
 
     record http-header {
@@ -135,6 +109,31 @@ interface base-runtime-api {
         info,
         debug,
         trace,
+    }
+
+    record message-id {
+        chain-id: chain-id,
+        height: block-height,
+        index: u32,
+    }
+
+    record owner {
+        inner0: crypto-hash,
+    }
+
+    record time-delta {
+        inner0: u64,
+    }
+
+    record timeout-config {
+        fast-round-duration: option<time-delta>,
+        base-timeout: time-delta,
+        timeout-increment: time-delta,
+        fallback-duration: time-delta,
+    }
+
+    record timestamp {
+        inner0: u64,
     }
 
     type u128 = tuple<u64, u64>;

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -10,38 +10,16 @@ interface contract-runtime-api {
     unsubscribe: func(chain: chain-id, channel: channel-name);
     transfer: func(source: option<account-owner>, destination: account, amount: amount);
     claim: func(source: account, destination: account, amount: amount);
-    consume-fuel: func(fuel: u64);
-    try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
-    emit: func(name: stream-name, key: list<u8>, value: list<u8>);
-    query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: amount) -> tuple<message-id, chain-id>;
     close-chain: func() -> result<tuple<>, close-chain-error>;
     change-application-permissions: func(application-permissions: application-permissions) -> result<tuple<>, change-application-permissions-error>;
     create-application: func(bytecode-id: bytecode-id, parameters: list<u8>, argument: list<u8>, required-application-ids: list<application-id>) -> application-id;
+    try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
+    emit: func(name: stream-name, key: list<u8>, value: list<u8>);
+    query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
+    consume-fuel: func(fuel: u64);
     validation-round: func() -> option<u32>;
-
     write-batch: func(operations: list<write-operation>);
-
-    variant write-operation {
-        delete(list<u8>),
-        delete-prefix(list<u8>),
-        put(tuple<list<u8>, list<u8>>),
-    }
-
-    record block-height {
-        inner0: u64,
-    }
-
-    record crypto-hash {
-        part1: u64,
-        part2: u64,
-        part3: u64,
-        part4: u64,
-    }
-
-    record owner {
-        inner0: crypto-hash,
-    }
 
     record account {
         chain-id: chain-id,
@@ -57,10 +35,20 @@ interface contract-runtime-api {
         inner0: u128,
     }
 
-    record message-id {
-        chain-id: chain-id,
-        height: block-height,
-        index: u32,
+    record application-id {
+        bytecode-id: bytecode-id,
+        creation: message-id,
+    }
+
+    record application-permissions {
+        execute-operations: option<list<application-id>>,
+        mandatory-applications: list<application-id>,
+        close-chain: list<application-id>,
+        change-application-permissions: list<application-id>,
+    }
+
+    record block-height {
+        inner0: u64,
     }
 
     record bytecode-id {
@@ -69,14 +57,50 @@ interface contract-runtime-api {
         vm-runtime: vm-runtime,
     }
 
-    record application-id {
-        bytecode-id: bytecode-id,
-        creation: message-id,
+    record chain-id {
+        inner0: crypto-hash,
+    }
+
+    record chain-ownership {
+        super-owners: list<owner>,
+        owners: list<tuple<owner, u64>>,
+        multi-leader-rounds: u32,
+        open-multi-leader-rounds: bool,
+        timeout-config: timeout-config,
+    }
+
+    enum change-application-permissions-error {
+        not-permitted,
+    }
+
+    record channel-name {
+        inner0: list<u8>,
+    }
+
+    enum close-chain-error {
+        not-permitted,
+    }
+
+    record crypto-hash {
+        part1: u64,
+        part2: u64,
+        part3: u64,
+        part4: u64,
     }
 
     variant destination {
         recipient(chain-id),
         subscribers(channel-name),
+    }
+
+    record message-id {
+        chain-id: chain-id,
+        height: block-height,
+        index: u32,
+    }
+
+    record owner {
+        inner0: crypto-hash,
     }
 
     record resources {
@@ -98,14 +122,6 @@ interface contract-runtime-api {
         message: list<u8>,
     }
 
-    record chain-id {
-        inner0: crypto-hash,
-    }
-
-    record channel-name {
-        inner0: list<u8>,
-    }
-
     record stream-name {
         inner0: list<u8>,
     }
@@ -121,33 +137,16 @@ interface contract-runtime-api {
         fallback-duration: time-delta,
     }
 
-    record chain-ownership {
-        super-owners: list<owner>,
-        owners: list<tuple<owner, u64>>,
-        multi-leader-rounds: u32,
-        open-multi-leader-rounds: bool,
-        timeout-config: timeout-config,
-    }
-
-    record application-permissions {
-        execute-operations: option<list<application-id>>,
-        mandatory-applications: list<application-id>,
-        close-chain: list<application-id>,
-        change-application-permissions: list<application-id>,
-    }
-
-    enum change-application-permissions-error {
-        not-permitted,
-    }
-
-    enum close-chain-error {
-        not-permitted,
-    }
-
     type u128 = tuple<u64, u64>;
 
     enum vm-runtime {
         wasm,
         evm,
+    }
+
+    variant write-operation {
+        delete(list<u8>),
+        delete-prefix(list<u8>),
+        put(tuple<list<u8>, list<u8>>),
     }
 }

--- a/linera-sdk/wit/contract.wit
+++ b/linera-sdk/wit/contract.wit
@@ -1,8 +1,8 @@
 package linera:app;
 
 world contract {
-    import base-runtime-api;
     import contract-runtime-api;
+    import base-runtime-api;
 
     export contract-entrypoints;
 }

--- a/linera-sdk/wit/service-runtime-api.wit
+++ b/linera-sdk/wit/service-runtime-api.wit
@@ -4,9 +4,24 @@ interface service-runtime-api {
     schedule-operation: func(operation: list<u8>);
     try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
     fetch-url: func(url: string) -> list<u8>;
-    
+
+    record application-id {
+        bytecode-id: bytecode-id,
+        creation: message-id,
+    }
+
     record block-height {
         inner0: u64,
+    }
+
+    record bytecode-id {
+        contract-blob-hash: crypto-hash,
+        service-blob-hash: crypto-hash,
+        vm-runtime: vm-runtime,
+    }
+
+    record chain-id {
+        inner0: crypto-hash,
     }
 
     record crypto-hash {
@@ -16,25 +31,10 @@ interface service-runtime-api {
         part4: u64,
     }
 
-    record chain-id {
-        inner0: crypto-hash,
-    }
-
     record message-id {
         chain-id: chain-id,
         height: block-height,
         index: u32,
-    }
-
-    record bytecode-id {
-        contract-blob-hash: crypto-hash,
-        service-blob-hash: crypto-hash,
-        vm-runtime: vm-runtime,
-    }
-
-    record application-id {
-        bytecode-id: bytecode-id,
-        creation: message-id,
     }
 
     enum vm-runtime {

--- a/linera-sdk/wit/service.wit
+++ b/linera-sdk/wit/service.wit
@@ -1,8 +1,8 @@
 package linera:app;
 
 world service {
-    import base-runtime-api;
     import service-runtime-api;
+    import base-runtime-api;
 
     export service-entrypoints;
 }


### PR DESCRIPTION
## Motivation

The WIT files are automatically generated by Witty from the Rust code. Therefore, they must be kept up-to-date with the Rust code for applications to work correctly.

There was a CI job to check this before, but it was accidentally removed when the CI jobs were refactored (#2786).

## Proposal

Add a new CI job to run `wit-generator -c`.

## Test Plan

CI should show if the job executed successfully.

## Release Plan

- Nothing to do because this only affects CI. Even though the WIT files were unsorted, they were correct.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
