### PR TITLE
(nit) add symlink to make binary formats more discoverable

### DIFF
--- a/linera-rpc/binary_formats.yaml
+++ b/linera-rpc/binary_formats.yaml
@@ -1,0 +1,1 @@
+tests/snapshots/format__format.yaml.snap


### PR DESCRIPTION
## Motivation

Tracking binary formats is important but the corresponding file is buried in the directory tree and looks like just another test snapshot.

## Proposal

* Create a symlink to make the file more visible

This more stable link could also be used later for `serde_generate`

## Test Plan

Nothing to do
