### PR TITLE
Do not pass a root key when calling the method `connect`

### DIFF
--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -49,11 +49,9 @@ where
         let exec_runtime_context =
             TestExecutionRuntimeContext::new(chain_id, ExecutionRuntimeConfig::default());
         let namespace = generate_test_namespace();
-        let root_key = &[];
         let context = MemoryContext::new_for_testing(
             TEST_MEMORY_MAX_STREAM_QUERIES,
             &namespace,
-            root_key,
             exec_runtime_context,
         );
         Self::load(context)

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -116,9 +116,6 @@ pub enum StorageConfig {
     },
 }
 
-/// The `root_key` used at startup before the `clone_with_root_key`.
-const ROOT_KEY: &[u8] = &[0];
-
 impl StorageConfig {
     #[cfg(feature = "rocksdb")]
     pub fn is_rocks_db(&self) -> bool {
@@ -508,22 +505,22 @@ impl StoreConfig {
             }),
             #[cfg(feature = "storage-service")]
             StoreConfig::Service(config, namespace) => {
-                ServiceStoreClient::maybe_create_and_connect(&config, &namespace, ROOT_KEY).await?;
+                ServiceStoreClient::maybe_create_and_connect(&config, &namespace).await?;
                 Ok(())
             }
             #[cfg(feature = "rocksdb")]
             StoreConfig::RocksDb(config, namespace) => {
-                RocksDbStore::maybe_create_and_connect(&config, &namespace, ROOT_KEY).await?;
+                RocksDbStore::maybe_create_and_connect(&config, &namespace).await?;
                 Ok(())
             }
             #[cfg(feature = "dynamodb")]
             StoreConfig::DynamoDb(config, namespace) => {
-                DynamoDbStore::maybe_create_and_connect(&config, &namespace, ROOT_KEY).await?;
+                DynamoDbStore::maybe_create_and_connect(&config, &namespace).await?;
                 Ok(())
             }
             #[cfg(feature = "scylladb")]
             StoreConfig::ScyllaDb(config, namespace) => {
-                ScyllaDbStore::maybe_create_and_connect(&config, &namespace, ROOT_KEY).await?;
+                ScyllaDbStore::maybe_create_and_connect(&config, &namespace).await?;
                 Ok(())
             }
         }
@@ -569,26 +566,22 @@ impl StoreConfig {
             #[cfg(feature = "storage-service")]
             StoreConfig::Service(config, namespace) => {
                 let store =
-                    ServiceStoreClient::maybe_create_and_connect(&config, &namespace, ROOT_KEY)
-                        .await?;
+                    ServiceStoreClient::maybe_create_and_connect(&config, &namespace).await?;
                 list_all_blob_ids(&store).await
             }
             #[cfg(feature = "rocksdb")]
             StoreConfig::RocksDb(config, namespace) => {
-                let store =
-                    RocksDbStore::maybe_create_and_connect(&config, &namespace, ROOT_KEY).await?;
+                let store = RocksDbStore::maybe_create_and_connect(&config, &namespace).await?;
                 list_all_blob_ids(&store).await
             }
             #[cfg(feature = "dynamodb")]
             StoreConfig::DynamoDb(config, namespace) => {
-                let store =
-                    DynamoDbStore::maybe_create_and_connect(&config, &namespace, ROOT_KEY).await?;
+                let store = DynamoDbStore::maybe_create_and_connect(&config, &namespace).await?;
                 list_all_blob_ids(&store).await
             }
             #[cfg(feature = "scylladb")]
             StoreConfig::ScyllaDb(config, namespace) => {
-                let store =
-                    ScyllaDbStore::maybe_create_and_connect(&config, &namespace, ROOT_KEY).await?;
+                let store = ScyllaDbStore::maybe_create_and_connect(&config, &namespace).await?;
                 list_all_blob_ids(&store).await
             }
         }
