### PR TITLE
Query prometheus metrics from benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,6 +4513,7 @@ dependencies = [
  "native-fungible",
  "non-fungible",
  "num-format",
+ "prometheus-parse",
  "proptest",
  "rand",
  "reqwest 0.11.27",
@@ -6320,6 +6321,18 @@ dependencies = [
  "parking_lot",
  "protobuf",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "prometheus-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "811031bea65e5a401fb2e1f37d802cca6601e204ac463809a3189352d13b78a5"
+dependencies = [
+ "chrono",
+ "itertools 0.12.1",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ prettyplease = "0.2.16"
 proc-macro-error = "1.0.4"
 proc-macro2 = "1.0"
 prometheus = "0.13.3"
+prometheus-parse = "0.2.5"
 proptest = { version = "1.6.0", default-features = false, features = ["alloc"] }
 prost = "0.13.2"
 quote = "1.0"

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -19,6 +19,9 @@ benchmark = [
     "dep:tokio-util",
     "dep:crossbeam-channel",
     "dep:num-format",
+    "dep:reqwest",
+    "dep:anyhow",
+    "dep:prometheus-parse",
 ]
 wasmer = [
     "linera-core/wasmer",
@@ -56,6 +59,7 @@ indexed-db = ["web", "indexed_db_futures", "serde-wasm-bindgen", "gloo-utils"]
 web-default = ["web", "wasmer", "indexed-db"]
 
 [dependencies]
+anyhow = { workspace = true, optional = true }
 async-trait.workspace = true
 bcs.workspace = true
 cfg-if.workspace = true
@@ -76,7 +80,9 @@ linera-storage-service = { workspace = true, optional = true }
 linera-version.workspace = true
 linera-views.workspace = true
 num-format = { workspace = true, optional = true }
+prometheus-parse = { workspace = true, optional = true }
 rand.workspace = true
+reqwest = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -616,6 +616,12 @@ pub enum ClientCommand {
         /// they're being closed.
         #[arg(long)]
         close_chains: bool,
+        /// A comma-separated list of host:port pairs to query for health metrics.
+        /// If provided, the benchmark will check these endpoints for validator health
+        /// and terminate if any validator is unhealthy.
+        /// Example: "127.0.0.1:21100,validator-1.some-network.linera.net:21100"
+        #[arg(long)]
+        health_check_endpoints: Option<String>,
     },
 
     /// Create genesis configuration for a Linera deployment.

--- a/linera-client/src/error.rs
+++ b/linera-client/src/error.rs
@@ -3,6 +3,8 @@
 
 use thiserror_context::Context;
 
+#[cfg(feature = "benchmark")]
+use crate::benchmark::BenchmarkError;
 use crate::{persistent, util};
 
 #[derive(Debug, thiserror::Error)]
@@ -35,11 +37,8 @@ pub(crate) enum Inner {
     #[error("incorrect chain ownership")]
     ChainOwnership,
     #[cfg(feature = "benchmark")]
-    #[error("failed to send message: {0}")]
-    SendError(#[from] crossbeam_channel::SendError<()>),
-    #[cfg(feature = "benchmark")]
-    #[error("failed to join task: {0}")]
-    JoinError(#[from] tokio::task::JoinError),
+    #[error("Benchmark error: {0}")]
+    Benchmark(#[from] BenchmarkError),
 }
 
 thiserror_context::impl_context!(Error(Inner));

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -738,6 +738,7 @@ impl Runnable for Job {
                 fungible_application_id,
                 bps,
                 close_chains,
+                health_check_endpoints,
             } => {
                 assert!(num_chains > 0, "Number of chains must be greater than 0");
                 assert!(
@@ -771,6 +772,7 @@ impl Runnable for Job {
                     committee,
                     context.client.local_node().clone(),
                     close_chains,
+                    health_check_endpoints,
                 )
                 .await?;
 
@@ -794,8 +796,13 @@ impl Runnable for Job {
 
                     info!("Updating wallet from chain clients...");
                     for chain_client in chain_clients.values() {
-                        context.update_wallet_from_client(chain_client).await?;
+                        context
+                            .wallet
+                            .as_mut()
+                            .update_from_state(chain_client)
+                            .await;
                     }
+                    context.save_wallet().await?;
                 }
             }
 


### PR DESCRIPTION
## Motivation

Right now, the only way of knowing if the benchmark is completely destroying validators is by checking Grafana for the metrics (which have a 2m delay), and stopping the benchmark manually. This is not ideal, as if latency becomes too high, the validators can take a very long time to recover after it.

## Proposal

Introduce a `--health_check_endpoints` to `linera benchmark`, that if provided, will query the specified metrics host:port pairs for metrics, to determine the health of the validators. For now this health is determined by the p99 proxy latency being below 400 ms.
We're querying the metrics endpoint from the proxy directly with this, so it works on all different kinds of deployments (docker compose, kubernetes, just binaries running locally, etc). The user is responsible for making sure the metrics endpoint is available at the provided endpoints (might need to port forward the metrics port, etc).
We'll query the endpoints once every 5 seconds, and calculate the p99 of the different validators in those last 5s. If we see one validator being above the 400 ms threshold, automatically stop the benchmark. We calculate the p99 doing the linear interpolation manually, based on the histogram data we get from the endpoints.

## Test Plan

Ran a network locally, ran the benchmark against it, saw the p99 values being printed matched what Grafana reported as well, and that if we cross the threshold the benchmark gets stopped automatically.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
