### PR TITLE
Add the `cache_key_absence` to the LruCachingConfig.

### DIFF
--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -193,6 +193,7 @@ impl ClientOptions {
             max_concurrent_queries: self.max_concurrent_queries,
             max_stream_queries: self.max_stream_queries,
             cache_size: self.cache_size,
+            cache_key_absence: false,
         }
     }
 

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -350,6 +350,7 @@ impl StorageConfigNamespace {
                 let config = ServiceStoreConfig {
                     inner_config,
                     cache_size: common_config.cache_size,
+                    cache_key_absence: common_config.cache_key_absence,
                 };
                 Ok(StoreConfig::Service(config, namespace))
             }

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -42,6 +42,7 @@ impl RocksDbRunner {
             max_concurrent_queries: config.client.max_concurrent_queries,
             max_stream_queries: config.client.max_stream_queries,
             cache_size: config.client.cache_size,
+            cache_key_absence: false,
         };
         let path_buf = config.client.storage.as_path().to_path_buf();
         let path_with_guard = PathWithGuard::new(path_buf);

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -39,6 +39,7 @@ impl ScyllaDbRunner {
             max_concurrent_queries: config.client.max_concurrent_queries,
             max_stream_queries: config.client.max_stream_queries,
             cache_size: config.client.cache_size,
+            cache_key_absence: false,
         };
         let namespace = config.client.table.clone();
         let root_key = &[];

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -386,6 +386,7 @@ impl ProxyOptions {
             max_concurrent_queries: self.max_concurrent_queries,
             max_stream_queries: self.max_stream_queries,
             cache_size: self.cache_size,
+            cache_key_absence: false,
         };
         let full_storage_config = self.storage_config.add_common_config(common_config).await?;
         let genesis_config: GenesisConfig = util::read_json(&self.genesis_config_path)?;

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -543,6 +543,7 @@ async fn run(options: ServerOptions) {
                 max_concurrent_queries,
                 max_stream_queries,
                 cache_size,
+                cache_key_absence: false,
             };
             let full_storage_config = storage_config
                 .add_common_config(common_config)
@@ -609,6 +610,7 @@ async fn run(options: ServerOptions) {
                 max_concurrent_queries,
                 max_stream_queries,
                 cache_size,
+                cache_key_absence: false,
             };
             let full_storage_config = storage_config
                 .add_common_config(common_config)

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -1205,6 +1205,7 @@ impl DynamoDbStoreConfig {
         DynamoDbStoreConfig {
             inner_config,
             cache_size: common_config.cache_size,
+            cache_key_absence: common_config.cache_key_absence,
         }
     }
 }

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -33,6 +33,7 @@ impl IndexedDbStoreConfig {
             max_concurrent_queries: None,
             max_stream_queries,
             cache_size: 1000,
+            cache_key_absence: false,
         };
         Self { common_config }
     }

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -641,6 +641,7 @@ impl RocksDbStoreConfig {
         RocksDbStoreConfig {
             inner_config,
             cache_size: common_config.cache_size,
+            cache_key_absence: common_config.cache_key_absence,
         }
     }
 }

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -923,6 +923,7 @@ impl ScyllaDbStoreConfig {
         ScyllaDbStoreConfig {
             inner_config,
             cache_size: common_config.cache_size,
+            cache_key_absence: common_config.cache_key_absence,
         }
     }
 }

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -29,6 +29,8 @@ pub struct CommonStoreConfig {
     pub max_stream_queries: usize,
     /// The cache size being used.
     pub cache_size: usize,
+    /// Caching the absence of keys.
+    pub cache_key_absence: bool,
 }
 
 impl CommonStoreConfig {
@@ -47,6 +49,7 @@ impl Default for CommonStoreConfig {
             max_concurrent_queries: None,
             max_stream_queries: 10,
             cache_size: 1000,
+            cache_key_absence: false,
         }
     }
 }

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -20,6 +20,15 @@ use wasm_bindgen_test::wasm_bindgen_test;
 #[cfg(web)]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
