### PR TITLE
fix: fix type issue in `test_key` function

### DIFF
--- a/linera-base/src/crypto/secp256k1.rs
+++ b/linera-base/src/crypto/secp256k1.rs
@@ -67,8 +67,8 @@ impl Secp256k1PublicKey {
     pub fn test_key(seed: u8) -> Self {
         use rand::SeedableRng;
         let mut rng = rand::rngs::StdRng::seed_from_u64(seed as u64);
-        let sk = k256::SecretKey::random(&mut rng);
-        Self(sk.public_key().into())
+        let sk = k256::ecdsa::SigningKey::random(&mut rng);
+        Self(sk.verifying_key().into())
     }
 
     /// Returns the bytes of the public key in compressed representation.


### PR DESCRIPTION
## Motivation

There was an inconsistency in the code where `SecretKey` was used in one place, while other parts of the code expected `SigningKey`. This could lead to compilation issues or runtime errors. The goal is to ensure consistency in the types being used across the codebase.

## Proposal

Change `k256::SecretKey::random` to `k256::ecdsa::SigningKey::random` and update the method for getting the public key to `verifying_key()`. This ensures the code works as expected and maintains type consistency.

## Test Plan

- Run the unit tests to ensure that no compilation errors or runtime issues occur after the change.
- Verify that the `test_key` function now correctly returns a public key from a `SigningKey`.