### PR TITLE
Stabilize HTTP oracles

### DIFF
--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -960,11 +960,6 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         &mut self,
         request: http::Request,
     ) -> Result<http::Response, ExecutionError> {
-        ensure!(
-            cfg!(feature = "unstable-oracles"),
-            ExecutionError::UnstableOracle
-        );
-
         let app_permissions = self
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::GetApplicationPermissions { callback })?

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -9,16 +9,13 @@ use std::{
 };
 
 use assert_matches::assert_matches;
-#[cfg(feature = "unstable-oracles")]
-use linera_base::data_types::ApplicationPermissions;
-#[cfg(feature = "unstable-oracles")]
-use linera_base::http;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
-        Amount, Blob, BlockHeight, CompressedBytecode, OracleResponse, Timestamp,
-        UserApplicationDescription,
+        Amount, ApplicationPermissions, Blob, BlockHeight, CompressedBytecode, OracleResponse,
+        Timestamp, UserApplicationDescription,
     },
+    http,
     identifiers::{
         Account, AccountOwner, ApplicationId, ChainDescription, ChainId, ModuleId, Owner,
     },
@@ -35,9 +32,7 @@ use linera_execution::{
     TransactionOutcome, TransactionTracker,
 };
 use linera_views::context::MemoryContext;
-#[cfg(feature = "unstable-oracles")]
-use test_case::test_case;
-use test_case::test_matrix;
+use test_case::{test_case, test_matrix};
 use test_strategy::proptest;
 
 /// Tests the contract system API to transfer tokens between accounts.
@@ -946,7 +941,6 @@ async fn test_query_service(authorized_apps: Option<Vec<()>>) -> Result<(), Exec
 }
 
 /// Tests the contract system API to make HTTP requests.
-#[cfg(feature = "unstable-oracles")] // # TODO: Remove once #3524 lands
 #[test_case(None => matches Ok(_); "when all authorized")]
 #[test_case(Some(vec![()]) => matches Ok(_); "when single app authorized")]
 #[test_case(Some(vec![]) => matches Err(ExecutionError::UnauthorizedApplication(_)); "when unauthorized")]

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -112,14 +112,14 @@ use test_case::test_case;
     Some(Amount::from_tokens(1_000));
     "with execution and an empty read and with owner account and grant"
 )]
-#[cfg_attr(feature = "unstable-oracles", test_case(
+#[test_case(
     vec![FeeSpend::HttpRequest],
     Amount::from_tokens(2),
     Some(Amount::from_tokens(1)),
     Some(Amount::from_tokens(1_000));
     "with one HTTP request"
-))]
-#[cfg_attr(feature = "unstable-oracles", test_case(
+)]
+#[test_case(
     vec![
         FeeSpend::HttpRequest,
         FeeSpend::HttpRequest,
@@ -129,8 +129,8 @@ use test_case::test_case;
     Some(Amount::from_tokens(1)),
     Some(Amount::from_tokens(1_000));
     "with three HTTP requests"
-))]
-#[cfg_attr(feature = "unstable-oracles", test_case(
+)]
+#[test_case(
     vec![
         FeeSpend::Fuel(11),
         FeeSpend::HttpRequest,
@@ -142,7 +142,7 @@ use test_case::test_case;
     Some(Amount::from_tokens(1)),
     Some(Amount::from_tokens(1_000));
     "with all fee spend operations"
-))]
+)]
 // TODO(#1601): Add more test cases
 #[tokio::test]
 async fn test_fee_consumption(


### PR DESCRIPTION
## Motivation

HTTP oracles is a desired feature by partners and developers. It should be available on the next testnet.

## Proposal

Now that HTTP oracles have minimal limits, fees and permission configurations, allow it to be included in the next build.

## Test Plan

Tested by running the "How-To Perform HTTP Requests" example's integration tests without enabling the `unstable-oracles` feature, and ensuring only the tests for services running as oracles fail:

https://github.com/jvff/linera-protocol-archive/commit/1a28b4d166b9b011e664b94117329d0fdb1bda44

## Release Plan

- Backporting is not possible but we may want to deploy a new `devnet` and release a new
      SDK soon, because this requires the fees, limits and permissions that were recently merged and are breaking changes.

## Links

- Closes #3525 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
