### PR TITLE
Separate types for Application and ApplicationId

### DIFF
--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -8,7 +8,7 @@ mod state;
 use amm::{AmmAbi, Message, Operation, Parameters};
 use fungible::{Account, FungibleTokenAbi};
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount, ApplicationId, ChainId, WithContractAbi},
+    linera_base_types::{AccountOwner, Amount, Application, ChainId, WithContractAbi},
     views::{RootView, View},
     Contract, ContractRuntime,
 };
@@ -443,7 +443,7 @@ impl AmmContract {
     }
 
     fn get_amm_app_owner(&mut self) -> AccountOwner {
-        AccountOwner::Application(self.runtime.application_id().forget_abi())
+        AccountOwner::Application(self.runtime.application().application_id())
     }
 
     fn get_amm_chain_id(&mut self) -> ChainId {
@@ -663,11 +663,11 @@ impl AmmContract {
     }
 
     fn get_pool_balance(&mut self, token_idx: u32) -> Amount {
-        let pool_owner = AccountOwner::Application(self.runtime.application_id().forget_abi());
+        let pool_owner = AccountOwner::Application(self.runtime.application().application_id());
         self.balance(&pool_owner, token_idx)
     }
 
-    fn fungible_id(&mut self, token_idx: u32) -> ApplicationId<FungibleTokenAbi> {
+    fn fungible_id(&mut self, token_idx: u32) -> Application<FungibleTokenAbi> {
         self.runtime.application_parameters().tokens[token_idx as usize]
     }
 

--- a/examples/crowd-funding/src/service.rs
+++ b/examples/crowd-funding/src/service.rs
@@ -11,7 +11,7 @@ use async_graphql::{EmptySubscription, Request, Response, Schema};
 use crowd_funding::Operation;
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{ApplicationId, WithServiceAbi},
+    linera_base_types::{Application, WithServiceAbi},
     views::View,
     Service, ServiceRuntime,
 };
@@ -29,7 +29,7 @@ impl WithServiceAbi for CrowdFundingService {
 }
 
 impl Service for CrowdFundingService {
-    type Parameters = ApplicationId<fungible::FungibleTokenAbi>;
+    type Parameters = Application<fungible::FungibleTokenAbi>;
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {
         let state = CrowdFundingState::load(runtime.root_view_storage_context())

--- a/examples/crowd-funding/tests/campaign_lifecycle.rs
+++ b/examples/crowd-funding/tests/campaign_lifecycle.rs
@@ -11,8 +11,8 @@ use crowd_funding::{CrowdFundingAbi, InstantiationArgument, Operation};
 use fungible::FungibleTokenAbi;
 use linera_sdk::{
     linera_base_types::{
-        AccountOwner, AccountSecretKey, Amount, ApplicationId, Ed25519SecretKey,
-        Secp256k1SecretKey, Timestamp,
+        AccountOwner, AccountSecretKey, Amount, Application, Ed25519SecretKey, Secp256k1SecretKey,
+        Timestamp,
     },
     test::TestValidator,
 };
@@ -30,7 +30,7 @@ async fn collect_pledges() {
 
     let (validator, module_id) = TestValidator::with_current_module::<
         CrowdFundingAbi,
-        ApplicationId<FungibleTokenAbi>,
+        Application<FungibleTokenAbi>,
         InstantiationArgument,
     >()
     .await;
@@ -62,7 +62,7 @@ async fn collect_pledges() {
             module_id,
             token_id,
             campaign_state,
-            vec![token_id.forget_abi()],
+            vec![token_id.application_id()],
         )
         .await;
 
@@ -134,7 +134,7 @@ async fn cancel_successful_campaign() {
 
     let (validator, module_id) = TestValidator::with_current_module::<
         CrowdFundingAbi,
-        ApplicationId<FungibleTokenAbi>,
+        Application<FungibleTokenAbi>,
         InstantiationArgument,
     >()
     .await;
@@ -164,7 +164,7 @@ async fn cancel_successful_campaign() {
             module_id,
             token_id,
             campaign_state,
-            vec![token_id.forget_abi()],
+            vec![token_id.application_id()],
         )
         .await;
 

--- a/examples/ethereum-tracker/src/contract.rs
+++ b/examples/ethereum-tracker/src/contract.rs
@@ -80,7 +80,7 @@ impl EthereumTrackerContract {
     async fn read_initial(&mut self) {
         let request = async_graphql::Request::new("query { readInitialEvent }");
 
-        let application_id = self.runtime.application_id();
+        let application_id = self.runtime.application();
         let response = self.runtime.query_service(application_id, request);
 
         let async_graphql::Value::Object(data_object) = response.data else {
@@ -113,7 +113,7 @@ impl EthereumTrackerContract {
             r#"query {{ readTransferEvents(endBlock: {end_block}) }}"#
         ));
 
-        let application_id = self.runtime.application_id();
+        let application_id = self.runtime.application();
         let response = self.runtime.query_service(application_id, request);
 
         let async_graphql::Value::Object(data_object) = response.data else {

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -11,7 +11,7 @@ use {
     async_graphql::InputType,
     futures::{stream, StreamExt},
     linera_sdk::{
-        linera_base_types::{ApplicationId, ModuleId},
+        linera_base_types::{Application, ModuleId},
         test::{ActiveChain, QueryOutcome, TestValidator},
     },
 };
@@ -49,7 +49,7 @@ pub async fn create_with_accounts(
     module_id: ModuleId<FungibleTokenAbi, Parameters, InitialState>,
     initial_amounts: impl IntoIterator<Item = Amount>,
 ) -> (
-    ApplicationId<FungibleTokenAbi>,
+    Application<FungibleTokenAbi>,
     Vec<(ActiveChain, AccountOwner, Amount)>,
 ) {
     let mut token_chain = validator.new_chain().await;
@@ -117,7 +117,7 @@ pub async fn create_with_accounts(
 /// Queries the balance of an account owned by `account_owner` on a specific `chain`.
 #[cfg(all(any(test, feature = "test"), not(target_arch = "wasm32")))]
 pub async fn query_account(
-    application_id: ApplicationId<FungibleTokenAbi>,
+    application_id: Application<FungibleTokenAbi>,
     chain: &ActiveChain,
     account_owner: AccountOwner,
 ) -> Option<Amount> {

--- a/examples/gen-nft/src/contract.rs
+++ b/examples/gen-nft/src/contract.rs
@@ -178,7 +178,7 @@ impl GenNftContract {
     async fn mint(&mut self, owner: AccountOwner, prompt: String) {
         let token_id = Nft::create_token_id(
             &self.runtime.chain_id(),
-            &self.runtime.application_id().forget_abi(),
+            &self.runtime.application().forget_abi(),
             &prompt,
             &owner,
             *self.state.num_minted_nfts.get(),

--- a/examples/gen-nft/src/lib.rs
+++ b/examples/gen-nft/src/lib.rs
@@ -9,7 +9,7 @@ use async_graphql::{InputObject, Request, Response, SimpleObject};
 use fungible::Account;
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, ApplicationId, ChainId, ContractAbi, ServiceAbi},
+    linera_base_types::{AccountOwner, Application, ChainId, ContractAbi, ServiceAbi},
     ToBcsBytes,
 };
 use serde::{Deserialize, Serialize};
@@ -122,7 +122,7 @@ impl Display for TokenId {
 impl Nft {
     pub fn create_token_id(
         chain_id: &ChainId,
-        application_id: &ApplicationId,
+        application_id: &Application,
         prompt: &String,
         minter: &AccountOwner,
         num_minted_nfts: u64,

--- a/examples/hex-game/src/contract.rs
+++ b/examples/hex-game/src/contract.rs
@@ -152,8 +152,8 @@ impl HexContract {
             100,
             TimeoutConfig::default(),
         );
-        let app_id = self.runtime.application_id();
-        let permissions = ApplicationPermissions::new_single(app_id.forget_abi());
+        let app_id = self.runtime.application();
+        let permissions = ApplicationPermissions::new_single(app_id.application_id());
         let (message_id, chain_id) = self.runtime.open_chain(ownership, permissions, fee_budget);
         for owner in &players {
             self.state

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -8,7 +8,7 @@ use std::cmp::min;
 
 use fungible::{Account, FungibleTokenAbi};
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount, ApplicationId, ChainId, WithContractAbi},
+    linera_base_types::{AccountOwner, Amount, Application, ChainId, WithContractAbi},
     views::{RootView, View},
     Contract, ContractRuntime,
 };
@@ -174,7 +174,7 @@ impl MatchingEngineContract {
 
     /// The application engine is trading between two tokens. Those tokens are the parameters of the
     /// construction of the exchange and are accessed by index in the system.
-    fn fungible_id(&mut self, token_idx: u32) -> ApplicationId<FungibleTokenAbi> {
+    fn fungible_id(&mut self, token_idx: u32) -> Application<FungibleTokenAbi> {
         self.runtime.application_parameters().tokens[token_idx as usize]
     }
 
@@ -188,7 +188,7 @@ impl MatchingEngineContract {
     ) {
         let destination = Account {
             chain_id: self.runtime.chain_id(),
-            owner: AccountOwner::Application(self.runtime.application_id().forget_abi()),
+            owner: AccountOwner::Application(self.runtime.application().application_id()),
         };
         let (amount, token_idx) = Self::get_amount_idx(nature, price, amount);
         self.transfer(*owner, amount, destination, token_idx)
@@ -197,7 +197,7 @@ impl MatchingEngineContract {
     /// Transfers `amount` tokens from the funds in custody to the `destination`.
     fn send_to(&mut self, transfer: Transfer) {
         let destination = transfer.account;
-        let owner_app = AccountOwner::Application(self.runtime.application_id().forget_abi());
+        let owner_app = AccountOwner::Application(self.runtime.application().application_id());
         self.transfer(owner_app, transfer.amount, destination, transfer.token_idx);
     }
 

--- a/examples/matching-engine/src/lib.rs
+++ b/examples/matching-engine/src/lib.rs
@@ -7,7 +7,7 @@ use async_graphql::{scalar, InputObject, Request, Response, SimpleObject};
 use fungible::FungibleTokenAbi;
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, Amount, ApplicationId, ContractAbi, ServiceAbi},
+    linera_base_types::{AccountOwner, Amount, Application, ContractAbi, ServiceAbi},
     views::{CustomSerialize, ViewError},
 };
 use serde::{Deserialize, Serialize};
@@ -168,7 +168,7 @@ scalar!(Order);
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct Parameters {
     /// The token0 and token1 used for the matching engine
-    pub tokens: [ApplicationId<FungibleTokenAbi>; 2],
+    pub tokens: [Application<FungibleTokenAbi>; 2],
 }
 
 scalar!(Parameters);

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -7,7 +7,7 @@
 
 use async_graphql::InputType;
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount, ApplicationId, ApplicationPermissions},
+    linera_base_types::{AccountOwner, Amount, Application, ApplicationPermissions},
     test::{ActiveChain, QueryOutcome, TestValidator},
 };
 use matching_engine::{
@@ -15,7 +15,7 @@ use matching_engine::{
 };
 
 pub async fn get_orders(
-    application_id: ApplicationId<MatchingEngineAbi>,
+    application_id: Application<MatchingEngineAbi>,
     chain: &ActiveChain,
     account_owner: AccountOwner,
 ) -> Option<Vec<OrderId>> {
@@ -132,7 +132,7 @@ async fn single_transaction() {
             module_id,
             matching_parameter,
             (),
-            vec![token_id_a.forget_abi(), token_id_b.forget_abi()],
+            vec![token_id_a.application_id(), token_id_b.application_id()],
         )
         .await;
 
@@ -265,7 +265,7 @@ async fn single_transaction() {
         .await;
     user_chain_a.handle_received_messages().await;
 
-    let permissions = ApplicationPermissions::new_single(matching_id.forget_abi());
+    let permissions = ApplicationPermissions::new_single(matching_id.application_id());
     matching_chain
         .add_block(|block| {
             block.with_change_application_permissions(permissions);

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
 use linera_sdk::{
-    linera_base_types::{ApplicationId, StreamName, WithContractAbi},
+    linera_base_types::{Application, StreamName, WithContractAbi},
     Contract, ContractRuntime, Resources,
 };
 use meta_counter::{Message, MetaCounterAbi, Operation};
@@ -16,7 +16,7 @@ pub struct MetaCounterContract {
 linera_sdk::contract!(MetaCounterContract);
 
 impl MetaCounterContract {
-    fn counter_id(&mut self) -> ApplicationId<counter::CounterAbi> {
+    fn counter_id(&mut self) -> Application<counter::CounterAbi> {
         self.runtime.application_parameters()
     }
 }
@@ -28,7 +28,7 @@ impl WithContractAbi for MetaCounterContract {
 impl Contract for MetaCounterContract {
     type Message = Message;
     type InstantiationArgument = ();
-    type Parameters = ApplicationId<counter::CounterAbi>;
+    type Parameters = Application<counter::CounterAbi>;
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {
         MetaCounterContract { runtime }

--- a/examples/meta-counter/src/service.rs
+++ b/examples/meta-counter/src/service.rs
@@ -5,7 +5,7 @@
 
 use async_graphql::{Request, Response};
 use linera_sdk::{
-    linera_base_types::{ApplicationId, WithServiceAbi},
+    linera_base_types::{Application, WithServiceAbi},
     Service, ServiceRuntime,
 };
 
@@ -20,7 +20,7 @@ impl WithServiceAbi for MetaCounterService {
 }
 
 impl Service for MetaCounterService {
-    type Parameters = ApplicationId<counter::CounterAbi>;
+    type Parameters = Application<counter::CounterAbi>;
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {
         MetaCounterService { runtime }

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -183,7 +183,7 @@ impl NonFungibleTokenContract {
         self.runtime.assert_data_blob_exists(blob_hash);
         let token_id = Nft::create_token_id(
             &self.runtime.chain_id(),
-            &self.runtime.application_id().forget_abi(),
+            &self.runtime.application().forget_abi(),
             &name,
             &owner,
             &blob_hash,

--- a/examples/non-fungible/src/lib.rs
+++ b/examples/non-fungible/src/lib.rs
@@ -9,7 +9,7 @@ use async_graphql::{InputObject, Request, Response, SimpleObject};
 use fungible::Account;
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, ApplicationId, ChainId, ContractAbi, ServiceAbi},
+    linera_base_types::{AccountOwner, Application, ChainId, ContractAbi, ServiceAbi},
     DataBlobHash, ToBcsBytes,
 };
 use serde::{Deserialize, Serialize};
@@ -127,7 +127,7 @@ impl Display for TokenId {
 impl Nft {
     pub fn create_token_id(
         chain_id: &ChainId,
-        application_id: &ApplicationId,
+        application_id: &Application,
         name: &String,
         minter: &AccountOwner,
         blob_hash: &DataBlobHash,

--- a/examples/rfq/src/contract.rs
+++ b/examples/rfq/src/contract.rs
@@ -143,7 +143,7 @@ impl Contract for RfqContract {
                     target_account: Account {
                         chain_id: temp_chain_id,
                         owner: AccountOwner::Application(
-                            self.runtime.application_id().forget_abi(),
+                            self.runtime.application().application_id(),
                         ),
                     },
                 };
@@ -261,7 +261,7 @@ impl Contract for RfqContract {
                     None => {
                         // This should never really happen, but if it does, return the
                         // sent tokens
-                        let app_id = self.runtime.application_id().forget_abi();
+                        let app_id = self.runtime.application().application_id();
                         self.runtime.call_application(
                             true,
                             tokens.token_id.with_abi::<fungible::FungibleTokenAbi>(),
@@ -275,7 +275,7 @@ impl Contract for RfqContract {
                     Some(held_tokens) => {
                         // we have tokens from both parties now: return them to the
                         // correct parties
-                        let app_id = self.runtime.application_id().forget_abi();
+                        let app_id = self.runtime.application().application_id();
                         self.runtime.call_application(
                             true,
                             tokens.token_id.with_abi::<fungible::FungibleTokenAbi>(),
@@ -333,8 +333,8 @@ impl RfqContract {
             100,
             TimeoutConfig::default(),
         );
-        let app_id = self.runtime.application_id();
-        let permissions = ApplicationPermissions::new_single(app_id.forget_abi());
+        let app_id = self.runtime.application();
+        let permissions = ApplicationPermissions::new_single(app_id.application_id());
         let (_, temp_chain_id) = self.runtime.open_chain(ownership, permissions, fee_budget);
 
         // transfer tokens to the new chain
@@ -343,7 +343,7 @@ impl RfqContract {
             amount: quote_provided.get_amount(),
             target_account: Account {
                 chain_id: temp_chain_id,
-                owner: AccountOwner::Application(self.runtime.application_id().forget_abi()),
+                owner: AccountOwner::Application(self.runtime.application().application_id()),
             },
         };
         let token = token_pair.token_offered;
@@ -377,7 +377,7 @@ impl RfqContract {
         // we're executing on the temporary chain
         // if we hold some tokens, we return them before closing
         if let Some(tokens) = self.state.temp_chain_held_tokens() {
-            let app_id = self.runtime.application_id().forget_abi();
+            let app_id = self.runtime.application().application_id();
             self.runtime.call_application(
                 true,
                 tokens.token_id.with_abi::<fungible::FungibleTokenAbi>(),

--- a/examples/rfq/src/lib.rs
+++ b/examples/rfq/src/lib.rs
@@ -7,7 +7,7 @@ use async_graphql::{scalar, InputObject, Request, Response, SimpleObject};
 use fungible::Account;
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{Amount, ApplicationId, ChainId, ContractAbi, Owner, ServiceAbi},
+    linera_base_types::{Amount, Application, ChainId, ContractAbi, Owner, ServiceAbi},
 };
 use serde::{Deserialize, Serialize};
 
@@ -26,8 +26,8 @@ impl ServiceAbi for RfqAbi {
 #[derive(Debug, Clone, Serialize, Deserialize, SimpleObject, InputObject)]
 #[graphql(input_name = "TokenPairInput")]
 pub struct TokenPair {
-    pub token_offered: ApplicationId,
-    pub token_asked: ApplicationId,
+    pub token_offered: Application,
+    pub token_asked: Application,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, SimpleObject, InputObject)]
@@ -70,7 +70,7 @@ impl RequestId {
 #[derive(Debug, Clone, Serialize, Deserialize, SimpleObject, InputObject)]
 #[graphql(input_name = "TokensInput")]
 pub struct Tokens {
-    pub token_id: ApplicationId,
+    pub token_id: Application,
     pub owner: Account,
     pub amount: Amount,
 }

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -34,8 +34,8 @@ use crate::{
     crypto::{BcsHashable, CryptoHash},
     doc_scalar, hex_debug, http,
     identifiers::{
-        ApplicationId, BlobId, BlobType, ChainId, Destination, EventId, GenericApplicationId,
-        ModuleId, StreamId, UserApplicationId,
+        Application, ApplicationId, BlobId, BlobType, ChainId, Destination, EventId,
+        GenericApplicationId, ModuleId, StreamId,
     },
     limited_writer::{LimitedWriter, LimitedWriterError},
     time::{Duration, SystemTime},
@@ -818,7 +818,7 @@ impl<'de> BcsHashable<'de> for OracleResponse {}
 
 /// Description of the necessary information to run a user application used within blobs.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Hash, Serialize)]
-pub struct UserApplicationDescription {
+pub struct ApplicationDescription {
     /// The unique ID of the bytecode to use for the application.
     pub module_id: ModuleId,
     /// The chain ID that created the application.
@@ -832,21 +832,29 @@ pub struct UserApplicationDescription {
     #[debug(with = "hex_debug")]
     pub parameters: Vec<u8>,
     /// Required dependencies.
-    pub required_application_ids: Vec<UserApplicationId>,
+    pub required_application_ids: Vec<ApplicationId>,
 }
 
-impl From<&UserApplicationDescription> for UserApplicationId {
-    fn from(description: &UserApplicationDescription) -> Self {
-        UserApplicationId::new(CryptoHash::new(&BlobContent::new_application_description(
+impl From<&ApplicationDescription> for Application {
+    fn from(description: &ApplicationDescription) -> Self {
+        Application::new(CryptoHash::new(&BlobContent::new_application_description(
             description,
         )))
     }
 }
 
-impl BcsHashable<'_> for UserApplicationDescription {}
+impl From<&ApplicationDescription> for ApplicationId {
+    fn from(description: &ApplicationDescription) -> Self {
+        ApplicationId::new(CryptoHash::new(&BlobContent::new_application_description(
+            description,
+        )))
+    }
+}
 
-impl UserApplicationDescription {
-    /// Gets the serialized bytes for this `UserApplicationDescription`.
+impl BcsHashable<'_> for ApplicationDescription {}
+
+impl ApplicationDescription {
+    /// Gets the serialized bytes for this `ApplicationIdDescription`.
     pub fn to_bytes(&self) -> Vec<u8> {
         bcs::to_bytes(self).expect("Serializing blob bytes should not fail!")
     }
@@ -1023,10 +1031,8 @@ impl BlobContent {
         )
     }
 
-    /// Creates a new application description [`BlobContent`] from a [`UserApplicationDescription`].
-    pub fn new_application_description(
-        application_description: &UserApplicationDescription,
-    ) -> Self {
+    /// Creates a new application description [`BlobContent`] from a [`ApplicationDescription`].
+    pub fn new_application_description(application_description: &ApplicationDescription) -> Self {
         let bytes = application_description.to_bytes();
         BlobContent::new(BlobType::ApplicationDescription, bytes)
     }
@@ -1102,9 +1108,7 @@ impl Blob {
 
     /// Creates a new application description [`BlobContent`] from the provided
     /// description.
-    pub fn new_application_description(
-        application_description: &UserApplicationDescription,
-    ) -> Self {
+    pub fn new_application_description(application_description: &ApplicationDescription) -> Self {
         Blob::new(BlobContent::new_application_description(
             application_description,
         ))
@@ -1226,7 +1230,7 @@ doc_scalar!(
     "A blob of binary data, with its content-addressed blob ID."
 );
 doc_scalar!(
-    UserApplicationDescription,
+    ApplicationDescription,
     "Description of the necessary information to run a user application"
 );
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -319,10 +319,8 @@ pub struct Application<A = ()> {
     WitType,
 )]
 #[cfg_attr(with_testing, derive(Default, test_strategy::Arbitrary))]
-pub struct ApplicationId {
-    /// The hash of the `ApplicationIdDescription` this refers to.
-    pub application_description_hash: CryptoHash,
-}
+/// The hash of the `ApplicationIdDescription` this refers to.
+pub struct ApplicationId(pub CryptoHash);
 
 /// A unique identifier for an application.
 #[derive(
@@ -888,24 +886,20 @@ impl Application {
 impl<A> Application<A> {
     /// Returns the application ID without the ABI.
     pub fn application_id(&self) -> ApplicationId {
-        ApplicationId {
-            application_description_hash: self.application_description_hash,
-        }
+        ApplicationId(self.application_description_hash)
     }
 }
 
 impl ApplicationId {
     /// Creates a user application ID from the application description hash.
     pub fn new(application_description_hash: CryptoHash) -> Self {
-        ApplicationId {
-            application_description_hash,
-        }
+        ApplicationId(application_description_hash)
     }
 
     /// Specializes a user application ID for a given ABI.
     pub fn with_abi<A>(self) -> Application<A> {
         Application {
-            application_description_hash: self.application_description_hash,
+            application_description_hash: self.0,
             _phantom: PhantomData,
         }
     }
@@ -913,10 +907,7 @@ impl ApplicationId {
     /// Converts the application ID to the ID of the blob containing the
     /// `ApplicationIdDescription`.
     pub fn description_blob_id(self) -> BlobId {
-        BlobId::new(
-            self.application_description_hash,
-            BlobType::ApplicationDescription,
-        )
+        BlobId::new(self.0, BlobType::ApplicationDescription)
     }
 }
 

--- a/linera-base/src/unit_tests.rs
+++ b/linera-base/src/unit_tests.rs
@@ -12,8 +12,8 @@ use crate::{
     crypto::{AccountPublicKey, CryptoHash},
     data_types::{Amount, BlockHeight, Resources, SendMessageRequest, TimeDelta, Timestamp},
     identifiers::{
-        Account, AccountOwner, ApplicationId, ChainId, ChannelName, Destination, MessageId,
-        ModuleId, Owner,
+        Account, AccountOwner, Application, ChainId, ChannelName, Destination, MessageId, ModuleId,
+        Owner,
     },
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
@@ -102,9 +102,9 @@ fn message_id_test_case() -> MessageId {
     }
 }
 
-/// Creates a dummy [`ApplicationId`] instance to use for the WIT roundtrip test.
-fn application_id_test_case() -> ApplicationId {
-    ApplicationId::new(CryptoHash::test_hash("application description"))
+/// Creates a dummy [`Application`] instance to use for the WIT roundtrip test.
+fn application_id_test_case() -> Application {
+    Application::new(CryptoHash::test_hash("application description"))
 }
 
 /// Creates a dummy [`ModuleId`] instance to use for the WIT roundtrip test.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -13,10 +13,10 @@ use futures::stream::{self, StreamExt, TryStreamExt};
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{
-        Amount, ArithmeticError, BlockHeight, OracleResponse, Timestamp, UserApplicationDescription,
+        Amount, ApplicationDescription, ArithmeticError, BlockHeight, OracleResponse, Timestamp,
     },
     ensure,
-    identifiers::{ChainId, ChannelFullName, Destination, MessageId, Owner, UserApplicationId},
+    identifiers::{ApplicationId, ChainId, ChannelFullName, Destination, MessageId, Owner},
     ownership::ChainOwnership,
 };
 use linera_execution::{
@@ -367,8 +367,8 @@ where
 
     pub async fn describe_application(
         &mut self,
-        application_id: UserApplicationId,
-    ) -> Result<UserApplicationDescription, ChainError> {
+        application_id: ApplicationId,
+    ) -> Result<ApplicationDescription, ChainError> {
         self.execution_state
             .system
             .describe_application(application_id, None)
@@ -1034,7 +1034,7 @@ where
     /// Verifies that the block is valid according to the chain's application permission settings.
     fn check_app_permissions(&self, block: &ProposedBlock) -> Result<(), ChainError> {
         let app_permissions = self.execution_state.system.application_permissions.get();
-        let mut mandatory = HashSet::<UserApplicationId>::from_iter(
+        let mut mandatory = HashSet::<ApplicationId>::from_iter(
             app_permissions.mandatory_applications.iter().cloned(),
         );
         for operation in &block.operations {

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -13,8 +13,8 @@ use assert_matches::assert_matches;
 use linera_base::{
     crypto::{AccountPublicKey, CryptoHash, ValidatorPublicKey},
     data_types::{
-        Amount, ApplicationPermissions, Blob, BlockHeight, Bytecode, Timestamp,
-        UserApplicationDescription,
+        Amount, ApplicationDescription, ApplicationPermissions, Blob, BlockHeight, Bytecode,
+        Timestamp,
     },
     hashed::Hashed,
     identifiers::{AccountOwner, ApplicationId, ChainId, MessageId, ModuleId},
@@ -66,7 +66,7 @@ where
     }
 }
 
-fn make_app_description() -> (UserApplicationDescription, Blob, Blob) {
+fn make_app_description() -> (ApplicationDescription, Blob, Blob) {
     let contract = Bytecode::new(b"contract".into());
     let service = Bytecode::new(b"service".into());
     let contract_blob = Blob::new_contract_bytecode(contract.compress());
@@ -75,7 +75,7 @@ fn make_app_description() -> (UserApplicationDescription, Blob, Blob) {
 
     let module_id = ModuleId::new(contract_blob.id().hash, service_blob.id().hash, vm_runtime);
     (
-        UserApplicationDescription {
+        ApplicationDescription {
             module_id,
             creator_chain_id: admin_id(),
             block_height: BlockHeight(2),

--- a/linera-chain/src/unit_tests/inbox_tests.rs
+++ b/linera-chain/src/unit_tests/inbox_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use assert_matches::assert_matches;
-use linera_base::{crypto::CryptoHash, data_types::Timestamp, identifiers::UserApplicationId};
+use linera_base::{crypto::CryptoHash, data_types::Timestamp, identifiers::ApplicationId};
 use linera_execution::{Message, MessageKind};
 
 use super::*;
@@ -16,7 +16,7 @@ fn make_bundle(
     message: impl Into<Vec<u8>>,
 ) -> MessageBundle {
     let message = Message::User {
-        application_id: UserApplicationId::default(),
+        application_id: ApplicationId::default(),
         bytes: message.into(),
     };
     MessageBundle {

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Utc};
 use linera_base::{
     crypto::{AccountPublicKey, CryptoHash, ValidatorPublicKey},
     data_types::{Amount, ApplicationPermissions, TimeDelta},
-    identifiers::{Account, ApplicationId, ChainId, MessageId, ModuleId, Owner, UserApplicationId},
+    identifiers::{Account, ApplicationId, ChainId, MessageId, ModuleId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
     time::Duration,
     vm::VmRuntime,
@@ -878,7 +878,7 @@ pub enum ClientCommand {
 
         /// The list of required dependencies of application, if any.
         #[arg(long, num_args(0..))]
-        required_application_ids: Option<Vec<UserApplicationId>>,
+        required_application_ids: Option<Vec<ApplicationId>>,
     },
 
     /// Create an application, and publish the required module.
@@ -915,7 +915,7 @@ pub enum ClientCommand {
 
         /// The list of required dependencies of application, if any.
         #[arg(long, num_args(0..))]
-        required_application_ids: Option<Vec<UserApplicationId>>,
+        required_application_ids: Option<Vec<ApplicationId>>,
     },
 
     /// Create an unassigned key pair.
@@ -1327,7 +1327,7 @@ pub enum ProjectCommand {
 
         /// The list of required dependencies of application, if any.
         #[arg(long, num_args(0..))]
-        required_application_ids: Option<Vec<UserApplicationId>>,
+        required_application_ids: Option<Vec<ApplicationId>>,
     },
 }
 

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -12,9 +12,9 @@ use std::{
 use custom_debug_derive::Debug;
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
-    data_types::{Blob, BlockHeight, Timestamp, UserApplicationDescription},
+    data_types::{ApplicationDescription, Blob, BlockHeight, Timestamp},
     hashed::Hashed,
-    identifiers::{BlobId, ChainId, UserApplicationId},
+    identifiers::{ApplicationId, BlobId, ChainId},
 };
 use linera_chain::{
     data_types::{BlockProposal, ExecutedBlock, MessageBundle, Origin, ProposedBlock, Target},
@@ -76,9 +76,9 @@ where
 
     /// Describe an application.
     DescribeApplication {
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         #[debug(skip)]
-        callback: oneshot::Sender<Result<UserApplicationDescription, WorkerError>>,
+        callback: oneshot::Sender<Result<ApplicationDescription, WorkerError>>,
     },
 
     /// Execute a block but discard any changes to the chain state.

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -14,10 +14,10 @@ use std::{
 
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
-    data_types::{Blob, BlockHeight, UserApplicationDescription},
+    data_types::{ApplicationDescription, Blob, BlockHeight},
     ensure,
     hashed::Hashed,
-    identifiers::{BlobId, ChainId, UserApplicationId},
+    identifiers::{ApplicationId, BlobId, ChainId},
 };
 use linera_chain::{
     data_types::{
@@ -168,8 +168,8 @@ where
     /// Returns an application's description.
     pub(super) async fn describe_application(
         &mut self,
-        application_id: UserApplicationId,
-    ) -> Result<UserApplicationDescription, WorkerError> {
+        application_id: ApplicationId,
+    ) -> Result<ApplicationDescription, WorkerError> {
         ChainWorkerStateWithTemporaryChanges::new(self)
             .await
             .describe_application(application_id)

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -6,9 +6,9 @@
 use std::collections::HashMap;
 
 use linera_base::{
-    data_types::{ArithmeticError, Timestamp, UserApplicationDescription},
+    data_types::{ApplicationDescription, ArithmeticError, Timestamp},
     ensure,
-    identifiers::{AccountOwner, ChannelFullName, GenericApplicationId, UserApplicationId},
+    identifiers::{AccountOwner, ApplicationId, ChannelFullName, GenericApplicationId},
 };
 use linera_chain::data_types::{
     BlockExecutionOutcome, ExecutedBlock, IncomingBundle, Medium, MessageAction, ProposalContent,
@@ -110,8 +110,8 @@ where
     /// Returns an application's description.
     pub(super) async fn describe_application(
         &mut self,
-        application_id: UserApplicationId,
-    ) -> Result<UserApplicationDescription, WorkerError> {
+        application_id: ApplicationId,
+    ) -> Result<ApplicationDescription, WorkerError> {
         self.0.ensure_is_active()?;
         let response = self.0.chain.describe_application(application_id).await?;
         Ok(response)

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -34,8 +34,8 @@ use linera_base::{
     ensure,
     hashed::Hashed,
     identifiers::{
-        Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, EventId, MessageId,
-        ModuleId, Owner, StreamId, UserApplicationId,
+        Account, AccountOwner, Application, ApplicationId, BlobId, BlobType, ChainId, EventId,
+        MessageId, ModuleId, Owner, StreamId,
     },
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -2260,7 +2260,7 @@ where
     #[instrument(level = "trace", skip(application_id, query))]
     pub async fn query_user_application<A: Abi>(
         &self,
-        application_id: ApplicationId<A>,
+        application_id: Application<A>,
         query: &A::Query,
     ) -> Result<QueryOutcome<A::QueryResponse>, ChainClientError> {
         let query = Query::user(application_id, query)?;
@@ -2936,9 +2936,8 @@ where
         module_id: ModuleId<A, Parameters, InstantiationArgument>,
         parameters: &Parameters,
         instantiation_argument: &InstantiationArgument,
-        required_application_ids: Vec<UserApplicationId>,
-    ) -> Result<ClientOutcome<(ApplicationId<A>, ConfirmedBlockCertificate)>, ChainClientError>
-    {
+        required_application_ids: Vec<ApplicationId>,
+    ) -> Result<ClientOutcome<(Application<A>, ConfirmedBlockCertificate)>, ChainClientError> {
         let instantiation_argument = serde_json::to_vec(instantiation_argument)?;
         let parameters = serde_json::to_vec(parameters)?;
         Ok(self
@@ -2968,9 +2967,8 @@ where
         module_id: ModuleId,
         parameters: Vec<u8>,
         instantiation_argument: Vec<u8>,
-        required_application_ids: Vec<UserApplicationId>,
-    ) -> Result<ClientOutcome<(UserApplicationId, ConfirmedBlockCertificate)>, ChainClientError>
-    {
+        required_application_ids: Vec<ApplicationId>,
+    ) -> Result<ClientOutcome<(ApplicationId, ConfirmedBlockCertificate)>, ChainClientError> {
         self.execute_operation(Operation::System(SystemOperation::CreateApplication {
             module_id,
             parameters,

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -10,8 +10,8 @@ use std::{
 use futures::{future::Either, stream, StreamExt as _, TryStreamExt as _};
 use linera_base::{
     crypto::ValidatorPublicKey,
-    data_types::{ArithmeticError, Blob, BlockHeight, UserApplicationDescription},
-    identifiers::{BlobId, ChainId, MessageId, UserApplicationId},
+    data_types::{ApplicationDescription, ArithmeticError, Blob, BlockHeight},
+    identifiers::{ApplicationId, BlobId, ChainId, MessageId},
 };
 use linera_chain::{
     data_types::{BlockProposal, ExecutedBlock, ProposedBlock},
@@ -279,8 +279,8 @@ where
     pub async fn describe_application(
         &self,
         chain_id: ChainId,
-        application_id: UserApplicationId,
-    ) -> Result<UserApplicationDescription, LocalNodeError> {
+        application_id: ApplicationId,
+    ) -> Result<ApplicationDescription, LocalNodeError> {
         let response = self
             .node
             .state

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -20,7 +20,7 @@ use async_graphql::Request;
 use counter::CounterAbi;
 use linera_base::{
     data_types::{Amount, Bytecode, Event, OracleResponse},
-    identifiers::{AccountOwner, ApplicationId, Owner, StreamId, StreamName},
+    identifiers::{AccountOwner, Application, Owner, StreamId, StreamName},
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
 };
@@ -313,7 +313,7 @@ where
             .unwrap()
     };
     let module_id2 =
-        module_id2.with_abi::<meta_counter::MetaCounterAbi, ApplicationId<CounterAbi>, ()>();
+        module_id2.with_abi::<meta_counter::MetaCounterAbi, Application<CounterAbi>, ()>();
 
     // Creator receives the bytecode files then creates the app.
     creator.synchronize_from_validators().await.unwrap();
@@ -328,7 +328,7 @@ where
             module_id2,
             &application_id1,
             &(),
-            vec![application_id1.forget_abi()],
+            vec![application_id1.application_id()],
         )
         .await
         .unwrap()
@@ -337,7 +337,7 @@ where
         certificate.block().body.events,
         vec![vec![Event {
             stream_id: StreamId {
-                application_id: application_id2.forget_abi().into(),
+                application_id: application_id2.application_id().into(),
                 stream_name: StreamName(b"announcements".to_vec()),
             },
             key: b"updates".to_vec(),

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -16,7 +16,7 @@ use assert_matches::assert_matches;
 use linera_base::{
     crypto::AccountSecretKey,
     data_types::{
-        Amount, Blob, BlockHeight, Bytecode, OracleResponse, Timestamp, UserApplicationDescription,
+        Amount, ApplicationDescription, Blob, BlockHeight, Bytecode, OracleResponse, Timestamp,
     },
     hashed::Hashed,
     identifiers::{ChainDescription, ChainId, ModuleId},
@@ -197,7 +197,7 @@ where
         instantiation_argument: initial_value_bytes.clone(),
         required_application_ids: vec![],
     };
-    let application_description = UserApplicationDescription {
+    let application_description = ApplicationDescription {
         module_id,
         creator_chain_id: creator_chain.into(),
         block_height: BlockHeight::from(0),

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -15,11 +15,11 @@ use linera_base::crypto::AccountPublicKey;
 use linera_base::{
     crypto::{AccountSecretKey, CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSecretKey},
     data_types::{
-        ArithmeticError, Blob, BlockHeight, DecompressionError, Round, UserApplicationDescription,
+        ApplicationDescription, ArithmeticError, Blob, BlockHeight, DecompressionError, Round,
     },
     doc_scalar,
     hashed::Hashed,
-    identifiers::{BlobId, ChainId, EventId, Owner, UserApplicationId},
+    identifiers::{ApplicationId, BlobId, ChainId, EventId, Owner},
     time::timer::{sleep, timeout},
 };
 use linera_chain::{
@@ -528,8 +528,8 @@ where
     pub async fn describe_application(
         &self,
         chain_id: ChainId,
-        application_id: UserApplicationId,
-    ) -> Result<UserApplicationDescription, WorkerError> {
+        application_id: ApplicationId,
+    ) -> Result<ApplicationDescription, WorkerError> {
         self.query_chain_worker(chain_id, move |callback| {
             ChainWorkerRequest::DescribeApplication {
                 application_id,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -27,11 +27,11 @@ use {
 
 use super::{runtime::ServiceRuntimeRequest, ExecutionRequest};
 use crate::{
-    resources::ResourceController, system::SystemExecutionStateView, ContractSyncRuntime,
-    ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message, MessageContext,
-    MessageKind, Operation, OperationContext, Query, QueryContext, QueryOutcome,
-    RawExecutionOutcome, RawOutgoingMessage, ServiceSyncRuntime, SystemMessage, TransactionTracker,
-    UserApplicationDescription, UserApplicationId,
+    resources::ResourceController, system::SystemExecutionStateView, ApplicationDescription,
+    ApplicationId, ContractSyncRuntime, ExecutionError, ExecutionRuntimeConfig,
+    ExecutionRuntimeContext, Message, MessageContext, MessageKind, Operation, OperationContext,
+    Query, QueryContext, QueryOutcome, RawExecutionOutcome, RawOutgoingMessage, ServiceSyncRuntime,
+    SystemMessage, TransactionTracker,
 };
 
 /// A view accessing the execution state of a chain.
@@ -40,7 +40,7 @@ pub struct ExecutionStateView<C> {
     /// System application.
     pub system: SystemExecutionStateView<C>,
     /// User applications.
-    pub users: HashedReentrantCollectionView<C, UserApplicationId, KeyValueStoreView<C>>,
+    pub users: HashedReentrantCollectionView<C, ApplicationId, KeyValueStoreView<C>>,
 }
 
 /// How to interact with a long-lived service runtime.
@@ -61,7 +61,7 @@ where
         &mut self,
         contract: UserContractCode,
         local_time: Timestamp,
-        application_description: UserApplicationDescription,
+        application_description: ApplicationDescription,
         instantiation_argument: Vec<u8>,
         contract_blob: Blob,
         service_blob: Blob,
@@ -166,7 +166,7 @@ where
     #[expect(clippy::too_many_arguments)]
     async fn run_user_action(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         chain_id: ChainId,
         local_time: Timestamp,
         action: UserAction,
@@ -192,7 +192,7 @@ where
     #[expect(clippy::too_many_arguments)]
     async fn run_user_action_with_runtime(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         chain_id: ChainId,
         local_time: Timestamp,
         action: UserAction,
@@ -453,7 +453,7 @@ where
 
     async fn query_user_application(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         context: QueryContext,
         query: Vec<u8>,
     ) -> Result<QueryOutcome<Vec<u8>>, ExecutionError> {
@@ -483,7 +483,7 @@ where
 
     async fn query_user_application_with_long_lived_service(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         context: QueryContext,
         query: Vec<u8>,
         incoming_execution_requests: &mut futures::channel::mpsc::UnboundedReceiver<
@@ -519,14 +519,14 @@ where
 
     pub async fn list_applications(
         &self,
-    ) -> Result<Vec<(UserApplicationId, UserApplicationDescription)>, ExecutionError> {
+    ) -> Result<Vec<(ApplicationId, ApplicationDescription)>, ExecutionError> {
         let mut applications = vec![];
         for blob_id in self.system.used_blobs.indices().await? {
             if blob_id.blob_type == BlobType::ApplicationDescription {
                 let blob_content = self.system.read_blob_content(blob_id).await?;
-                let application_description: UserApplicationDescription =
+                let application_description: ApplicationDescription =
                     bcs::from_bytes(blob_content.bytes())?;
-                let app_id = UserApplicationId::from(&application_description);
+                let app_id = ApplicationId::from(&application_description);
                 applications.push((app_id, application_description));
             }
         }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -18,8 +18,8 @@ use linera_base::{
     },
     ensure, http,
     identifiers::{
-        Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, ChannelFullName,
-        ChannelName, MessageId, Owner, StreamId, StreamName,
+        Account, AccountOwner, BlobId, BlobType, ChainId, ChannelFullName, ChannelName, MessageId,
+        Owner, StreamId, StreamName,
     },
     ownership::ChainOwnership,
 };
@@ -32,11 +32,11 @@ use crate::{
     resources::ResourceController,
     system::CreateApplicationResult,
     util::{ReceiverExt, UnboundedSenderExt},
-    BaseRuntime, ContractRuntime, ExecutionError, FinalizeContext, MessageContext, ModuleId,
-    Operation, OperationContext, QueryContext, QueryOutcome, RawExecutionOutcome,
-    RawOutgoingMessage, ServiceRuntime, TransactionTracker, UserApplicationDescription,
-    UserApplicationId, UserContractCode, UserContractInstance, UserServiceCode,
-    UserServiceInstance, MAX_EVENT_KEY_LEN, MAX_STREAM_NAME_LEN,
+    ApplicationDescription, ApplicationId, BaseRuntime, ContractRuntime, ExecutionError,
+    FinalizeContext, MessageContext, ModuleId, Operation, OperationContext, QueryContext,
+    QueryOutcome, RawExecutionOutcome, RawOutgoingMessage, ServiceRuntime, TransactionTracker,
+    UserContractCode, UserContractInstance, UserServiceCode, UserServiceInstance,
+    MAX_EVENT_KEY_LEN, MAX_STREAM_NAME_LEN,
 };
 
 #[cfg(test)]
@@ -86,21 +86,21 @@ pub struct SyncRuntimeInternal<UserInstance> {
     /// If [`true`], disables cross-application calls.
     is_finalizing: bool,
     /// Applications that need to be finalized.
-    applications_to_finalize: Vec<UserApplicationId>,
+    applications_to_finalize: Vec<ApplicationId>,
 
     /// Application instances loaded in this transaction.
-    loaded_applications: HashMap<UserApplicationId, LoadedApplication<UserInstance>>,
+    loaded_applications: HashMap<ApplicationId, LoadedApplication<UserInstance>>,
     /// The current stack of application descriptions.
     call_stack: Vec<ApplicationStatus>,
     /// The set of the IDs of the applications that are in the `call_stack`.
-    active_applications: HashSet<UserApplicationId>,
+    active_applications: HashSet<ApplicationId>,
     /// The tracking information for this transaction.
     transaction_tracker: TransactionTracker,
     /// The operations scheduled during this query.
     scheduled_operations: Vec<Operation>,
 
     /// Track application states based on views.
-    view_user_states: BTreeMap<UserApplicationId, ViewUserState>,
+    view_user_states: BTreeMap<ApplicationId, ViewUserState>,
 
     /// The deadline this runtime should finish executing.
     ///
@@ -118,11 +118,11 @@ pub struct SyncRuntimeInternal<UserInstance> {
 #[derive(Debug)]
 struct ApplicationStatus {
     /// The caller application ID, if forwarded during the call.
-    caller_id: Option<UserApplicationId>,
+    caller_id: Option<ApplicationId>,
     /// The application ID.
-    id: UserApplicationId,
+    id: ApplicationId,
     /// The application description.
-    description: UserApplicationDescription,
+    description: ApplicationDescription,
     /// The authenticated signer for the execution thread, if any.
     signer: Option<Owner>,
 }
@@ -131,12 +131,12 @@ struct ApplicationStatus {
 #[derive(Debug)]
 struct LoadedApplication<Instance> {
     instance: Arc<Mutex<Instance>>,
-    description: UserApplicationDescription,
+    description: ApplicationDescription,
 }
 
 impl<Instance> LoadedApplication<Instance> {
     /// Creates a new [`LoadedApplication`] entry from the `instance` and its `description`.
-    fn new(instance: Instance, description: UserApplicationDescription) -> Self {
+    fn new(instance: Instance, description: ApplicationDescription) -> Self {
         LoadedApplication {
             instance: Arc::new(Mutex::new(instance)),
             description,
@@ -366,7 +366,7 @@ impl<UserInstance> SyncRuntimeInternal<UserInstance> {
     /// Returns an error if there already is an entry for `application_id` in the call stack.
     fn check_for_reentrancy(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
     ) -> Result<(), ExecutionError> {
         ensure!(
             !self.active_applications.contains(&application_id),
@@ -381,7 +381,7 @@ impl SyncRuntimeInternal<UserContractInstance> {
     fn load_contract_instance(
         &mut self,
         this: SyncRuntimeHandle<UserContractInstance>,
-        id: UserApplicationId,
+        id: ApplicationId,
     ) -> Result<LoadedApplication<UserContractInstance>, ExecutionError> {
         match self.loaded_applications.entry(id) {
             // TODO(#2927): support dynamic loading of modules on the Web
@@ -421,7 +421,7 @@ impl SyncRuntimeInternal<UserContractInstance> {
         &mut self,
         this: ContractSyncRuntimeHandle,
         authenticated: bool,
-        callee_id: UserApplicationId,
+        callee_id: ApplicationId,
     ) -> Result<(Arc<Mutex<UserContractInstance>>, OperationContext), ExecutionError> {
         self.check_for_reentrancy(callee_id)?;
 
@@ -516,7 +516,7 @@ impl SyncRuntimeInternal<UserServiceInstance> {
     fn load_service_instance(
         &mut self,
         this: ServiceSyncRuntimeHandle,
-        id: UserApplicationId,
+        id: ApplicationId,
     ) -> Result<LoadedApplication<UserServiceInstance>, ExecutionError> {
         match self.loaded_applications.entry(id) {
             // TODO(#2927): support dynamic loading of modules on the Web
@@ -595,7 +595,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeHandle<UserInstance> {
         self.inner().block_height()
     }
 
-    fn application_id(&mut self) -> Result<UserApplicationId, ExecutionError> {
+    fn application_id(&mut self) -> Result<ApplicationId, ExecutionError> {
         self.inner().application_id()
     }
 
@@ -746,7 +746,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         Ok(self.height)
     }
 
-    fn application_id(&mut self) -> Result<UserApplicationId, ExecutionError> {
+    fn application_id(&mut self) -> Result<ApplicationId, ExecutionError> {
         Ok(self.current_application().id)
     }
 
@@ -1075,9 +1075,9 @@ impl ContractSyncRuntime {
 
     pub(crate) fn preload_contract(
         &self,
-        id: UserApplicationId,
+        id: ApplicationId,
         code: UserContractCode,
-        description: UserApplicationDescription,
+        description: ApplicationDescription,
     ) -> Result<(), ExecutionError> {
         let this = self
             .0
@@ -1100,7 +1100,7 @@ impl ContractSyncRuntime {
     /// Main entry point to start executing a user action.
     pub(crate) fn run_action(
         mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         chain_id: ChainId,
         action: UserAction,
     ) -> Result<(Option<Vec<u8>>, ResourceController, TransactionTracker), ExecutionError> {
@@ -1121,7 +1121,7 @@ impl ContractSyncRuntime {
 impl ContractSyncRuntimeHandle {
     fn run_action(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         chain_id: ChainId,
         action: UserAction,
     ) -> Result<Option<Vec<u8>>, ExecutionError> {
@@ -1178,7 +1178,7 @@ impl ContractSyncRuntimeHandle {
     /// Executes a `closure` with the contract code for the `application_id`.
     fn execute(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         signer: Option<Owner>,
         closure: impl FnOnce(&mut UserContractInstance) -> Result<Option<Vec<u8>>, ExecutionError>,
     ) -> Result<Option<Vec<u8>>, ExecutionError> {
@@ -1233,7 +1233,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             .map(|metadata| metadata.is_bouncing))
     }
 
-    fn authenticated_caller_id(&mut self) -> Result<Option<UserApplicationId>, ExecutionError> {
+    fn authenticated_caller_id(&mut self) -> Result<Option<ApplicationId>, ExecutionError> {
         let this = self.inner();
         if this.call_stack.len() <= 1 {
             return Ok(None);
@@ -1348,7 +1348,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
     fn try_call_application(
         &mut self,
         authenticated: bool,
-        callee_id: UserApplicationId,
+        callee_id: ApplicationId,
         argument: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
         let (contract, context) =
@@ -1488,8 +1488,8 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         module_id: ModuleId,
         parameters: Vec<u8>,
         argument: Vec<u8>,
-        required_application_ids: Vec<UserApplicationId>,
-    ) -> Result<UserApplicationId, ExecutionError> {
+        required_application_ids: Vec<ApplicationId>,
+    ) -> Result<ApplicationId, ExecutionError> {
         let chain_id = self.inner().chain_id;
         let block_height = self.block_height()?;
 
@@ -1610,9 +1610,9 @@ impl ServiceSyncRuntime {
     /// Loads a service into the runtime's memory.
     pub(crate) fn preload_service(
         &self,
-        id: UserApplicationId,
+        id: ApplicationId,
         code: UserServiceCode,
-        description: UserApplicationDescription,
+        description: ApplicationDescription,
     ) -> Result<(), ExecutionError> {
         let this = self
             .runtime
@@ -1664,10 +1664,10 @@ impl ServiceSyncRuntime {
         }
     }
 
-    /// Queries an application specified by its [`UserApplicationId`].
+    /// Queries an application specified by its [`ApplicationId`].
     pub(crate) fn run_query(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         query: Vec<u8>,
     ) -> Result<QueryOutcome<Vec<u8>>, ExecutionError> {
         let this = self.handle_mut();
@@ -1692,7 +1692,7 @@ impl ServiceRuntime for ServiceSyncRuntimeHandle {
     /// Note that queries are not available from writable contexts.
     fn try_query_application(
         &mut self,
-        queried_id: UserApplicationId,
+        queried_id: ApplicationId,
         argument: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
         let (query_context, service) = {
@@ -1747,7 +1747,7 @@ impl ServiceRuntime for ServiceSyncRuntimeHandle {
 /// A request to the service runtime actor.
 pub enum ServiceRuntimeRequest {
     Query {
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         context: QueryContext,
         query: Vec<u8>,
         callback: oneshot::Sender<Result<QueryOutcome<Vec<u8>>, ExecutionError>>,

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -11,7 +11,9 @@ use custom_debug_derive::Debug;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, ApplicationPermissions, Blob, Timestamp},
-    identifiers::{AccountOwner, ApplicationId, BlobId, ChainDescription, ChainId, Owner},
+    identifiers::{
+        AccountOwner, Application, ApplicationId, BlobId, ChainDescription, ChainId, Owner,
+    },
     ownership::ChainOwnership,
 };
 use linera_views::{
@@ -26,9 +28,9 @@ use crate::{
     committee::{Committee, Epoch},
     execution::UserAction,
     system::SystemChannel,
-    ChannelSubscription, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext,
-    ExecutionStateView, OperationContext, ResourceControlPolicy, ResourceController,
-    ResourceTracker, TestExecutionRuntimeContext, UserApplicationDescription, UserContractCode,
+    ApplicationDescription, ChannelSubscription, ExecutionError, ExecutionRuntimeConfig,
+    ExecutionRuntimeContext, ExecutionStateView, OperationContext, ResourceControlPolicy,
+    ResourceController, ResourceTracker, TestExecutionRuntimeContext, UserContractCode,
 };
 
 /// A system execution state, not represented as a view but as a simple struct.
@@ -163,7 +165,7 @@ impl RegisterMockApplication for SystemExecutionState {
 
     async fn register_mock_application_with(
         &mut self,
-        description: UserApplicationDescription,
+        description: ApplicationDescription,
         contract: Blob,
         service: Blob,
     ) -> anyhow::Result<(ApplicationId, MockApplication)> {

--- a/linera-execution/src/unit_tests/applications_tests.rs
+++ b/linera-execution/src/unit_tests/applications_tests.rs
@@ -9,7 +9,7 @@ use linera_base::{
 };
 
 use super::{
-    ApplicationRegistry, ApplicationRegistryView, UserApplicationDescription, UserApplicationId,
+    ApplicationRegistry, ApplicationRegistryView, ApplicationIdDescription, ApplicationId,
 };
 
 fn message_id(index: u32) -> MessageId {
@@ -28,15 +28,15 @@ fn module_id() -> ModuleId {
     )
 }
 
-fn app_id(index: u32) -> UserApplicationId {
-    UserApplicationId {
+fn app_id(index: u32) -> ApplicationId {
+    ApplicationId {
         module_id: module_id(),
         creation: message_id(index),
     }
 }
 
-fn app_description(index: u32, deps: Vec<u32>) -> UserApplicationDescription {
-    UserApplicationDescription {
+fn app_description(index: u32, deps: Vec<u32>) -> ApplicationIdDescription {
+    ApplicationIdDescription {
         module_id: module_id(),
         creation: message_id(index),
         parameters: vec![],

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -205,7 +205,7 @@ fn create_dummy_application() -> ApplicationStatus {
     }
 }
 
-/// Creates a dummy [`ApplicationId`].
+/// Creates a dummy [`Application`].
 fn create_dummy_application_id() -> ApplicationId {
     ApplicationId::new(CryptoHash::test_hash("application description"))
 }

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -39,10 +39,10 @@ fn expected_application_id(
     context: &OperationContext,
     module_id: &ModuleId,
     parameters: Vec<u8>,
-    required_application_ids: Vec<UserApplicationId>,
+    required_application_ids: Vec<ApplicationId>,
     application_index: u32,
-) -> UserApplicationId {
-    let description = UserApplicationDescription {
+) -> ApplicationId {
+    let description = ApplicationDescription {
         module_id: *module_id,
         creator_chain_id: context.chain_id,
         block_height: context.height,

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -12,8 +12,8 @@ use assert_matches::assert_matches;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
-        Amount, ApplicationPermissions, ApplicationDescription, Blob, BlockHeight, CompressedBytecode, OracleResponse,
-        Timestamp,
+        Amount, ApplicationDescription, ApplicationPermissions, Blob, BlockHeight,
+        CompressedBytecode, OracleResponse, Timestamp,
     },
     http,
     identifiers::{

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -12,8 +12,8 @@ use assert_matches::assert_matches;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
-        Amount, ApplicationPermissions, Blob, BlockHeight, CompressedBytecode, OracleResponse,
-        Timestamp, UserApplicationDescription,
+        Amount, ApplicationPermissions, ApplicationDescription, Blob, BlockHeight, CompressedBytecode, OracleResponse,
+        Timestamp,
     },
     http,
     identifiers::{
@@ -697,18 +697,18 @@ impl TransferTestEndpoint {
         Owner(CryptoHash::test_hash("sender"))
     }
 
-    /// Returns the [`ApplicationId`] used to represent a sender that's an application.
+    /// Returns the [`Application`] used to represent a sender that's an application.
     fn sender_application_id() -> ApplicationId {
         ApplicationId::from(&Self::sender_application_description())
     }
 
-    /// Returns the [`UserApplicationDescription`] used to represent a sender that's an application.
-    fn sender_application_description() -> UserApplicationDescription {
+    /// Returns the [`ApplicationIdDescription`] used to represent a sender that's an application.
+    fn sender_application_description() -> ApplicationDescription {
         let contract_id = Self::sender_application_contract_blob().id().hash;
         let service_id = Self::sender_application_service_blob().id().hash;
         let vm_runtime = VmRuntime::Wasm;
 
-        UserApplicationDescription {
+        ApplicationDescription {
             module_id: ModuleId::new(contract_id, service_id, vm_runtime),
             creator_chain_id: ChainId::root(1000),
             block_height: BlockHeight(0),
@@ -739,7 +739,7 @@ impl TransferTestEndpoint {
         Owner(CryptoHash::test_hash("recipient"))
     }
 
-    /// Returns the [`ApplicationId`] used to represent a recipient that's an application.
+    /// Returns the [`Application`] used to represent a recipient that's an application.
     fn recipient_application_id() -> ApplicationId {
         ApplicationId::new(CryptoHash::test_hash("recipient application description"))
     }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -57,9 +57,8 @@ AdminOperation:
 Amount:
   NEWTYPESTRUCT: U128
 ApplicationId:
-  STRUCT:
-    - application_description_hash:
-        TYPENAME: CryptoHash
+  NEWTYPESTRUCT:
+    TYPENAME: CryptoHash
 ApplicationPermissions:
   STRUCT:
     - execute_operations:

--- a/linera-sdk/src/base/conversions_from_wit.rs
+++ b/linera-sdk/src/base/conversions_from_wit.rs
@@ -69,7 +69,7 @@ macro_rules! impl_from_wit {
 
         impl From<$wit_base_api::ApplicationId> for ApplicationId {
             fn from(application_id: $wit_base_api::ApplicationId) -> Self {
-                ApplicationId::new(application_id.application_description_hash.into())
+                ApplicationId::new(application_id.inner0.into())
             }
         }
 

--- a/linera-sdk/src/base/conversions_to_wit.rs
+++ b/linera-sdk/src/base/conversions_to_wit.rs
@@ -69,9 +69,7 @@ macro_rules! impl_to_wit {
         impl From<ApplicationId> for $wit_base_api::ApplicationId {
             fn from(application_id: ApplicationId) -> Self {
                 $wit_base_api::ApplicationId {
-                    application_description_hash: application_id
-                        .application_description_hash
-                        .into(),
+                    inner0: application_id.0.into(),
                 }
             }
         }

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -61,7 +61,7 @@ impl From<wit_contract_api::MessageId> for MessageId {
 
 impl From<wit_contract_api::ApplicationId> for ApplicationId {
     fn from(application_id: wit_contract_api::ApplicationId) -> Self {
-        ApplicationId::new(application_id.application_description_hash.into())
+        ApplicationId::new(application_id.inner0.into())
     }
 }
 

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -123,7 +123,7 @@ impl From<MessageId> for wit_contract_api::MessageId {
 impl From<ApplicationId> for wit_contract_api::ApplicationId {
     fn from(application_id: ApplicationId) -> Self {
         wit_contract_api::ApplicationId {
-            application_description_hash: application_id.application_description_hash.into(),
+            inner0: application_id.0.into(),
         }
     }
 }

--- a/linera-sdk/src/service/conversions_to_wit.rs
+++ b/linera-sdk/src/service/conversions_to_wit.rs
@@ -23,7 +23,7 @@ impl From<CryptoHash> for wit_service_api::CryptoHash {
 impl From<ApplicationId> for wit_service_api::ApplicationId {
     fn from(application_id: ApplicationId) -> Self {
         wit_service_api::ApplicationId {
-            application_description_hash: application_id.application_description_hash.into(),
+            inner0: application_id.0.into(),
         }
     }
 }

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -10,7 +10,8 @@ use linera_base::{
     data_types::{Amount, ApplicationPermissions, Round, Timestamp},
     hashed::Hashed,
     identifiers::{
-        AccountOwner, Application, ApplicationId, ChainId, ChannelFullName, GenericApplicationId, Owner,
+        AccountOwner, Application, ApplicationId, ChainId, ChannelFullName, GenericApplicationId,
+        Owner,
     },
     ownership::TimeoutConfig,
 };

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -10,7 +10,7 @@ use linera_base::{
     data_types::{Amount, ApplicationPermissions, Round, Timestamp},
     hashed::Hashed,
     identifiers::{
-        AccountOwner, ApplicationId, ChainId, ChannelFullName, GenericApplicationId, Owner,
+        AccountOwner, Application, ApplicationId, ChainId, ChannelFullName, GenericApplicationId, Owner,
     },
     ownership::TimeoutConfig,
 };
@@ -140,14 +140,14 @@ impl BlockBuilder {
     /// `application`.
     pub fn with_operation<Abi>(
         &mut self,
-        application_id: ApplicationId<Abi>,
+        application: Application<Abi>,
         operation: Abi::Operation,
     ) -> &mut Self
     where
         Abi: ContractAbi,
     {
         self.with_raw_operation(
-            application_id.forget_abi(),
+            application.application_id(),
             operation
                 .to_bcs_bytes()
                 .expect("Failed to serialize operation"),

--- a/linera-sdk/src/test/mock_stubs.rs
+++ b/linera-sdk/src/test/mock_stubs.rs
@@ -10,7 +10,7 @@
 
 use linera_base::{
     data_types::{Amount, Timestamp},
-    identifiers::{ApplicationId, ChainId},
+    identifiers::{Application, ChainId},
 };
 use linera_views::context::MemoryContext;
 use serde::Serialize;
@@ -30,7 +30,7 @@ pub fn mock_chain_id(_chain_id: impl Into<Option<ChainId>>) {
 }
 
 /// Sets the mocked application ID.
-pub fn mock_application_id(_application_id: impl Into<Option<ApplicationId>>) {
+pub fn mock_application_id(_application_id: impl Into<Option<Application>>) {
     unreachable!("{ERROR_MESSAGE}");
 }
 
@@ -66,7 +66,7 @@ pub fn mock_key_value_store() -> MemoryContext<()> {
 
 /// Mocks the `try_query_application` system API.
 pub fn mock_try_query_application<E>(
-    _handler: impl FnMut(ApplicationId, Vec<u8>) -> Result<Vec<u8>, E> + 'static,
+    _handler: impl FnMut(Application, Vec<u8>) -> Result<Vec<u8>, E> + 'static,
 ) where
     E: ToString + 'static,
 {

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -16,7 +16,7 @@ use futures::{
 use linera_base::{
     crypto::{AccountSecretKey, ValidatorKeypair, ValidatorSecretKey},
     data_types::{Amount, ApplicationPermissions, Blob, BlobContent, Timestamp},
-    identifiers::{ApplicationId, ChainDescription, ChainId, MessageId, ModuleId, Owner},
+    identifiers::{Application, ChainDescription, ChainId, MessageId, ModuleId, Owner},
     ownership::ChainOwnership,
 };
 use linera_core::worker::WorkerState;
@@ -129,12 +129,12 @@ impl TestValidator {
     /// The bytecode is first published on one microchain, then the application is created on
     /// another microchain.
     ///
-    /// Returns the new [`TestValidator`], the [`ApplicationId`] of the created application, and
+    /// Returns the new [`TestValidator`], the [`Application`] of the created application, and
     /// the chain on which it was created.
     pub async fn with_current_application<Abi, Parameters, InstantiationArgument>(
         parameters: Parameters,
         instantiation_argument: InstantiationArgument,
-    ) -> (TestValidator, ApplicationId<Abi>, ActiveChain)
+    ) -> (TestValidator, Application<Abi>, ActiveChain)
     where
         Abi: ContractAbi,
         Parameters: Serialize,

--- a/linera-sdk/wit/base-runtime-api.wit
+++ b/linera-sdk/wit/base-runtime-api.wit
@@ -41,7 +41,7 @@ interface base-runtime-api {
     }
 
     record application-id {
-        application-description-hash: crypto-hash,
+        inner0: crypto-hash,
     }
 
     record block-height {

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -37,7 +37,7 @@ interface contract-runtime-api {
     }
 
     record application-id {
-        application-description-hash: crypto-hash,
+        inner0: crypto-hash,
     }
 
     record application-permissions {

--- a/linera-sdk/wit/service-runtime-api.wit
+++ b/linera-sdk/wit/service-runtime-api.wit
@@ -6,7 +6,7 @@ interface service-runtime-api {
     check-execution-time: func(fuel-consumed: u64);
 
     record application-id {
-        application-description-hash: crypto-hash,
+        inner0: crypto-hash,
     }
 
     record crypto-hash {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -14,13 +14,18 @@ A non-negative amount of tokens.
 scalar Amount
 
 """
+Description of the necessary information to run a user application
+"""
+scalar ApplicationDescription
+
+"""
 A unique identifier for a user application
 """
 scalar ApplicationId
 
 type ApplicationOverview {
 	id: ApplicationId!
-	description: UserApplicationDescription!
+	description: ApplicationDescription!
 	link: String!
 }
 
@@ -1222,11 +1227,6 @@ type TimestampedBundleInInbox {
 	"""
 	seen: Timestamp!
 }
-
-"""
-Description of the necessary information to run a user application
-"""
-scalar UserApplicationDescription
 
 scalar VersionInfo
 

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -32,7 +32,7 @@ mod types {
     pub type Operation = Value;
     pub type Origin = Value;
     pub type Target = Value;
-    pub type UserApplicationDescription = Value;
+    pub type ApplicationDescription = Value;
     pub type OperationResult = Value;
 
     #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -62,8 +62,7 @@ mod types {
 #[cfg(not(target_arch = "wasm32"))]
 mod types {
     pub use linera_base::{
-        data_types::UserApplicationDescription, identifiers::ChannelFullName,
-        ownership::ChainOwnership,
+        data_types::ApplicationDescription, identifiers::ChannelFullName, ownership::ChainOwnership,
     };
     pub use linera_chain::{
         data_types::{MessageAction, MessageBundle, OperationResult, Origin, Target},

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -9,7 +9,7 @@ use futures::future::{join_all, try_join_all};
 use linera_base::{
     async_graphql::InputType,
     data_types::Amount,
-    identifiers::{Account, AccountOwner, ApplicationId, ChainId, Owner},
+    identifiers::{Account, AccountOwner, Application, ChainId, Owner},
     time::timer::Instant,
 };
 use linera_sdk::abis::fungible::{self, FungibleTokenAbi, InitialState, Parameters};
@@ -140,7 +140,7 @@ async fn benchmark_with_fungible(
         .await?;
 
     struct BenchmarkContext {
-        application_id: ApplicationId<FungibleTokenAbi>,
+        application_id: Application<FungibleTokenAbi>,
         owner: Owner,
         default_chain: ChainId,
     }

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -15,10 +15,10 @@ use axum::{extract::Path, http::StatusCode, response, response::IntoResponse, Ex
 use futures::{lock::Mutex, Future};
 use linera_base::{
     crypto::{CryptoError, CryptoHash},
-    data_types::{Amount, ApplicationPermissions, Bytecode, TimeDelta, UserApplicationDescription},
+    data_types::{Amount, ApplicationDescription, ApplicationPermissions, Bytecode, TimeDelta},
     ensure,
     hashed::Hashed,
-    identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId, Owner, UserApplicationId},
+    identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
     BcsHexParseError,
@@ -619,7 +619,7 @@ where
         module_id: ModuleId,
         parameters: String,
         instantiation_argument: String,
-        required_application_ids: Vec<UserApplicationId>,
+        required_application_ids: Vec<ApplicationId>,
     ) -> Result<ApplicationId, Error> {
         self.apply_client_command(&chain_id, move |client| {
             let parameters = parameters.as_bytes().to_vec();
@@ -805,15 +805,15 @@ where
 
 #[derive(SimpleObject)]
 pub struct ApplicationOverview {
-    id: UserApplicationId,
-    description: UserApplicationDescription,
+    id: ApplicationId,
+    description: ApplicationDescription,
     link: String,
 }
 
 impl ApplicationOverview {
     fn new(
-        id: UserApplicationId,
-        description: UserApplicationDescription,
+        id: ApplicationId,
+        description: ApplicationDescription,
         port: NonZeroU16,
         chain_id: ChainId,
     ) -> Self {
@@ -953,7 +953,7 @@ where
     /// Handles queries for user applications.
     async fn user_application_query(
         &self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         request: &Request,
         chain_id: ChainId,
     ) -> Result<async_graphql::Response, NodeServiceError> {
@@ -975,7 +975,7 @@ where
     /// Handles mutations for user applications.
     async fn user_application_mutation(
         &self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         request: &Request,
         chain_id: ChainId,
     ) -> Result<async_graphql::Response, NodeServiceError> {
@@ -1024,7 +1024,7 @@ where
     /// Queries a user application, returning the raw [`QueryOutcome`].
     async fn query_user_application(
         &self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         request: &Request,
         chain_id: ChainId,
     ) -> Result<QueryOutcome<Vec<u8>>, NodeServiceError> {
@@ -1080,7 +1080,7 @@ where
         let operation_type = operation_type(parsed_query)?;
 
         let chain_id: ChainId = chain_id.parse().map_err(NodeServiceError::InvalidChainId)?;
-        let application_id: UserApplicationId = application_id.parse()?;
+        let application_id: ApplicationId = application_id.parse()?;
 
         let response = match operation_type {
             OperationType::Query => {

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -29,7 +29,7 @@ use linera_base::{
     command::resolve_binary,
     crypto::CryptoHash,
     data_types::Amount,
-    identifiers::{Account, AccountOwner, ApplicationId, ChainId},
+    identifiers::{Account, AccountOwner, Application, ChainId},
     vm::VmRuntime,
 };
 use linera_chain::data_types::{Medium, Origin};
@@ -177,7 +177,7 @@ struct NonFungibleApp(ApplicationWrapper<non_fungible::NonFungibleTokenAbi>);
 impl NonFungibleApp {
     pub fn create_token_id(
         chain_id: &ChainId,
-        application_id: &ApplicationId,
+        application_id: &Application,
         name: &String,
         minter: &AccountOwner,
         hash: &DataBlobHash,
@@ -1284,7 +1284,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
     };
     let (contract_crowd, service_crowd) = client1.build_example("crowd-funding").await?;
     let application_id_crowd = client1
-        .publish_and_create::<CrowdFundingAbi, ApplicationId<FungibleTokenAbi>, InstantiationArgument>(
+        .publish_and_create::<CrowdFundingAbi, Application<FungibleTokenAbi>, InstantiationArgument>(
             contract_crowd,
             service_crowd,
             VmRuntime::Wasm,
@@ -1837,7 +1837,7 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
         )
         .await?;
 
-    let owner_amm_app = AccountOwner::Application(application_id_amm.forget_abi());
+    let owner_amm_app = AccountOwner::Application(application_id_amm.application_id());
 
     // Create AMM wrappers
     let app_amm = AmmApp(

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -11,7 +11,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Blob, TimeDelta, Timestamp},
     hashed::Hashed,
-    identifiers::{BlobId, ChainId, EventId, UserApplicationId},
+    identifiers::{ApplicationId, BlobId, ChainId, EventId},
 };
 use linera_chain::{
     types::{ConfirmedBlock, ConfirmedBlockCertificate, LiteCertificate},
@@ -263,8 +263,8 @@ pub struct DbStorage<Store, Clock> {
     store: Arc<Store>,
     clock: Clock,
     wasm_runtime: Option<WasmRuntime>,
-    user_contracts: Arc<DashMap<UserApplicationId, UserContractCode>>,
-    user_services: Arc<DashMap<UserApplicationId, UserServiceCode>>,
+    user_contracts: Arc<DashMap<ApplicationId, UserContractCode>>,
+    user_services: Arc<DashMap<ApplicationId, UserServiceCode>>,
     execution_runtime_config: ExecutionRuntimeConfig,
 }
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -14,11 +14,10 @@ use dashmap::{mapref::entry::Entry, DashMap};
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
-        Amount, Blob, BlockHeight, CompressedBytecode, TimeDelta, Timestamp,
-        UserApplicationDescription,
+        Amount, ApplicationDescription, Blob, BlockHeight, CompressedBytecode, TimeDelta, Timestamp,
     },
     hashed::Hashed,
-    identifiers::{BlobId, BlobType, ChainDescription, ChainId, EventId, Owner, UserApplicationId},
+    identifiers::{ApplicationId, BlobId, BlobType, ChainDescription, ChainId, EventId, Owner},
     ownership::ChainOwnership,
     vm::VmRuntime,
 };
@@ -254,7 +253,7 @@ pub trait Storage: Sized {
     /// by the `application_description`.
     async fn load_contract(
         &self,
-        application_description: &UserApplicationDescription,
+        application_description: &ApplicationDescription,
     ) -> Result<UserContractCode, ExecutionError> {
         let contract_bytecode_blob_id = BlobId::new(
             application_description.module_id.contract_blob_hash,
@@ -314,7 +313,7 @@ pub trait Storage: Sized {
     /// by the `application_description`.
     async fn load_service(
         &self,
-        application_description: &UserApplicationDescription,
+        application_description: &ApplicationDescription,
     ) -> Result<UserServiceCode, ExecutionError> {
         let service_bytecode_blob_id = BlobId::new(
             application_description.module_id.service_blob_hash,
@@ -375,8 +374,8 @@ pub struct ChainRuntimeContext<S> {
     storage: S,
     chain_id: ChainId,
     execution_runtime_config: ExecutionRuntimeConfig,
-    user_contracts: Arc<DashMap<UserApplicationId, UserContractCode>>,
-    user_services: Arc<DashMap<UserApplicationId, UserServiceCode>>,
+    user_contracts: Arc<DashMap<ApplicationId, UserContractCode>>,
+    user_services: Arc<DashMap<ApplicationId, UserServiceCode>>,
 }
 
 #[cfg_attr(not(web), async_trait)]
@@ -393,17 +392,17 @@ where
         self.execution_runtime_config
     }
 
-    fn user_contracts(&self) -> &Arc<DashMap<UserApplicationId, UserContractCode>> {
+    fn user_contracts(&self) -> &Arc<DashMap<ApplicationId, UserContractCode>> {
         &self.user_contracts
     }
 
-    fn user_services(&self) -> &Arc<DashMap<UserApplicationId, UserServiceCode>> {
+    fn user_services(&self) -> &Arc<DashMap<ApplicationId, UserServiceCode>> {
         &self.user_services
     }
 
     async fn get_user_contract(
         &self,
-        description: &UserApplicationDescription,
+        description: &ApplicationDescription,
     ) -> Result<UserContractCode, ExecutionError> {
         match self.user_contracts.entry(description.into()) {
             Entry::Occupied(entry) => Ok(entry.get().clone()),
@@ -417,7 +416,7 @@ where
 
     async fn get_user_service(
         &self,
-        description: &UserApplicationDescription,
+        description: &ApplicationDescription,
     ) -> Result<UserServiceCode, ExecutionError> {
         match self.user_services.entry(description.into()) {
             Entry::Occupied(entry) => Ok(entry.get().clone()),


### PR DESCRIPTION
## Motivation

We want to fix and expand our notion of `Address` (currently `Owner`, `GenericApplicationId`, etc.) to different type of addresses (32-byte Linera/Solana, 20-byte EVM). In order to do that we need to prepare the code for the introduction of new variants.

## Proposal

Add a separate type for `ApplicationId(hash)` vs `Application` (a hash + type-safe ABI). Previously the presence of `A` type parameter in "address" enum made it more difficult to refactor. After this PR we have separate types for application's address and application with ABI (used mostly in tests and CLI now).

## Test Plan

CI should catch regressions.


## Release Plan

- Nothing to do / These changes follow the usual release cycle.
## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
