### PR TITLE
Implement multiplem address for EVM.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4396,6 +4396,7 @@ dependencies = [
 name = "linera-base"
 version = "0.14.0"
 dependencies = [
+ "alloy",
  "alloy-primitives",
  "anyhow",
  "async-graphql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "foldhash",
+ "getrandom",
  "hashbrown 0.15.2",
  "indexmap 2.7.0",
  "itoa",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3508,6 +3508,7 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 name = "linera-base"
 version = "0.14.0"
 dependencies = [
+ "alloy",
  "alloy-primitives",
  "anyhow",
  "async-graphql",

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -30,6 +30,7 @@ web = [
 ]
 
 [dependencies]
+alloy.workspace = true
 alloy-primitives.workspace = true
 anyhow.workspace = true
 async-graphql.workspace = true

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -90,6 +90,7 @@ zstd.workspace = true
 
 [dev-dependencies]
 bcs.workspace = true
+alloy = { workspace = true, features = ["getrandom"] }
 linera-base = { path = ".", default-features = false, features = ["test"] }
 linera-witty = { workspace = true, features = ["test"] }
 test-case.workspace = true

--- a/linera-base/src/crypto/hash.rs
+++ b/linera-base/src/crypto/hash.rs
@@ -110,6 +110,31 @@ impl<'de> Deserialize<'de> for CryptoHash {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use linera_base::crypto::CryptoHash;
+    fn random_cryptohash() -> CryptoHash {
+        CryptoHash::from([23323_u64, 25455543444_u64, 56563335699_u64, 67676666666_u64])
+    }
+
+    #[test]
+    fn test_cryptohash_conversion() {
+        let hash1 = random_cryptohash();
+        let array = <[u64; 4]>::from(hash1);
+        let hash2 = CryptoHash::from(array);
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_cryptohash_serialization_human_readable() {
+        let hash1 = random_cryptohash();
+	let json_str = serde_json::to_string(&hash1).unwrap();
+        let hash2 = serde_json::from_str::<CryptoHash>(&json_str).unwrap();
+        assert_eq!(hash1, hash2);
+    }
+}
+
+
 impl FromStr for CryptoHash {
     type Err = CryptoError;
 

--- a/linera-base/src/vm.rs
+++ b/linera-base/src/vm.rs
@@ -4,12 +4,156 @@
 //! The virtual machines being supported.
 
 use std::str::FromStr;
+use std::borrow::Cow;
+use linera_witty::{
+    GuestPointer,
+    HList,
+    InstanceWithMemory,
+    Runtime,
+    Layout,
+    Memory,
+    RuntimeError,
+    RuntimeMemory,
+};
 
+#[cfg(with_testing)]
+use {
+    alloy_primitives::FixedBytes,
+    proptest::{
+        collection::{vec, VecStrategy},
+        prelude::{Arbitrary, Strategy},
+        strategy,
+    },
+    std::ops::RangeInclusive,
+};
+
+
+use alloy::primitives::Address;
 use async_graphql::scalar;
 use derive_more::Display;
 use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+/// Encapsulation of address type so that we can implement WitType, WitLoad, WitStore
+#[derive(Clone, Copy, Debug, Display, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize, PartialEq)]
+pub struct EncapsulateAddress {
+    /// The encapsulated address
+    pub address: Address,
+}
+
+impl From<[u32; 5]> for EncapsulateAddress {
+    fn from(integers: [u32; 5]) -> Self {
+        let mut vec = [0_u8; 20];
+        let mut pos = 0;
+        for val in integers {
+            let val = val.to_le_bytes();
+            for item in val {
+                vec[pos] = item;
+                pos += 1;
+            }
+        }
+        let address = Address::new(vec);
+        Self { address }
+    }
+}
+
+impl From<EncapsulateAddress> for [u32; 5] {
+    fn from(address: EncapsulateAddress) -> Self {
+        let data = address.address.into_array();
+        let vec = data.chunks_exact(4)
+            .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
+            .collect::<Vec<_>>();
+        vec.try_into().unwrap()
+    }
+}
+
+impl WitType for EncapsulateAddress {
+    const SIZE: u32 = <(u32, u32, u32, u32, u32) as WitType>::SIZE;
+    type Layout = <(u32, u32, u32, u32, u32) as WitType>::Layout;
+    type Dependencies = HList![];
+
+    fn wit_type_name() -> Cow<'static, str> {
+        "address".into()
+    }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        concat!(
+            "    record address {\n",
+            "        part1: u32,\n",
+            "        part2: u32,\n",
+            "        part3: u32,\n",
+            "        part4: u32,\n",
+            "        part5: u32,\n",
+            "    }\n",
+        )
+        .into()
+    }
+}
+
+impl WitLoad for EncapsulateAddress {
+    fn load<Instance>(
+        memory: &Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let (part1, part2, part3, part4, part5) = WitLoad::load(memory, location)?;
+        Ok(EncapsulateAddress::from([part1, part2, part3, part4, part5]))
+    }
+
+    fn lift_from<Instance>(
+        flat_layout: <Self::Layout as linera_witty::Layout>::Flat,
+        memory: &Memory<'_, Instance>,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+     	let (part1, part2, part3, part4, part5) = WitLoad::lift_from(flat_layout, memory)?;
+        Ok(EncapsulateAddress::from([part1, part2, part3, part4, part5]))
+    }
+}
+
+impl WitStore for EncapsulateAddress {
+    fn store<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<(), RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let [part1, part2, part3, part4, part5] = (*self).into();
+        (part1, part2, part3, part4, part5).store(memory, location)
+    }
+
+    fn lower<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+    ) -> Result<<Self::Layout as Layout>::Flat, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let [part1, part2, part3, part4, part5] = (*self).into();
+        (part1, part2, part3, part4, part5).lower(memory)
+    }
+}
+
+#[cfg(with_testing)]
+impl Arbitrary for EncapsulateAddress {
+    type Parameters = ();
+    type Strategy = strategy::Map<VecStrategy<RangeInclusive<u8>>, fn(Vec<u8>) -> EncapsulateAddress>;
+
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
+        vec(u8::MIN..=u8::MAX, FixedBytes::<20>::len_bytes())
+            .prop_map(|vector| EncapsulateAddress { address: Address::new(vector.try_into().unwrap())})
+    }
+}
 
 #[derive(
     Clone,
