### PR TITLE
Merge `SystemExecutionError` into `ExecutionError`.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -59,8 +59,7 @@ use linera_execution::{
         AdminOperation, OpenChainConfig, Recipient, SystemOperation, EPOCH_STREAM_NAME,
         OPEN_CHAIN_MESSAGE_INDEX, REMOVED_EPOCH_STREAM_NAME,
     },
-    ExecutionError, Operation, Query, QueryOutcome, QueryResponse, SystemExecutionError,
-    SystemQuery, SystemResponse,
+    ExecutionError, Operation, Query, QueryOutcome, QueryResponse, SystemQuery, SystemResponse,
 };
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::ViewError;
@@ -2365,9 +2364,10 @@ where
                 ChainError::ExecutionError(
                     execution_error,
                     ChainExecutionContext::Block
-                ) if matches!(**execution_error, ExecutionError::SystemError(
-                    SystemExecutionError::InsufficientFundingForFees { .. }
-                ))
+                ) if matches!(
+                    **execution_error,
+                    ExecutionError::InsufficientFundingForFees { .. }
+                )
             ) =>
             {
                 // We can't even pay for the execution of one empty block. Let's return zero.

--- a/linera-core/src/unit_tests/test_helpers.rs
+++ b/linera-core/src/unit_tests/test_helpers.rs
@@ -3,7 +3,7 @@
 
 use assert_matches::assert_matches;
 use linera_chain::{ChainError, ChainExecutionContext};
-use linera_execution::{ExecutionError, SystemExecutionError};
+use linera_execution::ExecutionError;
 
 use crate::{client::ChainClientError, local_node::LocalNodeError, worker::WorkerError};
 
@@ -31,8 +31,8 @@ pub fn assert_insufficient_funding_during_operation<T>(
 
     assert_matches!(
         *execution_error,
-        ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }),
-        "Expected ExecutionError::SystemError::InsufficientFunding, found: {execution_error:#?}"
+        ExecutionError::InsufficientFunding { .. },
+        "Expected ExecutionError::InsufficientFunding, found: {execution_error:#?}"
     );
 }
 
@@ -55,8 +55,8 @@ pub fn assert_insufficient_funding_fees<T>(obtained_error: Result<T, ChainClient
 
     assert_matches!(
         *execution_error,
-        ExecutionError::SystemError(SystemExecutionError::InsufficientFundingForFees { .. }),
-        "Expected ExecutionError::SystemError::InsufficientFundingForFees, found: {execution_error:#?}"
+        ExecutionError::InsufficientFundingForFees { .. },
+        "Expected ExecutionError::InsufficientFundingForFees, found: {execution_error:#?}"
     );
 }
 
@@ -82,7 +82,7 @@ pub fn assert_insufficient_funding<T>(
 
     assert_matches!(
         *execution_error,
-        ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }),
-        "Expected ExecutionError::SystemError::InsufficientFunding, found: {execution_error:#?}"
+        ExecutionError::InsufficientFunding { .. },
+        "Expected ExecutionError::InsufficientFunding, found: {execution_error:#?}"
     );
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -50,7 +50,7 @@ use linera_execution::{
     },
     test_utils::{ExpectedCall, RegisterMockApplication, SystemExecutionState},
     ExecutionError, Message, MessageKind, OutgoingMessage, Query, QueryContext, QueryOutcome,
