### PR TITLE
Stabilize service as oracles

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -121,10 +121,10 @@ jobs:
     - name: Compile Wasm test modules for Witty integration tests
       run: |
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown
-    - name: Run all tests using the default features (plus unstable-oracles, except storage-service)
+    - name: Run all tests using the default features (except storage-service)
       run: |
         # TODO(#2764): Actually link this to the default features
-        cargo test --no-default-features --features fs,macros,wasmer,rocksdb,unstable-oracles --locked
+        cargo test --no-default-features --features fs,macros,wasmer,rocksdb --locked
     - name: Run Witty integration tests
       run: |
         cargo test -p linera-witty --features wasmer,wasmtime
@@ -208,7 +208,7 @@ jobs:
     - name: Run Ethereum tests
       run: |
         cargo test -p linera-ethereum --features ethereum
-        cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum,storage-service,unstable-oracles
+        cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum,storage-service
     - name: Run REVM test
       run: |
         cargo test -p linera-execution test_fuel_for_counter_revm_application --features revm
@@ -231,7 +231,7 @@ jobs:
     - name: Run the storage-service instance and the storage-service tests
       run: |
         cargo run --release -p linera-storage-service -- memory --endpoint $LINERA_STORAGE_SERVICE &
-        cargo test --features storage-service,unstable-oracles -- storage_service --nocapture
+        cargo test --features storage-service -- storage_service --nocapture
 
   web:
     runs-on: ubuntu-latest

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -21,7 +21,6 @@ test = [
     "linera-base/test",
     "linera-execution/test",
 ]
-unstable-oracles = ["linera-execution/unstable-oracles"]
 web = ["linera-base/web", "linera-views/web", "linera-execution/web"]
 
 [dependencies]

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -5,11 +5,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    iter,
-};
-#[cfg(feature = "unstable-oracles")]
-use std::{
-    thread,
+    iter, thread,
     time::{Duration, Instant},
 };
 
@@ -31,12 +27,10 @@ use linera_execution::{
     committee::{Committee, Epoch, ValidatorState},
     system::{OpenChainConfig, Recipient},
     test_utils::{ExpectedCall, MockApplication},
-    BaseRuntime, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message,
-    MessageKind, Operation, ResourceControlPolicy, SystemMessage, SystemOperation,
-    TestExecutionRuntimeContext,
+    BaseRuntime, ContractRuntime, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext,
+    Message, MessageKind, Operation, ResourceControlPolicy, ServiceRuntime, SystemMessage,
+    SystemOperation, TestExecutionRuntimeContext,
 };
-#[cfg(feature = "unstable-oracles")]
-use linera_execution::{ContractRuntime, ServiceRuntime};
 use linera_views::{
     context::{Context as _, MemoryContext, ViewContext},
     memory::MemoryStore,
@@ -306,7 +300,6 @@ async fn test_application_permissions() -> anyhow::Result<()> {
 }
 
 /// Tests if services can execute as oracles if the total execution time is less than the limit.
-#[cfg(feature = "unstable-oracles")]
 #[test_case(&[100]; "single service as oracle call")]
 #[test_case(&[50, 50]; "two service as oracle calls")]
 #[test_case(&[90, 10]; "long and short service as oracle calls")]
@@ -349,7 +342,6 @@ async fn test_service_as_oracles(service_oracle_execution_times_ms: &[u64]) -> a
 }
 
 /// Tests if execution fails if services executing as oracles exceed the time limit.
-#[cfg(feature = "unstable-oracles")]
 #[test_case(&[120]; "single service as oracle call")]
 #[test_case(&[60, 60]; "two service as oracle calls")]
 #[test_case(&[105, 15]; "long and short service as oracle calls")]
@@ -406,7 +398,6 @@ async fn test_service_as_oracle_exceeding_time_limit(
 }
 
 /// Tests if execution fails early if services call `check_execution_time`.
-#[cfg(feature = "unstable-oracles")]
 #[test_case(&[120]; "single service as oracle call")]
 #[test_case(&[60, 60]; "two service as oracle calls")]
 #[test_case(&[105, 15]; "long and short service as oracle calls")]
@@ -475,7 +466,6 @@ async fn test_service_as_oracle_timeout_early_stop(
 }
 
 /// Tests service-as-oracle response size limit.
-#[cfg(feature = "unstable-oracles")]
 #[test_case(50, 49 => matches Ok(_); "smaller than limit")]
 #[test_case(
     50, 51
@@ -567,7 +557,6 @@ async fn test_contract_http_response_size_limit(
 }
 
 /// Tests service HTTP response size limit.
-#[cfg(feature = "unstable-oracles")]
 #[test_case(150, 140, 139 => matches Ok(_); "smaller than both limits")]
 #[test_case(140, 150, 142 => matches Ok(_); "larger than oracle limit")]
 #[test_case(

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -31,10 +31,6 @@ rocksdb = ["linera-views/rocksdb"]
 dynamodb = ["linera-views/dynamodb"]
 scylladb = ["linera-views/scylladb"]
 storage-service = ["linera-storage-service"]
-unstable-oracles = [
-    "linera-chain/unstable-oracles",
-    "linera-execution/unstable-oracles",
-]
 metrics = [
     "prometheus",
     "linera-base/metrics",

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -354,8 +354,7 @@ where
         }]]
     );
 
