### PR TITLE
Add configurable permissions for making HTTP requests

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -223,6 +223,7 @@ Open (i.e. activate) a new multi-owner chain deriving the UID from an existing o
 * `--close-chain <CLOSE_CHAIN>` — These applications are allowed to close the current chain using the system API
 * `--change-application-permissions <CHANGE_APPLICATION_PERMISSIONS>` — These applications are allowed to change the application permissions on the current chain using the system API
 * `--call-service-as-oracle <CALL_SERVICE_AS_ORACLE>` — These applications are allowed to call services as oracles on the current chain using the system API
+* `--make-http-requests <MAKE_HTTP_REQUESTS>` — These applications are allowed to make HTTP requests on the current chain using the system API
 * `--initial-balance <BALANCE>` — The initial balance of the new chain. This is subtracted from the parent chain's balance
 
   Default value: `0`
@@ -274,6 +275,7 @@ Changes the application permissions configuration
 * `--close-chain <CLOSE_CHAIN>` — These applications are allowed to close the current chain using the system API
 * `--change-application-permissions <CHANGE_APPLICATION_PERMISSIONS>` — These applications are allowed to change the application permissions on the current chain using the system API
 * `--call-service-as-oracle <CALL_SERVICE_AS_ORACLE>` — These applications are allowed to call services as oracles on the current chain using the system API
+* `--make-http-requests <MAKE_HTTP_REQUESTS>` — These applications are allowed to make HTTP requests on the current chain using the system API
 
 
 

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -734,8 +734,8 @@ pub struct ApplicationPermissions {
     pub call_service_as_oracle: Option<Vec<ApplicationId>>,
     /// These applications are allowed to perform HTTP requests.
     #[graphql(default)]
-    #[debug(skip_if = Vec::is_empty)]
-    pub make_http_requests: Vec<ApplicationId>,
+    #[debug(skip_if = Option::is_none)]
+    pub make_http_requests: Option<Vec<ApplicationId>>,
 }
 
 impl ApplicationPermissions {
@@ -748,7 +748,7 @@ impl ApplicationPermissions {
             close_chain: vec![app_id],
             change_application_permissions: vec![app_id],
             call_service_as_oracle: Some(vec![app_id]),
-            make_http_requests: vec![],
+            make_http_requests: Some(vec![app_id]),
         }
     }
 
@@ -782,7 +782,10 @@ impl ApplicationPermissions {
 
     /// Returns whether the given application can make HTTP requests.
     pub fn can_make_http_requests(&self, app_id: &ApplicationId) -> bool {
-        self.make_http_requests.contains(app_id)
+        self.make_http_requests
+            .as_ref()
+            .map(|app_ids| app_ids.contains(app_id))
+            .unwrap_or(true)
     }
 }
 

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -732,6 +732,10 @@ pub struct ApplicationPermissions {
     #[graphql(default)]
     #[debug(skip_if = Option::is_none)]
     pub call_service_as_oracle: Option<Vec<ApplicationId>>,
+    /// These applications are allowed to perform HTTP requests.
+    #[graphql(default)]
+    #[debug(skip_if = Vec::is_empty)]
+    pub make_http_requests: Vec<ApplicationId>,
 }
 
 impl ApplicationPermissions {
@@ -744,6 +748,7 @@ impl ApplicationPermissions {
             close_chain: vec![app_id],
             change_application_permissions: vec![app_id],
             call_service_as_oracle: Some(vec![app_id]),
+            make_http_requests: vec![],
         }
     }
 