-    QueryResponse, SystemExecutionError, SystemQuery, SystemResponse,
+    QueryResponse, SystemQuery, SystemResponse,
 };
 use linera_storage::{DbStorage, Storage, TestClock};
 use linera_views::{
@@ -494,9 +494,7 @@ where
             WorkerError::ChainError(error)
         ) if matches!(&*error, ChainError::ExecutionError(
             execution_error, ChainExecutionContext::Operation(_)
-        ) if matches!(**execution_error, ExecutionError::SystemError(
-            SystemExecutionError::IncorrectTransferAmount
-        )))
+        ) if matches!(**execution_error, ExecutionError::IncorrectTransferAmount))
     );
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
@@ -905,9 +903,7 @@ where
                     WorkerError::ChainError(error)
                 ) if matches!(&*error, ChainError::ExecutionError(
                     execution_error, ChainExecutionContext::Operation(_)
-                ) if matches!(**execution_error, ExecutionError::SystemError(
-                    SystemExecutionError::InsufficientFunding { .. }
-                )))
+                ) if matches!(**execution_error, ExecutionError::InsufficientFunding { .. }))
         );
     }
     {
@@ -1151,9 +1147,7 @@ where
             WorkerError::ChainError(error)
         ) if matches!(&*error, ChainError::ExecutionError(
                 execution_error, ChainExecutionContext::Operation(_)
-        ) if matches!(**execution_error, ExecutionError::SystemError(
-            SystemExecutionError::InsufficientFunding { .. }
-        )))
+        ) if matches!(**execution_error, ExecutionError::InsufficientFunding { .. }))
     );
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
@@ -3515,8 +3509,8 @@ where
     let result = worker.handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::ChainError(error)) if matches!(&*error,
         ChainError::ExecutionError(error, _) if matches!(&**error,
-        ExecutionError::SystemError(SystemExecutionError::UnauthenticatedTransferOwner
-    ))));
+        ExecutionError::UnauthenticatedTransferOwner
+    )));
 
     // Without the transfer, a random key pair can propose a block.
     let proposal = make_child_block(&change_ownership_value)

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -30,8 +30,8 @@ use crate::{
     system::{CreateApplicationResult, OpenChainConfig, Recipient},
     util::RespondExt,
     ExecutionError, ExecutionRuntimeContext, ExecutionStateView, ModuleId, RawExecutionOutcome,
-    RawOutgoingMessage, SystemExecutionError, SystemMessage, TransactionTracker,
-    UserApplicationDescription, UserApplicationId, UserContractCode, UserServiceCode,
+    RawOutgoingMessage, SystemMessage, TransactionTracker, UserApplicationDescription,
+    UserApplicationId, UserContractCode, UserServiceCode,
 };
 
 #[cfg(with_metrics)]
