### PR TITLE
Support custom `ResourceControlPolicy` in integration tests

### DIFF
--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -380,4 +380,9 @@ impl Committee {
     pub fn policy(&self) -> &ResourceControlPolicy {
         &self.policy
     }
+
+    /// Returns a mutable reference to this committee's [`ResourceControlPolicy`].
+    pub fn policy_mut(&mut self) -> &mut ResourceControlPolicy {
+        &mut self.policy
+    }
 }

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -19,6 +19,7 @@ use linera_chain::{
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
 };
 use linera_execution::{
+    committee::Epoch,
     system::{Recipient, SystemChannel, SystemOperation},
     Operation,
 };
@@ -48,6 +49,7 @@ impl BlockBuilder {
     pub(crate) fn new(
         chain_id: ChainId,
         owner: Owner,
+        epoch: Epoch,
         previous_block: Option<&ConfirmedBlockCertificate>,
         validator: TestValidator,
     ) -> Self {
@@ -64,7 +66,7 @@ impl BlockBuilder {
 
         BlockBuilder {
             block: ProposedBlock {
-                epoch: 0.into(),
+                epoch,
                 chain_id,
                 incoming_bundles: vec![],
                 operations: vec![],

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -226,7 +226,8 @@ impl BlockBuilder {
             Round::Fast,
             self.validator.key_pair(),
         );
-        let mut builder = SignatureAggregator::new(value, Round::Fast, self.validator.committee());
+        let committee = self.validator.committee().await;
+        let mut builder = SignatureAggregator::new(value, Round::Fast, &committee);
         let certificate = builder
             .append(vote.public_key, vote.signature)
             .expect("Failed to sign block")

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -259,6 +259,7 @@ impl ActiveChain {
         let mut block = BlockBuilder::new(
             self.description.into(),
             self.key_pair.public().into(),
+            self.epoch().await,
             tip.as_ref(),
             self.validator.clone(),
         );

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -22,6 +22,7 @@ use linera_base::{
 use linera_chain::{types::ConfirmedBlockCertificate, ChainError, ChainExecutionContext};
 use linera_core::{data_types::ChainInfoQuery, worker::WorkerError};
 use linera_execution::{
+    committee::Epoch,
     system::{
         SystemExecutionError, SystemOperation, SystemQuery, SystemResponse,
         CREATE_APPLICATION_MESSAGE_INDEX,
@@ -91,6 +92,20 @@ impl ActiveChain {
     /// Sets the [`AccountSecretKey`] to use for signing new blocks.
     pub fn set_key_pair(&mut self, key_pair: AccountSecretKey) {
         self.key_pair = key_pair
+    }
+
+    /// Returns the current [`Epoch`] the chain is in.
+    pub async fn epoch(&self) -> Epoch {
+        self.validator
+            .worker()
+            .chain_state_view(self.id())
+            .await
+            .expect("Failed to load chain")
+            .execution_state
+            .system
+            .epoch
+            .get()
+            .expect("Active chains should be in an epoch")
     }
 
     /// Reads the current shared balance available to all of the owners of this microchain.

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -9,7 +9,10 @@
 use std::{num::NonZeroUsize, sync::Arc};
 
 use dashmap::DashMap;
-use futures::FutureExt as _;
+use futures::{
+    lock::{MappedMutexGuard, Mutex, MutexGuard},
+    FutureExt as _,
+};
 use linera_base::{
     crypto::{AccountSecretKey, ValidatorKeypair, ValidatorSecretKey},
     data_types::{Amount, ApplicationPermissions, Timestamp},
@@ -45,7 +48,7 @@ use crate::ContractAbi;
 pub struct TestValidator {
     validator_secret: ValidatorSecretKey,
     account_secret: AccountSecretKey,
-    committee: Committee,
+    committee: Arc<Mutex<(Epoch, Committee)>>,
     storage: DbStorage<MemoryStore, TestClock>,
     worker: WorkerState<DbStorage<MemoryStore, TestClock>>,
     clock: TestClock,
@@ -71,10 +74,13 @@ impl TestValidator {
     pub async fn new() -> Self {
         let validator_keypair = ValidatorKeypair::generate();
         let account_secret = AccountSecretKey::generate();
-        let committee = Committee::make_simple(vec![(
-            validator_keypair.public_key,
-            account_secret.public(),
-        )]);
+        let committee = Arc::new(Mutex::new((
+            Epoch::ZERO,
+            Committee::make_simple(vec![(
+                validator_keypair.public_key,
+                account_secret.public(),
+            )]),
+        )));
         let wasm_runtime = Some(WasmRuntime::default());
         let storage = DbStorage::<MemoryStore, _>::make_test_storage(wasm_runtime)
             .now_or_never()
@@ -166,11 +172,11 @@ impl TestValidator {
         &self.validator_secret
     }
 
-    /// Returns the committee that this test validator is part of.
+    /// Returns the latest committee that this test validator is part of.
     ///
     /// The committee contains only this validator.
-    pub fn committee(&self) -> &Committee {
-        &self.committee
+    pub async fn committee(&self) -> MappedMutexGuard<'_, (Epoch, Committee), Committee> {
+        MutexGuard::map(self.committee.lock().await, |(_epoch, committee)| committee)
     }
 
     /// Creates a new microchain and returns the [`ActiveChain`] that can be used to add blocks to
@@ -199,13 +205,13 @@ impl TestValidator {
             .get(&admin_id)
             .expect("Admin chain should be created when the `TestValidator` is constructed");
 
+        let (epoch, committee) = self.committee.lock().await.clone();
+
         let new_chain_config = OpenChainConfig {
             ownership: ChainOwnership::single(owner),
-            committees: [(Epoch::ZERO, self.committee.clone())]
-                .into_iter()
-                .collect(),
+            committees: [(epoch, committee)].into_iter().collect(),
             admin_id,
-            epoch: Epoch::ZERO,
+            epoch,
             balance: Amount::ZERO,
             application_permissions: ApplicationPermissions::default(),
         };
@@ -233,11 +239,12 @@ impl TestValidator {
     async fn create_admin_chain(&self) {
         let key_pair = AccountSecretKey::generate();
         let description = ChainDescription::Root(0);
+        let committee = self.committee.lock().await.1.clone();
 
         self.worker()
             .storage_client()
             .create_chain(
-                self.committee.clone(),
+                committee,
                 ChainId::root(0),
                 description,
                 key_pair.public().into(),


### PR DESCRIPTION
## Motivation

In integration tests, the `ResourceControlPolicy` was hardcoded to use the default value. With the addition of an HTTP allow list (#3427), the tests aren't able to test any HTTP requests.

## Proposal

Allow changing the `ResourceControlPolicy` used inside a test, allowing to add hosts to the allow list. For the policy change to work, a new committee and epoch must be published. Therefore the epoch and committee can't be assumed to be constant anymore.

## Test Plan

Wrote some (upcoming) tests that try to perform an HTTP request without changing the policy and after adding the host to the policy, and ensured that the former fails while the latter succeeds.

## Release Plan

- These changes follow the usual release cycle, because this will help with tests that use a feature that has not yet been released.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
