### PR TITLE
Add missing options from ResourceControlPolicy.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -466,7 +466,7 @@ View or update the resource control policy
 * `--message <MESSAGE>` — Set the base price of sending a message from a block..
 * `--message-byte <MESSAGE_BYTE>` — Set the additional price for each byte in the argument of a user message
 * `--service-as-oracle-query <SERVICE_AS_ORACLE_QUERY>` — Set the price per query to a service as an oracle
-* `--http-request <HTTP_REQUEST>` — Set the price for a performing an HTTP request
+* `--http-request <HTTP_REQUEST>` — Set the price for performing an HTTP request
 * `--maximum-fuel-per-block <MAXIMUM_FUEL_PER_BLOCK>` — Set the maximum amount of fuel per block
 * `--maximum-service-oracle-execution-ms <MAXIMUM_SERVICE_ORACLE_EXECUTION_MS>` — Set the maximum time in milliseconds that a block can spend executing services as oracles
 * `--maximum-executed-block-size <MAXIMUM_EXECUTED_BLOCK_SIZE>` — Set the maximum size of an executed block, in bytes
@@ -525,7 +525,7 @@ Create genesis configuration for a Linera deployment. Create initial user chains
 * `--message-price <MESSAGE_PRICE>` — Set the base price of sending a message from a block.. (This will overwrite value from `--policy-config`)
 * `--message-byte-price <MESSAGE_BYTE_PRICE>` — Set the additional price for each byte in the argument of a user message. (This will overwrite value from `--policy-config`)
 * `--service-as-oracle-query-price <SERVICE_AS_ORACLE_QUERY_PRICE>` — Set the price per query to a service as an oracle
-* `--http-request-price <HTTP_REQUEST_PRICE>` — Set the price for a performing an HTTP request
+* `--http-request-price <HTTP_REQUEST_PRICE>` — Set the price for performing an HTTP request
 * `--maximum-fuel-per-block <MAXIMUM_FUEL_PER_BLOCK>` — Set the maximum amount of fuel per block. (This will overwrite value from `--policy-config`)
 * `--maximum-service-oracle-execution-ms <MAXIMUM_SERVICE_ORACLE_EXECUTION_MS>` — Set the maximum time in milliseconds that a block can spend executing services as oracles
 * `--maximum-executed-block-size <MAXIMUM_EXECUTED_BLOCK_SIZE>` — Set the maximum size of an executed block. (This will overwrite value from `--policy-config`)

--- a/CLI.md
+++ b/CLI.md
@@ -465,7 +465,10 @@ View or update the resource control policy
 * `--operation-byte <OPERATION_BYTE>` — Set the additional price for each byte in the argument of a user operation
 * `--message <MESSAGE>` — Set the base price of sending a message from a block..
 * `--message-byte <MESSAGE_BYTE>` — Set the additional price for each byte in the argument of a user message
+* `--service-as-oracle-query <SERVICE_AS_ORACLE_QUERY>` — Set the price per query to a service as an oracle
+* `--http-request <HTTP_REQUEST>` — Set the price for a performing an HTTP request
 * `--maximum-fuel-per-block <MAXIMUM_FUEL_PER_BLOCK>` — Set the maximum amount of fuel per block
+* `--maximum-service-oracle-execution-ms <MAXIMUM_SERVICE_ORACLE_EXECUTION_MS>` — Set the maximum time in milliseconds that a block can spend executing services as oracles
 * `--maximum-executed-block-size <MAXIMUM_EXECUTED_BLOCK_SIZE>` — Set the maximum size of an executed block, in bytes
 * `--maximum-blob-size <MAXIMUM_BLOB_SIZE>` — Set the maximum size of data blobs, compressed bytecode and other binary blobs, in bytes
 * `--maximum-published-blobs <MAXIMUM_PUBLISHED_BLOBS>` — Set the maximum number of published blobs per block
