### PR TITLE
Print right url info for faucet service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,6 +222,7 @@ web-sys = "0.3.69"
 web-time = "1.1.0"
 wit-bindgen = "0.24.0"
 zstd = "0.13.2"
+local-ip-address = "0.6.1"
 
 linera-base = { version = "0.14.0", path = "./linera-base" }
 linera-chain = { version = "0.14.0", path = "./linera-chain" }

--- a/linera-faucet/Cargo.toml
+++ b/linera-faucet/Cargo.toml
@@ -6,6 +6,7 @@ repository.workspace = true
 homepage.workspace = true
 license.workspace = true
 edition.workspace = true
+local-ip-address.workspace = true
 
 [dependencies]
 linera-base.workspace = true

--- a/linera-faucet/Cargo.toml
+++ b/linera-faucet/Cargo.toml
@@ -6,7 +6,6 @@ repository.workspace = true
 homepage.workspace = true
 license.workspace = true
 edition.workspace = true
-local-ip-address.workspace = true
 
 [dependencies]
 linera-base.workspace = true

--- a/linera-faucet/server/Cargo.toml
+++ b/linera-faucet/server/Cargo.toml
@@ -23,6 +23,7 @@ serde_json.workspace = true
 tokio.workspace = true
 tower-http = { workspace = true, features = ["cors"] }
 tracing.workspace = true
+local-ip-address.workspace = true
 
 [dev-dependencies]
 async-trait.workspace = true

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -21,6 +21,7 @@ use linera_client::{
 };
 use linera_core::data_types::ClientOutcome;
 use linera_storage::{Clock as _, Storage};
+use local_ip_address::local_ip;
 use serde::Deserialize;
 use tower_http::cors::CorsLayer;
 use tracing::info;
@@ -282,7 +283,9 @@ where
             .layer(Extension(self.clone()))
             .layer(CorsLayer::permissive());
 
+        let ip_addr = local_ip().unwrap_or(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
         info!("GraphiQL IDE: http://localhost:{}", port);
+        info!("              http://{}:{}", ip_addr_, port);
 
         ChainListener::new(self.config.clone())
             .run(Arc::clone(&self.context), self.storage.clone())

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -3,7 +3,11 @@
 
 //! The server component of the Linera faucet.
 
-use std::{net::SocketAddr, num::NonZeroU16, sync::Arc};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    num::NonZeroU16,
+    sync::Arc,
+};
 
 use async_graphql::{EmptySubscription, Error, Schema, SimpleObject};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse, GraphQLSubscription};
@@ -285,7 +289,7 @@ where
 
         let ip_addr = local_ip().unwrap_or(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
         info!("GraphiQL IDE: http://localhost:{}", port);
-        info!("              http://{}:{}", ip_addr_, port);
+        info!("              http://{}:{}", ip_addr, port);
 
         ChainListener::new(self.config.clone())
             .run(Arc::clone(&self.context), self.storage.clone())


### PR DESCRIPTION
## Motivation

Faucet always print `http://localhost:8080` to users.

## Proposal

I think we can provide urls with localhost and $LAN_IP to users here.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

https://github.com/linera-io/linera-protocol/issues/3587
