### PR TITLE
Simplify testing GraphGL mutations in integration tests

### DIFF
--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -6,6 +6,7 @@
 //! Helps with the construction of blocks, adding operations and
 
 use linera_base::{
+    abi::ContractAbi,
     data_types::{Amount, ApplicationPermissions, Round, Timestamp},
     hashed::Hashed,
     identifiers::{ApplicationId, ChainId, ChannelFullName, GenericApplicationId, Owner},
@@ -147,8 +148,11 @@ impl BlockBuilder {
     pub fn with_operation<Abi>(
         &mut self,
         application_id: ApplicationId<Abi>,
-        operation: impl ToBcsBytes,
-    ) -> &mut Self {
+        operation: Abi::Operation,
+    ) -> &mut Self
+    where
+        Abi: ContractAbi,
+    {
         self.block.operations.push(Operation::User {
             application_id: application_id.forget_abi(),
             bytes: operation

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -153,11 +153,23 @@ impl BlockBuilder {
     where
         Abi: ContractAbi,
     {
-        self.block.operations.push(Operation::User {
-            application_id: application_id.forget_abi(),
-            bytes: operation
+        self.with_raw_operation(
+            application_id.forget_abi(),
+            operation
                 .to_bcs_bytes()
                 .expect("Failed to serialize operation"),
+        )
+    }
+
+    /// Adds an already serialized user `operation` to this block.
+    pub fn with_raw_operation(
+        &mut self,
+        application_id: ApplicationId,
+        operation: impl Into<Vec<u8>>,
+    ) -> &mut Self {
+        self.block.operations.push(Operation::User {
+            application_id,
+            bytes: operation.into(),
         });
         self
     }

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -26,7 +26,7 @@ use linera_execution::{
         SystemExecutionError, SystemOperation, SystemQuery, SystemResponse,
         CREATE_APPLICATION_MESSAGE_INDEX,
     },
-    ExecutionError, Query, QueryOutcome, QueryResponse,
+    ExecutionError, Operation, Query, QueryOutcome, QueryResponse,
 };
 use linera_storage::Storage as _;
 use serde::Serialize;
@@ -645,5 +645,37 @@ impl ActiveChain {
             response: json_response,
             operations,
         }
+    }
+
+    /// Executes a GraphQL `mutation` on an `application` and proposes a block with the resulting
+    /// scheduled operations.
+    ///
+    /// Returns the certificate of the new block.
+    pub async fn graphql_mutation<Abi>(
+        &self,
+        application_id: ApplicationId<Abi>,
+        query: impl Into<async_graphql::Request>,
+    ) -> ConfirmedBlockCertificate
+    where
+        Abi: ServiceAbi<Query = async_graphql::Request, QueryResponse = async_graphql::Response>,
+    {
+        let QueryOutcome { operations, .. } = self.graphql_query(application_id, query).await;
+
+        self.add_block(|block| {
+            for operation in operations {
+                match operation {
+                    Operation::User {
+                        application_id,
+                        bytes,
+                    } => {
+                        block.with_raw_operation(application_id, bytes);
+                    }
+                    Operation::System(system_operation) => {
+                        block.with_system_operation(system_operation);
+                    }
+                }
+            }
+        })
+        .await
     }
 }


### PR DESCRIPTION
## Motivation

It is useful in integration tests to test the flow from a service mutation up to the contract execution. This could be done previously by calling `graphql_query` and then manually adding a new block. However, this had some limitations, as for example if the service called another service which created an operation for the called application could not easily be added.

Also, given how frequent GraphQL mutations are used in applications, it makes sense to make testing it as seamless as possible.

## Proposal

Add an `ActiveChain::graphql_mutation` helper method, which queries the service and attempts to create a block with the scheduled operations.

## Test Plan

Tested manually in some upcoming integration tests for HTTP requests.

## Release Plan

- These changes follow the usual release cycle, because they contain non-breaking new features.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
