### PR TITLE
Refactor `ChainStateView::execute_block`.

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -14,14 +14,14 @@ use linera_base::{
     hashed::Hashed,
     identifiers::{BlobId, ChainId, MessageId, Owner},
 };
-use linera_execution::{committee::Epoch, BlobState, Operation, OutgoingMessage};
+use linera_execution::{committee::Epoch, BlobState, Operation, OperationResult, OutgoingMessage};
 use serde::{ser::SerializeStruct, Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
     data_types::{
         BlockExecutionOutcome, ExecutedBlock, IncomingBundle, Medium, MessageBundle,
-        OperationResult, OutgoingMessageExt, ProposedBlock,
+        OutgoingMessageExt, ProposedBlock,
     },
     types::CertificateValue,
     ChainError,

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -18,13 +18,12 @@ use linera_base::{
     data_types::{Amount, Blob, BlockHeight, Event, OracleResponse, Round, Timestamp},
     doc_scalar, ensure,
     hashed::Hashed,
-    hex_debug,
     identifiers::{Account, BlobId, ChainId, ChannelFullName, Destination, MessageId, Owner},
 };
 use linera_execution::{
     committee::{Committee, Epoch},
     system::OpenChainConfig,
-    Message, MessageKind, Operation, OutgoingMessage, SystemMessage,
+    Message, MessageKind, Operation, OperationResult, OutgoingMessage, SystemMessage,
 };
 use serde::{Deserialize, Serialize};
 
@@ -352,21 +351,6 @@ impl OutgoingMessageExt for OutgoingMessage {
         }
     }
 }