@@ -648,37 +641,32 @@ where
         StoreConfig::Memory(config, namespace) => {
             let store_config = MemoryStoreConfig::new(config.common_config.max_stream_queries);
             let mut storage =
-                DbStorage::<MemoryStore, _>::new(store_config, &namespace, ROOT_KEY, wasm_runtime)
-                    .await?;
+                DbStorage::<MemoryStore, _>::new(store_config, &namespace, wasm_runtime).await?;
             genesis_config.initialize_storage(&mut storage).await?;
             Ok(job.run(storage).await)
         }
         #[cfg(feature = "storage-service")]
         StoreConfig::Service(config, namespace) => {
             let storage =
-                DbStorage::<ServiceStoreClient, _>::new(config, &namespace, ROOT_KEY, wasm_runtime)
-                    .await?;
+                DbStorage::<ServiceStoreClient, _>::new(config, &namespace, wasm_runtime).await?;
             Ok(job.run(storage).await)
         }
         #[cfg(feature = "rocksdb")]
         StoreConfig::RocksDb(config, namespace) => {
             let storage =
-                DbStorage::<RocksDbStore, _>::new(config, &namespace, ROOT_KEY, wasm_runtime)
-                    .await?;
+                DbStorage::<RocksDbStore, _>::new(config, &namespace, wasm_runtime).await?;
             Ok(job.run(storage).await)
         }
         #[cfg(feature = "dynamodb")]
         StoreConfig::DynamoDb(config, namespace) => {
             let storage =
-                DbStorage::<DynamoDbStore, _>::new(config, &namespace, ROOT_KEY, wasm_runtime)
-                    .await?;
+                DbStorage::<DynamoDbStore, _>::new(config, &namespace, wasm_runtime).await?;
             Ok(job.run(storage).await)
         }
         #[cfg(feature = "scylladb")]
         StoreConfig::ScyllaDb(config, namespace) => {
             let storage =
-                DbStorage::<ScyllaDbStore, _>::new(config, &namespace, ROOT_KEY, wasm_runtime)
-                    .await?;
+                DbStorage::<ScyllaDbStore, _>::new(config, &namespace, wasm_runtime).await?;
             Ok(job.run(storage).await)
         }
     }
@@ -696,49 +684,30 @@ pub async fn full_initialize_storage(
         #[cfg(feature = "storage-service")]
         StoreConfig::Service(config, namespace) => {
             let wasm_runtime = None;
-            let mut storage = DbStorage::<ServiceStoreClient, _>::initialize(
-                config,
-                &namespace,
-                ROOT_KEY,
-                wasm_runtime,
-            )
-            .await?;
+            let mut storage =
+                DbStorage::<ServiceStoreClient, _>::initialize(config, &namespace, wasm_runtime)
+                    .await?;
             Ok(genesis_config.initialize_storage(&mut storage).await?)
         }
         #[cfg(feature = "rocksdb")]
         StoreConfig::RocksDb(config, namespace) => {
             let wasm_runtime = None;
-            let mut storage = DbStorage::<RocksDbStore, _>::initialize(
-                config,
-                &namespace,
-                ROOT_KEY,
-                wasm_runtime,
-            )
-            .await?;
+            let mut storage =
+                DbStorage::<RocksDbStore, _>::initialize(config, &namespace, wasm_runtime).await?;
             Ok(genesis_config.initialize_storage(&mut storage).await?)
         }
         #[cfg(feature = "dynamodb")]
         StoreConfig::DynamoDb(config, namespace) => {
             let wasm_runtime = None;
-            let mut storage = DbStorage::<DynamoDbStore, _>::initialize(
-                config,
-                &namespace,
-                ROOT_KEY,
-                wasm_runtime,
-            )
-            .await?;
+            let mut storage =
+                DbStorage::<DynamoDbStore, _>::initialize(config, &namespace, wasm_runtime).await?;
             Ok(genesis_config.initialize_storage(&mut storage).await?)
         }
         #[cfg(feature = "scylladb")]
         StoreConfig::ScyllaDb(config, namespace) => {
             let wasm_runtime = None;
-            let mut storage = DbStorage::<ScyllaDbStore, _>::initialize(
-                config,
-                &namespace,
-                ROOT_KEY,
-                wasm_runtime,
-            )
-            .await?;
+            let mut storage =
+                DbStorage::<ScyllaDbStore, _>::initialize(config, &namespace, wasm_runtime).await?;
             Ok(genesis_config.initialize_storage(&mut storage).await?)
         }
     }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -1030,15 +1030,10 @@ impl StorageBuilder for MemoryStorageBuilder {
             self.namespace = generate_test_namespace();
         }
         let namespace = format!("{}_{}", self.namespace, self.instance_counter);
