### PR TITLE
Remove metrics_host

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -170,7 +170,7 @@ jobs:
 
   ethereum-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v3

--- a/configuration/compose/validator.toml
+++ b/configuration/compose/validator.toml
@@ -6,7 +6,6 @@
 server_config_path = "server.json"
 host = "127.0.0.1"
 port = 19100
-metrics_host = "proxy"
 metrics_port = 21100
 internal_host = "proxy"
 internal_port = 20100
@@ -18,23 +17,19 @@ Grpc = "ClearText"
 [[shards]]
 host = "docker-shard-1"
 port = 19100
-metrics_host = "docker-shard-1"
 metrics_port = 21100
 
 [[shards]]
 host = "docker-shard-2"
 port = 19100
-metrics_host = "docker-shard-2"
 metrics_port = 21100
 
 [[shards]]
 host = "docker-shard-3"
 port = 19100
-metrics_host = "docker-shard-3"
 metrics_port = 21100
 
 [[shards]]
 host = "docker-shard-4"
 port = 19100
-metrics_host = "docker-shard-4"
 metrics_port = 21100

--- a/configuration/k8s-local/validator_1.toml
+++ b/configuration/k8s-local/validator_1.toml
@@ -1,7 +1,6 @@
 server_config_path = "server_1.json"
 host = "127.0.0.1"
 port = 19100
-metrics_host = "proxy-internal.default.svc.cluster.local"
 metrics_port = 21100
 internal_host = "proxy-internal.default.svc.cluster.local"
 internal_port = 20100
@@ -13,59 +12,49 @@ Grpc = "ClearText"
 [[shards]]
 host = "shards-0.shards.default.svc.cluster.local"
 port = 19100
-metrics_host = "shards-0.shards.default.svc.cluster.local"
 metrics_port = 21100
 
 [[shards]]
 host = "shards-1.shards.default.svc.cluster.local"
 port = 19100
-metrics_host = "shards-1.shards.default.svc.cluster.local"
 metrics_port = 21100
 
 [[shards]]
 host = "shards-2.shards.default.svc.cluster.local"
 port = 19100
-metrics_host = "shards-2.shards.default.svc.cluster.local"
 metrics_port = 21100
 
 [[shards]]
 host = "shards-3.shards.default.svc.cluster.local"
 port = 19100
-metrics_host = "shards-3.shards.default.svc.cluster.local"
 metrics_port = 21100
 
 [[shards]]
 host = "shards-4.shards.default.svc.cluster.local"
 port = 19100
-metrics_host = "shards-4.shards.default.svc.cluster.local"
 metrics_port = 21100
 
 [[shards]]
 host = "shards-5.shards.default.svc.cluster.local"
 port = 19100
-metrics_host = "shards-5.shards.default.svc.cluster.local"
 metrics_port = 21100
 
 [[shards]]
 host = "shards-6.shards.default.svc.cluster.local"
 port = 19100
-metrics_host = "shards-6.shards.default.svc.cluster.local"
 metrics_port = 21100
 
 [[shards]]
 host = "shards-7.shards.default.svc.cluster.local"
 port = 19100
-metrics_host = "shards-7.shards.default.svc.cluster.local"
 metrics_port = 21100
 
 [[shards]]
 host = "shards-8.shards.default.svc.cluster.local"
 port = 19100
-metrics_host = "shards-8.shards.default.svc.cluster.local"
 metrics_port = 21100
 
 [[shards]]
 host = "shards-9.shards.default.svc.cluster.local"
 port = 19100
-metrics_host = "shards-9.shards.default.svc.cluster.local"
 metrics_port = 21100

--- a/configuration/local/validator_1.toml
+++ b/configuration/local/validator_1.toml
@@ -1,7 +1,6 @@
 server_config_path = "server_1.json"
 host = "127.0.0.1"
 port = 19100
-metrics_host = "127.0.0.1"
 metrics_port = 21100
 internal_host = "127.0.0.1"
 internal_port = 20100
@@ -13,23 +12,19 @@ Grpc = "ClearText"
 [[shards]]
 host = "127.0.0.1"
 port = 19101
-metrics_host = "127.0.0.1"
 metrics_port = 21101
 
 [[shards]]
 host = "127.0.0.1"
 port = 19102
-metrics_host = "127.0.0.1"
 metrics_port = 21102
 
 [[shards]]
 host = "127.0.0.1"
 port = 19103
-metrics_host = "127.0.0.1"
 metrics_port = 21103
 
 [[shards]]
 host = "127.0.0.1"
 port = 19104
-metrics_host = "127.0.0.1"
 metrics_port = 21104

--- a/configuration/local/validator_2.toml
+++ b/configuration/local/validator_2.toml
@@ -3,7 +3,6 @@ host = "127.0.0.1"
 port = 9200
 internal_host = "127.0.0.1"
 internal_port = 10200
-metrics_host = "127.0.0.1"
 metrics_port = 11200
 [external_protocol]
 Grpc = "ClearText"
@@ -13,23 +12,19 @@ Grpc = "ClearText"
 [[shards]]
 host = "127.0.0.1"
 port = 9201
-metrics_host = "127.0.0.1"
 metrics_port = 11201
 
 [[shards]]
 host = "127.0.0.1"
 port = 9202
-metrics_host = "127.0.0.1"
 metrics_port = 11202
 
 [[shards]]
 host = "127.0.0.1"
 port = 9203
-metrics_host = "127.0.0.1"
 metrics_port = 11203
 
 [[shards]]
 host = "127.0.0.1"
 port = 9204
-metrics_host = "127.0.0.1"
 metrics_port = 11204