@@ -35,17 +179,23 @@ pub enum VmRuntime {
     #[default]
     Wasm,
     /// The Evm virtual machine
-    Evm,
+    Evm(EncapsulateAddress),
 }
 
+
 impl FromStr for VmRuntime {
-    type Err = InvalidVmRuntime;
+    type Err = VmRuntimeError;
 
     fn from_str(string: &str) -> Result<Self, Self::Err> {
+        if let Some(address) = string.strip_prefix("evm") {
+            let address = Address::parse_checksummed(address, None)
+                .map_err(|_| VmRuntimeError::InvalidAddress(address.to_string()))?;
+            let address = EncapsulateAddress { address };
+            return Ok(VmRuntime::Evm(address));
+        }
         match string {
             "wasm" => Ok(VmRuntime::Wasm),
-            "evm" => Ok(VmRuntime::Evm),
-            unknown => Err(InvalidVmRuntime(unknown.to_owned())),
+            unknown => Err(VmRuntimeError::InvalidVmRuntime(unknown.to_owned())),
         }
     }
 }
@@ -55,4 +205,9 @@ scalar!(VmRuntime);
 /// Error caused by invalid VM runtimes
 #[derive(Clone, Debug, Error)]
 #[error("{0:?} is not a valid virtual machine runtime")]
-pub struct InvalidVmRuntime(String);
+pub enum VmRuntimeError {
+    /// The runtime is invalid
+    InvalidVmRuntime(String),
+    /// The address is invalid
+    InvalidAddress(String),
+}

--- a/linera-base/src/vm.rs
+++ b/linera-base/src/vm.rs
@@ -199,6 +199,15 @@ mod tests {
         let address2 = EncapsulateAddress::from(array);
         assert_eq!(address1, address2);
     }
