### PR TITLE
chore: fix incorrect string comparison in JSON-RPC check

### DIFF
--- a/linera-ethereum/src/client.rs
+++ b/linera-ethereum/src/client.rs
@@ -45,7 +45,7 @@ pub trait JsonRpcClient {
         let res = serde_json::from_str(raw.get())?;
         ensure!(id == result.id, EthereumQueryError::IdIsNotMatching);
         ensure!(
-            *"2.0" == result.jsonrpc,
+            "2.0" == result.jsonrpc,
             EthereumQueryError::WrongJsonRpcVersion
         );
         Ok(res)


### PR DESCRIPTION
## Motivation  
The comparison of `"2.0"` with `result.jsonrpc` was incorrect. Since `"2.0"` is already a string literal, the dereference (`*`) was unnecessary and didn’t make sense. This could lead to unexpected behavior.  

## Proposal  
Removed the unnecessary dereference to ensure proper string comparison in the JSON-RPC check.  

## Test Plan  
Verified that the comparison now works correctly by testing with valid and invalid `jsonrpc` versions. Ensured no regressions in existing functionality.  

## Release Plan  
No breaking changes. This is a straightforward fix that improves correctness. Safe to include in the next release.