@@ -473,6 +476,9 @@ View or update the resource control policy
 * `--maximum-block-proposal-size <MAXIMUM_BLOCK_PROPOSAL_SIZE>` — Set the maximum size of a block proposal, in bytes
 * `--maximum-bytes-read-per-block <MAXIMUM_BYTES_READ_PER_BLOCK>` — Set the maximum read data per block
 * `--maximum-bytes-written-per-block <MAXIMUM_BYTES_WRITTEN_PER_BLOCK>` — Set the maximum write data per block
+* `--maximum-http-response-bytes <MAXIMUM_HTTP_RESPONSE_BYTES>` — Set the maximum size in bytes of a received HTTP response
+* `--http-request-timeout-ms <HTTP_REQUEST_TIMEOUT_MS>` — Set the maximum amount of time allowed to wait for an HTTP response
+* `--http-request-allow-list <HTTP_REQUEST_ALLOW_LIST>` — Set the list of hosts that contracts and services can send HTTP requests to
 
 
 
@@ -518,7 +524,10 @@ Create genesis configuration for a Linera deployment. Create initial user chains
 * `--operation-byte-price <OPERATION_BYTE_PRICE>` — Set the additional price for each byte in the argument of a user operation. (This will overwrite value from `--policy-config`)
 * `--message-price <MESSAGE_PRICE>` — Set the base price of sending a message from a block.. (This will overwrite value from `--policy-config`)
 * `--message-byte-price <MESSAGE_BYTE_PRICE>` — Set the additional price for each byte in the argument of a user message. (This will overwrite value from `--policy-config`)
+* `--service-as-oracle-query-price <SERVICE_AS_ORACLE_QUERY_PRICE>` — Set the price per query to a service as an oracle
+* `--http-request-price <HTTP_REQUEST_PRICE>` — Set the price for a performing an HTTP request
 * `--maximum-fuel-per-block <MAXIMUM_FUEL_PER_BLOCK>` — Set the maximum amount of fuel per block. (This will overwrite value from `--policy-config`)
+* `--maximum-service-oracle-execution-ms <MAXIMUM_SERVICE_ORACLE_EXECUTION_MS>` — Set the maximum time in milliseconds that a block can spend executing services as oracles
 * `--maximum-executed-block-size <MAXIMUM_EXECUTED_BLOCK_SIZE>` — Set the maximum size of an executed block. (This will overwrite value from `--policy-config`)
 * `--maximum-bytecode-size <MAXIMUM_BYTECODE_SIZE>` — Set the maximum size of decompressed contract or service bytecode, in bytes. (This will overwrite value from `--policy-config`)
 * `--maximum-blob-size <MAXIMUM_BLOB_SIZE>` — Set the maximum size of data blobs, compressed bytecode and other binary blobs, in bytes. (This will overwrite value from `--policy-config`)
@@ -526,7 +535,9 @@ Create genesis configuration for a Linera deployment. Create initial user chains
 * `--maximum-block-proposal-size <MAXIMUM_BLOCK_PROPOSAL_SIZE>` — Set the maximum size of a block proposal, in bytes. (This will overwrite value from `--policy-config`)
 * `--maximum-bytes-read-per-block <MAXIMUM_BYTES_READ_PER_BLOCK>` — Set the maximum read data per block. (This will overwrite value from `--policy-config`)
 * `--maximum-bytes-written-per-block <MAXIMUM_BYTES_WRITTEN_PER_BLOCK>` — Set the maximum write data per block. (This will overwrite value from `--policy-config`)
