### PR TITLE
We're not using cargo sort anymore, change CI job name

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -328,7 +328,7 @@ jobs:
       run: |
         cargo fmt -- --check
 
-  lint-cargo-sort:
+  lint-taplo-fmt:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -338,7 +338,7 @@ jobs:
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - name: Install taplo-sort
+    - name: Install taplo-fmt
       run: |
         RUSTFLAGS='' cargo install taplo-cli@0.9.3 --locked
     - name: Check if Cargo.toml files are sorted


### PR DESCRIPTION
## Motivation

We recently changed to use taplo sort instead of cargo sort

## Proposal

Update the CI job name to avoid confusion

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
