### PR TITLE
Add exists chain to TestValidator to test new created chain

### DIFF
--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -189,7 +189,7 @@ impl TestValidator {
         chain
     }
 
-    /// Add an exists [`ActiveChain`]
+    /// Add an existing [`ActiveChain`]
     pub fn add_chain(&self, chain: ActiveChain) {
         self.chains.insert(chain.id(), chain.clone());
     }

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -189,7 +189,7 @@ impl TestValidator {
         chain
     }
 
-    /// Add a exists [`ActiveChain`]
+    /// Add an exists [`ActiveChain`]
     pub fn add_chain(&self, chain: ActiveChain) {
         self.chains.insert(chain.id(), chain.clone());
     }

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -194,7 +194,7 @@ impl TestValidator {
         let key_pair = AccountSecretKey::generate();
         self.new_chain_with_keypair(key_pair).await
     }
-    
+
     /// Add an existing [`ActiveChain`]
     pub fn add_chain(&self, chain: ActiveChain) {
         self.chains.insert(chain.id(), chain);

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -190,7 +190,7 @@ impl TestValidator {
     }
 
     /// Add a exists [`ActiveChain`]
-    pub async fn add_chain(&self, chain: ActiveChain) {
+    pub fn add_chain(&self, chain: ActiveChain) {
         self.chains.insert(chain.id(), chain.clone());
     }
 

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -195,7 +195,7 @@ impl TestValidator {
         self.new_chain_with_keypair(key_pair).await
     }
 
-    /// Add an existing [`ActiveChain`]
+    /// Adds an existing [`ActiveChain`].
     pub fn add_chain(&self, chain: ActiveChain) {
         self.chains.insert(chain.id(), chain);
     }

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -189,6 +189,11 @@ impl TestValidator {
         chain
     }
 
+    /// Add a exists [`ActiveChain`]
+    pub async fn add_chain(&self, chain: ActiveChain) {
+        self.chains.insert(chain.id(), chain.clone());
+    }
+
     /// Adds a block to the admin chain to create a new chain.
     ///
     /// Returns the [`ChainDescription`] of the new chain.

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -191,7 +191,7 @@ impl TestValidator {
 
     /// Add an existing [`ActiveChain`]
     pub fn add_chain(&self, chain: ActiveChain) {
-        self.chains.insert(chain.id(), chain.clone());
+        self.chains.insert(chain.id(), chain);
     }
 
     /// Adds a block to the admin chain to create a new chain.


### PR DESCRIPTION
## Motivation

If we create new chain with `open_chain` in `contract.rs`, it won't be maintained by `TestValidator` in integration tests. Thus we won't be able to test some functionalities of the new chain in integration tests. For example, if we would like to call operation from another user chain to the created chain's application, the user chain should register the application firstly, then call it. At that time we'll get error `Chain not found` with the `TestValidator`.

## Proposal

If we could add exists chain to `TestValidator`, then I think we'll be able to test those created chains in integration tests.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

