### PR TITLE
Implement the EVM test in the end-to-end test.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -212,6 +212,7 @@ jobs:
     - name: Run REVM test
       run: |
         cargo test -p linera-execution test_fuel_for_counter_revm_application --features revm
+        cargo test test_evm_end_to_end_counter --features revm,storage-service
 
   storage-service-tests:
     runs-on: ubuntu-latest-16-cores

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4907,6 +4907,7 @@ name = "linera-service"
 version = "0.14.0"
 dependencies = [
  "alloy",
+ "alloy-sol-types",
  "amm",
  "anyhow",
  "assert_matches",

--- a/linera-execution/src/revm.rs
+++ b/linera-execution/src/revm.rs
@@ -444,8 +444,6 @@ enum Choice {
     Call,
 }
 
-// The OperationContext / MessageContext / FinalizeContext are not used
-// in the wasmer / wasmtime. Should we used it? It seems
 impl<Runtime> UserContract for RevmContractInstance<Runtime>
 where
     Runtime: ContractRuntime,

--- a/linera-execution/src/revm.rs
+++ b/linera-execution/src/revm.rs
@@ -608,16 +608,15 @@ where
         let argument: serde_json::Value = serde_json::from_slice(&argument)?;
         let argument = argument["query"].to_string();
         if let Some(residual) = argument.strip_prefix("\"mutation { v") {
-            let operation = &residual[0..residual.len()-3];
-            let operation = hex::decode(&operation).unwrap();
+            let operation = &residual[0..residual.len() - 3];
+            let operation = hex::decode(operation).unwrap();
             let mut runtime = self.db.runtime.lock().expect("The lock should be possible");
             runtime.schedule_operation(operation)?;
             let answer = serde_json::json!({"data": ""});
             let answer = serde_json::to_vec(&answer).unwrap();
             return Ok(answer);
         }
-
-        let argument = argument[10..argument.len()-3].to_string();
+        let argument = argument[10..argument.len() - 3].to_string();
         let argument = hex::decode(&argument).unwrap();
         let tx_data = Bytes::copy_from_slice(&argument);
         let address = self.db.contract_address;
@@ -642,7 +641,7 @@ where
         };
         let answer = output.as_ref().to_vec();
         let answer = hex::encode(&answer);
-        let answer : serde_json::Value = serde_json::json!({"data": answer});
+        let answer: serde_json::Value = serde_json::json!({"data": answer});
         let answer = serde_json::to_vec(&answer).unwrap();
         Ok(answer)
     }

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -5,9 +5,9 @@
 // items for the tests where they aren't used
 #![allow(unused_imports)]
 
+mod mock_application;
 #[cfg(with_revm)]
 pub mod solidity;
-mod mock_application;
 mod system_execution_state;
 
 use std::{collections::BTreeMap, sync::Arc, thread, vec};

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -5,6 +5,8 @@
 // items for the tests where they aren't used
 #![allow(unused_imports)]
 
+#[cfg(with_revm)]
+pub mod solidity;
 mod mock_application;
 mod system_execution_state;
 

