### PR TITLE
Introduce one smart contract without GraphQL and the corresponding end-to-end test.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,6 +2081,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "counter-no-graphql"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "linera-sdk",
+ "serde",
+]
+
+[[package]]
 name = "cpp_demangle"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4983,6 +4992,7 @@ dependencies = [
  "comfy-table",
  "convert_case",
  "counter",
+ "counter-no-graphql",
  "criterion",
  "crowd-funding",
  "current_platform",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,6 +250,7 @@ linera-witty-macros = { version = "0.14.0", path = "./linera-witty-macros" }
 
 amm = { path = "./examples/amm" }
 counter = { path = "./examples/counter" }
+counter-no-graphql = { path = "./examples/counter-no-graphql" }
 crowd-funding = { path = "./examples/crowd-funding" }
 ethereum-tracker = { path = "./examples/ethereum-tracker" }
 fungible = { path = "./examples/fungible" }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1515,6 +1515,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "counter-no-graphql"
+version = "0.1.0"
+dependencies = [
+ "assert_matches",
+ "futures",
+ "linera-sdk",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "amm",
     "counter",
+    "counter-no-graphql",
     "crowd-funding",
     "ethereum-tracker",
     "fungible",

--- a/examples/counter-no-graphql/Cargo.toml
+++ b/examples/counter-no-graphql/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "counter-no-graphql"
+version = "0.1.0"
+authors = ["Linera <contact@linera.io>"]
+edition = "2021"
+
+[dependencies]
+futures.workspace = true
+linera-sdk.workspace = true
+serde.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+linera-sdk = { workspace = true, features = ["test", "wasmer"] }
+tokio = { workspace = true, features = ["rt", "sync"] }
+
+[dev-dependencies]
+assert_matches.workspace = true
+linera-sdk = { workspace = true, features = ["test"] }
+
+[[bin]]
+name = "counter_no_graphql_contract"
+path = "src/contract.rs"
+
+[[bin]]
+name = "counter_no_graphql_service"
+path = "src/service.rs"

--- a/examples/counter-no-graphql/README.md
+++ b/examples/counter-no-graphql/README.md
@@ -1,0 +1,16 @@
+# Counter No GraphQL Example Application
+
+This example application implements a simple counter contract, it is initialized with an
+unsigned integer that can be increased by the `increment` operation. In contrast with the
+counter application, it works without GraphQL 
+
+## How It Works
+
+It is a very basic Linera application, which is initialized by a `u64` which can be incremented
+by a `u64`.
+
+For example, if the contract was initialized with 1, querying the contract would give us 1. Now if we want to
+`increment` it by 3, we will have to perform an operation with the parameter being 3. Now querying the
+application would give us 4 (1+3 = 4).
+
+## Usage

--- a/examples/counter-no-graphql/src/contract.rs
+++ b/examples/counter-no-graphql/src/contract.rs
@@ -1,0 +1,139 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+mod state;
+
+use counter_no_graphql::{CounterNoGraphQlAbi, CounterOperation};
+use linera_sdk::{
+    linera_base_types::WithContractAbi,
+    views::{RootView, View},
+    Contract, ContractRuntime,
+};
+
+use self::state::CounterState;
+
+pub struct CounterContract {
+    state: CounterState,
+    runtime: ContractRuntime<Self>,
+}
+
+linera_sdk::contract!(CounterContract);
+
+impl WithContractAbi for CounterContract {
+    type Abi = CounterNoGraphQlAbi;
+}
+
+impl Contract for CounterContract {
+    type Message = ();
+    type InstantiationArgument = u64;
+    type Parameters = ();
+
+    async fn load(runtime: ContractRuntime<Self>) -> Self {
+        let state = CounterState::load(runtime.root_view_storage_context())
+            .await
+            .expect("Failed to load state");
+        CounterContract { state, runtime }
+    }
+
+    async fn instantiate(&mut self, value: u64) {
+        // Validate that the application parameters were configured correctly.
+        self.runtime.application_parameters();
+
+        self.state.value.set(value);
+    }
+
+    async fn execute_operation(&mut self, operation: CounterOperation) -> u64 {
+        let previous_value = self.state.value.get();
+        let CounterOperation::Increment(value) = operation;
+        let new_value = previous_value + value;
+        self.state.value.set(new_value);
+        new_value
+    }
+
+    async fn execute_message(&mut self, _message: ()) {
+        panic!("Counter application doesn't support any cross-chain messages");
+    }
+
+    async fn store(mut self) {
+        self.state.save().await.expect("Failed to save state");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::FutureExt as _;
+    use linera_sdk::{util::BlockingWait, views::View, Contract, ContractRuntime};
+
+    use super::{CounterContract, CounterOperation, CounterState};
+
+    #[test]
+    fn operation() {
+        let initial_value = 72_u64;
+        let mut counter = create_and_instantiate_counter(initial_value);
+
+        let increment = 42_308_u64;
+        let operation = CounterOperation::Increment(increment);
+
+        let response = counter
+            .execute_operation(operation)
+            .now_or_never()
+            .expect("Execution of counter operation should not await anything");
+
+        let expected_value = initial_value + increment;
+
+        assert_eq!(response, expected_value);
+        assert_eq!(*counter.state.value.get(), initial_value + increment);
+    }
+
+    #[test]
+    #[should_panic(expected = "Counter application doesn't support any cross-chain messages")]
+    fn message() {
+        let initial_value = 72_u64;
+        let mut counter = create_and_instantiate_counter(initial_value);
+
+        counter
+            .execute_message(())
+            .now_or_never()
+            .expect("Execution of counter operation should not await anything");
+    }
+
+    #[test]
+    fn cross_application_call() {
+        let initial_value = 2_845_u64;
+        let mut counter = create_and_instantiate_counter(initial_value);
+
+        let increment = 8_u64;
+        let operation = CounterOperation::Increment(increment);
+
+        let response = counter
+            .execute_operation(operation)
+            .now_or_never()
+            .expect("Execution of counter operation should not await anything");
+
+        let expected_value = initial_value + increment;
+
+        assert_eq!(response, expected_value);
+        assert_eq!(*counter.state.value.get(), expected_value);
+    }
+
+    fn create_and_instantiate_counter(initial_value: u64) -> CounterContract {
+        let runtime = ContractRuntime::new().with_application_parameters(());
+        let mut contract = CounterContract {
+            state: CounterState::load(runtime.root_view_storage_context())
+                .blocking_wait()
+                .expect("Failed to read from mock key value store"),
+            runtime,
+        };
+
+        contract
+            .instantiate(initial_value)
+            .now_or_never()
+            .expect("Initialization of counter state should not await anything");
+
+        assert_eq!(*contract.state.value.get(), initial_value);
+
+        contract
+    }
+}

--- a/examples/counter-no-graphql/src/lib.rs
+++ b/examples/counter-no-graphql/src/lib.rs
@@ -1,0 +1,30 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*! ABI of the Counter Example Application that does not use GraphQL */
+
+use linera_sdk::linera_base_types::{ContractAbi, ServiceAbi};
+use serde::{Deserialize, Serialize};
+
+pub struct CounterNoGraphQlAbi;
+
+impl ContractAbi for CounterNoGraphQlAbi {
+    type Operation = CounterOperation;
+    type Response = u64;
+}
+
+impl ServiceAbi for CounterNoGraphQlAbi {
+    type Query = CounterRequest;
+    type QueryResponse = u64;
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum CounterRequest {
+    Query,
+    Increment(u64),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum CounterOperation {
+    Increment(u64),
+}

--- a/examples/counter-no-graphql/src/service.rs
+++ b/examples/counter-no-graphql/src/service.rs
@@ -1,0 +1,79 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+mod state;
+
+use std::sync::Arc;
+
+use counter_no_graphql::{CounterOperation, CounterRequest};
+use linera_sdk::{linera_base_types::WithServiceAbi, views::View, Service, ServiceRuntime};
+
+use self::state::CounterState;
+
+pub struct CounterService {
+    state: CounterState,
+    runtime: Arc<ServiceRuntime<Self>>,
+}
+
+linera_sdk::service!(CounterService);
+
+impl WithServiceAbi for CounterService {
+    type Abi = counter_no_graphql::CounterNoGraphQlAbi;
+}
+
+impl Service for CounterService {
+    type Parameters = ();
+
+    async fn new(runtime: ServiceRuntime<Self>) -> Self {
+        let state = CounterState::load(runtime.root_view_storage_context())
+            .await
+            .expect("Failed to load state");
+        CounterService {
+            state,
+            runtime: Arc::new(runtime),
+        }
+    }
+
+    async fn handle_query(&self, request: CounterRequest) -> u64 {
+        match request {
+            CounterRequest::Query => *self.state.value.get(),
+            CounterRequest::Increment(value) => {
+                let operation = CounterOperation::Increment(value);
+                self.runtime.schedule_operation(&operation);
+                0
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use futures::FutureExt as _;
+    use linera_sdk::{util::BlockingWait, views::View, Service, ServiceRuntime};
+
+    use super::{CounterRequest, CounterService, CounterState};
+
+    #[test]
+    fn query() {
+        let value = 61_098_721_u64;
+        let runtime = Arc::new(ServiceRuntime::<CounterService>::new());
+        let mut state = CounterState::load(runtime.root_view_storage_context())
+            .blocking_wait()
+            .expect("Failed to read from mock key value store");
+        state.value.set(value);
+
+        let service = CounterService { state, runtime };
+        let request = CounterRequest::Query;
+
+        let response = service
+            .handle_query(request)
+            .now_or_never()
+            .expect("Query should not await anything");
+
+        assert_eq!(response, value)
+    }
+}

--- a/examples/counter-no-graphql/src/state.rs
+++ b/examples/counter-no-graphql/src/state.rs
@@ -1,0 +1,11 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use linera_sdk::views::{linera_views, RegisterView, RootView, ViewStorageContext};
+
+/// The application state.
+#[derive(RootView)]
+#[view(context = "ViewStorageContext")]
+pub struct CounterState {
+    pub value: RegisterView<u64>,
+}

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -150,6 +150,7 @@ alloy = { workspace = true, default-features = false, features = [
 amm.workspace = true
 base64.workspace = true
 counter.workspace = true
+counter-no-graphql.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
 crowd-funding.workspace = true
 ethereum-tracker.workspace = true

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -1376,39 +1376,37 @@ pub struct ApplicationWrapper<A> {
 }
 
 impl<A> ApplicationWrapper<A> {
-    pub async fn raw_query(&self, query: impl AsRef<str>) -> Result<Value> {
+    pub async fn json_query(&self, query: impl AsRef<str>) -> Result<Value> {
+        let query = query.as_ref();
+        let value = self.raw_query(json!({ "query": query })).await?;
+        Ok(value["data"].clone())
+    }
+
+    pub async fn raw_query<T: Serialize>(&self, query: T) -> Result<Value> {
         const MAX_RETRIES: usize = 5;
 
         for i in 0.. {
-            let query = query.as_ref();
             let client = reqwest_client();
-            let result = client
-                .post(&self.uri)
-                .json(&json!({ "query": query }))
-                .send()
-                .await;
+            let result = client.post(&self.uri).json(&query).send().await;
             let response = match result {
                 Ok(response) => response,
                 Err(error) if i < MAX_RETRIES => {
                     warn!(
                         "Failed to post query \"{}\": {error}; retrying",
-                        truncate_query_output(query),
+                        truncate_query_output(&serde_json::to_string(&query)?),
                     );
                     continue;
                 }
                 Err(error) => {
-                    return Err(error).with_context(|| {
-                        format!(
-                            "raw_query: failed to post query={}",
-                            truncate_query_output(query)
-                        )
-                    });
+                    let query = truncate_query_output(&serde_json::to_string(&query)?);
+                    return Err(error)
+                        .with_context(|| format!("raw_query: failed to post query={query}"));
                 }
             };
             anyhow::ensure!(
                 response.status().is_success(),
                 "Query \"{}\" failed: {}",
-                truncate_query_output(query),
+                truncate_query_output(&serde_json::to_string(&query)?),
                 response
                     .text()
                     .await
@@ -1418,18 +1416,18 @@ impl<A> ApplicationWrapper<A> {
             if let Some(errors) = value.get("errors") {
                 bail!(
                     "Query \"{}\" failed: {}",
-                    truncate_query_output(query),
+                    truncate_query_output(&serde_json::to_string(&query)?),
                     errors
                 );
             }
-            return Ok(value["data"].clone());
+            return Ok(value);
         }
         unreachable!()
     }
 
     pub async fn query(&self, query: impl AsRef<str>) -> Result<Value> {
         let query = query.as_ref();
-        self.raw_query(&format!("query {{ {query} }}")).await
+        self.json_query(&format!("query {{ {query} }}")).await
     }
 
     pub async fn query_json<T: DeserializeOwned>(&self, query: impl AsRef<str>) -> Result<T> {
@@ -1444,7 +1442,7 @@ impl<A> ApplicationWrapper<A> {
 
     pub async fn mutate(&self, mutation: impl AsRef<str>) -> Result<Value> {
         let mutation = mutation.as_ref();
-        self.raw_query(&format!("mutation {{ {mutation} }}")).await
+        self.json_query(&format!("mutation {{ {mutation} }}")).await
     }
 }
 

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -405,7 +405,7 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
     let query = hex::encode(&query);
     let query = format!("query {{ v{} }}", query);
 
-    let result = application.json_query(query).await?;
+    let result = application.run_graphql_query(query).await?;
     let result = result.to_string();
     let result = hex::decode(&result[1..result.len() - 1])?;
 
@@ -417,14 +417,14 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
     let mutation = hex::encode(&mutation);
     let mutation = format!("mutation {{ v{} }}", mutation);
 
-    application.json_query(mutation).await?;
+    application.run_graphql_query(mutation).await?;
 
     let query = get_valueCall {};
     let query = query.abi_encode();
     let query = hex::encode(&query);
     let query = format!("query {{ v{} }}", query);
 
-    let result = application.json_query(query).await?;
+    let result = application.run_graphql_query(query).await?;
     let result = result.to_string();
     let result = hex::decode(&result[1..result.len() - 1])?;
 
@@ -530,16 +530,16 @@ async fn test_wasm_end_to_end_counter_no_graphql(config: impl LineraNetConfig) -
         .await?;
 
     let query = CounterRequest::Query;
-    let read_counter_value = application.raw_query(&query).await?;
+    let read_counter_value = application.run_json_query(&query).await?;
     let mut counter_value = original_counter_value;
     assert_eq!(read_counter_value, counter_value);
 
     // executing a query that mutates the state
 
     let query_increment = CounterRequest::Increment(increment);
-    application.raw_query(&query_increment).await?;
+    application.run_json_query(&query_increment).await?;
 
-    let read_counter_value = application.raw_query(&query).await?;
+    let read_counter_value = application.run_json_query(&query).await?;
     counter_value += increment;
     assert_eq!(read_counter_value, counter_value);
 

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -405,7 +405,7 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
     let query = hex::encode(&query);
     let query = format!("query {{ v{} }}", query);
 
-    let result = application.raw_query(query).await?;
+    let result = application.json_query(query).await?;
     let result = result.to_string();
     let result = hex::decode(&result[1..result.len() - 1])?;
 
@@ -417,14 +417,14 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
     let mutation = hex::encode(&mutation);
     let mutation = format!("mutation {{ v{} }}", mutation);
 
-    application.raw_query(mutation).await?;
+    application.json_query(mutation).await?;
 
     let query = get_valueCall {};
     let query = query.abi_encode();
     let query = hex::encode(&query);
     let query = format!("query {{ v{} }}", query);
 
-    let result = application.raw_query(query).await?;
+    let result = application.json_query(query).await?;
     let result = result.to_string();
     let result = hex::decode(&result[1..result.len() - 1])?;
 
@@ -483,6 +483,65 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()
 
     let counter_value: u64 = application.query_json("value").await?;
     assert_eq!(counter_value, original_counter_value + increment);
+
+    node_service.ensure_is_running()?;
+
+    net.ensure_is_running().await?;
+    net.terminate().await?;
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
+#[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_wasm_end_to_end_counter_no_graphql(config: impl LineraNetConfig) -> Result<()> {
+    use counter_no_graphql::{CounterNoGraphQlAbi, CounterRequest};
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let (mut net, client) = config.instantiate().await?;
+
+    let original_counter_value = 35;
+    let increment = 5;
+
+    let chain = client.load_wallet()?.default_chain().unwrap();
+    let (contract, service) = client.build_example("counter-no-graphql").await?;
+
+    let application_id = client
+        .publish_and_create::<CounterNoGraphQlAbi, (), u64>(
+            contract,
+            service,
+            VmRuntime::Wasm,
+            &(),
+            &original_counter_value,
+            &[],
+            None,
+        )
+        .await?;
+    let port = get_node_port().await;
+    let mut node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
+
+    let application = node_service
+        .make_application(&chain, &application_id)
+        .await?;
+
+    let query = CounterRequest::Query;
+    let read_counter_value = application.raw_query(&query).await?;
+    let mut counter_value = original_counter_value;
+    assert_eq!(read_counter_value, counter_value);
+
+    // executing a query that mutates the state
+
+    let query_increment = CounterRequest::Increment(increment);
+    application.raw_query(&query_increment).await?;
+
+    let read_counter_value = application.raw_query(&query).await?;
+    counter_value += increment;
+    assert_eq!(read_counter_value, counter_value);
 
     node_service.ensure_is_running()?;
 


### PR DESCRIPTION
## Motivation

GraphQL is used all over the Linera code. This led to the question whether we can program a Linera application without GraphQL. This PR demonstrates that it is possible.

## Proposal

The following was done:
* Introduce an application `counter-no-graphql` that works without GraphQL but still uses the `linera-sdk`.
* The `ApplicationWrapper` has been restructured to separate between json queries and GraphQL queries.

This PR led to some further questions to address in next PRs:
* The `counter-no-graphql` application does not use GraphQL, but it still typed. We should also have a `counter_untyped` for which `execute_operation` takes a `Vec<u8>` and does not use the `linera-sdk` macros.
* Different serializations are being used in the code: `bcs::to_bytes` and `serde_json::to_vec`. No effort was made to unify this.
* The `raw_operation` function is returning some `CryptoHash` instead of a `Vec<u8>`. It was not clear how to obtain the result of the `execute_operation` from the resulting entry.
* The EVM application are untyped. Moving to the `raw_application` seems premature.

## Test Plan

The test running without GraphQL has been inserted.

## Release Plan

This should be included in next TestNet release.

## Links

None.