@@ -303,7 +303,7 @@ where
                 application_permissions,
                 callback,
             } => {
-                let inactive_err = || SystemExecutionError::InactiveChain;
+                let inactive_err = || ExecutionError::InactiveChain;
                 let config = OpenChainConfig {
                     ownership,
                     admin_id: self.system.admin_id.get().ok_or_else(inactive_err)?,

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -14,10 +14,7 @@ use linera_base::{
 use linera_views::{context::Context, views::ViewError};
 use serde::Serialize;
 
-use crate::{
-    system::SystemExecutionError, ExecutionError, ExecutionStateView, Message, Operation,
-    ResourceControlPolicy,
-};
+use crate::{ExecutionError, ExecutionStateView, Message, Operation, ResourceControlPolicy};
 
 #[derive(Clone, Debug, Default)]
 pub struct ResourceController<Account = Amount, Tracker = ResourceTracker> {
@@ -89,7 +86,7 @@ where
         if other <= initial {
             self.account
                 .try_sub_assign(initial.try_sub(other).expect("other <= initial"))
-                .map_err(|_| SystemExecutionError::InsufficientFundingForFees {
+                .map_err(|_| ExecutionError::InsufficientFundingForFees {
                     balance: self.balance().unwrap_or(Amount::MAX),
                 })?;
         } else {
@@ -102,7 +99,7 @@ where
     /// Subtracts an amount from a balance and reports an error if that is impossible.
     fn update_balance(&mut self, fees: Amount) -> Result<(), ExecutionError> {
         self.account.try_sub_assign(fees).map_err(|_| {
-            SystemExecutionError::InsufficientFundingForFees {
+            ExecutionError::InsufficientFundingForFees {
                 balance: self.balance().unwrap_or(Amount::MAX),
             }
         })?;

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -12,7 +12,7 @@ use linera_base::{
 
 use crate::{
     ExecutionError, Message, OutgoingMessage, RawExecutionOutcome, RawOutgoingMessage,
-    SystemExecutionError, SystemMessage,
+    SystemMessage,
 };
 
 /// Tracks oracle responses and execution outcomes of an ongoing transaction execution, as well
@@ -186,11 +186,11 @@ impl TransactionTracker {
     pub fn replay_oracle_response(
         &mut self,
         oracle_response: OracleResponse,
-    ) -> Result<bool, SystemExecutionError> {
+    ) -> Result<bool, ExecutionError> {
         let replaying = if let Some(recorded_response) = self.next_replayed_oracle_response()? {
             ensure!(
                 recorded_response == oracle_response,
-                SystemExecutionError::OracleResponseMismatch
+                ExecutionError::OracleResponseMismatch
             );
             true
         } else {
@@ -209,13 +209,13 @@ impl TransactionTracker {
     /// `add_oracle_response`.
     pub fn next_replayed_oracle_response(
         &mut self,
-    ) -> Result<Option<OracleResponse>, SystemExecutionError> {
+    ) -> Result<Option<OracleResponse>, ExecutionError> {
         let Some(responses) = &mut self.replaying_oracle_responses else {
             return Ok(None); // Not in replay mode.
         };
         let response = responses
             .next()
-            .ok_or_else(|| SystemExecutionError::MissingOracleResponse)?;
+            .ok_or_else(|| ExecutionError::MissingOracleResponse)?;
         Ok(Some(response))
     }
 

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -29,8 +29,8 @@ use linera_execution::{
         test_accounts_strategy, ExpectedCall, RegisterMockApplication, SystemExecutionState,
     },
     BaseRuntime, ContractRuntime, ExecutionError, Message, MessageContext, Operation,
-    OperationContext, ResourceController, SystemExecutionError, SystemExecutionStateView,
-    TestExecutionRuntimeContext, TransactionOutcome, TransactionTracker,
+    OperationContext, ResourceController, SystemExecutionStateView, TestExecutionRuntimeContext,
+    TransactionOutcome, TransactionTracker,
 };
 use linera_views::context::MemoryContext;
 #[cfg(feature = "unstable-oracles")]
@@ -202,12 +202,7 @@ async fn test_unauthorized_transfer_system_api(
         )
         .await;
 
-    assert_matches!(
-        result,
-        Err(ExecutionError::SystemError(
-            SystemExecutionError::UnauthenticatedTransferOwner
-        ))
-    );
+    assert_matches!(result, Err(ExecutionError::UnauthenticatedTransferOwner));
 
     Ok(())
 }
@@ -455,12 +450,7 @@ async fn test_unauthorized_claims(
         )
         .await;
 
-    assert_matches!(
-        result,
-        Err(ExecutionError::SystemError(
-            SystemExecutionError::UnauthenticatedClaimOwner
-        ))
-    );
+    assert_matches!(result, Err(ExecutionError::UnauthenticatedClaimOwner));
 
     Ok(())
 }

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -17,7 +17,7 @@ use linera_base::{
 };
 use linera_execution::{
     committee::{Committee, Epoch},
-    system::{SystemExecutionError, SystemMessage},
+    system::SystemMessage,
     test_utils::{
         blob_oracle_responses, create_dummy_message_context, create_dummy_operation_context,
         create_dummy_user_application_registrations, ExpectedCall, RegisterMockApplication,
@@ -1458,30 +1458,22 @@ async fn test_close_chain() -> anyhow::Result<()> {
 )]
 #[test_case(
     Some(AccountPublicKey::test_key(1).into()), Some(AccountPublicKey::test_key(2).into())
-    => matches Ok(Err(
-        ExecutionError::SystemError(SystemExecutionError::UnauthenticatedTransferOwner)
-    ));
+    => matches Ok(Err(ExecutionError::UnauthenticatedTransferOwner));
     "fails if sender is not a receiving chain owner"
 )]
 #[test_case(
     Some(AccountPublicKey::test_key(1).into()), None
-    => matches Ok(Err(
-        ExecutionError::SystemError(SystemExecutionError::UnauthenticatedTransferOwner)
-    ));
+    => matches Ok(Err(ExecutionError::UnauthenticatedTransferOwner));
     "fails if unauthenticated"
 )]
 #[test_case(
     None, None
-    => matches Ok(Err(
-        ExecutionError::SystemError(SystemExecutionError::UnauthenticatedTransferOwner)
-    ));
+    => matches Ok(Err(ExecutionError::UnauthenticatedTransferOwner));
     "fails if unauthenticated and receiving chain has no owners"
 )]
 #[test_case(
     None, Some(AccountPublicKey::test_key(1).into())
-    => matches Ok(Err(
-        ExecutionError::SystemError(SystemExecutionError::UnauthenticatedTransferOwner)
-    ));
+    => matches Ok(Err(ExecutionError::UnauthenticatedTransferOwner));
     "fails if receiving chain has no owners"
 )]
 #[tokio::test]


### PR DESCRIPTION
## Motivation

As we keep adding functionality to the contract runtime, more and more "system" execution state functions are called through contracts, and the distinction between the two error types becomes less meaningful and sometimes even an obstacle (e.g. for https://github.com/linera-io/linera-protocol/pull/3546). Several variants are duplicated between the two. The many levels of nesting also make some tests more difficult to read.

## Proposal

Merge `SystemExecutionError` into `ExecutionError`, deduplicating and removing unused variants.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