+#[cfg(with_dynamodb)]
+use linera_views::dynamo_db::DynamoDbStore;
+#[cfg(with_rocksdb)]
+use linera_views::rocks_db::RocksDbStore;
+#[cfg(with_scylladb)]
+use linera_views::scylla_db::ScyllaDbStore;
+#[cfg(any(with_dynamodb, with_scylladb))]
+use linera_views::test_utils::test_cache_check_absence_admin_test;
+
 #[ignore]
 #[tokio::test]
 async fn test_read_multi_values_memory() {
@@ -31,7 +40,6 @@ async fn test_read_multi_values_memory() {
 #[cfg(with_dynamodb)]
 #[tokio::test]
 async fn test_read_multi_values_dynamo_db() {
-    use linera_views::dynamo_db::DynamoDbStore;
     let config = DynamoDbStore::new_test_config().await.unwrap();
     big_read_multi_values::<DynamoDbStore>(config, 22000000, 1000).await;
 }
@@ -40,7 +48,6 @@ async fn test_read_multi_values_dynamo_db() {
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_read_multi_values_scylla_db() {
-    use linera_views::scylla_db::ScyllaDbStore;
     let config = ScyllaDbStore::new_test_config().await.unwrap();
     big_read_multi_values::<ScyllaDbStore>(config, 22200000, 200).await;
 }
@@ -65,9 +72,7 @@ async fn test_reads_memory() {
 #[tokio::test]
 async fn test_reads_rocks_db() {
     for scenario in get_random_test_scenarios() {
-        let store = linera_views::rocks_db::RocksDbStore::new_test_store()
-            .await
-            .unwrap();
+        let store = RocksDbStore::new_test_store().await.unwrap();
         run_reads(store, scenario).await;
     }
 }
@@ -76,9 +81,7 @@ async fn test_reads_rocks_db() {
 #[tokio::test]
 async fn test_reads_dynamo_db() {
     for scenario in get_random_test_scenarios() {
-        let store = linera_views::dynamo_db::DynamoDbStore::new_test_store()
-            .await
-            .unwrap();
+        let store = DynamoDbStore::new_test_store().await.unwrap();
         run_reads(store, scenario).await;
     }
 }
@@ -87,9 +90,7 @@ async fn test_reads_dynamo_db() {
 #[tokio::test]
 async fn test_reads_scylla_db() {
     for scenario in get_random_test_scenarios() {
-        let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
-            .await
-            .unwrap();
+        let store = ScyllaDbStore::new_test_store().await.unwrap();
         run_reads(store, scenario).await;
     }
 }
@@ -146,27 +147,21 @@ async fn test_key_value_store_view_memory_writes_from_blank() {
 #[cfg(with_rocksdb)]
 #[tokio::test]
 async fn test_rocks_db_writes_from_blank() {
-    let store = linera_views::rocks_db::RocksDbStore::new_test_store()
-        .await
-        .unwrap();
+    let store = RocksDbStore::new_test_store().await.unwrap();
     run_writes_from_blank(&store).await;
 }
 
 #[cfg(with_dynamodb)]
 #[tokio::test]
 async fn test_dynamo_db_writes_from_blank() {
-    let store = linera_views::dynamo_db::DynamoDbStore::new_test_store()
-        .await
-        .unwrap();
+    let store = DynamoDbStore::new_test_store().await.unwrap();
     run_writes_from_blank(&store).await;
 }
 
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_writes_from_blank() {
-    let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
-        .await
-        .unwrap();
+    let store = ScyllaDbStore::new_test_store().await.unwrap();
     run_writes_from_blank(&store).await;
 }
 
@@ -200,18 +195,14 @@ async fn test_big_value_read_write() {
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn scylla_db_tombstone_triggering_test() {
-    let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
-        .await
-        .unwrap();
+    let store = ScyllaDbStore::new_test_store().await.unwrap();
     linera_views::test_utils::tombstone_triggering_test(store).await;
 }
 
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_big_write_read() {
-    let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
-        .await
-        .unwrap();
+    let store = ScyllaDbStore::new_test_store().await.unwrap();
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
     run_big_write_read(store, target_size, value_sizes).await;
@@ -228,9 +219,7 @@ async fn test_memory_big_write_read() {
 #[cfg(with_rocksdb)]
 #[tokio::test]
 async fn test_rocks_db_big_write_read() {
-    let store = linera_views::rocks_db::RocksDbStore::new_test_store()
-        .await
-        .unwrap();
+    let store = RocksDbStore::new_test_store().await.unwrap();
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
     run_big_write_read(store, target_size, value_sizes).await;
@@ -248,9 +237,7 @@ async fn test_indexed_db_big_write_read() {
 #[cfg(with_dynamodb)]
 #[tokio::test]
 async fn test_dynamo_db_big_write_read() {
-    let store = linera_views::dynamo_db::DynamoDbStore::new_test_store()
-        .await
-        .unwrap();
+    let store = DynamoDbStore::new_test_store().await.unwrap();
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
     run_big_write_read(store, target_size, value_sizes).await;
@@ -265,9 +252,7 @@ async fn test_memory_writes_from_state() {
 #[cfg(with_rocksdb)]
 #[tokio::test]
 async fn test_rocks_db_writes_from_state() {
-    let store = linera_views::rocks_db::RocksDbStore::new_test_store()
-        .await
-        .unwrap();
+    let store = RocksDbStore::new_test_store().await.unwrap();
     run_writes_from_state(&store).await;
 }
 
@@ -281,17 +266,25 @@ async fn test_indexed_db_writes_from_state() {
 #[cfg(with_dynamodb)]
 #[tokio::test]
 async fn test_dynamo_db_writes_from_state() {
-    let store = linera_views::dynamo_db::DynamoDbStore::new_test_store()
-        .await
-        .unwrap();
+    let store = DynamoDbStore::new_test_store().await.unwrap();
     run_writes_from_state(&store).await;
 }
 
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_writes_from_state() {
-    let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
-        .await
-        .unwrap();
+    let store = ScyllaDbStore::new_test_store().await.unwrap();
     run_writes_from_state(&store).await;
+}
+
+#[cfg(with_scylladb)]
+#[tokio::test]
+async fn test_scylladb_cache_key_absence() {
+    test_cache_check_absence_admin_test::<ScyllaDbStore>().await
+}
+
+#[cfg(with_dynamodb)]
+#[tokio::test]
+async fn test_dynamodb_cache_key_absence() {
+    test_cache_check_absence_admin_test::<DynamoDbStore>().await
 }

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -132,7 +132,8 @@ impl StateStorage for LruMemoryStorage {
     async fn new() -> Self {
         let store = MemoryStore::new_test_store().await.unwrap();
         let cache_size = 1000;
-        let store = LruCachingStore::new(store, cache_size);
+        let cache_key_absence = true;
+        let store = LruCachingStore::new(store, cache_size, cache_key_absence);
         LruMemoryStorage {
             accessed_chains: BTreeSet::new(),
             store,


### PR DESCRIPTION
## Motivation

The PR on epoch-events revealed that caching absence is creating some problems when another worker is writing data.
The error occurred because one worker had in its cache that a key was absent, then another worker wrote it but since in the cache it was indicating it as absent then it was absent.

## Proposal

The following changes are made:
* Instead of completely disabling the caching of absence, it is added as an option. We have to be realistic, caching is not going to get any simpler.
* The feature `cache_key_absence` is added to the `LruCachingConfig` and to the `CommonStoreConfig`. The default value is false.

The fact that this works is that the values being cached are Blobs which are immutable. 

## Test Plan

The test with `cache_key_absence = true` is added to the `LruMemoryStorage`. But for the other tests, the `cache_key_absence = false` is used.

## Release Plan

In relation to the work on `epoch-event`, fairly important.

## Links

None.