### PR TITLE
Remove `RawExecutionOutcome` and `RawOutgoingMessage`.

### DIFF
--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -955,6 +955,32 @@ pub struct OutgoingMessage {
 
 impl<'de> BcsHashable<'de> for OutgoingMessage {}
 
+impl OutgoingMessage {
+    /// Creates a new simple outgoing message with no grant and no authenticated signer.
+    pub fn new(recipient: ChainId, message: impl Into<Message>) -> Self {
+        OutgoingMessage {
+            destination: Destination::Recipient(recipient),
+            authenticated_signer: None,
+            grant: Amount::ZERO,
+            refund_grant_to: None,
+            kind: MessageKind::Simple,
+            message: message.into(),
+        }
+    }
+
+    /// Returns the same message, with the specified kind.
+    pub fn with_kind(mut self, kind: MessageKind) -> Self {
+        self.kind = kind;
+        self
+    }
+
+    /// Returns the same message, with the specified authenticated signer.
+    pub fn with_authenticated_signer(mut self, authenticated_signer: Option<Owner>) -> Self {
+        self.authenticated_signer = authenticated_signer;
+        self
+    }
+}
+
 /// Externally visible results of an execution. These results are meant in the context of
 /// the application that created them.
 #[derive(Debug)]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -981,20 +981,6 @@ impl OutgoingMessage {
     }
 }
 
-/// Externally visible results of an execution. These results are meant in the context of
-/// the application that created them.
-#[derive(Debug)]
-#[cfg_attr(with_testing, derive(Eq, PartialEq))]
-pub struct RawExecutionOutcome<Message> {
-    /// The signer who created the messages.
-    pub authenticated_signer: Option<Owner>,
-    /// Where to send a refund for the unused part of each grant after execution, if any.
-    pub refund_grant_to: Option<Account>,
-    /// Sends messages to the given destinations, possibly forwarding the authenticated
-    /// signer and including grant with the refund policy described above.
-    pub messages: Vec<RawOutgoingMessage<Message, Amount>>,
-}
-
 /// The identifier of a channel, relative to a particular application.
 #[derive(
     Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Hash, Serialize, Deserialize, SimpleObject,
@@ -1004,56 +990,6 @@ pub struct ChannelSubscription {
     pub chain_id: ChainId,
     /// The name of the channel.
     pub name: ChannelName,
-}
-
-impl<Message> RawExecutionOutcome<Message> {
-    pub fn with_authenticated_signer(mut self, authenticated_signer: Option<Owner>) -> Self {
-        self.authenticated_signer = authenticated_signer;
-        self
-    }
-
-    pub fn with_refund_grant_to(mut self, refund_grant_to: Option<Account>) -> Self {
-        self.refund_grant_to = refund_grant_to;
-        self
-    }
-
-    /// Adds a `message` to this [`RawExecutionOutcome`].
-    pub fn with_message(mut self, message: RawOutgoingMessage<Message, Amount>) -> Self {
-        self.messages.push(message);
-        self
-    }
-}
-
-impl<Message> Default for RawExecutionOutcome<Message> {
-    fn default() -> Self {
-        Self {
-            authenticated_signer: None,
-            refund_grant_to: None,
-            messages: Vec::new(),
-        }
-    }
-}
-
-impl<Message> RawOutgoingMessage<Message, Resources> {
-    pub fn into_priced(
-        self,
-        policy: &ResourceControlPolicy,
-    ) -> Result<RawOutgoingMessage<Message, Amount>, ArithmeticError> {
-        let RawOutgoingMessage {
-            destination,
-            authenticated,
-            grant,
-            kind,
-            message,
-        } = self;
-        Ok(RawOutgoingMessage {
-            destination,
-            authenticated,
-            grant: policy.total_price(&grant)?,
-            kind,
-            message,
-        })
-    }
 }
 
 impl OperationContext {

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -10,10 +10,7 @@ use linera_base::{
     identifiers::{ApplicationId, BlobId, ChainId, ChannelFullName, StreamId},
 };
 
-use crate::{
-    ExecutionError, Message, OutgoingMessage, RawExecutionOutcome, RawOutgoingMessage,
-    SystemMessage,
-};
+use crate::{ExecutionError, Message, OutgoingMessage, RawExecutionOutcome, RawOutgoingMessage};
 
 /// Tracks oracle responses and execution outcomes of an ongoing transaction execution, as well
 /// as replayed oracle responses.
@@ -89,13 +86,6 @@ impl TransactionTracker {
         index
     }
 
-    pub fn add_system_outcome(
-        &mut self,
-        outcome: RawExecutionOutcome<SystemMessage>,
-    ) -> Result<(), ArithmeticError> {
-        self.add_outcome(Message::System, outcome)
-    }
-
     pub fn add_user_outcome(
         &mut self,
         application_id: ApplicationId,
@@ -140,12 +130,25 @@ impl TransactionTracker {
         Ok(())
     }
 
-    fn add_outgoing_message(&mut self, message: OutgoingMessage) -> Result<(), ArithmeticError> {
+    pub fn add_outgoing_message(
+        &mut self,
+        message: OutgoingMessage,
+    ) -> Result<(), ArithmeticError> {
         self.next_message_index = self
             .next_message_index
             .checked_add(1)
             .ok_or(ArithmeticError::Overflow)?;
         self.outgoing_messages.push(message);
+        Ok(())
+    }
+
+    pub fn add_outgoing_messages(
+        &mut self,
+        messages: impl IntoIterator<Item = OutgoingMessage>,
+    ) -> Result<(), ArithmeticError> {
+        for message in messages {
+            self.add_outgoing_message(message)?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Motivation

As of https://github.com/linera-io/linera-protocol/pull/3513, `RawExecutionOutcome` and `RawOutgoingMessage` are not really needed anymore.

## Proposal

Remove them.

In the first commit, their usage in production is replaced by directly creating `OutgoingMessage`s. The `linera-execution` tests still passed, so the behavior didn't change.

In the second commit, their usage is also removed from the tests.

## Test Plan

Existing tests were updated.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
