### PR TITLE
Increase value cache size

### DIFF
--- a/linera-core/src/value_cache.rs
+++ b/linera-core/src/value_cache.rs
@@ -17,7 +17,7 @@ use lru::LruCache;
 use {linera_base::prometheus_util::register_int_counter_vec, prometheus::IntCounterVec};
 
 /// The default cache size.
-pub const DEFAULT_VALUE_CACHE_SIZE: usize = 1000;
+pub const DEFAULT_VALUE_CACHE_SIZE: usize = 10_000;
 
 /// A counter metric for the number of cache hits in the [`ValueCache`].
 #[cfg(with_metrics)]


### PR DESCRIPTION
## Motivation

This is a bit of a workaround to some of the inefficiencies we see on ScyllaDB, but also doesn't hurt to have a slightly bigger cache, as the hit rate of it seems to be pretty good.

## Proposal

Increase value cache size

## Test Plan

CI + deployed a few networks with this

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