-        let root_key = &[];
-        Ok(DbStorage::new_for_testing(
-            config,
-            &namespace,
-            root_key,
-            self.wasm_runtime,
-            self.clock.clone(),
+        Ok(
+            DbStorage::new_for_testing(config, &namespace, self.wasm_runtime, self.clock.clone())
+                .await?,
         )
-        .await?)
     }
 
     fn clock(&self) -> &TestClock {
@@ -1102,15 +1097,10 @@ impl StorageBuilder for RocksDbStorageBuilder {
             self.namespace = generate_test_namespace();
         }
         let namespace = format!("{}_{}", self.namespace, self.instance_counter);
-        let root_key = &[];
-        Ok(DbStorage::new_for_testing(
-            config,
-            &namespace,
-            root_key,
-            self.wasm_runtime,
-            self.clock.clone(),
+        Ok(
+            DbStorage::new_for_testing(config, &namespace, self.wasm_runtime, self.clock.clone())
+                .await?,
         )
-        .await?)
     }
 
     fn clock(&self) -> &TestClock {
@@ -1155,15 +1145,10 @@ impl StorageBuilder for ServiceStorageBuilder {
             self.namespace = generate_test_namespace();
         }
         let namespace = format!("{}_{}", self.namespace, self.instance_counter);
-        let root_key = &[];
-        Ok(DbStorage::new_for_testing(
-            config,
-            &namespace,
-            root_key,
-            self.wasm_runtime,
-            self.clock.clone(),
+        Ok(
+            DbStorage::new_for_testing(config, &namespace, self.wasm_runtime, self.clock.clone())
+                .await?,
         )
-        .await?)
     }
 
     fn clock(&self) -> &TestClock {
@@ -1205,15 +1190,10 @@ impl StorageBuilder for DynamoDbStorageBuilder {
             self.namespace = generate_test_namespace();
         }
         let namespace = format!("{}_{}", self.namespace, self.instance_counter);
-        let root_key = &[];
-        Ok(DbStorage::new_for_testing(
-            config,
-            &namespace,
-            root_key,
-            self.wasm_runtime,
-            self.clock.clone(),
+        Ok(
+            DbStorage::new_for_testing(config, &namespace, self.wasm_runtime, self.clock.clone())
+                .await?,
         )
-        .await?)
     }
 
     fn clock(&self) -> &TestClock {
@@ -1255,15 +1235,10 @@ impl StorageBuilder for ScyllaDbStorageBuilder {
             self.namespace = generate_test_namespace();
         }
         let namespace = format!("{}_{}", self.namespace, self.instance_counter);
-        let root_key = &[];
-        Ok(DbStorage::new_for_testing(
-            config,
-            &namespace,
-            root_key,
-            self.wasm_runtime,
-            self.clock.clone(),
+        Ok(
+            DbStorage::new_for_testing(config, &namespace, self.wasm_runtime, self.clock.clone())
+                .await?,
         )
-        .await?)
     }
 
     fn clock(&self) -> &TestClock {

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3007,11 +3007,9 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     // Make a committee and worker (only used for signing certificates)
     let store_config = MemoryStore::new_test_config().await?;
     let namespace = generate_test_namespace();
-    let root_key = &[];
     let store = DbStorage::<MemoryStore, _>::new_for_testing(
         store_config,
         &namespace,
-        root_key,
         None,
         TestClock::new(),
     )

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -129,13 +129,8 @@ impl SystemExecutionState {
         }
 
         let namespace = generate_test_namespace();
-        let root_key = &[];
-        let context = MemoryContext::new_for_testing(
-            TEST_MEMORY_MAX_STREAM_QUERIES,
-            &namespace,
-            root_key,
-            extra,
-        );
+        let context =
+            MemoryContext::new_for_testing(TEST_MEMORY_MAX_STREAM_QUERIES, &namespace, extra);
         let mut view = ExecutionStateView::load(context)
             .await
             .expect("Loading from memory should work");

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -50,9 +50,7 @@ impl RocksDbRunner {
         let spawn_mode = RocksDbSpawnMode::SpawnBlocking;
         let store_config = RocksDbStoreConfig::new(spawn_mode, path_with_guard, common_config);
         let namespace = config.client.namespace.clone();
-        let root_key = &[];
-        let store =
-            RocksDbStore::maybe_create_and_connect(&store_config, &namespace, root_key).await?;
+        let store = RocksDbStore::maybe_create_and_connect(&store_config, &namespace).await?;
         Self::new(config, store).await
     }
 }

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -41,9 +41,8 @@ impl ScyllaDbRunner {
             cache_size: config.client.cache_size,
         };
         let namespace = config.client.table.clone();
-        let root_key = &[];
         let store_config = ScyllaDbStoreConfig::new(config.client.uri.clone(), common_config);
-        let store = ScyllaDbStore::connect(&store_config, &namespace, root_key).await?;
+        let store = ScyllaDbStore::connect(&store_config, &namespace).await?;
         Self::new(config, store).await
     }
 }

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -209,8 +209,7 @@ async fn main() -> std::io::Result<()> {
 
     let store_config = MemoryStoreConfig::new(TEST_MEMORY_MAX_STREAM_QUERIES);
     let namespace = "schema_export";
-    let root_key = &[];
-    let storage = DbStorage::<MemoryStore, _>::initialize(store_config, namespace, root_key, None)
+    let storage = DbStorage::<MemoryStore, _>::initialize(store_config, namespace, None)
         .await
         .expect("storage");
     let config = ChainListenerConfig::default();

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -415,11 +415,7 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
         "service store".to_string()
     }
 
-    async fn connect(
-        config: &Self::Config,
-        namespace: &str,
-        root_key: &[u8],
-    ) -> Result<Self, ServiceStoreError> {
+    async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, ServiceStoreError> {
         let semaphore = config
             .common_config
             .max_concurrent_queries
@@ -428,7 +424,6 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
         let max_stream_queries = config.common_config.max_stream_queries;
         let mut start_key = vec![KeyPrefix::Key as u8];
         start_key.extend(&namespace);
-        start_key.extend(root_key);
         let prefix_len = namespace.len() + 1;
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
@@ -568,8 +563,7 @@ pub async fn storage_service_check_absence(endpoint: &str) -> Result<bool, Servi
 pub async fn storage_service_check_validity(endpoint: &str) -> Result<(), ServiceStoreError> {
     let config = service_config_from_endpoint(endpoint).unwrap();
     let namespace = "namespace";
-    let root_key = &[];
-    let store = ServiceStoreClientInternal::connect(&config, namespace, root_key).await?;
+    let store = ServiceStoreClientInternal::connect(&config, namespace).await?;
     let _value = store.read_value_bytes(&[42]).await?;
     Ok(())
 }

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -600,11 +600,9 @@ async fn main() {
     let options = <ServiceStoreServerOptions as clap::Parser>::parse();
     let common_config = CommonStoreConfig::default();
     let namespace = "linera_storage_service";
-    let root_key = &[];
     let (store, endpoint) = match options {
         ServiceStoreServerOptions::Memory { endpoint } => {
-            let store =
-                MemoryStore::new(common_config.max_stream_queries, namespace, root_key).unwrap();
+            let store = MemoryStore::new(common_config.max_stream_queries, namespace).unwrap();
             let store = ServiceStoreServerInternal::Memory(store);
             (store, endpoint)
         }
@@ -615,7 +613,7 @@ async fn main() {
             // The server is run in multi-threaded mode so we can use the block_in_place.
             let spawn_mode = RocksDbSpawnMode::get_spawn_mode_from_runtime();
             let config = RocksDbStoreConfig::new(spawn_mode, path_with_guard, common_config);
-            let store = RocksDbStore::maybe_create_and_connect(&config, namespace, root_key)
+            let store = RocksDbStore::maybe_create_and_connect(&config, namespace)
                 .await
                 .expect("store");
             let store = ServiceStoreServerInternal::RocksDb(store);

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -891,20 +891,18 @@ where
     pub async fn initialize(
         config: Store::Config,
         namespace: &str,
-        root_key: &[u8],
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, Store::Error> {
-        let store = Store::maybe_create_and_connect(&config, namespace, root_key).await?;
+        let store = Store::maybe_create_and_connect(&config, namespace).await?;
         Ok(Self::create(store, wasm_runtime, WallClock))
     }
 
     pub async fn new(
         config: Store::Config,
         namespace: &str,
-        root_key: &[u8],
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, Store::Error> {
-        let store = Store::connect(&config, namespace, root_key).await?;
+        let store = Store::connect(&config, namespace).await?;
         Ok(Self::create(store, wasm_runtime, WallClock))
     }
 }
@@ -918,11 +916,9 @@ where
     pub async fn make_test_storage(wasm_runtime: Option<WasmRuntime>) -> Self {
         let config = Store::new_test_config().await.unwrap();
         let namespace = generate_test_namespace();
-        let root_key = &[];
         DbStorage::<Store, TestClock>::new_for_testing(
             config,
             &namespace,
-            root_key,
             wasm_runtime,
             TestClock::new(),
         )
@@ -933,11 +929,10 @@ where
     pub async fn new_for_testing(
         config: Store::Config,
         namespace: &str,
-        root_key: &[u8],
         wasm_runtime: Option<WasmRuntime>,
         clock: TestClock,
     ) -> Result<Self, Store::Error> {
-        let store = Store::recreate_and_connect(&config, namespace, root_key).await?;
+        let store = Store::recreate_and_connect(&config, namespace).await?;
         Ok(Self::create(store, wasm_runtime, clock))
     }
 }

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -242,9 +242,9 @@ impl BatchExt for Batch {
         WRITE_CERTIFICATE_COUNTER.with_label_values(&[]).inc();
         let hash = certificate.hash();
         let cert_key = bcs::to_bytes(&BaseKey::Certificate(hash))?;
-        let value_key = bcs::to_bytes(&BaseKey::ConfirmedBlock(hash))?;
+        let block_key = bcs::to_bytes(&BaseKey::ConfirmedBlock(hash))?;
         self.put_key_value(cert_key.to_vec(), &certificate.lite_certificate())?;
-        self.put_key_value(value_key.to_vec(), certificate.value())?;
+        self.put_key_value(block_key.to_vec(), certificate.value())?;
         Ok(())
     }
 
@@ -545,8 +545,8 @@ where
         &self,
         hash: CryptoHash,
     ) -> Result<Hashed<ConfirmedBlock>, ViewError> {
-        let value_key = bcs::to_bytes(&BaseKey::ConfirmedBlock(hash))?;
-        let maybe_value = self.store.read_value::<ConfirmedBlock>(&value_key).await?;
+        let block_key = bcs::to_bytes(&BaseKey::ConfirmedBlock(hash))?;
+        let maybe_value = self.store.read_value::<ConfirmedBlock>(&block_key).await?;
         #[cfg(with_metrics)]
         READ_HASHED_CONFIRMED_BLOCK_COUNTER
             .with_label_values(&[])
@@ -842,8 +842,8 @@ where
             .iter()
             .flat_map(|hash| {
                 let cert_key = bcs::to_bytes(&BaseKey::Certificate(*hash));
-                let value_key = bcs::to_bytes(&BaseKey::ConfirmedBlock(*hash));
-                vec![cert_key, value_key]
+                let block_key = bcs::to_bytes(&BaseKey::ConfirmedBlock(*hash));
+                vec![cert_key, block_key]
             })
             .collect::<Result<_, _>>()?)
     }

--- a/linera-views/src/backends/dual.rs
+++ b/linera-views/src/backends/dual.rs
@@ -244,18 +244,14 @@ where
         format!("dual {} and {}", S1::get_name(), S2::get_name())
     }
 
-    async fn connect(
-        config: &Self::Config,
-        namespace: &str,
-        root_key: &[u8],
-    ) -> Result<Self, Self::Error> {
-        let first_store = S1::connect(&config.first_config, namespace, root_key)
+    async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, Self::Error> {
+        let first_store = S1::connect(&config.first_config, namespace)
             .await
             .map_err(DualStoreError::First)?;
-        let second_store = S2::connect(&config.second_config, namespace, root_key)
+        let second_store = S2::connect(&config.second_config, namespace)
             .await
             .map_err(DualStoreError::Second)?;
-        let store_in_use = A::assigned_store(root_key)?;
+        let store_in_use = A::assigned_store(&[])?;
         Ok(Self {
             first_store,
             second_store,

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -351,7 +351,6 @@ impl AdminKeyValueStore for DynamoDbStoreInternal {
     async fn connect(
         config: &Self::Config,
         namespace: &str,
-        root_key: &[u8],
     ) -> Result<Self, DynamoDbStoreInternalError> {
         Self::check_namespace(namespace)?;
         let client = config.client().await?;
@@ -361,7 +360,7 @@ impl AdminKeyValueStore for DynamoDbStoreInternal {
             .map(|n| Arc::new(Semaphore::new(n)));
         let max_stream_queries = config.common_config.max_stream_queries;
         let namespace = namespace.to_string();
-        let start_key = extend_root_key(root_key);
+        let start_key = extend_root_key(&[]);
         let store = Self {
             client,
             namespace,
@@ -416,7 +415,7 @@ impl AdminKeyValueStore for DynamoDbStoreInternal {
         config: &Self::Config,
         namespace: &str,
     ) -> Result<Vec<Vec<u8>>, DynamoDbStoreInternalError> {
-        let mut store = Self::connect(config, namespace, &[]).await?;
+        let mut store = Self::connect(config, namespace).await?;
         store.start_key = PARTITION_KEY_ROOT_KEY.to_vec();
 
         let keys = store.find_keys_by_prefix(EMPTY_ROOT_KEY).await?;

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -272,13 +272,8 @@ impl LocalAdminKeyValueStore for IndexedDbStore {
         "indexed db".to_string()
     }
 
-    async fn connect(
-        config: &Self::Config,
-        namespace: &str,
-        root_key: &[u8],
-    ) -> Result<Self, IndexedDbStoreError> {
-        let mut start_key = ROOT_KEY_DOMAIN.to_vec();
-        start_key.extend(root_key);
+    async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, IndexedDbStoreError> {
+        let start_key = ROOT_KEY_DOMAIN.to_vec();
         Self::connect_internal(config, namespace, start_key).await
     }
 
@@ -297,8 +292,7 @@ impl LocalAdminKeyValueStore for IndexedDbStore {
     }
 
     async fn list_all(config: &Self::Config) -> Result<Vec<String>, IndexedDbStoreError> {
-        let root_key = &[];
-        Ok(Self::connect(config, "", root_key)
+        Ok(Self::connect(config, "")
             .await?
             .database
             .object_store_names()
@@ -315,8 +309,7 @@ impl LocalAdminKeyValueStore for IndexedDbStore {
     }
 
     async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, IndexedDbStoreError> {
-        let root_key = &[];
-        Ok(Self::connect(config, "", root_key)
+        Ok(Self::connect(config, "")
             .await?
             .database
             .object_store_names()
@@ -324,8 +317,7 @@ impl LocalAdminKeyValueStore for IndexedDbStore {
     }
 
     async fn create(config: &Self::Config, namespace: &str) -> Result<(), IndexedDbStoreError> {
-        let root_key = &[];
-        Self::connect(config, "", root_key)
+        Self::connect(config, "")
             .await?
             .database
             .create_object_store(namespace)?;
@@ -333,8 +325,7 @@ impl LocalAdminKeyValueStore for IndexedDbStore {
     }
 
     async fn delete(config: &Self::Config, namespace: &str) -> Result<(), IndexedDbStoreError> {
-        let root_key = &[];
-        Ok(Self::connect(config, "", root_key)
+        Ok(Self::connect(config, "")
             .await?
             .database
             .delete_object_store(namespace)?)
@@ -352,10 +343,7 @@ mod testing {
     ) -> IndexedDbStore {
         let config = IndexedDbStoreConfig::new(max_stream_queries);
         let namespace = generate_test_namespace();
-        let root_key = &[];
-        IndexedDbStore::connect(&config, &namespace, root_key)
-            .await
-            .unwrap()
+        IndexedDbStore::connect(&config, &namespace).await.unwrap()
     }
 
     /// Creates a test IndexedDB store for working.

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -182,12 +182,8 @@ where
         format!("journaling {}", K::get_name())
     }
 
-    async fn connect(
-        config: &Self::Config,
-        namespace: &str,
-        root_key: &[u8],
-    ) -> Result<Self, Self::Error> {
-        let store = K::connect(config, namespace, root_key).await?;
+    async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, Self::Error> {
+        let store = K::connect(config, namespace).await?;
         Ok(Self { store })
     }
 

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -294,12 +294,8 @@ where
         format!("lru caching {}", K::get_name())
     }
 
-    async fn connect(
-        config: &Self::Config,
-        namespace: &str,
-        root_key: &[u8],
-    ) -> Result<Self, Self::Error> {
-        let store = K::connect(&config.inner_config, namespace, root_key).await?;
+    async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, Self::Error> {
+        let store = K::connect(&config.inner_config, namespace).await?;
         let cache_size = config.cache_size;
         Ok(LruCachingStore::new(store, cache_size))
     }

--- a/linera-views/src/backends/metering.rs
+++ b/linera-views/src/backends/metering.rs
@@ -446,15 +446,11 @@ where
         K::get_name()
     }
 
-    async fn connect(
-        config: &Self::Config,
-        namespace: &str,
-        root_key: &[u8],
-    ) -> Result<Self, Self::Error> {
+    async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, Self::Error> {
         let name = K::get_name();
         let counter = get_counter(&name);
         let _latency = counter.connect_latency.measure_latency();
-        let store = K::connect(config, namespace, root_key).await?;
+        let store = K::connect(config, namespace).await?;
         let counter = get_counter(&name);
         Ok(Self { counter, store })
     }

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -435,10 +435,8 @@ impl AdminKeyValueStore for RocksDbStoreInternal {
     async fn connect(
         config: &Self::Config,
         namespace: &str,
-        root_key: &[u8],
     ) -> Result<Self, RocksDbStoreInternalError> {
-        let mut start_key = ROOT_KEY_DOMAIN.to_vec();
-        start_key.extend(root_key);
+        let start_key = ROOT_KEY_DOMAIN.to_vec();
         RocksDbStoreInternal::build(config, namespace, start_key)
     }
 

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -644,7 +644,6 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
     async fn connect(
         config: &Self::Config,
         namespace: &str,
-        root_key: &[u8],
     ) -> Result<Self, ScyllaDbStoreInternalError> {
         Self::check_namespace(namespace)?;
         let session = SessionBuilder::new()
@@ -659,7 +658,7 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
             .max_concurrent_queries
             .map(|n| Arc::new(Semaphore::new(n)));
         let max_stream_queries = config.common_config.max_stream_queries;
-        let root_key = get_big_root_key(root_key);
+        let root_key = get_big_root_key(&[]);
         Ok(Self {
             store,
             semaphore,

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -289,12 +289,8 @@ where
         format!("value splitting {}", K::get_name())
     }
 
-    async fn connect(
-        config: &Self::Config,
-        namespace: &str,
-        root_key: &[u8],
-    ) -> Result<Self, Self::Error> {
-        let store = K::connect(config, namespace, root_key).await?;
+    async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, Self::Error> {
+        let store = K::connect(config, namespace).await?;
         Ok(Self { store })
     }
 
@@ -475,10 +471,8 @@ impl LimitedTestMemoryStore {
     /// Creates a `LimitedTestMemoryStore`
     pub fn new() -> Self {
         let namespace = generate_test_namespace();
-        let root_key = &[];
         let store =
-            MemoryStore::new_for_testing(TEST_MEMORY_MAX_STREAM_QUERIES, &namespace, root_key)
-                .unwrap();
+            MemoryStore::new_for_testing(TEST_MEMORY_MAX_STREAM_QUERIES, &namespace).unwrap();
         LimitedTestMemoryStore { store }
     }
 }

--- a/linera-views/src/context.rs
+++ b/linera-views/src/context.rs
@@ -277,11 +277,9 @@ pub type MemoryContext<E> = ViewContext<E, MemoryStore>;
 #[cfg(with_testing)]
 pub fn create_test_memory_context() -> MemoryContext<()> {
     let namespace = crate::random::generate_test_namespace();
-    let root_key = &[];
     MemoryContext::new_for_testing(
         crate::memory::TEST_MEMORY_MAX_STREAM_QUERIES,
         &namespace,
-        root_key,
         (),
     )
 }
@@ -289,13 +287,8 @@ pub fn create_test_memory_context() -> MemoryContext<()> {
 impl<E> MemoryContext<E> {
     /// Creates a [`Context`] instance in memory for testing.
     #[cfg(with_testing)]
-    pub fn new_for_testing(
-        max_stream_queries: usize,
-        namespace: &str,
-        root_key: &[u8],
-        extra: E,
-    ) -> Self {
-        let store = MemoryStore::new_for_testing(max_stream_queries, namespace, root_key).unwrap();
+    pub fn new_for_testing(max_stream_queries: usize, namespace: &str, extra: E) -> Self {
+        let store = MemoryStore::new_for_testing(max_stream_queries, namespace).unwrap();
         let base_key = Vec::new();
         Self {
             store,

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -167,11 +167,7 @@ pub trait LocalAdminKeyValueStore: WithError + Sized {
     fn get_name() -> String;
 
     /// Connects to an existing namespace using the given configuration.
-    async fn connect(
-        config: &Self::Config,
-        namespace: &str,
-        root_key: &[u8],
-    ) -> Result<Self, Self::Error>;
+    async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, Self::Error>;
 
     /// Takes a connection and creates a new one with a different `root_key`.
     fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, Self::Error>;
@@ -210,13 +206,12 @@ pub trait LocalAdminKeyValueStore: WithError + Sized {
     fn maybe_create_and_connect(
         config: &Self::Config,
         namespace: &str,
-        root_key: &[u8],
     ) -> impl Future<Output = Result<Self, Self::Error>> {
         async {
             if !Self::exists(config, namespace).await? {
                 Self::create(config, namespace).await?;
             }
-            Self::connect(config, namespace, root_key).await
+            Self::connect(config, namespace).await
         }
     }
 
@@ -224,14 +219,13 @@ pub trait LocalAdminKeyValueStore: WithError + Sized {
     fn recreate_and_connect(
         config: &Self::Config,
         namespace: &str,
-        root_key: &[u8],
     ) -> impl Future<Output = Result<Self, Self::Error>> {
         async {
             if Self::exists(config, namespace).await? {
                 Self::delete(config, namespace).await?;
             }
             Self::create(config, namespace).await?;
-            Self::connect(config, namespace, root_key).await
+            Self::connect(config, namespace).await
         }
     }
 }
@@ -286,8 +280,7 @@ pub trait TestKeyValueStore: KeyValueStore {
         async {
             let config = Self::new_test_config().await?;
             let namespace = generate_test_namespace();
-            let root_key = &[];
-            Self::recreate_and_connect(&config, &namespace, root_key).await
+            Self::recreate_and_connect(&config, &namespace).await
         }
     }
 }

--- a/linera-views/src/views/unit_tests/views.rs
+++ b/linera-views/src/views/unit_tests/views.rs
@@ -216,8 +216,7 @@ impl TestContextFactory for RocksDbContextFactory {
     async fn new_context(&mut self) -> Result<Self::Context, anyhow::Error> {
         let config = RocksDbStore::new_test_config().await?;
         let namespace = generate_test_namespace();
-        let root_key = &[];
-        let store = RocksDbStore::recreate_and_connect(&config, &namespace, root_key).await?;
+        let store = RocksDbStore::recreate_and_connect(&config, &namespace).await?;
         let context = ViewContext::create_root_context(store, ()).await?;
 
         Ok(context)
@@ -235,8 +234,7 @@ impl TestContextFactory for DynamoDbContextFactory {
     async fn new_context(&mut self) -> Result<Self::Context, anyhow::Error> {
         let config = DynamoDbStore::new_test_config().await?;
         let namespace = generate_test_namespace();
-        let root_key = &[];
-        let store = DynamoDbStore::recreate_and_connect(&config, &namespace, root_key).await?;
+        let store = DynamoDbStore::recreate_and_connect(&config, &namespace).await?;
         Ok(ViewContext::create_root_context(store, ()).await?)
     }
 }
@@ -252,8 +250,7 @@ impl TestContextFactory for ScyllaDbContextFactory {
     async fn new_context(&mut self) -> Result<Self::Context, anyhow::Error> {
         let config = ScyllaDbStore::new_test_config().await?;
         let namespace = generate_test_namespace();
-        let root_key = &[];
-        let store = ScyllaDbStore::recreate_and_connect(&config, &namespace, root_key).await?;
+        let store = ScyllaDbStore::recreate_and_connect(&config, &namespace).await?;
         let context = ViewContext::create_root_context(store, ()).await?;
         Ok(context)
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,1 +1,1 @@
-toolchains/stable/rust-toolchain.toml
+toolchains/nightly/rust-toolchain.toml


### PR DESCRIPTION
## Motivation

* First step in distinguishing immutable shared data from root views
* Simplify code

## Proposal

Do not pass a root key when calling the method `connect`.

The current code will use the empty vector, but this could also change later to enforce a separation between the locked mode (with root key -- for root views) and the default mode (no root key -- for blobs).

## Test Plan

CI
