### PR TITLE
Refactor how outgoing messages are exported by linera-execution

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -14,14 +14,14 @@ use linera_base::{
     hashed::Hashed,
     identifiers::{BlobId, ChainId, MessageId, Owner},
 };
-use linera_execution::{committee::Epoch, BlobState, Operation};
+use linera_execution::{committee::Epoch, BlobState, Operation, OutgoingMessage};
 use serde::{ser::SerializeStruct, Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
     data_types::{
         BlockExecutionOutcome, ExecutedBlock, IncomingBundle, Medium, MessageBundle,
-        OutgoingMessage, ProposedBlock,
+        OutgoingMessageExt, ProposedBlock,
     },
     types::CertificateValue,
     ChainError,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -1143,7 +1143,7 @@ where
         lift: F,
         messages: &mut Vec<OutgoingMessage>,
         height: BlockHeight,
-        raw_outcome: RawExecutionOutcome<E, Amount>,
+        raw_outcome: RawExecutionOutcome<E>,
     ) -> Result<(), ChainError>
     where
         F: Fn(E) -> Message,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -26,9 +26,9 @@ use linera_execution::{
     committee::{Committee, Epoch},
     system::OpenChainConfig,
     ExecutionOutcome, ExecutionRuntimeContext, ExecutionStateView, Message, MessageContext,
-    Operation, OperationContext, Query, QueryContext, QueryOutcome, RawExecutionOutcome,
-    RawOutgoingMessage, ResourceController, ResourceTracker, ServiceRuntimeEndpoint,
-    TransactionTracker,
+    Operation, OperationContext, OutgoingMessage, Query, QueryContext, QueryOutcome,
+    RawExecutionOutcome, RawOutgoingMessage, ResourceController, ResourceTracker,
+    ServiceRuntimeEndpoint, TransactionTracker,
 };
 use linera_views::{
     context::Context,
@@ -44,7 +44,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     data_types::{
         BlockExecutionOutcome, ChainAndHeight, IncomingBundle, MessageAction, MessageBundle,
-        Origin, OutgoingMessage, PostedMessage, ProposedBlock, Target, Transaction,
+        Origin, PostedMessage, ProposedBlock, Target, Transaction,
     },
     inbox::{Cursor, InboxError, InboxStateView},
     manager::ChainManager,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -16,19 +16,15 @@ use linera_base::{
         Amount, ArithmeticError, BlockHeight, OracleResponse, Timestamp, UserApplicationDescription,
     },
     ensure,
-    identifiers::{
-        ChainId, ChannelFullName, Destination, GenericApplicationId, MessageId, Owner,
-        UserApplicationId,
-    },
+    identifiers::{ChainId, ChannelFullName, Destination, MessageId, Owner, UserApplicationId},
     ownership::ChainOwnership,
 };
 use linera_execution::{
     committee::{Committee, Epoch},
     system::OpenChainConfig,
-    ExecutionOutcome, ExecutionRuntimeContext, ExecutionStateView, Message, MessageContext,
-    Operation, OperationContext, OutgoingMessage, Query, QueryContext, QueryOutcome,
-    RawExecutionOutcome, RawOutgoingMessage, ResourceController, ResourceTracker,
-    ServiceRuntimeEndpoint, TransactionTracker,
+    ExecutionRuntimeContext, ExecutionStateView, Message, MessageContext, Operation,
+    OperationContext, OutgoingMessage, Query, QueryContext, QueryOutcome, ResourceController,
+    ResourceTracker, ServiceRuntimeEndpoint, TransactionTracker,
 };
 use linera_views::{
     context::Context,
@@ -851,8 +847,7 @@ where
 
             // Update the channels.
             self.process_unsubscribes(txn_outcome.unsubscribe).await?;
-            let txn_messages = self
-                .process_execution_outcomes(block.height, txn_outcome.outcomes)
+            self.process_outgoing_messages(block.height, &txn_outcome.outgoing_messages)
                 .await?;
             self.process_subscribes(txn_outcome.subscribe).await?;
             if matches!(
@@ -863,7 +858,7 @@ where
                         ..
                     })
             ) {
-                for message_out in &txn_messages {
+                for message_out in &txn_outcome.outgoing_messages {
                     resource_controller
                         .with_state(&mut self.execution_state)
                         .await?
@@ -875,7 +870,7 @@ where
             resource_controller
                 .track_block_size_of(&(
                     &txn_outcome.oracle_responses,
-                    &txn_messages,
+                    &txn_outcome.outgoing_messages,
                     &txn_outcome.events,
                 ))
                 .with_execution_context(chain_execution_context)?;
@@ -889,7 +884,7 @@ where
                 .track_executed_block_size_sequence_extension(events.len(), 1)
                 .with_execution_context(chain_execution_context)?;
             oracle_responses.push(txn_outcome.oracle_responses);
-            messages.push(txn_messages);
+            messages.push(txn_outcome.outgoing_messages);
             events.push(txn_outcome.events);
             blobs.push(txn_outcome.blobs);
         }
@@ -1101,85 +1096,32 @@ where
             .observe(tracker.bytes_written as f64);
     }
 
-    async fn process_execution_outcomes(
+    async fn process_outgoing_messages(
         &mut self,
         height: BlockHeight,
-        results: Vec<ExecutionOutcome>,
-    ) -> Result<Vec<OutgoingMessage>, ChainError> {
-        let mut messages = Vec::new();
-        for result in results {
-            match result {
-                ExecutionOutcome::System(result) => {
-                    self.process_raw_execution_outcome(
-                        GenericApplicationId::System,
-                        Message::System,
-                        &mut messages,
-                        height,
-                        result,
-                    )
-                    .await?;
-                }
-                ExecutionOutcome::User(application_id, result) => {
-                    self.process_raw_execution_outcome(
-                        GenericApplicationId::User(application_id),
-                        |bytes| Message::User {
-                            application_id,
-                            bytes,
-                        },
-                        &mut messages,
-                        height,
-                        result,
-                    )
-                    .await?;
-                }
-            }
-        }
-        Ok(messages)
-    }
-
-    async fn process_raw_execution_outcome<E, F>(
-        &mut self,
-        application_id: GenericApplicationId,
-        lift: F,
-        messages: &mut Vec<OutgoingMessage>,
-        height: BlockHeight,
-        raw_outcome: RawExecutionOutcome<E>,
-    ) -> Result<(), ChainError>
-    where
-        F: Fn(E) -> Message,
-    {
+        messages: &[OutgoingMessage],
+    ) -> Result<(), ChainError> {
         let max_stream_queries = self.context().max_stream_queries();
         // Record the messages of the execution. Messages are understood within an
         // application.
         let mut recipients = HashSet::new();
         let mut channel_broadcasts = HashSet::new();
-        for RawOutgoingMessage {
-            destination,
-            authenticated,
-            grant,
-            kind,
-            message,
-        } in raw_outcome.messages
-        {
-            match &destination {
+        for message in messages {
+            match &message.destination {
                 Destination::Recipient(id) => {
                     recipients.insert(*id);
                 }
                 Destination::Subscribers(name) => {
-                    ensure!(grant == Amount::ZERO, ChainError::GrantUseOnBroadcast);
-                    channel_broadcasts.insert(name.clone());
+                    ensure!(
+                        message.grant == Amount::ZERO,
+                        ChainError::GrantUseOnBroadcast
+                    );
+                    channel_broadcasts.insert(ChannelFullName {
+                        application_id: message.message.application_id(),
+                        name: name.clone(),
+                    });
                 }
             }
-            let authenticated_signer = raw_outcome.authenticated_signer.filter(|_| authenticated);
-            let refund_grant_to = raw_outcome.refund_grant_to.filter(|_| grant > Amount::ZERO);
-            messages.push(OutgoingMessage {
-                destination,
-                authenticated_signer,
-                grant,
-                refund_grant_to,
-                kind,
-                message: lift(message),
-            });
         }
 
         // Update the (regular) outboxes.
@@ -1195,13 +1137,7 @@ where
             }
         }
 
-        let full_names = channel_broadcasts
-            .into_iter()
-            .map(|name| ChannelFullName {
-                application_id,
-                name,
-            })
-            .collect::<Vec<_>>();
+        let full_names = channel_broadcasts.into_iter().collect::<Vec<_>>();
         let channels = self.channels.try_load_entries_mut(&full_names).await?;
         let stream = full_names.into_iter().zip(channels);
         let stream = stream::iter(stream)

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -10,13 +10,12 @@ use linera_base::{
     data_types::Timestamp,
     identifiers::{ChainId, Destination},
 };
-use linera_chain::data_types::OutgoingMessage;
 use linera_core::{
     client::{ChainClient, ChainClientError},
     node::ValidatorNodeProvider,
     worker::Reason,
 };
-use linera_execution::{Message, SystemMessage};
+use linera_execution::{Message, OutgoingMessage, SystemMessage};
 use linera_storage::{Clock as _, Storage};
 use tracing::{debug, error, info, instrument, warn, Instrument as _};
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -31,8 +31,8 @@ use linera_base::{
 use linera_chain::{
     data_types::{
         BlockExecutionOutcome, BlockProposal, ChainAndHeight, ExecutedBlock, IncomingBundle,
-        LiteValue, LiteVote, Medium, MessageAction, MessageBundle, Origin, OutgoingMessage,
-        PostedMessage, ProposedBlock, SignatureAggregator,
+        LiteValue, LiteVote, Medium, MessageAction, MessageBundle, Origin, PostedMessage,
+        ProposedBlock, SignatureAggregator,
     },
     manager::LockingBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
@@ -48,8 +48,8 @@ use linera_execution::{
         AdminOperation, OpenChainConfig, Recipient, SystemChannel, SystemMessage, SystemOperation,
     },
     test_utils::{ExpectedCall, RegisterMockApplication, SystemExecutionState},
-    ChannelSubscription, ExecutionError, Message, MessageKind, Query, QueryContext, QueryOutcome,
-    QueryResponse, SystemExecutionError, SystemQuery, SystemResponse,
+    ChannelSubscription, ExecutionError, Message, MessageKind, OutgoingMessage, Query,
+    QueryContext, QueryOutcome, QueryResponse, SystemExecutionError, SystemQuery, SystemResponse,
 };
 use linera_storage::{DbStorage, Storage, TestClock};
 use linera_views::{

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -479,7 +479,7 @@ pub enum ExecutionRequest {
         signer: Option<Owner>,
         application_id: UserApplicationId,
         #[debug(skip)]
-        callback: Sender<RawExecutionOutcome<SystemMessage, Amount>>,
+        callback: Sender<RawExecutionOutcome<SystemMessage>>,
     },
 
     Claim {
@@ -490,7 +490,7 @@ pub enum ExecutionRequest {
         signer: Option<Owner>,
         application_id: UserApplicationId,
         #[debug(skip)]
-        callback: Sender<RawExecutionOutcome<SystemMessage, Amount>>,
+        callback: Sender<RawExecutionOutcome<SystemMessage>>,
     },
 
     SystemTimestamp {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -943,31 +943,6 @@ pub struct ChannelSubscription {
     pub name: ChannelName,
 }
 
-/// Externally visible results of an execution, tagged by their application.
-#[derive(Debug)]
-#[cfg_attr(with_testing, derive(Eq, PartialEq))]
-#[expect(clippy::large_enum_variant)]
-pub enum ExecutionOutcome {
-    System(RawExecutionOutcome<SystemMessage>),
-    User(UserApplicationId, RawExecutionOutcome<Vec<u8>>),
-}
-
-impl ExecutionOutcome {
-    pub fn application_id(&self) -> GenericApplicationId {
-        match self {
-            ExecutionOutcome::System(_) => GenericApplicationId::System,
-            ExecutionOutcome::User(app_id, _) => GenericApplicationId::User(*app_id),
-        }
-    }
-
-    pub fn message_count(&self) -> usize {
-        match self {
-            ExecutionOutcome::System(outcome) => outcome.messages.len(),
-            ExecutionOutcome::User(_, outcome) => outcome.messages.len(),
-        }
-    }
-}
-
 impl<Message> RawExecutionOutcome<Message> {
     pub fn with_authenticated_signer(mut self, authenticated_signer: Option<Owner>) -> Self {
         self.authenticated_signer = authenticated_signer;

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -896,6 +896,28 @@ pub enum MessageKind {
     Bouncing,
 }
 
+/// A posted message together with routing information.
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
+pub struct OutgoingMessage {
+    /// The destination of the message.
+    pub destination: Destination,
+    /// The user authentication carried by the message, if any.
+    #[debug(skip_if = Option::is_none)]
+    pub authenticated_signer: Option<Owner>,
+    /// A grant to pay for the message execution.
+    #[debug(skip_if = Amount::is_zero)]
+    pub grant: Amount,
+    /// Where to send a refund for the unused part of the grant after execution, if any.
+    #[debug(skip_if = Option::is_none)]
+    pub refund_grant_to: Option<Account>,
+    /// The kind of message being sent.
+    pub kind: MessageKind,
+    /// The message itself.
+    pub message: Message,
+}
+
+impl<'de> BcsHashable<'de> for OutgoingMessage {}
+
 /// Externally visible results of an execution. These results are meant in the context of
 /// the application that created them.
 #[derive(Debug)]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -900,14 +900,14 @@ pub enum MessageKind {
 /// the application that created them.
 #[derive(Debug)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
-pub struct RawExecutionOutcome<Message, Grant> {
+pub struct RawExecutionOutcome<Message> {
     /// The signer who created the messages.
     pub authenticated_signer: Option<Owner>,
     /// Where to send a refund for the unused part of each grant after execution, if any.
     pub refund_grant_to: Option<Account>,
     /// Sends messages to the given destinations, possibly forwarding the authenticated
     /// signer and including grant with the refund policy described above.
-    pub messages: Vec<RawOutgoingMessage<Message, Grant>>,
+    pub messages: Vec<RawOutgoingMessage<Message, Amount>>,
 }
 
 /// The identifier of a channel, relative to a particular application.
@@ -926,8 +926,8 @@ pub struct ChannelSubscription {
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 #[expect(clippy::large_enum_variant)]
 pub enum ExecutionOutcome {
-    System(RawExecutionOutcome<SystemMessage, Amount>),
-    User(UserApplicationId, RawExecutionOutcome<Vec<u8>, Amount>),
+    System(RawExecutionOutcome<SystemMessage>),
+    User(UserApplicationId, RawExecutionOutcome<Vec<u8>>),
 }
 
 impl ExecutionOutcome {
@@ -946,7 +946,7 @@ impl ExecutionOutcome {
     }
 }
 
-impl<Message, Grant> RawExecutionOutcome<Message, Grant> {
+impl<Message> RawExecutionOutcome<Message> {
     pub fn with_authenticated_signer(mut self, authenticated_signer: Option<Owner>) -> Self {
         self.authenticated_signer = authenticated_signer;
         self
@@ -958,13 +958,13 @@ impl<Message, Grant> RawExecutionOutcome<Message, Grant> {
     }
 
     /// Adds a `message` to this [`RawExecutionOutcome`].
-    pub fn with_message(mut self, message: RawOutgoingMessage<Message, Grant>) -> Self {
+    pub fn with_message(mut self, message: RawOutgoingMessage<Message, Amount>) -> Self {
         self.messages.push(message);
         self
     }
 }
 
-impl<Message, Grant> Default for RawExecutionOutcome<Message, Grant> {
+impl<Message> Default for RawExecutionOutcome<Message> {
     fn default() -> Self {
         Self {
             authenticated_signer: None,
@@ -992,28 +992,6 @@ impl<Message> RawOutgoingMessage<Message, Resources> {
             grant: policy.total_price(&grant)?,
             kind,
             message,
-        })
-    }
-}
-
-impl<Message> RawExecutionOutcome<Message, Resources> {
-    pub fn into_priced(
-        self,
-        policy: &ResourceControlPolicy,
-    ) -> Result<RawExecutionOutcome<Message, Amount>, ArithmeticError> {
-        let RawExecutionOutcome {
-            authenticated_signer,
-            refund_grant_to,
-            messages,
-        } = self;
-        let messages = messages
-            .into_iter()
-            .map(|message| message.into_priced(policy))
-            .collect::<Result<_, _>>()?;
-        Ok(RawExecutionOutcome {
-            authenticated_signer,
-            refund_grant_to,
-            messages,
         })
     }
 }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -785,7 +785,7 @@ where
         &mut self,
         context: MessageContext,
         message: SystemMessage,
-    ) -> Result<RawExecutionOutcome<SystemMessage, Amount>, SystemExecutionError> {
+    ) -> Result<RawExecutionOutcome<SystemMessage>, SystemExecutionError> {
         let mut outcome = RawExecutionOutcome::default();
         use SystemMessage::*;
         match message {

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeMap, vec};
 
 use custom_debug_derive::Debug;
 use linera_base::{
-    data_types::{Amount, ArithmeticError, Blob, Event, OracleResponse},
+    data_types::{ArithmeticError, Blob, Event, OracleResponse},
     ensure,
     identifiers::{ApplicationId, BlobId, ChainId, ChannelFullName, StreamId},
 };
@@ -86,7 +86,7 @@ impl TransactionTracker {
 
     pub fn add_system_outcome(
         &mut self,
-        outcome: RawExecutionOutcome<SystemMessage, Amount>,
+        outcome: RawExecutionOutcome<SystemMessage>,
     ) -> Result<(), ArithmeticError> {
         self.add_outcome(ExecutionOutcome::System(outcome))
     }
@@ -94,7 +94,7 @@ impl TransactionTracker {
     pub fn add_user_outcome(
         &mut self,
         application_id: ApplicationId,
-        outcome: RawExecutionOutcome<Vec<u8>, Amount>,
+        outcome: RawExecutionOutcome<Vec<u8>>,
     ) -> Result<(), ArithmeticError> {
         self.add_outcome(ExecutionOutcome::User(application_id, outcome))
     }

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -218,7 +218,7 @@ async fn test_fee_consumption(
     .await?;
 
     let txn_outcome = txn_tracker.into_outcome()?;
-    assert!(txn_outcome.outcomes.is_empty());
+    assert!(txn_outcome.outgoing_messages.is_empty());
 
     match initial_grant {
         None => {

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -6,14 +6,13 @@
 use linera_base::{
     crypto::{AccountSecretKey, CryptoHash},
     data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::{Account, AccountOwner, ChainDescription, ChainId, MessageId, Owner},
+    identifiers::{ChainDescription, ChainId, MessageId, Owner},
     ownership::ChainOwnership,
 };
 use linera_execution::{
-    system::Recipient, test_utils::SystemExecutionState, ExecutionOutcome, Message, MessageContext,
-    Operation, OperationContext, Query, QueryContext, QueryOutcome, QueryResponse,
-    RawExecutionOutcome, ResourceController, SystemMessage, SystemOperation, SystemQuery,
-    SystemResponse, TransactionTracker,
+    system::Recipient, test_utils::SystemExecutionState, Message, MessageContext, Operation,
+    OperationContext, Query, QueryContext, QueryOutcome, QueryResponse, ResourceController,
+    SystemMessage, SystemOperation, SystemQuery, SystemResponse, TransactionTracker,
 };
 
 #[tokio::test]
@@ -55,19 +54,8 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
     .await
     .unwrap();
     assert_eq!(view.system.balance.get(), &Amount::ZERO);
-    let account = Account {
-        chain_id: ChainId::root(0),
-        owner: Some(AccountOwner::User(owner)),
-    };
     let txn_outcome = txn_tracker.into_outcome().unwrap();
-    assert_eq!(
-        txn_outcome.outcomes,
-        vec![ExecutionOutcome::System(
-            RawExecutionOutcome::default()
-                .with_authenticated_signer(Some(owner))
-                .with_refund_grant_to(Some(account))
-        )]
-    );
+    assert!(txn_outcome.outgoing_messages.is_empty());
     Ok(())
 }
 
@@ -109,10 +97,7 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
     .unwrap();
     assert_eq!(view.system.balance.get(), &Amount::from_tokens(4));
     let txn_outcome = txn_tracker.into_outcome().unwrap();
-    assert_eq!(
-        txn_outcome.outcomes,
-        vec![ExecutionOutcome::System(RawExecutionOutcome::default())]
-    );
+    assert!(txn_outcome.outgoing_messages.is_empty());
     Ok(())
 }
 

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -112,7 +112,7 @@ async fn test_fuel_for_counter_wasm_application(
         )
         .await?;
         let txn_outcome = txn_tracker.into_outcome().unwrap();
-        assert!(txn_outcome.outcomes.is_empty());
+        assert!(txn_outcome.outgoing_messages.is_empty());
     }
     assert_eq!(controller.tracker.fuel, expected_fuel);
     assert_eq!(

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -136,11 +136,10 @@ mod from {
     use linera_base::{data_types::Event, hashed::Hashed, identifiers::StreamId};
     use linera_chain::{
         block::{Block, BlockBody, BlockHeader},
-        data_types::{
-            ExecutedBlock, IncomingBundle, MessageBundle, OutgoingMessage, PostedMessage,
-        },
+        data_types::{ExecutedBlock, IncomingBundle, MessageBundle, PostedMessage},
         types::ConfirmedBlock,
     };
+    use linera_execution::OutgoingMessage;
 
     use super::*;
 


### PR DESCRIPTION
## Motivation

Simplify the code some more after #3513

## Proposal

* Move the definition of `OutgoingMessage` to `linera-execution`
* Use `OutgoingMessage` instead of `ExecutionOutcome` in the transaction tracker

`RawExecutionOutcome` is still use internally to `linera-execution` as a way to create messages, notably in `system.rs` (and in tests). We should probably also get rid of this concept at some point.

To be rebased on top of #3513

## Test Plan

CI

## Release Plan

This PR should not modify the protocol.