--- a/configuration/local/validator_3.toml
+++ b/configuration/local/validator_3.toml
@@ -3,7 +3,6 @@ host = "127.0.0.1"
 port = 9300
 internal_host = "127.0.0.1"
 internal_port = 10300
-metrics_host = "127.0.0.1"
 metrics_port = 11300
 [external_protocol]
 Grpc = "ClearText"
@@ -13,23 +12,19 @@ Grpc = "ClearText"
 [[shards]]
 host = "127.0.0.1"
 port = 9301
-metrics_host = "127.0.0.1"
 metrics_port = 11301
 
 [[shards]]
 host = "127.0.0.1"
 port = 9302
-metrics_host = "127.0.0.1"
 metrics_port = 11302
 
 [[shards]]
 host = "127.0.0.1"
 port = 9303
-metrics_host = "127.0.0.1"
 metrics_port = 11303
 
 [[shards]]
 host = "127.0.0.1"
 port = 9304
-metrics_host = "127.0.0.1"
 metrics_port = 11304

--- a/configuration/local/validator_4.toml
+++ b/configuration/local/validator_4.toml
@@ -3,7 +3,6 @@ host = "127.0.0.1"
 port = 9400
 internal_host = "127.0.0.1"
 internal_port = 10400
-metrics_host = "127.0.0.1"
 metrics_port = 11400
 [external_protocol]
 Grpc = "ClearText"
@@ -13,23 +12,19 @@ Grpc = "ClearText"
 [[shards]]
 host = "127.0.0.1"
 port = 9401
-metrics_host = "127.0.0.1"
 metrics_port = 11401
 
 [[shards]]
 host = "127.0.0.1"
 port = 9402
-metrics_host = "127.0.0.1"
 metrics_port = 11402
 
 [[shards]]
 host = "127.0.0.1"
 port = 9403
-metrics_host = "127.0.0.1"
 metrics_port = 11403
 
 [[shards]]
 host = "127.0.0.1"
 port = 9404
-metrics_host = "127.0.0.1"
 metrics_port = 11404

--- a/linera-rpc/src/config.rs
+++ b/linera-rpc/src/config.rs
@@ -50,8 +50,6 @@ pub struct ShardConfig {
     pub host: String,
     /// The port.
     pub port: u16,
-    /// The host on which metrics are served.
-    pub metrics_host: String,
     /// The port on which metrics are served.
     pub metrics_port: Option<u16>,
 }
@@ -113,8 +111,6 @@ pub struct ValidatorInternalNetworkPreConfig<P> {
     pub host: String,
     /// The port the proxy listens on the internal network.
     pub port: u16,
-    /// The host name of the proxy's metrics endpoint.
-    pub metrics_host: String,
     /// The port of the proxy's metrics endpoint.
     pub metrics_port: u16,
 }
@@ -127,7 +123,6 @@ impl<P> ValidatorInternalNetworkPreConfig<P> {
             shards: self.shards.clone(),
             host: self.host.clone(),
             port: self.port,
-            metrics_host: self.metrics_host.clone(),
             metrics_port: self.metrics_port,
         }
     }

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -348,7 +348,6 @@ impl LocalKubernetesNet {
                 port = {port}
                 internal_host = "proxy-internal.default.svc.cluster.local"
                 internal_port = {internal_port}
-                metrics_host = "proxy-internal.default.svc.cluster.local"
                 metrics_port = {metrics_port}
                 [external_protocol]
                 Grpc = "ClearText"
@@ -365,7 +364,6 @@ impl LocalKubernetesNet {
                 [[shards]]
                 host = "shards-{k}.shards.default.svc.cluster.local"
                 port = {shard_port}
-                metrics_host = "shards-{k}.shards.default.svc.cluster.local"
                 metrics_port = {shard_metrics_port}
                 "#
             ));

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -417,7 +417,6 @@ impl LocalNet {
                 port = {port}
                 internal_host = "{internal_host}"
                 internal_port = {internal_port}
-                metrics_host = "{external_host}"
                 metrics_port = {metrics_port}
                 external_protocol = {external_protocol}
                 internal_protocol = {internal_protocol}
@@ -432,7 +431,6 @@ impl LocalNet {
                 [[shards]]
                 host = "{internal_host}"
                 port = {shard_port}
-                metrics_host = "{external_host}"
                 metrics_port = {shard_metrics_port}
                 "#
             ));

--- a/scripts/deploy-validator.sh
+++ b/scripts/deploy-validator.sh
@@ -67,7 +67,6 @@ cat > $VALIDATOR_CONFIG <<EOL
 server_config_path = "server.json"
 host = "$HOST"
 port = $PORT
-metrics_host = "proxy"
 metrics_port = $METRICS_PORT
 internal_host = "proxy"
 internal_port = 20100
@@ -79,25 +78,21 @@ Grpc = "ClearText"
 [[shards]]
 host = "docker-shard-1"
 port = $PORT
-metrics_host = "docker-shard-1"
 metrics_port = $METRICS_PORT
 
 [[shards]]
 host = "docker-shard-2"
 port = $PORT
-metrics_host = "docker-shard-2"
 metrics_port = $METRICS_PORT
 
 [[shards]]
 host = "docker-shard-3"
 port = $PORT
-metrics_host = "docker-shard-3"
 metrics_port = $METRICS_PORT
 
 [[shards]]
 host = "docker-shard-4"
 port = $PORT
-metrics_host = "docker-shard-4"
 metrics_port = $METRICS_PORT
 EOL
 


### PR DESCRIPTION
## Motivation

The metrics host will always be the same as the internal host, because the internal host will actually have the metrics endpoint that the server pulls from. If we ever change to a strictly push model, this might change, but I don't see that changing anytime soon.

## Proposal

Remove metrics host as it's not necessary

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
