### PR TITLE
[benchmark] Don't obliterate validators as much when wrapping up

### DIFF
--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -103,7 +103,6 @@ where
         blocks_infos: Vec<(ChainId, Vec<Operation>, AccountSecretKey)>,
         committee: Committee,
         local_node: LocalNodeClient<S>,
-        close_chains: bool,
         health_check_endpoints: Option<String>,
     ) -> Result<(), BenchmarkError> {
         let shutdown_notifier = CancellationToken::new();
@@ -200,7 +199,6 @@ where
                             sender,
                             committee,
                             local_node,
-                            close_chains,
                         )
                         .await?;
 
@@ -487,7 +485,6 @@ where
         sender: crossbeam_channel::Sender<()>,
         committee: Committee,
         local_node: LocalNodeClient<S>,
-        close_chains: bool,
     ) -> Result<(), BenchmarkError> {
         let chain_id = chain_client.chain_id();
         info!(
@@ -549,16 +546,13 @@ where
             }
         }
 
-        if close_chains {
-            Self::close_benchmark_chain(chain_client).await?;
-        }
         info!("Exiting task...");
         Ok(())
     }
 
     /// Closes the chain that was created for the benchmark.
-    async fn close_benchmark_chain(
-        chain_client: ChainClient<NodeProvider, S>,
+    pub async fn close_benchmark_chain(
+        chain_client: &ChainClient<NodeProvider, S>,
     ) -> Result<(), BenchmarkError> {
         let start = Instant::now();
         chain_client

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -622,6 +622,11 @@ pub enum ClientCommand {
         /// Example: "127.0.0.1:21100,validator-1.some-network.linera.net:21100"
         #[arg(long)]
         health_check_endpoints: Option<String>,
+        /// The maximum number of in-flight requests to validators when wrapping up the benchmark.
+        /// While wrapping up, this controls the concurrency level when processing inboxes and
+        /// closing chains.
+        #[arg(long, default_value = "5")]
+        wrap_up_max_in_flight: usize,
     },
 
     /// Create genesis configuration for a Linera deployment.


### PR DESCRIPTION
## Motivation

Right now if we have the `--close-chains` option on, we'll close all the chains in parallel. If we don't, we'll process all the inboxes in parallel also before saving the benchmark chains to the wallet.
This is not ideal because depending on how many chains we're using, this can pound the validators pretty hard, and drive latency up to the point of us getting a bunch of timeouts when wrapping things up.
Also, when latency spikes up too much, the validators take a while to recover.

## Proposal

Introduce a `--wrap-up-max-in-flight` argument to limit the concurrency when wrapping things up

## Test Plan

Tested locally, no timeouts anymore, and things actually go faster (if we timeout, we retry, and this can take a while until we actually eventually succeed within the timeout constraint)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