@@ -773,6 +778,11 @@ impl ApplicationPermissions {
             .as_ref()
             .map(|app_ids| app_ids.contains(app_id))
             .unwrap_or(true)
+    }
+
+    /// Returns whether the given application can make HTTP requests.
+    pub fn can_make_http_requests(&self, app_id: &ApplicationId) -> bool {
+        self.make_http_requests.contains(app_id)
     }
 }
 

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -119,7 +119,7 @@ async fn test_block_size_limit() {
     let mut chain = ChainStateView::new(chain_id).await;
 
     // The size of the executed valid block below.
-    let maximum_executed_block_size = 750;
+    let maximum_executed_block_size = 751;
 
     // Initialize the chain.
     let mut config = make_open_chain_config();

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -1470,7 +1470,7 @@ impl From<ApplicationPermissionsConfig> for ApplicationPermissions {
                 .change_application_permissions
                 .unwrap_or_default(),
             call_service_as_oracle: config.call_service_as_oracle,
-            make_http_requests: config.make_http_requests.unwrap_or_default(),
+            make_http_requests: config.make_http_requests,
         }
     }
 }

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -1454,6 +1454,10 @@ pub struct ApplicationPermissionsConfig {
     /// system API.
     #[arg(long)]
     pub call_service_as_oracle: Option<Vec<ApplicationId>>,
+    /// These applications are allowed to make HTTP requests on the current chain using the system
+    /// API.
+    #[arg(long)]
+    pub make_http_requests: Option<Vec<ApplicationId>>,
 }
 
 impl From<ApplicationPermissionsConfig> for ApplicationPermissions {
@@ -1466,6 +1470,7 @@ impl From<ApplicationPermissionsConfig> for ApplicationPermissions {
                 .change_application_permissions
                 .unwrap_or_default(),
             call_service_as_oracle: config.call_service_as_oracle,
+            make_http_requests: config.make_http_requests.unwrap_or_default(),
         }
     }
 }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -955,6 +955,18 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
             cfg!(feature = "unstable-oracles"),
             ExecutionError::UnstableOracle
         );
