### PR TITLE
Add runtime API for services to stop executing on timeout

### DIFF
--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -641,6 +641,9 @@ pub trait ServiceRuntime: BaseRuntime {
 
     /// Schedules an operation to be included in the block proposed after execution.
     fn schedule_operation(&mut self, operation: Vec<u8>) -> Result<(), ExecutionError>;
+
+    /// Checks if the service has exceeded its execution time limit.
+    fn check_execution_time(&mut self) -> Result<(), ExecutionError>;
 }
 
 pub trait ContractRuntime: BaseRuntime {

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1710,6 +1710,10 @@ impl ServiceRuntime for ServiceSyncRuntimeHandle {
 
         Ok(())
     }
+
+    fn check_execution_time(&mut self) -> Result<(), ExecutionError> {
+        Ok(())
+    }
 }
 
 /// A request to the service runtime actor.

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1725,6 +1725,11 @@ impl ServiceRuntime for ServiceSyncRuntimeHandle {
     }
 
     fn check_execution_time(&mut self) -> Result<(), ExecutionError> {
+        if let Some(deadline) = self.inner().deadline {
+            if Instant::now() >= deadline {
+                return Err(ExecutionError::MaximumServiceOracleExecutionTimeExceeded);
+            }
+        }
         Ok(())
     }
 }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -102,6 +102,11 @@ pub struct SyncRuntimeInternal<UserInstance> {
     /// Track application states based on views.
     view_user_states: BTreeMap<UserApplicationId, ViewUserState>,
 
+    /// The deadline this runtime should finish executing.
+    ///
+    /// Used to limit the execution time of services running as oracles.
+    deadline: Option<Instant>,
+
     /// Where to send a refund for the unused part of the grant after execution, if any.
     #[debug(skip_if = Option::is_none)]
     refund_grant_to: Option<Account>,
@@ -292,6 +297,7 @@ impl<UserInstance> SyncRuntimeInternal<UserInstance> {
         authenticated_signer: Option<Owner>,
         executing_message: Option<ExecutingMessage>,
         execution_state_sender: ExecutionStateSender,
+        deadline: Option<Instant>,
         refund_grant_to: Option<Account>,
         resource_controller: ResourceController,
         transaction_tracker: TransactionTracker,
@@ -310,6 +316,7 @@ impl<UserInstance> SyncRuntimeInternal<UserInstance> {
             call_stack: Vec::new(),
             active_applications: HashSet::new(),
             view_user_states: BTreeMap::new(),
+            deadline,
             refund_grant_to,
             resource_controller,
             transaction_tracker,
@@ -478,7 +485,7 @@ impl SyncRuntimeInternal<UserContractInstance> {
         let txn_tracker = TransactionTracker::default()
             .with_blobs(self.transaction_tracker.created_blobs().clone());
         let mut service_runtime =
-            ServiceSyncRuntime::new_with_txn_tracker(sender, context, txn_tracker);
+            ServiceSyncRuntime::new_with_txn_tracker(sender, context, None, txn_tracker);
 
         // TODO(#3533): Use the timeout to limit execution time.
         let _timeout = self
@@ -1047,6 +1054,7 @@ impl ContractSyncRuntime {
                     None
                 },
                 execution_state_sender,
+                None,
                 refund_grant_to,
                 resource_controller,
                 txn_tracker,
@@ -1552,6 +1560,7 @@ impl ServiceSyncRuntime {
         Self::new_with_txn_tracker(
             execution_state_sender,
             context,
+            None,
             TransactionTracker::default(),
         )
     }
@@ -1560,6 +1569,7 @@ impl ServiceSyncRuntime {
     pub fn new_with_txn_tracker(
         execution_state_sender: ExecutionStateSender,
         context: QueryContext,
+        deadline: Option<Instant>,
         txn_tracker: TransactionTracker,
     ) -> Self {
         let runtime = SyncRuntime(Some(
@@ -1571,6 +1581,7 @@ impl ServiceSyncRuntime {
                 None,
                 None,
                 execution_state_sender,
+                deadline,
                 None,
                 ResourceController::default(),
                 txn_tracker,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -484,14 +484,16 @@ impl SyncRuntimeInternal<UserContractInstance> {
 
         let txn_tracker = TransactionTracker::default()
             .with_blobs(self.transaction_tracker.created_blobs().clone());
-        let mut service_runtime =
-            ServiceSyncRuntime::new_with_txn_tracker(sender, context, None, txn_tracker);
 
-        // TODO(#3533): Use the timeout to limit execution time.
-        let _timeout = self
+        let timeout = self
             .resource_controller
             .remaining_service_oracle_execution_time()?;
         let execution_start = Instant::now();
+        let deadline = Some(execution_start + timeout);
+
+        let mut service_runtime =
+            ServiceSyncRuntime::new_with_txn_tracker(sender, context, deadline, txn_tracker);
+
         let result = service_runtime.run_query(application_id, query);
 
         // Always track the execution time, irrespective to whether the service ran successfully or

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -185,6 +185,7 @@ fn create_runtime<Application>() -> (
         None,
         execution_state_sender,
         None,
+        None,
         resource_controller,
         TransactionTracker::new(0, 0, Some(Vec::new())),
     );

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -664,4 +664,16 @@ where
             .try_query_application(application, argument)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
+
+    /// Checks if the service has exceeded its execution time limit.
+    ///
+    /// This is called by the metering instrumentation, but the fuel consumed argument is
+    /// ignored.
+    fn check_execution_time(caller: &mut Caller, _fuel_consumed: u64) -> Result<(), RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime_mut()
+            .check_execution_time()
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
 }

--- a/linera-sdk/wit/service-runtime-api.wit
+++ b/linera-sdk/wit/service-runtime-api.wit
@@ -3,6 +3,7 @@ package linera:app;
 interface service-runtime-api {
     schedule-operation: func(operation: list<u8>);
     try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
+    check-execution-time: func(fuel-consumed: u64);
 
     record application-id {
         application-description-hash: crypto-hash,


### PR DESCRIPTION
## Motivation

Services running as oracles should run in bounded time. Since adding a timeout was not possible, the Wasm runtimes' metering services need to be used. The goal is to instrument the services in order to force them to periodically check if they have exceeded their execution time, and stop executing if they have. For this to be possible, the runtime needs a new function to be called from the services.

## Proposal

Add a `ServiceRuntime::check_execution_time` runtime API for services, and export it to the WIT interface. Add an optional `deadline` to the `SyncRuntimeInternal` to be used by services running as oracles. When the new runtime API is called, return an error if it is has passed its deadline.

## Test Plan

A unit test was added to check that execution stops early.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.
- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- Backporting is not possible but we may want to deploy a new `devnet` and release a new
      SDK soon.

## Links

- Depends on #3536 
- Closes #3530 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
