### PR TITLE
Check for overwriting events, fix typos, duplications, and minor inconsistencies.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -18,14 +18,12 @@ use linera_base::{
     data_types::{Amount, BlockHeight, Event, OracleResponse, Round, Timestamp},
     doc_scalar, ensure,
     hashed::Hashed,
-    identifiers::{
-        Account, BlobId, BlobType, ChainId, ChannelFullName, Destination, MessageId, Owner,
-    },
+    identifiers::{Account, BlobId, ChainId, ChannelFullName, Destination, MessageId, Owner},
 };
 use linera_execution::{
     committee::{Committee, Epoch},
     system::OpenChainConfig,
-    Message, MessageKind, Operation, SystemMessage, SystemOperation,
+    Message, MessageKind, Operation, SystemMessage,
 };
 use serde::{Deserialize, Serialize};
 
@@ -81,20 +79,10 @@ pub struct ProposedBlock {
 impl ProposedBlock {
     /// Returns all the published blob IDs in this block's operations.
     pub fn published_blob_ids(&self) -> BTreeSet<BlobId> {
-        let mut blob_ids = BTreeSet::new();
-        for operation in &self.operations {
-            if let Operation::System(SystemOperation::PublishDataBlob { blob_hash }) = operation {
-                blob_ids.insert(BlobId::new(*blob_hash, BlobType::Data));
-            }
-            if let Operation::System(SystemOperation::PublishModule { module_id }) = operation {
-                blob_ids.extend([
-                    BlobId::new(module_id.contract_blob_hash, BlobType::ContractBytecode),
-                    BlobId::new(module_id.service_blob_hash, BlobType::ServiceBytecode),
-                ]);
-            }
-        }
-
-        blob_ids
+        self.operations
+            .iter()
+            .flat_map(Operation::published_blob_ids)
+            .collect()
     }
 
     /// Returns whether the block contains only rejected incoming messages, which

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -567,7 +567,7 @@ fn missing_blob_ids(maybe_blobs: &BTreeMap<BlobId, Option<Blob>>) -> Vec<BlobId>
     maybe_blobs
         .iter()
         .filter(|(_, maybe_blob)| maybe_blob.is_none())
-        .map(|(chain_id, _)| *chain_id)
+        .map(|(blob_id, _)| *blob_id)
         .collect()
 }
 

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -3,6 +3,8 @@
 
 //! Operations that don't persist any changes to the chain state.
 
+use std::collections::HashMap;
+
 use linera_base::{
     data_types::{ArithmeticError, Timestamp, UserApplicationDescription},
     ensure,
@@ -14,7 +16,7 @@ use linera_chain::data_types::{
 };
 use linera_execution::{ChannelSubscription, Query, QueryOutcome};
 use linera_storage::{Clock as _, Storage};
-use linera_views::views::View;
+use linera_views::views::{View, ViewError};
 #[cfg(with_testing)]
 use {
     linera_base::{crypto::CryptoHash, data_types::BlockHeight},
@@ -171,6 +173,26 @@ where
         } else {
             Box::pin(chain.execute_block(block, local_time, round.multi_leader(), None)).await?
         };
+
+        // Verify that no event values are overwritten.
+        let mut new_events = HashMap::new();
+        for event in outcome.events.iter().flatten() {
+            let event_id = event.id(chain.chain_id());
+            if let Some(old_value) = new_events.insert(event_id.clone(), &event.value) {
+                ensure!(
+                    *old_value == event.value,
+                    WorkerError::OverwritingEvent(Box::new(event_id))
+                );
+            }
+            match self.0.storage.read_event(event_id.clone()).await {
+                Ok(old_value) => ensure!(
+                    old_value == event.value,
+                    WorkerError::OverwritingEvent(Box::new(event_id))
+                ),
+                Err(ViewError::EventsNotFound(_)) => {}
+                Err(err) => return Err(err.into()),
+            }
+        }
 
         let executed_block = outcome.with(block.clone());
         ensure!(

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2987,29 +2987,11 @@ where
         &self,
         committee: Committee,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
-        loop {
-            let epoch = self.epoch().await?;
-            match self
-                .execute_block(
-                    vec![Operation::System(SystemOperation::Admin(
-                        AdminOperation::CreateCommittee {
-                            epoch: epoch.try_add_one()?,
-                            committee: committee.clone(),
-                        },
-                    ))],
-                    vec![],
-                )
-                .await?
-            {
-                ExecuteBlockOutcome::Executed(certificate) => {
-                    return Ok(ClientOutcome::Committed(certificate))
-                }
-                ExecuteBlockOutcome::Conflict(_) => continue,
-                ExecuteBlockOutcome::WaitForTimeout(timeout) => {
-                    return Ok(ClientOutcome::WaitForTimeout(timeout));
-                }
-            };
-        }
+        let epoch = self.epoch().await?.try_add_one()?;
+        self.execute_operation(Operation::System(SystemOperation::Admin(
+            AdminOperation::CreateCommittee { epoch, committee },
+        )))
+        .await
     }
 
     /// Synchronizes the chain with the validators and creates blocks without any operations to

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -19,7 +19,7 @@ use linera_base::{
     },
     doc_scalar,
     hashed::Hashed,
-    identifiers::{BlobId, ChainId, Owner, UserApplicationId},
+    identifiers::{BlobId, ChainId, EventId, Owner, UserApplicationId},
     time::timer::{sleep, timeout},
 };
 use linera_chain::{
@@ -212,6 +212,8 @@ pub enum WorkerError {
     BlobsNotFound(Vec<BlobId>),
     #[error("The block proposal is invalid: {0}")]
     InvalidBlockProposal(String),
+    #[error("Trying to overwrite an event: {0:?}")]
+    OverwritingEvent(Box<EventId>),
     #[error("The worker is too busy to handle new chains")]
     FullChainWorkerCache,
     #[error("Failed to join spawned worker task")]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -43,8 +43,8 @@ use linera_base::{
     },
     doc_scalar, hex_debug, http,
     identifiers::{
-        Account, AccountOwner, ApplicationId, BlobId, ChainId, ChannelName, Destination, EventId,
-        GenericApplicationId, MessageId, ModuleId, Owner, StreamName, UserApplicationId,
+        Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, ChannelName, Destination,
+        EventId, GenericApplicationId, MessageId, ModuleId, Owner, StreamName, UserApplicationId,
     },
     ownership::ChainOwnership,
     task,
@@ -1207,6 +1207,20 @@ impl Operation {
         match self {
             Self::System(_) => GenericApplicationId::System,
             Self::User { application_id, .. } => GenericApplicationId::User(*application_id),
+        }
+    }
+
+    /// Returns the IDs of all blobs published in this operation.
+    pub fn published_blob_ids(&self) -> Vec<BlobId> {
+        match self {
+            Operation::System(SystemOperation::PublishDataBlob { blob_hash }) => {
+                vec![BlobId::new(*blob_hash, BlobType::Data)]
+            }
+            Operation::System(SystemOperation::PublishModule { module_id }) => vec![
+                BlobId::new(module_id.contract_blob_hash, BlobType::ContractBytecode),
+                BlobId::new(module_id.service_blob_hash, BlobType::ServiceBytecode),
+            ],
+            _ => vec![],
         }
     }
 }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -799,7 +799,7 @@ type MutationRoot {
 	the admin chain so that they can migrate to the new epoch (by accepting the
 	notification as an "incoming message" in a next block).
 	"""
-	createCommittee(chainId: ChainId!, epoch: Epoch!, committee: Committee!): CryptoHash!
+	createCommittee(chainId: ChainId!, committee: Committee!): CryptoHash!
 	"""
 	Subscribes to a system channel.
 	"""


### PR DESCRIPTION
## Motivation

Working on https://github.com/linera-io/linera-protocol/pull/3432 I found a few issues that can be fixed separately.

## Proposal

* Move the operation inspection code from the two `published_blob_ids` implementations to `Operation` and deduplicate it.
* Use the `select!` macro in the client listener. This will make it easier to add another stream, to listen for admin chain events.
* Fix a typo where a blob ID was called `chain_id`.
* Add a check that events don't get overwritten. Testing this will be complicated, and possibly require more SDK features: https://github.com/linera-io/linera-protocol/issues/3488
* Treat `stage_new_committee` like other client operations. The issue with conflicting blocks needs to be addressed for all operations anyway, and admin operations are always on a single-user chain in our case. https://github.com/linera-io/linera-protocol/issues/3172
* Use `stage_new_committee` in the node service` instead of manually creating the operation. There is no reason to have different semantics here in CLI vs. the node service API, and to have the user input the current epoch manually.

## Test Plan

CI should catch regressions. I created #3488 for the events check.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Found while working on https://github.com/linera-io/linera-protocol/pull/3432.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
