### PR TITLE
Reduce size of `Operation` type

### DIFF
--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -557,7 +557,7 @@ where
     ) -> Result<(), BenchmarkError> {
         let start = Instant::now();
         chain_client
-            .execute_operation(Operation::System(SystemOperation::CloseChain))
+            .execute_operation(Operation::system(SystemOperation::CloseChain))
             .await?
             .expect("Close chain operation should not fail!");
 
@@ -593,7 +593,7 @@ where
                     public_key,
                     amount,
                 ),
-                None => Operation::System(SystemOperation::Transfer {
+                None => Operation::system(SystemOperation::Transfer {
                     owner: AccountOwner::Chain,
                     recipient: Recipient::chain(previous_chain_id),
                     amount,

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -885,7 +885,7 @@ where
             balance,
             application_permissions: Default::default(),
         };
-        let operations = iter::repeat(Operation::System(SystemOperation::OpenChain(config)))
+        let operations = iter::repeat(Operation::system(SystemOperation::OpenChain(config)))
             .take(num_new_chains)
             .collect();
         info!("Executing {} OpenChain operations", num_new_chains);

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2758,7 +2758,7 @@ where
             let mut owners = ownership.owners.into_iter().collect::<Vec<_>>();
             owners.extend(ownership.super_owners.into_iter().zip(iter::repeat(100)));
             owners.push((new_owner, new_weight));
-            let operations = vec![Operation::System(SystemOperation::ChangeOwnership {
+            let operations = vec![Operation::system(SystemOperation::ChangeOwnership {
                 super_owners: Vec::new(),
                 owners,
                 multi_leader_rounds: ownership.multi_leader_rounds,
@@ -2830,7 +2830,7 @@ where
                 balance,
                 application_permissions: application_permissions.clone(),
             };
-            let operation = Operation::System(SystemOperation::OpenChain(config));
+            let operation = Operation::system(SystemOperation::OpenChain(config));
             let certificate = match self.execute_block(vec![operation], vec![]).await? {
                 ExecuteBlockOutcome::Executed(certificate) => certificate,
                 ExecuteBlockOutcome::Conflict(_) => continue,
@@ -2895,7 +2895,7 @@ where
         module_id: ModuleId,
     ) -> Result<ClientOutcome<(ModuleId, ConfirmedBlockCertificate)>, ChainClientError> {
         self.execute_operations(
-            vec![Operation::System(SystemOperation::PublishModule {
+            vec![Operation::system(SystemOperation::PublishModule {
                 module_id,
             })],
             vec![contract_blob, service_blob],
@@ -2914,7 +2914,7 @@ where
         let publish_blob_operations = blobs
             .clone()
             .map(|blob| {
-                Operation::System(SystemOperation::PublishDataBlob {
+                Operation::system(SystemOperation::PublishDataBlob {
                     blob_hash: blob.id().hash,
                 })
             })
@@ -3019,7 +3019,7 @@ where
         let blob_hash = blob.id().hash;
         match self
             .execute_operations(
-                vec![Operation::System(SystemOperation::Admin(
+                vec![Operation::system(SystemOperation::Admin(
                     AdminOperation::PublishCommitteeBlob { blob_hash },
                 ))],
                 vec![blob],
@@ -3102,7 +3102,7 @@ where
         };
         let mut epoch_change_ops = Vec::new();
         while self.has_admin_event(EPOCH_STREAM_NAME, next_epoch).await? {
-            epoch_change_ops.push(Operation::System(SystemOperation::ProcessNewEpoch(
+            epoch_change_ops.push(Operation::system(SystemOperation::ProcessNewEpoch(
                 next_epoch,
             )));
             next_epoch.try_add_assign_one()?;
@@ -3111,7 +3111,7 @@ where
             .has_admin_event(REMOVED_EPOCH_STREAM_NAME, min_epoch)
             .await?
         {
-            epoch_change_ops.push(Operation::System(SystemOperation::ProcessRemovedEpoch(
+            epoch_change_ops.push(Operation::system(SystemOperation::ProcessRemovedEpoch(
                 min_epoch,
             )));
             min_epoch.try_add_assign_one()?;
@@ -3153,7 +3153,7 @@ where
             .keys()
             .filter_map(|epoch| {
                 if *epoch != current_epoch {
-                    Some(Operation::System(SystemOperation::Admin(
+                    Some(Operation::system(SystemOperation::Admin(
                         AdminOperation::RemoveCommittee { epoch: *epoch },
                     )))
                 } else {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1316,7 +1316,7 @@ where
 
     // Try to read a blob without publishing it first, should fail
     let result = client1_a
-        .execute_operation(SystemOperation::ReadBlob { blob_id: blob0_id }.into())
+        .execute_operation(SystemOperation::ReadBlob { blob_id: blob0_id })
         .await;
     assert_matches!(
         result,
@@ -1345,7 +1345,7 @@ where
     // and cache locally the blobs that were published by `client_a`. So this will succeed.
     client1_b.prepare_chain().await?;
     let certificate = client1_b
-        .execute_operation(SystemOperation::ReadBlob { blob_id: blob0_id }.into())
+        .execute_operation(SystemOperation::ReadBlob { blob_id: blob0_id })
         .await?
         .unwrap();
     assert_eq!(certificate.round, Round::MultiLeader(0));
@@ -2318,7 +2318,7 @@ where
 
     // Client 3 should be able to update validator 3 about the blob and the message.
     let certificate = client3
-        .execute_operation(SystemOperation::ReadBlob { blob_id }.into())
+        .execute_operation(SystemOperation::ReadBlob { blob_id })
         .await
         .unwrap()
         .unwrap();

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1364,8 +1364,8 @@ where
     let blob1_hash = blob1.id().hash;
 
     let blob_0_1_operations = vec![
-        Operation::System(SystemOperation::ReadBlob { blob_id: blob0_id }),
-        Operation::System(SystemOperation::PublishDataBlob {
+        Operation::system(SystemOperation::ReadBlob { blob_id: blob0_id }),
+        Operation::system(SystemOperation::PublishDataBlob {
             blob_hash: blob1_hash,
         }),
     ];
@@ -1437,7 +1437,7 @@ where
         .block()
         .body
         .operations
-        .contains(&Operation::System(SystemOperation::Transfer {
+        .contains(&Operation::system(SystemOperation::Transfer {
             owner: AccountOwner::Chain,
             recipient: Recipient::Burn,
             amount: Amount::from_tokens(1),
@@ -1469,7 +1469,7 @@ where
     let owner2_a = Owner::from(client2_a.public_key().await.unwrap());
     let key_pair2_b = AccountSecretKey::generate();
     let owner2_b = Owner::from(key_pair2_b.public());
-    let owner_change_op = Operation::System(SystemOperation::ChangeOwnership {
+    let owner_change_op = Operation::system(SystemOperation::ChangeOwnership {
         super_owners: Vec::new(),
         owners: vec![(owner2_a, 50), (owner2_b, 50)],
         multi_leader_rounds: 10,
@@ -1512,8 +1512,8 @@ where
     let blob1_hash = blob1.id().hash;
 
     let blob_0_1_operations = vec![
-        Operation::System(SystemOperation::ReadBlob { blob_id: blob0_id }),
-        Operation::System(SystemOperation::PublishDataBlob {
+        Operation::system(SystemOperation::ReadBlob { blob_id: blob0_id }),
+        Operation::system(SystemOperation::PublishDataBlob {
             blob_hash: blob1_hash,
         }),
     ];
@@ -1564,7 +1564,7 @@ where
         .block()
         .body
         .operations
-        .contains(&Operation::System(SystemOperation::Transfer {
+        .contains(&Operation::system(SystemOperation::Transfer {
             owner: AccountOwner::Chain,
             recipient: Recipient::Burn,
             amount: Amount::from_tokens(1),
@@ -1600,7 +1600,7 @@ where
     let owner3_b = Owner::from(key_pair3_b.public());
     let key_pair3_c = AccountSecretKey::generate();
     let owner3_c = Owner::from(key_pair3_c.public());
-    let owner_change_op = Operation::System(SystemOperation::ChangeOwnership {
+    let owner_change_op = Operation::system(SystemOperation::ChangeOwnership {
         super_owners: Vec::new(),
         owners: vec![(owner3_a, 50), (owner3_b, 50), (owner3_c, 50)],
         multi_leader_rounds: 10,
@@ -1667,8 +1667,8 @@ where
     let blob1_hash = blob1.id().hash;
 
     let blob_0_1_operations = vec![
-        Operation::System(SystemOperation::ReadBlob { blob_id: blob0_id }),
-        Operation::System(SystemOperation::PublishDataBlob {
+        Operation::system(SystemOperation::ReadBlob { blob_id: blob0_id }),
+        Operation::system(SystemOperation::PublishDataBlob {
             blob_hash: blob1_hash,
         }),
     ];
@@ -1735,8 +1735,8 @@ where
     let blob3_hash = blob3.id().hash;
 
     let blob_2_3_operations = vec![
-        Operation::System(SystemOperation::ReadBlob { blob_id: blob2_id }),
-        Operation::System(SystemOperation::PublishDataBlob {
+        Operation::system(SystemOperation::ReadBlob { blob_id: blob2_id }),
+        Operation::system(SystemOperation::PublishDataBlob {
             blob_hash: blob3_hash,
         }),
     ];
@@ -1807,7 +1807,7 @@ where
         .block()
         .body
         .operations
-        .contains(&Operation::System(SystemOperation::PublishDataBlob {
+        .contains(&Operation::system(SystemOperation::PublishDataBlob {
             blob_hash: blob4.id().hash
         })));
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -558,8 +558,9 @@ where
     assert!(sender.pending_proposal().is_none());
     assert!(sender.key_pair().await.is_ok());
     assert_matches!(
-        certificate.block().body.operations[open_chain_message_id.index as usize],
-        Operation::System(SystemOperation::OpenChain(_)),
+        certificate.block().body.operations[open_chain_message_id.index as usize]
+            .as_system_operation(),
+        Some(SystemOperation::OpenChain(_)),
         "Unexpected certificate value",
     );
     assert_eq!(
@@ -648,8 +649,9 @@ where
     assert!(sender.pending_proposal().is_none());
     assert!(sender.key_pair().await.is_ok());
     assert_matches!(
-        certificate.block().body.operations[open_chain_message_id.index as usize],
-        Operation::System(SystemOperation::OpenChain(_)),
+        certificate.block().body.operations[open_chain_message_id.index as usize]
+            .as_system_operation(),
+        Some(SystemOperation::OpenChain(_)),
         "Unexpected certificate value",
     );
     assert_eq!(
@@ -763,9 +765,14 @@ where
     let client2 = builder.add_root_chain(2, Amount::from_tokens(4)).await?;
 
     let certificate = client1.close_chain().await.unwrap().unwrap().unwrap();
+    assert_eq!(
+        certificate.block().body.operations.len(),
+        1,
+        "Unexpected operations in certificate"
+    );
     assert_matches!(
-        certificate.block().body.operations[..],
-        [Operation::System(SystemOperation::CloseChain)],
+        certificate.block().body.operations[0].as_system_operation(),
+        Some(SystemOperation::CloseChain),
         "Unexpected certificate value",
     );
     assert_eq!(client1.next_block_height(), BlockHeight::from(1));

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -267,7 +267,7 @@ where
             Operation::System(op) => {
                 let new_application = self
                     .system
-                    .execute_operation(context, op, txn_tracker, resource_controller)
+                    .execute_operation(context, *op, txn_tracker, resource_controller)
                     .await?;
                 if let Some((application_id, argument)) = new_application {
                     let user_action = UserAction::Instantiate(context, argument);

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1178,16 +1178,14 @@ impl Operation {
 
     /// Returns the IDs of all blobs published in this operation.
     pub fn published_blob_ids(&self) -> Vec<BlobId> {
-        match self {
-            Operation::System(SystemOperation::PublishDataBlob { blob_hash }) => {
+        match self.as_system_operation() {
+            Some(SystemOperation::PublishDataBlob { blob_hash }) => {
                 vec![BlobId::new(*blob_hash, BlobType::Data)]
             }
-            Operation::System(SystemOperation::Admin(AdminOperation::PublishCommitteeBlob {
-                blob_hash,
-            })) => {
+            Some(SystemOperation::Admin(AdminOperation::PublishCommitteeBlob { blob_hash })) => {
                 vec![BlobId::new(*blob_hash, BlobType::Committee)]
             }
-            Operation::System(SystemOperation::PublishModule { module_id }) => vec![
+            Some(SystemOperation::PublishModule { module_id }) => vec![
                 BlobId::new(module_id.contract_blob_hash, BlobType::ContractBytecode),
                 BlobId::new(module_id.service_blob_hash, BlobType::ServiceBytecode),
             ],

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -786,7 +786,7 @@ pub trait ContractRuntime: BaseRuntime {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub enum Operation {
     /// A system operation.
-    System(SystemOperation),
+    System(Box<SystemOperation>),
     /// A user operation (in serialized form).
     User {
         application_id: UserApplicationId,
@@ -1129,13 +1129,13 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
 
 impl From<SystemOperation> for Operation {
     fn from(operation: SystemOperation) -> Self {
-        Operation::System(operation)
+        Operation::System(Box::new(operation))
     }
 }
 
 impl Operation {
     pub fn system(operation: SystemOperation) -> Self {
-        Operation::System(operation)
+        Operation::System(Box::new(operation))
     }
 
     /// Creates a new user application operation following the `application_id`'s [`Abi`].

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1160,6 +1160,15 @@ impl Operation {
         })
     }
 
+    /// Returns a reference to the [`SystemOperation`] in this [`Operation`], if this [`Operation`]
+    /// is for the system application.
+    pub fn as_system_operation(&self) -> Option<&SystemOperation> {
+        match self {
+            Operation::System(system_operation) => Some(system_operation),
+            Operation::User { .. } => None,
+        }
+    }
+
     pub fn application_id(&self) -> GenericApplicationId {
         match self {
             Self::System(_) => GenericApplicationId::System,

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -47,7 +47,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
     view.execute_operation(
         context,
         Timestamp::from(0),
-        Operation::System(operation),
+        Operation::system(operation),
         &mut txn_tracker,
         &mut controller,
     )

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -629,7 +629,7 @@ impl ActiveChain {
                         block.with_raw_operation(application_id, bytes);
                     }
                     Operation::System(system_operation) => {
-                        block.with_system_operation(system_operation);
+                        block.with_system_operation(*system_operation);
                     }
                 }
             }

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -132,7 +132,7 @@ where
     ) -> Result<CryptoHash, Error> {
         let certificate = self
             .apply_client_command(&chain_id, move |client| {
-                let operation = Operation::System(system_operation.clone());
+                let operation = Operation::system(system_operation.clone());
                 async move {
                     let result = client
                         .execute_operation(operation)


### PR DESCRIPTION
## Motivation

While migrating to a newer nightly version of Rust (see #3622), some new lints were suggested. One of them was that the `Operation` type had unbalanced variants. More specifically, the `User` variant was small and had a heap allocation with the bytes for the user operation, while the `System` variant had a large `SystemOperation` type inside.

## Proposal

Apply the suggested fix by the linter to move the `SystemOperation` to the heap by boxing it.

## Test Plan

CI should catch any regressions.

## Release Plan

- Nothing to do, because this is an internal refactor.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
