### PR TITLE
Rename `AccountOwner` to `MultiAddress`

### DIFF
--- a/examples/amm/src/lib.rs
+++ b/examples/amm/src/lib.rs
@@ -6,7 +6,7 @@
 use async_graphql::{scalar, Request, Response};
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, Amount, ContractAbi, ServiceAbi},
+    linera_base_types::{Amount, ContractAbi, MultiAddress, ServiceAbi},
 };
 pub use matching_engine::Parameters;
 use serde::{Deserialize, Serialize};
@@ -33,7 +33,7 @@ pub enum Operation {
     /// calculated based on the current AMM ratio
     /// Owner here is the user executing the Swap
     Swap {
-        owner: AccountOwner,
+        owner: MultiAddress,
         input_token_idx: u32,
         input_amount: Amount,
     },
@@ -45,7 +45,7 @@ pub enum Operation {
     /// Owner here is the user adding liquidity, which currently can only
     /// be a chain owner
     AddLiquidity {
-        owner: AccountOwner,
+        owner: MultiAddress,
         max_token0_amount: Amount,
         max_token1_amount: Amount,
     },
@@ -58,7 +58,7 @@ pub enum Operation {
     /// Owner here is the user removing liquidity, which currently can only
     /// be a chain owner
     RemoveLiquidity {
-        owner: AccountOwner,
+        owner: MultiAddress,
         token_to_remove_idx: u32,
         token_to_remove_amount: Amount,
     },
@@ -66,7 +66,7 @@ pub enum Operation {
     /// Remove all the liquidity added by the given user, that is remaining in the AMM.
     /// Owner here is the user removing liquidity, which currently can only
     /// be a chain owner
-    RemoveAllAddedLiquidity { owner: AccountOwner },
+    RemoveAllAddedLiquidity { owner: MultiAddress },
     /// Close this chain, and remove all added liquidity
     /// Requires that this application is authorized to close the chain.
     CloseChain,
@@ -77,21 +77,21 @@ scalar!(Operation);
 #[derive(Debug, Deserialize, Serialize)]
 pub enum Message {
     Swap {
-        owner: AccountOwner,
+        owner: MultiAddress,
         input_token_idx: u32,
         input_amount: Amount,
     },
     AddLiquidity {
-        owner: AccountOwner,
+        owner: MultiAddress,
         max_token0_amount: Amount,
         max_token1_amount: Amount,
     },
     RemoveLiquidity {
-        owner: AccountOwner,
+        owner: MultiAddress,
         token_to_remove_idx: u32,
         token_to_remove_amount: Amount,
     },
     RemoveAllAddedLiquidity {
-        owner: AccountOwner,
+        owner: MultiAddress,
     },
 }

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -8,7 +8,7 @@ mod state;
 use crowd_funding::{CrowdFundingAbi, InstantiationArgument, Message, Operation};
 use fungible::{Account, FungibleTokenAbi};
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount, ApplicationId, WithContractAbi},
+    linera_base_types::{Amount, ApplicationId, MultiAddress, WithContractAbi},
     views::{RootView, View},
     Contract, ContractRuntime,
 };
@@ -91,7 +91,7 @@ impl CrowdFundingContract {
     }
 
     /// Adds a pledge from a local account to the remote campaign chain.
-    fn execute_pledge_with_transfer(&mut self, owner: AccountOwner, amount: Amount) {
+    fn execute_pledge_with_transfer(&mut self, owner: MultiAddress, amount: Amount) {
         assert!(amount > Amount::ZERO, "Pledge is empty");
         // The campaign chain.
         let chain_id = self.runtime.application_creator_chain_id();
@@ -115,7 +115,7 @@ impl CrowdFundingContract {
     }
 
     /// Adds a pledge from a local account to the campaign chain.
-    async fn execute_pledge_with_account(&mut self, owner: AccountOwner, amount: Amount) {
+    async fn execute_pledge_with_account(&mut self, owner: MultiAddress, amount: Amount) {
         assert!(amount > Amount::ZERO, "Pledge is empty");
         self.receive_from_account(owner, amount);
         self.finish_pledge(owner, amount).await
@@ -123,7 +123,7 @@ impl CrowdFundingContract {
 
     /// Marks a pledge in the application state, so that it can be returned if the campaign is
     /// cancelled.
-    async fn finish_pledge(&mut self, source: AccountOwner, amount: Amount) {
+    async fn finish_pledge(&mut self, source: MultiAddress, amount: Amount) {
         match self.state.status.get() {
             Status::Active => self
                 .state
@@ -192,7 +192,7 @@ impl CrowdFundingContract {
 
     /// Queries the token application to determine the total amount of tokens in custody.
     fn balance(&mut self) -> Amount {
-        let owner = AccountOwner::from(self.runtime.application_id().forget_abi());
+        let owner = MultiAddress::from(self.runtime.application_id().forget_abi());
         let fungible_id = self.fungible_id();
         let response = self.runtime.call_application(
             true,
@@ -206,13 +206,13 @@ impl CrowdFundingContract {
     }
 
     /// Transfers `amount` tokens from the funds in custody to the `owner`'s account.
-    fn send_to(&mut self, amount: Amount, owner: AccountOwner) {
+    fn send_to(&mut self, amount: Amount, owner: MultiAddress) {
         let target_account = Account {
             chain_id: self.runtime.chain_id(),
             owner,
         };
         let transfer = fungible::Operation::Transfer {
-            owner: AccountOwner::from(self.runtime.application_id().forget_abi()),
+            owner: MultiAddress::from(self.runtime.application_id().forget_abi()),
             amount,
             target_account,
         };
@@ -221,10 +221,10 @@ impl CrowdFundingContract {
     }
 
     /// Calls into the Fungible Token application to receive tokens from the given account.
-    fn receive_from_account(&mut self, owner: AccountOwner, amount: Amount) {
+    fn receive_from_account(&mut self, owner: MultiAddress, amount: Amount) {
         let target_account = Account {
             chain_id: self.runtime.chain_id(),
-            owner: AccountOwner::from(self.runtime.application_id().forget_abi()),
+            owner: MultiAddress::from(self.runtime.application_id().forget_abi()),
         };
         let transfer = fungible::Operation::Transfer {
             owner,

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -6,7 +6,7 @@
 use async_graphql::{Request, Response, SimpleObject};
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, Amount, ContractAbi, ServiceAbi, Timestamp},
+    linera_base_types::{Amount, ContractAbi, MultiAddress, ServiceAbi, Timestamp},
 };
 use serde::{Deserialize, Serialize};
 
@@ -26,7 +26,7 @@ impl ServiceAbi for CrowdFundingAbi {
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, SimpleObject)]
 pub struct InstantiationArgument {
     /// The receiver of the pledges of a successful campaign.
-    pub owner: AccountOwner,
+    pub owner: MultiAddress,
     /// The deadline of the campaign, after which it can be cancelled if it hasn't met its target.
     pub deadline: Timestamp,
     /// The funding target of the campaign.
@@ -47,7 +47,7 @@ impl std::fmt::Display for InstantiationArgument {
 #[derive(Debug, Deserialize, Serialize, GraphQLMutationRoot)]
 pub enum Operation {
     /// Pledge some tokens to the campaign (from an account on the current chain to the campaign chain).
-    Pledge { owner: AccountOwner, amount: Amount },
+    Pledge { owner: MultiAddress, amount: Amount },
     /// Collect the pledges after the campaign has reached its target (campaign chain only).
     Collect,
     /// Cancel the campaign and refund all pledges after the campaign has reached its deadline (campaign chain only).
@@ -58,5 +58,5 @@ pub enum Operation {
 #[derive(Debug, Deserialize, Serialize)]
 pub enum Message {
     /// Pledge some tokens to the campaign (from an account on the receiver chain).
-    PledgeWithAccount { owner: AccountOwner, amount: Amount },
+    PledgeWithAccount { owner: MultiAddress, amount: Amount },
 }

--- a/examples/crowd-funding/src/state.rs
+++ b/examples/crowd-funding/src/state.rs
@@ -4,7 +4,7 @@
 use async_graphql::scalar;
 use crowd_funding::InstantiationArgument;
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount},
+    linera_base_types::{Amount, MultiAddress},
     views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
 };
 use serde::{Deserialize, Serialize};
@@ -30,7 +30,7 @@ pub struct CrowdFundingState {
     /// The status of the campaign.
     pub status: RegisterView<Status>,
     /// The map of pledges that will be collected if the campaign succeeds.
-    pub pledges: MapView<AccountOwner, Amount>,
+    pub pledges: MapView<MultiAddress, Amount>,
     /// The instantiation data that determines the details of the campaign.
     pub instantiation_argument: RegisterView<Option<InstantiationArgument>>,
 }

--- a/examples/crowd-funding/tests/campaign_lifecycle.rs
+++ b/examples/crowd-funding/tests/campaign_lifecycle.rs
@@ -11,7 +11,7 @@ use crowd_funding::{CrowdFundingAbi, InstantiationArgument, Operation};
 use fungible::FungibleTokenAbi;
 use linera_sdk::{
     linera_base_types::{
-        AccountOwner, AccountSecretKey, Amount, ApplicationId, Ed25519SecretKey,
+        AccountSecretKey, Amount, ApplicationId, Ed25519SecretKey, MultiAddress,
         Secp256k1SecretKey, Timestamp,
     },
     test::TestValidator,
@@ -39,7 +39,7 @@ async fn collect_pledges() {
     let fungible_publisher_chain = validator.new_chain_with_keypair(fungible_chain_owner).await;
     let campaign_chain_owner = AccountSecretKey::Secp256k1(Secp256k1SecretKey::generate());
     let mut campaign_chain = validator.new_chain_with_keypair(campaign_chain_owner).await;
-    let campaign_account = AccountOwner::from(campaign_chain.public_key());
+    let campaign_account = MultiAddress::from(campaign_chain.public_key());
 
     let fungible_module_id = fungible_publisher_chain
         .publish_bytecode_files_in("../fungible")
@@ -141,7 +141,7 @@ async fn cancel_successful_campaign() {
 
     let fungible_publisher_chain = validator.new_chain().await;
     let mut campaign_chain = validator.new_chain().await;
-    let campaign_account = AccountOwner::from(campaign_chain.public_key());
+    let campaign_account = MultiAddress::from(campaign_chain.public_key());
 
     let fungible_module_id = fungible_publisher_chain
         .publish_bytecode_files_in("../fungible")

--- a/examples/ethereum-tracker/src/service.rs
+++ b/examples/ethereum-tracker/src/service.rs
@@ -84,7 +84,7 @@ impl Query {
         let address_value = event_values.next().expect("Missing initial address value");
         let balance_value = event_values.next().expect("Missing initial balance value");
 
-        let EthereumDataType::Address(address) = address_value else {
+        let EthereumDataType::MultiAddress(address) = address_value else {
             panic!("wrong type for the first entry");
         };
         let EthereumDataType::Uint256(balance) = balance_value else {
@@ -118,10 +118,10 @@ impl Query {
                     .expect("Missing destination address in response");
                 let amount_value = event_values.next().expect("Missing amount in response");
 
-                let EthereumDataType::Address(source) = source_value else {
+                let EthereumDataType::MultiAddress(source) = source_value else {
                     panic!("Wrong type for the source address");
                 };
-                let EthereumDataType::Address(destination) = destination_value else {
+                let EthereumDataType::MultiAddress(destination) = destination_value else {
                     panic!("Wrong type for the destination address");
                 };
                 let EthereumDataType::Uint256(value) = amount_value else {

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -11,7 +11,7 @@ use fungible::{
     Account, FungibleResponse, FungibleTokenAbi, InitialState, Message, Operation, Parameters,
 };
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount, WithContractAbi},
+    linera_base_types::{Amount, MultiAddress, WithContractAbi},
     views::{RootView, View},
     Contract, ContractRuntime,
 };
@@ -49,7 +49,7 @@ impl Contract for FungibleTokenContract {
         if state.accounts.is_empty() {
             if let Some(owner) = self.runtime.authenticated_signer() {
                 state.accounts.insert(
-                    AccountOwner::from(owner),
+                    MultiAddress::from(owner),
                     Amount::from_str("1000000").unwrap(),
                 );
             }
@@ -127,9 +127,9 @@ impl Contract for FungibleTokenContract {
 
 impl FungibleTokenContract {
     /// Verifies that a transfer is authenticated for this local account.
-    fn check_account_authentication(&mut self, owner: AccountOwner) {
+    fn check_account_authentication(&mut self, owner: MultiAddress) {
         match owner {
-            AccountOwner::Address32(address) => {
+            MultiAddress::Address32(address) => {
                 assert!(
                     self.runtime.authenticated_signer().map(|owner| owner.0) == Some(address)
                         || self.runtime.authenticated_caller_id().map(|owner| owner.0)
@@ -137,7 +137,7 @@ impl FungibleTokenContract {
                     "The requested transfer is not correctly authenticated."
                 )
             }
-            AccountOwner::Chain => {
+            MultiAddress::Chain => {
                 panic!("Chain account is not supported")
             }
         }
@@ -166,7 +166,7 @@ impl FungibleTokenContract {
         &mut self,
         amount: Amount,
         target_account: Account,
-        source: AccountOwner,
+        source: MultiAddress,
     ) {
         if target_account.chain_id == self.runtime.chain_id() {
             self.state.credit(target_account.owner, amount).await;

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -4,7 +4,7 @@
 /* ABI of the Fungible Token Example Application */
 
 pub use linera_sdk::abis::fungible::*;
-use linera_sdk::linera_base_types::{AccountOwner, Amount};
+use linera_sdk::linera_base_types::{Amount, MultiAddress};
 use serde::{Deserialize, Serialize};
 #[cfg(all(any(test, feature = "test"), not(target_arch = "wasm32")))]
 use {
@@ -23,17 +23,17 @@ pub enum Message {
     /// `source` is credited instead.
     Credit {
         /// Target account to credit amount to
-        target: AccountOwner,
+        target: MultiAddress,
         /// Amount to be credited
         amount: Amount,
         /// Source account to remove amount from
-        source: AccountOwner,
+        source: MultiAddress,
     },
 
     /// Withdraws from the given account and starts a transfer to the target account.
     Withdraw {
         /// Account to withdraw from
-        owner: AccountOwner,
+        owner: MultiAddress,
         /// Amount to be withdrawn
         amount: Amount,
         /// Target account to transfer amount to
@@ -50,7 +50,7 @@ pub async fn create_with_accounts(
     initial_amounts: impl IntoIterator<Item = Amount>,
 ) -> (
     ApplicationId<FungibleTokenAbi>,
-    Vec<(ActiveChain, AccountOwner, Amount)>,
+    Vec<(ActiveChain, MultiAddress, Amount)>,
 ) {
     let mut token_chain = validator.new_chain().await;
     let mut initial_state = InitialStateBuilder::default();
@@ -58,7 +58,7 @@ pub async fn create_with_accounts(
     let accounts = stream::iter(initial_amounts)
         .then(|initial_amount| async move {
             let chain = validator.new_chain().await;
-            let account = AccountOwner::from(chain.public_key());
+            let account = MultiAddress::from(chain.public_key());
 
             (chain, account, initial_amount)
         })
@@ -119,7 +119,7 @@ pub async fn create_with_accounts(
 pub async fn query_account(
     application_id: ApplicationId<FungibleTokenAbi>,
     chain: &ActiveChain,
-    account_owner: AccountOwner,
+    account_owner: MultiAddress,
 ) -> Option<Amount> {
     let query = format!(
         "query {{ accounts {{ entry(key: {}) {{ value }} }} }}",

--- a/examples/fungible/src/service.rs
+++ b/examples/fungible/src/service.rs
@@ -11,7 +11,7 @@ use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
 use fungible::{Operation, Parameters};
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, Amount, WithServiceAbi},
+    linera_base_types::{Amount, MultiAddress, WithServiceAbi},
     views::{MapView, View},
     Service, ServiceRuntime,
 };
@@ -56,7 +56,7 @@ impl Service for FungibleTokenService {
 
 #[Object]
 impl FungibleTokenService {
-    async fn accounts(&self) -> &MapView<AccountOwner, Amount> {
+    async fn accounts(&self) -> &MapView<MultiAddress, Amount> {
         &self.state.accounts
     }
 

--- a/examples/fungible/src/state.rs
+++ b/examples/fungible/src/state.rs
@@ -3,7 +3,7 @@
 
 use fungible::InitialState;
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount},
+    linera_base_types::{Amount, MultiAddress},
     views::{linera_views, MapView, RootView, ViewStorageContext},
 };
 
@@ -11,7 +11,7 @@ use linera_sdk::{
 #[derive(RootView)]
 #[view(context = "ViewStorageContext")]
 pub struct FungibleTokenState {
-    pub accounts: MapView<AccountOwner, Amount>,
+    pub accounts: MapView<MultiAddress, Amount>,
 }
 
 #[allow(dead_code)]
@@ -28,7 +28,7 @@ impl FungibleTokenState {
     }
 
     /// Obtains the balance for an `account`, returning None if there's no entry for the account.
-    pub(crate) async fn balance(&self, account: &AccountOwner) -> Option<Amount> {
+    pub(crate) async fn balance(&self, account: &MultiAddress) -> Option<Amount> {
         self.accounts
             .get(account)
             .await
@@ -36,12 +36,12 @@ impl FungibleTokenState {
     }
 
     /// Obtains the balance for an `account`.
-    pub(crate) async fn balance_or_default(&self, account: &AccountOwner) -> Amount {
+    pub(crate) async fn balance_or_default(&self, account: &MultiAddress) -> Amount {
         self.balance(account).await.unwrap_or_default()
     }
 
     /// Credits an `account` with the provided `amount`.
-    pub(crate) async fn credit(&mut self, account: AccountOwner, amount: Amount) {
+    pub(crate) async fn credit(&mut self, account: MultiAddress, amount: Amount) {
         if amount == Amount::ZERO {
             return;
         }
@@ -53,7 +53,7 @@ impl FungibleTokenState {
     }
 
     /// Tries to debit the requested `amount` from an `account`.
-    pub(crate) async fn debit(&mut self, account: AccountOwner, amount: Amount) {
+    pub(crate) async fn debit(&mut self, account: MultiAddress, amount: Amount) {
         if amount == Amount::ZERO {
             return;
         }

--- a/examples/fungible/tests/cross_chain.rs
+++ b/examples/fungible/tests/cross_chain.rs
@@ -9,7 +9,7 @@ use fungible::{
     Account, FungibleTokenAbi, InitialState, InitialStateBuilder, Operation, Parameters,
 };
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount},
+    linera_base_types::{Amount, MultiAddress},
     test::{Medium, MessageAction, TestValidator},
 };
 
@@ -28,7 +28,7 @@ async fn test_cross_chain_transfer() {
         )
         .await;
     let mut sender_chain = validator.new_chain().await;
-    let sender_account = AccountOwner::from(sender_chain.public_key());
+    let sender_account = MultiAddress::from(sender_chain.public_key());
 
     let initial_state = InitialStateBuilder::default().with_account(sender_account, initial_amount);
     let params = Parameters::new("FUN");
@@ -37,7 +37,7 @@ async fn test_cross_chain_transfer() {
         .await;
 
     let receiver_chain = validator.new_chain().await;
-    let receiver_account = AccountOwner::from(receiver_chain.public_key());
+    let receiver_account = MultiAddress::from(receiver_chain.public_key());
 
     sender_chain
         .add_block(|block| {
@@ -82,7 +82,7 @@ async fn test_bouncing_tokens() {
     let (validator, module_id) =
         TestValidator::with_current_module::<FungibleTokenAbi, Parameters, InitialState>().await;
     let mut sender_chain = validator.new_chain().await;
-    let sender_account = AccountOwner::from(sender_chain.public_key());
+    let sender_account = MultiAddress::from(sender_chain.public_key());
 
     let initial_state = InitialStateBuilder::default().with_account(sender_account, initial_amount);
     let params = Parameters::new("RET");
@@ -91,7 +91,7 @@ async fn test_bouncing_tokens() {
         .await;
 
     let receiver_chain = validator.new_chain().await;
-    let receiver_account = AccountOwner::from(receiver_chain.public_key());
+    let receiver_account = MultiAddress::from(receiver_chain.public_key());
 
     let certificate = sender_chain
         .add_block(|block| {

--- a/examples/fungible/web-frontend/src/qql/gql.ts
+++ b/examples/fungible/web-frontend/src/qql/gql.ts
@@ -13,9 +13,9 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  */
 const documents = {
-    "\n  query Accounts($owner: AccountOwner!) {\n    accounts {\n      entry(key: $owner) {\n        value\n      }\n    }\n  }\n": types.AccountsDocument,
+    "\n  query Accounts($owner: MultiAddress!) {\n    accounts {\n      entry(key: $owner) {\n        value\n      }\n    }\n  }\n": types.AccountsDocument,
     "\n  query TickerSymbol {\n    tickerSymbol\n  }\n": types.TickerSymbolDocument,
-    "\n  mutation Transfer($owner: AccountOwner!, $amount: Amount!, $targetAccount: FungibleAccount!) {\n    transfer(owner: $owner, amount: $amount, targetAccount: $targetAccount)\n  }\n": types.TransferDocument,
+    "\n  mutation Transfer($owner: MultiAddress!, $amount: Amount!, $targetAccount: FungibleAccount!) {\n    transfer(owner: $owner, amount: $amount, targetAccount: $targetAccount)\n  }\n": types.TransferDocument,
 };
 
 /**
@@ -35,7 +35,7 @@ export function graphql(source: string): unknown;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  query Accounts($owner: AccountOwner!) {\n    accounts {\n      entry(key: $owner) {\n        value\n      }\n    }\n  }\n"): (typeof documents)["\n  query Accounts($owner: AccountOwner!) {\n    accounts {\n      entry(key: $owner) {\n        value\n      }\n    }\n  }\n"];
+export function graphql(source: "\n  query Accounts($owner: MultiAddress!) {\n    accounts {\n      entry(key: $owner) {\n        value\n      }\n    }\n  }\n"): (typeof documents)["\n  query Accounts($owner: MultiAddress!) {\n    accounts {\n      entry(key: $owner) {\n        value\n      }\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
@@ -43,7 +43,7 @@ export function graphql(source: "\n  query TickerSymbol {\n    tickerSymbol\n  }
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  mutation Transfer($owner: AccountOwner!, $amount: Amount!, $targetAccount: FungibleAccount!) {\n    transfer(owner: $owner, amount: $amount, targetAccount: $targetAccount)\n  }\n"): (typeof documents)["\n  mutation Transfer($owner: AccountOwner!, $amount: Amount!, $targetAccount: FungibleAccount!) {\n    transfer(owner: $owner, amount: $amount, targetAccount: $targetAccount)\n  }\n"];
+export function graphql(source: "\n  mutation Transfer($owner: MultiAddress!, $amount: Amount!, $targetAccount: FungibleAccount!) {\n    transfer(owner: $owner, amount: $amount, targetAccount: $targetAccount)\n  }\n"): (typeof documents)["\n  mutation Transfer($owner: MultiAddress!, $amount: Amount!, $targetAccount: FungibleAccount!) {\n    transfer(owner: $owner, amount: $amount, targetAccount: $targetAccount)\n  }\n"];
 
 export function graphql(source: string) {
   return (documents as any)[source] ?? {};

--- a/examples/fungible/web-frontend/src/qql/graphql.ts
+++ b/examples/fungible/web-frontend/src/qql/graphql.ts
@@ -15,7 +15,7 @@ export type Scalars = {
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
   /** An owner of an account. */
-  AccountOwner: { input: any; output: any; }
+  MultiAddress: { input: any; output: any; }
   /** A non-negative amount of tokens. */
   Amount: { input: any; output: any; }
   /** The unique identifier (UID) of a chain. This is currently computed as the hash value of a ChainDescription. */
@@ -25,7 +25,7 @@ export type Scalars = {
 /** A GraphQL-visible map item, complete with key. */
 export type Entry_AccountOwner_Amount_92cf94e6 = {
   __typename?: 'Entry_AccountOwner_Amount_92cf94e6';
-  key: Scalars['AccountOwner']['output'];
+  key: Scalars['MultiAddress']['output'];
   value?: Maybe<Scalars['Amount']['output']>;
 };
 
@@ -34,7 +34,7 @@ export type FungibleAccount = {
   /** Chain ID of the account */
   chainId: Scalars['ChainId']['input'];
   /** Owner of the account */
-  owner: Scalars['AccountOwner']['input'];
+  owner: Scalars['MultiAddress']['input'];
 };
 
 export type FungibleTokenService = {
@@ -44,7 +44,7 @@ export type FungibleTokenService = {
 };
 
 export type MapFilters_AccountOwner_2fb690f5 = {
-  keys?: InputMaybe<Array<Scalars['AccountOwner']['input']>>;
+  keys?: InputMaybe<Array<Scalars['MultiAddress']['input']>>;
 };
 
 export type MapInput_AccountOwner_30d769cb = {
@@ -55,7 +55,7 @@ export type MapView_AccountOwner_Amount_Ea496e19 = {
   __typename?: 'MapView_AccountOwner_Amount_ea496e19';
   entries: Array<Entry_AccountOwner_Amount_92cf94e6>;
   entry: Entry_AccountOwner_Amount_92cf94e6;
-  keys: Array<Scalars['AccountOwner']['output']>;
+  keys: Array<Scalars['MultiAddress']['output']>;
 };
 
 
@@ -65,7 +65,7 @@ export type MapView_AccountOwner_Amount_Ea496e19EntriesArgs = {
 
 
 export type MapView_AccountOwner_Amount_Ea496e19EntryArgs = {
-  key: Scalars['AccountOwner']['input'];
+  key: Scalars['MultiAddress']['input'];
 };
 
 
@@ -83,7 +83,7 @@ export type OperationMutationRoot = {
 
 
 export type OperationMutationRootBalanceArgs = {
-  owner: Scalars['AccountOwner']['input'];
+  owner: Scalars['MultiAddress']['input'];
 };
 
 
@@ -96,12 +96,12 @@ export type OperationMutationRootClaimArgs = {
 
 export type OperationMutationRootTransferArgs = {
   amount: Scalars['Amount']['input'];
-  owner: Scalars['AccountOwner']['input'];
+  owner: Scalars['MultiAddress']['input'];
   targetAccount: FungibleAccount;
 };
 
 export type AccountsQueryVariables = Exact<{
-  owner: Scalars['AccountOwner']['input'];
+  owner: Scalars['MultiAddress']['input'];
 }>;
 
 
@@ -113,7 +113,7 @@ export type TickerSymbolQueryVariables = Exact<{ [key: string]: never; }>;
 export type TickerSymbolQuery = { __typename?: 'FungibleTokenService', tickerSymbol: string };
 
 export type TransferMutationVariables = Exact<{
-  owner: Scalars['AccountOwner']['input'];
+  owner: Scalars['MultiAddress']['input'];
   amount: Scalars['Amount']['input'];
   targetAccount: FungibleAccount;
 }>;
@@ -122,6 +122,6 @@ export type TransferMutationVariables = Exact<{
 export type TransferMutation = { __typename?: 'OperationMutationRoot', transfer: Array<number> };
 
 
-export const AccountsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Accounts"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"owner"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AccountOwner"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"accounts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"entry"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"key"},"value":{"kind":"Variable","name":{"kind":"Name","value":"owner"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"value"}}]}}]}}]}}]} as unknown as DocumentNode<AccountsQuery, AccountsQueryVariables>;
+export const AccountsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Accounts"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"owner"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"MultiAddress"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"accounts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"entry"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"key"},"value":{"kind":"Variable","name":{"kind":"Name","value":"owner"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"value"}}]}}]}}]}}]} as unknown as DocumentNode<AccountsQuery, AccountsQueryVariables>;
 export const TickerSymbolDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"TickerSymbol"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tickerSymbol"}}]}}]} as unknown as DocumentNode<TickerSymbolQuery, TickerSymbolQueryVariables>;
-export const TransferDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"Transfer"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"owner"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AccountOwner"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"amount"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Amount"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"targetAccount"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"FungibleAccount"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"transfer"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"owner"},"value":{"kind":"Variable","name":{"kind":"Name","value":"owner"}}},{"kind":"Argument","name":{"kind":"Name","value":"amount"},"value":{"kind":"Variable","name":{"kind":"Name","value":"amount"}}},{"kind":"Argument","name":{"kind":"Name","value":"targetAccount"},"value":{"kind":"Variable","name":{"kind":"Name","value":"targetAccount"}}}]}]}}]} as unknown as DocumentNode<TransferMutation, TransferMutationVariables>;
+export const TransferDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"Transfer"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"owner"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"MultiAddress"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"amount"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Amount"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"targetAccount"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"FungibleAccount"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"transfer"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"owner"},"value":{"kind":"Variable","name":{"kind":"Name","value":"owner"}}},{"kind":"Argument","name":{"kind":"Name","value":"amount"},"value":{"kind":"Variable","name":{"kind":"Name","value":"amount"}}},{"kind":"Argument","name":{"kind":"Name","value":"targetAccount"},"value":{"kind":"Variable","name":{"kind":"Name","value":"targetAccount"}}}]}]}}]} as unknown as DocumentNode<TransferMutation, TransferMutationVariables>;

--- a/examples/gen-nft/src/contract.rs
+++ b/examples/gen-nft/src/contract.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeSet;
 use fungible::Account;
 use gen_nft::{GenNftAbi, Message, Nft, Operation, TokenId};
 use linera_sdk::{
-    linera_base_types::{AccountOwner, WithContractAbi},
+    linera_base_types::{MultiAddress, WithContractAbi},
     views::{RootView, View},
     Contract, ContractRuntime,
 };
@@ -124,9 +124,9 @@ impl Contract for GenNftContract {
 
 impl GenNftContract {
     /// Verifies that a transfer is authenticated for this local account.
-    fn check_account_authentication(&mut self, owner: AccountOwner) {
+    fn check_account_authentication(&mut self, owner: MultiAddress) {
         match owner {
-            AccountOwner::Address32(address) => {
+            MultiAddress::Address32(address) => {
                 assert!(
                     self.runtime.authenticated_signer().map(|owner| owner.0) == Some(address)
                         || self.runtime.authenticated_caller_id().map(|owner| owner.0)
@@ -134,7 +134,7 @@ impl GenNftContract {
                     "The requested transfer is not correctly authenticated."
                 )
             }
-            AccountOwner::Chain => {
+            MultiAddress::Chain => {
                 panic!("Chain account is not supported")
             }
         }
@@ -169,7 +169,7 @@ impl GenNftContract {
             .expect("NFT not found")
     }
 
-    async fn mint(&mut self, owner: AccountOwner, prompt: String) {
+    async fn mint(&mut self, owner: MultiAddress, prompt: String) {
         let token_id = Nft::create_token_id(
             &self.runtime.chain_id(),
             &self.runtime.application_id().forget_abi(),

--- a/examples/gen-nft/src/lib.rs
+++ b/examples/gen-nft/src/lib.rs
@@ -9,7 +9,7 @@ use async_graphql::{InputObject, Request, Response, SimpleObject};
 use fungible::Account;
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, ChainId, ContractAbi, ServiceAbi, UserApplicationId},
+    linera_base_types::{ChainId, ContractAbi, MultiAddress, ServiceAbi, UserApplicationId},
     ToBcsBytes,
 };
 use serde::{Deserialize, Serialize};
@@ -39,12 +39,12 @@ impl ServiceAbi for GenNftAbi {
 pub enum Operation {
     /// Mints a token
     Mint {
-        minter: AccountOwner,
+        minter: MultiAddress,
         prompt: String,
     },
     /// Transfers a token from a (locally owned) account to a (possibly remote) account.
     Transfer {
-        source_owner: AccountOwner,
+        source_owner: MultiAddress,
         token_id: TokenId,
         target_account: Account,
     },
@@ -77,18 +77,18 @@ pub enum Message {
 #[serde(rename_all = "camelCase")]
 pub struct Nft {
     pub token_id: TokenId,
-    pub owner: AccountOwner,
+    pub owner: MultiAddress,
     pub prompt: String,
-    pub minter: AccountOwner,
+    pub minter: MultiAddress,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, SimpleObject, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct NftOutput {
     pub token_id: String,
-    pub owner: AccountOwner,
+    pub owner: MultiAddress,
     pub prompt: String,
-    pub minter: AccountOwner,
+    pub minter: MultiAddress,
 }
 
 impl NftOutput {
@@ -124,7 +124,7 @@ impl Nft {
         chain_id: &ChainId,
         application_id: &UserApplicationId,
         prompt: &String,
-        minter: &AccountOwner,
+        minter: &MultiAddress,
         num_minted_nfts: u64,
     ) -> Result<TokenId, bcs::Error> {
         use sha3::Digest as _;

--- a/examples/gen-nft/src/service.rs
+++ b/examples/gen-nft/src/service.rs
@@ -19,7 +19,7 @@ use fungible::Account;
 use gen_nft::{NftOutput, Operation, TokenId};
 use linera_sdk::{
     http,
-    linera_base_types::{AccountOwner, WithServiceAbi},
+    linera_base_types::{MultiAddress, WithServiceAbi},
     views::View,
     Service, ServiceRuntime,
 };
@@ -108,7 +108,7 @@ impl QueryRoot {
         nfts
     }
 
-    async fn owned_token_ids_by_owner(&self, owner: AccountOwner) -> BTreeSet<String> {
+    async fn owned_token_ids_by_owner(&self, owner: MultiAddress) -> BTreeSet<String> {
         self.non_fungible_token
             .owned_token_ids
             .get(&owner)
@@ -120,7 +120,7 @@ impl QueryRoot {
             .collect()
     }
 
-    async fn owned_token_ids(&self) -> BTreeMap<AccountOwner, BTreeSet<String>> {
+    async fn owned_token_ids(&self) -> BTreeMap<MultiAddress, BTreeSet<String>> {
         let mut owners = BTreeMap::new();
         self.non_fungible_token
             .owned_token_ids
@@ -140,7 +140,7 @@ impl QueryRoot {
         owners
     }
 
-    async fn owned_nfts(&self, owner: AccountOwner) -> BTreeMap<String, NftOutput> {
+    async fn owned_nfts(&self, owner: MultiAddress) -> BTreeMap<String, NftOutput> {
         let mut result = BTreeMap::new();
         let owned_token_ids = self
             .non_fungible_token
@@ -187,7 +187,7 @@ struct MutationRoot {
 
 #[Object]
 impl MutationRoot {
-    async fn mint(&self, minter: AccountOwner, prompt: String) -> [u8; 0] {
+    async fn mint(&self, minter: MultiAddress, prompt: String) -> [u8; 0] {
         let operation = Operation::Mint { minter, prompt };
         self.runtime.schedule_operation(&operation);
         []
@@ -195,7 +195,7 @@ impl MutationRoot {
 
     async fn transfer(
         &self,
-        source_owner: AccountOwner,
+        source_owner: MultiAddress,
         token_id: String,
         target_account: Account,
     ) -> [u8; 0] {

--- a/examples/gen-nft/src/state.rs
+++ b/examples/gen-nft/src/state.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeSet;
 use async_graphql::SimpleObject;
 use gen_nft::{Nft, TokenId};
 use linera_sdk::{
-    linera_base_types::AccountOwner,
+    linera_base_types::MultiAddress,
     views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
 };
 
@@ -17,7 +17,7 @@ pub struct GenNftState {
     // Map from token ID to the NFT data
     pub nfts: MapView<TokenId, Nft>,
     // Map from owners to the set of NFT token IDs they own
-    pub owned_token_ids: MapView<AccountOwner, BTreeSet<TokenId>>,
+    pub owned_token_ids: MapView<MultiAddress, BTreeSet<TokenId>>,
     // Counter of NFTs minted in this chain, used for hash uniqueness
     pub num_minted_nfts: RegisterView<u64>,
 }

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -8,7 +8,7 @@ use std::cmp::min;
 
 use fungible::{Account, FungibleTokenAbi};
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount, ApplicationId, ChainId, WithContractAbi},
+    linera_base_types::{Amount, ApplicationId, ChainId, MultiAddress, WithContractAbi},
     views::{RootView, View},
     Contract, ContractRuntime,
 };
@@ -132,7 +132,7 @@ impl Contract for MatchingEngineContract {
 
 impl MatchingEngineContract {
     /// Get the owner from the order
-    fn get_owner(order: &Order) -> AccountOwner {
+    fn get_owner(order: &Order) -> MultiAddress {
         match order {
             Order::Insert {
                 owner,
@@ -150,9 +150,9 @@ impl MatchingEngineContract {
     }
 
     /// authenticate the originator of the message
-    fn check_account_authentication(&mut self, owner: AccountOwner) {
+    fn check_account_authentication(&mut self, owner: MultiAddress) {
         match owner {
-            AccountOwner::Address32(address) => {
+            MultiAddress::Address32(address) => {
                 assert!(
                     self.runtime.authenticated_signer().map(|owner| owner.0) == Some(address)
                         || self.runtime.authenticated_caller_id().map(|owner| owner.0)
@@ -160,7 +160,7 @@ impl MatchingEngineContract {
                     "Unauthorized."
                 )
             }
-            AccountOwner::Chain => {
+            MultiAddress::Chain => {
                 panic!("Chain account is not supported")
             }
         }
@@ -175,14 +175,14 @@ impl MatchingEngineContract {
     /// Calls into the Fungible Token application to receive tokens from the given account.
     fn receive_from_account(
         &mut self,
-        owner: &AccountOwner,
+        owner: &MultiAddress,
         amount: &Amount,
         nature: &OrderNature,
         price: &Price,
     ) {
         let destination = Account {
             chain_id: self.runtime.chain_id(),
-            owner: AccountOwner::from(self.runtime.application_id().forget_abi()),
+            owner: MultiAddress::from(self.runtime.application_id().forget_abi()),
         };
         let (amount, token_idx) = Self::get_amount_idx(nature, price, amount);
         self.transfer(*owner, amount, destination, token_idx)
@@ -191,14 +191,14 @@ impl MatchingEngineContract {
     /// Transfers `amount` tokens from the funds in custody to the `destination`.
     fn send_to(&mut self, transfer: Transfer) {
         let destination = transfer.account;
-        let owner_app = AccountOwner::from(self.runtime.application_id().forget_abi());
+        let owner_app = MultiAddress::from(self.runtime.application_id().forget_abi());
         self.transfer(owner_app, transfer.amount, destination, transfer.token_idx);
     }
 
     /// Transfers tokens from the owner to the destination
     fn transfer(
         &mut self,
-        owner: AccountOwner,
+        owner: MultiAddress,
         amount: Amount,
         target_account: Account,
         token_idx: u32,
@@ -296,7 +296,7 @@ impl MatchingEngineContract {
     }
 
     /// Checks that the order exists and has been issued by the claimed owner.
-    async fn check_order_id(&self, order_id: &OrderId, owner: &AccountOwner) {
+    async fn check_order_id(&self, order_id: &OrderId, owner: &MultiAddress) {
         let value = self
             .state
             .orders
@@ -322,7 +322,7 @@ impl MatchingEngineContract {
         &mut self,
         order_id: OrderId,
         cancel_amount: ModifyAmount,
-        owner: &AccountOwner,
+        owner: &MultiAddress,
     ) {
         self.check_order_id(&order_id, owner).await;
         let transfer = self
@@ -543,7 +543,7 @@ impl MatchingEngineContract {
         nature: &OrderNature,
         price_level: Price,
         price_insert: Price,
-    ) -> Vec<(AccountOwner, OrderId)> {
+    ) -> Vec<(MultiAddress, OrderId)> {
         let mut remove_order = Vec::new();
         let orders = view
             .queue
@@ -606,7 +606,7 @@ impl MatchingEngineContract {
     /// Removes one single (owner, order_id) from the database
     /// * This is done for the info by owners
     /// * And the symbolic information of orders
-    async fn remove_order_id(&mut self, entry: (AccountOwner, OrderId)) {
+    async fn remove_order_id(&mut self, entry: (MultiAddress, OrderId)) {
         let (owner, order_id) = entry;
         let account_info = self
             .state
@@ -619,7 +619,7 @@ impl MatchingEngineContract {
     }
 
     /// Removes a bunch of order_id
-    async fn remove_order_ids(&mut self, entries: Vec<(AccountOwner, OrderId)>) {
+    async fn remove_order_ids(&mut self, entries: Vec<(MultiAddress, OrderId)>) {
         for entry in entries {
             self.remove_order_id(entry).await;
         }

--- a/examples/matching-engine/src/lib.rs
+++ b/examples/matching-engine/src/lib.rs
@@ -7,7 +7,7 @@ use async_graphql::{scalar, InputObject, Request, Response, SimpleObject};
 use fungible::FungibleTokenAbi;
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, Amount, ApplicationId, ContractAbi, ServiceAbi},
+    linera_base_types::{Amount, ApplicationId, ContractAbi, MultiAddress, ServiceAbi},
     views::{CustomSerialize, ViewError},
 };
 use serde::{Deserialize, Serialize};
@@ -142,19 +142,19 @@ scalar!(OrderNature);
 pub enum Order {
     /// Insertion of an order
     Insert {
-        owner: AccountOwner,
+        owner: MultiAddress,
         amount: Amount,
         nature: OrderNature,
         price: Price,
     },
     /// Cancelling of an order
     Cancel {
-        owner: AccountOwner,
+        owner: MultiAddress,
         order_id: OrderId,
     },
     /// Modifying order (only decreasing is allowed)
     Modify {
-        owner: AccountOwner,
+        owner: MultiAddress,
         order_id: OrderId,
         cancel_amount: Amount,
     },

--- a/examples/matching-engine/src/state.rs
+++ b/examples/matching-engine/src/state.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeSet;
 use async_graphql::SimpleObject;
 use fungible::Account;
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount},
+    linera_base_types::{Amount, MultiAddress},
     views::{
         linera_views, CustomCollectionView, MapView, QueueView, RegisterView, RootView, View,
         ViewStorageContext,
@@ -77,5 +77,5 @@ pub struct MatchingEngineState {
     pub orders: MapView<OrderId, KeyBook>,
     /// The map giving for each account owner the set of order_id
     /// owned by that owner.
-    pub account_info: MapView<AccountOwner, AccountInfo>,
+    pub account_info: MapView<MultiAddress, AccountInfo>,
 }

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -7,7 +7,7 @@
 
 use async_graphql::InputType;
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount, ApplicationId, ApplicationPermissions},
+    linera_base_types::{Amount, ApplicationId, ApplicationPermissions, MultiAddress},
     test::{ActiveChain, QueryOutcome, TestValidator},
 };
 use matching_engine::{
@@ -17,7 +17,7 @@ use matching_engine::{
 pub async fn get_orders(
     application_id: ApplicationId<MatchingEngineAbi>,
     chain: &ActiveChain,
-    account_owner: AccountOwner,
+    account_owner: MultiAddress,
 ) -> Option<Vec<OrderId>> {
     let query = format!(
         "query {{ accountInfo {{ entry(key: {}) {{ value {{ orders }} }} }} }}",
@@ -70,11 +70,11 @@ async fn single_transaction() {
         TestValidator::with_current_module::<MatchingEngineAbi, Parameters, ()>().await;
 
     let mut user_chain_a = validator.new_chain().await;
-    let owner_a = AccountOwner::from(user_chain_a.public_key());
+    let owner_a = MultiAddress::from(user_chain_a.public_key());
     let mut user_chain_b = validator.new_chain().await;
-    let owner_b = AccountOwner::from(user_chain_b.public_key());
+    let owner_b = MultiAddress::from(user_chain_b.public_key());
     let mut matching_chain = validator.new_chain().await;
-    let admin_account = AccountOwner::from(matching_chain.public_key());
+    let admin_account = MultiAddress::from(matching_chain.public_key());
 
     let fungible_module_id_a = user_chain_a
         .publish_bytecode_files_in::<fungible::FungibleTokenAbi, fungible::Parameters, fungible::InitialState>("../fungible")

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -5,7 +5,7 @@
 
 use fungible::{FungibleResponse, FungibleTokenAbi, InitialState, Operation, Parameters};
 use linera_sdk::{
-    linera_base_types::{Account, AccountOwner, ChainId, WithContractAbi},
+    linera_base_types::{Account, ChainId, MultiAddress, WithContractAbi},
     Contract, ContractRuntime,
 };
 use native_fungible::{Message, TICKER_SYMBOL};
@@ -40,7 +40,7 @@ impl Contract for NativeFungibleTokenContract {
                 chain_id: self.runtime.chain_id(),
                 owner,
             };
-            self.runtime.transfer(AccountOwner::Chain, account, amount);
+            self.runtime.transfer(MultiAddress::Chain, account, amount);
         }
     }
 
@@ -134,9 +134,9 @@ impl NativeFungibleTokenContract {
     }
 
     /// Verifies that a transfer is authenticated for this local account.
-    fn check_account_authentication(&mut self, owner: AccountOwner) {
+    fn check_account_authentication(&mut self, owner: MultiAddress) {
         match owner {
-            AccountOwner::Address32(address) => {
+            MultiAddress::Address32(address) => {
                 assert!(
                     self.runtime.authenticated_signer().map(|owner| owner.0) == Some(address)
                         || self.runtime.authenticated_caller_id().map(|owner| owner.0)
@@ -144,7 +144,7 @@ impl NativeFungibleTokenContract {
                     "The requested transfer is not correctly authenticated."
                 )
             }
-            AccountOwner::Chain => {
+            MultiAddress::Chain => {
                 panic!("Chain accounts are not supported")
             }
         }

--- a/examples/native-fungible/src/lib.rs
+++ b/examples/native-fungible/src/lib.rs
@@ -4,14 +4,14 @@
 /*! ABI of the Native Fungible Token Example Application */
 
 use async_graphql::SimpleObject;
-use linera_sdk::linera_base_types::{AccountOwner, Amount};
+use linera_sdk::linera_base_types::{Amount, MultiAddress};
 use serde::{Deserialize, Serialize};
 
 pub const TICKER_SYMBOL: &str = "NAT";
 
 #[derive(Deserialize, SimpleObject)]
 pub struct AccountEntry {
-    pub key: AccountOwner,
+    pub key: MultiAddress,
     pub value: Amount,
 }
 

--- a/examples/native-fungible/src/service.rs
+++ b/examples/native-fungible/src/service.rs
@@ -9,7 +9,7 @@ use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
 use fungible::{Operation, Parameters};
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, WithServiceAbi},
+    linera_base_types::{MultiAddress, WithServiceAbi},
     Service, ServiceRuntime,
 };
 use native_fungible::{AccountEntry, TICKER_SYMBOL};
@@ -52,7 +52,7 @@ struct Accounts {
 #[Object]
 impl Accounts {
     // Define a field that lets you query by key
-    async fn entry(&self, key: AccountOwner) -> AccountEntry {
+    async fn entry(&self, key: MultiAddress) -> AccountEntry {
         let value = self.runtime.owner_balance(key);
 
         AccountEntry { key, value }
@@ -69,7 +69,7 @@ impl Accounts {
             .collect()
     }
 
-    async fn keys(&self) -> Vec<AccountOwner> {
+    async fn keys(&self) -> Vec<MultiAddress> {
         self.runtime.balance_owners()
     }
 }

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use fungible::{self, FungibleTokenAbi};
 use linera_sdk::{
-    linera_base_types::{Account, AccountOwner, Amount, ChainId, CryptoHash, Owner},
+    linera_base_types::{Account, Amount, ChainId, CryptoHash, MultiAddress, Owner},
     test::{ActiveChain, Recipient, TestValidator},
 };
 
@@ -33,7 +33,7 @@ async fn chain_balance_transfers() {
 
     let transfer_certificate = funding_chain
         .add_block(|block| {
-            block.with_native_token_transfer(AccountOwner::Chain, recipient, transfer_amount);
+            block.with_native_token_transfer(MultiAddress::Chain, recipient, transfer_amount);
         })
         .await;
 
@@ -69,7 +69,7 @@ async fn transfer_to_owner() {
 
     let transfer_certificate = funding_chain
         .add_block(|block| {
-            block.with_native_token_transfer(AccountOwner::Chain, recipient, transfer_amount);
+            block.with_native_token_transfer(MultiAddress::Chain, recipient, transfer_amount);
         })
         .await;
 
@@ -102,7 +102,7 @@ async fn transfer_to_multiple_owners() {
 
     let account_owners = (1..=number_of_owners)
         .map(|index| Owner(CryptoHash::test_hash(format!("owner{index}"))))
-        .map(AccountOwner::from)
+        .map(MultiAddress::from)
         .collect::<Vec<_>>();
 
     let recipients = account_owners
@@ -114,7 +114,7 @@ async fn transfer_to_multiple_owners() {
     let transfer_certificate = funding_chain
         .add_block(|block| {
             for (recipient, transfer_amount) in recipients.zip(transfer_amounts.clone()) {
-                block.with_native_token_transfer(AccountOwner::Chain, recipient, transfer_amount);
+                block.with_native_token_transfer(MultiAddress::Chain, recipient, transfer_amount);
             }
         })
         .await;
@@ -154,7 +154,7 @@ async fn emptied_account_disappears_from_queries() {
 
     let transfer_certificate = funding_chain
         .add_block(|block| {
-            block.with_native_token_transfer(AccountOwner::Chain, recipient, transfer_amount);
+            block.with_native_token_transfer(MultiAddress::Chain, recipient, transfer_amount);
         })
         .await;
 
@@ -167,7 +167,7 @@ async fn emptied_account_disappears_from_queries() {
     recipient_chain
         .add_block(|block| {
             block.with_native_token_transfer(
-                AccountOwner::from(owner),
+                MultiAddress::from(owner),
                 Recipient::Burn,
                 transfer_amount,
             );
@@ -176,7 +176,7 @@ async fn emptied_account_disappears_from_queries() {
 
     assert_eq!(
         recipient_chain
-            .owner_balance(&AccountOwner::from(owner))
+            .owner_balance(&MultiAddress::from(owner))
             .await,
         None
     );
@@ -186,7 +186,7 @@ async fn emptied_account_disappears_from_queries() {
 /// Asserts that all the accounts in the [`ActiveChain`] have the `expected_balances`.
 async fn assert_balances(
     chain: &ActiveChain,
-    expected_balances: impl IntoIterator<Item = (AccountOwner, Amount)>,
+    expected_balances: impl IntoIterator<Item = (MultiAddress, Amount)>,
 ) {
     let expected_balances = expected_balances.into_iter().collect::<BTreeMap<_, _>>();
     let accounts = expected_balances.keys().copied().collect::<Vec<_>>();
@@ -197,7 +197,7 @@ async fn assert_balances(
         .into_iter()
         .map(CryptoHash::test_hash)
         .map(Owner)
-        .map(AccountOwner::from)
+        .map(MultiAddress::from)
         .collect::<Vec<_>>();
 
     let accounts_to_query = accounts

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeSet;
 
 use fungible::Account;
 use linera_sdk::{
-    linera_base_types::{AccountOwner, WithContractAbi},
+    linera_base_types::{MultiAddress, WithContractAbi},
     views::{RootView, View},
     Contract, ContractRuntime, DataBlobHash,
 };
@@ -128,9 +128,9 @@ impl Contract for NonFungibleTokenContract {
 
 impl NonFungibleTokenContract {
     /// Verifies that a transfer is authenticated for this local account.
-    fn check_account_authentication(&mut self, owner: AccountOwner) {
+    fn check_account_authentication(&mut self, owner: MultiAddress) {
         match owner {
-            AccountOwner::Address32(address) => {
+            MultiAddress::Address32(address) => {
                 assert!(
                     self.runtime.authenticated_signer().map(|owner| owner.0) == Some(address)
                         || self.runtime.authenticated_caller_id().map(|owner| owner.0)
@@ -138,7 +138,7 @@ impl NonFungibleTokenContract {
                     "The requested transfer is not correctly authenticated."
                 )
             }
-            AccountOwner::Chain => {
+            MultiAddress::Chain => {
                 panic!("Chain account is not supported")
             }
         }
@@ -173,7 +173,7 @@ impl NonFungibleTokenContract {
             .expect("NFT not found")
     }
 
-    async fn mint(&mut self, owner: AccountOwner, name: String, blob_hash: DataBlobHash) {
+    async fn mint(&mut self, owner: MultiAddress, name: String, blob_hash: DataBlobHash) {
         self.runtime.assert_data_blob_exists(blob_hash);
         let token_id = Nft::create_token_id(
             &self.runtime.chain_id(),

--- a/examples/non-fungible/src/lib.rs
+++ b/examples/non-fungible/src/lib.rs
@@ -9,7 +9,7 @@ use async_graphql::{InputObject, Request, Response, SimpleObject};
 use fungible::Account;
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, ChainId, ContractAbi, ServiceAbi, UserApplicationId},
+    linera_base_types::{ChainId, ContractAbi, MultiAddress, ServiceAbi, UserApplicationId},
     DataBlobHash, ToBcsBytes,
 };
 use serde::{Deserialize, Serialize};
@@ -39,13 +39,13 @@ impl ServiceAbi for NonFungibleTokenAbi {
 pub enum Operation {
     /// Mints a token
     Mint {
-        minter: AccountOwner,
+        minter: MultiAddress,
         name: String,
         blob_hash: DataBlobHash,
     },
     /// Transfers a token from a (locally owned) account to a (possibly remote) account.
     Transfer {
-        source_owner: AccountOwner,
+        source_owner: MultiAddress,
         token_id: TokenId,
         target_account: Account,
     },
@@ -78,9 +78,9 @@ pub enum Message {
 #[serde(rename_all = "camelCase")]
 pub struct Nft {
     pub token_id: TokenId,
-    pub owner: AccountOwner,
+    pub owner: MultiAddress,
     pub name: String,
-    pub minter: AccountOwner,
+    pub minter: MultiAddress,
     pub blob_hash: DataBlobHash,
 }
 
@@ -88,9 +88,9 @@ pub struct Nft {
 #[serde(rename_all = "camelCase")]
 pub struct NftOutput {
     pub token_id: String,
-    pub owner: AccountOwner,
+    pub owner: MultiAddress,
     pub name: String,
-    pub minter: AccountOwner,
+    pub minter: MultiAddress,
     pub payload: Vec<u8>,
 }
 
@@ -129,7 +129,7 @@ impl Nft {
         chain_id: &ChainId,
         application_id: &UserApplicationId,
         name: &String,
-        minter: &AccountOwner,
+        minter: &MultiAddress,
         blob_hash: &DataBlobHash,
         num_minted_nfts: u64,
     ) -> Result<TokenId, bcs::Error> {

--- a/examples/non-fungible/src/service.rs
+++ b/examples/non-fungible/src/service.rs
@@ -14,7 +14,7 @@ use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
 use base64::engine::{general_purpose::STANDARD_NO_PAD, Engine as _};
 use fungible::Account;
 use linera_sdk::{
-    linera_base_types::{AccountOwner, WithServiceAbi},
+    linera_base_types::{MultiAddress, WithServiceAbi},
     views::View,
     DataBlobHash, Service, ServiceRuntime,
 };
@@ -104,7 +104,7 @@ impl QueryRoot {
         nfts
     }
 
-    async fn owned_token_ids_by_owner(&self, owner: AccountOwner) -> BTreeSet<String> {
+    async fn owned_token_ids_by_owner(&self, owner: MultiAddress) -> BTreeSet<String> {
         self.non_fungible_token
             .owned_token_ids
             .get(&owner)
@@ -116,7 +116,7 @@ impl QueryRoot {
             .collect()
     }
 
-    async fn owned_token_ids(&self) -> BTreeMap<AccountOwner, BTreeSet<String>> {
+    async fn owned_token_ids(&self) -> BTreeMap<MultiAddress, BTreeSet<String>> {
         let mut owners = BTreeMap::new();
         self.non_fungible_token
             .owned_token_ids
@@ -136,7 +136,7 @@ impl QueryRoot {
         owners
     }
 
-    async fn owned_nfts(&self, owner: AccountOwner) -> BTreeMap<String, NftOutput> {
+    async fn owned_nfts(&self, owner: MultiAddress) -> BTreeMap<String, NftOutput> {
         let mut result = BTreeMap::new();
         let owned_token_ids = self
             .non_fungible_token
@@ -168,7 +168,7 @@ struct MutationRoot {
 
 #[Object]
 impl MutationRoot {
-    async fn mint(&self, minter: AccountOwner, name: String, blob_hash: DataBlobHash) -> [u8; 0] {
+    async fn mint(&self, minter: MultiAddress, name: String, blob_hash: DataBlobHash) -> [u8; 0] {
         let operation = Operation::Mint {
             minter,
             name,
@@ -180,7 +180,7 @@ impl MutationRoot {
 
     async fn transfer(
         &self,
-        source_owner: AccountOwner,
+        source_owner: MultiAddress,
         token_id: String,
         target_account: Account,
     ) -> [u8; 0] {

--- a/examples/non-fungible/src/state.rs
+++ b/examples/non-fungible/src/state.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeSet;
 
 use async_graphql::SimpleObject;
 use linera_sdk::{
-    linera_base_types::AccountOwner,
+    linera_base_types::MultiAddress,
     views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
 };
 use non_fungible::{Nft, TokenId};
@@ -17,7 +17,7 @@ pub struct NonFungibleTokenState {
     // Map from token ID to the NFT data
     pub nfts: MapView<TokenId, Nft>,
     // Map from owners to the set of NFT token IDs they own
-    pub owned_token_ids: MapView<AccountOwner, BTreeSet<TokenId>>,
+    pub owned_token_ids: MapView<MultiAddress, BTreeSet<TokenId>>,
     // Counter of NFTs minted in this chain, used for hash uniqueness
     pub num_minted_nfts: RegisterView<u64>,
 }

--- a/examples/rfq/src/contract.rs
+++ b/examples/rfq/src/contract.rs
@@ -8,7 +8,7 @@ mod state;
 use fungible::{Account, FungibleTokenAbi};
 use linera_sdk::{
     linera_base_types::{
-        AccountOwner, Amount, ApplicationPermissions, ChainId, ChainOwnership, Owner,
+        Amount, ApplicationPermissions, ChainId, ChainOwnership, MultiAddress, Owner,
         TimeoutConfig, WithContractAbi,
     },
     views::{RootView, View},
@@ -142,7 +142,7 @@ impl Contract for RfqContract {
                     amount: awaiting_tokens.amount_offered,
                     target_account: Account {
                         chain_id: temp_chain_id,
-                        owner: AccountOwner::from(self.runtime.application_id().forget_abi()),
+                        owner: MultiAddress::from(self.runtime.application_id().forget_abi()),
                     },
                 };
                 let token = token_pair.token_asked;
@@ -264,7 +264,7 @@ impl Contract for RfqContract {
                             true,
                             tokens.token_id.with_abi::<fungible::FungibleTokenAbi>(),
                             &fungible::Operation::Transfer {
-                                owner: AccountOwner::from(app_id),
+                                owner: MultiAddress::from(app_id),
                                 amount: tokens.amount,
                                 target_account: tokens.owner,
                             },
@@ -278,7 +278,7 @@ impl Contract for RfqContract {
                             true,
                             tokens.token_id.with_abi::<fungible::FungibleTokenAbi>(),
                             &fungible::Operation::Transfer {
-                                owner: AccountOwner::from(app_id),
+                                owner: MultiAddress::from(app_id),
                                 amount: tokens.amount,
                                 target_account: held_tokens.owner,
                             },
@@ -289,7 +289,7 @@ impl Contract for RfqContract {
                                 .token_id
                                 .with_abi::<fungible::FungibleTokenAbi>(),
                             &fungible::Operation::Transfer {
-                                owner: AccountOwner::from(app_id),
+                                owner: MultiAddress::from(app_id),
                                 amount: held_tokens.amount,
                                 target_account: tokens.owner,
                             },
@@ -341,7 +341,7 @@ impl RfqContract {
             amount: quote_provided.get_amount(),
             target_account: Account {
                 chain_id: temp_chain_id,
-                owner: AccountOwner::from(self.runtime.application_id().forget_abi()),
+                owner: MultiAddress::from(self.runtime.application_id().forget_abi()),
             },
         };
         let token = token_pair.token_offered;
@@ -380,7 +380,7 @@ impl RfqContract {
                 true,
                 tokens.token_id.with_abi::<fungible::FungibleTokenAbi>(),
                 &fungible::Operation::Transfer {
-                    owner: AccountOwner::from(app_id),
+                    owner: MultiAddress::from(app_id),
                     amount: tokens.amount,
                     target_account: tokens.owner,
                 },

--- a/examples/rfq/src/state.rs
+++ b/examples/rfq/src/state.rs
@@ -3,7 +3,7 @@
 
 use async_graphql::{InputObject, SimpleObject, Union};
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount, ChainId, Owner},
+    linera_base_types::{Amount, ChainId, MultiAddress, Owner},
     views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
 };
 use rfq::{RequestId, TokenPair, Tokens};
@@ -42,7 +42,7 @@ pub struct ExchangeInProgress {
 pub struct AwaitingTokens {
     pub token_pair: TokenPair,
     pub amount_offered: Amount,
-    pub quoter_account: AccountOwner,
+    pub quoter_account: MultiAddress,
     pub temp_chain_id: ChainId,
 }
 
@@ -71,7 +71,7 @@ pub struct RequestData {
 
 #[derive(Clone, Debug, Serialize, Deserialize, SimpleObject)]
 pub struct TempChainTokenHolder {
-    pub account_owner: AccountOwner,
+    pub account_owner: MultiAddress,
     pub chain_id: ChainId,
 }
 

--- a/linera-base/src/unit_tests.rs
+++ b/linera-base/src/unit_tests.rs
@@ -12,7 +12,7 @@ use crate::{
     crypto::{AccountPublicKey, CryptoHash},
     data_types::{Amount, BlockHeight, Resources, SendMessageRequest, TimeDelta, Timestamp},
     identifiers::{
-        Account, AccountOwner, ChainId, ChannelName, Destination, MessageId, ModuleId, Owner,
+        Account, ChainId, ChannelName, Destination, MessageId, ModuleId, MultiAddress, Owner,
         UserApplicationId,
     },
     ownership::{ChainOwnership, TimeoutConfig},
@@ -97,7 +97,7 @@ fn send_message_request_test_case() -> SendMessageRequest<Vec<u8>> {
 fn account_test_case() -> Account {
     Account {
         chain_id: ChainId::root(10),
-        owner: AccountOwner::Address32(CryptoHash::test_hash("account")),
+        owner: MultiAddress::Address32(CryptoHash::test_hash("account")),
     }
 }
 

--- a/linera-chain/src/test/mod.rs
+++ b/linera-chain/src/test/mod.rs
@@ -9,7 +9,7 @@ use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey},
     data_types::{Amount, BlockHeight, Round, Timestamp},
     hashed::Hashed,
-    identifiers::{AccountOwner, ChainId, Owner},
+    identifiers::{ChainId, MultiAddress, Owner},
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorState},
@@ -65,7 +65,7 @@ pub trait BlockTestExt: Sized {
     fn with_operation(self, operation: impl Into<Operation>) -> Self;
 
     /// Returns the block with a transfer operation appended at the end.
-    fn with_transfer(self, owner: AccountOwner, recipient: Recipient, amount: Amount) -> Self;
+    fn with_transfer(self, owner: MultiAddress, recipient: Recipient, amount: Amount) -> Self;
 
     /// Returns the block with a simple transfer operation appended at the end.
     fn with_simple_transfer(self, chain_id: ChainId, amount: Amount) -> Self;
@@ -100,7 +100,7 @@ impl BlockTestExt for ProposedBlock {
         self
     }
 
-    fn with_transfer(self, owner: AccountOwner, recipient: Recipient, amount: Amount) -> Self {
+    fn with_transfer(self, owner: MultiAddress, recipient: Recipient, amount: Amount) -> Self {
         self.with_operation(SystemOperation::Transfer {
             owner,
             recipient,
@@ -109,7 +109,7 @@ impl BlockTestExt for ProposedBlock {
     }
 
     fn with_simple_transfer(self, chain_id: ChainId, amount: Amount) -> Self {
-        self.with_transfer(AccountOwner::Chain, Recipient::chain(chain_id), amount)
+        self.with_transfer(MultiAddress::Chain, Recipient::chain(chain_id), amount)
     }
 
     fn with_incoming_bundle(mut self, incoming_bundle: IncomingBundle) -> Self {

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -19,7 +19,7 @@ use linera_base::{
     },
     hashed::Hashed,
     http,
-    identifiers::{AccountOwner, ChainId, MessageId, ModuleId, UserApplicationId},
+    identifiers::{ChainId, MessageId, ModuleId, MultiAddress, UserApplicationId},
     ownership::ChainOwnership,
     vm::VmRuntime,
 };
@@ -166,7 +166,7 @@ async fn test_block_size_limit() {
     let invalid_block = valid_block
         .clone()
         .with_operation(SystemOperation::Transfer {
-            owner: AccountOwner::Chain,
+            owner: MultiAddress::Chain,
             recipient: Recipient::root(0),
             amount: Amount::ONE,
         });

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -7,7 +7,7 @@ use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey},
     data_types::{Amount, Timestamp},
     hashed::Hashed,
-    identifiers::{AccountOwner, ChainId, Owner, UserApplicationId},
+    identifiers::{ChainId, MultiAddress, Owner, UserApplicationId},
     listen_for_shutdown_signals,
     time::Instant,
 };
@@ -594,7 +594,7 @@ where
                     amount,
                 ),
                 None => Operation::System(SystemOperation::Transfer {
-                    owner: AccountOwner::Chain,
+                    owner: MultiAddress::Chain,
                     recipient: Recipient::chain(previous_chain_id),
                     amount,
                 }),
@@ -618,10 +618,10 @@ where
     ) -> Operation {
         let target_account = fungible::Account {
             chain_id,
-            owner: AccountOwner::from(receiver),
+            owner: MultiAddress::from(receiver),
         };
         let bytes = bcs::to_bytes(&fungible::Operation::Transfer {
-            owner: AccountOwner::from(sender),
+            owner: MultiAddress::from(sender),
             amount,
             target_account,
         })

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -10,7 +10,7 @@ use futures::{lock::Mutex, FutureExt as _};
 use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey, Secp256k1SecretKey},
     data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
-    identifiers::{AccountOwner, ChainId},
+    identifiers::{ChainId, MultiAddress},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_core::{
@@ -161,7 +161,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     // the message.
     let recipient0 = Recipient::chain(chain_id0);
     client1
-        .transfer(AccountOwner::Chain, Amount::ONE, recipient0)
+        .transfer(MultiAddress::Chain, Amount::ONE, recipient0)
         .await?;
     for i in 0.. {
         client0.synchronize_from_validators().boxed().await?;

--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -4,7 +4,7 @@
 use criterion::{criterion_group, criterion_main, measurement::Measurement, BatchSize, Criterion};
 use linera_base::{
     data_types::Amount,
-    identifiers::{Account, AccountOwner},
+    identifiers::{Account, MultiAddress},
     time::Duration,
 };
 use linera_core::{
@@ -59,7 +59,7 @@ where
 
     let account = Account::address32(chain2.chain_id(), owner1.0);
     let cert = chain1
-        .transfer_to_account(AccountOwner::Chain, amt, account)
+        .transfer_to_account(MultiAddress::Chain, amt, account)
         .await
         .unwrap()
         .unwrap();

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use linera_base::{
     data_types::{ArithmeticError, Blob, Timestamp, UserApplicationDescription},
     ensure,
-    identifiers::{AccountOwner, ChannelFullName, GenericApplicationId, Owner, UserApplicationId},
+    identifiers::{ChannelFullName, GenericApplicationId, MultiAddress, Owner, UserApplicationId},
 };
 use linera_chain::{
     data_types::{
@@ -147,7 +147,7 @@ where
                 .execution_state
                 .system
                 .balances
-                .get(&AccountOwner::Address32(signer.0))
+                .get(&MultiAddress::Address32(signer.0))
                 .await?;
         }
 
@@ -279,11 +279,11 @@ where
             info.requested_committees = Some(chain.execution_state.system.committees.get().clone());
         }
         match query.request_owner_balance {
-            owner @ AccountOwner::Address32(_) => {
+            owner @ MultiAddress::Address32(_) => {
                 info.requested_owner_balance =
                     chain.execution_state.system.balances.get(&owner).await?;
             }
-            AccountOwner::Chain => {
+            MultiAddress::Chain => {
                 info.requested_owner_balance = Some(*chain.execution_state.system.balance.get());
             }
         }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -34,8 +34,8 @@ use linera_base::{
     ensure,
     hashed::Hashed,
     identifiers::{
-        Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, EventId, MessageId,
-        ModuleId, Owner, StreamId, UserApplicationId,
+        Account, ApplicationId, BlobId, BlobType, ChainId, EventId, MessageId, ModuleId,
+        MultiAddress, Owner, StreamId, UserApplicationId,
     },
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -1610,7 +1610,7 @@ where
     #[instrument(level = "trace")]
     pub async fn transfer(
         &self,
-        owner: AccountOwner,
+        owner: MultiAddress,
         amount: Amount,
         recipient: Recipient,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
@@ -2289,7 +2289,7 @@ where
     /// block.
     #[instrument(level = "trace")]
     pub async fn query_balance(&self) -> Result<Amount, ChainClientError> {
-        let (balance, _) = self.query_balances_with_owner(AccountOwner::Chain).await?;
+        let (balance, _) = self.query_balances_with_owner(MultiAddress::Chain).await?;
         Ok(balance)
     }
 
@@ -2302,7 +2302,7 @@ where
     #[instrument(level = "trace", skip(owner))]
     pub async fn query_owner_balance(
         &self,
-        owner: AccountOwner,
+        owner: MultiAddress,
     ) -> Result<Amount, ChainClientError> {
         Ok(self
             .query_balances_with_owner(owner)
@@ -2320,7 +2320,7 @@ where
     #[instrument(level = "trace", skip(owner))]
     async fn query_balances_with_owner(
         &self,
-        owner: AccountOwner,
+        owner: MultiAddress,
     ) -> Result<(Amount, Option<Amount>), ChainClientError> {
         let incoming_bundles = self.pending_message_bundles().await?;
         let (previous_block_hash, height, timestamp) = {
@@ -2339,8 +2339,8 @@ where
             previous_block_hash,
             height,
             authenticated_signer: match owner {
-                AccountOwner::Address32(user) => Some(Owner(user)),
-                AccountOwner::Chain => None, // These should be unreachable?
+                MultiAddress::Address32(user) => Some(Owner(user)),
+                MultiAddress::Chain => None, // These should be unreachable?
             },
             timestamp,
         };
@@ -2377,7 +2377,7 @@ where
     /// Does not process the inbox or attempt to synchronize with validators.
     #[instrument(level = "trace")]
     pub async fn local_balance(&self) -> Result<Amount, ChainClientError> {
-        let (balance, _) = self.local_balances_with_owner(AccountOwner::Chain).await?;
+        let (balance, _) = self.local_balances_with_owner(MultiAddress::Chain).await?;
         Ok(balance)
     }
 
@@ -2387,7 +2387,7 @@ where
     #[instrument(level = "trace", skip(owner))]
     pub async fn local_owner_balance(
         &self,
-        owner: AccountOwner,
+        owner: MultiAddress,
     ) -> Result<Amount, ChainClientError> {
         Ok(self
             .local_balances_with_owner(owner)
@@ -2402,7 +2402,7 @@ where
     #[instrument(level = "trace", skip(owner))]
     async fn local_balances_with_owner(
         &self,
-        owner: AccountOwner,
+        owner: MultiAddress,
     ) -> Result<(Amount, Option<Amount>), ChainClientError> {
         let next_block_height = self.next_block_height();
         ensure!(
@@ -2426,7 +2426,7 @@ where
     #[instrument(level = "trace")]
     pub async fn transfer_to_account(
         &self,
-        from: AccountOwner,
+        from: MultiAddress,
         amount: Amount,
         account: Account,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
@@ -2438,7 +2438,7 @@ where
     #[instrument(level = "trace")]
     pub async fn burn(
         &self,
-        owner: AccountOwner,
+        owner: MultiAddress,
         amount: Amount,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
         self.transfer(owner, amount, Recipient::Burn).await
@@ -3167,7 +3167,7 @@ where
     #[instrument(level = "trace")]
     pub async fn transfer_to_account_unsafe_unconfirmed(
         &self,
-        owner: AccountOwner,
+        owner: MultiAddress,
         amount: Amount,
         account: Account,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -11,7 +11,7 @@ use linera_base::{
         ValidatorSignature,
     },
     data_types::{Amount, BlockHeight, Round, Timestamp},
-    identifiers::{AccountOwner, ChainDescription, ChainId},
+    identifiers::{ChainDescription, ChainId, MultiAddress},
 };
 use linera_chain::{
     data_types::{ChainAndHeight, IncomingBundle, Medium, MessageBundle},
@@ -70,8 +70,8 @@ pub struct ChainInfoQuery {
     /// Optionally test that the block height is the one expected.
     #[debug(skip_if = Option::is_none)]
     pub test_next_block_height: Option<BlockHeight>,
-    /// Request the balance of a given [`AccountOwner`].
-    pub request_owner_balance: AccountOwner,
+    /// Request the balance of a given [`MultiAddress`].
+    pub request_owner_balance: MultiAddress,
     /// Query the current committees.
     #[debug(skip_if = Not::not)]
     pub request_committees: bool,
@@ -101,7 +101,7 @@ impl ChainInfoQuery {
             chain_id,
             test_next_block_height: None,
             request_committees: false,
-            request_owner_balance: AccountOwner::Chain,
+            request_owner_balance: MultiAddress::Chain,
             request_pending_message_bundles: false,
             request_sent_certificate_hashes_in_range: None,
             request_received_log_excluding_first_n: None,
@@ -121,7 +121,7 @@ impl ChainInfoQuery {
         self
     }
 
-    pub fn with_owner_balance(mut self, owner: AccountOwner) -> Self {
+    pub fn with_owner_balance(mut self, owner: MultiAddress) -> Self {
         self.request_owner_balance = owner;
         self
     }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -11,7 +11,7 @@ use futures::StreamExt;
 use linera_base::{
     crypto::AccountSecretKey,
     data_types::*,
-    identifiers::{Account, AccountOwner, ChainId, MessageId, Owner},
+    identifiers::{Account, ChainId, MessageId, MultiAddress, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
@@ -104,7 +104,7 @@ where
     {
         let certificate = sender
             .transfer_to_account(
-                AccountOwner::Chain,
+                MultiAddress::Chain,
                 Amount::from_tokens(3),
                 Account::chain(ChainId::root(2)),
             )
@@ -150,13 +150,13 @@ where
         .with_policy(ResourceControlPolicy::fuel_and_block());
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let owner_identity = sender.identity().await?;
-    let owner = AccountOwner::from(owner_identity);
+    let owner = MultiAddress::from(owner_identity);
     let receiver = builder.add_root_chain(2, Amount::ZERO).await?;
     let receiver_id = receiver.chain_id();
     let friend = receiver.identity().await?;
     sender
         .transfer_to_account(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::from_tokens(3),
             Account::address32(receiver_id, owner_identity.0),
         )
@@ -165,7 +165,7 @@ where
         .unwrap();
     let cert = sender
         .transfer_to_account(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::from_millis(100),
             Account::address32(receiver_id, friend.0),
         )
@@ -183,7 +183,7 @@ where
     // The friend paid to receive the message.
     assert_eq!(
         receiver
-            .local_owner_balance(AccountOwner::from(friend))
+            .local_owner_balance(MultiAddress::from(friend))
             .await
             .unwrap(),
         Amount::from_millis(99)
@@ -292,7 +292,7 @@ where
     sender.synchronize_from_validators().await.unwrap();
     // Can still use the chain.
     sender
-        .burn(AccountOwner::Chain, Amount::from_tokens(3))
+        .burn(MultiAddress::Chain, Amount::from_tokens(3))
         .await
         .unwrap();
     Ok(())
@@ -339,7 +339,7 @@ where
     // Cannot use the chain any more.
     assert_matches!(
         sender
-            .burn(AccountOwner::Chain, Amount::from_tokens(3))
+            .burn(MultiAddress::Chain, Amount::from_tokens(3))
             .await,
         Err(ChainClientError::CannotFindKeyForChain(_))
     );
@@ -382,7 +382,7 @@ where
     sender.synchronize_from_validators().await.unwrap();
     // Can still use the chain with the old client.
     sender
-        .burn(AccountOwner::Chain, Amount::from_tokens(2))
+        .burn(MultiAddress::Chain, Amount::from_tokens(2))
         .await
         .unwrap();
     assert_eq!(sender.next_block_height(), BlockHeight::from(2));
@@ -409,7 +409,7 @@ where
 
     // We need at least three validators for making an operation.
     builder.set_fault_type([0, 1], FaultType::Offline).await;
-    let result = client.burn(AccountOwner::Chain, Amount::ONE).await;
+    let result = client.burn(MultiAddress::Chain, Amount::ONE).await;
     assert_matches!(
         result,
         Err(ChainClientError::CommunicationError(
@@ -419,7 +419,7 @@ where
     builder.set_fault_type([0, 1], FaultType::Honest).await;
     builder.set_fault_type([2, 3], FaultType::Offline).await;
     assert_matches!(
-        sender.burn(AccountOwner::Chain, Amount::ONE).await,
+        sender.burn(MultiAddress::Chain, Amount::ONE).await,
         Err(ChainClientError::CommunicationError(
             CommunicationError::Trusted(ClientIoError { .. })
         ))
@@ -438,7 +438,7 @@ where
     );
     client.clear_pending_proposal();
     client
-        .burn(AccountOwner::Chain, Amount::ONE)
+        .burn(MultiAddress::Chain, Amount::ONE)
         .await
         .unwrap()
         .unwrap();
@@ -448,7 +448,7 @@ where
     sender.process_inbox().await.unwrap();
     assert_eq!(sender.local_balance().await.unwrap(), Amount::ONE);
     sender.clear_pending_proposal();
-    sender.burn(AccountOwner::Chain, Amount::ONE).await.unwrap();
+    sender.burn(MultiAddress::Chain, Amount::ONE).await.unwrap();
 
     // That's it, we spent all our money on this test!
     assert_eq!(sender.local_balance().await.unwrap(), Amount::ZERO);
@@ -535,7 +535,7 @@ where
     // Transfer before creating the chain. The validators will ignore the cross-chain messages.
     sender
         .transfer_to_account(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::from_tokens(2),
             Account::chain(new_id),
         )
@@ -581,7 +581,7 @@ where
     // process the cross-chain messages.
     let certificate2 = sender
         .transfer_to_account(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::from_tokens(1),
             Account::chain(new_id),
         )
@@ -597,7 +597,7 @@ where
         Amount::from_tokens(3)
     );
     client
-        .burn(AccountOwner::Chain, Amount::from_tokens(3))
+        .burn(MultiAddress::Chain, Amount::from_tokens(3))
         .await
         .unwrap();
     Ok(())
@@ -626,7 +626,7 @@ where
     // Transfer before creating the chain.
     sender
         .transfer_to_account(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::from_tokens(3),
             Account::chain(new_id),
         )
@@ -668,7 +668,7 @@ where
         .await
         .unwrap();
     let result = client
-        .burn(AccountOwner::Chain, Amount::from_tokens(3))
+        .burn(MultiAddress::Chain, Amount::from_tokens(3))
         .await;
     assert_matches!(
         result,
@@ -710,7 +710,7 @@ where
     // Transfer after creating the chain.
     let transfer_certificate = sender
         .transfer_to_account(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::from_tokens(3),
             Account::chain(new_id),
         )
@@ -739,7 +739,7 @@ where
         Amount::from_tokens(3)
     );
     client
-        .burn(AccountOwner::Chain, Amount::from_tokens(3))
+        .burn(MultiAddress::Chain, Amount::from_tokens(3))
         .await
         .unwrap();
     assert_eq!(client.local_balance().await.unwrap(), Amount::ZERO);
@@ -780,7 +780,7 @@ where
     );
     // Cannot use the chain for operations any more.
     let result = client1
-        .burn(AccountOwner::Chain, Amount::from_tokens(3))
+        .burn(MultiAddress::Chain, Amount::from_tokens(3))
         .await;
     assert!(
         matches!(
@@ -796,7 +796,7 @@ where
     // Incoming messages now get rejected.
     client2
         .transfer_to_account(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::from_tokens(3),
             Account::chain(client1.chain_id()),
         )
@@ -854,7 +854,7 @@ where
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let result = sender
         .transfer_to_account_unsafe_unconfirmed(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::from_tokens(3),
             Account::chain(ChainId::root(2)),
         )
@@ -904,7 +904,7 @@ where
     );
     let certificate = client1
         .transfer_to_account(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::from_tokens(3),
             Account::chain(client2.chain_id),
         )
@@ -953,7 +953,7 @@ where
     assert_eq!(client2.next_block_height(), BlockHeight::ZERO);
     client2
         .transfer_to_account(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::ONE,
             Account::chain(client1.chain_id),
         )
@@ -999,7 +999,7 @@ where
     let client2 = builder.add_root_chain(2, Amount::ZERO).await?;
     let certificate = client1
         .transfer_to_account_unsafe_unconfirmed(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::from_tokens(2),
             Account::chain(client2.chain_id),
         )
@@ -1049,7 +1049,7 @@ where
     // Confirming to a quorum of nodes only at the end.
     client1
         .transfer_to_account_unsafe_unconfirmed(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::ONE,
             Account::chain(client2.chain_id),
         )
@@ -1057,7 +1057,7 @@ where
         .unwrap();
     client1
         .transfer_to_account_unsafe_unconfirmed(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::ONE,
             Account::chain(client2.chain_id),
         )
@@ -1077,7 +1077,7 @@ where
     // Sending money from client2 fails, as a consequence.
     let obtained_error = client2
         .transfer_to_account_unsafe_unconfirmed(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::from_tokens(2),
             Account::chain(client3.chain_id),
         )
@@ -1094,7 +1094,7 @@ where
     client2.synchronize_from_validators().await.unwrap();
     let certificate = client2
         .transfer_to_account(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::from_tokens(2),
             Account::chain(client3.chain_id),
         )
@@ -1170,7 +1170,7 @@ where
     // Sending money from the admin chain is supported.
     let cert = admin
         .transfer_to_account(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::from_tokens(2),
             Account::chain(user.chain_id()),
         )
@@ -1179,7 +1179,7 @@ where
         .unwrap();
     admin
         .transfer_to_account(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::ONE,
             Account::chain(user.chain_id()),
         )
@@ -1205,7 +1205,7 @@ where
     // Try to make a transfer back to the admin chain.
     let cert = user
         .transfer_to_account(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::from_tokens(2),
             Account::chain(admin.chain_id()),
         )
@@ -1221,7 +1221,7 @@ where
     // Try again to make a transfer back to the admin chain.
     let cert = user
         .transfer_to_account(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::ONE,
             Account::chain(admin.chain_id()),
         )
@@ -1251,12 +1251,12 @@ where
     let sender = builder.add_root_chain(1, Amount::from_tokens(3)).await?;
 
     let obtained_error = sender
-        .burn(AccountOwner::Chain, Amount::from_tokens(4))
+        .burn(MultiAddress::Chain, Amount::from_tokens(4))
         .await;
     assert_insufficient_funding_during_operation(obtained_error, 0);
 
     let obtained_error = sender
-        .burn(AccountOwner::Chain, Amount::from_tokens(3))
+        .burn(MultiAddress::Chain, Amount::from_tokens(3))
         .await;
     assert_insufficient_funding_fees(obtained_error);
     Ok(())
@@ -1421,7 +1421,7 @@ where
         *info2_b.manager.requested_locking.unwrap()
     );
     let bt_certificate = client2_b
-        .burn(AccountOwner::Chain, Amount::from_tokens(1))
+        .burn(MultiAddress::Chain, Amount::from_tokens(1))
         .await
         .unwrap()
         .unwrap();
@@ -1438,7 +1438,7 @@ where
         .body
         .operations
         .contains(&Operation::System(SystemOperation::Transfer {
-            owner: AccountOwner::Chain,
+            owner: MultiAddress::Chain,
             recipient: Recipient::Burn,
             amount: Amount::from_tokens(1),
         })));
@@ -1548,7 +1548,7 @@ where
 
     client2_b.prepare_chain().await.unwrap();
     let bt_certificate = client2_b
-        .burn(AccountOwner::Chain, Amount::from_tokens(1))
+        .burn(MultiAddress::Chain, Amount::from_tokens(1))
         .await
         .unwrap()
         .unwrap();
@@ -1565,7 +1565,7 @@ where
         .body
         .operations
         .contains(&Operation::System(SystemOperation::Transfer {
-            owner: AccountOwner::Chain,
+            owner: MultiAddress::Chain,
             recipient: Recipient::Burn,
             amount: Amount::from_tokens(1),
         })));
@@ -1897,7 +1897,7 @@ where
 
     // The other owner is leader now. Trying to submit a block should return `WaitForTimeout`.
     let result = client
-        .transfer(AccountOwner::Chain, Amount::ONE, Recipient::root(2))
+        .transfer(MultiAddress::Chain, Amount::ONE, Recipient::root(2))
         .await
         .unwrap();
     let timeout = match result {
@@ -1924,7 +1924,7 @@ where
 
     // Now we are the leader, and the transfer should succeed.
     let _certificate = client
-        .transfer(AccountOwner::Chain, Amount::ONE, Recipient::root(2))
+        .transfer(MultiAddress::Chain, Amount::ONE, Recipient::root(2))
         .await
         .unwrap()
         .unwrap();
@@ -1982,7 +1982,7 @@ where
         .set_fault_type([2], FaultType::OfflineWithInfo)
         .await;
     let result = client0
-        .burn(AccountOwner::Chain, Amount::from_tokens(3))
+        .burn(MultiAddress::Chain, Amount::from_tokens(3))
         .await;
     assert!(result.is_err());
 
@@ -2025,7 +2025,7 @@ where
     // Client 0 now only tries to burn 1 token. Before that, they automatically finalize the
     // pending block, which publishes the blob, leaving 10 - 1 = 9.
     client0
-        .burn(AccountOwner::Chain, Amount::from_tokens(1))
+        .burn(MultiAddress::Chain, Amount::from_tokens(1))
         .await
         .unwrap();
     client0.synchronize_from_validators().await.unwrap();
@@ -2039,7 +2039,7 @@ where
     // Burn another token so Client 1 sees that the blob is already published
     client1.prepare_chain().await.unwrap();
     client1
-        .burn(AccountOwner::Chain, Amount::from_tokens(1))
+        .burn(MultiAddress::Chain, Amount::from_tokens(1))
         .await
         .unwrap();
     client1.synchronize_from_validators().await.unwrap();
@@ -2071,7 +2071,7 @@ where
         .set_fault_type([2], FaultType::OfflineWithInfo)
         .await;
     let result = client
-        .burn(AccountOwner::Chain, Amount::from_tokens(3))
+        .burn(MultiAddress::Chain, Amount::from_tokens(3))
         .await;
     assert!(result.is_err());
 
@@ -2080,7 +2080,7 @@ where
 
     // The client tries to burn another token. Before that, they automatically finalize the
     // pending block, which burns 3 tokens, leaving 10 - 3 - 1 = 6.
-    client.burn(AccountOwner::Chain, Amount::ONE).await.unwrap();
+    client.burn(MultiAddress::Chain, Amount::ONE).await.unwrap();
     client.synchronize_from_validators().await.unwrap();
     client.process_inbox().await.unwrap();
     assert_eq!(
@@ -2131,7 +2131,7 @@ where
         .await;
     builder.set_fault_type([3], FaultType::Offline).await;
     let result = client0
-        .burn(AccountOwner::Chain, Amount::from_tokens(3))
+        .burn(MultiAddress::Chain, Amount::from_tokens(3))
         .await;
     assert!(result.is_err());
     let manager = client0
@@ -2169,7 +2169,7 @@ where
     assert!(manager.requested_locking.is_none());
     assert_eq!(manager.current_round, Round::MultiLeader(0));
     let result = client1
-        .burn(AccountOwner::Chain, Amount::from_tokens(2))
+        .burn(MultiAddress::Chain, Amount::from_tokens(2))
         .await;
     assert!(result.is_err());
 
@@ -2190,7 +2190,7 @@ where
     assert_eq!(manager.current_round, Round::MultiLeader(1));
     assert!(client1.pending_proposal().is_some());
     client1
-        .burn(AccountOwner::Chain, Amount::from_tokens(4))
+        .burn(MultiAddress::Chain, Amount::from_tokens(4))
         .await
         .unwrap();
 
@@ -2217,7 +2217,7 @@ where
     let mut receiver = builder.add_root_chain(2, Amount::ZERO).await?;
     let recipient = Recipient::chain(receiver.chain_id());
     let cert = sender
-        .transfer(AccountOwner::Chain, Amount::ONE, recipient)
+        .transfer(MultiAddress::Chain, Amount::ONE, recipient)
         .await
         .unwrap()
         .unwrap();
@@ -2303,7 +2303,7 @@ where
     // Send a message from chain 2 to chain 3.
     let certificate = client2
         .transfer(
-            AccountOwner::Chain,
+            MultiAddress::Chain,
             Amount::from_millis(1),
             Recipient::chain(chain_id3),
         )

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -20,7 +20,7 @@ use async_graphql::Request;
 use counter::CounterAbi;
 use linera_base::{
     data_types::{Amount, Bytecode, Event, OracleResponse},
-    identifiers::{AccountOwner, ApplicationId, BlobId, BlobType, StreamId, StreamName},
+    identifiers::{ApplicationId, BlobId, BlobType, MultiAddress, StreamId, StreamName},
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
 };
@@ -554,9 +554,9 @@ where
     let module_id = module_id
         .with_abi::<fungible::FungibleTokenAbi, fungible::Parameters, fungible::InitialState>();
 
-    let sender_owner = AccountOwner::from(sender.key_pair().await?.public());
-    let receiver_owner = AccountOwner::from(receiver.key_pair().await?.public());
-    let receiver2_owner = AccountOwner::from(receiver2.key_pair().await?.public());
+    let sender_owner = MultiAddress::from(sender.key_pair().await?.public());
+    let receiver_owner = MultiAddress::from(receiver.key_pair().await?.public());
+    let receiver2_owner = MultiAddress::from(receiver2.key_pair().await?.public());
 
     let accounts = BTreeMap::from_iter([(sender_owner, Amount::from_tokens(1_000_000))]);
     let state = fungible::InitialState { accounts };

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -23,7 +23,7 @@ use linera_base::{
     data_types::*,
     hashed::Hashed,
     identifiers::{
-        Account, AccountOwner, ChainDescription, ChainId, Destination, EventId, MessageId, Owner,
+        Account, ChainDescription, ChainId, Destination, EventId, MessageId, MultiAddress, Owner,
         StreamId,
     },
     ownership::{ChainOwnership, TimeoutConfig},
@@ -203,7 +203,7 @@ where
         chain_description,
         key_pair,
         Some(key_pair.public().into()),
-        AccountOwner::Chain,
+        MultiAddress::Chain,
         Recipient::chain(target_id),
         amount,
         incoming_bundles,
@@ -222,13 +222,13 @@ async fn make_transfer_certificate<S>(
     chain_description: ChainDescription,
     key_pair: &AccountSecretKey,
     authenticated_signer: Option<Owner>,
-    source: AccountOwner,
+    source: MultiAddress,
     recipient: Recipient,
     amount: Amount,
     incoming_bundles: Vec<IncomingBundle>,
     committee: &Committee,
     balance: Amount,
-    balances: BTreeMap<AccountOwner, Amount>,
+    balances: BTreeMap<MultiAddress, Amount>,
     worker: &WorkerState<S>,
     previous_confirmed_block: Option<&ConfirmedBlockCertificate>,
 ) -> ConfirmedBlockCertificate
@@ -258,14 +258,14 @@ async fn make_transfer_certificate_for_epoch<S>(
     chain_description: ChainDescription,
     key_pair: &AccountSecretKey,
     authenticated_signer: Option<Owner>,
-    source: AccountOwner,
+    source: MultiAddress,
     recipient: Recipient,
     amount: Amount,
     incoming_bundles: Vec<IncomingBundle>,
     epoch: Epoch,
     committee: &Committee,
     balance: Amount,
-    balances: BTreeMap<AccountOwner, Amount>,
+    balances: BTreeMap<MultiAddress, Amount>,
     worker: &WorkerState<S>,
     previous_confirmed_block: Option<&ConfirmedBlockCertificate>,
 ) -> ConfirmedBlockCertificate
@@ -372,16 +372,16 @@ fn direct_outgoing_message(
 
 fn system_credit_message(amount: Amount) -> Message {
     Message::System(SystemMessage::Credit {
-        source: AccountOwner::Chain,
-        target: AccountOwner::Chain,
+        source: MultiAddress::Chain,
+        target: MultiAddress::Chain,
         amount,
     })
 }
 
 fn direct_credit_message(recipient: ChainId, amount: Amount) -> OutgoingMessage {
     let message = SystemMessage::Credit {
-        source: AccountOwner::Chain,
-        target: AccountOwner::Chain,
+        source: MultiAddress::Chain,
+        target: MultiAddress::Chain,
         amount,
     };
     direct_outgoing_message(recipient, MessageKind::Tracked, message)
@@ -1390,7 +1390,7 @@ where
         ChainDescription::Root(2),
         &sender_key_pair,
         Some(chain_key_pair.public().into()),
-        AccountOwner::Chain,
+        MultiAddress::Chain,
         Recipient::chain(ChainId::root(2)),
         Amount::from_tokens(5),
         Vec::new(),
@@ -2091,14 +2091,14 @@ where
     let sender = Owner::from(sender_key_pair.public());
     let sender_account = Account {
         chain_id: ChainId::root(1),
-        owner: AccountOwner::from(sender),
+        owner: MultiAddress::from(sender),
     };
 
     let recipient_key_pair = AccountSecretKey::generate();
     let recipient = Owner::from(sender_key_pair.public());
     let recipient_account = Account {
         chain_id: ChainId::root(2),
-        owner: AccountOwner::from(recipient),
+        owner: MultiAddress::from(recipient),
     };
 
     let (committee, worker) = init_worker_with_chains(
@@ -2124,7 +2124,7 @@ where
         ChainDescription::Root(1),
         &sender_key_pair,
         Some(Owner::from(sender_key_pair.public())),
-        AccountOwner::Chain,
+        MultiAddress::Chain,
         Recipient::Account(sender_account),
         Amount::from_tokens(5),
         Vec::new(),
@@ -2144,7 +2144,7 @@ where
         ChainDescription::Root(1),
         &sender_key_pair,
         Some(Owner::from(sender_key_pair.public())),
-        AccountOwner::Chain,
+        MultiAddress::Chain,
         Recipient::Burn,
         Amount::ONE,
         vec![IncomingBundle {
@@ -2155,8 +2155,8 @@ where
                 timestamp: Timestamp::from(0),
                 transaction_index: 0,
                 messages: vec![Message::System(SystemMessage::Credit {
-                    source: AccountOwner::Chain,
-                    target: AccountOwner::from(sender),
+                    source: MultiAddress::Chain,
+                    target: MultiAddress::from(sender),
                     amount: Amount::from_tokens(5),
                 })
                 .to_posted(0, MessageKind::Tracked)],
@@ -2165,7 +2165,7 @@ where
         }],
         &committee,
         Amount::ZERO,
-        BTreeMap::from_iter([(AccountOwner::Address32(sender.0), Amount::from_tokens(5))]),
+        BTreeMap::from_iter([(MultiAddress::Address32(sender.0), Amount::from_tokens(5))]),
         &worker,
         Some(&certificate00),
     )
@@ -2186,13 +2186,13 @@ where
         ChainDescription::Root(1),
         &sender_key_pair,
         Some(sender),
-        AccountOwner::from(sender),
+        MultiAddress::from(sender),
         Recipient::Account(recipient_account),
         Amount::from_tokens(3),
         Vec::new(),
         &committee,
         Amount::ZERO,
-        BTreeMap::from_iter([(AccountOwner::Address32(sender.0), Amount::from_tokens(2))]),
+        BTreeMap::from_iter([(MultiAddress::Address32(sender.0), Amount::from_tokens(2))]),
         &worker,
         Some(&certificate01),
     )
@@ -2206,7 +2206,7 @@ where
         ChainDescription::Root(1),
         &sender_key_pair,
         Some(sender),
-        AccountOwner::from(sender),
+        MultiAddress::from(sender),
         Recipient::Account(recipient_account),
         Amount::from_tokens(2),
         Vec::new(),
@@ -2227,7 +2227,7 @@ where
         ChainDescription::Root(2),
         &recipient_key_pair,
         Some(recipient),
-        AccountOwner::from(recipient),
+        MultiAddress::from(recipient),
         Recipient::Burn,
         Amount::ONE,
         vec![
@@ -2239,8 +2239,8 @@ where
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
                     messages: vec![Message::System(SystemMessage::Credit {
-                        source: AccountOwner::from(sender),
-                        target: AccountOwner::from(recipient),
+                        source: MultiAddress::from(sender),
+                        target: MultiAddress::from(recipient),
                         amount: Amount::from_tokens(3),
                     })
                     .to_posted(0, MessageKind::Tracked)],
@@ -2255,8 +2255,8 @@ where
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
                     messages: vec![Message::System(SystemMessage::Credit {
-                        source: AccountOwner::from(sender),
-                        target: AccountOwner::from(recipient),
+                        source: MultiAddress::from(sender),
+                        target: MultiAddress::from(recipient),
                         amount: Amount::from_tokens(2),
                     })
                     .to_posted(0, MessageKind::Tracked)],
@@ -2266,7 +2266,7 @@ where
         ],
         &committee,
         Amount::ZERO,
-        BTreeMap::from_iter([(AccountOwner::Address32(recipient.0), Amount::from_tokens(1))]),
+        BTreeMap::from_iter([(MultiAddress::Address32(recipient.0), Amount::from_tokens(1))]),
         &worker,
         None,
     )
@@ -2287,7 +2287,7 @@ where
         ChainDescription::Root(1),
         &sender_key_pair,
         Some(sender),
-        AccountOwner::from(sender),
+        MultiAddress::from(sender),
         Recipient::Burn,
         Amount::from_tokens(3),
         vec![IncomingBundle {
@@ -2298,8 +2298,8 @@ where
                 timestamp: Timestamp::from(0),
                 transaction_index: 0,
                 messages: vec![Message::System(SystemMessage::Credit {
-                    source: AccountOwner::from(sender),
-                    target: AccountOwner::from(recipient),
+                    source: MultiAddress::from(sender),
+                    target: MultiAddress::from(recipient),
                     amount: Amount::from_tokens(3),
                 })
                 .to_posted(0, MessageKind::Bouncing)],
@@ -2983,7 +2983,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
         ChainDescription::Root(0),
         &key_pair0,
         Some(key_pair0.public().into()),
-        AccountOwner::Chain,
+        MultiAddress::Chain,
         Recipient::chain(id1),
         Amount::ONE,
         Vec::new(),
@@ -2999,7 +2999,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
         ChainDescription::Root(0),
         &key_pair0,
         Some(key_pair0.public().into()),
-        AccountOwner::Chain,
+        MultiAddress::Chain,
         Recipient::chain(id1),
         Amount::ONE,
         Vec::new(),
@@ -3015,7 +3015,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
         ChainDescription::Root(0),
         &key_pair0,
         Some(key_pair0.public().into()),
-        AccountOwner::Chain,
+        MultiAddress::Chain,
         Recipient::chain(id1),
         Amount::ONE,
         Vec::new(),
@@ -3032,7 +3032,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
         ChainDescription::Root(0),
         &key_pair0,
         Some(key_pair0.public().into()),
-        AccountOwner::Chain,
+        MultiAddress::Chain,
         Recipient::chain(id1),
         Amount::ONE,
         Vec::new(),
@@ -3515,7 +3515,7 @@ where
     // The first round is the multi-leader round 0. Anyone is allowed to propose.
     // But non-owners are not allowed to transfer the chain's funds.
     let proposal = make_child_block(&change_ownership_value)
-        .with_transfer(AccountOwner::Chain, Recipient::Burn, Amount::from_tokens(1))
+        .with_transfer(MultiAddress::Chain, Recipient::Burn, Amount::from_tokens(1))
         .into_proposal_with_round(&AccountSecretKey::generate(), Round::MultiLeader(0));
     let result = worker.handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::ChainError(error)) if matches!(&*error,

--- a/linera-ethereum/src/common.rs
+++ b/linera-ethereum/src/common.rs
@@ -84,7 +84,7 @@ pub enum EthereumServiceError {
 /// entries of Ethereum events.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EthereumDataType {
-    Address(String),
+    MultiAddress(String),
     Uint256(U256),
     Uint64(u64),
     Int64(i64),
@@ -108,7 +108,7 @@ fn parse_entry(entry: B256, ethereum_type: &str) -> Result<EthereumDataType, Eth
     if ethereum_type == "address" {
         let address = Address::from_word(entry);
         let address = format!("{:?}", address);
-        return Ok(EthereumDataType::Address(address));
+        return Ok(EthereumDataType::MultiAddress(address));
     }
     if ethereum_type == "uint256" {
         let entry = U256::from_be_bytes(entry.0);

--- a/linera-ethereum/tests/ethereum_test.rs
+++ b/linera-ethereum/tests/ethereum_test.rs
@@ -66,8 +66,8 @@ async fn test_event_numerics() -> anyhow::Result<()> {
     let big_value = U256::from_str("239675476885367459284564394732743434463843674346373355625")?;
     let target_event = EthereumEvent {
         values: vec![
-            EthereumDataType::Address(addr0.clone()),
-            EthereumDataType::Address(addr0.clone()),
+            EthereumDataType::MultiAddress(addr0.clone()),
+            EthereumDataType::MultiAddress(addr0.clone()),
             EthereumDataType::Uint256(big_value),
             EthereumDataType::Uint64(4611686018427387904),
             EthereumDataType::Int64(-1152921504606846976),
@@ -119,8 +119,8 @@ async fn test_simple_token_events() -> anyhow::Result<()> {
     let value = U256::from(10);
     let target_event = EthereumEvent {
         values: vec![
-            EthereumDataType::Address(addr0),
-            EthereumDataType::Address(addr1),
+            EthereumDataType::MultiAddress(addr0),
+            EthereumDataType::MultiAddress(addr1),
             EthereumDataType::Uint256(value),
         ],
         block_number: 2,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -6,7 +6,7 @@ use std::{mem, vec};
 use futures::{FutureExt, StreamExt};
 use linera_base::{
     data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::{Account, AccountOwner, BlobType, ChainId, Destination, Owner},
+    identifiers::{Account, BlobType, ChainId, Destination, MultiAddress, Owner},
 };
 use linera_views::{
     context::Context,
@@ -370,8 +370,8 @@ where
             amount,
             source: context
                 .authenticated_signer
-                .map(|o| AccountOwner::Address32(o.0))
-                .unwrap_or(AccountOwner::Chain),
+                .map(MultiAddress::from)
+                .unwrap_or(MultiAddress::Chain),
             target: account.owner,
         };
         txn_tracker.add_outgoing_message(

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -17,7 +17,7 @@ use linera_base::prometheus_util::{
 use linera_base::{
     data_types::{Amount, ApplicationPermissions, BlobContent, BlockHeight, Timestamp},
     ensure, hex_debug, hex_vec_debug, http,
-    identifiers::{Account, AccountOwner, BlobId, BlobType, ChainId, MessageId, Owner},
+    identifiers::{Account, BlobId, BlobType, ChainId, MessageId, MultiAddress, Owner},
     ownership::ChainOwnership,
 };
 use linera_views::{batch::Batch, context::Context, views::View};
@@ -544,23 +544,23 @@ pub enum ExecutionRequest {
     },
 
     OwnerBalance {
-        owner: AccountOwner,
+        owner: MultiAddress,
         #[debug(skip)]
         callback: Sender<Amount>,
     },
 
     OwnerBalances {
         #[debug(skip)]
-        callback: Sender<Vec<(AccountOwner, Amount)>>,
+        callback: Sender<Vec<(MultiAddress, Amount)>>,
     },
 
     BalanceOwners {
         #[debug(skip)]
-        callback: Sender<Vec<AccountOwner>>,
+        callback: Sender<Vec<MultiAddress>>,
     },
 
     Transfer {
-        source: AccountOwner,
+        source: MultiAddress,
         destination: Account,
         amount: Amount,
         #[debug(skip_if = Option::is_none)]

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -7,7 +7,7 @@ use linera_base::{
     crypto::ValidatorPublicKey,
     data_types::{Amount, Timestamp},
     doc_scalar,
-    identifiers::{AccountOwner, ChainDescription, ChainId},
+    identifiers::{ChainDescription, ChainId, MultiAddress},
     ownership::ChainOwnership,
 };
 use linera_views::{context::Context, map_view::MapView};
@@ -94,7 +94,7 @@ impl<C: Send + Sync + Context> SystemExecutionStateView<C> {
     }
 
     #[graphql(derived(name = "balances"))]
-    async fn _balances(&self) -> &MapView<C, AccountOwner, Amount> {
+    async fn _balances(&self) -> &MapView<C, MultiAddress, Amount> {
         &self.balances
     }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -42,8 +42,9 @@ use linera_base::{
     },
     doc_scalar, hex_debug, http,
     identifiers::{
-        Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, ChannelName, Destination,
-        EventId, GenericApplicationId, MessageId, ModuleId, Owner, StreamName, UserApplicationId,
+        Account, ApplicationId, BlobId, BlobType, ChainId, ChannelName, Destination, EventId,
+        GenericApplicationId, MessageId, ModuleId, MultiAddress, Owner, StreamName,
+        UserApplicationId,
     },
     ownership::ChainOwnership,
     task,
@@ -524,13 +525,13 @@ pub trait BaseRuntime {
     fn read_chain_balance(&mut self) -> Result<Amount, ExecutionError>;
 
     /// Reads the owner balance.
-    fn read_owner_balance(&mut self, owner: AccountOwner) -> Result<Amount, ExecutionError>;
+    fn read_owner_balance(&mut self, owner: MultiAddress) -> Result<Amount, ExecutionError>;
 
     /// Reads the balances from all owners.
-    fn read_owner_balances(&mut self) -> Result<Vec<(AccountOwner, Amount)>, ExecutionError>;
+    fn read_owner_balances(&mut self) -> Result<Vec<(MultiAddress, Amount)>, ExecutionError>;
 
     /// Reads balance owners.
-    fn read_balance_owners(&mut self) -> Result<Vec<AccountOwner>, ExecutionError>;
+    fn read_balance_owners(&mut self) -> Result<Vec<MultiAddress>, ExecutionError>;
 
     /// Reads the current ownership configuration for this chain.
     fn chain_ownership(&mut self) -> Result<ChainOwnership, ExecutionError>;
@@ -712,7 +713,7 @@ pub trait ContractRuntime: BaseRuntime {
     /// Transfers amount from source to destination.
     fn transfer(
         &mut self,
-        source: AccountOwner,
+        source: MultiAddress,
         destination: Account,
         amount: Amount,
     ) -> Result<(), ExecutionError>;
@@ -996,7 +997,7 @@ impl OperationContext {
     fn refund_grant_to(&self) -> Option<Account> {
         self.authenticated_signer.map(|owner| Account {
             chain_id: self.chain_id,
-            owner: AccountOwner::from(owner),
+            owner: MultiAddress::from(owner),
         })
     }
 

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -9,7 +9,7 @@ use custom_debug_derive::Debug;
 use linera_base::{
     data_types::{Amount, ArithmeticError, BlobContent},
     ensure,
-    identifiers::{AccountOwner, Owner},
+    identifiers::{MultiAddress, Owner},
 };
 use linera_views::{context::Context, views::ViewError};
 use serde::Serialize;
@@ -528,7 +528,7 @@ impl ResourceController<Option<Owner>, ResourceTracker> {
         if let Some(owner) = &self.account {
             if let Some(balance) = view
                 .balances
-                .get_mut(&AccountOwner::Address32(owner.0))
+                .get_mut(&MultiAddress::Address32(owner.0))
                 .await?
             {
                 sources.push(balance);

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -18,7 +18,7 @@ use linera_base::{
     },
     ensure, http,
     identifiers::{
-        Account, AccountOwner, BlobId, BlobType, ChainId, ChannelFullName, ChannelName, MessageId,
+        Account, BlobId, BlobType, ChainId, ChannelFullName, ChannelName, MessageId, MultiAddress,
         Owner, StreamId, StreamName,
     },
     ownership::ChainOwnership,
@@ -634,21 +634,21 @@ where
             .recv_response()
     }
 
-    fn read_owner_balance(&mut self, owner: AccountOwner) -> Result<Amount, ExecutionError> {
+    fn read_owner_balance(&mut self, owner: MultiAddress) -> Result<Amount, ExecutionError> {
         self.inner()
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::OwnerBalance { owner, callback })?
             .recv_response()
     }
 
-    fn read_owner_balances(&mut self) -> Result<Vec<(AccountOwner, Amount)>, ExecutionError> {
+    fn read_owner_balances(&mut self) -> Result<Vec<(MultiAddress, Amount)>, ExecutionError> {
         self.inner()
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::OwnerBalances { callback })?
             .recv_response()
     }
 
-    fn read_balance_owners(&mut self) -> Result<Vec<AccountOwner>, ExecutionError> {
+    fn read_balance_owners(&mut self) -> Result<Vec<MultiAddress>, ExecutionError> {
         self.inner()
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::BalanceOwners { callback })?
@@ -1217,7 +1217,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
 
     fn transfer(
         &mut self,
-        source: AccountOwner,
+        source: MultiAddress,
         destination: Account,
         amount: Amount,
     ) -> Result<(), ExecutionError> {

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -16,7 +16,7 @@ use linera_base::{
     crypto::{BcsSignable, CryptoHash},
     data_types::{Amount, Blob, BlockHeight, CompressedBytecode, OracleResponse, Timestamp},
     identifiers::{
-        AccountOwner, BlobId, BlobType, ChainId, MessageId, ModuleId, Owner, UserApplicationId,
+        BlobId, BlobType, ChainId, MessageId, ModuleId, MultiAddress, Owner, UserApplicationId,
     },
     vm::VmRuntime,
 };
@@ -243,11 +243,11 @@ impl QueryContext {
     }
 }
 
-/// Creates a [`Strategy`] for creating a [`BTreeMap`] of [`AccountOwner`]s with an initial
+/// Creates a [`Strategy`] for creating a [`BTreeMap`] of [`MultiAddress`]s with an initial
 /// non-zero [`Amount`] of tokens.
-pub fn test_accounts_strategy() -> impl Strategy<Value = BTreeMap<AccountOwner, Amount>> {
+pub fn test_accounts_strategy() -> impl Strategy<Value = BTreeMap<MultiAddress, Amount>> {
     proptest::collection::btree_map(
-        any::<AccountOwner>(),
+        any::<MultiAddress>(),
         (1_u128..).prop_map(Amount::from_tokens),
         0..5,
     )

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -11,7 +11,7 @@ use custom_debug_derive::Debug;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, ApplicationPermissions, Blob, Timestamp},
-    identifiers::{AccountOwner, BlobId, ChainDescription, ChainId, Owner, UserApplicationId},
+    identifiers::{BlobId, ChainDescription, ChainId, MultiAddress, Owner, UserApplicationId},
     ownership::ChainOwnership,
 };
 use linera_views::{
@@ -41,7 +41,7 @@ pub struct SystemExecutionState {
     pub ownership: ChainOwnership,
     pub balance: Amount,
     #[debug(skip_if = BTreeMap::is_empty)]
-    pub balances: BTreeMap<AccountOwner, Amount>,
+    pub balances: BTreeMap<MultiAddress, Amount>,
     pub timestamp: Timestamp,
     pub used_blobs: BTreeSet<BlobId>,
     #[debug(skip_if = Not::not)]

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -128,7 +128,7 @@ async fn open_chain_message_index() {
 /// Tests if an account is removed from storage if it is drained.
 #[tokio::test]
 async fn empty_accounts_are_removed() -> anyhow::Result<()> {
-    let owner = AccountOwner::Address32(CryptoHash::test_hash("account owner"));
+    let owner = MultiAddress::Address32(CryptoHash::test_hash("account owner"));
     let amount = Amount::from_tokens(99);
 
     let mut view = SystemExecutionState {

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -8,7 +8,7 @@ use linera_base::{
     data_types::{Amount, ApplicationPermissions, BlockHeight, SendMessageRequest, Timestamp},
     http,
     identifiers::{
-        Account, AccountOwner, ChainId, ChannelName, MessageId, Owner, StreamName,
+        Account, ChainId, ChannelName, MessageId, MultiAddress, Owner, StreamName,
         UserApplicationId,
     },
     ownership::{ChainOwnership, ChangeApplicationPermissionsError, CloseChainError},
@@ -159,7 +159,7 @@ where
     /// Returns the balance of one of the accounts on this chain.
     fn read_owner_balance(
         caller: &mut Caller,
-        owner: AccountOwner,
+        owner: MultiAddress,
     ) -> Result<Amount, RuntimeError> {
         caller
             .user_data_mut()
@@ -171,7 +171,7 @@ where
     /// Returns the balances of all accounts on the chain.
     fn read_owner_balances(
         caller: &mut Caller,
-    ) -> Result<Vec<(AccountOwner, Amount)>, RuntimeError> {
+    ) -> Result<Vec<(MultiAddress, Amount)>, RuntimeError> {
         caller
             .user_data_mut()
             .runtime
@@ -180,7 +180,7 @@ where
     }
 
     /// Returns the owners of accounts on this chain.
-    fn read_balance_owners(caller: &mut Caller) -> Result<Vec<AccountOwner>, RuntimeError> {
+    fn read_balance_owners(caller: &mut Caller) -> Result<Vec<MultiAddress>, RuntimeError> {
         caller
             .user_data_mut()
             .runtime
@@ -474,7 +474,7 @@ where
     /// balance) to `destination`.
     fn transfer(
         caller: &mut Caller,
-        source: AccountOwner,
+        source: MultiAddress,
         destination: Account,
         amount: Amount,
     ) -> Result<(), RuntimeError> {

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -17,7 +17,7 @@ use linera_base::{
     },
     http,
     identifiers::{
-        Account, AccountOwner, ChainDescription, ChainId, ModuleId, Owner, UserApplicationId,
+        Account, ChainDescription, ChainId, ModuleId, MultiAddress, Owner, UserApplicationId,
     },
     ownership::ChainOwnership,
     vm::VmRuntime,
@@ -514,7 +514,7 @@ async fn test_read_chain_balance_system_api(chain_balance: Amount) {
 /// Tests the contract system API to read a single account balance.
 #[proptest(async = "tokio")]
 async fn test_read_owner_balance_system_api(
-    #[strategy(test_accounts_strategy())] accounts: BTreeMap<AccountOwner, Amount>,
+    #[strategy(test_accounts_strategy())] accounts: BTreeMap<MultiAddress, Amount>,
 ) {
     let mut view = SystemExecutionState {
         description: Some(ChainDescription::Root(0)),
@@ -556,7 +556,7 @@ async fn test_read_owner_balance_system_api(
 
 /// Tests if reading the balance of a missing account returns zero.
 #[proptest(async = "tokio")]
-async fn test_read_owner_balance_returns_zero_for_missing_accounts(missing_account: AccountOwner) {
+async fn test_read_owner_balance_returns_zero_for_missing_accounts(missing_account: MultiAddress) {
     let mut view = SystemExecutionState {
         description: Some(ChainDescription::Root(0)),
         ..SystemExecutionState::default()
@@ -598,7 +598,7 @@ async fn test_read_owner_balance_returns_zero_for_missing_accounts(missing_accou
 /// Tests the contract system API to read all account balances.
 #[proptest(async = "tokio")]
 async fn test_read_owner_balances_system_api(
-    #[strategy(test_accounts_strategy())] accounts: BTreeMap<AccountOwner, Amount>,
+    #[strategy(test_accounts_strategy())] accounts: BTreeMap<MultiAddress, Amount>,
 ) {
     let mut view = SystemExecutionState {
         description: Some(ChainDescription::Root(0)),
@@ -642,7 +642,7 @@ async fn test_read_owner_balances_system_api(
 /// Tests the contract system API to read all account owners.
 #[proptest(async = "tokio")]
 async fn test_read_balance_owners_system_api(
-    #[strategy(test_accounts_strategy())] accounts: BTreeMap<AccountOwner, Amount>,
+    #[strategy(test_accounts_strategy())] accounts: BTreeMap<MultiAddress, Amount>,
 ) {
     let mut view = SystemExecutionState {
         description: Some(ChainDescription::Root(0)),
@@ -756,14 +756,14 @@ impl TransferTestEndpoint {
                 let owner = Self::sender_owner();
                 (
                     Amount::ZERO,
-                    vec![(AccountOwner::Address32(owner.0), transfer_amount)],
+                    vec![(MultiAddress::Address32(owner.0), transfer_amount)],
                     Some(owner),
                 )
             }
             TransferTestEndpoint::Application => (
                 Amount::ZERO,
                 vec![(
-                    AccountOwner::Address32(Self::sender_application_id().0),
+                    MultiAddress::Address32(Self::sender_application_id().0),
                     transfer_amount,
                 )],
                 None,
@@ -784,26 +784,26 @@ impl TransferTestEndpoint {
         }
     }
 
-    /// Returns the [`AccountOwner`] to represent this transfer endpoint as a sender.
-    pub fn sender_account_owner(&self) -> AccountOwner {
+    /// Returns the [`MultiAddress`] to represent this transfer endpoint as a sender.
+    pub fn sender_account_owner(&self) -> MultiAddress {
         match self {
-            TransferTestEndpoint::Chain => AccountOwner::Chain,
-            TransferTestEndpoint::User => AccountOwner::Address32(Self::sender_owner().0),
+            TransferTestEndpoint::Chain => MultiAddress::Chain,
+            TransferTestEndpoint::User => MultiAddress::Address32(Self::sender_owner().0),
             TransferTestEndpoint::Application => {
-                AccountOwner::Address32(Self::sender_application_id().0)
+                MultiAddress::Address32(Self::sender_application_id().0)
             }
         }
     }
 
-    /// Returns the [`AccountOwner`] to represent this transfer endpoint as an unauthorized sender.
-    pub fn unauthorized_sender_account_owner(&self) -> AccountOwner {
+    /// Returns the [`MultiAddress`] to represent this transfer endpoint as an unauthorized sender.
+    pub fn unauthorized_sender_account_owner(&self) -> MultiAddress {
         match self {
-            TransferTestEndpoint::Chain => AccountOwner::Chain,
+            TransferTestEndpoint::Chain => MultiAddress::Chain,
             TransferTestEndpoint::User => {
-                AccountOwner::Address32(CryptoHash::test_hash("attacker"))
+                MultiAddress::Address32(CryptoHash::test_hash("attacker"))
             }
             TransferTestEndpoint::Application => {
-                AccountOwner::Address32(Self::recipient_application_id().0)
+                MultiAddress::Address32(Self::recipient_application_id().0)
             }
         }
     }
@@ -828,13 +828,13 @@ impl TransferTestEndpoint {
         }
     }
 
-    /// Returns the [`AccountOwner`] to represent this transfer endpoint as a recipient.
-    pub fn recipient_account_owner(&self) -> AccountOwner {
+    /// Returns the [`MultiAddress`] to represent this transfer endpoint as a recipient.
+    pub fn recipient_account_owner(&self) -> MultiAddress {
         match self {
-            TransferTestEndpoint::Chain => AccountOwner::Chain,
-            TransferTestEndpoint::User => AccountOwner::Address32(Self::recipient_owner().0),
+            TransferTestEndpoint::Chain => MultiAddress::Chain,
+            TransferTestEndpoint::User => MultiAddress::Address32(Self::recipient_owner().0),
             TransferTestEndpoint::Application => {
-                AccountOwner::Address32(Self::recipient_application_id().0)
+                MultiAddress::Address32(Self::recipient_application_id().0)
             }
         }
     }
@@ -847,7 +847,7 @@ impl TransferTestEndpoint {
         amount: Amount,
     ) -> anyhow::Result<()> {
         let (expected_chain_balance, expected_balances) = match self.recipient_account_owner() {
-            AccountOwner::Chain => (amount, vec![]),
+            MultiAddress::Chain => (amount, vec![]),
             account_owner => (Amount::ZERO, vec![(account_owner, amount)]),
         };
 

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -11,7 +11,7 @@ use linera_base::{
     crypto::{AccountPublicKey, CryptoHash},
     data_types::{Amount, BlockHeight, OracleResponse, Timestamp},
     http,
-    identifiers::{Account, AccountOwner, ChainDescription, ChainId, MessageId, Owner},
+    identifiers::{Account, ChainDescription, ChainId, MessageId, MultiAddress, Owner},
 };
 use linera_execution::{
     test_utils::{
@@ -196,7 +196,7 @@ async fn test_fee_consumption(
     let mut oracle_responses = blob_oracle_responses(blobs.iter());
 
     let signer = Owner::from(AccountPublicKey::test_key(0));
-    let owner = AccountOwner::Address32(signer.0);
+    let owner = MultiAddress::Address32(signer.0);
     view.system.balance.set(chain_balance);
     if let Some(owner_balance) = owner_balance {
         view.system.balances.insert(&owner, owner_balance)?;
@@ -270,7 +270,7 @@ async fn test_fee_consumption(
     let refund_grant_to = authenticated_signer
         .map(|owner| Account {
             chain_id: ChainId::root(0),
-            owner: AccountOwner::from(owner),
+            owner: MultiAddress::from(owner),
         })
         .or(None);
     let context = MessageContext {

--- a/linera-execution/tests/service_runtime_apis.rs
+++ b/linera-execution/tests/service_runtime_apis.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeMap, vec};
 
 use linera_base::{
     data_types::Amount,
-    identifiers::{AccountOwner, ChainDescription},
+    identifiers::{ChainDescription, MultiAddress},
 };
 use linera_execution::{
     test_utils::{
@@ -51,7 +51,7 @@ async fn test_read_chain_balance_system_api(chain_balance: Amount) {
 /// Tests the contract system API to read a single account balance.
 #[proptest(async = "tokio")]
 async fn test_read_owner_balance_system_api(
-    #[strategy(test_accounts_strategy())] accounts: BTreeMap<AccountOwner, Amount>,
+    #[strategy(test_accounts_strategy())] accounts: BTreeMap<MultiAddress, Amount>,
 ) {
     let mut view = SystemExecutionState {
         description: Some(ChainDescription::Root(0)),
@@ -84,7 +84,7 @@ async fn test_read_owner_balance_system_api(
 
 /// Tests if reading the balance of a missing account returns zero.
 #[proptest(async = "tokio")]
-async fn test_read_owner_balance_returns_zero_for_missing_accounts(missing_account: AccountOwner) {
+async fn test_read_owner_balance_returns_zero_for_missing_accounts(missing_account: MultiAddress) {
     let mut view = SystemExecutionState {
         description: Some(ChainDescription::Root(0)),
         ..SystemExecutionState::default()
@@ -117,7 +117,7 @@ async fn test_read_owner_balance_returns_zero_for_missing_accounts(missing_accou
 /// Tests the contract system API to read all account balances.
 #[proptest(async = "tokio")]
 async fn test_read_owner_balances_system_api(
-    #[strategy(test_accounts_strategy())] accounts: BTreeMap<AccountOwner, Amount>,
+    #[strategy(test_accounts_strategy())] accounts: BTreeMap<MultiAddress, Amount>,
 ) {
     let mut view = SystemExecutionState {
         description: Some(ChainDescription::Root(0)),
@@ -152,7 +152,7 @@ async fn test_read_owner_balances_system_api(
 /// Tests the contract system API to read all account owners.
 #[proptest(async = "tokio")]
 async fn test_read_balance_owners_system_api(
-    #[strategy(test_accounts_strategy())] accounts: BTreeMap<AccountOwner, Amount>,
+    #[strategy(test_accounts_strategy())] accounts: BTreeMap<MultiAddress, Amount>,
 ) {
     let mut view = SystemExecutionState {
         description: Some(ChainDescription::Root(0)),

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -13,7 +13,7 @@ use linera_base::{
         SendMessageRequest, Timestamp,
     },
     identifiers::{
-        Account, AccountOwner, ChainDescription, ChainId, Destination, MessageId, Owner,
+        Account, ChainDescription, ChainId, Destination, MessageId, MultiAddress, Owner,
     },
     ownership::ChainOwnership,
 };
@@ -1288,7 +1288,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
         move |runtime, _context, _operation| {
             assert_eq!(runtime.chain_ownership()?, ownership);
             let destination = Account::chain(ChainId::root(2));
-            runtime.transfer(AccountOwner::Chain, destination, Amount::ONE)?;
+            runtime.transfer(MultiAddress::Chain, destination, Amount::ONE)?;
             let id = runtime.application_id()?;
             let application_permissions = ApplicationPermissions::new_single(id);
             let (actual_message_id, chain_id) =
@@ -1485,11 +1485,11 @@ async fn test_message_receipt_spending_chain_balance(
 
     let (application_id, application, blobs) = view.register_mock_application(0).await?;
 
-    let receiver_chain_account = AccountOwner::Chain;
+    let receiver_chain_account = MultiAddress::Chain;
     let sender_chain_id = ChainId::root(2);
     let recipient = Account {
         chain_id: sender_chain_id,
-        owner: AccountOwner::Chain,
+        owner: MultiAddress::Chain,
     };
 
     application.expect_call(ExpectedCall::execute_message(

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -6,7 +6,7 @@
 use linera_base::{
     crypto::{AccountSecretKey, CryptoHash},
     data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::{AccountOwner, ChainDescription, ChainId, MessageId, Owner},
+    identifiers::{ChainDescription, ChainId, MessageId, MultiAddress, Owner},
     ownership::ChainOwnership,
 };
 use linera_execution::{
@@ -30,7 +30,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
     };
     let mut view = state.into_view().await;
     let operation = SystemOperation::Transfer {
-        owner: AccountOwner::Chain,
+        owner: MultiAddress::Chain,
         amount: Amount::from_tokens(4),
         recipient: Recipient::Burn,
     };
@@ -66,8 +66,8 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
     let mut view = state.into_view().await;
     let message = SystemMessage::Credit {
         amount: Amount::from_tokens(4),
-        target: AccountOwner::Chain,
-        source: AccountOwner::Chain,
+        target: MultiAddress::Chain,
+        source: MultiAddress::Chain,
     };
     let context = MessageContext {
         chain_id: ChainId::root(0),

--- a/linera-explorer/src/components/Entrypoint.test.ts
+++ b/linera-explorer/src/components/Entrypoint.test.ts
@@ -19,7 +19,7 @@ test('Entrypoint mounting', () => {
             name: 'accountOwner',
             type: {
               kind: 'SCALAR',
-              name: 'AccountOwner'
+              name: 'MultiAddress'
             }
           } ],
         }

--- a/linera-explorer/src/components/InputType.test.ts
+++ b/linera-explorer/src/components/InputType.test.ts
@@ -8,7 +8,7 @@ test('InputType mounting', () => {
       props: {
         elt: {
           kind: 'SCALAR',
-          name: 'AccountOwner'
+          name: 'MultiAddress'
         }, offset: false
       },
     })

--- a/linera-indexer/example/tests/test.rs
+++ b/linera-indexer/example/tests/test.rs
@@ -12,7 +12,7 @@ use std::{str::FromStr, sync::LazyLock, time::Duration};
 use linera_base::{
     command::resolve_binary,
     data_types::Amount,
-    identifiers::{Account, AccountOwner, ChainId},
+    identifiers::{Account, ChainId, MultiAddress},
 };
 use linera_indexer_graphql_client::{
     indexer::{plugins, state, Plugins, State},
@@ -76,7 +76,7 @@ fn indexer_running(child: &mut Child) {
 async fn transfer(client: &reqwest::Client, from: ChainId, to: Account, amount: &str) {
     let variables = transfer::Variables {
         chain_id: from,
-        owner: AccountOwner::Chain,
+        owner: MultiAddress::Chain,
         recipient_chain: to.chain_id,
         recipient_account: to.owner,
         amount: Amount::from_str(amount).unwrap(),

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -190,7 +190,7 @@ message ChainInfoQuery {
   bool request_leader_timeout = 8;
 
   // Query the balance of a given owner.
-  AccountOwner request_owner_balance = 9;
+  MultiAddress request_owner_balance = 9;
 
   // Request a signed vote for fallback mode.
   bool request_fallback = 10;
@@ -336,7 +336,7 @@ message CryptoHash {
   bytes bytes = 1;
 }
 
-message AccountOwner {
+message MultiAddress {
   bytes bytes = 1;
 }
 

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -9,7 +9,7 @@ use linera_base::{
     data_types::{BlobContent, BlockHeight},
     ensure,
     hashed::Hashed,
-    identifiers::{AccountOwner, BlobId, ChainId, Owner},
+    identifiers::{BlobId, ChainId, MultiAddress, Owner},
 };
 use linera_chain::{
     data_types::{BlockProposal, LiteValue, ProposalContent},
@@ -778,20 +778,20 @@ impl From<api::BlockHeight> for BlockHeight {
     }
 }
 
-impl TryFrom<AccountOwner> for api::AccountOwner {
+impl TryFrom<MultiAddress> for api::MultiAddress {
     type Error = GrpcProtoConversionError;
 
-    fn try_from(account_owner: AccountOwner) -> Result<Self, Self::Error> {
+    fn try_from(account_owner: MultiAddress) -> Result<Self, Self::Error> {
         Ok(Self {
             bytes: bincode::serialize(&account_owner)?,
         })
     }
 }
 
-impl TryFrom<api::AccountOwner> for AccountOwner {
+impl TryFrom<api::MultiAddress> for MultiAddress {
     type Error = GrpcProtoConversionError;
 
-    fn try_from(account_owner: api::AccountOwner) -> Result<Self, Self::Error> {
+    fn try_from(account_owner: api::MultiAddress) -> Result<Self, Self::Error> {
         Ok(bincode::deserialize(&account_owner.bytes)?)
     }
 }
@@ -1103,7 +1103,7 @@ pub mod tests {
             chain_id: ChainId::root(0),
             test_next_block_height: Some(BlockHeight::from(10)),
             request_committees: false,
-            request_owner_balance: AccountOwner::Chain,
+            request_owner_balance: MultiAddress::Chain,
             request_pending_message_bundles: false,
             request_sent_certificate_hashes_in_range: Some(
                 linera_core::data_types::BlockHeightRange {

--- a/linera-rpc/tests/format.rs
+++ b/linera-rpc/tests/format.rs
@@ -6,7 +6,7 @@ use linera_base::{
     crypto::{AccountPublicKey, AccountSignature, TestString},
     data_types::{BlobContent, OracleResponse, Round},
     hashed::Hashed,
-    identifiers::{AccountOwner, BlobType, ChainDescription, Destination, GenericApplicationId},
+    identifiers::{BlobType, ChainDescription, Destination, GenericApplicationId, MultiAddress},
     ownership::ChainOwnership,
     vm::VmRuntime,
 };
@@ -75,7 +75,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<RpcMessage>(&samples)?;
     tracer.trace_type::<BlobType>(&samples)?;
     tracer.trace_type::<BlobContent>(&samples)?;
-    tracer.trace_type::<AccountOwner>(&samples)?;
+    tracer.trace_type::<MultiAddress>(&samples)?;
     tracer.registry()
 }
 

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -7,15 +7,7 @@ Account:
     - chain_id:
         TYPENAME: ChainId
     - owner:
-        TYPENAME: AccountOwner
-AccountOwner:
-  ENUM:
-    0:
-      Address32:
-        NEWTYPE:
-          TYPENAME: CryptoHash
-    1:
-      Chain: UNIT
+        TYPENAME: MultiAddress
 AccountPublicKey:
   ENUM:
     0:
@@ -288,7 +280,7 @@ ChainInfoQuery:
         OPTION:
           TYPENAME: BlockHeight
     - request_owner_balance:
-        TYPENAME: AccountOwner
+        TYPENAME: MultiAddress
     - request_committees: BOOL
     - request_pending_message_bundles: BOOL
     - request_sent_certificate_hashes_in_range:
@@ -606,6 +598,14 @@ ModuleId:
         TYPENAME: CryptoHash
     - vm_runtime:
         TYPENAME: VmRuntime
+MultiAddress:
+  ENUM:
+    0:
+      Address32:
+        NEWTYPE:
+          TYPENAME: CryptoHash
+    1:
+      Chain: UNIT
 NodeError:
   ENUM:
     0:
@@ -1056,16 +1056,16 @@ SystemMessage:
       Credit:
         STRUCT:
           - target:
-              TYPENAME: AccountOwner
+              TYPENAME: MultiAddress
           - amount:
               TYPENAME: Amount
           - source:
-              TYPENAME: AccountOwner
+              TYPENAME: MultiAddress
     1:
       Withdraw:
         STRUCT:
           - owner:
-              TYPENAME: AccountOwner
+              TYPENAME: MultiAddress
           - amount:
               TYPENAME: Amount
           - recipient:
@@ -1096,7 +1096,7 @@ SystemOperation:
       Transfer:
         STRUCT:
           - owner:
-              TYPENAME: AccountOwner
+              TYPENAME: MultiAddress
           - recipient:
               TYPENAME: Recipient
           - amount:

--- a/linera-sdk/src/abis/fungible.rs
+++ b/linera-sdk/src/abis/fungible.rs
@@ -9,7 +9,7 @@ use async_graphql::{InputObject, Request, Response, SimpleObject};
 use linera_base::{
     abi::{ContractAbi, ServiceAbi},
     data_types::Amount,
-    identifiers::{AccountOwner, ChainId},
+    identifiers::{ChainId, MultiAddress},
 };
 use linera_sdk_derive::GraphQLMutationRootInCrate;
 use serde::{Deserialize, Serialize};
@@ -33,14 +33,14 @@ pub enum Operation {
     /// Requests an account balance.
     Balance {
         /// Owner to query the balance for
-        owner: AccountOwner,
+        owner: MultiAddress,
     },
     /// Requests this fungible token's ticker symbol.
     TickerSymbol,
     /// Transfers tokens from a (locally owned) account to a (possibly remote) account.
     Transfer {
         /// Owner to transfer from
-        owner: AccountOwner,
+        owner: MultiAddress,
         /// Amount to be transferred
         amount: Amount,
         /// Target account to transfer the amount to
@@ -75,7 +75,7 @@ pub enum FungibleResponse {
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct InitialState {
     /// Accounts and their respective initial balances
-    pub accounts: BTreeMap<AccountOwner, Amount>,
+    pub accounts: BTreeMap<MultiAddress, Amount>,
 }
 
 /// The parameters to instantiate fungible with
@@ -112,19 +112,19 @@ pub struct Account {
     /// Chain ID of the account
     pub chain_id: ChainId,
     /// Owner of the account
-    pub owner: AccountOwner,
+    pub owner: MultiAddress,
 }
 
 /// A builder type for constructing the initial state of the application.
 #[derive(Debug, Default)]
 pub struct InitialStateBuilder {
     /// Accounts and their respective initial balances
-    account_balances: BTreeMap<AccountOwner, Amount>,
+    account_balances: BTreeMap<MultiAddress, Amount>,
 }
 
 impl InitialStateBuilder {
     /// Adds an account to the initial state of the application.
-    pub fn with_account(mut self, account: AccountOwner, balance: impl Into<Amount>) -> Self {
+    pub fn with_account(mut self, account: MultiAddress, balance: impl Into<Amount>) -> Self {
         self.account_balances.insert(account, balance.into());
         self
     }

--- a/linera-sdk/src/base/conversions_from_wit.rs
+++ b/linera-sdk/src/base/conversions_from_wit.rs
@@ -7,7 +7,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
     http,
-    identifiers::{AccountOwner, ChainId, Owner, UserApplicationId},
+    identifiers::{ChainId, MultiAddress, Owner, UserApplicationId},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 
@@ -35,13 +35,13 @@ macro_rules! impl_from_wit {
             }
         }
 
-        impl From<$wit_base_api::AccountOwner> for AccountOwner {
-            fn from(account_owner: $wit_base_api::AccountOwner) -> Self {
+        impl From<$wit_base_api::MultiAddress> for MultiAddress {
+            fn from(account_owner: $wit_base_api::MultiAddress) -> Self {
                 match account_owner {
-                    $wit_base_api::AccountOwner::Address32(owner) => {
-                        AccountOwner::Address32(owner.into())
+                    $wit_base_api::MultiAddress::Address32(owner) => {
+                        MultiAddress::Address32(owner.into())
                     }
-                    $wit_base_api::AccountOwner::Chain => AccountOwner::Chain,
+                    $wit_base_api::MultiAddress::Chain => MultiAddress::Chain,
                 }
             }
         }

--- a/linera-sdk/src/base/conversions_to_wit.rs
+++ b/linera-sdk/src/base/conversions_to_wit.rs
@@ -7,7 +7,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{BlockHeight, Timestamp},
     http,
-    identifiers::{AccountOwner, ChainId, Owner, UserApplicationId},
+    identifiers::{ChainId, MultiAddress, Owner, UserApplicationId},
 };
 
 use crate::{
@@ -38,13 +38,13 @@ macro_rules! impl_to_wit {
             }
         }
 
-        impl From<AccountOwner> for $wit_base_api::AccountOwner {
-            fn from(account_owner: AccountOwner) -> Self {
+        impl From<MultiAddress> for $wit_base_api::MultiAddress {
+            fn from(account_owner: MultiAddress) -> Self {
                 match account_owner {
-                    AccountOwner::Address32(owner) => {
-                        $wit_base_api::AccountOwner::Address32(owner.into())
+                    MultiAddress::Address32(owner) => {
+                        $wit_base_api::MultiAddress::Address32(owner.into())
                     }
-                    AccountOwner::Chain => $wit_base_api::AccountOwner::Chain,
+                    MultiAddress::Chain => $wit_base_api::MultiAddress::Chain,
                 }
             }
         }

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -9,7 +9,7 @@ use linera_base::{
         Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, TimeDelta,
     },
     identifiers::{
-        Account, AccountOwner, ChainId, ChannelName, Destination, MessageId, ModuleId, Owner,
+        Account, ChainId, ChannelName, Destination, MessageId, ModuleId, MultiAddress, Owner,
         StreamName, UserApplicationId,
     },
     ownership::{ChainOwnership, TimeoutConfig},
@@ -63,13 +63,13 @@ impl From<Account> for wit_contract_api::Account {
     }
 }
 
-impl From<AccountOwner> for wit_contract_api::AccountOwner {
-    fn from(account_owner: AccountOwner) -> Self {
+impl From<MultiAddress> for wit_contract_api::MultiAddress {
+    fn from(account_owner: MultiAddress) -> Self {
         match account_owner {
-            AccountOwner::Address32(owner) => {
-                wit_contract_api::AccountOwner::Address32(owner.into())
+            MultiAddress::Address32(owner) => {
+                wit_contract_api::MultiAddress::Address32(owner.into())
             }
-            AccountOwner::Chain => wit_contract_api::AccountOwner::Chain,
+            MultiAddress::Chain => wit_contract_api::MultiAddress::Chain,
         }
     }
 }

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -10,8 +10,8 @@ use linera_base::{
     },
     http,
     identifiers::{
-        Account, AccountOwner, ApplicationId, ChainId, ChannelName, Destination, MessageId,
-        ModuleId, Owner, StreamName, UserApplicationId,
+        Account, ApplicationId, ChainId, ChannelName, Destination, MessageId, ModuleId,
+        MultiAddress, Owner, StreamName, UserApplicationId,
     },
     ownership::{ChainOwnership, ChangeApplicationPermissionsError, CloseChainError},
 };
@@ -127,7 +127,7 @@ where
     }
 
     /// Returns the balance of one of the accounts on this chain.
-    pub fn owner_balance(&mut self, owner: AccountOwner) -> Amount {
+    pub fn owner_balance(&mut self, owner: MultiAddress) -> Amount {
         base_wit::read_owner_balance(owner.into()).into()
     }
 
@@ -231,7 +231,7 @@ where
 
     /// Transfers an `amount` of native tokens from `source` owner account (or the current chain's
     /// balance) to `destination`.
-    pub fn transfer(&mut self, source: AccountOwner, destination: Account, amount: Amount) {
+    pub fn transfer(&mut self, source: MultiAddress, destination: Account, amount: Amount) {
         contract_wit::transfer(source.into(), destination.into(), amount.into())
     }
 

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -9,7 +9,7 @@ use linera_base::{
     abi::ServiceAbi,
     data_types::{Amount, BlockHeight, Timestamp},
     http,
-    identifiers::{AccountOwner, ApplicationId, ChainId, UserApplicationId},
+    identifiers::{ApplicationId, ChainId, MultiAddress, UserApplicationId},
 };
 use serde::Serialize;
 
@@ -27,8 +27,8 @@ where
     next_block_height: Mutex<Option<BlockHeight>>,
     timestamp: Mutex<Option<Timestamp>>,
     chain_balance: Mutex<Option<Amount>>,
-    owner_balances: Mutex<Option<Vec<(AccountOwner, Amount)>>>,
-    balance_owners: Mutex<Option<Vec<AccountOwner>>>,
+    owner_balances: Mutex<Option<Vec<(MultiAddress, Amount)>>>,
+    balance_owners: Mutex<Option<Vec<MultiAddress>>>,
 }
 
 impl<Application> ServiceRuntime<Application>
@@ -106,12 +106,12 @@ where
     }
 
     /// Returns the balance of one of the accounts on this chain.
-    pub fn owner_balance(&self, owner: AccountOwner) -> Amount {
+    pub fn owner_balance(&self, owner: MultiAddress) -> Amount {
         base_wit::read_owner_balance(owner.into()).into()
     }
 
     /// Returns the balances of all accounts on the chain.
-    pub fn owner_balances(&self) -> Vec<(AccountOwner, Amount)> {
+    pub fn owner_balances(&self) -> Vec<(MultiAddress, Amount)> {
         Self::fetch_value_through_cache(&self.owner_balances, || {
             base_wit::read_owner_balances()
                 .into_iter()
@@ -121,11 +121,11 @@ where
     }
 
     /// Returns the owners of accounts on this chain.
-    pub fn balance_owners(&self) -> Vec<AccountOwner> {
+    pub fn balance_owners(&self) -> Vec<MultiAddress> {
         Self::fetch_value_through_cache(&self.balance_owners, || {
             base_wit::read_balance_owners()
                 .into_iter()
-                .map(AccountOwner::from)
+                .map(MultiAddress::from)
                 .collect()
         })
     }

--- a/linera-sdk/src/service/test_runtime.rs
+++ b/linera-sdk/src/service/test_runtime.rs
@@ -13,7 +13,7 @@ use linera_base::{
     abi::ServiceAbi,
     data_types::{Amount, BlockHeight, Timestamp},
     hex, http,
-    identifiers::{AccountOwner, ApplicationId, ChainId, UserApplicationId},
+    identifiers::{ApplicationId, ChainId, MultiAddress, UserApplicationId},
 };
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -30,7 +30,7 @@ where
     next_block_height: Mutex<Option<BlockHeight>>,
     timestamp: Mutex<Option<Timestamp>>,
     chain_balance: Mutex<Option<Amount>>,
-    owner_balances: Mutex<Option<HashMap<AccountOwner, Amount>>>,
+    owner_balances: Mutex<Option<HashMap<MultiAddress, Amount>>>,
     query_application_handler: Mutex<Option<QueryApplicationHandler>>,
     expected_http_requests: Mutex<VecDeque<(http::Request, http::Response)>>,
     blobs: Mutex<Option<HashMap<DataBlobHash, Vec<u8>>>>,
@@ -214,7 +214,7 @@ where
     /// Configures the balances on the chain to use during the test.
     pub fn with_owner_balances(
         self,
-        owner_balances: impl IntoIterator<Item = (AccountOwner, Amount)>,
+        owner_balances: impl IntoIterator<Item = (MultiAddress, Amount)>,
     ) -> Self {
         *self.owner_balances.lock().unwrap() = Some(owner_balances.into_iter().collect());
         self
@@ -223,20 +223,20 @@ where
     /// Configures the balances on the chain to use during the test.
     pub fn set_owner_balances(
         &self,
-        owner_balances: impl IntoIterator<Item = (AccountOwner, Amount)>,
+        owner_balances: impl IntoIterator<Item = (MultiAddress, Amount)>,
     ) -> &Self {
         *self.owner_balances.lock().unwrap() = Some(owner_balances.into_iter().collect());
         self
     }
 
     /// Configures the balance of one account on the chain to use during the test.
-    pub fn with_owner_balance(self, owner: AccountOwner, balance: Amount) -> Self {
+    pub fn with_owner_balance(self, owner: MultiAddress, balance: Amount) -> Self {
         self.set_owner_balance(owner, balance);
         self
     }
 
     /// Configures the balance of one account on the chain to use during the test.
-    pub fn set_owner_balance(&self, owner: AccountOwner, balance: Amount) -> &Self {
+    pub fn set_owner_balance(&self, owner: MultiAddress, balance: Amount) -> &Self {
         self.owner_balances
             .lock()
             .unwrap()
@@ -246,7 +246,7 @@ where
     }
 
     /// Returns the balance of one of the accounts on this chain.
-    pub fn owner_balance(&self, owner: AccountOwner) -> Amount {
+    pub fn owner_balance(&self, owner: MultiAddress) -> Amount {
         self.owner_balances
             .lock()
             .unwrap()
@@ -262,7 +262,7 @@ where
     }
 
     /// Returns the balances of all accounts on the chain.
-    pub fn owner_balances(&self) -> Vec<(AccountOwner, Amount)> {
+    pub fn owner_balances(&self) -> Vec<(MultiAddress, Amount)> {
         self.owner_balances
             .lock()
             .unwrap()
@@ -277,7 +277,7 @@ where
     }
 
     /// Returns the owners of accounts on this chain.
-    pub fn balance_owners(&self) -> Vec<AccountOwner> {
+    pub fn balance_owners(&self) -> Vec<MultiAddress> {
         self.owner_balances
             .lock()
             .unwrap()

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -10,7 +10,7 @@ use linera_base::{
     data_types::{Amount, ApplicationPermissions, Blob, Round, Timestamp},
     hashed::Hashed,
     identifiers::{
-        AccountOwner, ApplicationId, ChainId, ChannelFullName, GenericApplicationId, Owner,
+        ApplicationId, ChainId, ChannelFullName, GenericApplicationId, MultiAddress, Owner,
         UserApplicationId,
     },
     ownership::TimeoutConfig,
@@ -92,7 +92,7 @@ impl BlockBuilder {
     /// Adds a native token transfer to this block.
     pub fn with_native_token_transfer(
         &mut self,
-        sender: AccountOwner,
+        sender: MultiAddress,
         recipient: Recipient,
         amount: Amount,
     ) -> &mut Self {

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -19,7 +19,7 @@ use linera_base::{
         Amount, Blob, BlockHeight, Bytecode, CompressedBytecode, UserApplicationDescription,
     },
     identifiers::{
-        AccountOwner, ApplicationId, ChainDescription, ChainId, ModuleId, UserApplicationId,
+        ApplicationId, ChainDescription, ChainId, ModuleId, MultiAddress, UserApplicationId,
     },
     vm::VmRuntime,
 };
@@ -127,8 +127,8 @@ impl ActiveChain {
         balance
     }
 
-    /// Reads the current account balance on this microchain of an [`AccountOwner`].
-    pub async fn owner_balance(&self, owner: &AccountOwner) -> Option<Amount> {
+    /// Reads the current account balance on this microchain of an [`MultiAddress`].
+    pub async fn owner_balance(&self, owner: &MultiAddress) -> Option<Amount> {
         let chain_state = self
             .validator
             .worker()
@@ -145,11 +145,11 @@ impl ActiveChain {
             .expect("Failed to read owner balance")
     }
 
-    /// Reads the current account balance on this microchain of all [`AccountOwner`]s.
+    /// Reads the current account balance on this microchain of all [`MultiAddress`]s.
     pub async fn owner_balances(
         &self,
-        owners: impl IntoIterator<Item = AccountOwner>,
-    ) -> HashMap<AccountOwner, Option<Amount>> {
+        owners: impl IntoIterator<Item = MultiAddress>,
+    ) -> HashMap<MultiAddress, Option<Amount>> {
         let chain_state = self
             .validator
             .worker()
@@ -174,8 +174,8 @@ impl ActiveChain {
         balances
     }
 
-    /// Reads a list of [`AccountOwner`]s that have a non-zero balance on this microchain.
-    pub async fn accounts(&self) -> Vec<AccountOwner> {
+    /// Reads a list of [`MultiAddress`]s that have a non-zero balance on this microchain.
+    pub async fn accounts(&self) -> Vec<MultiAddress> {
         let chain_state = self
             .validator
             .worker()
@@ -193,7 +193,7 @@ impl ActiveChain {
     }
 
     /// Reads all the non-zero account balances on this microchain.
-    pub async fn all_owner_balances(&self) -> HashMap<AccountOwner, Amount> {
+    pub async fn all_owner_balances(&self) -> HashMap<MultiAddress, Amount> {
         self.owner_balances(self.accounts().await)
             .await
             .into_iter()

--- a/linera-sdk/wit/base-runtime-api.wit
+++ b/linera-sdk/wit/base-runtime-api.wit
@@ -9,9 +9,9 @@ interface base-runtime-api {
     get-chain-ownership: func() -> chain-ownership;
     read-system-timestamp: func() -> timestamp;
     read-chain-balance: func() -> amount;
-    read-owner-balance: func(owner: account-owner) -> amount;
-    read-owner-balances: func() -> list<tuple<account-owner, amount>>;
-    read-balance-owners: func() -> list<account-owner>;
+    read-owner-balance: func(owner: multi-address) -> amount;
+    read-owner-balances: func() -> list<tuple<multi-address, amount>>;
+    read-balance-owners: func() -> list<multi-address>;
     perform-http-request: func(request: http-request) -> http-response;
     assert-before: func(timestamp: timestamp);
     read-data-blob: func(hash: crypto-hash) -> list<u8>;
@@ -29,11 +29,6 @@ interface base-runtime-api {
     find-keys-wait: func(promise-id: u32) -> list<list<u8>>;
     find-key-values-new: func(key-prefix: list<u8>) -> u32;
     find-key-values-wait: func(promise-id: u32) -> list<tuple<list<u8>, list<u8>>>;
-
-    variant account-owner {
-        address32(crypto-hash),
-        chain,
-    }
 
     record amount {
         inner0: u128,
@@ -98,6 +93,11 @@ interface base-runtime-api {
         info,
         debug,
         trace,
+    }
+
+    variant multi-address {
+        address32(crypto-hash),
+        chain,
     }
 
     record owner {

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -8,7 +8,7 @@ interface contract-runtime-api {
     send-message: func(message: send-message-request);
     subscribe: func(chain: chain-id, channel: channel-name);
     unsubscribe: func(chain: chain-id, channel: channel-name);
-    transfer: func(source: account-owner, destination: account, amount: amount);
+    transfer: func(source: multi-address, destination: account, amount: amount);
     claim: func(source: account, destination: account, amount: amount);
     open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: amount) -> tuple<message-id, chain-id>;
     close-chain: func() -> result<tuple<>, close-chain-error>;
@@ -23,12 +23,7 @@ interface contract-runtime-api {
 
     record account {
         chain-id: chain-id,
-        owner: account-owner,
-    }
-
-    variant account-owner {
-        address32(crypto-hash),
-        chain,
+        owner: multi-address,
     }
 
     record amount {
@@ -94,6 +89,11 @@ interface contract-runtime-api {
         contract-blob-hash: crypto-hash,
         service-blob-hash: crypto-hash,
         vm-runtime: vm-runtime,
+    }
+
+    variant multi-address {
+        address32(crypto-hash),
+        chain,
     }
 
     record owner {

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -358,6 +358,6 @@ subscription Notifications($chainId: ChainId!) {
   notifications(chainId: $chainId)
 }
 
-mutation Transfer($chainId: ChainId!, $owner: AccountOwner!, $recipient_chain: ChainId!, $recipient_account: AccountOwner!, $amount: Amount!) {
+mutation Transfer($chainId: ChainId!, $owner: MultiAddress!, $recipient_chain: ChainId!, $recipient_account: MultiAddress!, $amount: Amount!) {
   transfer(chainId: $chainId, owner: $owner, recipient: { Account: { chain_id: $recipient_chain, owner: $recipient_account } }, amount: $amount)
 }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -4,11 +4,6 @@ An account
 scalar Account
 
 """
-An owner of an account.
-"""
-scalar AccountOwner
-
-"""
 A non-negative amount of tokens.
 """
 scalar Amount
@@ -455,14 +450,6 @@ scalar Destination
 """
 A GraphQL-visible map item, complete with key.
 """
-type Entry_AccountOwner_Amount_aaf96548 {
-	key: AccountOwner!
-	value: Amount
-}
-
-"""
-A GraphQL-visible map item, complete with key.
-"""
 type Entry_BlobId_Blob_50b95aa1 {
 	key: BlobId!
 	value: Blob
@@ -482,6 +469,14 @@ A GraphQL-visible map item, complete with key.
 type Entry_ChannelFullName_ChannelStateView_bd1de7ae {
 	key: ChannelFullName!
 	value: ChannelStateView!
+}
+
+"""
+A GraphQL-visible map item, complete with key.
+"""
+type Entry_MultiAddress_Amount_f77e45dd {
+	key: MultiAddress!
+	value: Amount
 }
 
 """
@@ -617,16 +612,16 @@ type LogView_CryptoHash_87fbb60c {
 	entries(start: Int, end: Int): [CryptoHash!]!
 }
 
-input MapFilters_AccountOwner_d6668c53 {
-	keys: [AccountOwner!]
-}
-
 input MapFilters_BlobId_4d2a0555 {
 	keys: [BlobId!]
 }
 
 input MapFilters_ChannelFullName_7b67e184 {
 	keys: [ChannelFullName!]
+}
+
+input MapFilters_MultiAddress_d72add63 {
+	keys: [MultiAddress!]
 }
 
 input MapFilters_Origin_742d451b {
@@ -641,16 +636,16 @@ input MapFilters_Target_7aac1e1c {
 	keys: [Target!]
 }
 
-input MapInput_AccountOwner_d6668c53 {
-	filters: MapFilters_AccountOwner_d6668c53
-}
-
 input MapInput_BlobId_4d2a0555 {
 	filters: MapFilters_BlobId_4d2a0555
 }
 
 input MapInput_ChannelFullName_7b67e184 {
 	filters: MapFilters_ChannelFullName_7b67e184
+}
+
+input MapInput_MultiAddress_d72add63 {
+	filters: MapFilters_MultiAddress_d72add63
 }
 
 input MapInput_Origin_742d451b {
@@ -665,12 +660,6 @@ input MapInput_Target_7aac1e1c {
 	filters: MapFilters_Target_7aac1e1c
 }
 
-type MapView_AccountOwner_Amount_11ef1379 {
-	keys(count: Int): [AccountOwner!]!
-	entry(key: AccountOwner!): Entry_AccountOwner_Amount_aaf96548!
-	entries(input: MapInput_AccountOwner_d6668c53): [Entry_AccountOwner_Amount_aaf96548!]!
-}
-
 type MapView_BlobId_Blob_3711e760 {
 	keys(count: Int): [BlobId!]!
 	entry(key: BlobId!): Entry_BlobId_Blob_9f0b41f3!
@@ -681,6 +670,12 @@ type MapView_BlobId_Blob_9f0b41f3 {
 	keys(count: Int): [BlobId!]!
 	entry(key: BlobId!): Entry_BlobId_Blob_50b95aa1!
 	entries(input: MapInput_BlobId_4d2a0555): [Entry_BlobId_Blob_50b95aa1!]!
+}
+
+type MapView_MultiAddress_Amount_d2aadac8 {
+	keys(count: Int): [MultiAddress!]!
+	entry(key: MultiAddress!): Entry_MultiAddress_Amount_f77e45dd!
+	entries(input: MapInput_MultiAddress_d72add63): [Entry_MultiAddress_Amount_f77e45dd!]!
 }
 
 """
@@ -729,6 +724,11 @@ A unique identifier for an application module
 """
 scalar ModuleId
 
+"""
+An owner of an account.
+"""
+scalar MultiAddress
+
 type MutationRoot {
 	"""
 	Processes the inbox and returns the lists of certificate hashes that were created, if any.
@@ -742,7 +742,7 @@ type MutationRoot {
 	Transfers `amount` units of value from the given owner's account to the recipient.
 	If no owner is given, try to take the units out of the chain account.
 	"""
-	transfer(chainId: ChainId!, owner: AccountOwner!, recipient: Recipient!, amount: Amount!): CryptoHash!
+	transfer(chainId: ChainId!, owner: MultiAddress!, recipient: Recipient!, amount: Amount!): CryptoHash!
 	"""
 	Claims `amount` units of value from the given owner's account in the remote
 	`target` chain. Depending on its configuration, the `target` chain may refuse to
@@ -1210,7 +1210,7 @@ type SystemExecutionStateView {
 	committees: JSONObject!
 	ownership: ChainOwnership!
 	balance: Amount!
-	balances: MapView_AccountOwner_Amount_11ef1379!
+	balances: MapView_MultiAddress_Amount_d2aadac8!
 	timestamp: Timestamp!
 }
 

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -6,8 +6,8 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, Blob, BlockHeight, OracleResponse, Round, Timestamp},
     identifiers::{
-        Account, AccountOwner, BlobId, ChainDescription, ChainId, ChannelName, Destination,
-        GenericApplicationId, Owner, StreamName,
+        Account, BlobId, ChainDescription, ChainId, ChannelName, Destination, GenericApplicationId,
+        MultiAddress, Owner, StreamName,
     },
 };
 

--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -12,7 +12,7 @@ use std::{collections::BTreeMap, str::FromStr, sync::LazyLock, time::Duration};
 use fungible::{FungibleTokenAbi, InitialState};
 use linera_base::{
     data_types::Amount,
-    identifiers::{Account, AccountOwner, ChainId},
+    identifiers::{Account, ChainId, MultiAddress},
     vm::VmRuntime,
 };
 use linera_service::cli_wrappers::{
@@ -38,7 +38,7 @@ fn reqwest_client() -> reqwest::Client {
 async fn transfer(client: &reqwest::Client, url: &str, from: ChainId, to: Account, amount: &str) {
     let variables = transfer::Variables {
         chain_id: from,
-        owner: AccountOwner::Chain,
+        owner: MultiAddress::Chain,
         recipient_chain: to.chain_id,
         recipient_account: to.owner,
         amount: Amount::from_str(amount).unwrap(),

--- a/linera-service/benches/transfers.rs
+++ b/linera-service/benches/transfers.rs
@@ -9,7 +9,7 @@ use futures::{
 use linera_base::{
     crypto::{AccountSecretKey, Ed25519SecretKey, Secp256k1SecretKey},
     data_types::Amount,
-    identifiers::{Account, AccountOwner, ChainId},
+    identifiers::{Account, ChainId, MultiAddress},
     time::{Duration, Instant},
 };
 use linera_execution::system::Recipient;
@@ -80,7 +80,7 @@ async fn setup_native_token_balances(
     for chain in &chains {
         let recipient = Recipient::Account(Account {
             chain_id: chain.id(),
-            owner: AccountOwner::from(chain.public_key()),
+            owner: MultiAddress::from(chain.public_key()),
         });
 
         // TODO: Support benchmarking chains with multiple owner accounts
@@ -88,7 +88,7 @@ async fn setup_native_token_balances(
         admin_chain
             .add_block(|block| {
                 block.with_native_token_transfer(
-                    AccountOwner::Chain,
+                    MultiAddress::Chain,
                     recipient,
                     Amount::from_tokens(initial_balance),
                 );
@@ -110,7 +110,7 @@ fn prepare_transfers(
         .iter()
         .map(|chain| Account {
             chain_id: chain.id(),
-            owner: AccountOwner::from(chain.public_key()),
+            owner: MultiAddress::from(chain.public_key()),
         })
         .collect::<Vec<_>>();
 
@@ -119,7 +119,7 @@ fn prepare_transfers(
         .enumerate()
         .map(|(index, chain)| {
             let chain_id = chain.id();
-            let sender = AccountOwner::from(chain.public_key());
+            let sender = MultiAddress::from(chain.public_key());
 
             let transfers = accounts
                 .iter()

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -23,7 +23,7 @@ use futures::{lock::Mutex, FutureExt as _, StreamExt};
 use linera_base::{
     crypto::{AccountSecretKey, CryptoHash, CryptoRng, Ed25519SecretKey},
     data_types::{ApplicationPermissions, Timestamp},
-    identifiers::{AccountOwner, ChainDescription, ChainId, Owner},
+    identifiers::{ChainDescription, ChainId, MultiAddress, Owner},
     ownership::ChainOwnership,
 };
 use linera_client::{
@@ -281,10 +281,10 @@ impl Runnable for Job {
                 info!("Reading the balance of {} from the local state", account);
                 let time_start = Instant::now();
                 let balance = match account.owner {
-                    AccountOwner::Address32(_) => {
+                    MultiAddress::Address32(_) => {
                         chain_client.local_owner_balance(account.owner).await?
                     }
-                    AccountOwner::Chain => chain_client.local_balance().await?,
+                    MultiAddress::Chain => chain_client.local_balance().await?,
                 };
                 let time_total = time_start.elapsed();
                 info!("Local balance obtained after {} ms", time_total.as_millis());
@@ -300,10 +300,10 @@ impl Runnable for Job {
                 );
                 let time_start = Instant::now();
                 let balance = match account.owner {
-                    AccountOwner::Address32(_) => {
+                    MultiAddress::Address32(_) => {
                         chain_client.query_owner_balance(account.owner).await?
                     }
-                    AccountOwner::Chain => chain_client.query_balance().await?,
+                    MultiAddress::Chain => chain_client.query_balance().await?,
                 };
                 let time_total = time_start.elapsed();
                 info!("Balance obtained after {} ms", time_total.as_millis());
@@ -318,10 +318,10 @@ impl Runnable for Job {
                 let time_start = Instant::now();
                 chain_client.synchronize_from_validators().await?;
                 let result = match account.owner {
-                    AccountOwner::Address32(_) => {
+                    MultiAddress::Address32(_) => {
                         chain_client.query_owner_balance(account.owner).await
                     }
-                    AccountOwner::Chain => chain_client.query_balance().await,
+                    MultiAddress::Chain => chain_client.query_balance().await,
                 };
                 context.update_wallet_from_client(&chain_client).await?;
                 let balance = result.context("Failed to synchronize from validators")?;

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -14,7 +14,7 @@ use linera_base::{
     crypto::{CryptoError, CryptoHash},
     data_types::{Amount, ApplicationPermissions, Bytecode, TimeDelta, UserApplicationDescription},
     hashed::Hashed,
-    identifiers::{AccountOwner, ChainId, ModuleId, Owner, UserApplicationId},
+    identifiers::{ChainId, ModuleId, MultiAddress, Owner, UserApplicationId},
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
     BcsHexParseError,
@@ -223,7 +223,7 @@ where
     async fn transfer(
         &self,
         chain_id: ChainId,
-        owner: AccountOwner,
+        owner: MultiAddress,
         recipient: Recipient,
         amount: Amount,
     ) -> Result<CryptoHash, Error> {

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -20,7 +20,7 @@ use linera_base::vm::VmRuntime;
 use linera_base::{
     crypto::Secp256k1SecretKey,
     data_types::{Amount, BlockHeight},
-    identifiers::{Account, AccountOwner, ChainId},
+    identifiers::{Account, ChainId, MultiAddress},
 };
 use linera_core::{data_types::ChainInfoQuery, node::ValidatorNode};
 use linera_execution::committee::Epoch;
@@ -42,9 +42,9 @@ use {
 };
 
 #[cfg(feature = "benchmark")]
-fn get_fungible_account_owner(client: &ClientWrapper) -> AccountOwner {
+fn get_fungible_account_owner(client: &ClientWrapper) -> MultiAddress {
     let owner = client.get_owner().unwrap();
-    AccountOwner::from(owner)
+    MultiAddress::from(owner)
 }
 
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Udp) ; "scylladb_udp"))]
@@ -177,7 +177,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
     }
 
     let recipient =
-        AccountOwner::from(AccountSecretKey::Secp256k1(Secp256k1SecretKey::generate()).public());
+        MultiAddress::from(AccountSecretKey::Secp256k1(Secp256k1SecretKey::generate()).public());
     client
         .transfer_with_accounts(
             Amount::from_tokens(5),


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->

## Proposal

Rename `AccountOwner` to `MultiAddress` to convey that the address is not only an account address but can be application (user or system). In the future it will receive more variants (like 20-bytes array for native EVM support).

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.
- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- Backporting is not possible but we may want to deploy a new `devnet` and release a new
      SDK soon.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
