### PR TITLE
Remove Owner and use MultiAddress

### DIFF
--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -311,15 +311,11 @@ impl Contract for AmmContract {
 impl AmmContract {
     /// authenticate the originator of the message
     fn check_account_authentication(&mut self, origin: MultiAddress) {
-        match origin {
-            MultiAddress::Address32(address) => {
-                assert!(
-                    self.runtime.authenticated_signer().map(|owner| owner.0) == Some(address)
-                        || self.runtime.authenticated_caller_id() == Some(origin),
-                    "Unauthorized"
-                )
-            }
-        }
+        assert!(
+            self.runtime.authenticated_signer() == Some(origin)
+                || self.runtime.authenticated_caller_id() == Some(origin),
+            "Unauthorized"
+        )
     }
 
     /// Obtains the current shares for an `account`.

--- a/examples/amm/src/lib.rs
+++ b/examples/amm/src/lib.rs
@@ -31,7 +31,7 @@ pub enum Operation {
     /// Given an input token idx (can be 0 or 1), and an input amount,
     /// Swap that token amount for an amount of the other token,
     /// calculated based on the current AMM ratio
-    /// Owner here is the user executing the Swap
+    /// MultiAddress here is the user executing the Swap
     Swap {
         owner: MultiAddress,
         input_token_idx: u32,
@@ -42,7 +42,7 @@ pub enum Operation {
     /// add liquidity to the AMM such that you'll be adding AT MOST
     /// `max_token0_amount` of token0, and `max_token1_amount` of token1,
     /// which will be calculated based on the current AMM ratio
-    /// Owner here is the user adding liquidity, which currently can only
+    /// MultiAddress here is the user adding liquidity, which currently can only
     /// be a chain owner
     AddLiquidity {
         owner: MultiAddress,
@@ -55,7 +55,7 @@ pub enum Operation {
     /// how much of the other token will also be removed, which will be calculated
     /// based on the current AMM ratio. Then remove the amounts from both tokens
     /// as a removal of liquidity
-    /// Owner here is the user removing liquidity, which currently can only
+    /// MultiAddress here is the user removing liquidity, which currently can only
     /// be a chain owner
     RemoveLiquidity {
         owner: MultiAddress,
@@ -64,7 +64,7 @@ pub enum Operation {
     },
     /// Remove all added liquidity operation
     /// Remove all the liquidity added by the given user, that is remaining in the AMM.
-    /// Owner here is the user removing liquidity, which currently can only
+    /// MultiAddress here is the user removing liquidity, which currently can only
     /// be a chain owner
     RemoveAllAddedLiquidity { owner: MultiAddress },
     /// Close this chain, and remove all added liquidity

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -48,10 +48,9 @@ impl Contract for FungibleTokenContract {
         // If initial accounts are empty, creator gets 1M tokens to act like a faucet.
         if state.accounts.is_empty() {
             if let Some(owner) = self.runtime.authenticated_signer() {
-                state.accounts.insert(
-                    MultiAddress::from(owner),
-                    Amount::from_str("1000000").unwrap(),
-                );
+                state
+                    .accounts
+                    .insert(owner, Amount::from_str("1000000").unwrap());
             }
         }
         self.state.initialize_accounts(state).await;
@@ -128,15 +127,11 @@ impl Contract for FungibleTokenContract {
 impl FungibleTokenContract {
     /// Verifies that a transfer is authenticated for this local account.
     fn check_account_authentication(&mut self, origin: MultiAddress) {
-        match origin {
-            MultiAddress::Address32(address) => {
-                assert!(
-                    self.runtime.authenticated_signer().map(|owner| owner.0) == Some(address)
-                        || self.runtime.authenticated_caller_id() == Some(origin),
-                    "The requested transfer is not correctly authenticated."
-                )
-            }
-        }
+        assert!(
+            self.runtime.authenticated_signer() == Some(origin)
+                || self.runtime.authenticated_caller_id() == Some(origin),
+            "The requested transfer is not correctly authenticated."
+        )
     }
 
     async fn claim(&mut self, source_account: Account, amount: Amount, target_account: Account) {

--- a/examples/fungible/web-frontend/src/qql/graphql.ts
+++ b/examples/fungible/web-frontend/src/qql/graphql.ts
@@ -33,7 +33,7 @@ export type Entry_AccountOwner_Amount_92cf94e6 = {
 export type FungibleAccount = {
   /** Chain ID of the account */
   chainId: Scalars['ChainId']['input'];
-  /** Owner of the account */
+  /** MultiAddress of the account */
   owner: Scalars['MultiAddress']['input'];
 };
 

--- a/examples/gen-nft/src/contract.rs
+++ b/examples/gen-nft/src/contract.rs
@@ -125,15 +125,11 @@ impl Contract for GenNftContract {
 impl GenNftContract {
     /// Verifies that a transfer is authenticated for this local account.
     fn check_account_authentication(&mut self, origin: MultiAddress) {
-        match origin {
-            MultiAddress::Address32(address) => {
-                assert!(
-                    self.runtime.authenticated_signer().map(|owner| owner.0) == Some(address)
-                        || self.runtime.authenticated_caller_id() == Some(origin),
-                    "The requested transfer is not correctly authenticated."
-                )
-            }
-        }
+        assert!(
+            self.runtime.authenticated_signer() == Some(origin)
+                || self.runtime.authenticated_caller_id() == Some(origin),
+            "The requested transfer is not correctly authenticated."
+        )
     }
 
     /// Transfers the specified NFT to another account.

--- a/examples/hex-game/src/contract.rs
+++ b/examples/hex-game/src/contract.rs
@@ -9,7 +9,7 @@ use async_graphql::ComplexObject;
 use hex_game::{Board, Clock, HexAbi, HexOutcome, Operation, Timeouts};
 use linera_sdk::{
     linera_base_types::{
-        Amount, ApplicationPermissions, ChainId, ChainOwnership, Owner, TimeoutConfig,
+        Amount, ApplicationPermissions, ChainId, ChainOwnership, MultiAddress, TimeoutConfig,
         WithContractAbi,
     },
     views::{RootView, View},
@@ -141,7 +141,7 @@ impl HexContract {
 
     async fn execute_start(
         &mut self,
-        players: [Owner; 2],
+        players: [MultiAddress; 2],
         board_size: u16,
         fee_budget: Amount,
         timeouts: Option<Timeouts>,
@@ -200,14 +200,17 @@ pub enum Message {
     /// Initializes a game. Sent from the main chain to a temporary chain.
     Start {
         /// The players.
-        players: [Owner; 2],
+        players: [MultiAddress; 2],
         /// The side length of the board. A typical size is 11.
         board_size: u16,
         /// Settings that determine how much time the players have to think about their turns.
         timeouts: Timeouts,
     },
     /// Reports the outcome of a game. Sent from a closed chain to the main chain.
-    End { winner: Owner, loser: Owner },
+    End {
+        winner: MultiAddress,
+        loser: MultiAddress,
+    },
 }
 
 /// This implementation is only nonempty in the service.

--- a/examples/hex-game/src/lib.rs
+++ b/examples/hex-game/src/lib.rs
@@ -8,7 +8,7 @@ use std::iter;
 use async_graphql::{Enum, InputObject, Request, Response, SimpleObject};
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{Amount, ContractAbi, Owner, ServiceAbi, TimeDelta, Timestamp},
+    linera_base_types::{Amount, ContractAbi, MultiAddress, ServiceAbi, TimeDelta, Timestamp},
 };
 use serde::{Deserialize, Serialize};
 
@@ -23,7 +23,7 @@ pub enum Operation {
     /// Start a game on a new temporary chain, with the given settings.
     Start {
         /// The public keys of player 1 and 2, respectively.
-        players: [Owner; 2],
+        players: [MultiAddress; 2],
         /// The side length of the board. A typical size is 11.
         board_size: u16,
         /// An amount transferred to the temporary chain to cover the fees.
@@ -248,7 +248,7 @@ impl Board {
         None
     }
 
-    /// Returns the `Owner` controlling the active player.
+    /// Returns the `MultiAddress` controlling the active player.
     pub fn active_player(&self) -> Player {
         self.active
     }

--- a/examples/hex-game/src/state.rs
+++ b/examples/hex-game/src/state.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeSet;
 use async_graphql::SimpleObject;
 use hex_game::{Board, Clock, Timeouts};
 use linera_sdk::{
-    linera_base_types::{ChainId, MessageId, Owner},
+    linera_base_types::{ChainId, MessageId, MultiAddress},
     views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
 };
 use serde::{Deserialize, Serialize};
@@ -25,8 +25,8 @@ pub struct GameChain {
 #[graphql(complex)]
 #[view(context = "ViewStorageContext")]
 pub struct HexState {
-    /// The `Owner`s controlling players `One` and `Two`.
-    pub owners: RegisterView<Option<[Owner; 2]>>,
+    /// The `MultiAddress`s controlling players `One` and `Two`.
+    pub owners: RegisterView<Option<[MultiAddress; 2]>>,
     /// The current game state.
     pub board: RegisterView<Board>,
     /// The game clock.
@@ -34,5 +34,5 @@ pub struct HexState {
     /// The timeouts.
     pub timeouts: RegisterView<Timeouts>,
     /// Temporary chains for individual games, by player.
-    pub game_chains: MapView<Owner, BTreeSet<GameChain>>,
+    pub game_chains: MapView<MultiAddress, BTreeSet<GameChain>>,
 }

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -151,15 +151,11 @@ impl MatchingEngineContract {
 
     /// authenticate the originator of the message
     fn check_account_authentication(&mut self, origin: MultiAddress) {
-        match origin {
-            MultiAddress::Address32(address) => {
-                assert!(
-                    self.runtime.authenticated_signer().map(|owner| owner.0) == Some(address)
-                        || self.runtime.authenticated_caller_id() == Some(origin),
-                    "Unauthorized."
-                )
-            }
-        }
+        assert!(
+            self.runtime.authenticated_signer() == Some(origin)
+                || self.runtime.authenticated_caller_id() == Some(origin),
+            "Unauthorized."
+        )
     }
 
     /// The application engine is trading between two tokens. Those tokens are the parameters of the

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -136,14 +136,10 @@ impl NativeFungibleTokenContract {
 
     /// Verifies that a transfer is authenticated for this local account.
     fn check_account_authentication(&mut self, origin: MultiAddress) {
-        match origin {
-            MultiAddress::Address32(address) => {
-                assert!(
-                    self.runtime.authenticated_signer().map(|owner| owner.0) == Some(address)
-                        || self.runtime.authenticated_caller_id() == Some(origin),
-                    "The requested transfer is not correctly authenticated."
-                )
-            }
-        }
+        assert!(
+            self.runtime.authenticated_signer() == Some(origin)
+                || self.runtime.authenticated_caller_id() == Some(origin),
+            "The requested transfer is not correctly authenticated."
+        )
     }
 }

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -129,15 +129,11 @@ impl Contract for NonFungibleTokenContract {
 impl NonFungibleTokenContract {
     /// Verifies that a transfer is authenticated for this local account.
     fn check_account_authentication(&mut self, origin: MultiAddress) {
-        match origin {
-            MultiAddress::Address32(address) => {
-                assert!(
-                    self.runtime.authenticated_signer().map(|owner| owner.0) == Some(address)
-                        || self.runtime.authenticated_caller_id() == Some(origin),
-                    "The requested transfer is not correctly authenticated."
-                )
-            }
-        }
+        assert!(
+            self.runtime.authenticated_signer() == Some(origin)
+                || self.runtime.authenticated_caller_id() == Some(origin),
+            "The requested transfer is not correctly authenticated."
+        )
     }
 
     /// Transfers the specified NFT to another account.

--- a/examples/rfq/src/contract.rs
+++ b/examples/rfq/src/contract.rs
@@ -8,7 +8,7 @@ mod state;
 use fungible::{Account, FungibleTokenAbi};
 use linera_sdk::{
     linera_base_types::{
-        Amount, ApplicationPermissions, ChainId, ChainOwnership, Owner, TimeoutConfig,
+        Amount, ApplicationPermissions, ChainId, ChainOwnership, MultiAddress, TimeoutConfig,
         WithContractAbi,
     },
     views::{RootView, View},
@@ -324,7 +324,7 @@ impl RfqContract {
         quote_provided: QuoteProvided,
         token_pair: TokenPair,
         fee_budget: Amount,
-        owner: Owner,
+        owner: MultiAddress,
     ) -> ChainId {
         let ownership = ChainOwnership::multiple(
             [(owner, 100), (quote_provided.get_quoter_owner(), 100)],
@@ -337,7 +337,7 @@ impl RfqContract {
 
         // transfer tokens to the new chain
         let transfer = fungible::Operation::Transfer {
-            owner: owner.into(),
+            owner,
             amount: quote_provided.get_amount(),
             target_account: Account {
                 chain_id: temp_chain_id,
@@ -358,7 +358,7 @@ impl RfqContract {
                 token_id: token,
                 owner: Account {
                     chain_id: self.runtime.chain_id(),
-                    owner: owner.into(),
+                    owner,
                 },
                 amount: quote_provided.get_amount(),
             }),

--- a/examples/rfq/src/lib.rs
+++ b/examples/rfq/src/lib.rs
@@ -7,7 +7,7 @@ use async_graphql::{scalar, InputObject, Request, Response, SimpleObject};
 use fungible::Account;
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{Amount, ChainId, ContractAbi, MultiAddress, Owner, ServiceAbi},
+    linera_base_types::{Amount, ChainId, ContractAbi, MultiAddress, ServiceAbi},
 };
 use serde::{Deserialize, Serialize};
 
@@ -86,11 +86,11 @@ pub enum Operation {
     ProvideQuote {
         request_id: RequestId,
         quote: Amount,
-        quoter_owner: Owner,
+        quoter_owner: MultiAddress,
     },
     AcceptQuote {
         request_id: RequestId,
-        owner: Owner,
+        owner: MultiAddress,
         fee_budget: Amount,
     },
     FinalizeDeal {
@@ -113,7 +113,7 @@ pub enum Message {
     ProvideQuote {
         seq_number: u64,
         quote: Amount,
-        quoter_owner: Owner,
+        quoter_owner: MultiAddress,
     },
     QuoteAccepted {
         request_id: RequestId,

--- a/examples/rfq/src/state.rs
+++ b/examples/rfq/src/state.rs
@@ -3,7 +3,7 @@
 
 use async_graphql::{InputObject, SimpleObject, Union};
 use linera_sdk::{
-    linera_base_types::{Amount, ChainId, MultiAddress, Owner},
+    linera_base_types::{Amount, ChainId, MultiAddress},
     views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
 };
 use rfq::{RequestId, TokenPair, Tokens};
@@ -20,11 +20,11 @@ pub struct QuoteProvided {
     token_pair: TokenPair,
     amount: Amount,
     amount_offered: Amount,
-    quoter_owner: Owner,
+    quoter_owner: MultiAddress,
 }
 
 impl QuoteProvided {
-    pub fn get_quoter_owner(&self) -> Owner {
+    pub fn get_quoter_owner(&self) -> MultiAddress {
         self.quoter_owner
     }
 
@@ -92,7 +92,7 @@ pub struct RfqState {
 }
 
 impl RequestData {
-    pub fn update_state_with_quote(&mut self, quote: Amount, quoter_owner: Owner) {
+    pub fn update_state_with_quote(&mut self, quote: Amount, quoter_owner: MultiAddress) {
         match &self.state {
             RequestState::QuoteRequested(QuoteRequested { token_pair, amount }) => {
                 self.state = RequestState::QuoteProvided(QuoteProvided {
@@ -133,7 +133,7 @@ impl RequestData {
                 self.state = RequestState::AwaitingTokens(Box::new(AwaitingTokens {
                     token_pair: token_pair.clone(),
                     amount_offered: *amount_offered,
-                    quoter_account: (*quoter_owner).into(),
+                    quoter_account: *quoter_owner,
                     temp_chain_id,
                 }));
             }

--- a/linera-base/src/crypto/ed25519.rs
+++ b/linera-base/src/crypto/ed25519.rs
@@ -15,9 +15,9 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     le_bytes_to_u64_array, u64_array_to_le_bytes, BcsHashable, BcsSignable, CryptoError,
-    CryptoHash, HasTypeName, Hashable,
+    HasTypeName, Hashable,
 };
-use crate::{doc_scalar, identifiers::Owner};
+use crate::doc_scalar;
 
 /// The label for the Ed25519 scheme.
 const ED25519_SCHEME_LABEL: &str = "Ed25519";
@@ -416,18 +416,6 @@ impl fmt::Display for Ed25519Signature {
 impl fmt::Debug for Ed25519Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(&self.0.to_bytes()[0..8]))
-    }
-}
-
-impl From<Ed25519PublicKey> for Owner {
-    fn from(value: Ed25519PublicKey) -> Self {
-        Self(CryptoHash::new(&value))
-    }
-}
-
-impl From<&Ed25519PublicKey> for Owner {
-    fn from(value: &Ed25519PublicKey) -> Self {
-        Self(CryptoHash::new(value))
     }
 }
 

--- a/linera-base/src/crypto/mod.rs
+++ b/linera-base/src/crypto/mod.rs
@@ -19,8 +19,6 @@ pub use secp256k1::{Secp256k1PublicKey, Secp256k1SecretKey, Secp256k1Signature};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::identifiers::Owner;
-
 /// The public key of a validator.
 pub type ValidatorPublicKey = secp256k1::Secp256k1PublicKey;
 /// The private key of a validator.
@@ -204,24 +202,6 @@ impl FromStr for AccountPublicKey {
 impl Display for AccountPublicKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", hex::encode(self.as_bytes()))
-    }
-}
-
-impl From<AccountPublicKey> for Owner {
-    fn from(public_key: AccountPublicKey) -> Self {
-        match public_key {
-            AccountPublicKey::Ed25519(public_key) => public_key.into(),
-            AccountPublicKey::Secp256k1(public_key) => public_key.into(),
-        }
-    }
-}
-
-impl From<&AccountPublicKey> for Owner {
-    fn from(public_key: &AccountPublicKey) -> Self {
-        match public_key {
-            AccountPublicKey::Ed25519(public_key) => public_key.into(),
-            AccountPublicKey::Secp256k1(public_key) => public_key.into(),
-        }
     }
 }
 

--- a/linera-base/src/crypto/secp256k1.rs
+++ b/linera-base/src/crypto/secp256k1.rs
@@ -23,7 +23,7 @@ use linera_witty::{
 use serde::{Deserialize, Serialize};
 
 use super::{BcsHashable, BcsSignable, CryptoError, CryptoHash, HasTypeName};
-use crate::{doc_scalar, identifiers::Owner};
+use crate::doc_scalar;
 
 /// Name of the secp256k1 scheme.
 const SECP256K1_SCHEME_LABEL: &str = "secp256k1";
@@ -189,18 +189,6 @@ impl fmt::Display for Secp256k1PublicKey {
 impl fmt::Debug for Secp256k1PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}..", hex::encode(&self.as_bytes()[0..9]))
-    }
-}
-
-impl From<Secp256k1PublicKey> for Owner {
-    fn from(value: Secp256k1PublicKey) -> Self {
-        Self(CryptoHash::new(&value))
-    }
-}
-
-impl From<&Secp256k1PublicKey> for Owner {
-    fn from(value: &Secp256k1PublicKey) -> Self {
-        Self(CryptoHash::new(value))
     }
 }
 

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 use crate::{
     data_types::{Round, TimeDelta},
     doc_scalar,
-    identifiers::Owner,
+    identifiers::MultiAddress,
 };
 
 /// The timeout configuration: how long fast, multi-leader and single-leader rounds last.
@@ -53,10 +53,10 @@ impl Default for TimeoutConfig {
 pub struct ChainOwnership {
     /// Super owners can propose fast blocks in the first round, and regular blocks in any round.
     #[debug(skip_if = BTreeSet::is_empty)]
-    pub super_owners: BTreeSet<Owner>,
+    pub super_owners: BTreeSet<MultiAddress>,
     /// The regular owners, with their weights that determine how often they are round leader.
     #[debug(skip_if = BTreeMap::is_empty)]
-    pub owners: BTreeMap<Owner, u64>,
+    pub owners: BTreeMap<MultiAddress, u64>,
     /// The number of rounds in which all owners are allowed to propose blocks.
     pub multi_leader_rounds: u32,
     /// Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners.
@@ -69,7 +69,7 @@ pub struct ChainOwnership {
 
 impl ChainOwnership {
     /// Creates a `ChainOwnership` with a single super owner.
-    pub fn single_super(owner: Owner) -> Self {
+    pub fn single_super(owner: MultiAddress) -> Self {
         ChainOwnership {
             super_owners: iter::once(owner).collect(),
             owners: BTreeMap::new(),
@@ -80,7 +80,7 @@ impl ChainOwnership {
     }
 
     /// Creates a `ChainOwnership` with a single regular owner.
-    pub fn single(owner: Owner) -> Self {
+    pub fn single(owner: MultiAddress) -> Self {
         ChainOwnership {
             super_owners: BTreeSet::new(),
             owners: iter::once((owner, 100)).collect(),
@@ -92,7 +92,7 @@ impl ChainOwnership {
 
     /// Creates a `ChainOwnership` with the specified regular owners.
     pub fn multiple(
-        owners_and_weights: impl IntoIterator<Item = (Owner, u64)>,
+        owners_and_weights: impl IntoIterator<Item = (MultiAddress, u64)>,
         multi_leader_rounds: u32,
         timeout_config: TimeoutConfig,
     ) -> Self {
@@ -106,7 +106,7 @@ impl ChainOwnership {
     }
 
     /// Adds a regular owner.
-    pub fn with_regular_owner(mut self, owner: Owner, weight: u64) -> Self {
+    pub fn with_regular_owner(mut self, owner: MultiAddress, weight: u64) -> Self {
         self.owners.insert(owner, weight);
         self
     }
@@ -119,7 +119,7 @@ impl ChainOwnership {
     }
 
     /// Returns `true` if this is an owner or super owner.
-    pub fn verify_owner(&self, owner: &Owner) -> bool {
+    pub fn verify_owner(&self, owner: &MultiAddress) -> bool {
         self.super_owners.contains(owner) || self.owners.contains_key(owner)
     }
 
@@ -157,7 +157,7 @@ impl ChainOwnership {
     }
 
     /// Returns an iterator over all super owners, followed by all owners.
-    pub fn all_owners(&self) -> impl Iterator<Item = &Owner> {
+    pub fn all_owners(&self) -> impl Iterator<Item = &MultiAddress> {
         self.super_owners.iter().chain(self.owners.keys())
     }
 
@@ -203,9 +203,9 @@ mod tests {
     #[test]
     fn test_ownership_round_timeouts() {
         let super_pub_key = Ed25519SecretKey::generate().public();
-        let super_owner = Owner::from(super_pub_key);
+        let super_owner = MultiAddress::from(super_pub_key);
         let pub_key = Secp256k1SecretKey::generate().public();
-        let owner = Owner::from(pub_key);
+        let owner = MultiAddress::from(pub_key);
 
         let ownership = ChainOwnership {
             super_owners: BTreeSet::from_iter([super_owner]),

--- a/linera-base/src/unit_tests.rs
+++ b/linera-base/src/unit_tests.rs
@@ -11,9 +11,7 @@ use test_case::test_case;
 use crate::{
     crypto::{AccountPublicKey, CryptoHash},
     data_types::{Amount, BlockHeight, Resources, SendMessageRequest, TimeDelta, Timestamp},
-    identifiers::{
-        Account, ChainId, ChannelName, Destination, MessageId, ModuleId, MultiAddress, Owner,
-    },
+    identifiers::{Account, ChainId, ChannelName, Destination, MessageId, ModuleId, MultiAddress},
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
 };
@@ -26,7 +24,7 @@ use crate::{
 #[test_case(Timestamp::from(6_400_003); "of_timestamp")]
 #[test_case(resources_test_case(); "of_resources")]
 #[test_case(send_message_request_test_case(); "of_send_message_request")]
-#[test_case(Owner(CryptoHash::test_hash("owner")); "of_owner")]
+#[test_case(MultiAddress::from(CryptoHash::test_hash("owner")); "of_owner")]
 #[test_case(account_test_case(); "of_account")]
 #[test_case(ChainId(CryptoHash::test_hash("chain_id")); "of_chain_id")]
 #[test_case(message_id_test_case(); "of_message_id")]
@@ -137,13 +135,18 @@ fn timeout_config_test_case() -> TimeoutConfig {
 fn chain_ownership_test_case() -> ChainOwnership {
     let super_owners = ["Alice", "Bob"]
         .into_iter()
-        .map(|owner_name| Owner(CryptoHash::test_hash(owner_name)))
+        .map(|owner_name| MultiAddress::from(CryptoHash::test_hash(owner_name)))
         .collect();
 
     let owners = ["Carol", "Dennis", "Eve"]
         .into_iter()
         .enumerate()
-        .map(|(index, owner_name)| (Owner(CryptoHash::test_hash(owner_name)), index as u64))
+        .map(|(index, owner_name)| {
+            (
+                MultiAddress::from(CryptoHash::test_hash(owner_name)),
+                index as u64,
+            )
+        })
         .collect();
 
     ChainOwnership {

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -12,7 +12,7 @@ use linera_base::{
     crypto::{BcsHashable, CryptoHash},
     data_types::{Blob, BlockHeight, Event, OracleResponse, Timestamp},
     hashed::Hashed,
-    identifiers::{BlobId, ChainId, MessageId, Owner},
+    identifiers::{BlobId, ChainId, MessageId, MultiAddress},
 };
 use linera_execution::{committee::Epoch, BlobState, Operation, OutgoingMessage};
 use serde::{ser::SerializeStruct, Deserialize, Serialize};
@@ -336,7 +336,7 @@ pub struct BlockHeader {
     /// fees. If set, this must be the `owner` in the block proposal. `None` means that
     /// the default account of the chain is used. This value is also used as recipient of
     /// potential refunds for the message grants created by the operations.
-    pub authenticated_signer: Option<Owner>,
+    pub authenticated_signer: Option<MultiAddress>,
 
     // Inputs to the block, chosen by the block proposer.
     /// Cryptographic hash of all the incoming bundles in the block.
@@ -640,7 +640,7 @@ struct SerializedHeader {
     timestamp: Timestamp,
     state_hash: CryptoHash,
     previous_block_hash: Option<CryptoHash>,
-    authenticated_signer: Option<Owner>,
+    authenticated_signer: Option<MultiAddress>,
 }
 
 mod hashing {

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -17,9 +17,7 @@ use linera_base::{
         UserApplicationDescription,
     },
     ensure,
-    identifiers::{
-        BlobType, ChainId, ChannelFullName, Destination, MessageId, MultiAddress, Owner,
-    },
+    identifiers::{BlobType, ChainId, ChannelFullName, Destination, MessageId, MultiAddress},
     ownership::ChainOwnership,
 };
 use linera_execution::{
@@ -223,7 +221,7 @@ where
     /// The incomplete set of blobs for the pending validated block.
     pub pending_validated_blobs: PendingBlobsView<C>,
     /// The incomplete sets of blobs for upcoming proposals.
-    pub pending_proposed_blobs: ReentrantCollectionView<C, Owner, PendingBlobsView<C>>,
+    pub pending_proposed_blobs: ReentrantCollectionView<C, MultiAddress, PendingBlobsView<C>>,
 
     /// Hashes of all certified blocks for this sender.
     /// This ends with `block_hash` and has length `usize::from(next_block_height)`.
@@ -980,7 +978,7 @@ where
         txn_index: u32,
         local_time: Timestamp,
         txn_tracker: &mut TransactionTracker,
-        resource_controller: &mut ResourceController<Option<Owner>>,
+        resource_controller: &mut ResourceController<Option<MultiAddress>>,
     ) -> Result<(), ChainError> {
         #[cfg(with_metrics)]
         let _message_latency = MESSAGE_EXECUTION_LATENCY.measure_latency();

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -19,7 +19,9 @@ use linera_base::{
     doc_scalar, ensure,
     hashed::Hashed,
     hex_debug,
-    identifiers::{Account, BlobId, ChainId, ChannelFullName, Destination, MessageId, Owner},
+    identifiers::{
+        Account, BlobId, ChainId, ChannelFullName, Destination, MessageId, MultiAddress,
+    },
 };
 use linera_execution::{
     committee::{Committee, Epoch},
@@ -71,7 +73,7 @@ pub struct ProposedBlock {
     /// the default account of the chain is used. This value is also used as recipient of
     /// potential refunds for the message grants created by the operations.
     #[debug(skip_if = Option::is_none)]
-    pub authenticated_signer: Option<Owner>,
+    pub authenticated_signer: Option<MultiAddress>,
     /// Certified hash (see `Certificate` below) of the previous block in the
     /// chain, if any.
     pub previous_block_hash: Option<CryptoHash>,
@@ -288,7 +290,7 @@ pub struct BlockProposal {
 pub struct PostedMessage {
     /// The user authentication carried by the message, if any.
     #[debug(skip_if = Option::is_none)]
-    pub authenticated_signer: Option<Owner>,
+    pub authenticated_signer: Option<MultiAddress>,
     /// A grant to pay for the message execution.
     #[debug(skip_if = Amount::is_zero)]
     pub grant: Amount,

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -78,7 +78,7 @@ use linera_base::{
     data_types::{Blob, BlockHeight, Round, Timestamp},
     ensure,
     hashed::Hashed,
-    identifiers::{BlobId, ChainId, Owner},
+    identifiers::{BlobId, ChainId, MultiAddress},
     ownership::ChainOwnership,
 };
 use linera_execution::{committee::Epoch, ExecutionRuntimeContext};
@@ -193,7 +193,7 @@ where
     #[graphql(skip)]
     pub current_round: RegisterView<C, Round>,
     /// The owners that take over in fallback mode.
-    pub fallback_owners: RegisterView<C, BTreeMap<Owner, u64>>,
+    pub fallback_owners: RegisterView<C, BTreeMap<MultiAddress, u64>>,
 }
 
 #[ComplexObject]
@@ -232,7 +232,7 @@ where
             None
         };
         let fallback_owners = fallback_owners
-            .map(|(pub_key, weight)| (Owner::from(pub_key), weight))
+            .map(|(pub_key, weight)| (MultiAddress::from(pub_key), weight))
             .collect::<BTreeMap<_, _>>();
         let fallback_distribution = if !fallback_owners.is_empty() {
             let weights = fallback_owners.values().copied().collect();
@@ -612,7 +612,7 @@ where
 
     /// Returns the leader who is allowed to propose a block in the given round, or `None` if every
     /// owner is allowed to propose. Exception: In `Round::Fast`, only super owners can propose.
-    fn round_leader(&self, round: Round) -> Option<&Owner> {
+    fn round_leader(&self, round: Round) -> Option<&MultiAddress> {
         match round {
             Round::SingleLeader(r) => {
                 let index = self.round_leader_index(r)?;
@@ -646,7 +646,7 @@ where
     }
 
     /// Returns whether the owner is a super owner.
-    fn is_super(&self, owner: &Owner) -> bool {
+    fn is_super(&self, owner: &MultiAddress) -> bool {
         self.ownership.get().super_owners.contains(owner)
     }
 
@@ -725,7 +725,7 @@ pub struct ChainManagerInfo {
     /// The current leader, who is allowed to propose the next block.
     /// `None` if everyone is allowed to propose.
     #[debug(skip_if = Option::is_none)]
-    pub leader: Option<Owner>,
+    pub leader: Option<MultiAddress>,
     /// The timestamp when the current round times out.
     #[debug(skip_if = Option::is_none)]
     pub round_timeout: Option<Timestamp>,
@@ -787,7 +787,7 @@ impl ChainManagerInfo {
 
     /// Returns whether the `identity` is allowed to propose a block in `round`.
     /// This is dependent on the type of round and whether `identity` is a validator or (super)owner.
-    pub fn can_propose(&self, identity: &Owner, round: Round) -> bool {
+    pub fn can_propose(&self, identity: &MultiAddress, round: Round) -> bool {
         match round {
             Round::Fast => self.ownership.super_owners.contains(identity),
             Round::MultiLeader(_) => true,

--- a/linera-chain/src/test/mod.rs
+++ b/linera-chain/src/test/mod.rs
@@ -9,7 +9,7 @@ use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey},
     data_types::{Amount, BlockHeight, Round, Timestamp},
     hashed::Hashed,
-    identifiers::{ChainId, MultiAddress, Owner},
+    identifiers::{ChainId, MultiAddress},
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorState},
@@ -59,7 +59,7 @@ pub fn make_first_block(chain_id: ChainId) -> ProposedBlock {
 /// A helper trait to simplify constructing blocks for tests.
 pub trait BlockTestExt: Sized {
     /// Returns the block with the given authenticated signer.
-    fn with_authenticated_signer(self, authenticated_signer: Option<Owner>) -> Self;
+    fn with_authenticated_signer(self, authenticated_signer: Option<MultiAddress>) -> Self;
 
     /// Returns the block with the given operation appended at the end.
     fn with_operation(self, operation: impl Into<Operation>) -> Self;
@@ -90,7 +90,7 @@ pub trait BlockTestExt: Sized {
 }
 
 impl BlockTestExt for ProposedBlock {
-    fn with_authenticated_signer(mut self, authenticated_signer: Option<Owner>) -> Self {
+    fn with_authenticated_signer(mut self, authenticated_signer: Option<MultiAddress>) -> Self {
         self.authenticated_signer = authenticated_signer;
         self
     }

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -121,7 +121,7 @@ async fn test_block_size_limit() {
     let mut chain = ChainStateView::new(chain_id).await;
 
     // The size of the executed valid block below.
-    let maximum_executed_block_size = 855;
+    let maximum_executed_block_size = 856;
 
     // Initialize the chain.
     let mut config = make_open_chain_config();

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -7,7 +7,7 @@ use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey},
     data_types::{Amount, Timestamp},
     hashed::Hashed,
-    identifiers::{ChainId, MultiAddress, Owner},
+    identifiers::{ChainId, MultiAddress},
     listen_for_shutdown_signals,
     time::Instant,
 };
@@ -506,7 +506,7 @@ where
                 operations: operations.clone(),
                 previous_block_hash: chain_client.block_hash(),
                 height: chain_client.next_block_height(),
-                authenticated_signer: Some(Owner::from(key_pair.public())),
+                authenticated_signer: Some(MultiAddress::from(key_pair.public())),
                 timestamp: chain_client.timestamp().max(Timestamp::now()),
             };
             let executed_block = local_node

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -10,7 +10,7 @@ use futures::Future;
 use linera_base::{
     crypto::{AccountSecretKey, CryptoHash, ValidatorPublicKey},
     data_types::{BlockHeight, Timestamp},
-    identifiers::{Account, ChainId, MessageId, Owner},
+    identifiers::{Account, ChainId, MessageId, MultiAddress},
     ownership::ChainOwnership,
     time::{Duration, Instant},
 };
@@ -31,7 +31,7 @@ use tracing::{debug, info};
 #[cfg(feature = "benchmark")]
 use {
     crate::benchmark::Benchmark,
-    linera_base::{data_types::Amount, identifiers::MultiAddress},
+    linera_base::data_types::Amount,
     linera_execution::{
         committee::{Committee, Epoch},
         system::{OpenChainConfig, SystemOperation, OPEN_CHAIN_MESSAGE_INDEX},
@@ -395,7 +395,7 @@ where
         &mut self,
         chain_id: ChainId,
         message_id: MessageId,
-        owner: Owner,
+        owner: MultiAddress,
         validators: Option<Vec<(ValidatorPublicKey, String)>>,
     ) -> Result<(), Error>
     where

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Utc};
 use linera_base::{
     crypto::{AccountPublicKey, CryptoHash, ValidatorPublicKey},
     data_types::{Amount, ApplicationPermissions, TimeDelta},
-    identifiers::{Account, ChainId, MessageId, ModuleId, MultiAddress, Owner},
+    identifiers::{Account, ChainId, MessageId, ModuleId, MultiAddress},
     ownership::{ChainOwnership, TimeoutConfig},
     time::Duration,
     vm::VmRuntime,
@@ -332,7 +332,7 @@ pub enum ClientCommand {
 
         /// The new owner (otherwise create a key pair and remember it)
         #[arg(long = "owner")]
-        owner: Option<Owner>,
+        owner: Option<MultiAddress>,
 
         /// The initial balance of the new chain. This is subtracted from the parent chain's
         /// balance.
@@ -1014,7 +1014,7 @@ pub enum ClientCommand {
     Assign {
         /// The owner to assign.
         #[arg(long)]
-        owner: Owner,
+        owner: MultiAddress,
 
         /// The ID of the message that created the chain. (This uniquely describes the
         /// chain and where it was created.)
@@ -1424,11 +1424,11 @@ pub enum ProjectCommand {
 pub struct ChainOwnershipConfig {
     /// The new super owners.
     #[arg(long, num_args(0..))]
-    super_owners: Vec<Owner>,
+    super_owners: Vec<MultiAddress>,
 
     /// The new regular owners.
     #[arg(long, num_args(0..))]
-    owners: Vec<Owner>,
+    owners: Vec<MultiAddress>,
 
     /// Weights for the new owners.
     ///

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -228,7 +228,7 @@ impl GenesisConfig {
                     committee.clone(),
                     self.admin_id,
                     description,
-                    public_key.into(),
+                    (*public_key).into(),
                     *balance,
                     self.timestamp,
                 )

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -10,7 +10,7 @@ use linera_base::{
     crypto::{AccountSecretKey, CryptoHash, CryptoRng},
     data_types::{BlockHeight, Timestamp},
     ensure,
-    identifiers::{ChainDescription, ChainId, Owner},
+    identifiers::{ChainDescription, ChainId, MultiAddress},
 };
 use linera_core::{
     client::{ChainClient, PendingProposal},
@@ -25,7 +25,7 @@ use crate::{config::GenesisConfig, error, Error};
 #[derive(Serialize, Deserialize)]
 pub struct Wallet {
     pub chains: BTreeMap<ChainId, UserChain>,
-    pub unassigned_key_pairs: HashMap<Owner, AccountSecretKey>,
+    pub unassigned_key_pairs: HashMap<MultiAddress, AccountSecretKey>,
     pub default: Option<ChainId>,
     pub genesis_config: GenesisConfig,
     pub testing_prng_seed: Option<u64>,
@@ -118,7 +118,7 @@ impl Wallet {
         self.unassigned_key_pairs.insert(owner, key_pair);
     }
 
-    pub fn key_pair_for_owner(&self, owner: &Owner) -> Option<AccountSecretKey> {
+    pub fn key_pair_for_owner(&self, owner: &MultiAddress) -> Option<AccountSecretKey> {
         if let Some(key_pair) = self
             .unassigned_key_pairs
             .get(owner)
@@ -129,13 +129,13 @@ impl Wallet {
         self.chains
             .values()
             .filter_map(|user_chain| user_chain.key_pair.as_ref())
-            .find(|key_pair| Owner::from(key_pair.public()) == *owner)
+            .find(|key_pair| MultiAddress::from(key_pair.public()) == *owner)
             .map(|key_pair| key_pair.copy())
     }
 
     pub fn assign_new_chain_to_owner(
         &mut self,
-        owner: Owner,
+        owner: MultiAddress,
         chain_id: ChainId,
         timestamp: Timestamp,
     ) -> Result<(), Error> {

--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -57,7 +57,7 @@ where
     let owner1 = chain1.identity().await.unwrap();
     let amt = Amount::ONE;
 
-    let account = Account::address32(chain2.chain_id(), owner1.0);
+    let account = Account::address32(chain2.chain_id(), owner1);
     let cert = chain1
         .transfer_to_account(MultiAddress::chain(), amt, account)
         .await

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -10,7 +10,7 @@ use linera_base::{
     crypto::ValidatorPublicKey,
     data_types::{Blob, BlockHeight, Timestamp},
     ensure,
-    identifiers::{ChainId, Owner},
+    identifiers::{ChainId, MultiAddress},
 };
 use linera_chain::{
     data_types::{
@@ -137,7 +137,7 @@ where
             signature: _,
         } = proposal;
 
-        let owner = Owner::from(public_key);
+        let owner = MultiAddress::from(*public_key);
         let mut maybe_blobs = self
             .state
             .maybe_get_required_blobs(proposal.required_blob_ids(), None)

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use linera_base::{
     data_types::{ArithmeticError, Blob, Timestamp, UserApplicationDescription},
     ensure,
-    identifiers::{ChannelFullName, MultiAddress, Owner},
+    identifiers::{ChannelFullName, MultiAddress},
 };
 use linera_chain::{
     data_types::{
@@ -147,7 +147,7 @@ where
                 .execution_state
                 .system
                 .balances
-                .get(&MultiAddress::Address32(signer.0))
+                .get(&signer)
                 .await?;
         }
 
@@ -172,7 +172,7 @@ where
         } = proposal;
         let block = &content.block;
 
-        let owner = Owner::from(public_key);
+        let owner = MultiAddress::from(*public_key);
         let chain = &self.0.chain;
         // Check the epoch.
         let (epoch, committee) = chain.current_committee()?;

--- a/linera-core/src/client/chain_client_state.rs
+++ b/linera-core/src/client/chain_client_state.rs
@@ -11,7 +11,7 @@ use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey, CryptoHash},
     data_types::{Blob, BlockHeight, Timestamp},
     ensure,
-    identifiers::Owner,
+    identifiers::MultiAddress,
     ownership::ChainOwnership,
 };
 use linera_chain::data_types::ProposedBlock;
@@ -35,7 +35,7 @@ pub struct ChainClientState {
     /// This is always at the same height as `next_block_height`.
     pending_proposal: Option<PendingProposal>,
     /// Known key pairs from present and past identities.
-    known_key_pairs: BTreeMap<Owner, AccountSecretKey>,
+    known_key_pairs: BTreeMap<MultiAddress, AccountSecretKey>,
 
     /// A mutex that is held whilst we are performing operations that should not be
     /// attempted by multiple clients at the same time.
@@ -52,7 +52,7 @@ impl ChainClientState {
     ) -> ChainClientState {
         let known_key_pairs = known_key_pairs
             .into_iter()
-            .map(|kp| (Owner::from(kp.public()), kp))
+            .map(|kp| (MultiAddress::from(kp.public()), kp))
             .collect();
         ChainClientState {
             known_key_pairs,
@@ -97,7 +97,7 @@ impl ChainClientState {
         }
     }
 
-    pub fn known_key_pairs(&self) -> &BTreeMap<Owner, AccountSecretKey> {
+    pub fn known_key_pairs(&self) -> &BTreeMap<MultiAddress, AccountSecretKey> {
         &self.known_key_pairs
     }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -11,7 +11,7 @@ use futures::StreamExt;
 use linera_base::{
     crypto::AccountSecretKey,
     data_types::*,
-    identifiers::{Account, ChainId, MessageId, MultiAddress, Owner},
+    identifiers::{Account, ChainId, MessageId, MultiAddress},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
@@ -149,8 +149,7 @@ where
         .await?
         .with_policy(ResourceControlPolicy::fuel_and_block());
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
-    let owner_identity = sender.identity().await?;
-    let owner = MultiAddress::from(owner_identity);
+    let owner = sender.identity().await?;
     let receiver = builder.add_root_chain(2, Amount::ZERO).await?;
     let receiver_id = receiver.chain_id();
     let friend = receiver.identity().await?;
@@ -158,7 +157,7 @@ where
         .transfer_to_account(
             MultiAddress::chain(),
             Amount::from_tokens(3),
-            Account::address32(receiver_id, owner_identity.0),
+            Account::address32(receiver_id, owner),
         )
         .await
         .unwrap()
@@ -167,7 +166,7 @@ where
         .transfer_to_account(
             MultiAddress::chain(),
             Amount::from_millis(100),
-            Account::address32(receiver_id, friend.0),
+            Account::address32(receiver_id, friend),
         )
         .await
         .unwrap()
@@ -182,10 +181,7 @@ where
     assert_eq!(receiver.process_inbox().await?.0.len(), 1);
     // The friend paid to receive the message.
     assert_eq!(
-        receiver
-            .local_owner_balance(MultiAddress::from(friend))
-            .await
-            .unwrap(),
+        receiver.local_owner_balance(friend).await.unwrap(),
         Amount::from_millis(99)
     );
     // The received amount is not in the unprotected balance.
@@ -211,7 +207,7 @@ where
     // First attempt that should be rejected.
     sender
         .claim(
-            owner_identity,
+            owner,
             receiver_id,
             Recipient::root(1),
             Amount::from_tokens(5),
@@ -221,7 +217,7 @@ where
     // Second attempt with a correct amount.
     let cert = sender
         .claim(
-            owner_identity,
+            owner,
             receiver_id,
             Recipient::root(1),
             Amount::from_tokens(2),
@@ -273,7 +269,7 @@ where
         .with_policy(ResourceControlPolicy::fuel_and_block());
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let new_key_pair = AccountSecretKey::generate();
-    let new_owner = Owner::from(new_key_pair.public());
+    let new_owner = MultiAddress::from(new_key_pair.public());
     let certificate = sender.rotate_key_pair(new_key_pair).await.unwrap().unwrap();
     assert_eq!(sender.next_block_height(), BlockHeight::from(1));
     assert!(sender.pending_proposal().is_none());
@@ -1469,9 +1465,9 @@ where
     let client1 = builder.add_root_chain(1, Amount::ZERO).await?;
     let client2_a = builder.add_root_chain(2, Amount::from_tokens(10)).await?;
     let chain_id2 = client2_a.chain_id();
-    let owner2_a = Owner::from(client2_a.public_key().await.unwrap());
+    let owner2_a = MultiAddress::from(client2_a.public_key().await.unwrap());
     let key_pair2_b = AccountSecretKey::generate();
-    let owner2_b = Owner::from(key_pair2_b.public());
+    let owner2_b = MultiAddress::from(key_pair2_b.public());
     let owner_change_op = Operation::System(SystemOperation::ChangeOwnership {
         super_owners: Vec::new(),
         owners: vec![(owner2_a, 50), (owner2_b, 50)],
@@ -1598,11 +1594,11 @@ where
     let client2 = builder.add_root_chain(2, Amount::ZERO).await?;
     let client3_a = builder.add_root_chain(3, Amount::from_tokens(10)).await?;
     let chain_id3 = client3_a.chain_id();
-    let owner3_a = Owner::from(client3_a.public_key().await.unwrap());
+    let owner3_a = MultiAddress::from(client3_a.public_key().await.unwrap());
     let key_pair3_b = AccountSecretKey::generate();
-    let owner3_b = Owner::from(key_pair3_b.public());
+    let owner3_b = MultiAddress::from(key_pair3_b.public());
     let key_pair3_c = AccountSecretKey::generate();
-    let owner3_c = Owner::from(key_pair3_c.public());
+    let owner3_c = MultiAddress::from(key_pair3_c.public());
     let owner_change_op = Operation::System(SystemOperation::ChangeOwnership {
         super_owners: Vec::new(),
         owners: vec![(owner3_a, 50), (owner3_b, 50), (owner3_c, 50)],

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -23,8 +23,7 @@ use linera_base::{
     data_types::*,
     hashed::Hashed,
     identifiers::{
-        Account, ChainDescription, ChainId, Destination, EventId, MessageId, MultiAddress, Owner,
-        StreamId,
+        Account, ChainDescription, ChainId, Destination, EventId, MessageId, MultiAddress, StreamId,
     },
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -114,7 +113,7 @@ where
 /// Same as `init_worker` but also instantiates some initial chains.
 async fn init_worker_with_chains<S, I>(storage: S, balances: I) -> (Committee, WorkerState<S>)
 where
-    I: IntoIterator<Item = (ChainDescription, Owner, Amount)>,
+    I: IntoIterator<Item = (ChainDescription, MultiAddress, Amount)>,
     S: Storage + Clone + Send + Sync + 'static,
 {
     let (committee, worker) = init_worker(
@@ -141,7 +140,7 @@ where
 async fn init_worker_with_chain<S>(
     storage: S,
     description: ChainDescription,
-    owner: Owner,
+    owner: MultiAddress,
     balance: Amount,
 ) -> (Committee, WorkerState<S>)
 where
@@ -221,7 +220,7 @@ where
 async fn make_transfer_certificate<S>(
     chain_description: ChainDescription,
     key_pair: &AccountSecretKey,
-    authenticated_signer: Option<Owner>,
+    authenticated_signer: Option<MultiAddress>,
     source: MultiAddress,
     recipient: Recipient,
     amount: Amount,
@@ -257,7 +256,7 @@ where
 async fn make_transfer_certificate_for_epoch<S>(
     chain_description: ChainDescription,
     key_pair: &AccountSecretKey,
-    authenticated_signer: Option<Owner>,
+    authenticated_signer: Option<MultiAddress>,
     source: MultiAddress,
     recipient: Recipient,
     amount: Amount,
@@ -387,13 +386,13 @@ fn direct_credit_message(recipient: ChainId, amount: Amount) -> OutgoingMessage 
     direct_outgoing_message(recipient, MessageKind::Tracked, message)
 }
 
-/// Creates `count` key pairs and returns them, sorted by the `Owner` created from their public key.
+/// Creates `count` key pairs and returns them, sorted by the `MultiAddress` created from their public key.
 fn generate_key_pairs(count: usize) -> Vec<AccountSecretKey> {
     let mut key_pairs = iter::repeat_with(Secp256k1SecretKey::generate)
         .map(AccountSecretKey::Secp256k1)
         .take(count)
         .collect::<Vec<_>>();
-    key_pairs.sort_by_key(|key_pair| Owner::from(key_pair.public()));
+    key_pairs.sort_by_key(|key_pair| MultiAddress::from(key_pair.public()));
     key_pairs
 }
 
@@ -2088,17 +2087,17 @@ where
     B: StorageBuilder,
 {
     let sender_key_pair = AccountSecretKey::generate();
-    let sender = Owner::from(sender_key_pair.public());
+    let sender = MultiAddress::from(sender_key_pair.public());
     let sender_account = Account {
         chain_id: ChainId::root(1),
-        owner: MultiAddress::from(sender),
+        owner: sender,
     };
 
     let recipient_key_pair = AccountSecretKey::generate();
-    let recipient = Owner::from(sender_key_pair.public());
+    let recipient = MultiAddress::from(sender_key_pair.public());
     let recipient_account = Account {
         chain_id: ChainId::root(2),
-        owner: MultiAddress::from(recipient),
+        owner: recipient,
     };
 
     let (committee, worker) = init_worker_with_chains(
@@ -2123,7 +2122,7 @@ where
     let certificate00 = make_transfer_certificate(
         ChainDescription::Root(1),
         &sender_key_pair,
-        Some(Owner::from(sender_key_pair.public())),
+        Some(MultiAddress::from(sender_key_pair.public())),
         MultiAddress::chain(),
         Recipient::Account(sender_account),
         Amount::from_tokens(5),
@@ -2143,7 +2142,7 @@ where
     let certificate01 = make_transfer_certificate(
         ChainDescription::Root(1),
         &sender_key_pair,
-        Some(Owner::from(sender_key_pair.public())),
+        Some(MultiAddress::from(sender_key_pair.public())),
         MultiAddress::chain(),
         Recipient::Burn,
         Amount::ONE,
@@ -2156,7 +2155,7 @@ where
                 transaction_index: 0,
                 messages: vec![Message::System(SystemMessage::Credit {
                     source: MultiAddress::chain(),
-                    target: MultiAddress::from(sender),
+                    target: sender,
                     amount: Amount::from_tokens(5),
                 })
                 .to_posted(0, MessageKind::Tracked)],
@@ -2165,7 +2164,7 @@ where
         }],
         &committee,
         Amount::ZERO,
-        BTreeMap::from_iter([(MultiAddress::Address32(sender.0), Amount::from_tokens(5))]),
+        BTreeMap::from_iter([(sender, Amount::from_tokens(5))]),
         &worker,
         Some(&certificate00),
     )
@@ -2186,13 +2185,13 @@ where
         ChainDescription::Root(1),
         &sender_key_pair,
         Some(sender),
-        MultiAddress::from(sender),
+        sender,
         Recipient::Account(recipient_account),
         Amount::from_tokens(3),
         Vec::new(),
         &committee,
         Amount::ZERO,
-        BTreeMap::from_iter([(MultiAddress::Address32(sender.0), Amount::from_tokens(2))]),
+        BTreeMap::from_iter([(sender, Amount::from_tokens(2))]),
         &worker,
         Some(&certificate01),
     )
@@ -2206,7 +2205,7 @@ where
         ChainDescription::Root(1),
         &sender_key_pair,
         Some(sender),
-        MultiAddress::from(sender),
+        sender,
         Recipient::Account(recipient_account),
         Amount::from_tokens(2),
         Vec::new(),
@@ -2227,7 +2226,7 @@ where
         ChainDescription::Root(2),
         &recipient_key_pair,
         Some(recipient),
-        MultiAddress::from(recipient),
+        recipient,
         Recipient::Burn,
         Amount::ONE,
         vec![
@@ -2239,8 +2238,8 @@ where
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
                     messages: vec![Message::System(SystemMessage::Credit {
-                        source: MultiAddress::from(sender),
-                        target: MultiAddress::from(recipient),
+                        source: sender,
+                        target: recipient,
                         amount: Amount::from_tokens(3),
                     })
                     .to_posted(0, MessageKind::Tracked)],
@@ -2255,8 +2254,8 @@ where
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
                     messages: vec![Message::System(SystemMessage::Credit {
-                        source: MultiAddress::from(sender),
-                        target: MultiAddress::from(recipient),
+                        source: sender,
+                        target: recipient,
                         amount: Amount::from_tokens(2),
                     })
                     .to_posted(0, MessageKind::Tracked)],
@@ -2266,7 +2265,7 @@ where
         ],
         &committee,
         Amount::ZERO,
-        BTreeMap::from_iter([(MultiAddress::Address32(recipient.0), Amount::from_tokens(1))]),
+        BTreeMap::from_iter([(recipient, Amount::from_tokens(1))]),
         &worker,
         None,
     )
@@ -2287,7 +2286,7 @@ where
         ChainDescription::Root(1),
         &sender_key_pair,
         Some(sender),
-        MultiAddress::from(sender),
+        sender,
         Recipient::Burn,
         Amount::from_tokens(3),
         vec![IncomingBundle {
@@ -2298,8 +2297,8 @@ where
                 timestamp: Timestamp::from(0),
                 transaction_index: 0,
                 messages: vec![Message::System(SystemMessage::Credit {
-                    source: MultiAddress::from(sender),
-                    target: MultiAddress::from(recipient),
+                    source: sender,
+                    target: recipient,
                     amount: Amount::from_tokens(3),
                 })
                 .to_posted(0, MessageKind::Bouncing)],
@@ -3193,8 +3192,8 @@ where
     let clock = storage_builder.clock();
     let chain_id = ChainId::root(0);
     let key_pairs = generate_key_pairs(2);
-    let owner0 = Owner::from(key_pairs[0].public());
-    let owner1 = Owner::from(key_pairs[1].public());
+    let owner0 = MultiAddress::from(key_pairs[0].public());
+    let owner1 = MultiAddress::from(key_pairs[1].public());
     let balances = vec![(ChainDescription::Root(0), owner0, Amount::from_tokens(2))];
     let (committee, worker) = init_worker_with_chains(storage, balances).await;
 
@@ -3397,8 +3396,8 @@ where
     let clock = storage_builder.clock();
     let chain_id = ChainId::root(0);
     let key_pairs = generate_key_pairs(2);
-    let owner0 = Owner::from(key_pairs[0].public());
-    let owner1 = Owner::from(key_pairs[1].public());
+    let owner0 = MultiAddress::from(key_pairs[0].public());
+    let owner1 = MultiAddress::from(key_pairs[1].public());
     let balances = vec![(ChainDescription::Root(0), owner0, Amount::from_tokens(2))];
     let (committee, worker) = init_worker_with_chains(storage, balances).await;
 
@@ -3554,8 +3553,8 @@ where
     let clock = storage_builder.clock();
     let chain_id = ChainId::root(0);
     let key_pairs = generate_key_pairs(2);
-    let owner0 = Owner::from(key_pairs[0].public());
-    let owner1 = Owner::from(key_pairs[1].public());
+    let owner0 = MultiAddress::from(key_pairs[0].public());
+    let owner1 = MultiAddress::from(key_pairs[1].public());
     let balances = vec![(ChainDescription::Root(0), owner0, Amount::from_tokens(2))];
     let (committee, worker) = init_worker_with_chains(storage, balances).await;
 
@@ -3581,7 +3580,7 @@ where
     assert_eq!(response.info.manager.current_round, Round::Fast);
     assert_eq!(response.info.manager.leader, None);
 
-    // Owner 0 proposes another block. The validator votes to confirm.
+    // MultiAddress 0 proposes another block. The validator votes to confirm.
     let block1 = make_child_block(&value0.clone());
     let proposal1 = block1
         .clone()
@@ -3718,7 +3717,7 @@ where
     let manager = response.info.manager;
     let account_key = worker.account_key();
     assert_eq!(manager.current_round, Round::Validator(0));
-    assert_eq!(manager.leader, Some(Owner::from(account_key)));
+    assert_eq!(manager.leader, Some(MultiAddress::from(account_key)));
     Ok(())
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -19,7 +19,7 @@ use linera_base::{
     },
     doc_scalar,
     hashed::Hashed,
-    identifiers::{BlobId, ChainId, EventId, MultiAddress, Owner},
+    identifiers::{BlobId, ChainId, EventId, MultiAddress},
     time::timer::{sleep, timeout},
 };
 use linera_chain::{
@@ -165,7 +165,7 @@ pub enum WorkerError {
     InvalidOwner,
 
     #[error("Operations in the block are not authenticated by the proper signer: {0}")]
-    InvalidSigner(Owner),
+    InvalidSigner(MultiAddress),
 
     // Chaining
     #[error(

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -6,7 +6,7 @@ use std::{mem, vec};
 use futures::{FutureExt, StreamExt};
 use linera_base::{
     data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::{Account, BlobType, ChainId, Destination, MultiAddress, Owner},
+    identifiers::{Account, BlobType, ChainId, Destination, MultiAddress},
 };
 use linera_views::{
     context::Context,
@@ -131,7 +131,7 @@ pub enum UserAction {
 }
 
 impl UserAction {
-    pub(crate) fn signer(&self) -> Option<Owner> {
+    pub(crate) fn signer(&self) -> Option<MultiAddress> {
         use UserAction::*;
         match self {
             Instantiate(context, _) => context.authenticated_signer,
@@ -172,7 +172,7 @@ where
         refund_grant_to: Option<Account>,
         grant: Option<&mut Amount>,
         txn_tracker: &mut TransactionTracker,
-        resource_controller: &mut ResourceController<Option<Owner>>,
+        resource_controller: &mut ResourceController<Option<MultiAddress>>,
     ) -> Result<(), ExecutionError> {
         let ExecutionRuntimeConfig {} = self.context().extra().execution_runtime_config();
         self.run_user_action_with_runtime(
@@ -198,7 +198,7 @@ where
         refund_grant_to: Option<Account>,
         grant: Option<&mut Amount>,
         txn_tracker: &mut TransactionTracker,
-        resource_controller: &mut ResourceController<Option<Owner>>,
+        resource_controller: &mut ResourceController<Option<MultiAddress>>,
     ) -> Result<(), ExecutionError> {
         let mut cloned_grant = grant.as_ref().map(|x| **x);
         let initial_balance = resource_controller
@@ -259,7 +259,7 @@ where
         local_time: Timestamp,
         operation: Operation,
         txn_tracker: &mut TransactionTracker,
-        resource_controller: &mut ResourceController<Option<Owner>>,
+        resource_controller: &mut ResourceController<Option<MultiAddress>>,
     ) -> Result<(), ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         match operation {
@@ -310,7 +310,7 @@ where
         message: Message,
         grant: Option<&mut Amount>,
         txn_tracker: &mut TransactionTracker,
-        resource_controller: &mut ResourceController<Option<Owner>>,
+        resource_controller: &mut ResourceController<Option<MultiAddress>>,
     ) -> Result<(), ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         match message {

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -17,7 +17,7 @@ use linera_base::prometheus_util::{
 use linera_base::{
     data_types::{Amount, ApplicationPermissions, BlobContent, BlockHeight, Timestamp},
     ensure, hex_debug, hex_vec_debug, http,
-    identifiers::{Account, BlobId, BlobType, ChainId, MessageId, MultiAddress, Owner},
+    identifiers::{Account, BlobId, BlobType, ChainId, MessageId, MultiAddress},
     ownership::ChainOwnership,
 };
 use linera_views::{batch::Batch, context::Context, views::View};
@@ -120,7 +120,7 @@ where
     pub(crate) async fn handle_request(
         &mut self,
         request: ExecutionRequest,
-        resource_controller: &mut ResourceController<Option<Owner>>,
+        resource_controller: &mut ResourceController<Option<MultiAddress>>,
     ) -> Result<(), ExecutionError> {
         use ExecutionRequest::*;
         match request {
@@ -564,7 +564,7 @@ pub enum ExecutionRequest {
         destination: Account,
         amount: Amount,
         #[debug(skip_if = Option::is_none)]
-        signer: Option<Owner>,
+        signer: Option<MultiAddress>,
         application_id: MultiAddress,
         #[debug(skip)]
         callback: Sender<Option<OutgoingMessage>>,
@@ -575,7 +575,7 @@ pub enum ExecutionRequest {
         destination: Account,
         amount: Amount,
         #[debug(skip_if = Option::is_none)]
-        signer: Option<Owner>,
+        signer: Option<MultiAddress>,
         application_id: MultiAddress,
         #[debug(skip)]
         callback: Sender<OutgoingMessage>,

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -9,7 +9,7 @@ use custom_debug_derive::Debug;
 use linera_base::{
     data_types::{Amount, ArithmeticError, BlobContent},
     ensure,
-    identifiers::{MultiAddress, Owner},
+    identifiers::MultiAddress,
 };
 use linera_views::{context::Context, views::ViewError};
 use serde::Serialize;
@@ -491,7 +491,7 @@ impl BalanceHolder for Sources<'_> {
     }
 }
 
-impl ResourceController<Option<Owner>, ResourceTracker> {
+impl ResourceController<Option<MultiAddress>, ResourceTracker> {
     /// Provides a reference to the current execution state and obtains a temporary object
     /// where the accounting functions of [`ResourceController`] are available.
     pub async fn with_state<'a, C>(
@@ -525,12 +525,8 @@ impl ResourceController<Option<Owner>, ResourceTracker> {
         }
         // Then the local account, if any. Currently, any negative fee (e.g. storage
         // refund) goes preferably to this account.
-        if let Some(owner) = &self.account {
-            if let Some(balance) = view
-                .balances
-                .get_mut(&MultiAddress::Address32(owner.0))
-                .await?
-            {
+        if let Some(address) = &self.account {
+            if let Some(balance) = view.balances.get_mut(address).await? {
                 sources.push(balance);
             }
         }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -19,7 +19,7 @@ use linera_base::{
     ensure, http,
     identifiers::{
         Account, BlobId, BlobType, ChainId, ChannelFullName, ChannelName, MessageId, MultiAddress,
-        Owner, StreamId, StreamName,
+        StreamId, StreamName,
     },
     ownership::ChainOwnership,
 };
@@ -73,7 +73,7 @@ pub struct SyncRuntimeInternal<UserInstance> {
     local_time: Timestamp,
     /// The authenticated signer of the operation or message, if any.
     #[debug(skip_if = Option::is_none)]
-    authenticated_signer: Option<Owner>,
+    authenticated_signer: Option<MultiAddress>,
     /// The current message being executed, if there is one.
     #[debug(skip_if = Option::is_none)]
     executing_message: Option<ExecutingMessage>,
@@ -124,7 +124,7 @@ struct ApplicationStatus {
     /// The application description.
     description: UserApplicationDescription,
     /// The authenticated signer for the execution thread, if any.
-    signer: Option<Owner>,
+    signer: Option<MultiAddress>,
 }
 
 /// A loaded application instance.
@@ -294,7 +294,7 @@ impl<UserInstance> SyncRuntimeInternal<UserInstance> {
         height: BlockHeight,
         round: Option<u32>,
         local_time: Timestamp,
-        authenticated_signer: Option<Owner>,
+        authenticated_signer: Option<MultiAddress>,
         executing_message: Option<ExecutingMessage>,
         execution_state_sender: ExecutionStateSender,
         deadline: Option<Instant>,
@@ -1085,7 +1085,7 @@ impl ContractSyncRuntimeHandle {
     fn execute(
         &mut self,
         application_id: MultiAddress,
-        signer: Option<Owner>,
+        signer: Option<MultiAddress>,
         closure: impl FnOnce(&mut UserContractInstance) -> Result<Option<Vec<u8>>, ExecutionError>,
     ) -> Result<Option<Vec<u8>>, ExecutionError> {
         let contract = {
@@ -1124,7 +1124,7 @@ impl ContractSyncRuntimeHandle {
 }
 
 impl ContractRuntime for ContractSyncRuntimeHandle {
-    fn authenticated_signer(&mut self) -> Result<Option<Owner>, ExecutionError> {
+    fn authenticated_signer(&mut self) -> Result<Option<MultiAddress>, ExecutionError> {
         Ok(self.inner().authenticated_signer)
     }
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -24,7 +24,7 @@ use linera_base::{
     ensure, hex_debug,
     identifiers::{
         Account, BlobId, BlobType, ChainDescription, ChainId, ChannelFullName, EventId, MessageId,
-        ModuleId, MultiAddress, Owner, StreamId,
+        ModuleId, MultiAddress, StreamId,
     },
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -122,7 +122,7 @@ pub enum SystemOperation {
     /// `target` chain. Depending on its configuration, the `target` chain may refuse to
     /// process the message.
     Claim {
-        owner: Owner,
+        owner: MultiAddress,
         target_id: ChainId,
         recipient: Recipient,
         amount: Amount,
@@ -136,10 +136,10 @@ pub enum SystemOperation {
     ChangeOwnership {
         /// Super owners can propose fast blocks in the first round, and regular blocks in any round.
         #[debug(skip_if = Vec::is_empty)]
-        super_owners: Vec<Owner>,
+        super_owners: Vec<MultiAddress>,
         /// The regular owners, with their weights that determine how often they are round leader.
         #[debug(skip_if = Vec::is_empty)]
-        owners: Vec<(Owner, u64)>,
+        owners: Vec<(MultiAddress, u64)>,
         /// The number of initial rounds after 0 in which all owners are allowed to propose blocks.
         multi_leader_rounds: u32,
         /// Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners.
@@ -368,7 +368,7 @@ where
         context: OperationContext,
         operation: SystemOperation,
         txn_tracker: &mut TransactionTracker,
-        resource_controller: &mut ResourceController<Option<Owner>>,
+        resource_controller: &mut ResourceController<Option<MultiAddress>>,
     ) -> Result<Option<(MultiAddress, Vec<u8>)>, ExecutionError> {
         use SystemOperation::*;
         let mut new_application = None;
@@ -422,7 +422,7 @@ where
                     .claim(
                         context.authenticated_signer,
                         None,
-                        MultiAddress::Address32(owner.0),
+                        owner,
                         target_id,
                         recipient,
                         amount,
@@ -622,7 +622,7 @@ where
 
     pub async fn transfer(
         &mut self,
-        authenticated_signer: Option<Owner>,
+        authenticated_signer: Option<MultiAddress>,
         authenticated_application_id: Option<MultiAddress>,
         source: MultiAddress,
         recipient: Recipient,
@@ -637,7 +637,7 @@ where
             )
         } else if let Some(authenticated_signer) = authenticated_signer {
             ensure!(
-                source == MultiAddress::from(authenticated_signer),
+                source == authenticated_signer,
                 ExecutionError::UnauthenticatedTransferOwner
             )
         } else if let Some(authenticated_application) = authenticated_application_id {
@@ -670,20 +670,17 @@ where
 
     pub async fn claim(
         &self,
-        authenticated_signer: Option<Owner>,
+        authenticated_signer: Option<MultiAddress>,
         authenticated_application_id: Option<MultiAddress>,
         source: MultiAddress,
         target_id: ChainId,
         recipient: Recipient,
         amount: Amount,
     ) -> Result<OutgoingMessage, ExecutionError> {
-        match source {
-            MultiAddress::Address32(owner) => ensure!(
-                authenticated_signer.map(|owner| owner.0) == Some(owner)
-                    || authenticated_application_id == Some(source),
-                ExecutionError::UnauthenticatedClaimOwner
-            ),
-        }
+        ensure!(
+            authenticated_signer == Some(source) || authenticated_application_id == Some(source),
+            ExecutionError::UnauthenticatedClaimOwner
+        );
         ensure!(amount > Amount::ZERO, ExecutionError::IncorrectClaimAmount);
 
         let message = SystemMessage::Withdraw {

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -15,7 +15,7 @@ use std::{collections::BTreeMap, sync::Arc, thread, vec};
 use linera_base::{
     crypto::{BcsSignable, CryptoHash},
     data_types::{Amount, Blob, BlockHeight, CompressedBytecode, OracleResponse, Timestamp},
-    identifiers::{BlobId, BlobType, ChainId, MessageId, ModuleId, MultiAddress, Owner},
+    identifiers::{BlobId, BlobType, ChainId, MessageId, ModuleId, MultiAddress},
     vm::VmRuntime,
 };
 use linera_views::{
@@ -80,7 +80,7 @@ pub fn create_dummy_operation_context() -> OperationContext {
 }
 
 /// Creates a dummy [`MessageContext`] to use in tests.
-pub fn create_dummy_message_context(authenticated_signer: Option<Owner>) -> MessageContext {
+pub fn create_dummy_message_context(authenticated_signer: Option<MultiAddress>) -> MessageContext {
     MessageContext {
         chain_id: ChainId::root(0),
         is_bouncing: false,

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -11,7 +11,7 @@ use custom_debug_derive::Debug;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, ApplicationPermissions, Blob, Timestamp},
-    identifiers::{BlobId, ChainDescription, ChainId, MultiAddress, Owner},
+    identifiers::{BlobId, ChainDescription, ChainId, MultiAddress},
     ownership::ChainOwnership,
 };
 use linera_views::{

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -7,7 +7,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, ApplicationPermissions, BlockHeight, SendMessageRequest, Timestamp},
     http,
-    identifiers::{Account, ChainId, ChannelName, MessageId, MultiAddress, Owner, StreamName},
+    identifiers::{Account, ChainId, ChannelName, MessageId, MultiAddress, StreamName},
     ownership::{ChainOwnership, ChangeApplicationPermissionsError, CloseChainError},
 };
 use linera_views::batch::{Batch, WriteOperation};
@@ -389,7 +389,7 @@ where
     Runtime: ContractRuntime + 'static,
 {
     /// Returns the authenticated signer for this execution, if there is one.
-    fn authenticated_signer(caller: &mut Caller) -> Result<Option<Owner>, RuntimeError> {
+    fn authenticated_signer(caller: &mut Caller) -> Result<Option<MultiAddress>, RuntimeError> {
         caller
             .user_data_mut()
             .runtime

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -16,7 +16,7 @@ use linera_base::{
         Timestamp, UserApplicationDescription,
     },
     http,
-    identifiers::{Account, ChainDescription, ChainId, ModuleId, MultiAddress, Owner},
+    identifiers::{Account, ChainDescription, ChainId, ModuleId, MultiAddress},
     ownership::ChainOwnership,
     vm::VmRuntime,
 };
@@ -690,9 +690,9 @@ enum TransferTestEndpoint {
 }
 
 impl TransferTestEndpoint {
-    /// Returns the [`Owner`] used to represent a sender that's a user.
-    fn sender_owner() -> Owner {
-        Owner(CryptoHash::test_hash("sender"))
+    /// Returns the [`MultiAddress`] used to represent a sender that's a user.
+    fn sender_owner() -> MultiAddress {
+        MultiAddress::from(CryptoHash::test_hash("sender"))
     }
 
     /// Returns the [`MultiAddress`] used to represent a sender that's an application.
@@ -732,14 +732,14 @@ impl TransferTestEndpoint {
         })
     }
 
-    /// Returns the [`Owner`] used to represent a recipient that's a user.
-    fn recipient_owner() -> Owner {
-        Owner(CryptoHash::test_hash("recipient"))
+    /// Returns the [`MultiAddress`] used to represent a recipient that's a user.
+    fn recipient_owner() -> MultiAddress {
+        MultiAddress::from(CryptoHash::test_hash("recipient"))
     }
 
     /// Returns the [`ApplicationId`] used to represent a recipient that's an application.
     fn recipient_application_id() -> MultiAddress {
-        MultiAddress::Address32(CryptoHash::test_hash("recipient application description"))
+        MultiAddress::from(CryptoHash::test_hash("recipient application description"))
     }
 
     /// Returns a [`SystemExecutionState`] initialized with this transfer endpoint's account
@@ -752,18 +752,11 @@ impl TransferTestEndpoint {
             TransferTestEndpoint::Chain => (transfer_amount, vec![], Some(Self::sender_owner())),
             TransferTestEndpoint::User => {
                 let owner = Self::sender_owner();
-                (
-                    Amount::ZERO,
-                    vec![(MultiAddress::Address32(owner.0), transfer_amount)],
-                    Some(owner),
-                )
+                (Amount::ZERO, vec![(owner, transfer_amount)], Some(owner))
             }
             TransferTestEndpoint::Application => (
                 Amount::ZERO,
-                vec![(
-                    MultiAddress::Address32(Self::sender_application_id().as_address()),
-                    transfer_amount,
-                )],
+                vec![(Self::sender_application_id(), transfer_amount)],
                 None,
             ),
         };
@@ -786,7 +779,7 @@ impl TransferTestEndpoint {
     pub fn sender_account_owner(&self) -> MultiAddress {
         match self {
             TransferTestEndpoint::Chain => MultiAddress::chain(),
-            TransferTestEndpoint::User => MultiAddress::Address32(Self::sender_owner().0),
+            TransferTestEndpoint::User => Self::sender_owner(),
             TransferTestEndpoint::Application => Self::sender_application_id(),
         }
     }
@@ -802,18 +795,18 @@ impl TransferTestEndpoint {
         }
     }
 
-    /// Returns the [`Owner`] that should be used as the authenticated signer in the transfer
+    /// Returns the [`MultiAddress`] that should be used as the authenticated signer in the transfer
     /// operation.
-    pub fn signer(&self) -> Option<Owner> {
+    pub fn signer(&self) -> Option<MultiAddress> {
         match self {
             TransferTestEndpoint::Chain | TransferTestEndpoint::User => Some(Self::sender_owner()),
             TransferTestEndpoint::Application => None,
         }
     }
 
-    /// Returns the [`Owner`] that should be used as the authenticated signer when testing an
+    /// Returns the [`MultiAddress`] that should be used as the authenticated signer when testing an
     /// unauthorized transfer operation.
-    pub fn unauthorized_signer(&self) -> Option<Owner> {
+    pub fn unauthorized_signer(&self) -> Option<MultiAddress> {
         match self {
             TransferTestEndpoint::Chain | TransferTestEndpoint::User => {
                 Some(Self::recipient_owner())
@@ -826,7 +819,7 @@ impl TransferTestEndpoint {
     pub fn recipient_account_owner(&self) -> MultiAddress {
         match self {
             TransferTestEndpoint::Chain => MultiAddress::chain(),
-            TransferTestEndpoint::User => MultiAddress::Address32(Self::recipient_owner().0),
+            TransferTestEndpoint::User => Self::recipient_owner(),
             TransferTestEndpoint::Application => Self::recipient_application_id(),
         }
     }

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -12,9 +12,7 @@ use linera_base::{
         Amount, ApplicationPermissions, Blob, BlockHeight, OracleResponse, Resources,
         SendMessageRequest, Timestamp,
     },
-    identifiers::{
-        Account, ChainDescription, ChainId, Destination, MessageId, MultiAddress, Owner,
-    },
+    identifiers::{Account, ChainDescription, ChainId, Destination, MessageId, MultiAddress},
     ownership::ChainOwnership,
 };
 use linera_execution::{
@@ -89,7 +87,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
     let (caller_id, caller_application, caller_blobs) = view.register_mock_application(0).await?;
     let (target_id, target_application, target_blobs) = view.register_mock_application(1).await?;
 
-    let owner = Owner::from(AccountPublicKey::test_key(0));
+    let owner = MultiAddress::from(AccountPublicKey::test_key(0));
     let state_key = vec![];
     let dummy_operation = vec![1];
 
@@ -1465,8 +1463,8 @@ async fn test_close_chain() -> anyhow::Result<()> {
 )]
 #[tokio::test]
 async fn test_message_receipt_spending_chain_balance(
-    receiving_chain_owner: Option<Owner>,
-    authenticated_signer: Option<Owner>,
+    receiving_chain_owner: Option<MultiAddress>,
+    authenticated_signer: Option<MultiAddress>,
 ) -> anyhow::Result<Result<(), ExecutionError>> {
     let amount = Amount::ONE;
     let super_owners = receiving_chain_owner.into_iter().collect();

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -6,7 +6,7 @@
 use linera_base::{
     crypto::{AccountSecretKey, CryptoHash},
     data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::{ChainDescription, ChainId, MessageId, MultiAddress, Owner},
+    identifiers::{ChainDescription, ChainId, MessageId, MultiAddress},
     ownership::ChainOwnership,
 };
 use linera_execution::{
@@ -18,7 +18,7 @@ use linera_execution::{
 #[tokio::test]
 async fn test_simple_system_operation() -> anyhow::Result<()> {
     let owner_key_pair = AccountSecretKey::generate();
-    let owner = Owner::from(owner_key_pair.public());
+    let owner = MultiAddress::from(owner_key_pair.public());
     let state = SystemExecutionState {
         description: Some(ChainDescription::Root(0)),
         balance: Amount::from_tokens(4),

--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -101,7 +101,7 @@ impl Faucet {
 
     pub async fn claim(
         &self,
-        owner: &linera_base::identifiers::Owner,
+        owner: &linera_base::identifiers::MultiAddress,
     ) -> Result<ClaimOutcome, Error> {
         let query = format!(
             "mutation {{ claim(owner: \"{owner}\") {{ \

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -12,7 +12,7 @@ use futures::lock::Mutex;
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{Amount, ApplicationPermissions, Timestamp},
-    identifiers::{ChainId, MessageId, Owner},
+    identifiers::{ChainId, MessageId, MultiAddress},
     ownership::ChainOwnership,
 };
 use linera_client::{
@@ -108,7 +108,7 @@ where
     C: ClientContext,
 {
     /// Creates a new chain with the given authentication key, and transfers tokens to it.
-    async fn claim(&self, owner: Owner) -> Result<ClaimOutcome, Error> {
+    async fn claim(&self, owner: MultiAddress) -> Result<ClaimOutcome, Error> {
         self.do_claim(owner).await
     }
 }
@@ -117,7 +117,7 @@ impl<C> MutationRoot<C>
 where
     C: ClientContext,
 {
-    async fn do_claim(&self, owner: Owner) -> Result<ClaimOutcome, Error> {
+    async fn do_claim(&self, owner: MultiAddress) -> Result<ClaimOutcome, Error> {
         let client = self.context.lock().await.make_chain_client(self.chain_id)?;
 
         if self.start_timestamp < self.end_timestamp {

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -208,7 +208,7 @@ message BlockProposal {
   AccountPublicKey public_key = 3;
 
   // Byte-encoded owner
-  Owner owner = 4;
+  MultiAddress owner = 4;
 
   // Signature by chain owner
   AccountSignature signature = 5;
@@ -337,10 +337,6 @@ message CryptoHash {
 }
 
 message MultiAddress {
-  bytes bytes = 1;
-}
-
-message Owner {
   bytes bytes = 1;
 }
 

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -168,7 +168,7 @@ BlockHeader:
           TYPENAME: CryptoHash
     - authenticated_signer:
         OPTION:
-          TYPENAME: Owner
+          TYPENAME: MultiAddress
 BlockHeight:
   NEWTYPESTRUCT: U64
 BlockHeightRange:
@@ -330,7 +330,7 @@ ChainManagerInfo:
         TYPENAME: Round
     - leader:
         OPTION:
-          TYPENAME: Owner
+          TYPENAME: MultiAddress
     - round_timeout:
         OPTION:
           TYPENAME: Timestamp
@@ -338,11 +338,11 @@ ChainOwnership:
   STRUCT:
     - super_owners:
         SEQ:
-          TYPENAME: Owner
+          TYPENAME: MultiAddress
     - owners:
         MAP:
           KEY:
-            TYPENAME: Owner
+            TYPENAME: MultiAddress
           VALUE: U64
     - multi_leader_rounds: U32
     - open_multi_leader_rounds: BOOL
@@ -759,7 +759,7 @@ OutgoingMessage:
         TYPENAME: Destination
     - authenticated_signer:
         OPTION:
-          TYPENAME: Owner
+          TYPENAME: MultiAddress
     - grant:
         TYPENAME: Amount
     - refund_grant_to:
@@ -769,14 +769,11 @@ OutgoingMessage:
         TYPENAME: MessageKind
     - message:
         TYPENAME: Message
-Owner:
-  NEWTYPESTRUCT:
-    TYPENAME: CryptoHash
 PostedMessage:
   STRUCT:
     - authenticated_signer:
         OPTION:
-          TYPENAME: Owner
+          TYPENAME: MultiAddress
     - grant:
         TYPENAME: Amount
     - refund_grant_to:
@@ -814,7 +811,7 @@ ProposedBlock:
         TYPENAME: Timestamp
     - authenticated_signer:
         OPTION:
-          TYPENAME: Owner
+          TYPENAME: MultiAddress
     - previous_block_hash:
         OPTION:
           TYPENAME: CryptoHash
@@ -1095,7 +1092,7 @@ SystemOperation:
       Claim:
         STRUCT:
           - owner:
-              TYPENAME: Owner
+              TYPENAME: MultiAddress
           - target_id:
               TYPENAME: ChainId
           - recipient:
@@ -1113,11 +1110,11 @@ SystemOperation:
         STRUCT:
           - super_owners:
               SEQ:
-                TYPENAME: Owner
+                TYPENAME: MultiAddress
           - owners:
               SEQ:
                 TUPLE:
-                  - TYPENAME: Owner
+                  - TYPENAME: MultiAddress
                   - U64
           - multi_leader_rounds: U32
           - open_multi_leader_rounds: BOOL

--- a/linera-sdk/src/abis/fungible.rs
+++ b/linera-sdk/src/abis/fungible.rs
@@ -32,14 +32,14 @@ impl ServiceAbi for FungibleTokenAbi {
 pub enum Operation {
     /// Requests an account balance.
     Balance {
-        /// Owner to query the balance for
+        /// MultiAddress to query the balance for
         owner: MultiAddress,
     },
     /// Requests this fungible token's ticker symbol.
     TickerSymbol,
     /// Transfers tokens from a (locally owned) account to a (possibly remote) account.
     Transfer {
-        /// Owner to transfer from
+        /// MultiAddress to transfer from
         owner: MultiAddress,
         /// Amount to be transferred
         amount: Amount,
@@ -111,7 +111,7 @@ impl Parameters {
 pub struct Account {
     /// Chain ID of the account
     pub chain_id: ChainId,
-    /// Owner of the account
+    /// MultiAddress of the account
     pub owner: MultiAddress,
 }
 

--- a/linera-sdk/src/base/conversions_from_wit.rs
+++ b/linera-sdk/src/base/conversions_from_wit.rs
@@ -7,7 +7,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
     http,
-    identifiers::{ChainId, MultiAddress, Owner},
+    identifiers::{ChainId, MultiAddress},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 
@@ -26,12 +26,6 @@ macro_rules! impl_from_wit {
                     hash_value.part3,
                     hash_value.part4,
                 ])
-            }
-        }
-
-        impl From<$wit_base_api::Owner> for Owner {
-            fn from(owner: $wit_base_api::Owner) -> Self {
-                Owner(owner.inner0.into())
             }
         }
 

--- a/linera-sdk/src/base/conversions_to_wit.rs
+++ b/linera-sdk/src/base/conversions_to_wit.rs
@@ -7,7 +7,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{BlockHeight, Timestamp},
     http,
-    identifiers::{ChainId, MultiAddress, Owner},
+    identifiers::{ChainId, MultiAddress},
 };
 
 use crate::{
@@ -26,14 +26,6 @@ macro_rules! impl_to_wit {
                     part2: parts[1],
                     part3: parts[2],
                     part4: parts[3],
-                }
-            }
-        }
-
-        impl From<Owner> for $wit_base_api::Owner {
-            fn from(owner: Owner) -> Self {
-                $wit_base_api::Owner {
-                    inner0: owner.0.into(),
                 }
             }
         }

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -6,7 +6,7 @@
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, BlockHeight},
-    identifiers::{ChainId, MessageId, ModuleId, MultiAddress, Owner},
+    identifiers::{ChainId, MessageId, ModuleId, MultiAddress},
     ownership::{ChangeApplicationPermissionsError, CloseChainError},
     vm::VmRuntime,
 };
@@ -21,12 +21,6 @@ impl From<wit_contract_api::CryptoHash> for CryptoHash {
             crypto_hash.part3,
             crypto_hash.part4,
         ])
-    }
-}
-
-impl From<wit_contract_api::Owner> for Owner {
-    fn from(owner: wit_contract_api::Owner) -> Self {
-        Owner(owner.inner0.into())
     }
 }
 

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -9,8 +9,7 @@ use linera_base::{
         Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, TimeDelta,
     },
     identifiers::{
-        Account, ChainId, ChannelName, Destination, MessageId, ModuleId, MultiAddress, Owner,
-        StreamName,
+        Account, ChainId, ChannelName, Destination, MessageId, ModuleId, MultiAddress, StreamName,
     },
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
@@ -35,14 +34,6 @@ impl From<CryptoHash> for wit_contract_api::CryptoHash {
 impl From<ChainId> for wit_contract_api::CryptoHash {
     fn from(chain_id: ChainId) -> Self {
         chain_id.0.into()
-    }
-}
-
-impl From<Owner> for wit_contract_api::Owner {
-    fn from(owner: Owner) -> Self {
-        wit_contract_api::Owner {
-            inner0: owner.0.into(),
-        }
     }
 }
 

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -11,7 +11,7 @@ use linera_base::{
     http,
     identifiers::{
         Account, ApplicationId, ChainId, ChannelName, Destination, MessageId, ModuleId,
-        MultiAddress, Owner, StreamName,
+        MultiAddress, StreamName,
     },
     ownership::{ChainOwnership, ChangeApplicationPermissionsError, CloseChainError},
 };
@@ -32,7 +32,7 @@ where
     application_id: Option<ApplicationId<Application::Abi>>,
     application_creator_chain_id: Option<ChainId>,
     chain_id: Option<ChainId>,
-    authenticated_signer: Option<Option<Owner>>,
+    authenticated_signer: Option<Option<MultiAddress>>,
     block_height: Option<BlockHeight>,
     message_is_bouncing: Option<Option<bool>>,
     message_id: Option<Option<MessageId>>,
@@ -172,10 +172,10 @@ where
     Application: Contract,
 {
     /// Returns the authenticated signer for this execution, if there is one.
-    pub fn authenticated_signer(&mut self) -> Option<Owner> {
+    pub fn authenticated_signer(&mut self) -> Option<MultiAddress> {
         *self
             .authenticated_signer
-            .get_or_insert_with(|| contract_wit::authenticated_signer().map(Owner::from))
+            .get_or_insert_with(|| contract_wit::authenticated_signer().map(MultiAddress::from))
     }
 
     /// Returns the ID of the incoming message that is being handled, or [`None`] if not executing

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -16,7 +16,7 @@ use linera_base::{
     http,
     identifiers::{
         Account, ApplicationId, ChainId, ChannelName, Destination, MessageId, ModuleId,
-        MultiAddress, Owner, StreamName,
+        MultiAddress, StreamName,
     },
     ownership::{ChainOwnership, ChangeApplicationPermissionsError, CloseChainError},
 };
@@ -41,7 +41,7 @@ where
     application_id: Option<ApplicationId<Application::Abi>>,
     application_creator_chain_id: Option<ChainId>,
     chain_id: Option<ChainId>,
-    authenticated_signer: Option<Option<Owner>>,
+    authenticated_signer: Option<Option<MultiAddress>>,
     block_height: Option<BlockHeight>,
     round: Option<u32>,
     message_id: Option<Option<MessageId>>,
@@ -221,7 +221,7 @@ where
     /// Configures the authenticated signer to return during the test.
     pub fn with_authenticated_signer(
         mut self,
-        authenticated_signer: impl Into<Option<Owner>>,
+        authenticated_signer: impl Into<Option<MultiAddress>>,
     ) -> Self {
         self.authenticated_signer = Some(authenticated_signer.into());
         self
@@ -230,14 +230,14 @@ where
     /// Configures the authenticated signer to return during the test.
     pub fn set_authenticated_signer(
         &mut self,
-        authenticated_signer: impl Into<Option<Owner>>,
+        authenticated_signer: impl Into<Option<MultiAddress>>,
     ) -> &mut Self {
         self.authenticated_signer = Some(authenticated_signer.into());
         self
     }
 
     /// Returns the authenticated signer for this execution, if there is one.
-    pub fn authenticated_signer(&mut self) -> Option<Owner> {
+    pub fn authenticated_signer(&mut self) -> Option<MultiAddress> {
         self.authenticated_signer.expect(
             "Authenticated signer has not been mocked, \
             please call `MockContractRuntime::set_authenticated_signer` first",
@@ -438,7 +438,7 @@ where
         self.owner_balances
             .as_mut()
             .expect(
-                "Owner balances have not been mocked, \
+                "MultiAddress balances have not been mocked, \
                 please call `MockContractRuntime::set_owner_balances` first",
             )
             .get_mut(&owner)

--- a/linera-sdk/src/service/test_runtime.rs
+++ b/linera-sdk/src/service/test_runtime.rs
@@ -268,7 +268,7 @@ where
             .unwrap()
             .as_ref()
             .expect(
-                "Owner balances have not been mocked, \
+                "MultiAddress balances have not been mocked, \
                 please call `MockServiceRuntime::set_owner_balances` first",
             )
             .iter()
@@ -283,7 +283,7 @@ where
             .unwrap()
             .as_ref()
             .expect(
-                "Owner balances have not been mocked, \
+                "MultiAddress balances have not been mocked, \
                 please call `MockServiceRuntime::set_owner_balances` first",
             )
             .keys()

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -9,7 +9,7 @@ use linera_base::{
     abi::ContractAbi,
     data_types::{Amount, ApplicationPermissions, Blob, Round, Timestamp},
     hashed::Hashed,
-    identifiers::{ApplicationId, ChainId, ChannelFullName, MultiAddress, Owner},
+    identifiers::{ApplicationId, ChainId, ChannelFullName, MultiAddress},
     ownership::TimeoutConfig,
 };
 use linera_chain::{
@@ -49,7 +49,7 @@ impl BlockBuilder {
     /// block.
     pub(crate) fn new(
         chain_id: ChainId,
-        owner: Owner,
+        owner: MultiAddress,
         epoch: Epoch,
         previous_block: Option<&ConfirmedBlockCertificate>,
         validator: TestValidator,
@@ -109,8 +109,8 @@ impl BlockBuilder {
     /// Adds an operation to change this chain's ownership.
     pub fn with_owner_change(
         &mut self,
-        super_owners: Vec<Owner>,
-        owners: Vec<(Owner, u64)>,
+        super_owners: Vec<MultiAddress>,
+        owners: Vec<(MultiAddress, u64)>,
         multi_leader_rounds: u32,
         open_multi_leader_rounds: bool,
         timeout_config: TimeoutConfig,

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -16,7 +16,7 @@ use futures::{
 use linera_base::{
     crypto::{AccountSecretKey, ValidatorKeypair, ValidatorSecretKey},
     data_types::{Amount, ApplicationPermissions, Blob, BlobContent, Timestamp},
-    identifiers::{ApplicationId, ChainDescription, ChainId, MessageId, ModuleId, Owner},
+    identifiers::{ApplicationId, ChainDescription, ChainId, MessageId, ModuleId, MultiAddress},
     ownership::ChainOwnership,
 };
 use linera_core::worker::WorkerState;
@@ -260,7 +260,7 @@ impl TestValidator {
     /// Adds a block to the admin chain to create a new chain.
     ///
     /// Returns the [`ChainDescription`] of the new chain.
-    async fn request_new_chain_from_admin_chain(&self, owner: Owner) -> ChainDescription {
+    async fn request_new_chain_from_admin_chain(&self, owner: MultiAddress) -> ChainDescription {
         let admin_id = ChainId::root(0);
         let admin_chain = self
             .chains

--- a/linera-sdk/wit/base-runtime-api.wit
+++ b/linera-sdk/wit/base-runtime-api.wit
@@ -43,8 +43,8 @@ interface base-runtime-api {
     }
 
     record chain-ownership {
-        super-owners: list<owner>,
-        owners: list<tuple<owner, u64>>,
+        super-owners: list<multi-address>,
+        owners: list<tuple<multi-address, u64>>,
         multi-leader-rounds: u32,
         open-multi-leader-rounds: bool,
         timeout-config: timeout-config,
@@ -97,10 +97,6 @@ interface base-runtime-api {
 
     variant multi-address {
         address32(crypto-hash),
-    }
-
-    record owner {
-        inner0: crypto-hash,
     }
 
     record time-delta {

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -1,7 +1,7 @@
 package linera:app;
 
 interface contract-runtime-api {
-    authenticated-signer: func() -> option<owner>;
+    authenticated-signer: func() -> option<multi-address>;
     get-message-id: func() -> option<message-id>;
     message-is-bouncing: func() -> option<bool>;
     authenticated-caller-id: func() -> option<multi-address>;
@@ -48,8 +48,8 @@ interface contract-runtime-api {
     }
 
     record chain-ownership {
-        super-owners: list<owner>,
-        owners: list<tuple<owner, u64>>,
+        super-owners: list<multi-address>,
+        owners: list<tuple<multi-address, u64>>,
         multi-leader-rounds: u32,
         open-multi-leader-rounds: bool,
         timeout-config: timeout-config,
@@ -93,10 +93,6 @@ interface contract-runtime-api {
 
     variant multi-address {
         address32(crypto-hash),
-    }
-
-    record owner {
-        inner0: crypto-hash,
     }
 
     record resources {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -147,7 +147,7 @@ type BlockHeader {
 	the default account of the chain is used. This value is also used as recipient of
 	potential refunds for the message grants created by the operations.
 	"""
-	authenticatedSigner: Owner
+	authenticatedSigner: MultiAddress
 	"""
 	Cryptographic hash of all the incoming bundles in the block.
 	"""
@@ -291,7 +291,7 @@ type ChainStateExtendedView {
 	"""
 	The incomplete sets of blobs for upcoming proposals.
 	"""
-	pendingProposedBlobs: ReentrantCollectionView_Owner_PendingBlobsView_3247061959!
+	pendingProposedBlobs: ReentrantCollectionView_MultiAddress_PendingBlobsView_3868766364!
 	"""
 	Hashes of all certified blocks for this sender.
 	This ends with `block_hash` and has length `usize::from(next_block_height)`.
@@ -482,17 +482,17 @@ type Entry_MultiAddress_Amount_f77e45dd {
 """
 A GraphQL-visible map item, complete with key.
 """
-type Entry_Origin_InboxStateView_c4db01d6 {
-	key: Origin!
-	value: InboxStateView!
+type Entry_MultiAddress_PendingBlobsView_6793bb1b {
+	key: MultiAddress!
+	value: PendingBlobsView!
 }
 
 """
 A GraphQL-visible map item, complete with key.
 """
-type Entry_Owner_PendingBlobsView_c4f6af6f {
-	key: Owner!
-	value: PendingBlobsView!
+type Entry_Origin_InboxStateView_c4db01d6 {
+	key: Origin!
+	value: InboxStateView!
 }
 
 """
@@ -623,10 +623,6 @@ input MapFilters_Origin_742d451b {
 	keys: [Origin!]
 }
 
-input MapFilters_Owner_6898ce22 {
-	keys: [Owner!]
-}
-
 input MapFilters_Target_7aac1e1c {
 	keys: [Target!]
 }
@@ -645,10 +641,6 @@ input MapInput_MultiAddress_d72add63 {
 
 input MapInput_Origin_742d451b {
 	filters: MapFilters_Origin_742d451b
-}
-
-input MapInput_Owner_6898ce22 {
-	filters: MapFilters_Owner_6898ce22
 }
 
 input MapInput_Target_7aac1e1c {
@@ -743,7 +735,7 @@ type MutationRoot {
 	`target` chain. Depending on its configuration, the `target` chain may refuse to
 	process the message.
 	"""
-	claim(chainId: ChainId!, owner: Owner!, targetId: ChainId!, recipient: Recipient!, amount: Amount!): CryptoHash!
+	claim(chainId: ChainId!, owner: MultiAddress!, targetId: ChainId!, recipient: Recipient!, amount: Amount!): CryptoHash!
 	"""
 	Test if a data blob is readable from a transaction in the current chain.
 	"""
@@ -752,12 +744,12 @@ type MutationRoot {
 	Creates (or activates) a new chain with the given owner.
 	This will automatically subscribe to the future committees created by `admin_id`.
 	"""
-	openChain(chainId: ChainId!, owner: Owner!, balance: Amount): ChainId!
+	openChain(chainId: ChainId!, owner: MultiAddress!, balance: Amount): ChainId!
 	"""
 	Creates (or activates) a new chain by installing the given authentication keys.
 	This will automatically subscribe to the future committees created by `admin_id`.
 	"""
-	openMultiOwnerChain(		chainId: ChainId!,		applicationPermissions: ApplicationPermissions,		owners: [Owner!]!,		weights: [Int!],		multiLeaderRounds: Int,		balance: Amount,
+	openMultiOwnerChain(		chainId: ChainId!,		applicationPermissions: ApplicationPermissions,		owners: [MultiAddress!]!,		weights: [Int!],		multiLeaderRounds: Int,		balance: Amount,
 		"""
 		The duration of the fast round, in milliseconds; default: no timeout
 		"""
@@ -782,11 +774,11 @@ type MutationRoot {
 	"""
 	Changes the authentication key of the chain.
 	"""
-	changeOwner(chainId: ChainId!, newOwner: Owner!): CryptoHash!
+	changeOwner(chainId: ChainId!, newOwner: MultiAddress!): CryptoHash!
 	"""
 	Changes the authentication key of the chain.
 	"""
-	changeMultipleOwners(		chainId: ChainId!,		newOwners: [Owner!]!,		newWeights: [Int!]!,		multiLeaderRounds: Int!,		openMultiLeaderRounds: Boolean!,
+	changeMultipleOwners(		chainId: ChainId!,		newOwners: [MultiAddress!]!,		newWeights: [Int!]!,		multiLeaderRounds: Int!,		openMultiLeaderRounds: Boolean!,
 		"""
 		The duration of the fast round, in milliseconds; default: no timeout
 		"""
@@ -899,7 +891,7 @@ type OutgoingMessage {
 	"""
 	The user authentication carried by the message, if any.
 	"""
-	authenticatedSigner: Owner
+	authenticatedSigner: MultiAddress
 	"""
 	A grant to pay for the message execution.
 	"""
@@ -917,11 +909,6 @@ type OutgoingMessage {
 	"""
 	message: Message!
 }
-
-"""
-The owner of a chain. This is currently the hash of the owner's public key used to verify signatures.
-"""
-scalar Owner
 
 """
 The pending blobs belonging to a block that can't be processed without them.
@@ -952,7 +939,7 @@ type PostedMessage {
 	"""
 	The user authentication carried by the message, if any.
 	"""
-	authenticatedSigner: Owner
+	authenticatedSigner: MultiAddress
 	"""
 	A grant to pay for the message execution.
 	"""
@@ -1010,16 +997,16 @@ type ReentrantCollectionView_ChannelFullName_ChannelStateView_3660287053 {
 	entries(input: MapInput_ChannelFullName_7b67e184): [Entry_ChannelFullName_ChannelStateView_bd1de7ae!]!
 }
 
+type ReentrantCollectionView_MultiAddress_PendingBlobsView_3868766364 {
+	keys: [MultiAddress!]!
+	entry(key: MultiAddress!): Entry_MultiAddress_PendingBlobsView_6793bb1b!
+	entries(input: MapInput_MultiAddress_d72add63): [Entry_MultiAddress_PendingBlobsView_6793bb1b!]!
+}
+
 type ReentrantCollectionView_Origin_InboxStateView_3699835794 {
 	keys: [Origin!]!
 	entry(key: Origin!): Entry_Origin_InboxStateView_c4db01d6!
 	entries(input: MapInput_Origin_742d451b): [Entry_Origin_InboxStateView_c4db01d6!]!
-}
-
-type ReentrantCollectionView_Owner_PendingBlobsView_3247061959 {
-	keys: [Owner!]!
-	entry(key: Owner!): Entry_Owner_PendingBlobsView_c4f6af6f!
-	entries(input: MapInput_Owner_6898ce22): [Entry_Owner_PendingBlobsView_c4f6af6f!]!
 }
 
 type ReentrantCollectionView_Target_OutboxStateView_2789119133 {

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -6,7 +6,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, Blob, BlockHeight, OracleResponse, Round, Timestamp},
     identifiers::{
-        Account, BlobId, ChainDescription, ChainId, ChannelName, Destination, MultiAddress, Owner,
+        Account, BlobId, ChainDescription, ChainId, ChannelName, Destination, MultiAddress,
         StreamName,
     },
 };

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -9,7 +9,7 @@ use futures::future::{join_all, try_join_all};
 use linera_base::{
     async_graphql::InputType,
     data_types::Amount,
-    identifiers::{Account, ApplicationId, ChainId, MultiAddress, Owner},
+    identifiers::{Account, ApplicationId, ChainId, MultiAddress},
     time::timer::Instant,
 };
 use linera_sdk::abis::fungible::{self, FungibleTokenAbi, InitialState, Parameters};
@@ -141,7 +141,7 @@ async fn benchmark_with_fungible(
 
     struct BenchmarkContext {
         application_id: ApplicationId<FungibleTokenAbi>,
-        owner: Owner,
+        owner: MultiAddress,
         default_chain: ChainId,
     }
 
@@ -151,10 +151,7 @@ async fn benchmark_with_fungible(
             let owner = client.get_owner().context("missing owner")?;
             let default_chain = client.default_chain().context("missing default chain")?;
             let initial_state = InitialState {
-                accounts: BTreeMap::from([(
-                    MultiAddress::from(owner),
-                    Amount::from_tokens(num_transactions as u128),
-                )]),
+                accounts: BTreeMap::from([(owner, Amount::from_tokens(num_transactions as u128))]),
             };
             let parameters = Parameters::new(format!("FUN{}", i).leak());
             let application_id = node_service
@@ -193,11 +190,11 @@ async fn benchmark_with_fungible(
                     .try_add_assign(Amount::ONE)
                     .unwrap();
                 sender_app.transfer(
-                    MultiAddress::from(sender_context.owner),
+                    sender_context.owner,
                     Amount::ONE,
                     fungible::Account {
                         chain_id: receiver_context.default_chain,
-                        owner: MultiAddress::from(receiver_context.owner),
+                        owner: receiver_context.owner,
                     },
                 )
             })
@@ -243,8 +240,7 @@ async fn benchmark_with_fungible(
                     );
                     for i in 0.. {
                         linera_base::time::timer::sleep(Duration::from_secs(i)).await;
-                        let actual_balance =
-                            app.get_amount(&MultiAddress::from(context.owner)).await;
+                        let actual_balance = app.get_amount(&context.owner).await;
                         if actual_balance == expected_balance {
                             break;
                         }
@@ -256,10 +252,7 @@ async fn benchmark_with_fungible(
                             );
                         }
                     }
-                    assert_eq!(
-                        app.get_amount(&MultiAddress::from(context.owner)).await,
-                        expected_balance
-                    );
+                    assert_eq!(app.get_amount(&context.owner).await, expected_balance);
                     Ok(())
                 },
             ))

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -23,7 +23,7 @@ use futures::{lock::Mutex, FutureExt as _, StreamExt};
 use linera_base::{
     crypto::{AccountSecretKey, CryptoHash, CryptoRng, Ed25519SecretKey},
     data_types::{ApplicationPermissions, Timestamp},
-    identifiers::{ChainDescription, ChainId, MultiAddress, Owner},
+    identifiers::{ChainDescription, ChainId, MultiAddress},
     ownership::ChainOwnership,
 };
 use linera_client::{
@@ -1573,7 +1573,7 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
             let start_time = Instant::now();
             let mut wallet = options.wallet().await?;
             let key_pair = wallet.generate_key_pair();
-            let owner = Owner::from(key_pair.public());
+            let owner = MultiAddress::from(key_pair.public());
             wallet
                 .mutate(|w| w.add_unassigned_key_pair(key_pair))
                 .await?;

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -14,7 +14,7 @@ use linera_base::{
     crypto::{CryptoError, CryptoHash},
     data_types::{Amount, ApplicationPermissions, Bytecode, TimeDelta, UserApplicationDescription},
     hashed::Hashed,
-    identifiers::{ChainId, ModuleId, MultiAddress, Owner},
+    identifiers::{ChainId, ModuleId, MultiAddress},
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
     BcsHexParseError,
@@ -247,7 +247,7 @@ where
     async fn claim(
         &self,
         chain_id: ChainId,
-        owner: Owner,
+        owner: MultiAddress,
         target_id: ChainId,
         recipient: Recipient,
         amount: Amount,
@@ -287,7 +287,7 @@ where
     async fn open_chain(
         &self,
         chain_id: ChainId,
-        owner: Owner,
+        owner: MultiAddress,
         balance: Option<Amount>,
     ) -> Result<ChainId, Error> {
         let ownership = ChainOwnership::single(owner);
@@ -315,7 +315,7 @@ where
         &self,
         chain_id: ChainId,
         application_permissions: Option<ApplicationPermissions>,
-        owners: Vec<Owner>,
+        owners: Vec<MultiAddress>,
         weights: Option<Vec<u64>>,
         multi_leader_rounds: Option<u32>,
         balance: Option<Amount>,
@@ -392,7 +392,11 @@ where
     }
 
     /// Changes the authentication key of the chain.
-    async fn change_owner(&self, chain_id: ChainId, new_owner: Owner) -> Result<CryptoHash, Error> {
+    async fn change_owner(
+        &self,
+        chain_id: ChainId,
+        new_owner: MultiAddress,
+    ) -> Result<CryptoHash, Error> {
         let operation = SystemOperation::ChangeOwnership {
             super_owners: vec![new_owner],
             owners: Vec::new(),
@@ -408,7 +412,7 @@ where
     async fn change_multiple_owners(
         &self,
         chain_id: ChainId,
-        new_owners: Vec<Owner>,
+        new_owners: Vec<MultiAddress>,
         new_weights: Vec<u64>,
         multi_leader_rounds: u32,
         open_multi_leader_rounds: bool,

--- a/linera-service/src/wallet.rs
+++ b/linera-service/src/wallet.rs
@@ -5,7 +5,7 @@ use comfy_table::{
     modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Attribute, Cell, Color, ContentArrangement,
     Table,
 };
-use linera_base::identifiers::{ChainId, Owner};
+use linera_base::identifiers::{ChainId, MultiAddress};
 pub use linera_client::wallet::*;
 
 pub fn pretty_print(wallet: &Wallet, chain_ids: impl IntoIterator<Item = ChainId>) {
@@ -47,7 +47,7 @@ fn update_table_with_chain(
         chain_id_cell,
         Cell::new(format!(
             r#"Public Key:         {}
-Owner:              {}
+MultiAddress:              {}
 Block Hash:         {}
 Timestamp:          {}
 Next Block Height:  {}"#,
@@ -59,7 +59,7 @@ Next Block Height:  {}"#,
             user_chain
                 .key_pair
                 .as_ref()
-                .map(|kp| Owner::from(kp.public()))
+                .map(|kp| MultiAddress::from(kp.public()))
                 .map(|o| o.to_string())
                 .unwrap_or_else(|| "-".to_string()),
             user_chain

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -35,7 +35,7 @@ use linera_base::{
 use linera_chain::data_types::{Medium, Origin};
 use linera_core::worker::{Notification, Reason};
 use linera_sdk::{
-    linera_base_types::{BlobContent, BlockHeight, Owner},
+    linera_base_types::{BlobContent, BlockHeight},
     DataBlobHash,
 };
 #[cfg(any(
@@ -84,8 +84,7 @@ fn test_iterations() -> Option<usize> {
 }
 
 fn get_fungible_account_owner(client: &ClientWrapper) -> MultiAddress {
-    let owner = client.get_owner().unwrap();
-    MultiAddress::Address32(owner.0)
+    client.get_owner().unwrap()
 }
 
 struct FungibleApp(ApplicationWrapper<fungible::FungibleTokenAbi>);
@@ -2429,7 +2428,7 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()
     let (mut net, client) = config.instantiate().await?;
 
     let chain1 = client.load_wallet()?.default_chain().unwrap();
-    let owner1 = Owner::from(
+    let owner1 = MultiAddress::from(
         client
             .load_wallet()?
             .get(chain1)

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -43,8 +43,7 @@ use {
 
 #[cfg(feature = "benchmark")]
 fn get_fungible_account_owner(client: &ClientWrapper) -> MultiAddress {
-    let owner = client.get_owner().unwrap();
-    MultiAddress::from(owner)
+    client.get_owner().unwrap()
 }
 
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Udp) ; "scylladb_udp"))]

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -18,7 +18,7 @@ use linera_base::{
         UserApplicationDescription,
     },
     hashed::Hashed,
-    identifiers::{BlobId, BlobType, ChainDescription, ChainId, EventId, MultiAddress, Owner},
+    identifiers::{BlobId, BlobType, ChainDescription, ChainId, EventId, MultiAddress},
     ownership::ChainOwnership,
     vm::VmRuntime,
 };
@@ -216,7 +216,7 @@ pub trait Storage: Sized {
         committee: Committee,
         admin_id: ChainId,
         description: ChainDescription,
-        owner: Owner,
+        owner: MultiAddress,
         balance: Amount,
         timestamp: Timestamp,
     ) -> Result<(), ChainError>


### PR DESCRIPTION
## Motivation

`Owner` is currently a wrapper around a `CryptoHash` which we unwrap when we check for equality.

## Proposal

Remove `Owner` type and use `MultiAddress` instead.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.


## Links


- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