-
-/// The execution result of a single operation.
-#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
-pub struct OperationResult(
-    #[debug(with = "hex_debug")]
-    #[serde(with = "serde_bytes")]
-    pub Vec<u8>,
-);
-
-impl<'de> BcsHashable<'de> for OperationResult {}
-
-doc_scalar!(
-    OperationResult,
-    "The execution result of a single operation."
-);
 
 /// A [`ProposedBlock`], together with the outcome from its execution.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, SimpleObject)]

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -158,8 +158,6 @@ pub enum ChainError {
     MissingMandatoryApplications(Vec<ApplicationId>),
     #[error("Can't use grant across different broadcast messages")]
     GrantUseOnBroadcast,
-    #[error("ExecutedBlock contains fewer oracle responses than requests")]
-    MissingOracleResponseList,
     #[error("Unexpected hash for CertificateValue! Expected: {expected:?}, Actual: {actual:?}")]
     CertificateValueHashMismatch {
         expected: CryptoHash,

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -24,14 +24,14 @@ use linera_base::{
     vm::VmRuntime,
 };
 use linera_chain::{
-    data_types::{BlockExecutionOutcome, OperationResult},
+    data_types::BlockExecutionOutcome,
     test::{make_child_block, make_first_block, BlockTestExt},
     types::ConfirmedBlock,
 };
 use linera_execution::{
     committee::Epoch, system::SystemOperation, test_utils::SystemExecutionState,
-    ExecutionRuntimeContext, Operation, OperationContext, ResourceController, TransactionTracker,
-    WasmContractModule, WasmRuntime,
+    ExecutionRuntimeContext, Operation, OperationContext, OperationResult, ResourceController,
+    TransactionTracker, WasmContractModule, WasmRuntime,
 };
 use linera_storage::{DbStorage, Storage};
 #[cfg(feature = "dynamodb")]

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -31,8 +31,8 @@ use linera_base::{
 use linera_chain::{
     data_types::{
         BlockExecutionOutcome, BlockProposal, ChainAndHeight, ExecutedBlock, IncomingBundle,
-        LiteValue, LiteVote, Medium, MessageAction, MessageBundle, OperationResult, Origin,
-        PostedMessage, ProposedBlock, SignatureAggregator,
+        LiteValue, LiteVote, Medium, MessageAction, MessageBundle, Origin, PostedMessage,
+        ProposedBlock, SignatureAggregator,
     },
     manager::LockingBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
@@ -49,8 +49,8 @@ use linera_execution::{
         EPOCH_STREAM_NAME as NEW_EPOCH_STREAM_NAME, REMOVED_EPOCH_STREAM_NAME,
     },
     test_utils::{ExpectedCall, RegisterMockApplication, SystemExecutionState},
-    ExecutionError, Message, MessageKind, OutgoingMessage, Query, QueryContext, QueryOutcome,
-    QueryResponse, SystemQuery, SystemResponse,
+    ExecutionError, Message, MessageKind, OperationResult, OutgoingMessage, Query, QueryContext,
+    QueryOutcome, QueryResponse, SystemQuery, SystemResponse,
 };
 use linera_storage::{DbStorage, Storage, TestClock};
 use linera_views::{

--- a/linera-execution/src/block_executor.rs
+++ b/linera-execution/src/block_executor.rs
@@ -1,0 +1,329 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{sync::Arc, vec};
+
+use custom_debug_derive::Debug;
+use linera_base::{
+    crypto::BcsHashable,
+    data_types::{Amount, Blob, Event, OracleResponse, Timestamp},
+    doc_scalar, hex_debug,
+    identifiers::{AccountOwner, BlobType, ChainId, ChannelFullName, Destination, Owner},
+};
+use linera_views::{context::Context, views::View};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    resources::Sources, ExecutionError, ExecutionRuntimeContext, ExecutionStateView, Message,
+    MessageContext, MessageKind, Operation, OperationContext, OutgoingMessage, ResourceController,
+    ResourceTracker, SystemMessage, TransactionTracker,
+};
+
+/// The execution result of a single operation.
+#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub struct OperationResult(
+    #[debug(with = "hex_debug")]
+    #[serde(with = "serde_bytes")]
+    pub Vec<u8>,
+);
+
+impl<'de> BcsHashable<'de> for OperationResult {}
+
+doc_scalar!(
+    OperationResult,
+    "The execution result of a single operation."
+);
+
+pub struct BlockExecutor<'a, C> {
+    pub state: &'a mut ExecutionStateView<C>,
+    pub resource_controller: ResourceController<Option<Owner>>,
+    replaying_oracle_responses: Option<vec::IntoIter<Vec<OracleResponse>>>,
+    next_message_index: u32,
+    next_application_index: u32,
+    local_time: Timestamp,
+    pub oracle_responses: Vec<Vec<OracleResponse>>,
+    pub events: Vec<Vec<Event>>,
+    pub blobs: Vec<Vec<Blob>>,
+    pub messages: Vec<Vec<OutgoingMessage>>,
+    pub operation_results: Vec<OperationResult>,
+    pub subscribe: Vec<(ChannelFullName, ChainId)>,
+    pub unsubscribe: Vec<(ChannelFullName, ChainId)>,
+}
+
+impl<'a, C> BlockExecutor<'a, C>
+where
+    C: Context + Clone + Send + Sync + 'static,
+    C::Extra: ExecutionRuntimeContext,
+{
+    pub fn new(
+        state: &'a mut ExecutionStateView<C>,
+        account: Option<Owner>,
+        replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
+        local_time: Timestamp,
+    ) -> Result<Self, ExecutionError> {
+        let (_, committee) = state
+            .system
+            .current_committee()
+            .ok_or_else(|| ExecutionError::InactiveChain)?;
+        let resource_controller = ResourceController {
+            policy: Arc::new(committee.policy().clone()),
+            tracker: ResourceTracker::default(),
+            account,
+        };
+        Ok(Self {
+            state,
+            resource_controller,
+            replaying_oracle_responses: replaying_oracle_responses.map(Vec::into_iter),
+            next_message_index: 0,
+            next_application_index: 0,
+            local_time,
+            oracle_responses: Vec::new(),
+            events: Vec::new(),
+            blobs: Vec::new(),
+            messages: Vec::new(),
+            operation_results: Vec::new(),
+            subscribe: Vec::new(),
+            unsubscribe: Vec::new(),
+        })
+    }
+
+    pub async fn track_block(
+        &mut self,
+        empty_block_size: usize,
+        incoming_bundle_count: usize,
+        operation_count: usize,
+        published_blobs: &[Blob],
+    ) -> Result<(), ExecutionError> {
+        self.resource_controller
+            .track_block_size(empty_block_size)?;
+        self.resource_controller
+            .track_executed_block_size_sequence_extension(0, incoming_bundle_count, 1)?;
+        self.resource_controller
+            .track_executed_block_size_sequence_extension(0, operation_count, 1)?;
+        for blob in published_blobs {
+            let blob_type = blob.content().blob_type();
+            if blob_type == BlobType::Data
+                || blob_type == BlobType::ContractBytecode
+                || blob_type == BlobType::ServiceBytecode
+            {
+                self.resource_controller_with_state()
+                    .await?
+                    .track_blob_published(blob.content())?;
+            }
+            self.state.system.used_blobs.insert(&blob.id())?;
+        }
+        Ok(())
+    }
+
+    pub fn new_transaction<'b>(
+        &'b mut self,
+    ) -> Result<TransactionExecutor<'a, 'b, C>, ExecutionError> {
+        let maybe_responses = match self.replaying_oracle_responses.as_mut().map(Iterator::next) {
+            Some(Some(responses)) => Some(responses),
+            Some(None) => return Err(ExecutionError::MissingOracleResponseList),
+            None => None,
+        };
+        let transaction_tracker = TransactionTracker::new(
+            self.next_message_index,
+            self.next_application_index,
+            maybe_responses,
+        );
+        Ok(TransactionExecutor {
+            block_executor: self,
+            transaction_tracker,
+        })
+    }
+
+    pub async fn resource_controller_with_state(
+        &mut self,
+    ) -> Result<ResourceController<Sources, &mut ResourceTracker>, ExecutionError> {
+        Ok(self
+            .resource_controller
+            .with_state(&mut self.state.system)
+            .await?)
+    }
+
+    fn chain_id(&self) -> ChainId {
+        self.state.context().extra().chain_id()
+    }
+}
+
+pub struct TransactionExecutor<'a, 'b, C> {
+    pub block_executor: &'b mut BlockExecutor<'a, C>,
+    pub transaction_tracker: TransactionTracker,
+}
+
+impl<'a, 'b, C> TransactionExecutor<'a, 'b, C>
+where
+    C: Context + Clone + Send + Sync + 'static,
+    C::Extra: ExecutionRuntimeContext,
+{
+    /// Executes an operation.
+    pub async fn execute_operation(
+        &mut self,
+        context: OperationContext,
+        operation: Operation,
+    ) -> Result<(), ExecutionError> {
+        self.block_executor
+            .resource_controller_with_state()
+            .await?
+            .track_operation(&operation)?;
+        self.block_executor
+            .state
+            .execute_operation(
+                context,
+                self.block_executor.local_time,
+                operation,
+                &mut self.transaction_tracker,
+                &mut self.block_executor.resource_controller,
+            )
+            .await
+    }
+
+    /// Executes a message as part of an incoming bundle in a block.
+    /// Refunds the remainder of the grant, if any.
+    pub async fn execute_message(
+        &mut self,
+        context: MessageContext,
+        message: Message,
+        mut grant: Amount,
+    ) -> Result<(), ExecutionError> {
+        self.block_executor
+            .state
+            .execute_message(
+                context,
+                self.block_executor.local_time,
+                message,
+                (grant > Amount::ZERO).then_some(&mut grant),
+                &mut self.transaction_tracker,
+                &mut self.block_executor.resource_controller,
+            )
+            .await?;
+        if grant > Amount::ZERO {
+            self.send_refund(context, grant).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn bounce_message(
+        &mut self,
+        context: MessageContext,
+        grant: Amount,
+        message: Message,
+    ) -> Result<(), ExecutionError> {
+        assert_eq!(context.chain_id, self.block_executor.chain_id());
+        self.transaction_tracker
+            .add_outgoing_message(OutgoingMessage {
+                destination: Destination::Recipient(context.message_id.chain_id),
+                authenticated_signer: context.authenticated_signer,
+                refund_grant_to: context.refund_grant_to.filter(|_| !grant.is_zero()),
+                grant,
+                kind: MessageKind::Bouncing,
+                message,
+            })?;
+        Ok(())
+    }
+
+    pub async fn send_refund(
+        &mut self,
+        context: MessageContext,
+        amount: Amount,
+    ) -> Result<(), ExecutionError> {
+        assert_eq!(context.chain_id, self.block_executor.chain_id());
+        // Nothing to do except maybe refund the grant.
+        let Some(refund_grant_to) = context.refund_grant_to else {
+            // See OperationContext::refund_grant_to()
+            return Err(ExecutionError::InternalError(
+                "Messages with grants should have a non-empty `refund_grant_to`",
+            ));
+        };
+        let message = SystemMessage::Credit {
+            amount,
+            source: context
+                .authenticated_signer
+                .map(AccountOwner::User)
+                .unwrap_or(AccountOwner::Chain),
+            target: refund_grant_to.owner,
+        };
+        self.transaction_tracker.add_outgoing_message(
+            OutgoingMessage::new(refund_grant_to.chain_id, message).with_kind(MessageKind::Tracked),
+        )?;
+        Ok(())
+    }
+
+    pub fn track_block_size_of(&mut self, data: &impl Serialize) -> Result<(), ExecutionError> {
+        self.block_executor
+            .resource_controller
+            .track_block_size_of(data)
+    }
+
+    pub async fn finalize_transaction(
+        self,
+        is_accepted_message: bool,
+        is_operation: bool,
+    ) -> Result<(), ExecutionError> {
+        let txn_outcome = self.transaction_tracker.into_outcome()?;
+
+        self.block_executor.next_message_index = txn_outcome.next_message_index;
+        self.block_executor.next_application_index = txn_outcome.next_application_index;
+
+        let transaction_count = self.block_executor.oracle_responses.len();
+        let operation_count = self.block_executor.operation_results.len();
+
+        let mut resource_controller = self.block_executor.resource_controller_with_state().await?;
+        if is_accepted_message || is_operation {
+            for message_out in &txn_outcome.outgoing_messages {
+                resource_controller.track_message(&message_out.message)?;
+            }
+        }
+        resource_controller.track_block_size_of(&(
+            &txn_outcome.oracle_responses,
+            &txn_outcome.outgoing_messages,
+            &txn_outcome.events,
+            &txn_outcome.blobs,
+        ))?;
+        for blob in &txn_outcome.blobs {
+            if blob.content().blob_type() == BlobType::Data {
+                resource_controller.track_blob_published(blob.content())?;
+            }
+        }
+        // The oracles, messages, blobs and events collections are each extended by one, and all
+        // have the same length.
+        resource_controller.track_executed_block_size_sequence_extension(
+            transaction_count,
+            1,
+            4,
+        )?;
+
+        if is_operation {
+            resource_controller.track_block_size_of(&(&txn_outcome.operation_result))?;
+            resource_controller.track_executed_block_size_sequence_extension(
+                operation_count,
+                1,
+                1,
+            )?;
+        }
+
+        self.block_executor
+            .oracle_responses
+            .push(txn_outcome.oracle_responses);
+        self.block_executor
+            .messages
+            .push(txn_outcome.outgoing_messages);
+        self.block_executor.subscribe.extend(txn_outcome.subscribe);
+        self.block_executor
+            .unsubscribe
+            .extend(txn_outcome.unsubscribe);
+        self.block_executor.events.push(txn_outcome.events);
+
+        self.block_executor.blobs.push(txn_outcome.blobs);
+
+        if is_operation {
+            self.block_executor
+                .operation_results
+                .push(OperationResult(txn_outcome.operation_result));
+        }
+
+        Ok(())
+    }
+}

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(web, feature(trait_upcasting))]
 #![deny(clippy::large_futures)]
 
+mod block_executor;
 pub mod committee;
 mod execution;
 mod execution_state_actor;
@@ -64,6 +65,7 @@ pub use crate::wasm::{
     ServiceRuntimeApi, WasmContractModule, WasmExecutionError, WasmServiceModule,
 };
 pub use crate::{
+    block_executor::{BlockExecutor, OperationResult},
     execution::{ExecutionStateView, ServiceRuntimeEndpoint},
     execution_state_actor::ExecutionRequest,
     policy::ResourceControlPolicy,
@@ -335,6 +337,10 @@ pub enum ExecutionError {
     InactiveChain,
     #[error("No recorded response for oracle query")]
     MissingOracleResponse,
+    #[error("ExecutedBlock contains fewer oracle responses than requests")]
+    MissingOracleResponseList,
+    #[error("Internal error: {0}")]
+    InternalError(&'static str),
 }
 
 impl From<ViewError> for ExecutionError {

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -371,13 +371,15 @@ impl<Account, Tracker> ResourceController<Account, Tracker>
 where
     Tracker: AsMut<ResourceTracker>,
 {
-    /// Tracks the extension of a sequence in an executed block.
+    /// Tracks the extension of a number of sequence in an executed block.
     ///
     /// The sequence length is ULEB128-encoded, so extending a sequence can add an additional byte.
+    /// The `multiplier` specifies the number of sequences of the given length that are being extended.
     pub fn track_executed_block_size_sequence_extension(
         &mut self,
         old_len: usize,
         delta: usize,
+        multiplier: usize,
     ) -> Result<(), ExecutionError> {
         if delta == 0 {
             return Ok(());
@@ -387,7 +389,7 @@ where
         let old_size = ((usize::BITS - old_len.leading_zeros()) / 7).max(1);
         let new_size = ((usize::BITS - new_len.leading_zeros()) / 7).max(1);
         if new_size > old_size {
-            self.track_block_size((new_size - old_size) as usize)?;
+            self.track_block_size((new_size - old_size) as usize * multiplier)?;
         }
         Ok(())
     }

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -66,11 +66,13 @@ mod types {
         ownership::ChainOwnership,
     };
     pub use linera_chain::{
-        data_types::{MessageAction, MessageBundle, OperationResult, Origin, Target},
+        data_types::{MessageAction, MessageBundle, Origin, Target},
         manager::ChainManager,
     };
     pub use linera_core::worker::{Notification, Reason};
-    pub use linera_execution::{committee::Epoch, Message, MessageKind, Operation};
+    pub use linera_execution::{
+        committee::Epoch, Message, MessageKind, Operation, OperationResult,
+    };
 }
 
 pub use types::*;


### PR DESCRIPTION
## Motivation

`ChainStateView::execute_block` has many local variables that together represent the intermediate state of a block execution.

## Proposal

Make the intermediate state explicit as a `linera_execution::BlockExecutor`.

## Test Plan

Only refactoring.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
