### PR TITLE
`linera_core::join_set_ext`: fix deadlock

### DIFF
--- a/linera-core/src/join_set_ext.rs
+++ b/linera-core/src/join_set_ext.rs
@@ -64,9 +64,7 @@ mod implementation {
         }
 
         fn reap_finished_tasks(&mut self) {
-            for mut done in self.0.drain(..) {
-                while done.try_recv() == Ok(None) {}
-            }
+            self.0.retain_mut(|task| task.try_recv() == Ok(None));
         }
     }
 }


### PR DESCRIPTION
## Motivation

On the Web, `reap_finished_tasks` busy-loops until all tasks are complete.  However, since it blocks the thread, this prevents any tasks from completing, leading to a deadlock.

## Proposal
Following the native implementation, optimistically reap only those tasks that have already finished, not blocking on any tasks that haven't.

## Test Plan
Being manually tested with the `hosted-counter` example.

## Release Plan
- Nothing to do / These changes follow the usual release cycle.

## Links
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