+
+    #[test]
+    fn test_address_serialization_human_readable() {
+        let address1 = EncapsulateAddress { address: Address::random() };
+        let json_str = serde_json::to_string(&address1).unwrap();
+        let address2 = serde_json::from_str::<EncapsulateAddress>(&json_str).unwrap();
+        assert_eq!(address1, address2);
+    }
+
 }
 
 

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -66,7 +66,11 @@ fn make_app_description() -> (UserApplicationDescription, Blob, Blob) {
     let contract_blob = Blob::new_contract_bytecode(contract.compress());
     let service_blob = Blob::new_service_bytecode(service.compress());
 
-    let module_id = ModuleId::new(contract_blob.id().hash, service_blob.id().hash, VmRuntime::Wasm);
+    let module_id = ModuleId::new(
+        contract_blob.id().hash,
+        service_blob.id().hash,
+        VmRuntime::Wasm,
+    );
     (
         UserApplicationDescription {
             module_id,

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -65,9 +65,8 @@ fn make_app_description() -> (UserApplicationDescription, Blob, Blob) {
     let service = Bytecode::new(b"service".into());
     let contract_blob = Blob::new_contract_bytecode(contract.compress());
     let service_blob = Blob::new_service_bytecode(service.compress());
-    let vm_runtime = VmRuntime::Wasm;
 
-    let module_id = ModuleId::new(contract_blob.id().hash, service_blob.id().hash, vm_runtime);
+    let module_id = ModuleId::new(contract_blob.id().hash, service_blob.id().hash, VmRuntime::Wasm);
     (
         UserApplicationDescription {
             module_id,

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -160,7 +160,11 @@ where
     let small_bytecode = Bytecode::new(vec![]);
     // Publishing bytecode that exceeds the limit fails.
     let result = publisher
-        .publish_module(large_bytecode.clone(), small_bytecode.clone(), VmRuntime::Wasm)
+        .publish_module(
+            large_bytecode.clone(),
+            small_bytecode.clone(),
+            VmRuntime::Wasm,
+        )
         .await;
     assert_matches!(
         result,

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -92,7 +92,6 @@ async fn run_test_create_application<B>(storage_builder: B) -> anyhow::Result<()
 where
     B: StorageBuilder,
 {
-    let vm_runtime = VmRuntime::Wasm;
     let (contract_path, service_path) =
         linera_execution::wasm_test::get_example_bytecode_paths("counter")?;
     let contract_bytecode = Bytecode::load_from_file(contract_path).await?;
@@ -113,7 +112,7 @@ where
     let creator = builder.add_root_chain(1, Amount::ONE).await?;
 
     let (module_id, _cert) = publisher
-        .publish_module(contract_bytecode, service_bytecode, vm_runtime)
+        .publish_module(contract_bytecode, service_bytecode, VmRuntime::Wasm)
         .await
         .unwrap()
         .unwrap();
@@ -161,7 +160,7 @@ where
     let small_bytecode = Bytecode::new(vec![]);
     // Publishing bytecode that exceeds the limit fails.
     let result = publisher
-        .publish_module(large_bytecode.clone(), small_bytecode.clone(), vm_runtime)
+        .publish_module(large_bytecode.clone(), small_bytecode.clone(), VmRuntime::Wasm)
         .await;
     assert_matches!(
         result,
@@ -170,7 +169,7 @@ where
         ))) if matches!(*error, ExecutionError::BytecodeTooLarge)
     );
     let result = publisher
-        .publish_module(small_bytecode, large_bytecode, vm_runtime)
+        .publish_module(small_bytecode, large_bytecode, VmRuntime::Wasm)
         .await;
     assert_matches!(
         result,
@@ -252,7 +251,6 @@ async fn run_test_run_application_with_dependency<B>(storage_builder: B) -> anyh
 where
     B: StorageBuilder,
 {
-    let vm_runtime = VmRuntime::Wasm;
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
         .with_policy(ResourceControlPolicy::all_categories());
@@ -292,7 +290,7 @@ where
             .publish_module(
                 Bytecode::load_from_file(contract_path).await?,
                 Bytecode::load_from_file(service_path).await?,
-                vm_runtime,
+                VmRuntime::Wasm,
             )
             .await
             .unwrap()
@@ -306,7 +304,7 @@ where
             .publish_module(
                 Bytecode::load_from_file(contract_path).await?,
                 Bytecode::load_from_file(service_path).await?,
-                vm_runtime,
+                VmRuntime::Wasm,
             )
             .await
             .unwrap()
@@ -524,7 +522,6 @@ async fn run_test_cross_chain_message<B>(storage_builder: B) -> anyhow::Result<(
 where
     B: StorageBuilder,
 {
-    let vm_runtime = VmRuntime::Wasm;
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
         .with_policy(ResourceControlPolicy::all_categories());
@@ -541,7 +538,7 @@ where
             .publish_module(
                 Bytecode::load_from_file(contract_path).await?,
                 Bytecode::load_from_file(service_path).await?,
-                vm_runtime,
+                VmRuntime::Wasm,
             )
             .await
             .unwrap()
@@ -705,7 +702,6 @@ async fn run_test_user_pub_sub_channels<B>(storage_builder: B) -> anyhow::Result
 where
     B: StorageBuilder,
 {
-    let vm_runtime = VmRuntime::Wasm;
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
         .with_policy(ResourceControlPolicy::all_categories());
@@ -719,7 +715,7 @@ where
             .publish_module(
                 Bytecode::load_from_file(contract_path).await?,
                 Bytecode::load_from_file(service_path).await?,
-                vm_runtime,
+                VmRuntime::Wasm,
             )
             .await
             .unwrap()
@@ -858,7 +854,6 @@ where
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_memory_fuel_limit(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
-    let vm_runtime = VmRuntime::Wasm;
     let storage_builder = MemoryStorageBuilder::with_wasm_runtime(wasm_runtime);
     // Set a fuel limit that is enough to instantiate the application and do one increment
     // operation, but not ten.
@@ -878,7 +873,7 @@ async fn test_memory_fuel_limit(wasm_runtime: WasmRuntime) -> anyhow::Result<()>
         .publish_module(
             Bytecode::load_from_file(contract_path).await?,
             Bytecode::load_from_file(service_path).await?,
-            vm_runtime,
+            VmRuntime::Wasm,
         )
         .await
         .unwrap()

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -100,7 +100,6 @@ async fn run_test_handle_certificates_to_create_application<S>(
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    let vm_runtime = VmRuntime::Wasm;
     let admin_id = ChainDescription::Root(0);
     let publisher_owner = AccountSecretKey::generate().public().into();
     let publisher_chain = ChainDescription::Root(1);
@@ -130,7 +129,7 @@ where
     let contract_blob_hash = contract_blob_id.hash;
     let service_blob_hash = service_blob_id.hash;
 
-    let module_id = ModuleId::new(contract_blob_hash, service_blob_hash, vm_runtime);
+    let module_id = ModuleId::new(contract_blob_hash, service_blob_hash, VmRuntime::Wasm);
     let contract = WasmContractModule::new(contract_bytecode, wasm_runtime).await?;
 
     // Publish the module.

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -54,10 +54,9 @@ pub fn create_dummy_user_application_description(
         compressed_bytes: service_bytes,
     });
 
-    let vm_runtime = VmRuntime::Wasm;
     (
         UserApplicationDescription {
-            module_id: ModuleId::new(contract_blob.id().hash, service_blob.id().hash, vm_runtime),
+            module_id: ModuleId::new(contract_blob.id().hash, service_blob.id().hash, VmRuntime::Wasm),
             creator_chain_id: chain_id,
             block_height: 0.into(),
             application_index: index,

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -56,7 +56,11 @@ pub fn create_dummy_user_application_description(
 
     (
         UserApplicationDescription {
-            module_id: ModuleId::new(contract_blob.id().hash, service_blob.id().hash, VmRuntime::Wasm),
+            module_id: ModuleId::new(
+                contract_blob.id().hash,
+                service_blob.id().hash,
+                VmRuntime::Wasm,
+            ),
             creator_chain_id: chain_id,
             block_height: 0.into(),
             application_index: index,

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -60,7 +60,11 @@ async fn application_message_index() -> anyhow::Result<()> {
     let service = Bytecode::new(b"service".into());
     let contract_blob = Blob::new_contract_bytecode(contract.compress());
     let service_blob = Blob::new_service_bytecode(service.compress());
-    let module_id = ModuleId::new(contract_blob.id().hash, service_blob.id().hash, VmRuntime::Wasm);
+    let module_id = ModuleId::new(
+        contract_blob.id().hash,
+        service_blob.id().hash,
+        VmRuntime::Wasm,
+    );
 
     let operation = SystemOperation::CreateApplication {
         module_id,

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -60,8 +60,7 @@ async fn application_message_index() -> anyhow::Result<()> {
     let service = Bytecode::new(b"service".into());
     let contract_blob = Blob::new_contract_bytecode(contract.compress());
     let service_blob = Blob::new_service_bytecode(service.compress());
-    let vm_runtime = VmRuntime::Wasm;
-    let module_id = ModuleId::new(contract_blob.id().hash, service_blob.id().hash, vm_runtime);
+    let module_id = ModuleId::new(contract_blob.id().hash, service_blob.id().hash, VmRuntime::Wasm);
 
     let operation = SystemOperation::CreateApplication {
         module_id,

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -731,10 +731,9 @@ impl TransferTestEndpoint {
     fn sender_application_description() -> UserApplicationDescription {
         let contract_id = Self::sender_application_contract_blob().id().hash;
         let service_id = Self::sender_application_service_blob().id().hash;
-        let vm_runtime = VmRuntime::Wasm;
 
         UserApplicationDescription {
-            module_id: ModuleId::new(contract_id, service_id, vm_runtime),
+            module_id: ModuleId::new(contract_id, service_id, VmRuntime::Wasm),
             creator_chain_id: ChainId::root(1000),
             block_height: BlockHeight(0),
             application_index: 0,

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -39,6 +39,11 @@ AccountSignature:
       Secp256k1:
         NEWTYPE:
           TYPENAME: Secp256k1Signature
+Address:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 20
 AdminOperation:
   ENUM:
     0:
@@ -1218,4 +1223,6 @@ VmRuntime:
     0:
       Wasm: UNIT
     1:
-      Evm: UNIT
+      Evm:
+        NEWTYPE:
+          TYPENAME: Address

--- a/linera-sdk/src/base/conversions_from_wit.rs
+++ b/linera-sdk/src/base/conversions_from_wit.rs
@@ -9,7 +9,7 @@ use linera_base::{
     http,
     identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
-    vm::VmRuntime,
+    vm::{EncapsulateAddress, VmRuntime},
 };
 
 use crate::{
@@ -26,6 +26,18 @@ macro_rules! impl_from_wit {
                     hash_value.part2,
                     hash_value.part3,
                     hash_value.part4,
+                ])
+            }
+        }
+
+        impl From<$wit_base_api::Address> for EncapsulateAddress {
+            fn from(value: $wit_base_api::Address) -> Self {
+                EncapsulateAddress::from([
+                    value.part1,
+                    value.part2,
+                    value.part3,
+                    value.part4,
+                    value.part5,
                 ])
             }
         }
@@ -81,7 +93,7 @@ macro_rules! impl_from_wit {
             fn from(vm_runtime: $wit_base_api::VmRuntime) -> Self {
                 match vm_runtime {
                     $wit_base_api::VmRuntime::Wasm => VmRuntime::Wasm,
-                    $wit_base_api::VmRuntime::Evm => VmRuntime::Evm,
+                    $wit_base_api::VmRuntime::Evm(address) => VmRuntime::Evm(address.into()),
                 }
             }
         }

--- a/linera-sdk/src/base/conversions_to_wit.rs
+++ b/linera-sdk/src/base/conversions_to_wit.rs
@@ -8,7 +8,7 @@ use linera_base::{
     data_types::{BlockHeight, Timestamp},
     http,
     identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId, Owner},
-    vm::VmRuntime,
+    vm::{EncapsulateAddress, VmRuntime},
 };
 
 use crate::{
@@ -27,6 +27,20 @@ macro_rules! impl_to_wit {
                     part2: parts[1],
                     part3: parts[2],
                     part4: parts[3],
+                }
+            }
+        }
+
+        impl From<EncapsulateAddress> for $wit_base_api::Address {
+            fn from(address: EncapsulateAddress) -> Self {
+                let parts = <[u32; 5]>::from(address);
+
+                $wit_base_api::Address {
+                    part1: parts[0],
+                    part2: parts[1],
+                    part3: parts[2],
+                    part4: parts[3],
+                    part5: parts[4],
                 }
             }
         }
@@ -80,7 +94,7 @@ macro_rules! impl_to_wit {
             fn from(vm_runtime: VmRuntime) -> Self {
                 match vm_runtime {
                     VmRuntime::Wasm => $wit_base_api::VmRuntime::Wasm,
-                    VmRuntime::Evm => $wit_base_api::VmRuntime::Evm,
+                    VmRuntime::Evm(address) => $wit_base_api::VmRuntime::Evm(address.into()),
                 }
             }
         }

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -8,7 +8,7 @@ use linera_base::{
     data_types::{Amount, BlockHeight},
     identifiers::{ApplicationId, ChainId, MessageId, ModuleId, Owner},
     ownership::{ChangeApplicationPermissionsError, CloseChainError},
-    vm::VmRuntime,
+    vm::{EncapsulateAddress, VmRuntime},
 };
 
 use super::wit::contract_runtime_api as wit_contract_api;
@@ -20,6 +20,18 @@ impl From<wit_contract_api::CryptoHash> for CryptoHash {
             crypto_hash.part2,
             crypto_hash.part3,
             crypto_hash.part4,
+        ])
+    }
+}
+
+impl From<wit_contract_api::Address> for EncapsulateAddress {
+    fn from(address: wit_contract_api::Address) -> Self {
+        EncapsulateAddress::from([
+            address.part1,
+            address.part2,
+            address.part3,
+            address.part4,
+            address.part5,
         ])
     }
 }
@@ -44,7 +56,7 @@ impl From<wit_contract_api::VmRuntime> for VmRuntime {
     fn from(vm_runtime: wit_contract_api::VmRuntime) -> Self {
         match vm_runtime {
             wit_contract_api::VmRuntime::Wasm => VmRuntime::Wasm,
-            wit_contract_api::VmRuntime::Evm => VmRuntime::Evm,
+            wit_contract_api::VmRuntime::Evm(address) => VmRuntime::Evm(address.into()),
         }
     }
 }

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -13,7 +13,7 @@ use linera_base::{
         ModuleId, Owner, StreamName,
     },
     ownership::{ChainOwnership, TimeoutConfig},
-    vm::VmRuntime,
+    vm::{EncapsulateAddress, VmRuntime},
 };
 use linera_views::batch::WriteOperation;
 
@@ -28,6 +28,20 @@ impl From<CryptoHash> for wit_contract_api::CryptoHash {
             part2: parts[1],
             part3: parts[2],
             part4: parts[3],
+        }
+    }
+}
+
+impl From<EncapsulateAddress> for wit_contract_api::Address {
+    fn from(address: EncapsulateAddress) -> Self {
+        let parts = <[u32; 5]>::from(address);
+
+        wit_contract_api::Address {
+            part1: parts[0],
+            part2: parts[1],
+            part3: parts[2],
+            part4: parts[3],
+            part5: parts[4],
         }
     }
 }
@@ -104,7 +118,7 @@ impl From<VmRuntime> for wit_contract_api::VmRuntime {
     fn from(vm_runtime: VmRuntime) -> Self {
         match vm_runtime {
             VmRuntime::Wasm => wit_contract_api::VmRuntime::Wasm,
-            VmRuntime::Evm => wit_contract_api::VmRuntime::Evm,
+            VmRuntime::Evm(address) => wit_contract_api::VmRuntime::Evm(address.into()),
         }
     }
 }

--- a/linera-sdk/src/service/conversions_to_wit.rs
+++ b/linera-sdk/src/service/conversions_to_wit.rs
@@ -6,7 +6,7 @@
 use linera_base::{
     crypto::CryptoHash,
     identifiers::{ApplicationId, ModuleId},
-    vm::VmRuntime,
+    vm::{EncapsulateAddress, VmRuntime},
 };
 
 use super::wit::service_runtime_api as wit_service_api;
@@ -20,6 +20,20 @@ impl From<CryptoHash> for wit_service_api::CryptoHash {
             part2: parts[1],
             part3: parts[2],
             part4: parts[3],
+        }
+    }
+}
+
+impl From<EncapsulateAddress> for wit_service_api::Address {
+    fn from(address: EncapsulateAddress) -> Self {
+        let parts = <[u32; 5]>::from(address);
+
+        wit_service_api::Address {
+            part1: parts[0],
+            part2: parts[1],
+            part3: parts[2],
+            part4: parts[3],
+            part5: parts[4],
         }
     }
 }
@@ -38,7 +52,7 @@ impl From<VmRuntime> for wit_service_api::VmRuntime {
     fn from(vm_runtime: VmRuntime) -> Self {
         match vm_runtime {
             VmRuntime::Wasm => wit_service_api::VmRuntime::Wasm,
-            VmRuntime::Evm => wit_service_api::VmRuntime::Evm,
+            VmRuntime::Evm(address) => wit_service_api::VmRuntime::Evm(address.into()),
         }
     }
 }

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -338,9 +338,8 @@ impl ActiveChain {
         let service_blob = Blob::new_service_bytecode(service);
         let contract_blob_hash = contract_blob.id().hash;
         let service_blob_hash = service_blob.id().hash;
-        let vm_runtime = VmRuntime::Wasm;
 
-        let module_id = ModuleId::new(contract_blob_hash, service_blob_hash, vm_runtime);
+        let module_id = ModuleId::new(contract_blob_hash, service_blob_hash, VmRuntime::Wasm);
 
         let certificate = self
             .add_block_with_blobs(

--- a/linera-sdk/wit/base-runtime-api.wit
+++ b/linera-sdk/wit/base-runtime-api.wit
@@ -35,6 +35,14 @@ interface base-runtime-api {
         application(application-id),
     }
 
+    record address {
+        part1: u32,
+        part2: u32,
+        part3: u32,
+        part4: u32,
+        part5: u32,
+    }
+
     record amount {
         inner0: u128,
     }
@@ -65,14 +73,6 @@ interface base-runtime-api {
         part2: u64,
         part3: u64,
         part4: u64,
-    }
-
-    record address {
-        part1: u32,
-        part2: u32,
-        part3: u32,
-        part4: u32,
-        part5: u32,
     }
 
     record http-header {

--- a/linera-sdk/wit/base-runtime-api.wit
+++ b/linera-sdk/wit/base-runtime-api.wit
@@ -67,6 +67,14 @@ interface base-runtime-api {
         part4: u64,
     }
 
+    record address {
+        part1: u32,
+        part2: u32,
+        part3: u32,
+        part4: u32,
+        part5: u32,
+    }
+
     record http-header {
         name: string,
         value: list<u8>,
@@ -132,8 +140,8 @@ interface base-runtime-api {
 
     type u128 = tuple<u64, u64>;
 
-    enum vm-runtime {
+    variant vm-runtime {
         wasm,
-        evm,
+        evm(address),
     }
 }

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -82,6 +82,14 @@ interface contract-runtime-api {
         part4: u64,
     }
 
+    record address {
+        part1: u32,
+        part2: u32,
+        part3: u32,
+        part4: u32,
+        part5: u32,
+    }
+
     variant destination {
         recipient(chain-id),
         subscribers(channel-name),
@@ -139,9 +147,9 @@ interface contract-runtime-api {
 
     type u128 = tuple<u64, u64>;
 
-    enum vm-runtime {
+    variant vm-runtime {
         wasm,
-        evm,
+        evm(address),
     }
 
     variant write-operation {

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -31,6 +31,14 @@ interface contract-runtime-api {
         application(application-id),
     }
 
+    record address {
+        part1: u32,
+        part2: u32,
+        part3: u32,
+        part4: u32,
+        part5: u32,
+    }
+
     record amount {
         inner0: u128,
     }
@@ -80,14 +88,6 @@ interface contract-runtime-api {
         part2: u64,
         part3: u64,
         part4: u64,
-    }
-
-    record address {
-        part1: u32,
-        part2: u32,
-        part3: u32,
-        part4: u32,
-        part5: u32,
     }
 
     variant destination {

--- a/linera-sdk/wit/service-runtime-api.wit
+++ b/linera-sdk/wit/service-runtime-api.wit
@@ -17,14 +17,22 @@ interface service-runtime-api {
         part4: u64,
     }
 
+    record address {
+        part1: u32,
+        part2: u32,
+        part3: u32,
+        part4: u32,
+        part5: u32,
+    }
+
     record module-id {
         contract-blob-hash: crypto-hash,
         service-blob-hash: crypto-hash,
         vm-runtime: vm-runtime,
     }
 
-    enum vm-runtime {
+    variant vm-runtime {
         wasm,
-        evm,
+        evm(address),
     }
 }

--- a/linera-sdk/wit/service-runtime-api.wit
+++ b/linera-sdk/wit/service-runtime-api.wit
@@ -5,6 +5,14 @@ interface service-runtime-api {
     try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
     fetch-url: func(url: string) -> list<u8>;
 
+    record address {
+        part1: u32,
+        part2: u32,
+        part3: u32,
+        part4: u32,
+        part5: u32,
+    }
+
     record application-id {
         application-description-hash: crypto-hash,
         module-id: module-id,
@@ -15,14 +23,6 @@ interface service-runtime-api {
         part2: u64,
         part3: u64,
         part4: u64,
-    }
-
-    record address {
-        part1: u32,
-        part2: u32,
-        part3: u32,
-        part4: u32,
-        part5: u32,
     }
 
     record module-id {

--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -59,7 +59,6 @@ async fn test_end_to_end_queries(config: impl LineraNetConfig) {
 
     // publishing an application
     let (contract, service) = client.build_example("fungible").await.unwrap();
-    let vm_runtime = VmRuntime::Wasm;
     let state = InitialState {
         accounts: BTreeMap::new(),
     };
@@ -68,7 +67,7 @@ async fn test_end_to_end_queries(config: impl LineraNetConfig) {
         .publish_and_create::<FungibleTokenAbi, fungible::Parameters, InitialState>(
             contract,
             service,
-            vm_runtime,
+            VmRuntime::Wasm,
             &params,
             &state,
             &[],

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -340,8 +340,9 @@ impl AmmApp {
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()> {
-    use alloy::primitives::U256;
+    use alloy::primitives::{Address, U256};
     use alloy_sol_types::{sol, SolCall, SolValue};
+    use linera_base::vm::EncapsulateAddress;
     use linera_execution::test_utils::solidity::get_example_counter;
     use linera_sdk::abis::evm::EvmAbi;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -381,11 +382,14 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
     type Parameter = ();
     type InstantiationArgument = Vec<u8>;
 
+    let vm_runtime = VmRuntime::Evm(EncapsulateAddress {
+        address: Address::ZERO,
+    });
     let application_id = client
         .publish_and_create::<EvmAbi, Parameter, InstantiationArgument>(
             contract,
             service,
-            VmRuntime::Evm,
+            vm_runtime,
             &(),
             &instantiation_argument,
             &[],

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -307,7 +307,7 @@ pub trait Storage: Sized {
                     }
                 }
             }
-            VmRuntime::Evm => {
+            VmRuntime::Evm(_) => {
                 cfg_if::cfg_if! {
                     if #[cfg(with_revm)] {
                         let evm_runtime = EvmRuntime::Revm;
@@ -366,7 +366,7 @@ pub trait Storage: Sized {
                     }
                 }
             }
-            VmRuntime::Evm => {
+            VmRuntime::Evm(_) => {
                 cfg_if::cfg_if! {
                     if #[cfg(with_revm)] {
                         let evm_runtime = EvmRuntime::Revm;


### PR DESCRIPTION
## Motivation

In order to execute EVM smart contract, we need to have access to the Linera address and to the EVM address.
The call in the EVM to another EVM smart contract is done via using the EVM address.
The implementation would be done (in next PR) in the following way:
* The cross contract call is intercepted by the inspector.
* The inspector translate the EVM address into Linera address.
* The inspector calls the other contract via the `try_call_application`.
* The inspector returns the value.

This PR is the first step in the conversion.

## Proposal

The following is done:
* The Address is added to the `Evm` option of the enum. For Wasm, nothing is needed as only one address is needed.
* The `Address` needs to be encapsulated into a `EncapsulateAddress` in order to implement the `Wit*` traits.

For the effective implementation there are two options:
* One is that the contracts that are needed are encoded into the `required_application_ids`. This could be accessed from the `BaseRuntime`. This would of course limit the list of available contracts to the one that are put in advance (a limitation which is not in EVM).
* Or any address could be used. This would also require adding an entry to the `system` of `ExecutionStateView` mapping EVM address to Linera address and this could be accessed by adding functionalities to the `BaseRuntime`.

Regardless, these two options depend on the insertion of the address into the `ModuleId`.

The first goal is to implement the EVM to EVM calls where there is no opportunity for change.

## Test Plan

Basic tests are done in the `vm.rs`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None