### PR TITLE
Add timeouts for HTTP requests

### DIFF
--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -117,7 +117,7 @@ async fn test_block_size_limit() {
     let mut chain = ChainStateView::new(chain_id).await;
 
     // The size of the executed valid block below.
-    let maximum_executed_block_size = 725;
+    let maximum_executed_block_size = 733;
 
     // Initialize the chain.
     let mut config = make_open_chain_config();

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -61,6 +61,8 @@ pub struct ResourceControlPolicy {
     pub maximum_bytes_read_per_block: u64,
     /// The maximum data to write per block
     pub maximum_bytes_written_per_block: u64,
+    /// The maximum amount of time allowed to wait for an HTTP response.
+    pub http_request_timeout_ms: u64,
     /// The list of hosts that contracts and services can send HTTP requests to.
     pub http_request_allow_list: BTreeSet<String>,
 }
@@ -88,6 +90,7 @@ impl fmt::Display for ResourceControlPolicy {
             maximum_bytes_read_per_block,
             maximum_bytes_written_per_block,
             http_request_allow_list,
+            http_request_timeout_ms,
         } = self;
         write!(
             f,
@@ -111,6 +114,7 @@ impl fmt::Display for ResourceControlPolicy {
             {maximum_block_proposal_size} maximum size of a block proposal\n\
             {maximum_bytes_read_per_block} maximum number bytes read per block\n\
             {maximum_bytes_written_per_block} maximum number bytes written per block\n\
+            {http_request_timeout_ms} ms timeout for HTTP requests\n\
             HTTP hosts allowed for contracts and services: {http_request_allow_list:#?}\n",
         )?;
         Ok(())
@@ -148,6 +152,7 @@ impl ResourceControlPolicy {
             maximum_block_proposal_size: u64::MAX,
             maximum_bytes_read_per_block: u64::MAX,
             maximum_bytes_written_per_block: u64::MAX,
+            http_request_timeout_ms: u64::MAX,
             http_request_allow_list: BTreeSet::new(),
         }
     }
@@ -213,6 +218,7 @@ impl ResourceControlPolicy {
             maximum_block_proposal_size: 13_000_000,
             maximum_bytes_read_per_block: 100_000_000,
             maximum_bytes_written_per_block: 10_000_000,
+            http_request_timeout_ms: 20_000,
             http_request_allow_list: BTreeSet::new(),
         }
     }

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -39,7 +39,7 @@ pub struct MockApplication {
 ///
 /// Will expect certain calls previously configured through [`MockApplication`].
 pub struct MockApplicationInstance<Runtime> {
-    expected_calls: VecDeque<ExpectedCall>,
+    expected_calls: Arc<Mutex<VecDeque<ExpectedCall>>>,
     runtime: Runtime,
     active_instances: Arc<AtomicUsize>,
 }
@@ -61,7 +61,7 @@ impl MockApplication {
         self.active_instances.fetch_add(1, Ordering::AcqRel);
 
         MockApplicationInstance {
-            expected_calls: mem::take(&mut self.expected_calls.lock().expect("Mutex is poisoned")),
+            expected_calls: self.expected_calls.clone(),
             runtime,
             active_instances: self.active_instances.clone(),
         }
@@ -292,7 +292,10 @@ impl UserServiceModule for MockApplication {
 impl<Runtime> MockApplicationInstance<Runtime> {
     /// Retrieves the next [`ExpectedCall`] in the queue.
     fn next_expected_call(&mut self) -> Option<ExpectedCall> {
-        self.expected_calls.pop_front()
+        self.expected_calls
+            .lock()
+            .expect("Queue of expected calls was poisoned")
+            .pop_front()
     }
 }
 

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -115,9 +115,7 @@ impl Eq for MockApplication {}
 
 impl<Runtime> Drop for MockApplicationInstance<Runtime> {
     fn drop(&mut self) {
-        if self.expected_calls.is_empty() {
-            self.active_instances.fetch_sub(1, Ordering::AcqRel);
-        }
+        self.active_instances.fetch_sub(1, Ordering::AcqRel);
     }
 }
 

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -153,6 +153,7 @@ async fn test_fee_consumption(
         maximum_block_proposal_size: 53,
         maximum_bytes_read_per_block: 59,
         maximum_bytes_written_per_block: 61,
+        http_request_timeout_ms: 67,
         http_request_allow_list: BTreeSet::new(),
     };
 

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -865,6 +865,7 @@ ResourceControlPolicy:
     - maximum_block_proposal_size: U64
     - maximum_bytes_read_per_block: U64
     - maximum_bytes_written_per_block: U64
+    - http_request_timeout_ms: U64
     - http_request_allow_list:
         SEQ: STR
 Response:

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -1112,6 +1112,10 @@ input ResourceControlPolicy {
 	"""
 	maximumBytesWrittenPerBlock: Int!
 	"""
+	The maximum amount of time allowed to wait for an HTTP response.
+	"""
+	httpRequestTimeoutMs: Int!
+	"""
 	The list of hosts that contracts and services can send HTTP requests to.
 	"""
 	httpRequestAllowList: [String!]!


### PR DESCRIPTION
## Motivation

HTTP requests can take a long time to complete, or attempt to stay open indefinitely. This should not be allowed because it may stall a chain.

## Proposal

Add a `http_request_timeout` policy to `ResourceControlPolicy`, and configure all HTTP requests to use that timeout.

## Test Plan

Wrote some [tests](https://github.com/jvff/linera-protocol-archive/compare/95da70cabb..test-http-timeouts-p1) out of this branch, possibly to be added to #3509.

## Release Plan

- Backporting is not possible but we may want to deploy a new `devnet` and `testnet` and release a new
      SDK soon, because this contains backwards incompatible changes to the chain state.

## Links

- Closes #3522 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
