### PR TITLE
Introduce the caching of `contains_key` operations.

### DIFF
--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -178,7 +178,9 @@ impl LruPrefixCache {
     /// Returns `Some(true)` or `Some(false)` if we know that the entry does or does not
     /// exist in the database. Returns `None` if that information is not in the cache.
     pub fn query_contains_key(&self, key: &[u8]) -> Option<bool> {
-        self.map.get(key).map(|entry| !matches!(entry, CacheEntry::DoesNotExist))
+        self.map
+            .get(key)
+            .map(|entry| !matches!(entry, CacheEntry::DoesNotExist))
     }
 }
 


### PR DESCRIPTION
## Motivation

The LRU caching is very minimal and can be extended.

## Proposal

The PR #2500 implements several improvements to the LRU caching,
but it proved impossible to review. Splitting the changes more atomically
might be mergeable into main.

The following was done:
* The `Option<Vec<u8>>` is replaced by a `CacheEntry` that encodes the status if missing.
* The lifetime is removed from the `fn query`, but that does not matter since it was cloned just after.
* The cache success/fault is split with read_value/contains_key.

## Test Plan

The CI.

## Release Plan

Normal release plan.

## Links

None.