### PR TITLE
Eliminate the `create_test_memory_context`.

### DIFF
--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -11,7 +11,7 @@ use linera_base::{
     identifiers::ChainId,
 };
 #[cfg(with_testing)]
-use linera_views::context::{create_test_memory_context, MemoryContext};
+use linera_views::context::MemoryContext;
 use linera_views::{
     context::Context,
     queue_view::QueueView,
@@ -329,7 +329,7 @@ where
     MemoryContext<()>: Context + Clone + Send + Sync + 'static,
 {
     pub async fn new() -> Self {
-        let context = create_test_memory_context();
+        let context = MemoryContext::new_for_testing(());
         Self::load(context)
             .await
             .expect("Loading from memory should work")

--- a/linera-chain/src/outbox.rs
+++ b/linera-chain/src/outbox.rs
@@ -6,7 +6,7 @@ use std::sync::LazyLock;
 
 use linera_base::data_types::{ArithmeticError, BlockHeight};
 #[cfg(with_testing)]
-use linera_views::context::{create_test_memory_context, MemoryContext};
+use linera_views::context::MemoryContext;
 use linera_views::{
     context::Context,
     queue_view::QueueView,
@@ -103,7 +103,7 @@ where
     MemoryContext<()>: Context + Clone + Send + Sync + 'static,
 {
     pub async fn new() -> Self {
-        let context = create_test_memory_context();
+        let context = MemoryContext::new_for_testing(());
         Self::load(context)
             .await
             .expect("Loading from memory should work")

--- a/linera-views/benches/reentrant_collection_view.rs
+++ b/linera-views/benches/reentrant_collection_view.rs
@@ -5,7 +5,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use linera_base::time::{Duration, Instant};
 use linera_views::{
     batch::Batch,
-    context::{create_test_memory_context, Context, MemoryContext},
+    context::{Context, MemoryContext},
     reentrant_collection_view::ReentrantCollectionView,
     register_view::RegisterView,
     views::View,
@@ -149,7 +149,7 @@ enum ComplexIndex {
 async fn create_populated_reentrant_collection_view(
 ) -> ReentrantCollectionView<MemoryContext<()>, ComplexIndex, RegisterView<MemoryContext<()>, String>>
 {
-    let context = create_test_memory_context();
+    let context = MemoryContext::new_for_testing(());
     let mut view: ReentrantCollectionView<_, ComplexIndex, RegisterView<_, String>> =
         ReentrantCollectionView::load(context)
             .await

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -643,7 +643,7 @@ impl BatchValueWriter<UnorderedBatch> for UnorderedBatchIter {
 mod tests {
     use linera_views::{
         batch::{Batch, SimpleUnorderedBatch, UnorderedBatch},
-        context::{create_test_memory_context, Context},
+        context::{Context, MemoryContext},
     };
 
     #[test]
@@ -700,7 +700,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_simplify_batch5() {
-        let context = create_test_memory_context();
+        let context = MemoryContext::new_for_testing(());
         let mut batch = Batch::new();
         batch.put_key_value_bytes(vec![1, 2, 3], vec![]);
         batch.put_key_value_bytes(vec![1, 2, 4], vec![]);
@@ -723,7 +723,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_simplify_batch6() {
-        let context = create_test_memory_context();
+        let context = MemoryContext::new_for_testing(());
         let insertions = vec![(vec![1, 2, 3], vec![])];
         let simple_unordered_batch = SimpleUnorderedBatch {
             insertions: insertions.clone(),

--- a/linera-views/src/context.rs
+++ b/linera-views/src/context.rs
@@ -273,12 +273,6 @@ where
 /// An implementation of [`crate::context::Context`] that stores all values in memory.
 pub type MemoryContext<E> = ViewContext<E, MemoryStore>;
 
-/// Provides a `MemoryContext<()>` that can be used for tests.
-#[cfg(with_testing)]
-pub fn create_test_memory_context() -> MemoryContext<()> {
-    MemoryContext::new_for_testing(())
-}
-
 impl<E> MemoryContext<E> {
     /// Creates a [`Context`] instance in memory for testing.
     #[cfg(with_testing)]

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -328,10 +328,10 @@ where
     /// Gets the number of entries in the container that are stored
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::bucket_queue_view::BucketQueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = BucketQueueView::<_, u8, 5>::load(context).await.unwrap();
     /// queue.push_back(34);
     /// assert_eq!(queue.stored_count(), 0);
@@ -356,10 +356,10 @@ where
     /// The total number of entries of the container
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::bucket_queue_view::BucketQueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = BucketQueueView::<_, u8, 5>::load(context).await.unwrap();
     /// queue.push_back(34);
     /// assert_eq!(queue.count(), 1);
@@ -379,10 +379,10 @@ where
     /// Gets a reference on the front value if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::bucket_queue_view::BucketQueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = BucketQueueView::<_, u8, 5>::load(context).await.unwrap();
     /// queue.push_back(34);
     /// queue.push_back(42);
@@ -405,10 +405,10 @@ where
     /// Reads the front value, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::bucket_queue_view::BucketQueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = BucketQueueView::<_, u8, 5>::load(context).await.unwrap();
     /// queue.push_back(34);
     /// queue.push_back(42);
@@ -433,10 +433,10 @@ where
     /// Deletes the front value, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::bucket_queue_view::BucketQueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = BucketQueueView::<_, u128, 5>::load(context).await.unwrap();
     /// queue.push_back(34 as u128);
     /// queue.delete_front().await.unwrap();
@@ -478,10 +478,10 @@ where
     /// Pushes a value to the end of the queue.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::bucket_queue_view::BucketQueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = BucketQueueView::<_, u128, 5>::load(context).await.unwrap();
     /// queue.push_back(34);
     /// assert_eq!(queue.elements().await.unwrap(), vec![34]);
@@ -494,10 +494,10 @@ where
     /// Returns the list of elements in the queue.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::bucket_queue_view::BucketQueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = BucketQueueView::<_, u128, 5>::load(context).await.unwrap();
     /// queue.push_back(34);
     /// queue.push_back(37);
@@ -512,10 +512,10 @@ where
     /// Returns the last element of a bucket queue view
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::bucket_queue_view::BucketQueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = BucketQueueView::<_, u128, 5>::load(context).await.unwrap();
     /// queue.push_back(34);
     /// queue.push_back(37);
@@ -605,10 +605,10 @@ where
     /// Returns the first elements of a bucket queue view
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::bucket_queue_view::BucketQueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = BucketQueueView::<_, u128, 5>::load(context).await.unwrap();
     /// queue.push_back(34);
     /// queue.push_back(37);
@@ -624,10 +624,10 @@ where
     /// Returns the last element of a bucket queue view
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::bucket_queue_view::BucketQueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = BucketQueueView::<_, u128, 5>::load(context).await.unwrap();
     /// queue.push_back(34);
     /// queue.push_back(37);
@@ -679,10 +679,10 @@ where
     /// Gets a mutable iterator on the entries of the queue
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::bucket_queue_view::BucketQueueView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = BucketQueueView::<_, u8, 5>::load(context).await.unwrap();
     /// queue.push_back(34);
     /// let mut iter = queue.iter_mut().await.unwrap();

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -215,11 +215,11 @@ where
     /// can be modified.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ByteCollectionView<_, RegisterView<_, String>> =
     ///     ByteCollectionView::load(context).await.unwrap();
     /// let subview = view.load_entry_mut(&[0, 1]).await.unwrap();
@@ -236,11 +236,11 @@ where
     /// is read-only.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ByteCollectionView<_, RegisterView<_, String>> =
     ///     ByteCollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&[0, 1]).await.unwrap();
@@ -258,11 +258,11 @@ where
     /// May fail if one subview is already being visited.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ByteCollectionView<_, RegisterView<_, String>> =
     ///     ByteCollectionView::load(context).await.unwrap();
     /// {
@@ -322,11 +322,11 @@ where
     /// Resets an entry to the default value.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ByteCollectionView<_, RegisterView<_, String>> =
     ///     ByteCollectionView::load(context).await.unwrap();
     /// let subview = view.load_entry_mut(&[0, 1]).await.unwrap();
@@ -353,11 +353,11 @@ where
     /// Tests if the collection contains a specified key and returns a boolean.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ByteCollectionView<_, RegisterView<_, String>> =
     ///     ByteCollectionView::load(context).await.unwrap();
     /// {
@@ -384,11 +384,11 @@ where
     /// Marks the entry as removed. If absent then nothing is done.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ByteCollectionView<_, RegisterView<_, String>> =
     ///     ByteCollectionView::load(context).await.unwrap();
     /// let subview = view.load_entry_mut(&[0, 1]).await.unwrap();
@@ -464,11 +464,11 @@ where
     /// ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ByteCollectionView<_, RegisterView<_, String>> =
     ///     ByteCollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&[0, 1]).await.unwrap();
@@ -532,11 +532,11 @@ where
     /// lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ByteCollectionView<_, RegisterView<_, String>> =
     ///     ByteCollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&[0, 1]).await.unwrap();
@@ -565,11 +565,11 @@ where
     /// Returns the list of keys in the collection. The order is lexicographic.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ByteCollectionView<_, RegisterView<_, String>> =
     ///     ByteCollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&[0, 1]).await.unwrap();
@@ -591,11 +591,11 @@ where
     /// Returns the number of entries in the collection.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ByteCollectionView<_, RegisterView<_, String>> =
     ///     ByteCollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&[0, 1]).await.unwrap();
@@ -764,11 +764,11 @@ where
     /// can be modified.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CollectionView<_, u64, RegisterView<_, String>> =
     ///     CollectionView::load(context).await.unwrap();
     /// let subview = view.load_entry_mut(&23).await.unwrap();
@@ -790,11 +790,11 @@ where
     /// is read-only.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CollectionView<_, u64, RegisterView<_, String>> =
     ///     CollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&23).await.unwrap();
@@ -817,11 +817,11 @@ where
     /// May fail if one subview is already being visited.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CollectionView<_, u64, RegisterView<_, String>> =
     ///     CollectionView::load(context).await.unwrap();
     /// {
@@ -850,11 +850,11 @@ where
     /// Resets an entry to the default value.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CollectionView<_, u64, RegisterView<_, String>> =
     ///     CollectionView::load(context).await.unwrap();
     /// let subview = view.load_entry_mut(&23).await.unwrap();
@@ -878,11 +878,11 @@ where
     /// Removes an entry from the `CollectionView`. If absent nothing happens.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CollectionView<_, u64, RegisterView<_, String>> =
     ///     CollectionView::load(context).await.unwrap();
     /// let subview = view.load_entry_mut(&23).await.unwrap();
@@ -920,11 +920,11 @@ where
     /// the serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CollectionView<_, u64, RegisterView<_, String>> =
     ///     CollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&23).await.unwrap();
@@ -946,11 +946,11 @@ where
     /// Returns the number of entries in the collection.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CollectionView<_, u64, RegisterView<_, String>> =
     ///     CollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&23).await.unwrap();
@@ -975,11 +975,11 @@ where
     /// the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CollectionView<_, u64, RegisterView<_, String>> =
     ///     CollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&23).await.unwrap();
@@ -1011,11 +1011,11 @@ where
     /// determined by the serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CollectionView<_, u64, RegisterView<_, String>> =
     ///     CollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&23).await.unwrap();
@@ -1144,11 +1144,11 @@ where
     /// can be modified.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     CustomCollectionView::load(context).await.unwrap();
     /// let subview = view.load_entry_mut(&23).await.unwrap();
@@ -1170,11 +1170,11 @@ where
     /// is read-only.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     CustomCollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&23).await.unwrap();
@@ -1197,11 +1197,11 @@ where
     /// May fail if one subview is already being visited.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     CustomCollectionView::load(context).await.unwrap();
     /// {
@@ -1230,11 +1230,11 @@ where
     /// Marks the entry so that it is removed in the next flush.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     CustomCollectionView::load(context).await.unwrap();
     /// let subview = view.load_entry_mut(&23).await.unwrap();
@@ -1258,11 +1258,11 @@ where
     /// Removes an entry from the `CollectionView`. If absent nothing happens.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     CustomCollectionView::load(context).await.unwrap();
     /// let subview = view.load_entry_mut(&23).await.unwrap();
@@ -1299,11 +1299,11 @@ where
     /// Returns the list of indices in the collection in the order determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     CustomCollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&23).await.unwrap();
@@ -1325,11 +1325,11 @@ where
     /// Returns the number of entries in the collection.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CollectionView<_, u64, RegisterView<_, String>> =
     ///     CollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&23).await.unwrap();
@@ -1354,11 +1354,11 @@ where
     /// then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     CustomCollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&28).await.unwrap();
@@ -1391,11 +1391,11 @@ where
     /// determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: CustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     CustomCollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&28).await.unwrap();

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -385,10 +385,10 @@ where
     /// Getting the total sizes that will be used for keys and values when stored
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::{KeyValueStoreView, SizeData};
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// let total_size = view.total_size();
     /// assert_eq!(total_size, SizeData::default());
@@ -402,10 +402,10 @@ where
     /// false, then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![0]).await.unwrap();
     /// view.insert(vec![0, 2], vec![0]).await.unwrap();
@@ -474,10 +474,10 @@ where
     /// Applies the function f over all indices.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![0]).await.unwrap();
     /// view.insert(vec![0, 2], vec![0]).await.unwrap();
@@ -507,10 +507,10 @@ where
     /// If the function f returns false then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![0]).await.unwrap();
     /// view.insert(vec![0, 2], vec![0]).await.unwrap();
@@ -578,10 +578,10 @@ where
     /// Applies the function f over all index/value pairs.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![0]).await.unwrap();
     /// view.insert(vec![0, 2], vec![0]).await.unwrap();
@@ -609,10 +609,10 @@ where
     /// Returns the list of indices in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![0]).await.unwrap();
     /// view.insert(vec![0, 2], vec![0]).await.unwrap();
@@ -633,10 +633,10 @@ where
     /// Returns the list of indices and values in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![0]).await.unwrap();
     /// view.insert(vec![0, 2], vec![0]).await.unwrap();
@@ -657,10 +657,10 @@ where
     /// Returns the number of entries.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![0]).await.unwrap();
     /// view.insert(vec![0, 2], vec![0]).await.unwrap();
@@ -681,10 +681,10 @@ where
     /// Obtains the value at the given index, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![42]).await.unwrap();
     /// assert_eq!(view.get(&[0, 1]).await.unwrap(), Some(vec![42]));
@@ -712,10 +712,10 @@ where
     /// Tests whether the store contains a specific index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![42]).await.unwrap();
     /// assert!(view.contains_key(&[0, 1]).await.unwrap());
@@ -743,10 +743,10 @@ where
     /// Tests whether the view contains a range of indices
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![42]).await.unwrap();
     /// let keys = vec![vec![0, 1], vec![0, 2]];
@@ -787,10 +787,10 @@ where
     /// Obtains the values of a range of indices
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![42]).await.unwrap();
     /// assert_eq!(
@@ -835,11 +835,11 @@ where
     /// Applies the given batch of `crate::common::WriteOperation`.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::batch::Batch;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![34]).await.unwrap();
     /// view.insert(vec![3, 4], vec![42]).await.unwrap();
@@ -921,10 +921,10 @@ where
     /// Sets or inserts a value.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![34]).await.unwrap();
     /// assert_eq!(view.get(&[0, 1]).await.unwrap(), Some(vec![34]));
@@ -939,10 +939,10 @@ where
     /// Removes a value. If absent then the action has no effect.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![34]).await.unwrap();
     /// view.remove(vec![0, 1]).await.unwrap();
@@ -958,10 +958,10 @@ where
     /// Deletes a key prefix.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![34]).await.unwrap();
     /// view.remove_by_prefix(vec![0]).await.unwrap();
@@ -977,10 +977,10 @@ where
     /// Iterates over all the keys matching the given prefix. The prefix is not included in the returned keys.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![34]).await.unwrap();
     /// view.insert(vec![3, 4], vec![42]).await.unwrap();
@@ -1050,10 +1050,10 @@ where
     /// prefix is not included in the returned keys.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![34]).await.unwrap();
     /// view.insert(vec![3, 4], vec![42]).await.unwrap();

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -151,10 +151,10 @@ where
     /// Pushes a value to the end of the log.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::log_view::LogView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut log = LogView::load(context).await.unwrap();
     /// log.push(34);
     /// # })
@@ -166,10 +166,10 @@ where
     /// Reads the size of the log.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::log_view::LogView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut log = LogView::load(context).await.unwrap();
     /// log.push(34);
     /// log.push(42);
@@ -199,10 +199,10 @@ where
     /// Reads the logged value with the given index (including staged ones).
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::log_view::LogView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut log = LogView::load(context).await.unwrap();
     /// log.push(34);
     /// assert_eq!(log.get(0).await.unwrap(), Some(34));
@@ -223,10 +223,10 @@ where
     /// Reads several logged keys (including staged ones)
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::log_view::LogView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut log = LogView::load(context).await.unwrap();
     /// log.push(34);
     /// log.push(42);
@@ -285,10 +285,10 @@ where
     /// Reads the logged values in the given range (including staged ones).
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::log_view::LogView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut log = LogView::load(context).await.unwrap();
     /// log.push(34);
     /// log.push(42);

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -198,10 +198,10 @@ where
     /// Inserts or resets the value of a key of the map.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// assert_eq!(map.keys().await.unwrap(), vec![vec![0, 1]]);
@@ -214,10 +214,10 @@ where
     /// Removes a value. If absent then nothing is done.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![0, 1], "Hello");
     /// map.remove(vec![0, 1]);
@@ -235,10 +235,10 @@ where
     /// Removes a value. If absent then nothing is done.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// map.insert(vec![0, 2], String::from("Bonjour"));
@@ -266,10 +266,10 @@ where
     /// Returns `true` if the map contains a value for the specified key.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// assert!(map.contains_key(&[0, 1]).await.unwrap());
@@ -301,10 +301,10 @@ where
     /// Reads the value at the given position, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// assert_eq!(map.get(&[0, 1]).await.unwrap(), Some(String::from("Hello")));
@@ -328,10 +328,10 @@ where
     /// Reads the values at the given positions, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// let values = map.multi_get(vec![vec![0, 1], vec![0, 2]]).await.unwrap();
@@ -364,10 +364,10 @@ where
     /// Obtains a mutable reference to a value at a given position if available.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// let value = map.get_mut(&[0, 1]).await.unwrap().unwrap();
@@ -407,10 +407,10 @@ where
     /// function and if it returns false, then the loop exits
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// map.insert(vec![1, 2], String::from("Bonjour"));
@@ -484,10 +484,10 @@ where
     /// lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// let mut count = 0;
@@ -521,10 +521,10 @@ where
     /// Returns the list of keys of the map in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// map.insert(vec![1, 2], String::from("Bonjour"));
@@ -553,10 +553,10 @@ where
     /// in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// map.insert(vec![1, 2], String::from("Bonjour"));
@@ -586,10 +586,10 @@ where
     /// Returns the number of keys of the map
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// map.insert(vec![1, 2], String::from("Bonjour"));
@@ -686,10 +686,10 @@ where
     /// prematurely
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// map.insert(vec![1, 2], String::from("Bonjour"));
@@ -754,10 +754,10 @@ where
     /// lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// let mut count = 0;
@@ -803,10 +803,10 @@ where
     /// in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![1, 2], String::from("Hello"));
     /// let prefix = vec![1];
@@ -839,10 +839,10 @@ where
     /// Returns the list of keys and values of the map in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![1, 2], String::from("Hello"));
     /// assert_eq!(
@@ -866,10 +866,10 @@ where
     /// Default value if the index is missing.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::ByteMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = ByteMapView::load(context).await.unwrap();
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// assert_eq!(map.get_mut_or_default(&[7]).await.unwrap(), "");
@@ -1021,10 +1021,10 @@ where
     /// Inserts or resets a value at an index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: MapView<_, u32, _> = MapView::load(context).await.unwrap();
     /// map.insert(&(24 as u32), String::from("Hello"));
     /// assert_eq!(
@@ -1046,10 +1046,10 @@ where
     /// Removes a value. If absent then the operation does nothing.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = MapView::<_, u32, String>::load(context).await.unwrap();
     /// map.remove(&(37 as u32));
     /// assert_eq!(map.get(&(37 as u32)).await.unwrap(), None);
@@ -1073,10 +1073,10 @@ where
     /// Returns `true` if the map contains a value for the specified key.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = MapView::<_, u32, String>::load(context).await.unwrap();
     /// map.insert(&(37 as u32), String::from("Hello"));
     /// assert!(map.contains_key(&(37 as u32)).await.unwrap());
@@ -1103,10 +1103,10 @@ where
     /// Reads the value at the given position, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: MapView<_, u32, _> = MapView::load(context).await.unwrap();
     /// map.insert(&(37 as u32), String::from("Hello"));
     /// assert_eq!(
@@ -1128,10 +1128,10 @@ where
     /// Obtains a mutable reference to a value at a given position if available
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: MapView<_, u32, String> = MapView::load(context).await.unwrap();
     /// map.insert(&(37 as u32), String::from("Hello"));
     /// assert_eq!(map.get_mut(&(34 as u32)).await.unwrap(), None);
@@ -1163,10 +1163,10 @@ where
     /// Returns the list of indices in the map. The order is determined by serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: MapView<_, u32, String> = MapView::load(context).await.unwrap();
     /// map.insert(&(37 as u32), String::from("Hello"));
     /// assert_eq!(map.indices().await.unwrap(), vec![37 as u32]);
@@ -1187,10 +1187,10 @@ where
     /// the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: MapView<_, u128, String> = MapView::load(context).await.unwrap();
     /// map.insert(&(34 as u128), String::from("Thanks"));
     /// map.insert(&(37 as u128), String::from("Spasiba"));
@@ -1226,10 +1226,10 @@ where
     /// determined by serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: MapView<_, u128, String> = MapView::load(context).await.unwrap();
     /// map.insert(&(34 as u128), String::from("Hello"));
     /// let mut count = 0;
@@ -1264,10 +1264,10 @@ where
     /// If the function returns false, then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: MapView<_, u128, String> = MapView::load(context).await.unwrap();
     /// map.insert(&(34 as u128), String::from("Thanks"));
     /// map.insert(&(37 as u128), String::from("Spasiba"));
@@ -1303,10 +1303,10 @@ where
     /// visited in an order determined by serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: MapView<_, Vec<u8>, _> = MapView::load(context).await.unwrap();
     /// map.insert(&vec![0, 1], String::from("Hello"));
     /// let mut count = 0;
@@ -1347,10 +1347,10 @@ where
     /// Obtains all the `(index,value)` pairs.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: MapView<_, String, _> = MapView::load(context).await.unwrap();
     /// map.insert("Italian", String::from("Ciao"));
     /// let index_values = map.index_values().await.unwrap();
@@ -1374,10 +1374,10 @@ where
     /// Obtains the number of entries in the map
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: MapView<_, String, _> = MapView::load(context).await.unwrap();
     /// map.insert("Italian", String::from("Ciao"));
     /// map.insert("French", String::from("Bonjour"));
@@ -1400,10 +1400,10 @@ where
     /// Default value if the index is missing.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: MapView<_, u32, u128> = MapView::load(context).await.unwrap();
     /// let value = map.get_mut_or_default(&(34 as u32)).await.unwrap();
     /// assert_eq!(*value, 0 as u128);
@@ -1516,10 +1516,10 @@ where
     /// Insert or resets a value.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: MapView<_, u128, _> = MapView::load(context).await.unwrap();
     /// map.insert(&(24 as u128), String::from("Hello"));
     /// assert_eq!(
@@ -1541,10 +1541,10 @@ where
     /// Removes a value. If absent then this does not do anything.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = MapView::<_, u128, String>::load(context).await.unwrap();
     /// map.remove(&(37 as u128));
     /// assert_eq!(map.get(&(37 as u128)).await.unwrap(), None);
@@ -1568,10 +1568,10 @@ where
     /// Returns `true` if the map contains a value for the specified key.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = MapView::<_, u128, String>::load(context).await.unwrap();
     /// map.insert(&(37 as u128), String::from("Hello"));
     /// assert!(map.contains_key(&(37 as u128)).await.unwrap());
@@ -1598,10 +1598,10 @@ where
     /// Reads the value at the given position, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::CustomMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: CustomMapView<MemoryContext<()>, u128, String> =
     ///     CustomMapView::load(context).await.unwrap();
     /// map.insert(&(34 as u128), String::from("Hello"));
@@ -1623,10 +1623,10 @@ where
     /// Obtains a mutable reference to a value at a given position if available
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::CustomMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: CustomMapView<_, u128, String> = CustomMapView::load(context).await.unwrap();
     /// map.insert(&(34 as u128), String::from("Hello"));
     /// let value = map.get_mut(&(34 as u128)).await.unwrap().unwrap();
@@ -1658,10 +1658,10 @@ where
     /// by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: MapView<_, u128, String> = MapView::load(context).await.unwrap();
     /// map.insert(&(34 as u128), String::from("Hello"));
     /// map.insert(&(37 as u128), String::from("Bonjour"));
@@ -1683,10 +1683,10 @@ where
     /// then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::CustomMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = CustomMapView::load(context).await.unwrap();
     /// map.insert(&(34 as u128), String::from("Hello"));
     /// map.insert(&(37 as u128), String::from("Hola"));
@@ -1721,10 +1721,10 @@ where
     /// determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::CustomMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = CustomMapView::load(context).await.unwrap();
     /// map.insert(&(34 as u128), String::from("Hello"));
     /// map.insert(&(37 as u128), String::from("Hola"));
@@ -1760,10 +1760,10 @@ where
     /// If the function returns false, then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::CustomMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map = CustomMapView::<_, u128, String>::load(context)
     ///     .await
     ///     .unwrap();
@@ -1800,10 +1800,10 @@ where
     /// visited in an order determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::CustomMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: CustomMapView<_, u128, String> = CustomMapView::load(context).await.unwrap();
     /// map.insert(&(34 as u128), String::from("Hello"));
     /// map.insert(&(37 as u128), String::from("Hola"));
@@ -1845,10 +1845,10 @@ where
     /// Obtains all the `(index,value)` pairs.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: MapView<_, String, _> = MapView::load(context).await.unwrap();
     /// map.insert("Italian", String::from("Ciao"));
     /// let index_values = map.index_values().await.unwrap();
@@ -1872,10 +1872,10 @@ where
     /// Obtains the number of entries in the map
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::MapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: MapView<_, String, _> = MapView::load(context).await.unwrap();
     /// map.insert("Italian", String::from("Ciao"));
     /// map.insert("French", String::from("Bonjour"));
@@ -1898,10 +1898,10 @@ where
     /// Default value if the index is missing.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::map_view::CustomMapView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut map: CustomMapView<_, u128, String> = CustomMapView::load(context).await.unwrap();
     /// assert_eq!(
     ///     *map.get_mut_or_default(&(34 as u128)).await.unwrap(),

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -192,10 +192,10 @@ where
     /// Reads the front value, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::queue_view::QueueView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = QueueView::load(context).await.unwrap();
     /// queue.push_back(34);
     /// queue.push_back(42);
@@ -215,10 +215,10 @@ where
     /// Reads the back value, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::queue_view::QueueView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = QueueView::load(context).await.unwrap();
     /// queue.push_back(34);
     /// queue.push_back(42);
@@ -236,10 +236,10 @@ where
     /// Deletes the front value, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::queue_view::QueueView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = QueueView::load(context).await.unwrap();
     /// queue.push_back(34 as u128);
     /// queue.delete_front();
@@ -257,10 +257,10 @@ where
     /// Pushes a value to the end of the queue.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::queue_view::QueueView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = QueueView::load(context).await.unwrap();
     /// queue.push_back(34);
     /// queue.push_back(37);
@@ -274,10 +274,10 @@ where
     /// Reads the size of the queue.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::queue_view::QueueView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = QueueView::load(context).await.unwrap();
     /// queue.push_back(34);
     /// assert_eq!(queue.count(), 1);
@@ -314,10 +314,10 @@ where
     /// Reads the `count` next values in the queue (including staged ones).
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::queue_view::QueueView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = QueueView::load(context).await.unwrap();
     /// queue.push_back(34);
     /// queue.push_back(42);
@@ -354,10 +354,10 @@ where
     /// Reads the `count` last values in the queue (including staged ones).
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::queue_view::QueueView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = QueueView::load(context).await.unwrap();
     /// queue.push_back(34);
     /// queue.push_back(42);
@@ -390,10 +390,10 @@ where
     /// Reads all the elements
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::queue_view::QueueView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = QueueView::load(context).await.unwrap();
     /// queue.push_back(34);
     /// queue.push_back(37);
@@ -427,10 +427,10 @@ where
     /// Gets a mutable iterator on the entries of the queue
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::queue_view::QueueView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut queue = QueueView::load(context).await.unwrap();
     /// queue.push_back(34);
     /// let mut iter = queue.iter_mut().await.unwrap();

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -324,11 +324,11 @@ where
     /// can be modified.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantByteCollectionView<_, RegisterView<_, String>> =
     ///     ReentrantByteCollectionView::load(context).await.unwrap();
     /// let subview = view.try_load_entry_mut(&[0, 1]).await.unwrap();
@@ -352,11 +352,11 @@ where
     /// If an entry is absent then `None` is returned.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantByteCollectionView<_, RegisterView<_, String>> =
     ///     ReentrantByteCollectionView::load(context).await.unwrap();
     /// {
@@ -383,11 +383,11 @@ where
     /// Returns `true` if the collection contains a value for the specified key.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantByteCollectionView<_, RegisterView<_, String>> =
     ///     ReentrantByteCollectionView::load(context).await.unwrap();
     /// let _subview = view.try_load_entry_mut(&[0, 1]).await.unwrap();
@@ -414,11 +414,11 @@ where
     /// Removes an entry. If absent then nothing happens.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantByteCollectionView<_, RegisterView<_, String>> =
     ///     ReentrantByteCollectionView::load(context).await.unwrap();
     /// let mut subview = view.try_load_entry_mut(&[0, 1]).await.unwrap();
@@ -442,11 +442,11 @@ where
     /// Marks the entry so that it is removed in the next flush.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantByteCollectionView<_, RegisterView<_, String>> =
     ///     ReentrantByteCollectionView::load(context).await.unwrap();
     /// {
@@ -489,11 +489,11 @@ where
     /// The entries in `short_keys` have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantByteCollectionView<_, RegisterView<_, String>> =
     ///     ReentrantByteCollectionView::load(context).await.unwrap();
     /// {
@@ -578,11 +578,11 @@ where
     /// The entries in `short_keys` have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantByteCollectionView<_, RegisterView<_, String>> =
     ///     ReentrantByteCollectionView::load(context).await.unwrap();
     /// {
@@ -665,11 +665,11 @@ where
     /// Loads all the entries for reading at once.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantByteCollectionView<_, RegisterView<_, String>> =
     ///     ReentrantByteCollectionView::load(context).await.unwrap();
     /// {
@@ -741,11 +741,11 @@ where
     /// Loads all the entries for writing at once.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantByteCollectionView<_, RegisterView<_, String>> =
     ///     ReentrantByteCollectionView::load(context).await.unwrap();
     /// {
@@ -820,11 +820,11 @@ where
     /// Returns the list of indices in the collection in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantByteCollectionView<_, RegisterView<_, String>> =
     ///     ReentrantByteCollectionView::load(context).await.unwrap();
     /// view.try_load_entry_mut(&[0, 1]).await.unwrap();
@@ -846,11 +846,11 @@ where
     /// Returns the number of indices of the collection.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantByteCollectionView<_, RegisterView<_, String>> =
     ///     ReentrantByteCollectionView::load(context).await.unwrap();
     /// view.try_load_entry_mut(&[0, 1]).await.unwrap();
@@ -873,11 +873,11 @@ where
     /// ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantByteCollectionView<_, RegisterView<_, String>> =
     ///     ReentrantByteCollectionView::load(context).await.unwrap();
     /// view.try_load_entry_mut(&[0, 1]).await.unwrap();
@@ -940,11 +940,11 @@ where
     /// lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantByteCollectionView<_, RegisterView<_, String>> =
     ///     ReentrantByteCollectionView::load(context).await.unwrap();
     /// view.try_load_entry_mut(&[0, 1]).await.unwrap();
@@ -1137,11 +1137,11 @@ where
     /// then be modified.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCollectionView<_, u64, RegisterView<_, String>> =
     ///     ReentrantCollectionView::load(context).await.unwrap();
     /// let subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1165,11 +1165,11 @@ where
     /// If an entry is absent then `None` is returned.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCollectionView<_, u64, RegisterView<_, String>> =
     ///     ReentrantCollectionView::load(context).await.unwrap();
     /// {
@@ -1195,11 +1195,11 @@ where
     /// Returns `true` if the collection contains a value for the specified key.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCollectionView<_, u64, RegisterView<_, String>> =
     ///     ReentrantCollectionView::load(context).await.unwrap();
     /// let _subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1219,11 +1219,11 @@ where
     /// Marks the entry so that it is removed in the next flush.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCollectionView<_, u64, RegisterView<_, String>> =
     ///     ReentrantCollectionView::load(context).await.unwrap();
     /// let mut subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1247,11 +1247,11 @@ where
     /// Marks the entry so that it is removed in the next flush.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCollectionView<_, u64, RegisterView<_, String>> =
     ///     ReentrantCollectionView::load(context).await.unwrap();
     /// {
@@ -1291,11 +1291,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCollectionView<_, u64, RegisterView<_, String>> =
     ///     ReentrantCollectionView::load(context).await.unwrap();
     /// let indices = vec![23, 42];
@@ -1325,11 +1325,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCollectionView<_, u64, RegisterView<_, String>> =
     ///     ReentrantCollectionView::load(context).await.unwrap();
     /// {
@@ -1361,11 +1361,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCollectionView<_, u64, RegisterView<_, String>> =
     ///     ReentrantCollectionView::load(context).await.unwrap();
     /// {
@@ -1396,11 +1396,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCollectionView<_, u64, RegisterView<_, String>> =
     ///     ReentrantCollectionView::load(context).await.unwrap();
     /// {
@@ -1439,11 +1439,11 @@ where
     /// by serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCollectionView<_, u64, RegisterView<_, String>> =
     ///     ReentrantCollectionView::load(context).await.unwrap();
     /// view.try_load_entry_mut(&23).await.unwrap();
@@ -1465,11 +1465,11 @@ where
     /// Returns the number of indices in the collection.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCollectionView<_, u64, RegisterView<_, String>> =
     ///     ReentrantCollectionView::load(context).await.unwrap();
     /// view.try_load_entry_mut(&23).await.unwrap();
@@ -1486,11 +1486,11 @@ where
     /// the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCollectionView<_, u64, RegisterView<_, String>> =
     ///     ReentrantCollectionView::load(context).await.unwrap();
     /// view.try_load_entry_mut(&23).await.unwrap();
@@ -1522,11 +1522,11 @@ where
     /// determined by the serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCollectionView<_, u64, RegisterView<_, String>> =
     ///     ReentrantCollectionView::load(context).await.unwrap();
     /// view.try_load_entry_mut(&23).await.unwrap();
@@ -1655,11 +1655,11 @@ where
     /// is absent then a default entry is put in the collection on this index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     ReentrantCustomCollectionView::load(context).await.unwrap();
     /// let subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1683,11 +1683,11 @@ where
     /// If an entry is absent then `None` is returned.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     ReentrantCustomCollectionView::load(context).await.unwrap();
     /// {
@@ -1713,11 +1713,11 @@ where
     /// Returns `true` if the collection contains a value for the specified key.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     ReentrantCustomCollectionView::load(context).await.unwrap();
     /// let _subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1737,11 +1737,11 @@ where
     /// Removes an entry. If absent then nothing happens.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     ReentrantCustomCollectionView::load(context).await.unwrap();
     /// let mut subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1765,11 +1765,11 @@ where
     /// Marks the entry so that it is removed in the next flush.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     ReentrantCustomCollectionView::load(context).await.unwrap();
     /// {
@@ -1811,11 +1811,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     ReentrantCustomCollectionView::load(context).await.unwrap();
     /// let indices = vec![23, 42];
@@ -1845,11 +1845,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     ReentrantCustomCollectionView::load(context).await.unwrap();
     /// {
@@ -1881,11 +1881,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     ReentrantCustomCollectionView::load(context).await.unwrap();
     /// {
@@ -1916,11 +1916,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     ReentrantCustomCollectionView::load(context).await.unwrap();
     /// {
@@ -1957,11 +1957,11 @@ where
     /// the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     ReentrantCustomCollectionView::load(context).await.unwrap();
     /// view.try_load_entry_mut(&23).await.unwrap();
@@ -1983,11 +1983,11 @@ where
     /// Returns the number of entries in the collection.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     ReentrantCustomCollectionView::load(context).await.unwrap();
     /// view.try_load_entry_mut(&23).await.unwrap();
@@ -2004,11 +2004,11 @@ where
     /// then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     ReentrantCustomCollectionView::load(context).await.unwrap();
     /// view.try_load_entry_mut(&28).await.unwrap();
@@ -2041,11 +2041,11 @@ where
     /// determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::{create_test_memory_context, MemoryContext};
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     ReentrantCustomCollectionView::load(context).await.unwrap();
     /// view.try_load_entry_mut(&28).await.unwrap();

--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -134,10 +134,10 @@ where
     /// Access the current value in the register.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut register = RegisterView::<_, u32>::load(context).await.unwrap();
     /// let value = register.get();
     /// assert_eq!(*value, 0);
@@ -153,10 +153,10 @@ where
     /// Sets the value in the register.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut register = RegisterView::load(context).await.unwrap();
     /// register.set(5);
     /// let value = register.get();
@@ -182,10 +182,10 @@ where
     /// Obtains a mutable reference to the value in the register.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::register_view::RegisterView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut register: RegisterView<_, u32> = RegisterView::load(context).await.unwrap();
     /// let value = register.get_mut();
     /// assert_eq!(*value, 0);

--- a/linera-views/src/views/set_view.rs
+++ b/linera-views/src/views/set_view.rs
@@ -136,9 +136,9 @@ where
     /// Insert a value. If already present then it has no effect.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{context::create_test_memory_context, set_view::ByteSetView};
+    /// # use linera_views::{context::MemoryContext, set_view::ByteSetView};
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = ByteSetView::load(context).await.unwrap();
     /// set.insert(vec![0, 1]);
     /// assert_eq!(set.contains(&[0, 1]).await.unwrap(), true);
@@ -151,9 +151,9 @@ where
     /// Removes a value from the set. If absent then no effect.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{context::create_test_memory_context, set_view::ByteSetView};
+    /// # use linera_views::{context::MemoryContext, set_view::ByteSetView};
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = ByteSetView::load(context).await.unwrap();
     /// set.remove(vec![0, 1]);
     /// assert_eq!(set.contains(&[0, 1]).await.unwrap(), false);
@@ -182,9 +182,9 @@ where
     /// Returns true if the given index exists in the set.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{context::create_test_memory_context, set_view::ByteSetView};
+    /// # use linera_views::{context::MemoryContext, set_view::ByteSetView};
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = ByteSetView::load(context).await.unwrap();
     /// set.insert(vec![0, 1]);
     /// assert_eq!(set.contains(&[34]).await.unwrap(), false);
@@ -215,9 +215,9 @@ where
     /// Returns the list of keys in the set. The order is lexicographic.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{context::create_test_memory_context, set_view::ByteSetView};
+    /// # use linera_views::{context::MemoryContext, set_view::ByteSetView};
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = ByteSetView::load(context).await.unwrap();
     /// set.insert(vec![0, 1]);
     /// set.insert(vec![0, 2]);
@@ -237,9 +237,9 @@ where
     /// Returns the number of entries in the set.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{context::create_test_memory_context, set_view::ByteSetView};
+    /// # use linera_views::{context::MemoryContext, set_view::ByteSetView};
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = ByteSetView::load(context).await.unwrap();
     /// set.insert(vec![0, 1]);
     /// set.insert(vec![0, 2]);
@@ -261,9 +261,9 @@ where
     /// prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{context::create_test_memory_context, set_view::ByteSetView};
+    /// # use linera_views::{context::MemoryContext, set_view::ByteSetView};
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = ByteSetView::load(context).await.unwrap();
     /// set.insert(vec![0, 1]);
     /// set.insert(vec![0, 2]);
@@ -326,9 +326,9 @@ where
     /// lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{context::create_test_memory_context, set_view::ByteSetView};
+    /// # use linera_views::{context::MemoryContext, set_view::ByteSetView};
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = ByteSetView::load(context).await.unwrap();
     /// set.insert(vec![0, 1]);
     /// set.insert(vec![0, 2]);
@@ -459,10 +459,10 @@ where
     /// Inserts a value. If already present then no effect.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::set_view::SetView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = SetView::<_, u32>::load(context).await.unwrap();
     /// set.insert(&(34 as u32));
     /// assert_eq!(set.indices().await.unwrap().len(), 1);
@@ -481,9 +481,9 @@ where
     /// Removes a value. If absent then nothing is done.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{context::create_test_memory_context, set_view::SetView};
+    /// # use linera_views::{context::MemoryContext, set_view::SetView};
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = SetView::<_, u32>::load(context).await.unwrap();
     /// set.remove(&(34 as u32));
     /// assert_eq!(set.indices().await.unwrap().len(), 0);
@@ -514,9 +514,9 @@ where
     /// Returns true if the given index exists in the set.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{context::create_test_memory_context, set_view::SetView};
+    /// # use linera_views::{context::MemoryContext, set_view::SetView};
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set: SetView<_, u32> = SetView::load(context).await.unwrap();
     /// set.insert(&(34 as u32));
     /// assert_eq!(set.contains(&(34 as u32)).await.unwrap(), true);
@@ -542,9 +542,9 @@ where
     /// Returns the list of indices in the set. The order is determined by serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{context::create_test_memory_context, set_view::SetView};
+    /// # use linera_views::{context::MemoryContext, set_view::SetView};
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set: SetView<_, u32> = SetView::load(context).await.unwrap();
     /// set.insert(&(34 as u32));
     /// assert_eq!(set.indices().await.unwrap(), vec![34 as u32]);
@@ -563,9 +563,9 @@ where
     /// Returns the number of entries in the set.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{context::create_test_memory_context, set_view::SetView};
+    /// # use linera_views::{context::MemoryContext, set_view::SetView};
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set: SetView<_, u32> = SetView::load(context).await.unwrap();
     /// set.insert(&(34 as u32));
     /// assert_eq!(set.count().await.unwrap(), 1);
@@ -580,10 +580,10 @@ where
     /// loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::set_view::SetView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = SetView::<_, u32>::load(context).await.unwrap();
     /// set.insert(&(34 as u32));
     /// set.insert(&(37 as u32));
@@ -615,10 +615,10 @@ where
     /// determined by the serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::set_view::SetView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = SetView::<_, u32>::load(context).await.unwrap();
     /// set.insert(&(34 as u32));
     /// set.insert(&(37 as u32));
@@ -742,10 +742,10 @@ where
     /// Inserts a value. If present then it has no effect.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::set_view::CustomSetView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = CustomSetView::<_, u128>::load(context).await.unwrap();
     /// set.insert(&(34 as u128));
     /// assert_eq!(set.indices().await.unwrap().len(), 1);
@@ -764,10 +764,10 @@ where
     /// Removes a value. If absent then nothing is done.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::set_view::CustomSetView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = CustomSetView::<_, u128>::load(context).await.unwrap();
     /// set.remove(&(34 as u128));
     /// assert_eq!(set.indices().await.unwrap().len(), 0);
@@ -798,10 +798,10 @@ where
     /// Returns true if the given index exists in the set.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::set_view::CustomSetView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = CustomSetView::<_, u128>::load(context).await.unwrap();
     /// set.insert(&(34 as u128));
     /// assert_eq!(set.contains(&(34 as u128)).await.unwrap(), true);
@@ -828,10 +828,10 @@ where
     /// serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::set_view::CustomSetView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = CustomSetView::<_, u128>::load(context).await.unwrap();
     /// set.insert(&(34 as u128));
     /// set.insert(&(37 as u128));
@@ -851,10 +851,10 @@ where
     /// Returns the number of entries of the set.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::set_view::CustomSetView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = CustomSetView::<_, u128>::load(context).await.unwrap();
     /// set.insert(&(34 as u128));
     /// set.insert(&(37 as u128));
@@ -870,10 +870,10 @@ where
     /// false, then the loop prematurely ends.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::set_view::CustomSetView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = CustomSetView::<_, u128>::load(context).await.unwrap();
     /// set.insert(&(34 as u128));
     /// set.insert(&(37 as u128));
@@ -905,10 +905,10 @@ where
     /// determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::context::MemoryContext;
     /// # use linera_views::set_view::CustomSetView;
     /// # use linera_views::views::View;
-    /// # let context = create_test_memory_context();
+    /// # let context = MemoryContext::new_for_testing(());
     /// let mut set = CustomSetView::<_, u128>::load(context).await.unwrap();
     /// set.insert(&(34 as u128));
     /// set.insert(&(37 as u128));

--- a/linera-views/tests/hashable_tests.rs
+++ b/linera-views/tests/hashable_tests.rs
@@ -4,7 +4,7 @@
 use anyhow::Result;
 use linera_views::{
     common::HasherOutput,
-    context::create_test_memory_context,
+    context::MemoryContext,
     hashable_wrapper::WrappedHashableContainerView,
     register_view::{HashedRegisterView, RegisterView},
     views::{HashableView, View},
@@ -20,7 +20,7 @@ struct TestType<C> {
 // TODO(#560): Implement the same for CryptoHash
 #[tokio::test]
 async fn check_hashable_container_hash() -> Result<()> {
-    let context = create_test_memory_context();
+    let context = MemoryContext::new_for_testing(());
     let test = TestType::load(context).await?;
     let hash1 = test.inner.hash().await?;
     let hash2 = test.wrap.hash().await?;
@@ -30,7 +30,7 @@ async fn check_hashable_container_hash() -> Result<()> {
 
 #[tokio::test]
 async fn check_hashable_hash() -> Result<()> {
-    let context = create_test_memory_context();
+    let context = MemoryContext::new_for_testing(());
     let mut view = HashedRegisterView::<_, u32>::load(context).await?;
     let hash0 = view.hash().await?;
     let val = view.get_mut();

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use linera_views::{
     bucket_queue_view::HashedBucketQueueView,
     collection_view::HashedCollectionView,
-    context::{create_test_memory_context, Context},
+    context::{Context, MemoryContext},
     key_value_store_view::{KeyValueStoreView, SizeData},
     map_view::HashedByteMapView,
     queue_view::HashedQueueView,
@@ -42,7 +42,7 @@ where
 
 #[tokio::test]
 async fn classic_collection_view_check() -> Result<()> {
-    let context = create_test_memory_context();
+    let context = MemoryContext::new_for_testing(());
     let mut rng = make_deterministic_rng();
     let mut map = BTreeMap::<u8, u32>::new();
     let n = 20;
@@ -156,7 +156,7 @@ fn total_size(vec: &Vec<(Vec<u8>, Vec<u8>)>) -> SizeData {
 
 #[tokio::test]
 async fn key_value_store_view_mutability() -> Result<()> {
-    let context = create_test_memory_context();
+    let context = MemoryContext::new_for_testing(());
     let mut rng = make_deterministic_rng();
     let mut state_map = BTreeMap::new();
     let n = 40;
@@ -255,7 +255,7 @@ pub struct ByteMapStateView<C> {
 }
 
 async fn run_map_view_mutability<R: RngCore + Clone>(rng: &mut R) -> Result<()> {
-    let context = create_test_memory_context();
+    let context = MemoryContext::new_for_testing(());
     let mut state_map = BTreeMap::new();
     let mut all_keys = BTreeSet::new();
     let n = 10;
@@ -410,7 +410,7 @@ pub struct BucketQueueStateView<C> {
 
 #[tokio::test]
 async fn bucket_queue_view_mutability_check() -> Result<()> {
-    let context = create_test_memory_context();
+    let context = MemoryContext::new_for_testing(());
     let mut rng = make_deterministic_rng();
     let mut vector = Vec::new();
     let n = 200;
@@ -516,7 +516,7 @@ pub struct QueueStateView<C> {
 
 #[tokio::test]
 async fn queue_view_mutability_check() -> Result<()> {
-    let context = create_test_memory_context();
+    let context = MemoryContext::new_for_testing(());
     let mut rng = make_deterministic_rng();
     let mut vector = Vec::new();
     let n = 20;
@@ -625,7 +625,7 @@ where
 
 #[tokio::test]
 async fn reentrant_collection_view_check() -> Result<()> {
-    let context = create_test_memory_context();
+    let context = MemoryContext::new_for_testing(());
     let mut rng = make_deterministic_rng();
     let mut map = BTreeMap::<u8, u32>::new();
     let n = 20;

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -3,7 +3,7 @@
 
 use linera_views::{
     batch::Batch,
-    context::{create_test_memory_context, Context as _},
+    context::{Context as _, MemoryContext},
     key_value_store_view::ViewContainer,
     memory::MemoryStore,
     random::make_deterministic_rng,
@@ -126,7 +126,7 @@ async fn test_reads_indexed_db() {
 #[tokio::test]
 async fn test_reads_key_value_store_view_memory() {
     for scenario in get_random_test_scenarios() {
-        let context = create_test_memory_context();
+        let context = MemoryContext::new_for_testing(());
         let key_value_store = ViewContainer::new(context).await.unwrap();
         run_reads(key_value_store, scenario).await;
     }
@@ -158,7 +158,7 @@ async fn test_memory_writes_from_blank() {
 
 #[tokio::test]
 async fn test_key_value_store_view_memory_writes_from_blank() {
-    let context = create_test_memory_context();
+    let context = MemoryContext::new_for_testing(());
     let key_value_store = ViewContainer::new(context).await.unwrap();
     run_writes_from_blank(&key_value_store).await;
 }
@@ -200,7 +200,7 @@ async fn test_indexed_db_writes_from_blank() {
 #[tokio::test]
 async fn test_big_value_read_write() {
     use rand::{distributions::Alphanumeric, Rng};
-    let context = create_test_memory_context();
+    let context = MemoryContext::new_for_testing(());
     for count in [50, 1024] {
         let rng = make_deterministic_rng();
         let test_string = rng

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -19,7 +19,7 @@ use linera_views::{
         WriteOperation::{Delete, DeletePrefix, Put},
     },
     collection_view::HashedCollectionView,
-    context::{create_test_memory_context, Context, MemoryContext, ViewContext},
+    context::{Context, MemoryContext, ViewContext},
     key_value_store_view::{KeyValueStoreView, ViewContainer},
     log_view::HashedLogView,
     lru_caching::{LruCachingMemoryStore, LruCachingStore},
@@ -103,7 +103,7 @@ impl StateStorage for KeyValueStoreTestStorage {
     type Context = ViewContext<usize, ViewContainer<MemoryContext<()>>>;
 
     async fn new() -> Self {
-        let context = create_test_memory_context();
+        let context = MemoryContext::new_for_testing(());
         let store = ViewContainer::new(context).await.unwrap();
         KeyValueStoreTestStorage {
             accessed_chains: BTreeSet::new(),
@@ -627,7 +627,7 @@ pub struct ByteMapStateView<C> {
 
 #[tokio::test]
 async fn test_byte_map_view() -> Result<()> {
-    let context = create_test_memory_context();
+    let context = MemoryContext::new_for_testing(());
     {
         let mut view = ByteMapStateView::load(context.clone()).await?;
         view.map.insert(vec![0, 1], 5);
@@ -824,7 +824,7 @@ async fn test_collection_removal() -> Result<()> {
     type EntryType = HashedRegisterView<MemoryContext<()>, u8>;
     type CollectionViewType = HashedCollectionView<MemoryContext<()>, u8, EntryType>;
 
-    let context = create_test_memory_context();
+    let context = MemoryContext::new_for_testing(());
 
     // Write a dummy entry into the collection.
     let mut collection = CollectionViewType::load(context.clone()).await?;
@@ -855,7 +855,7 @@ async fn test_removal_api_first_second_condition(
     type EntryType = HashedRegisterView<MemoryContext<()>, u8>;
     type CollectionViewType = HashedCollectionView<MemoryContext<()>, u8, EntryType>;
 
-    let context = create_test_memory_context();
+    let context = MemoryContext::new_for_testing(());
 
     // First add an entry `1` with value `100` and commit
     let mut collection: CollectionViewType = HashedCollectionView::load(context.clone()).await?;


### PR DESCRIPTION
## Motivation

The `create_test_memory_context` had been reduced to a wrapper for `MemoryContext::new_for_testing`.
We can eliminate it.

## Proposal

The replacement is done in a straightforward way.

## Test Plan

The CI.

## Release Plan

Not relevant.

## Links

None.