--- a/linera-execution/src/test_utils/solidity.rs
+++ b/linera-execution/src/test_utils/solidity.rs
@@ -1,0 +1,101 @@
+use std::{fs::File, io::Write, path::Path, process::{Command, Stdio}};
+
+use anyhow::Context;
+use tempfile::tempdir;
+
+fn write_compilation_json(path: &Path, file_name: &str) -> anyhow::Result<()> {
+    let mut source = File::create(path).unwrap();
+    writeln!(
+        source,
+        r#"
+{{
+  "language": "Solidity",
+  "sources": {{
+    "{file_name}": {{
+      "urls": ["./{file_name}"]
+    }}
+  }},
+  "settings": {{
+    "viaIR": true,
+    "outputSelection": {{
+      "*": {{
+        "*": ["evm.bytecode"]
+      }}
+    }}
+  }}
+}}
+"#
+    )?;
+    Ok(())
+}
+
+fn get_bytecode_path(path: &Path, file_name: &str, contract_name: &str) -> anyhow::Result<Vec<u8>> {
+    let config_path = path.join("config.json");
+    write_compilation_json(&config_path, file_name)?;
+    let config_file = File::open(config_path)?;
+
+    let output_path = path.join("result.json");
+    let output_file = File::create(output_path.clone())?;
+
+    let status = Command::new("solc")
+        .current_dir(path)
+        .arg("--standard-json")
+        .stdin(Stdio::from(config_file))
+        .stdout(Stdio::from(output_file))
+        .status()?;
+    assert!(status.success());
+
+    let contents = std::fs::read_to_string(output_path)?;
+    let json_data: serde_json::Value = serde_json::from_str(&contents)?;
+    let contracts = json_data
+        .get("contracts")
+        .context("failed to get contracts")?;
+    let file_name_contract = contracts
+        .get(file_name)
+        .context("failed to get {file_name}")?;
+    let test_data = file_name_contract
+        .get(contract_name)
+        .context("failed to get contract_name={contract_name}")?;
+    let evm_data = test_data.get("evm").context("failed to get evm")?;
+    let bytecode = evm_data.get("bytecode").context("failed to get bytecode")?;
+    let object = bytecode.get("object").context("failed to get object")?;
+    let object = object.to_string();
+    let object = object.trim_matches(|c| c == '"').to_string();
+    Ok(hex::decode(&object)?)
+}
+
+pub fn get_bytecode(source_code: &str, contract_name: &str) -> anyhow::Result<Vec<u8>> {
+    let dir = tempdir().unwrap();
+    let path = dir.path();
+    let file_name = "test_code.sol";
+    let test_code_path = path.join(file_name);
+    let mut test_code_file = File::create(&test_code_path)?;
+    writeln!(test_code_file, "{}", source_code)?;
+    get_bytecode_path(path, file_name, contract_name)
+}
+
+pub fn get_example_counter() -> anyhow::Result<Vec<u8>> {
+    let source_code = r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ExampleCounter {
+  uint256 value;
+  constructor(uint256 start_value) {
+    value = start_value;
+  }
+
+  function increment(uint256 input) external returns (uint256) {
+    value = value + input;
+    return value;
+  }
+
+  function get_value() external view returns (uint256) {
+    return value;
+  }
+
+}
+"#
+        .to_string();
+    get_bytecode(&source_code, "ExampleCounter")
+}

