### PR TITLE
Simplify service requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4974,7 +4974,6 @@ dependencies = [
  "async-tungstenite",
  "axum",
  "base64 0.22.1",
- "bcs",
  "cargo_toml",
  "cfg_aliases",
  "chrono",

--- a/examples/amm/README.md
+++ b/examples/amm/README.md
@@ -178,20 +178,6 @@ mutation {
 ```
 
 All operations can only be from a remote chain i.e. other than the chain on which `AMM` is deployed to.
-We can do it from GraphiQL by performing the `requestApplication` mutation so that we can perform the
-operation from the chain.
-
-```gql,uri=http://localhost:8080
-mutation {
-  requestApplication (
-    chainId:"$CHAIN_1",
-    applicationId: "$AMM_APPLICATION_ID",
-    targetChainId: "$CHAIN_AMM"
-  )
-}
-```
-
-Note: The above mutation has to be performed from `http://localhost:8080`.
 
 Before performing any operation we need to provide liquidity to it, so we will use the `AddLiquidity` operation,
 navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID"`.
@@ -207,18 +193,6 @@ mutation {
   )
 }
 ```
-
-```gql,uri=http://localhost:8080
-mutation {
-  requestApplication (
-    chainId:"$CHAIN_2",
-    applicationId: "$AMM_APPLICATION_ID",
-    targetChainId: "$CHAIN_AMM"
-  )
-}
-```
-
-Note: The above mutation has to be performed from `http://localhost:8080`.
 
 To perform the `Swap` operation, navigate to the URL you get by running `echo "http://localhost:8080/chains/$CHAIN_2/applications/$AMM_APPLICATION_ID"` and
 perform the following mutation:

--- a/examples/crowd-funding/README.md
+++ b/examples/crowd-funding/README.md
@@ -181,10 +181,6 @@ query { applications(
 
 The response will have two entries, one for each application.
 
-If you enter the `applications` query again, both entries will appear in the second wallet as
-well now. `$APP_ID_0` has been registered, too, because it is a dependency of the other
-application.
-
 On both http://localhost:8080 and http://localhost:8081, you recognize the crowd-funding
 application by its ID. The entry also has a field `link`. If you open that in a new tab, you
 see the GraphQL API for that application on that chain.

--- a/examples/crowd-funding/README.md
+++ b/examples/crowd-funding/README.md
@@ -181,17 +181,6 @@ query { applications(
 
 The response will have two entries, one for each application.
 
-If you do the same with the other chain ID in http://localhost:8081, the node service for the
-other wallet, it will have no entries at all, because the applications haven't been registered
-there yet. Request `crowd-funding` from the other chain. As an application ID, use `$APP_ID_1`:
-
-```gql,uri=http://localhost:8081
-mutation { requestApplication(
-  chainId: "$CHAIN_1"
-  applicationId: "$APP_ID_1"
-) }
-```
-
 If you enter the `applications` query again, both entries will appear in the second wallet as
 well now. `$APP_ID_0` has been registered, too, because it is a dependency of the other
 application.

--- a/examples/social/README.md
+++ b/examples/social/README.md
@@ -92,35 +92,6 @@ linera --with-wallet 1 service --port 8081 &
 sleep 2
 ```
 
-Type each of these in the GraphiQL interface and substitute the env variables with their actual values that we've defined above.
-
-Point your browser to http://localhost:8081. This is the wallet that didn't create the
-application, so we have to request it from the creator chain. As the chain ID specifies the
-one of the chain where it isn't registered yet:
-
-```gql,uri=http://localhost:8081
-mutation {
-  requestApplication(
-    chainId: "$CHAIN_1",
-    applicationId: "$APP_ID"
-  )
-}
-```
-
-Now in both http://localhost:8080 and http://localhost:8081, this should list the
-application and provide a link to its GraphQL API. Remember to use each wallet's chain ID:
-
-```gql,uri=http://localhost:8081
-query {
-  applications(
-    chainId: "$CHAIN_1"
-  ) {
-    id
-    link
-  }
-}
-```
-
 Open both URLs under the entry `link`. Now you can use the application on each chain.
 For the 8081 tab, you can run `echo "http://localhost:8081/chains/$CHAIN_1/applications/$APP_ID"`
 to print the URL to navigate to, then subscribe to the other chain using the following query:

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -85,7 +85,6 @@ async-lock.workspace = true
 async-trait.workspace = true
 async-tungstenite.workspace = true
 axum = { workspace = true, features = ["ws"] }
-bcs.workspace = true
 cargo_toml.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 clap.workspace = true


### PR DESCRIPTION
## Motivation

After #3217, we do not need to introspect service queries to applications.

## Proposal

* Minimize assumptions about application APIs. After this PR, we only assume UTF8 bytes as input and JSON as output.
* Simplify requests handlers
* Somehow this revealed silently failing queries in our README files. Also fix that.

Note the assumption on JSON outputs could be relaxed if we stopped returning the hash of the certified block and return the query response instead. However, this is a breaking change so this should be a separate PR.

## Test Plan

CI