### PR TITLE
Take blobs into account for block size computation.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -899,6 +899,7 @@ where
                     &txn_outcome.oracle_responses,
                     &txn_outcome.outgoing_messages,
                     &txn_outcome.events,
+                    &txn_outcome.blobs,
                 ))
                 .with_execution_context(chain_execution_context)?;
             for blob in &txn_outcome.blobs {
@@ -918,6 +919,9 @@ where
                 .with_execution_context(chain_execution_context)?;
             resource_controller
                 .track_executed_block_size_sequence_extension(events.len(), 1)
+                .with_execution_context(chain_execution_context)?;
+            resource_controller
+                .track_executed_block_size_sequence_extension(blobs.len(), 1)
                 .with_execution_context(chain_execution_context)?;
             oracle_responses.push(txn_outcome.oracle_responses);
             messages.push(txn_outcome.outgoing_messages);


### PR DESCRIPTION
## Motivation

During block execution we keep track of the final block's size, but we are not taking into account the collection of created blobs.

## Proposal

Take them into account.

## Test Plan

Writing a test for this will be very complicated. I created https://github.com/linera-io/linera-protocol/issues/3613 for this.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