--- a/linera-execution/src/test_utils/solidity.rs
+++ b/linera-execution/src/test_utils/solidity.rs
@@ -1,3 +1,8 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Code for compiling solidity smart contracts for testing purposes.
+
 use std::{
     fs::File,
     io::Write,

--- a/linera-execution/src/test_utils/solidity.rs
+++ b/linera-execution/src/test_utils/solidity.rs
@@ -1,4 +1,9 @@
-use std::{fs::File, io::Write, path::Path, process::{Command, Stdio}};
+use std::{
+    fs::File,
+    io::Write,
+    path::Path,
+    process::{Command, Stdio},
+};
 
 use anyhow::Context;
 use tempfile::tempdir;
@@ -96,6 +101,6 @@ contract ExampleCounter {
 
 }
 "#
-        .to_string();
+    .to_string();
     get_bytecode(&source_code, "ExampleCounter")
 }

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -12,7 +12,10 @@ use linera_base::{
 };
 use linera_execution::{
     revm::{EvmContractModule, EvmServiceModule},
-    test_utils::{create_dummy_user_application_description, SystemExecutionState, solidity::get_example_counter},
+    test_utils::{
+        create_dummy_user_application_description, solidity::get_example_counter,
+        SystemExecutionState,
+    },
     ExecutionRuntimeConfig, ExecutionRuntimeContext, Operation, OperationContext, Query,
     QueryContext, QueryResponse, ResourceControlPolicy, ResourceController, ResourceTracker,
     TransactionTracker,

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -3,127 +3,26 @@
 
 #![cfg(with_revm)]
 
-use std::{
-    fs::File,
-    io::Write,
-    path::Path,
-    process::{Command, Stdio},
-    sync::Arc,
-};
+use std::sync::Arc;
 
 use alloy_sol_types::{sol, SolCall, SolValue};
-use anyhow::Context;
 use linera_base::{
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{ChainDescription, ChainId},
 };
 use linera_execution::{
     revm::{EvmContractModule, EvmServiceModule},
-    test_utils::{create_dummy_user_application_description, SystemExecutionState},
+    test_utils::{create_dummy_user_application_description, SystemExecutionState, solidity::get_example_counter},
     ExecutionRuntimeConfig, ExecutionRuntimeContext, Operation, OperationContext, Query,
     QueryContext, QueryResponse, ResourceControlPolicy, ResourceController, ResourceTracker,
     TransactionTracker,
 };
 use linera_views::{context::Context as _, views::View};
 use revm_primitives::U256;
-use tempfile::tempdir;
-
-fn write_compilation_json(path: &Path, file_name: &str) {
-    let mut source = File::create(path).unwrap();
-    writeln!(
-        source,
-        r#"
-{{
-  "language": "Solidity",
-  "sources": {{
-    "{file_name}": {{
-      "urls": ["./{file_name}"]
-    }}
-  }},
-  "settings": {{
-    "viaIR": true,
-    "outputSelection": {{
-      "*": {{
-        "*": ["evm.bytecode"]
-      }}
-    }}
-  }}
-}}
-"#
-    )
-    .unwrap();
-}
-
-fn get_bytecode_path(path: &Path, file_name: &str, contract_name: &str) -> anyhow::Result<Vec<u8>> {
-    let config_path = path.join("config.json");
-    write_compilation_json(&config_path, file_name);
-    let config_file = File::open(config_path)?;
-
-    let output_path = path.join("result.json");
-    let output_file = File::create(output_path.clone())?;
-
-    let status = Command::new("solc")
-        .current_dir(path)
-        .arg("--standard-json")
-        .stdin(Stdio::from(config_file))
-        .stdout(Stdio::from(output_file))
-        .status()?;
-    assert!(status.success());
-
-    let contents = std::fs::read_to_string(output_path)?;
-    let json_data: serde_json::Value = serde_json::from_str(&contents)?;
-    let contracts = json_data
-        .get("contracts")
-        .context("failed to get contracts")?;
-    let file_name_contract = contracts
-        .get(file_name)
-        .context("failed to get {file_name}")?;
-    let test_data = file_name_contract
-        .get(contract_name)
-        .context("failed to get contract_name={contract_name}")?;
-    let evm_data = test_data.get("evm").context("failed to get evm")?;
-    let bytecode = evm_data.get("bytecode").context("failed to get bytecode")?;
-    let object = bytecode.get("object").context("failed to get object")?;
-    let object = object.to_string();
-    let object = object.trim_matches(|c| c == '"').to_string();
-    Ok(hex::decode(&object)?)
-}
-
-fn get_bytecode(source_code: &str, contract_name: &str) -> anyhow::Result<Vec<u8>> {
-    let dir = tempdir().unwrap();
-    let path = dir.path();
-    let file_name = "test_code.sol";
-    let test_code_path = path.join(file_name);
-    let mut test_code_file = File::create(&test_code_path)?;
-    writeln!(test_code_file, "{}", source_code)?;
-    get_bytecode_path(path, file_name, contract_name)
-}
 
 #[tokio::test]
 async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
-    let source_code = r#"
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
-
-contract ExampleCounter {
-  uint256 value;
-  constructor(uint256 start_value) {
-    value = start_value;
-  }
-
-  function increment(uint256 input) external returns (uint256) {
-    value = value + input;
-    return value;
-  }
-
-  function get_value() external view returns (uint256) {
-    return value;
-  }
-
-}
-"#
-    .to_string();
-    let module = get_bytecode(&source_code, "ExampleCounter")?;
+    let module = get_example_counter()?;
 
     sol! {
         struct ConstructorArgs {

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -24,6 +24,7 @@ ignored = ["base64ct"]
 
 [features]
 ethereum = ["async-trait", "linera-ethereum"]
+revm = ["linera-execution/revm"]
 unstable-oracles = [
     "linera-core/unstable-oracles",
     "linera-execution/unstable-oracles",

--- a/linera-sdk/build.rs
+++ b/linera-sdk/build.rs
@@ -3,6 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
+        with_revm: { feature = "revm" },
         with_testing: { any(test, feature = "test") },
         with_wasm_runtime: { any(feature = "wasmer", feature = "wasmtime") },
         with_integration_testing: {

--- a/linera-sdk/src/abis/evm.rs
+++ b/linera-sdk/src/abis/evm.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! An ABI for applications that implement a fungible token.
-use linera_base::{
-    abi::{ContractAbi, ServiceAbi},
-};
+use linera_base::abi::{ContractAbi, ServiceAbi};
 
 /// An ABI for applications that implement a fungible token.
 pub struct EvmAbi;

--- a/linera-sdk/src/abis/evm.rs
+++ b/linera-sdk/src/abis/evm.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! An ABI for applications that implement a fungible token.
+//! An ABI for applications that implement an EVM runtime.
 use linera_base::abi::{ContractAbi, ServiceAbi};
 
-/// An ABI for applications that implement a fungible token.
+/// An ABI for applications that implement an EVM runtime.
 pub struct EvmAbi;
 
 impl ContractAbi for EvmAbi {

--- a/linera-sdk/src/abis/evm.rs
+++ b/linera-sdk/src/abis/evm.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! An ABI for applications that implement a fungible token.
+use linera_base::{
+    abi::{ContractAbi, ServiceAbi},
+};
+
+/// An ABI for applications that implement a fungible token.
+pub struct EvmAbi;
+
+impl ContractAbi for EvmAbi {
+    type Operation = Vec<u8>;
+    type Response = Vec<u8>;
+}
+
+impl ServiceAbi for EvmAbi {
+    type Query = Vec<u8>;
+    type QueryResponse = Vec<u8>;
+}

--- a/linera-sdk/src/abis/mod.rs
+++ b/linera-sdk/src/abis/mod.rs
@@ -3,6 +3,6 @@
 
 //! Common ABIs that may have multiple implementations.
 
-pub mod fungible;
 #[cfg(with_revm)]
 pub mod evm;
+pub mod fungible;

--- a/linera-sdk/src/abis/mod.rs
+++ b/linera-sdk/src/abis/mod.rs
@@ -4,3 +4,5 @@
 //! Common ABIs that may have multiple implementations.
 
 pub mod fungible;
+#[cfg(with_revm)]
+pub mod evm;

--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -10,7 +10,7 @@
 use std::{collections::BTreeMap, str::FromStr, sync::LazyLock, time::Duration};
 
 use fungible::{FungibleTokenAbi, InitialState};
-use linera_base::{data_types::Amount, identifiers::ChainId};
+use linera_base::{data_types::Amount, identifiers::ChainId, vm::VmRuntime};
 use linera_service::cli_wrappers::{
     local_net::{Database, LocalNetConfig, ProcessInbox},
     LineraNet, LineraNetConfig, Network,
@@ -60,6 +60,7 @@ async fn test_end_to_end_queries(config: impl LineraNetConfig) {
 
     // publishing an application
     let (contract, service) = client.build_example("fungible").await.unwrap();
+    let vm_runtime = VmRuntime::Wasm;
     let state = InitialState {
         accounts: BTreeMap::new(),
     };
@@ -68,6 +69,7 @@ async fn test_end_to_end_queries(config: impl LineraNetConfig) {
         .publish_and_create::<FungibleTokenAbi, fungible::Parameters, InitialState>(
             contract,
             service,
+            vm_runtime,
             &params,
             &state,
             &[],

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -14,7 +14,12 @@ version.workspace = true
 [features]
 ethereum = []
 default = ["wasmer", "rocksdb", "storage-service"]
-revm = ["linera-execution/revm", "linera-storage/revm", "linera-sdk/revm", "dep:alloy-sol-types"]
+revm = [
+    "linera-execution/revm",
+    "linera-storage/revm",
+    "linera-sdk/revm",
+    "dep:alloy-sol-types",
+]
 unstable-oracles = ["linera-core/unstable-oracles"]
 test = [
     "linera-base/test",
@@ -65,8 +70,8 @@ metrics = ["prometheus", "linera-base/metrics", "linera-client/metrics"]
 storage-service = ["linera-client/storage-service", "linera-storage-service"]
 
 [dependencies]
-anyhow.workspace = true
 alloy-sol-types = { workspace = true, optional = true }
+anyhow.workspace = true
 assert_matches.workspace = true
 async-graphql.workspace = true
 async-graphql-axum.workspace = true

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 [features]
 ethereum = []
 default = ["wasmer", "rocksdb", "storage-service"]
+revm = ["linera-execution/revm", "linera-storage/revm", "linera-sdk/revm", "dep:alloy-sol-types"]
 unstable-oracles = ["linera-core/unstable-oracles"]
 test = [
     "linera-base/test",
@@ -65,6 +66,7 @@ storage-service = ["linera-client/storage-service", "linera-storage-service"]
 
 [dependencies]
 anyhow.workspace = true
+alloy-sol-types = { workspace = true, optional = true }
 assert_matches.workspace = true
 async-graphql.workspace = true
 async-graphql-axum.workspace = true

--- a/linera-service/build.rs
+++ b/linera-service/build.rs
@@ -3,6 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
+        with_revm: { feature = "revm" },
         with_testing: { any(test, feature = "test") },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
     };

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -342,6 +342,7 @@ impl ClientWrapper {
     }
 
     /// Runs `linera wallet publish-and-create`.
+    #[allow(clippy::too_many_arguments)]
     pub async fn publish_and_create<
         A: ContractAbi,
         Parameters: Serialize,
@@ -350,6 +351,7 @@ impl ClientWrapper {
         &self,
         contract: PathBuf,
         service: PathBuf,
+        vm_runtime: VmRuntime,
         parameters: &Parameters,
         argument: &InstantiationArgument,
         required_application_ids: &[ApplicationId],
@@ -358,9 +360,11 @@ impl ClientWrapper {
         let json_parameters = serde_json::to_string(parameters)?;
         let json_argument = serde_json::to_string(argument)?;
         let mut command = self.command().await?;
+        let vm_runtime = format!("{}", vm_runtime);
         command
             .arg("publish-and-create")
             .args([contract, service])
+            .args(["--vm-runtime", &vm_runtime.to_lowercase()])
             .args(publisher.into().iter().map(ChainId::to_string))
             .args(["--json-parameters", &json_parameters])
             .args(["--json-argument", &json_argument]);

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -507,7 +507,7 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
     let instantiation_argument = ConstructorArgs {
         initial_value: original_counter_value,
     };
-    let instantiation_argument = instantiation_argument.abi_encode().into();
+    let instantiation_argument = instantiation_argument.abi_encode();
 
     let increment = U256::from(5);
 
@@ -547,36 +547,33 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
         .make_application(&chain, &application_id)
         .await?;
 
-    let query1 = get_valueCall {};
-    let query2 = query1.abi_encode();
-    let query3 = hex::encode(&query2);
-    let query4 = format!("query {{ v{} }}", query3);
+    let query = get_valueCall {};
+    let query = query.abi_encode();
+    let query = hex::encode(&query);
+    let query = format!("query {{ v{} }}", query);
 
-    let result : Value = application.raw_query(query4).await?;
-    let result : String = result.to_string();
-    let result = hex::decode(&result[1..result.len()-1])?;
+    let result = application.raw_query(query).await?;
+    let result = result.to_string();
+    let result = hex::decode(&result[1..result.len() - 1])?;
 
     let counter_value = U256::from_be_slice(&result);
     assert_eq!(counter_value, original_counter_value);
 
-    let mutation1 = incrementCall {input: increment };
-    let mutation2 = mutation1.abi_encode();
-    let mutation3 = hex::encode(&mutation2);
-    let mutation4 = format!("mutation {{ v{} }}", mutation3);
+    let mutation = incrementCall { input: increment };
+    let mutation = mutation.abi_encode();
+    let mutation = hex::encode(&mutation);
+    let mutation = format!("mutation {{ v{} }}", mutation);
 
-    application.raw_query(mutation4).await?;
+    application.raw_query(mutation).await?;
 
+    let query = get_valueCall {};
+    let query = query.abi_encode();
+    let query = hex::encode(&query);
+    let query = format!("query {{ v{} }}", query);
 
-
-
-    let query1 = get_valueCall {};
-    let query2 = query1.abi_encode();
-    let query3 = hex::encode(&query2);
-    let query4 = format!("query {{ v{} }}", query3);
-
-    let result : Value = application.raw_query(query4).await?;
-    let result : String = result.to_string();
-    let result = hex::decode(&result[1..result.len()-1])?;
+    let result = application.raw_query(query).await?;
+    let result = result.to_string();
+    let result = hex::decode(&result[1..result.len() - 1])?;
 
     let counter_value = U256::from_be_slice(&result);
     assert_eq!(counter_value, original_counter_value + increment);

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2004,7 +2004,12 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
 
     // Create AMM application on Admin chain
     let module_id = node_service_amm
-        .publish_module::<AmmAbi, Parameters, ()>(&chain_amm, contract_amm, service_amm, VmRuntime::Wasm)
+        .publish_module::<AmmAbi, Parameters, ()>(
+            &chain_amm,
+            contract_amm,
+            service_amm,
+            VmRuntime::Wasm,
+        )
         .await?;
     let application_id_amm = node_service_amm
         .create_application(

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -423,13 +423,12 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
     client.change_ownership(chain, vec![], vec![owner1]).await?;
 
     let (contract, service) = client.build_example("ethereum-tracker").await?;
-    let vm_runtime = VmRuntime::Wasm;
 
     let application_id = client
         .publish_and_create::<EthereumTrackerAbi, (), InstantiationArgument>(
             contract,
             service,
-            vm_runtime,
+            VmRuntime::Wasm,
             &(),
             &argument,
             &[],
@@ -524,7 +523,6 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
 
     let contract = app_path.to_path_buf();
     let service = app_path.to_path_buf();
-    let vm_runtime = VmRuntime::Evm;
     type Parameter = ();
     type InstantiationArgument = Vec<u8>;
 
@@ -532,7 +530,7 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
         .publish_and_create::<EvmAbi, Parameter, InstantiationArgument>(
             contract,
             service,
-            vm_runtime,
+            VmRuntime::Evm,
             &(),
             &instantiation_argument,
             &[],
@@ -602,13 +600,12 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()
 
     let chain = client.load_wallet()?.default_chain().unwrap();
     let (contract, service) = client.build_example("counter").await?;
-    let vm_runtime = VmRuntime::Wasm;
 
     let application_id = client
         .publish_and_create::<CounterAbi, (), u64>(
             contract,
             service,
-            vm_runtime,
+            VmRuntime::Wasm,
             &(),
             &original_counter_value,
             &[],
@@ -833,7 +830,6 @@ async fn test_wasm_end_to_end_fungible(
     let state = InitialState { accounts };
     // Setting up the application and verifying
     let (contract, service) = client1.build_example(example_name).await?;
-    let vm_runtime = VmRuntime::Wasm;
     let params = if example_name == "native-fungible" {
         // Native Fungible has a fixed NAT ticker symbol, anything else will be rejected
         Parameters::new("NAT")
@@ -844,7 +840,7 @@ async fn test_wasm_end_to_end_fungible(
         .publish_and_create::<FungibleTokenAbi, Parameters, InitialState>(
             contract,
             service,
-            vm_runtime,
+            VmRuntime::Wasm,
             &params,
             &state,
             &[],
@@ -1007,7 +1003,6 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     let state = InitialState { accounts };
     // Setting up the application and verifying
     let (contract, service) = client1.build_example(example_name).await?;
-    let vm_runtime = VmRuntime::Wasm;
     let params = if example_name == "native-fungible" {
         // Native Fungible has a fixed NAT ticker symbol, anything else will be rejected
         Parameters::new("NAT")
@@ -1018,7 +1013,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
         .publish_and_create::<FungibleTokenAbi, Parameters, InitialState>(
             contract,
             service,
-            vm_runtime,
+            VmRuntime::Wasm,
             &params,
             &state,
             &[],
@@ -1112,12 +1107,11 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
 
     // Setting up the application and verifying
     let (contract, service) = client1.build_example("non-fungible").await?;
-    let vm_runtime = VmRuntime::Wasm;
     let application_id = client1
         .publish_and_create::<NonFungibleTokenAbi, (), ()>(
             contract,
             service,
-            vm_runtime,
+            VmRuntime::Wasm,
             &(),
             &(),
             &[],
@@ -1408,13 +1402,12 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
 
     // Setting up the application fungible
     let (contract_fungible, service_fungible) = client1.build_example("fungible").await?;
-    let vm_runtime = VmRuntime::Wasm;
     let params = Parameters::new("FUN");
     let application_id_fungible = client1
         .publish_and_create::<FungibleTokenAbi, Parameters, InitialState>(
             contract_fungible,
             service_fungible,
-            vm_runtime,
+            VmRuntime::Wasm,
             &params,
             &state_fungible,
             &[],
@@ -1431,12 +1424,11 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
         target,
     };
     let (contract_crowd, service_crowd) = client1.build_example("crowd-funding").await?;
-    let vm_runtime = VmRuntime::Wasm;
     let application_id_crowd = client1
         .publish_and_create::<CrowdFundingAbi, ApplicationId<FungibleTokenAbi>, InstantiationArgument>(
             contract_crowd,
             service_crowd,
-            vm_runtime,
+            VmRuntime::Wasm,
             // TODO(#723): This hack will disappear soon.
             &application_id_fungible,
             &state_crowd,
@@ -1528,7 +1520,6 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
-    let vm_runtime = VmRuntime::Wasm;
     let (mut net, client_admin) = config.instantiate().await?;
 
     let client_a = net.make_client().await;
@@ -1567,7 +1558,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
         .publish_and_create::<fungible::FungibleTokenAbi, fungible::Parameters, fungible::InitialState>(
             contract_fungible_a,
             service_fungible_a,
-            vm_runtime,
+            VmRuntime::Wasm,
             &params0,
             &state_fungible0,
             &[],
@@ -1579,7 +1570,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
         .publish_and_create::<fungible::FungibleTokenAbi, fungible::Parameters, fungible::InitialState>(
             contract_fungible_b,
             service_fungible_b,
-            vm_runtime,
+            VmRuntime::Wasm,
             &params1,
             &state_fungible1,
             &[],
@@ -1670,7 +1661,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
             &chain_admin,
             contract_matching,
             service_matching,
-            vm_runtime,
+            VmRuntime::Wasm,
         )
         .await?;
     let application_id_matching = node_service_admin
@@ -1823,7 +1814,6 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
-    let vm_runtime = VmRuntime::Wasm;
     let (mut net, client_amm) = config.instantiate().await?;
 
     let client0 = net.make_client().await;
@@ -1874,7 +1864,7 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
             &chain_amm,
             contract_fungible,
             service_fungible,
-            vm_runtime,
+            VmRuntime::Wasm,
         )
         .await?;
 
@@ -2015,7 +2005,7 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
 
     // Create AMM application on Admin chain
     let module_id = node_service_amm
-        .publish_module::<AmmAbi, Parameters, ()>(&chain_amm, contract_amm, service_amm, vm_runtime)
+        .publish_module::<AmmAbi, Parameters, ()>(&chain_amm, contract_amm, service_amm, VmRuntime::Wasm)
         .await?;
     let application_id_amm = node_service_amm
         .create_application(
@@ -2586,13 +2576,12 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()
     let accounts = BTreeMap::from([(owner, Amount::from_tokens(10))]);
     let state = fungible::InitialState { accounts };
     let (contract, service) = client.build_example("fungible").await?;
-    let vm_runtime = VmRuntime::Wasm;
     let params = fungible::Parameters::new("FUN");
     let application_id = client
         .publish_and_create::<fungible::FungibleTokenAbi, fungible::Parameters, fungible::InitialState>(
             contract,
             service,
-            vm_runtime,
+            VmRuntime::Wasm,
             &params,
             &state,
             &[],

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -1429,7 +1429,6 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
             contract_crowd,
             service_crowd,
             VmRuntime::Wasm,
-            // TODO(#723): This hack will disappear soon.
             &application_id_fungible,
             &state_crowd,
             &[application_id_fungible.forget_abi()],

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -423,11 +423,13 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
     client.change_ownership(chain, vec![], vec![owner1]).await?;
 
     let (contract, service) = client.build_example("ethereum-tracker").await?;
+    let vm_runtime = VmRuntime::Wasm;
 
     let application_id = client
         .publish_and_create::<EthereumTrackerAbi, (), InstantiationArgument>(
             contract,
             service,
+            vm_runtime,
             &(),
             &argument,
             &[],
@@ -494,11 +496,13 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()
 
     let chain = client.load_wallet()?.default_chain().unwrap();
     let (contract, service) = client.build_example("counter").await?;
+    let vm_runtime = VmRuntime::Wasm;
 
     let application_id = client
         .publish_and_create::<CounterAbi, (), u64>(
             contract,
             service,
+            vm_runtime,
             &(),
             &original_counter_value,
             &[],
@@ -723,6 +727,7 @@ async fn test_wasm_end_to_end_fungible(
     let state = InitialState { accounts };
     // Setting up the application and verifying
     let (contract, service) = client1.build_example(example_name).await?;
+    let vm_runtime = VmRuntime::Wasm;
     let params = if example_name == "native-fungible" {
         // Native Fungible has a fixed NAT ticker symbol, anything else will be rejected
         Parameters::new("NAT")
@@ -733,6 +738,7 @@ async fn test_wasm_end_to_end_fungible(
         .publish_and_create::<FungibleTokenAbi, Parameters, InitialState>(
             contract,
             service,
+            vm_runtime,
             &params,
             &state,
             &[],
@@ -895,6 +901,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     let state = InitialState { accounts };
     // Setting up the application and verifying
     let (contract, service) = client1.build_example(example_name).await?;
+    let vm_runtime = VmRuntime::Wasm;
     let params = if example_name == "native-fungible" {
         // Native Fungible has a fixed NAT ticker symbol, anything else will be rejected
         Parameters::new("NAT")
@@ -905,6 +912,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
         .publish_and_create::<FungibleTokenAbi, Parameters, InitialState>(
             contract,
             service,
+            vm_runtime,
             &params,
             &state,
             &[],
@@ -998,8 +1006,17 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
 
     // Setting up the application and verifying
     let (contract, service) = client1.build_example("non-fungible").await?;
+    let vm_runtime = VmRuntime::Wasm;
     let application_id = client1
-        .publish_and_create::<NonFungibleTokenAbi, (), ()>(contract, service, &(), &(), &[], None)
+        .publish_and_create::<NonFungibleTokenAbi, (), ()>(
+            contract,
+            service,
+            vm_runtime,
+            &(),
+            &(),
+            &[],
+            None,
+        )
         .await?;
 
     let port1 = get_node_port().await;
@@ -1285,11 +1302,13 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
 
     // Setting up the application fungible
     let (contract_fungible, service_fungible) = client1.build_example("fungible").await?;
+    let vm_runtime = VmRuntime::Wasm;
     let params = Parameters::new("FUN");
     let application_id_fungible = client1
         .publish_and_create::<FungibleTokenAbi, Parameters, InitialState>(
             contract_fungible,
             service_fungible,
+            vm_runtime,
             &params,
             &state_fungible,
             &[],
@@ -1306,10 +1325,12 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
         target,
     };
     let (contract_crowd, service_crowd) = client1.build_example("crowd-funding").await?;
+    let vm_runtime = VmRuntime::Wasm;
     let application_id_crowd = client1
         .publish_and_create::<CrowdFundingAbi, ApplicationId<FungibleTokenAbi>, InstantiationArgument>(
             contract_crowd,
             service_crowd,
+            vm_runtime,
             // TODO(#723): This hack will disappear soon.
             &application_id_fungible,
             &state_crowd,
@@ -1440,6 +1461,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
         .publish_and_create::<fungible::FungibleTokenAbi, fungible::Parameters, fungible::InitialState>(
             contract_fungible_a,
             service_fungible_a,
+            vm_runtime,
             &params0,
             &state_fungible0,
             &[],
@@ -1451,6 +1473,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
         .publish_and_create::<fungible::FungibleTokenAbi, fungible::Parameters, fungible::InitialState>(
             contract_fungible_b,
             service_fungible_b,
+            vm_runtime,
             &params1,
             &state_fungible1,
             &[],
@@ -2457,11 +2480,13 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()
     let accounts = BTreeMap::from([(owner, Amount::from_tokens(10))]);
     let state = fungible::InitialState { accounts };
     let (contract, service) = client.build_example("fungible").await?;
+    let vm_runtime = VmRuntime::Wasm;
     let params = fungible::Parameters::new("FUN");
     let application_id = client
         .publish_and_create::<fungible::FungibleTokenAbi, fungible::Parameters, fungible::InitialState>(
             contract,
             service,
+            vm_runtime,
             &params,
             &state,
             &[],

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -758,13 +758,12 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
     let accounts = BTreeMap::from([(account_owner, Amount::from_tokens(1_000_000))]);
     let state = InitialState { accounts };
     let (contract, service) = client.build_example("fungible").await?;
-    let vm_runtime = VmRuntime::Wasm;
     let params = Parameters::new("FUN");
     let application_id = client
         .publish_and_create::<FungibleTokenAbi, Parameters, InitialState>(
             contract,
             service,
-            vm_runtime,
+            VmRuntime::Wasm,
             &params,
             &state,
             &[],

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -19,6 +19,7 @@ use linera_base::{
     crypto::Secp256k1SecretKey,
     data_types::{Amount, BlockHeight},
     identifiers::{Account, AccountOwner, ChainId},
+    vm::VmRuntime,
 };
 use linera_core::{data_types::ChainInfoQuery, node::ValidatorNode};
 use linera_execution::committee::Epoch;
@@ -756,11 +757,13 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
     let accounts = BTreeMap::from([(account_owner, Amount::from_tokens(1_000_000))]);
     let state = InitialState { accounts };
     let (contract, service) = client.build_example("fungible").await?;
+    let vm_runtime = VmRuntime::Wasm;
     let params = Parameters::new("FUN");
     let application_id = client
         .publish_and_create::<FungibleTokenAbi, Parameters, InitialState>(
             contract,
             service,
+            vm_runtime,
             &params,
             &state,
             &[],

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -15,11 +15,12 @@ use std::{env, path::PathBuf, time::Duration};
 
 use anyhow::Result;
 use guard::INTEGRATION_TEST_GUARD;
+#[cfg(feature = "benchmark")]
+use linera_base::vm::VmRuntime;
 use linera_base::{
     crypto::Secp256k1SecretKey,
     data_types::{Amount, BlockHeight},
     identifiers::{Account, AccountOwner, ChainId},
-    vm::VmRuntime,
 };
 use linera_core::{data_types::ChainInfoQuery, node::ValidatorNode};
 use linera_execution::committee::Epoch;


### PR DESCRIPTION
## Motivation

The end-to-end test for Evm is needed as a tool.

## Proposal

The following is done:
* The compilation functionalities are moved to a `solidity.rs` file so that it can be used in the end-to-end test.
* The `EvmAbi` is implemented. The Evm applications are untyped so there is no point in adding specific types.
* The bytecode is written directly to file in order to have a system that works in the same way as for Wasm.
* The `VmRuntime`is added to the `publish_and_create`.
* The code in `revm` is changed so that it suits the framework of Wasm:
  - The `handle_query` is parsing the initial entry and returning the parsed value.
  - The `execute_operation` is not changed as it is put in the `schedule_operation`.

The design of the parsing of json entries is not great. But it reflects the design of json for the Wasm.

## Test Plan

The counter test using EVM is added to the `linera_net_tests.rs`.

## Release Plan

The functionality could be added to the TestNet.

## Links

None.