### PR TITLE
Fix blob storage

### DIFF
--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -45,7 +45,7 @@ pub enum JournalConsistencyError {
     #[error("The journal block could not be retrieved, it could be missing or corrupted.")]
     FailureToRetrieveJournalBlock,
 
-    #[error("Refusing to use the journal with exclusive database access to the root object.")]
+    #[error("Refusing to use the journal without exclusive database access to the root object.")]
     JournalRequiresExclusiveAccess,
 }
 

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -40,10 +40,13 @@ sa::const_assert!(JOURNAL_TAG < MIN_VIEW_TAG);
 
 /// Data type indicating that the database is not consistent
 #[derive(Error, Debug)]
+#[allow(missing_docs)]
 pub enum JournalConsistencyError {
-    /// The journal block could not be retrieved, it could be missing or corrupted
-    #[error("the journal block could not be retrieved, it could be missing or corrupted")]
+    #[error("The journal block could not be retrieved, it could be missing or corrupted.")]
     FailureToRetrieveJournalBlock,
+
+    #[error("Refusing to use the journal with exclusive database access to the root object.")]
+    JournalRequiresExclusiveAccess,
 }
 
 #[repr(u8)]
@@ -102,6 +105,8 @@ struct JournalHeader {
 pub struct JournalingKeyValueStore<K> {
     /// The inner store.
     store: K,
+    /// Whether we have exclusive R/W access to the keys under root key.
+    has_exclusive_access: bool,
 }
 
 impl<K> DeletePrefixExpander for &JournalingKeyValueStore<K>
@@ -184,12 +189,18 @@ where
 
     async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, Self::Error> {
         let store = K::connect(config, namespace).await?;
-        Ok(Self { store })
+        Ok(Self {
+            store,
+            has_exclusive_access: false,
+        })
     }
 
     fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, Self::Error> {
         let store = self.store.clone_with_root_key(root_key)?;
-        Ok(Self { store })
+        Ok(Self {
+            store,
+            has_exclusive_access: true,
+        })
     }
 
     async fn list_all(config: &Self::Config) -> Result<Vec<String>, Self::Error> {
@@ -233,6 +244,9 @@ where
         if Self::is_fastpath_feasible(&batch) {
             self.store.write_batch(batch).await
         } else {
+            if !self.has_exclusive_access {
+                return Err(JournalConsistencyError::JournalRequiresExclusiveAccess.into());
+            }
             let header = self.write_journal(batch).await?;
             self.coherently_resolve_journal(header).await
         }
@@ -406,6 +420,9 @@ where
 impl<K> JournalingKeyValueStore<K> {
     /// Creates a new journaling store.
     pub fn new(store: K) -> Self {
-        Self { store }
+        Self {
+            store,
+            has_exclusive_access: false,
+        }
     }
 }

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -397,12 +397,9 @@ impl<K> LruCachingStore<K> {
 
     /// Sets the value `has_exclusive_access` to `true`, if applicable.
     pub fn enable_exclusive_access(&self) {
-        match &self.lru_read_values {
-            None => (),
-            Some(lru_read_values) => {
-                let mut lru_read_values = lru_read_values.lock().unwrap();
-                lru_read_values.has_exclusive_access = true;
-            }
+        if let Some(lru_read_values) = &self.lru_read_values {
+            let mut lru_read_values = lru_read_values.lock().unwrap();
+            lru_read_values.has_exclusive_access = true;
         }
     }
 }

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -64,6 +64,7 @@ impl<'a> LruPrefixCache {
         if value.is_none() && !self.has_exclusive_access {
             // Just forget about the entry.
             self.map.remove(&key);
+            self.queue.remove(&key);
             return;
         }
         match self.map.entry(key.clone()) {
@@ -100,6 +101,7 @@ impl<'a> LruPrefixCache {
             }
             for key in keys {
                 self.map.remove(&key);
+                self.queue.remove(&key);
             }
         }
     }

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -38,7 +38,7 @@ static NUM_CACHE_SUCCESS: LazyLock<IntCounterVec> =
 
 /// Stores the data for simple `read_values` queries.
 ///
-/// This data-structure is inspired by the crate `lru-cache` but was modified to support
+/// This data structure is inspired by the crate `lru-cache` but was modified to support
 /// range deletions.
 struct LruPrefixCache {
     map: BTreeMap<Vec<u8>, Option<Vec<u8>>>,

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -36,15 +36,10 @@ static NUM_CACHE_FAULT: LazyLock<IntCounterVec> =
 static NUM_CACHE_SUCCESS: LazyLock<IntCounterVec> =
     LazyLock::new(|| register_int_counter_vec("num_cache_success", "Number of cache success", &[]));
 
-/// The `LruPrefixCache` stores the data for simple `read_values` queries
-/// It is inspired by the crate `lru-cache`.
+/// Stores the data for simple `read_values` queries.
 ///
-/// We cannot apply this crate directly because the batch operation
-/// need to update the cache. In the case of `DeletePrefix` we have to
-/// handle the keys by prefixes. And so we need to have a `BTreeMap` to
-/// keep track of this.
-
-/// The data structures
+/// This data-structure is inspired by the crate `lru-cache` but was modified to support
+/// range deletions.
 struct LruPrefixCache {
     map: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
     queue: LinkedHashMap<Vec<u8>, (), RandomState>,

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -427,6 +427,7 @@ pub async fn big_read_multi_values<C: LocalKeyValueStore>(
     let mut rng = make_deterministic_rng();
     let namespace = generate_test_namespace();
     let store = C::recreate_and_connect(&config, &namespace).await.unwrap();
+    let store = store.clone_with_root_key(&[]).unwrap();
     let key_prefix = vec![42, 54];
     let mut batch = Batch::new();
     let mut keys = Vec::new();
@@ -442,6 +443,7 @@ pub async fn big_read_multi_values<C: LocalKeyValueStore>(
     store.write_batch(batch).await.unwrap();
     // We reconnect so that the read is not using the cache.
     let store = C::connect(&config, &namespace).await.unwrap();
+    let store = store.clone_with_root_key(&[]).unwrap();
     let values_read = store.read_multi_values_bytes(keys).await.unwrap();
     assert_eq!(values, values_read);
 }

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -102,7 +102,7 @@ async fn test_reads_scylla_db() {
 
 #[cfg(with_scylladb)]
 #[tokio::test]
-async fn test_reads_scylla_db_no_journaling() {
+async fn test_reads_scylla_db_no_root_key() {
     for scenario in get_random_test_scenarios() {
         let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
             .await

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -217,18 +217,24 @@ async fn test_big_value_read_write() {
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn scylla_db_tombstone_triggering_test() {
+    use linera_views::store::AdminKeyValueStore as _;
+
     let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
         .await
         .unwrap();
+    let store = store.clone_with_root_key(&[]).unwrap();
     linera_views::test_utils::tombstone_triggering_test(store).await;
 }
 
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_big_write_read() {
+    use linera_views::store::AdminKeyValueStore as _;
+
     let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
         .await
         .unwrap();
+    let store = store.clone_with_root_key(&[]).unwrap();
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
     run_big_write_read(store, target_size, value_sizes).await;
@@ -265,9 +271,12 @@ async fn test_indexed_db_big_write_read() {
 #[cfg(with_dynamodb)]
 #[tokio::test]
 async fn test_dynamo_db_big_write_read() {
+    use linera_views::store::AdminKeyValueStore as _;
+
     let store = linera_views::dynamo_db::DynamoDbStore::new_test_store()
         .await
         .unwrap();
+    let store = store.clone_with_root_key(&[]).unwrap();
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
     run_big_write_read(store, target_size, value_sizes).await;

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -75,10 +75,13 @@ async fn test_reads_rocks_db() {
 #[cfg(with_dynamodb)]
 #[tokio::test]
 async fn test_reads_dynamo_db() {
+    use linera_views::store::AdminKeyValueStore as _;
+
     for scenario in get_random_test_scenarios() {
         let store = linera_views::dynamo_db::DynamoDbStore::new_test_store()
             .await
             .unwrap();
+        let store = store.clone_with_root_key(&[]).unwrap();
         run_reads(store, scenario).await;
     }
 }
@@ -86,6 +89,20 @@ async fn test_reads_dynamo_db() {
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_reads_scylla_db() {
+    use linera_views::store::AdminKeyValueStore as _;
+
+    for scenario in get_random_test_scenarios() {
+        let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
+            .await
+            .unwrap();
+        let store = store.clone_with_root_key(&[]).unwrap();
+        run_reads(store, scenario).await;
+    }
+}
+
+#[cfg(with_scylladb)]
+#[tokio::test]
+async fn test_reads_scylla_db_no_journaling() {
     for scenario in get_random_test_scenarios() {
         let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
             .await


### PR DESCRIPTION
## Motivation

* As noted by @MathieuDutSik in #3496, LRU-caching is incorrect outside views.
* However, journaling outside of views is also incorrect

## Proposal

On top of #3501, we simply deactivate the features that require exclusive access to an object in storage.
* Journaling is not authorized.
* LRU cache should never insert `None` but instead forget about the deleted key. (Not that we delete blobs but who knows in the future.)

We may want to rename `connect` and `clone_with_root_keys` later in another PR.

## Test Plan

* CI
* Verified that this solves the issue with #3453

## Release Plan

In principle, this chould be backported to the latest `testnet` branch.
