### PR TITLE
Fix epoch update in `TestValidator::change_resource_control_policy`

### DIFF
--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -22,9 +22,7 @@ use linera_base::{
 use linera_core::worker::WorkerState;
 use linera_execution::{
     committee::{Committee, Epoch},
-    system::{
-        AdminOperation, OpenChainConfig, SystemChannel, SystemOperation, OPEN_CHAIN_MESSAGE_INDEX,
-    },
+    system::{AdminOperation, OpenChainConfig, SystemOperation, OPEN_CHAIN_MESSAGE_INDEX},
     ResourceControlPolicy, WasmRuntime,
 };
 use linera_storage::{DbStorage, Storage, TestClock};
@@ -210,7 +208,7 @@ impl TestValidator {
             .await
             .expect("Should write committee blob");
 
-        let certificate = admin_chain
+        admin_chain
             .add_block(|block| {
                 block.with_system_operation(SystemOperation::Admin(
                     AdminOperation::CreateCommittee { epoch, blob_hash },
@@ -223,7 +221,7 @@ impl TestValidator {
 
             chain
                 .add_block(|block| {
-                    block.with_system_messages_from(&certificate, SystemChannel::Admin);
+                    block.with_system_operation(SystemOperation::ProcessNewEpoch(epoch));
                 })
                 .await;
         }

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -197,7 +197,8 @@ impl TestValidator {
             (*epoch, committee.clone())
         };
 
-        let admin_chain = self.get_chain(&ChainId::root(0));
+        let admin_chain_id = ChainId::root(0);
+        let admin_chain = self.get_chain(&admin_chain_id);
 
         let committee_blob = Blob::new(BlobContent::new_committee(
             bcs::to_bytes(&committee).unwrap(),
@@ -219,11 +220,13 @@ impl TestValidator {
         for entry in self.chains.iter() {
             let chain = entry.value();
 
-            chain
-                .add_block(|block| {
-                    block.with_system_operation(SystemOperation::ProcessNewEpoch(epoch));
-                })
-                .await;
+            if chain.id() != admin_chain_id {
+                chain
+                    .add_block(|block| {
+                        block.with_system_operation(SystemOperation::ProcessNewEpoch(epoch));
+                    })
+                    .await;
+            }
         }
     }
 


### PR DESCRIPTION
## Motivation

Epoch changes were recently changed to use events (#3432), but the `TestValidator::change_resource_control_policy` was still trying to receive epoch change system messages instead of creating an operation to process the new epoch.

## Proposal

Use the new `SystemOperation::ProcessNewEpoch` to update the chains to use the new epoch, and skip updating the admin chain because it fails to try to process the same epoch twice.

## Test Plan

Tested with a rebased version of the tests in #3509. The tests stop working after #3432 but pass again after this PR.

## Release Plan

- These changes follow the usual release cycle, because it fixes an issue with SDK that is not present in any released version.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
