### PR TITLE
Adjust end value bucket for inbox size

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -157,7 +157,7 @@ static NUM_INBOXES: LazyLock<HistogramVec> = LazyLock::new(|| {
         "num_inboxes",
         "Number of inboxes",
         &[],
-        exponential_bucket_interval(1.0, 10000.0),
+        exponential_bucket_interval(1.0, 10_000.0),
     )
 });
 
@@ -167,7 +167,7 @@ static NUM_OUTBOXES: LazyLock<HistogramVec> = LazyLock::new(|| {
         "num_outboxes",
         "Number of outboxes",
         &[],
-        exponential_bucket_interval(1.0, 10000.0),
+        exponential_bucket_interval(1.0, 10_000.0),
     )
 });
 

--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -39,7 +39,7 @@ static INBOX_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
         "inbox_size",
         "Inbox size",
         &[],
-        exponential_bucket_interval(1.0, 10000.0),
+        exponential_bucket_interval(1.0, 500_000.0),
     )
 });
 
@@ -49,7 +49,7 @@ static REMOVED_BUNDLES: LazyLock<HistogramVec> = LazyLock::new(|| {
         "removed_bundles",
         "Number of bundles removed by anticipation",
         &[],
-        exponential_bucket_interval(1.0, 10000.0),
+        exponential_bucket_interval(1.0, 10_000.0),
     )
 });
 

--- a/linera-chain/src/outbox.rs
+++ b/linera-chain/src/outbox.rs
@@ -30,7 +30,7 @@ static OUTBOX_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
         "outbox_size",
         "Outbox size",
         &[],
-        exponential_bucket_interval(1.0, 10000.0),
+        exponential_bucket_interval(1.0, 10_000.0),
     )
 });
 


### PR DESCRIPTION
## Motivation

When running benchmarks, inbox size can shoot up to 10k pretty quickly...

## Proposal

Increase the end value bucket to a pretty generous value

## Test Plan

Deploy network, see the new max value for metric

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
