### PR TITLE
Increase test-crates-and-docrs timeout

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -58,7 +58,7 @@ jobs:
 
   test-crates-and-docrs:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Motivation

This seems to be intermittently failing on `main`, seems like compilation is taking longer now making it timeout.

## Proposal

Since this runs only on `main`, we don't particularly care about it finishing quickly, so staying on `ubuntu-latest` seems ideal to reduce costs.
So just increasing the timeout. 

## Test Plan

Merge

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