-    let query_service = cfg!(feature = "unstable-oracles");
-    let mut operation = meta_counter::Operation::increment(receiver_id, 5, query_service);
+    let mut operation = meta_counter::Operation::increment(receiver_id, 5, true);
     operation.fuel_grant = 1000000;
     let cert = creator
         .execute_operation(Operation::user(application_id2, &operation)?)
@@ -367,16 +366,12 @@ where
     let [_, responses] = &responses[..] else {
         panic!("Unexpected oracle responses: {:?}", responses);
     };
-    if cfg!(feature = "unstable-oracles") {
-        let [OracleResponse::Service(json)] = &responses[..] else {
-            assert_eq!(&responses[..], &[]);
-            panic!("Unexpected oracle responses: {:?}", responses);
-        };
-        let response_json = serde_json::from_slice::<serde_json::Value>(json).unwrap();
-        assert_eq!(response_json["data"], json!({"value": 10}));
-    } else {
-        assert!(responses.is_empty());
-    }
+    let [OracleResponse::Service(json)] = &responses[..] else {
+        assert_eq!(&responses[..], &[]);
+        panic!("Unexpected oracle responses: {:?}", responses);
+    };
+    let response_json = serde_json::from_slice::<serde_json::Value>(json).unwrap();
+    assert_eq!(response_json["data"], json!({"value": 10}));
 
     receiver.synchronize_from_validators().await.unwrap();
     receiver

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -23,7 +23,6 @@ revm = [
 ]
 fs = ["tokio/fs"]
 metrics = ["prometheus", "linera-views/metrics"]
-unstable-oracles = []
 wasmer = [
     "dep:wasmer",
     "wasmer/enable-serde",

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -275,10 +275,6 @@ pub enum ExecutionError {
     UnauthorizedHttpRequest(reqwest::Url),
     #[error("Attempt to perform an HTTP request to an invalid URL")]
     InvalidUrlForHttpRequest(#[from] url::ParseError),
-    // TODO(#2127): Remove this error and the unstable-oracles feature once there are fees
-    // and enforced limits for all oracles.
-    #[error("Unstable oracles are disabled on this network.")]
-    UnstableOracle,
     #[error("Failed to send contract code to worker thread: {0:?}")]
     ContractModuleSend(#[from] linera_base::task::SendError<UserContractCode>),
     #[error("Failed to send service code to worker thread: {0:?}")]

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1318,11 +1318,6 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         application_id: ApplicationId,
         query: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
-        ensure!(
-            cfg!(feature = "unstable-oracles"),
-            ExecutionError::UnstableOracle
-        );
-
         let mut this = self.inner();
 
         let app_permissions = this

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -861,7 +861,6 @@ impl TransferTestEndpoint {
 }
 
 /// Tests the contract system API to query an application service.
-#[cfg(feature = "unstable-oracles")] // # TODO: Remove once #3524 lands
 #[test_case(None => matches Ok(_); "when all authorized")]
 #[test_case(Some(vec![()]) => matches Ok(_); "when single app authorized")]
 #[test_case(Some(vec![]) => matches Err(ExecutionError::UnauthorizedApplication(_)); "when unauthorized")]

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -112,7 +112,7 @@ use test_case::test_case;
     Some(Amount::from_tokens(1_000));
     "with execution and an empty read and with owner account and grant"
 )]
-#[cfg_attr(feature = "unstable-oracles", test_case(
+#[test_case(
     vec![
         FeeSpend::QueryServiceOracle,
     ],
@@ -120,8 +120,8 @@ use test_case::test_case;
     Some(Amount::from_tokens(1)),
     Some(Amount::from_tokens(1_000));
     "with only a service oracle call"
-))]
-#[cfg_attr(feature = "unstable-oracles", test_case(
+)]
+#[test_case(
     vec![
         FeeSpend::QueryServiceOracle,
         FeeSpend::QueryServiceOracle,
@@ -131,8 +131,8 @@ use test_case::test_case;
     Some(Amount::from_tokens(1)),
     Some(Amount::from_tokens(1_000));
     "with three service oracle calls"
-))]
-#[cfg_attr(feature = "unstable-oracles", test_case(
+)]
+#[test_case(
     vec![
         FeeSpend::Fuel(91),
         FeeSpend::QueryServiceOracle,
@@ -146,7 +146,7 @@ use test_case::test_case;
     Some(Amount::from_tokens(1_000)),
     None;
     "with service oracle calls, fuel consumption and a read operation"
-))]
+)]
 #[test_case(
     vec![FeeSpend::HttpRequest],
     Amount::from_tokens(2),

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -25,10 +25,6 @@ ignored = ["base64ct"]
 [features]
 ethereum = ["async-trait", "linera-ethereum"]
 revm = ["linera-execution/revm"]
-unstable-oracles = [
-    "linera-core/unstable-oracles",
-    "linera-execution/unstable-oracles",
-]
 wasmer = [
     "linera-core/wasmer",
     "linera-execution/wasmer",

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -20,7 +20,6 @@ revm = [
     "linera-sdk/revm",
     "dep:alloy-sol-types",
 ]
-unstable-oracles = ["linera-core/unstable-oracles"]
 test = [
     "linera-base/test",
     "linera-execution/test",


### PR DESCRIPTION
## Motivation

Running services as oracles is required for executing most HTTP requests due to non-deterministic answers. Now that running services as oracles is charged for and limited, it's possible to mark it as stable.

## Proposal

Remove the `unstable-oracles` feature.

## Test Plan

CI should catch any regressions.

## Release Plan

- These changes follow the usual release cycle, since it adds a new feature to be included in the next testnet.

## Links

- Closes #3524 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
