### PR TITLE
Remove obsolete `fetch_url` serviece runtime API

### DIFF
--- a/examples/gen-nft/src/service.rs
+++ b/examples/gen-nft/src/service.rs
@@ -18,6 +18,7 @@ use base64::engine::{general_purpose::STANDARD_NO_PAD, Engine as _};
 use fungible::Account;
 use gen_nft::{NftOutput, Operation, TokenId};
 use linera_sdk::{
+    http,
     linera_base_types::{AccountOwner, WithServiceAbi},
     views::View,
     Service, ServiceRuntime,
@@ -166,9 +167,12 @@ impl QueryRoot {
     async fn prompt(&self, ctx: &Context<'_>, prompt: String) -> String {
         let runtime = ctx.data::<Arc<ServiceRuntime<GenNftService>>>().unwrap();
         info!("prompt: {}", prompt);
-        let raw_weights = runtime.fetch_url("http://localhost:10001/model.bin");
+        let response = runtime.http_request(http::Request::get("http://localhost:10001/model.bin"));
+        let raw_weights = response.body;
         info!("got weights: {}B", raw_weights.len());
-        let tokenizer_bytes = runtime.fetch_url("http://localhost:10001/tokenizer.json");
+        let response =
+            runtime.http_request(http::Request::get("http://localhost:10001/tokenizer.json"));
+        let tokenizer_bytes = response.body;
         let model_context = ModelContext {
             model: raw_weights,
             tokenizer: tokenizer_bytes,

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -367,11 +367,6 @@ where
                 callback.respond(Ok(create_application_result));
             }
 
-            FetchUrl { url, callback } => {
-                let bytes = reqwest::get(url).await?.bytes().await?.to_vec();
-                callback.respond(bytes);
-            }
-
             PerformHttpRequest { request, callback } => {
                 let headers = request
                     .headers
@@ -589,12 +584,6 @@ pub enum ExecutionRequest {
         txn_tracker: TransactionTracker,
         #[debug(skip)]
         callback: Sender<Result<CreateApplicationResult, ExecutionError>>,
-    },
-
-    FetchUrl {
-        url: String,
-        #[debug(skip)]
-        callback: Sender<Vec<u8>>,
     },
 
     PerformHttpRequest {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -637,9 +637,6 @@ pub trait ServiceRuntime: BaseRuntime {
         argument: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError>;
 
-    /// Fetches blob of bytes from an arbitrary URL.
-    fn fetch_url(&mut self, url: &str) -> Result<Vec<u8>, ExecutionError>;
-
     /// Schedules an operation to be included in the block proposed after execution.
     fn schedule_operation(&mut self, operation: Vec<u8>) -> Result<(), ExecutionError>;
 }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1664,15 +1664,6 @@ impl ServiceRuntime for ServiceSyncRuntimeHandle {
         Ok(response)
     }
 
-    /// Get a blob of bytes from an arbitrary URL.
-    fn fetch_url(&mut self, url: &str) -> Result<Vec<u8>, ExecutionError> {
-        let this = self.inner();
-        let url = url.to_string();
-        this.execution_state_sender
-            .send_request(|callback| ExecutionRequest::FetchUrl { url, callback })?
-            .recv_response()
-    }
-
     fn schedule_operation(&mut self, operation: Vec<u8>) -> Result<(), ExecutionError> {
         let mut this = self.inner();
         let application_id = this.application_id()?;

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -664,13 +664,4 @@ where
             .try_query_application(application, argument)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
-
-    /// Fetches a blob of bytes from a given URL.
-    fn fetch_url(caller: &mut Caller, url: String) -> Result<Vec<u8>, RuntimeError> {
-        caller
-            .user_data_mut()
-            .runtime
-            .fetch_url(&url)
-            .map_err(|error| RuntimeError::Custom(error.into()))
-    }
 }

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -187,11 +187,6 @@ where
         serde_json::from_slice(&response_bytes)
             .expect("Failed to deserialize query response from application")
     }
-
-    /// Fetches a blob of bytes from a given URL.
-    pub fn fetch_url(&self, url: &str) -> Vec<u8> {
-        service_wit::fetch_url(url)
-    }
 }
 
 impl<Application> ServiceRuntime<Application>

--- a/linera-sdk/src/service/test_runtime.rs
+++ b/linera-sdk/src/service/test_runtime.rs
@@ -33,7 +33,6 @@ where
     owner_balances: Mutex<Option<HashMap<AccountOwner, Amount>>>,
     query_application_handler: Mutex<Option<QueryApplicationHandler>>,
     expected_http_requests: Mutex<VecDeque<(http::Request, http::Response)>>,
-    url_blobs: Mutex<Option<HashMap<String, Vec<u8>>>>,
     blobs: Mutex<Option<HashMap<DataBlobHash, Vec<u8>>>>,
     scheduled_operations: Mutex<Vec<Vec<u8>>>,
     key_value_store: KeyValueStore,
@@ -64,7 +63,6 @@ where
             owner_balances: Mutex::new(None),
             query_application_handler: Mutex::new(None),
             expected_http_requests: Mutex::new(VecDeque::new()),
-            url_blobs: Mutex::new(None),
             blobs: Mutex::new(None),
             scheduled_operations: Mutex::new(vec![]),
             key_value_store: KeyValueStore::mock(),
@@ -402,49 +400,6 @@ where
         let (expected_request, response) = maybe_request.expect("Unexpected HTTP request");
         assert_eq!(request, expected_request);
         response
-    }
-
-    /// Configures the blobs returned when fetching from URLs during the test.
-    pub fn with_url_blobs(self, url_blobs: impl IntoIterator<Item = (String, Vec<u8>)>) -> Self {
-        *self.url_blobs.lock().unwrap() = Some(url_blobs.into_iter().collect());
-        self
-    }
-
-    /// Configures the blobs returned when fetching from URLs during the test.
-    pub fn set_url_blobs(&self, url_blobs: impl IntoIterator<Item = (String, Vec<u8>)>) -> &Self {
-        *self.url_blobs.lock().unwrap() = Some(url_blobs.into_iter().collect());
-        self
-    }
-
-    /// Configures the `blob` returned when fetching from the `url` during the test.
-    pub fn with_url_blob(self, url: impl Into<String>, blob: Vec<u8>) -> Self {
-        self.set_url_blob(url, blob);
-        self
-    }
-
-    /// Configures the `blob` returned when fetching from the `url` during the test.
-    pub fn set_url_blob(&self, url: impl Into<String>, blob: Vec<u8>) -> &Self {
-        self.url_blobs
-            .lock()
-            .unwrap()
-            .get_or_insert_with(HashMap::new)
-            .insert(url.into(), blob);
-        self
-    }
-
-    /// Fetches a blob of bytes from a given URL.
-    pub fn fetch_url(&self, url: &str) -> Vec<u8> {
-        self.url_blobs
-            .lock()
-            .unwrap()
-            .as_mut()
-            .and_then(|url_blobs| url_blobs.get(url).cloned())
-            .unwrap_or_else(|| {
-                panic!(
-                    "Blob for URL {url:?} has not been mocked, \
-                    please call `MockServiceRuntime::set_url_blob` first"
-                )
-            })
     }
 
     /// Configures the `blobs` returned when fetching from hashes during the test.

--- a/linera-sdk/wit/service-runtime-api.wit
+++ b/linera-sdk/wit/service-runtime-api.wit
@@ -3,7 +3,6 @@ package linera:app;
 interface service-runtime-api {
     schedule-operation: func(operation: list<u8>);
     try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
-    fetch-url: func(url: string) -> list<u8>;
 
     record application-id {
         application-description-hash: crypto-hash,


### PR DESCRIPTION
## Motivation

The `fetch_url` runtime API was superseded by the `perform_http_request` runtime API, which is more feature complete and has better safety mechanisms. Therefore the old API should be removed.

## Proposal

Remove the old API and update the examples to use the new API.

## Test Plan

CI should catch any regressions.

## Release Plan

- Backporting is not possible but we may want to deploy a new `devnet` and release a new
      SDK soon, because this changes the WIT interface.

## Links

- Closes #3542 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