+
+        let app_permissions = self
+            .execution_state_sender
+            .send_request(|callback| ExecutionRequest::GetApplicationPermissions { callback })?
+            .recv_response()?;
+
+        let app_id = self.current_application().id;
+        ensure!(
+            app_permissions.can_make_http_requests(&app_id),
+            ExecutionError::UnauthorizedApplication(app_id)
+        );
+
         let response =
             if let Some(response) = self.transaction_tracker.next_replayed_oracle_response()? {
                 match response {

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -907,7 +907,7 @@ async fn test_query_service(authorized_apps: Option<Vec<()>>) -> Result<(), Exec
         .expect("should register mock application");
 
     let call_service_as_oracle =
-        authorized_apps.map(|apps| apps.into_iter().map(|_| application_id).collect());
+        authorized_apps.map(|apps| apps.into_iter().map(|()| application_id).collect());
 
     view.system
         .application_permissions
@@ -987,7 +987,7 @@ async fn test_perform_http_request(authorized_apps: Option<Vec<()>>) -> Result<(
         .expect("should register mock application");
 
     let make_http_requests =
-        authorized_apps.map(|apps| apps.into_iter().map(|_| application_id).collect());
+        authorized_apps.map(|apps| apps.into_iter().map(|()| application_id).collect());
 
     view.system
         .application_permissions

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -11,6 +11,8 @@ use std::{
 use assert_matches::assert_matches;
 #[cfg(feature = "unstable-oracles")]
 use linera_base::data_types::ApplicationPermissions;
+#[cfg(feature = "unstable-oracles")]
+use linera_base::http;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
@@ -944,6 +946,84 @@ async fn test_query_service(authorized_apps: Option<Vec<()>>) -> Result<(), Exec
                 OracleResponse::Blob(contract_blob_id),
                 OracleResponse::Blob(service_blob_id),
                 OracleResponse::Service(vec![]),
+            ]),
+        ),
+        &mut controller,
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Tests the contract system API to make HTTP requests.
+#[cfg(feature = "unstable-oracles")] // # TODO: Remove once #3524 lands
+#[test_case(vec![()] => matches Ok(_); "when authorized")]
+#[test_case(vec![] => matches Err(ExecutionError::UnauthorizedApplication(_)); "when unauthorized")]
+#[test_log::test(tokio::test)]
+async fn test_perform_http_request(authorized_apps: Vec<()>) -> Result<(), ExecutionError> {
+    let mut view = SystemExecutionState {
+        description: Some(ChainDescription::Root(0)),
+        ownership: ChainOwnership::default(),
+        balance: Amount::ONE,
+        balances: BTreeMap::new(),
+        ..SystemExecutionState::default()
+    }
+    .into_view()
+    .await;
+
+    let contract_blob = TransferTestEndpoint::sender_application_contract_blob();
+    let service_blob = TransferTestEndpoint::sender_application_service_blob();
+    let contract_blob_id = contract_blob.id();
+    let service_blob_id = service_blob.id();
+
+    let application_description = TransferTestEndpoint::sender_application_description();
+    let application_description_blob = Blob::new_application_description(&application_description);
+    let app_desc_blob_id = application_description_blob.id();
+
+    let (application_id, application) = view
+        .register_mock_application_with(application_description, contract_blob, service_blob)
+        .await
+        .expect("should register mock application");
+
+    let make_http_requests = authorized_apps
+        .into_iter()
+        .map(|_| application_id)
+        .collect();
+
+    view.system
+        .application_permissions
+        .set(ApplicationPermissions {
+            make_http_requests,
+            ..ApplicationPermissions::new_single(application_id)
+        });
+
+    application.expect_call(ExpectedCall::execute_operation(
+        move |runtime, _context, _operation| {
+            runtime.perform_http_request(http::Request::get("http://localhost"))?;
+            Ok(vec![])
+        },
+    ));
+    application.expect_call(ExpectedCall::default_finalize());
+
+    let context = create_dummy_operation_context();
+    let mut controller = ResourceController::default();
+    let operation = Operation::User {
+        application_id,
+        bytes: vec![],
+    };
+
+    view.execute_operation(
+        context,
+        Timestamp::from(0),
+        operation,
+        &mut TransactionTracker::new(
+            0,
+            0,
+            Some(vec![
+                OracleResponse::Blob(app_desc_blob_id),
+                OracleResponse::Blob(contract_blob_id),
+                OracleResponse::Blob(service_blob_id),
+                OracleResponse::Http(http::Response::ok(vec![])),
             ]),
         ),
         &mut controller,

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -78,6 +78,9 @@ ApplicationPermissions:
         OPTION:
           SEQ:
             TYPENAME: ApplicationId
+    - make_http_requests:
+        SEQ:
+          TYPENAME: ApplicationId
 BlobContent:
   STRUCT:
     - blob_type:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -79,8 +79,9 @@ ApplicationPermissions:
           SEQ:
             TYPENAME: ApplicationId
     - make_http_requests:
-        SEQ:
-          TYPENAME: ApplicationId
+        OPTION:
+          SEQ:
+            TYPENAME: ApplicationId
 BlobContent:
   STRUCT:
     - blob_type:

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -229,7 +229,8 @@ impl From<ApplicationPermissions> for wit_contract_api::ApplicationPermissions {
                 .collect(),
             call_service_as_oracle: call_service_as_oracle
                 .map(|app_ids| app_ids.into_iter().map(Into::into).collect()),
-            make_http_requests: make_http_requests.into_iter().map(Into::into).collect(),
+            make_http_requests: make_http_requests
+                .map(|app_ids| app_ids.into_iter().map(Into::into).collect()),
         }
     }
 }

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -216,6 +216,7 @@ impl From<ApplicationPermissions> for wit_contract_api::ApplicationPermissions {
             close_chain,
             change_application_permissions,
             call_service_as_oracle,
+            make_http_requests,
         } = permissions;
         Self {
             execute_operations: execute_operations
@@ -228,6 +229,7 @@ impl From<ApplicationPermissions> for wit_contract_api::ApplicationPermissions {
                 .collect(),
             call_service_as_oracle: call_service_as_oracle
                 .map(|app_ids| app_ids.into_iter().map(Into::into).collect()),
+            make_http_requests: make_http_requests.into_iter().map(Into::into).collect(),
         }
     }
 }

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -45,7 +45,7 @@ interface contract-runtime-api {
         close-chain: list<application-id>,
         change-application-permissions: list<application-id>,
         call-service-as-oracle: option<list<application-id>>,
-        make-http-requests: list<application-id>,
+        make-http-requests: option<list<application-id>>,
     }
 
     record block-height {

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -45,6 +45,7 @@ interface contract-runtime-api {
         close-chain: list<application-id>,
         change-application-permissions: list<application-id>,
         call-service-as-oracle: option<list<application-id>>,
+        make-http-requests: list<application-id>,
     }
 
     record block-height {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -54,7 +54,7 @@ input ApplicationPermissions {
 	"""
 	These applications are allowed to perform HTTP requests.
 	"""
-	makeHttpRequests: [ApplicationId!]! = []
+	makeHttpRequests: [ApplicationId!] = null
 }
 
 """
@@ -817,7 +817,7 @@ type MutationRoot {
 	"""
 	Changes the application permissions configuration on this chain.
 	"""
-	changeApplicationPermissions(chainId: ChainId!, closeChain: [ApplicationId!]!, executeOperations: [ApplicationId!], mandatoryApplications: [ApplicationId!]!, changeApplicationPermissions: [ApplicationId!]!, callServiceAsOracle: [ApplicationId!], makeHttpRequests: [ApplicationId!]!): CryptoHash!
+	changeApplicationPermissions(chainId: ChainId!, closeChain: [ApplicationId!]!, executeOperations: [ApplicationId!], mandatoryApplications: [ApplicationId!]!, changeApplicationPermissions: [ApplicationId!]!, callServiceAsOracle: [ApplicationId!], makeHttpRequests: [ApplicationId!]): CryptoHash!
 	"""
 	(admin chain only) Registers a new committee. This will notify the subscribers of
 	the admin chain so that they can migrate to the new epoch (by accepting the

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -51,6 +51,10 @@ input ApplicationPermissions {
 	These applications are allowed to perform calls to services as oracles.
 	"""
 	callServiceAsOracle: [ApplicationId!] = null
+	"""
+	These applications are allowed to perform HTTP requests.
+	"""
+	makeHttpRequests: [ApplicationId!]! = []
 }
 
 """
@@ -813,7 +817,7 @@ type MutationRoot {
 	"""
 	Changes the application permissions configuration on this chain.
 	"""
-	changeApplicationPermissions(chainId: ChainId!, closeChain: [ApplicationId!]!, executeOperations: [ApplicationId!], mandatoryApplications: [ApplicationId!]!, changeApplicationPermissions: [ApplicationId!]!, callServiceAsOracle: [ApplicationId!]): CryptoHash!
+	changeApplicationPermissions(chainId: ChainId!, closeChain: [ApplicationId!]!, executeOperations: [ApplicationId!], mandatoryApplications: [ApplicationId!]!, changeApplicationPermissions: [ApplicationId!]!, callServiceAsOracle: [ApplicationId!], makeHttpRequests: [ApplicationId!]!): CryptoHash!
 	"""
 	(admin chain only) Registers a new committee. This will notify the subscribers of
 	the admin chain so that they can migrate to the new epoch (by accepting the

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -498,7 +498,7 @@ where
         mandatory_applications: Vec<ApplicationId>,
         change_application_permissions: Vec<ApplicationId>,
         call_service_as_oracle: Option<Vec<ApplicationId>>,
-        make_http_requests: Vec<ApplicationId>,
+        make_http_requests: Option<Vec<ApplicationId>>,
     ) -> Result<CryptoHash, Error> {
         let operation = SystemOperation::ChangeApplicationPermissions(ApplicationPermissions {
             execute_operations,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -498,6 +498,7 @@ where
         mandatory_applications: Vec<ApplicationId>,
         change_application_permissions: Vec<ApplicationId>,
         call_service_as_oracle: Option<Vec<ApplicationId>>,
+        make_http_requests: Vec<ApplicationId>,
     ) -> Result<CryptoHash, Error> {
         let operation = SystemOperation::ChangeApplicationPermissions(ApplicationPermissions {
             execute_operations,
@@ -505,6 +506,7 @@ where
             close_chain,
             change_application_permissions,
             call_service_as_oracle,
+            make_http_requests,
         });
         self.execute_system_operation(operation, chain_id).await
     }


### PR DESCRIPTION
## Motivation

Chains may want to prevent applications from performing HTTP requests.

## Proposal

This adds a new field to ApplicationPermissions that controls which applications can make HTTP requests. If the calling application is not on the list, the call will fail with an UnauthorizedApplication error.

## Test Plan

Unit tests were added that exercise new functionality.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #3531 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