-* `--http-allow-list <HTTP_ALLOW_LIST>` — Set the list of hosts that contracts and services can send HTTP requests to
+* `--maximum-http-response-bytes <MAXIMUM_HTTP_RESPONSE_BYTES>` — Set the maximum size in bytes of a received HTTP response
+* `--http-request-timeout-ms <HTTP_REQUEST_TIMEOUT_MS>` — Set the maximum amount of time allowed to wait for an HTTP response
+* `--http-request-allow-list <HTTP_REQUEST_ALLOW_LIST>` — Set the list of hosts that contracts and services can send HTTP requests to
 * `--testing-prng-seed <TESTING_PRNG_SEED>` — Force this wallet to generate keys using a PRNG and a given seed. USE FOR TESTING ONLY
 * `--network-name <NETWORK_NAME>` — A unique name to identify this network
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -567,9 +567,21 @@ pub enum ClientCommand {
         #[arg(long)]
         message_byte: Option<Amount>,
 
+        /// Set the price per query to a service as an oracle.
+        #[arg(long)]
+        service_as_oracle_query: Option<Amount>,
+
+        /// Set the price for a performing an HTTP request.
+        #[arg(long)]
+        http_request: Option<Amount>,
+
         /// Set the maximum amount of fuel per block.
         #[arg(long)]
         maximum_fuel_per_block: Option<u64>,
+
+        /// Set the maximum time in milliseconds that a block can spend executing services as oracles.
+        #[arg(long)]
+        maximum_service_oracle_execution_ms: Option<u64>,
 
         /// Set the maximum size of an executed block, in bytes.
         #[arg(long)]
@@ -599,6 +611,18 @@ pub enum ClientCommand {
         /// Set the maximum write data per block.
         #[arg(long)]
         maximum_bytes_written_per_block: Option<u64>,
+
+        /// Set the maximum size in bytes of a received HTTP response.
+        #[arg(long)]
+        maximum_http_response_bytes: Option<u64>,
+
+        /// Set the maximum amount of time allowed to wait for an HTTP response.
+        #[arg(long)]
+        http_request_timeout_ms: Option<u64>,
+
+        /// Set the list of hosts that contracts and services can send HTTP requests to.
+        #[arg(long)]
+        http_request_allow_list: Option<Vec<String>>,
     },
 
     /// Send one transfer per chain in bulk mode
@@ -752,10 +776,22 @@ pub enum ClientCommand {
         #[arg(long)]
         message_byte_price: Option<Amount>,
 
+        /// Set the price per query to a service as an oracle.
+        #[arg(long)]
+        service_as_oracle_query_price: Option<Amount>,
+
+        /// Set the price for a performing an HTTP request.
+        #[arg(long)]
+        http_request_price: Option<Amount>,
+
         /// Set the maximum amount of fuel per block.
         /// (This will overwrite value from `--policy-config`)
         #[arg(long)]
         maximum_fuel_per_block: Option<u64>,
+
+        /// Set the maximum time in milliseconds that a block can spend executing services as oracles.
+        #[arg(long)]
+        maximum_service_oracle_execution_ms: Option<u64>,
 
         /// Set the maximum size of an executed block.
         /// (This will overwrite value from `--policy-config`)
@@ -793,9 +829,17 @@ pub enum ClientCommand {
         #[arg(long)]
         maximum_bytes_written_per_block: Option<u64>,
 
+        /// Set the maximum size in bytes of a received HTTP response.
+        #[arg(long)]
+        maximum_http_response_bytes: Option<u64>,
+
+        /// Set the maximum amount of time allowed to wait for an HTTP response.
+        #[arg(long)]
+        http_request_timeout_ms: Option<u64>,
+
         /// Set the list of hosts that contracts and services can send HTTP requests to.
         #[arg(long)]
-        http_allow_list: Option<Vec<String>>,
+        http_request_allow_list: Option<Vec<String>>,
 
         /// Force this wallet to generate keys using a PRNG and a given seed. USE FOR
         /// TESTING ONLY.

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -571,7 +571,7 @@ pub enum ClientCommand {
         #[arg(long)]
         service_as_oracle_query: Option<Amount>,
 
-        /// Set the price for a performing an HTTP request.
+        /// Set the price for performing an HTTP request.
         #[arg(long)]
         http_request: Option<Amount>,
 
@@ -780,7 +780,7 @@ pub enum ClientCommand {
         #[arg(long)]
         service_as_oracle_query_price: Option<Amount>,
 
-        /// Set the price for a performing an HTTP request.
+        /// Set the price for performing an HTTP request.
         #[arg(long)]
         http_request_price: Option<Amount>,
 

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -254,7 +254,9 @@ impl ClientWrapper {
                 &policy_config.to_string().to_kebab_case(),
             ]);
         if let Some(allow_list) = http_allow_list {
-            command.arg("--http-allow-list").arg(allow_list.join(","));
+            command
+                .arg("--http-request-allow-list")
+                .arg(allow_list.join(","));
         }
         if let Some(seed) = self.testing_prng_seed {
             command.arg("--testing-prng-seed").arg(seed.to_string());

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -620,7 +620,10 @@ impl Runnable for Job {
                                     operation_byte,
                                     message,
                                     message_byte,
+                                    service_as_oracle_query,
+                                    http_request,
                                     maximum_fuel_per_block,
+                                    maximum_service_oracle_execution_ms,
                                     maximum_executed_block_size,
                                     maximum_blob_size,
                                     maximum_published_blobs,
@@ -628,88 +631,76 @@ impl Runnable for Job {
                                     maximum_block_proposal_size,
                                     maximum_bytes_read_per_block,
                                     maximum_bytes_written_per_block,
+                                    maximum_http_response_bytes,
+                                    http_request_timeout_ms,
+                                    http_request_allow_list,
                                 } => {
-                                    if let Some(block) = block {
-                                        policy.block = block;
-                                    }
-                                    if let Some(fuel_unit) = fuel_unit {
-                                        policy.fuel_unit = fuel_unit;
-                                    }
-                                    if let Some(read_operation) = read_operation {
-                                        policy.read_operation = read_operation;
-                                    }
-                                    if let Some(write_operation) = write_operation {
-                                        policy.write_operation = write_operation;
-                                    }
-                                    if let Some(byte_read) = byte_read {
-                                        policy.byte_read = byte_read;
-                                    }
-                                    if let Some(byte_written) = byte_written {
-                                        policy.byte_written = byte_written;
-                                    }
-                                    if let Some(blob_read) = blob_read {
-                                        policy.blob_read = blob_read
-                                    }
-                                    if let Some(blob_published) = blob_published {
-                                        policy.blob_published = blob_published
-                                    }
-                                    if let Some(blob_byte_read) = blob_byte_read {
-                                        policy.blob_byte_read = blob_byte_read;
-                                    }
-                                    if let Some(blob_byte_published) = blob_byte_published {
-                                        policy.blob_byte_published = blob_byte_published;
-                                    }
-                                    if let Some(byte_stored) = byte_stored {
-                                        policy.byte_stored = byte_stored;
-                                    }
-                                    if let Some(operation) = operation {
-                                        policy.operation = operation;
-                                    }
-                                    if let Some(operation_byte) = operation_byte {
-                                        policy.operation_byte = operation_byte;
-                                    }
-                                    if let Some(message) = message {
-                                        policy.message = message;
-                                    }
-                                    if let Some(message_byte) = message_byte {
-                                        policy.message_byte = message_byte;
-                                    }
-                                    if let Some(maximum_fuel_per_block) = maximum_fuel_per_block {
-                                        policy.maximum_fuel_per_block = maximum_fuel_per_block;
-                                    }
-                                    if let Some(maximum_executed_block_size) =
-                                        maximum_executed_block_size
-                                    {
-                                        policy.maximum_executed_block_size =
-                                            maximum_executed_block_size;
-                                    }
-                                    if let Some(maximum_bytecode_size) = maximum_bytecode_size {
-                                        policy.maximum_bytecode_size = maximum_bytecode_size;
-                                    }
-                                    if let Some(maximum_blob_size) = maximum_blob_size {
-                                        policy.maximum_blob_size = maximum_blob_size;
-                                    }
-                                    if let Some(maximum_published_blobs) = maximum_published_blobs {
-                                        policy.maximum_published_blobs = maximum_published_blobs;
-                                    }
-                                    if let Some(maximum_block_proposal_size) =
-                                        maximum_block_proposal_size
-                                    {
-                                        policy.maximum_block_proposal_size =
-                                            maximum_block_proposal_size;
-                                    }
-                                    if let Some(maximum_bytes_read_per_block) =
-                                        maximum_bytes_read_per_block
-                                    {
-                                        policy.maximum_bytes_read_per_block =
-                                            maximum_bytes_read_per_block;
-                                    }
-                                    if let Some(maximum_bytes_written_per_block) =
-                                        maximum_bytes_written_per_block
-                                    {
-                                        policy.maximum_bytes_written_per_block =
-                                            maximum_bytes_written_per_block;
-                                    }
+                                    let existing_policy = policy.clone();
+                                    policy = linera_execution::ResourceControlPolicy {
+                                        block: block.unwrap_or(existing_policy.block),
+                                        fuel_unit: fuel_unit.unwrap_or(existing_policy.fuel_unit),
+                                        read_operation: read_operation
+                                            .unwrap_or(existing_policy.read_operation),
+                                        write_operation: write_operation
+                                            .unwrap_or(existing_policy.write_operation),
+                                        byte_read: byte_read.unwrap_or(existing_policy.byte_read),
+                                        byte_written: byte_written
+                                            .unwrap_or(existing_policy.byte_written),
+                                        blob_read: blob_read
+                                            .unwrap_or(existing_policy.blob_read),
+                                        blob_published: blob_published
+                                            .unwrap_or(existing_policy.blob_published),
+                                        blob_byte_read: blob_byte_read
+                                            .unwrap_or(existing_policy.blob_byte_read),
+                                        blob_byte_published: blob_byte_published
+                                            .unwrap_or(existing_policy.blob_byte_published),
+                                        byte_stored: byte_stored
+                                            .unwrap_or(existing_policy.byte_stored),
+                                        operation: operation.unwrap_or(existing_policy.operation),
+                                        operation_byte: operation_byte
+                                            .unwrap_or(existing_policy.operation_byte),
+                                        message: message.unwrap_or(existing_policy.message),
+                                        message_byte: message_byte
+                                            .unwrap_or(existing_policy.message_byte),
+                                        service_as_oracle_query: service_as_oracle_query
+                                            .unwrap_or(existing_policy.service_as_oracle_query),
+                                        http_request: http_request
+                                            .unwrap_or(existing_policy.http_request),
+                                        maximum_fuel_per_block: maximum_fuel_per_block
+                                            .unwrap_or(existing_policy.maximum_fuel_per_block),
+                                        maximum_service_oracle_execution_ms:
+                                            maximum_service_oracle_execution_ms.unwrap_or(
+                                                existing_policy.maximum_service_oracle_execution_ms,
+                                            ),
+                                        maximum_executed_block_size: maximum_executed_block_size
+                                            .unwrap_or(existing_policy.maximum_executed_block_size),
+                                        maximum_bytecode_size: maximum_bytecode_size
+                                            .unwrap_or(existing_policy.maximum_bytecode_size),
+                                        maximum_blob_size: maximum_blob_size
+                                            .unwrap_or(existing_policy.maximum_blob_size),
+                                        maximum_published_blobs: maximum_published_blobs
+                                            .unwrap_or(existing_policy.maximum_published_blobs),
+                                        maximum_block_proposal_size: maximum_block_proposal_size
+                                            .unwrap_or(existing_policy.maximum_block_proposal_size),
+                                        maximum_bytes_read_per_block: maximum_bytes_read_per_block
+                                            .unwrap_or(
+                                                existing_policy.maximum_bytes_read_per_block,
+                                            ),
+                                        maximum_bytes_written_per_block:
+                                            maximum_bytes_written_per_block.unwrap_or(
+                                                existing_policy.maximum_bytes_written_per_block,
+                                            ),
+                                        maximum_http_response_bytes: maximum_http_response_bytes
+                                            .unwrap_or(existing_policy.maximum_http_response_bytes),
+                                        http_request_timeout_ms: http_request_timeout_ms
+                                            .unwrap_or(existing_policy.http_request_timeout_ms),
+                                        http_request_allow_list: match http_request_allow_list {
+                                            None => existing_policy.http_request_allow_list,
+                                            Some(http_request_allow_list) => {
+                                                BTreeSet::from_iter(http_request_allow_list)
+                                            }
+                                        },
+                                    };
                                     info!("{policy}");
                                     if committee.policy() == &policy {
                                         return Ok(ClientOutcome::Committed(None));
@@ -1430,7 +1421,10 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
             operation_byte_price,
             message_price,
             message_byte_price,
+            service_as_oracle_query_price,
+            http_request_price,
             maximum_fuel_per_block,
+            maximum_service_oracle_execution_ms,
             maximum_executed_block_size,
             maximum_blob_size,
             maximum_published_blobs,
@@ -1438,86 +1432,68 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
             maximum_block_proposal_size,
             maximum_bytes_read_per_block,
             maximum_bytes_written_per_block,
+            maximum_http_response_bytes,
+            http_request_timeout_ms,
+            http_request_allow_list,
             testing_prng_seed,
             network_name,
-            http_allow_list,
         } => {
             let start_time = Instant::now();
             let committee_config: CommitteeConfig = util::read_json(committee_config_path)
                 .expect("Unable to read committee config file");
-            let mut policy = policy_config.into_policy();
-            if let Some(block_price) = block_price {
-                policy.block = *block_price;
-            }
-            if let Some(fuel_unit_price) = fuel_unit_price {
-                policy.fuel_unit = *fuel_unit_price;
-            }
-            if let Some(read_operation_price) = read_operation_price {
-                policy.read_operation = *read_operation_price;
-            }
-            if let Some(write_operation_price) = write_operation_price {
-                policy.write_operation = *write_operation_price;
-            }
-            if let Some(byte_read_price) = byte_read_price {
-                policy.byte_read = *byte_read_price;
-            }
-            if let Some(byte_written_price) = byte_written_price {
-                policy.byte_written = *byte_written_price;
-            }
-            if let Some(blob_read_price) = blob_read_price {
-                policy.blob_read = *blob_read_price;
-            }
-            if let Some(blob_published_price) = blob_published_price {
-                policy.blob_published = *blob_published_price;
-            }
-            if let Some(blob_byte_read_price) = blob_byte_read_price {
-                policy.blob_byte_read = *blob_byte_read_price;
-            }
-            if let Some(blob_byte_published_price) = blob_byte_published_price {
-                policy.blob_byte_published = *blob_byte_published_price;
-            }
-            if let Some(byte_stored_price) = byte_stored_price {
-                policy.byte_stored = *byte_stored_price;
-            }
-            if let Some(operation_price) = operation_price {
-                policy.operation = *operation_price;
-            }
-            if let Some(operation_byte_price) = operation_byte_price {
-                policy.operation_byte = *operation_byte_price;
-            }
-            if let Some(message_price) = message_price {
-                policy.message = *message_price;
-            }
-            if let Some(message_byte_price) = message_byte_price {
-                policy.message_byte = *message_byte_price;
-            }
-            if let Some(maximum_fuel_per_block) = maximum_fuel_per_block {
-                policy.maximum_fuel_per_block = *maximum_fuel_per_block;
-            }
-            if let Some(maximum_executed_block_size) = maximum_executed_block_size {
-                policy.maximum_executed_block_size = *maximum_executed_block_size;
-            }
-            if let Some(maximum_blob_size) = maximum_blob_size {
-                policy.maximum_blob_size = *maximum_blob_size;
-            }
-            if let Some(maximum_published_blobs) = maximum_published_blobs {
-                policy.maximum_published_blobs = *maximum_published_blobs;
-            }
-            if let Some(maximum_bytecode_size) = maximum_bytecode_size {
-                policy.maximum_bytecode_size = *maximum_bytecode_size;
-            }
-            if let Some(maximum_block_proposal_size) = maximum_block_proposal_size {
-                policy.maximum_block_proposal_size = *maximum_block_proposal_size;
-            }
-            if let Some(maximum_bytes_read_per_block) = maximum_bytes_read_per_block {
-                policy.maximum_bytes_read_per_block = *maximum_bytes_read_per_block;
-            }
-            if let Some(maximum_bytes_written_per_block) = maximum_bytes_written_per_block {
-                policy.maximum_bytes_written_per_block = *maximum_bytes_written_per_block;
-            }
-            if let Some(http_allow_list) = http_allow_list {
-                policy.http_request_allow_list = BTreeSet::from_iter(http_allow_list.clone());
-            }
+            let existing_policy = policy_config.into_policy();
+            let policy = linera_execution::ResourceControlPolicy {
+                block: block_price.unwrap_or(existing_policy.block),
+                fuel_unit: fuel_unit_price.unwrap_or(existing_policy.fuel_unit),
+                read_operation: read_operation_price.unwrap_or(existing_policy.read_operation),
+                write_operation: write_operation_price.unwrap_or(existing_policy.write_operation),
+                byte_read: byte_read_price.unwrap_or(existing_policy.byte_read),
+                byte_written: byte_written_price.unwrap_or(existing_policy.byte_written),
+                blob_read: blob_read_price
+                    .unwrap_or(existing_policy.blob_read),
+                blob_published: blob_published_price
+                    .unwrap_or(existing_policy.blob_published),
+                blob_byte_read: blob_byte_read_price
+                    .unwrap_or(existing_policy.blob_byte_read),
+                blob_byte_published: blob_byte_published_price
+                    .unwrap_or(existing_policy.blob_byte_published),
+                byte_stored: byte_stored_price.unwrap_or(existing_policy.byte_stored),
+                operation: operation_price.unwrap_or(existing_policy.operation),
+                operation_byte: operation_byte_price.unwrap_or(existing_policy.operation_byte),
+                message: message_price.unwrap_or(existing_policy.message),
+                message_byte: message_byte_price.unwrap_or(existing_policy.message_byte),
+                service_as_oracle_query: service_as_oracle_query_price
+                    .unwrap_or(existing_policy.service_as_oracle_query),
+                http_request: http_request_price.unwrap_or(existing_policy.http_request),
+                maximum_fuel_per_block: maximum_fuel_per_block
+                    .unwrap_or(existing_policy.maximum_fuel_per_block),
+                maximum_service_oracle_execution_ms: maximum_service_oracle_execution_ms
+                    .unwrap_or(existing_policy.maximum_service_oracle_execution_ms),
+                maximum_executed_block_size: maximum_executed_block_size
+                    .unwrap_or(existing_policy.maximum_executed_block_size),
+                maximum_bytecode_size: maximum_bytecode_size
+                    .unwrap_or(existing_policy.maximum_bytecode_size),
+                maximum_blob_size: maximum_blob_size.unwrap_or(existing_policy.maximum_blob_size),
+                maximum_published_blobs: maximum_published_blobs
+                    .unwrap_or(existing_policy.maximum_published_blobs),
+                maximum_block_proposal_size: maximum_block_proposal_size
+                    .unwrap_or(existing_policy.maximum_block_proposal_size),
+                maximum_bytes_read_per_block: maximum_bytes_read_per_block
+                    .unwrap_or(existing_policy.maximum_bytes_read_per_block),
+                maximum_bytes_written_per_block: maximum_bytes_written_per_block
+                    .unwrap_or(existing_policy.maximum_bytes_written_per_block),
+                maximum_http_response_bytes: maximum_http_response_bytes
+                    .unwrap_or(existing_policy.maximum_http_response_bytes),
+                http_request_timeout_ms: http_request_timeout_ms
+                    .unwrap_or(existing_policy.http_request_timeout_ms),
+                http_request_allow_list: match http_request_allow_list {
+                    None => existing_policy.http_request_allow_list,
+                    Some(http_request_allow_list) => http_request_allow_list
+                        .iter()
+                        .cloned()
+                        .collect::<BTreeSet<_>>(),
+                },
+            };
             let timestamp = start_timestamp
                 .map(|st| {
                     let micros =

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -646,8 +646,7 @@ impl Runnable for Job {
                                         byte_read: byte_read.unwrap_or(existing_policy.byte_read),
                                         byte_written: byte_written
                                             .unwrap_or(existing_policy.byte_written),
-                                        blob_read: blob_read
-                                            .unwrap_or(existing_policy.blob_read),
+                                        blob_read: blob_read.unwrap_or(existing_policy.blob_read),
                                         blob_published: blob_published
                                             .unwrap_or(existing_policy.blob_published),
                                         blob_byte_read: blob_byte_read
@@ -694,12 +693,9 @@ impl Runnable for Job {
                                             .unwrap_or(existing_policy.maximum_http_response_bytes),
                                         http_request_timeout_ms: http_request_timeout_ms
                                             .unwrap_or(existing_policy.http_request_timeout_ms),
-                                        http_request_allow_list: match http_request_allow_list {
-                                            None => existing_policy.http_request_allow_list,
-                                            Some(http_request_allow_list) => {
-                                                BTreeSet::from_iter(http_request_allow_list)
-                                            }
-                                        },
+                                        http_request_allow_list: http_request_allow_list
+                                            .map(BTreeSet::from_iter)
+                                            .unwrap_or(existing_policy.http_request_allow_list),
                                     };
                                     info!("{policy}");
                                     if committee.policy() == &policy {
@@ -1449,12 +1445,9 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                 write_operation: write_operation_price.unwrap_or(existing_policy.write_operation),
                 byte_read: byte_read_price.unwrap_or(existing_policy.byte_read),
                 byte_written: byte_written_price.unwrap_or(existing_policy.byte_written),
-                blob_read: blob_read_price
-                    .unwrap_or(existing_policy.blob_read),
-                blob_published: blob_published_price
-                    .unwrap_or(existing_policy.blob_published),
-                blob_byte_read: blob_byte_read_price
-                    .unwrap_or(existing_policy.blob_byte_read),
+                blob_read: blob_read_price.unwrap_or(existing_policy.blob_read),
+                blob_published: blob_published_price.unwrap_or(existing_policy.blob_published),
+                blob_byte_read: blob_byte_read_price.unwrap_or(existing_policy.blob_byte_read),
                 blob_byte_published: blob_byte_published_price
                     .unwrap_or(existing_policy.blob_byte_published),
                 byte_stored: byte_stored_price.unwrap_or(existing_policy.byte_stored),

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1479,13 +1479,10 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                     .unwrap_or(existing_policy.maximum_http_response_bytes),
                 http_request_timeout_ms: http_request_timeout_ms
                     .unwrap_or(existing_policy.http_request_timeout_ms),
-                http_request_allow_list: match http_request_allow_list {
-                    None => existing_policy.http_request_allow_list,
-                    Some(http_request_allow_list) => http_request_allow_list
-                        .iter()
-                        .cloned()
-                        .collect::<BTreeSet<_>>(),
-                },
+                http_request_allow_list: http_request_allow_list
+                    .as_ref()
+                    .map(|list| list.iter().cloned().collect())
+                    .unwrap_or(existing_policy.http_request_allow_list),
             };
             let timestamp = start_timestamp
                 .map(|st| {


### PR DESCRIPTION
## Motivation

A reading of `ResourceControlPolicy` in `policy.rs` and `ResourceControlPolicy` in `client_options.rs` revealed some discrepancies which are most likely oversights.

Fixes #3532 

## Proposal

Implement the needed insert and rename `http_allow_list` as `http_request_allow_list`.

## Test Plan

The CI.

## Release Plan

Normal release process.

## Links

Closes #3532.