### PR TITLE
`.github/workflows/rust.yml`: use `--diff` with `taplo`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -334,16 +334,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Put lint toolchain file in place
-      run: |
-        ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - name: Install taplo-fmt
-      run: |
-        RUSTFLAGS='' cargo install taplo-cli@0.9.3 --locked
-    - name: Check if Cargo.toml files are sorted
-      run: |
-        taplo fmt --check
+    - name: Install `taplo-cli`
+      run: RUSTFLAGS='' cargo install taplo-cli@0.9.3 --locked
+    - name: Check if `Cargo.toml` files are formatted
+      run: taplo fmt --check --diff
 
   lint-check-for-outdated-readme:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation
Taplo doesn't explain the problem on failure by default, which hurts developer experience.

## Proposal
Pass `--diff` alongside `--check`.  This causes Taplo to tell us what's wrong when checking fails instead of just failing silently.

## Test Plan
CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
