### PR TITLE
remove alias `UserApplicationId` and rename `UserApplicationDescription`

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -824,7 +824,7 @@ pub enum OracleResponse {
 
 impl<'de> BcsHashable<'de> for OracleResponse {}
 
-/// Description of the necessary information to run a user application used within blobs.
+/// Description of a user application.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Hash, Serialize)]
 pub struct ApplicationDescription {
     /// The unique ID of the bytecode to use for the application.
@@ -1229,10 +1229,7 @@ doc_scalar!(
     Blob,
     "A blob of binary data, with its content-addressed blob ID."
 );
-doc_scalar!(
-    ApplicationDescription,
-    "Description of the necessary information to run a user application"
-);
+doc_scalar!(ApplicationDescription, "Description of a user application");
 
 /// The time it takes to compress a bytecode.
 #[cfg(with_metrics)]

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -35,7 +35,7 @@ use crate::{
     doc_scalar, hex_debug, http,
     identifiers::{
         ApplicationId, BlobId, BlobType, ChainId, Destination, EventId, GenericApplicationId,
-        ModuleId, StreamId, UserApplicationId,
+        ModuleId, StreamId,
     },
     limited_writer::{LimitedWriter, LimitedWriterError},
     time::{Duration, SystemTime},
@@ -840,12 +840,12 @@ pub struct UserApplicationDescription {
     #[debug(with = "hex_debug")]
     pub parameters: Vec<u8>,
     /// Required dependencies.
-    pub required_application_ids: Vec<UserApplicationId>,
+    pub required_application_ids: Vec<ApplicationId>,
 }
 
-impl From<&UserApplicationDescription> for UserApplicationId {
+impl From<&UserApplicationDescription> for ApplicationId {
     fn from(description: &UserApplicationDescription) -> Self {
-        UserApplicationId::new(CryptoHash::new(&BlobContent::new_application_description(
+        ApplicationId::new(CryptoHash::new(&BlobContent::new_application_description(
             description,
         )))
     }

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -826,7 +826,7 @@ impl<'de> BcsHashable<'de> for OracleResponse {}
 
 /// Description of the necessary information to run a user application used within blobs.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Hash, Serialize)]
-pub struct UserApplicationDescription {
+pub struct ApplicationDescription {
     /// The unique ID of the bytecode to use for the application.
     pub module_id: ModuleId,
     /// The chain ID that created the application.
@@ -843,18 +843,18 @@ pub struct UserApplicationDescription {
     pub required_application_ids: Vec<ApplicationId>,
 }
 
-impl From<&UserApplicationDescription> for ApplicationId {
-    fn from(description: &UserApplicationDescription) -> Self {
+impl From<&ApplicationDescription> for ApplicationId {
+    fn from(description: &ApplicationDescription) -> Self {
         ApplicationId::new(CryptoHash::new(&BlobContent::new_application_description(
             description,
         )))
     }
 }
 
-impl BcsHashable<'_> for UserApplicationDescription {}
+impl BcsHashable<'_> for ApplicationDescription {}
 
-impl UserApplicationDescription {
-    /// Gets the serialized bytes for this `UserApplicationDescription`.
+impl ApplicationDescription {
+    /// Gets the serialized bytes for this `ApplicationDescription`.
     pub fn to_bytes(&self) -> Vec<u8> {
         bcs::to_bytes(self).expect("Serializing blob bytes should not fail!")
     }
@@ -1031,10 +1031,8 @@ impl BlobContent {
         )
     }
 
-    /// Creates a new application description [`BlobContent`] from a [`UserApplicationDescription`].
-    pub fn new_application_description(
-        application_description: &UserApplicationDescription,
-    ) -> Self {
+    /// Creates a new application description [`BlobContent`] from a [`ApplicationDescription`].
+    pub fn new_application_description(application_description: &ApplicationDescription) -> Self {
         let bytes = application_description.to_bytes();
         BlobContent::new(BlobType::ApplicationDescription, bytes)
     }
@@ -1110,9 +1108,7 @@ impl Blob {
 
     /// Creates a new application description [`BlobContent`] from the provided
     /// description.
-    pub fn new_application_description(
-        application_description: &UserApplicationDescription,
-    ) -> Self {
+    pub fn new_application_description(application_description: &ApplicationDescription) -> Self {
         Blob::new(BlobContent::new_application_description(
             application_description,
         ))
@@ -1234,7 +1230,7 @@ doc_scalar!(
     "A blob of binary data, with its content-addressed blob ID."
 );
 doc_scalar!(
-    UserApplicationDescription,
+    ApplicationDescription,
     "Description of the necessary information to run a user application"
 );
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -37,7 +37,7 @@ pub enum AccountOwner {
     /// An account owned by a user.
     User(Owner),
     /// An account for an application.
-    Application(UserApplicationId),
+    Application(ApplicationId),
     /// Chain account.
     Chain,
 }
@@ -302,10 +302,6 @@ pub struct ApplicationId<A = ()> {
     _phantom: PhantomData<A>,
 }
 
-/// Alias for `ApplicationId`. Use this alias in the core
-/// protocol where the distinction with the more general enum `GenericApplicationId` matters.
-pub type UserApplicationId = ApplicationId<()>;
-
 /// A unique identifier for an application.
 #[derive(
     Eq,
@@ -326,7 +322,7 @@ pub enum GenericApplicationId {
     /// The system application.
     System,
     /// A user application.
-    User(UserApplicationId),
+    User(ApplicationId),
 }
 
 impl GenericApplicationId {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -295,7 +295,7 @@ pub struct MessageId {
 #[derive(Debug, WitLoad, WitStore, WitType)]
 #[cfg_attr(with_testing, derive(Default, test_strategy::Arbitrary))]
 pub struct ApplicationId<A = ()> {
-    /// The hash of the `UserApplicationDescription` this refers to.
+    /// The hash of the `ApplicationDescription` this refers to.
     pub application_description_hash: CryptoHash,
     #[witty(skip)]
     #[debug(skip)]
@@ -873,7 +873,7 @@ impl<A> ApplicationId<A> {
     }
 
     /// Converts the application ID to the ID of the blob containing the
-    /// `UserApplicationDescription`.
+    /// `ApplicationDescription`.
     pub fn description_blob_id(self) -> BlobId {
         BlobId::new(
             self.application_description_hash,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -13,8 +13,8 @@ use futures::stream::{self, StreamExt, TryStreamExt};
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{
-        Amount, ArithmeticError, Blob, BlockHeight, OracleResponse, Timestamp,
-        UserApplicationDescription,
+        Amount, ApplicationDescription, ArithmeticError, Blob, BlockHeight, OracleResponse,
+        Timestamp,
     },
     ensure,
     identifiers::{
@@ -371,7 +371,7 @@ where
     pub async fn describe_application(
         &mut self,
         application_id: ApplicationId,
-    ) -> Result<UserApplicationDescription, ChainError> {
+    ) -> Result<ApplicationDescription, ChainError> {
         self.execution_state
             .system
             .describe_application(application_id, None)

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -18,7 +18,7 @@ use linera_base::{
     },
     ensure,
     identifiers::{
-        BlobType, ChainId, ChannelFullName, Destination, MessageId, Owner, UserApplicationId,
+        ApplicationId, BlobType, ChainId, ChannelFullName, Destination, MessageId, Owner,
     },
     ownership::ChainOwnership,
 };
@@ -370,7 +370,7 @@ where
 
     pub async fn describe_application(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
     ) -> Result<UserApplicationDescription, ChainError> {
         self.execution_state
             .system
@@ -1073,7 +1073,7 @@ where
     /// Verifies that the block is valid according to the chain's application permission settings.
     fn check_app_permissions(&self, block: &ProposedBlock) -> Result<(), ChainError> {
         let app_permissions = self.execution_state.system.application_permissions.get();
-        let mut mandatory = HashSet::<UserApplicationId>::from_iter(
+        let mut mandatory = HashSet::<ApplicationId>::from_iter(
             app_permissions.mandatory_applications.iter().cloned(),
         );
         for operation in &block.operations {

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -14,8 +14,8 @@ use axum::{routing::get, Router};
 use linera_base::{
     crypto::{AccountPublicKey, CryptoHash, ValidatorPublicKey},
     data_types::{
-        Amount, ApplicationPermissions, Blob, BlockHeight, Bytecode, Timestamp,
-        UserApplicationDescription,
+        Amount, ApplicationDescription, ApplicationPermissions, Blob, BlockHeight, Bytecode,
+        Timestamp,
     },
     hashed::Hashed,
     http,
@@ -64,7 +64,7 @@ where
     }
 }
 
-fn make_app_description() -> (UserApplicationDescription, Blob, Blob) {
+fn make_app_description() -> (ApplicationDescription, Blob, Blob) {
     let contract = Bytecode::new(b"contract".into());
     let service = Bytecode::new(b"service".into());
     let contract_blob = Blob::new_contract_bytecode(contract.compress());
@@ -73,7 +73,7 @@ fn make_app_description() -> (UserApplicationDescription, Blob, Blob) {
 
     let module_id = ModuleId::new(contract_blob.id().hash, service_blob.id().hash, vm_runtime);
     (
-        UserApplicationDescription {
+        ApplicationDescription {
             module_id,
             creator_chain_id: admin_id(),
             block_height: BlockHeight(2),

--- a/linera-chain/src/unit_tests/inbox_tests.rs
+++ b/linera-chain/src/unit_tests/inbox_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use assert_matches::assert_matches;
-use linera_base::{crypto::CryptoHash, data_types::Timestamp, identifiers::UserApplicationId};
+use linera_base::{crypto::CryptoHash, data_types::Timestamp, identifiers::ApplicationId};
 use linera_execution::{Message, MessageKind};
 
 use super::*;
@@ -16,7 +16,7 @@ fn make_bundle(
     message: impl Into<Vec<u8>>,
 ) -> MessageBundle {
     let message = Message::User {
-        application_id: UserApplicationId::default(),
+        application_id: ApplicationId::default(),
         bytes: message.into(),
     };
     MessageBundle {

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Utc};
 use linera_base::{
     crypto::{AccountPublicKey, CryptoHash, ValidatorPublicKey},
     data_types::{Amount, ApplicationPermissions, TimeDelta},
-    identifiers::{Account, ApplicationId, ChainId, MessageId, ModuleId, Owner, UserApplicationId},
+    identifiers::{Account, ApplicationId, ChainId, MessageId, ModuleId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
     time::Duration,
     vm::VmRuntime,
@@ -967,7 +967,7 @@ pub enum ClientCommand {
 
         /// The list of required dependencies of application, if any.
         #[arg(long, num_args(0..))]
-        required_application_ids: Option<Vec<UserApplicationId>>,
+        required_application_ids: Option<Vec<ApplicationId>>,
     },
 
     /// Create an application, and publish the required module.
@@ -1004,7 +1004,7 @@ pub enum ClientCommand {
 
         /// The list of required dependencies of application, if any.
         #[arg(long, num_args(0..))]
-        required_application_ids: Option<Vec<UserApplicationId>>,
+        required_application_ids: Option<Vec<ApplicationId>>,
     },
 
     /// Create an unassigned key pair.
@@ -1416,7 +1416,7 @@ pub enum ProjectCommand {
 
         /// The list of required dependencies of application, if any.
         #[arg(long, num_args(0..))]
-        required_application_ids: Option<Vec<UserApplicationId>>,
+        required_application_ids: Option<Vec<ApplicationId>>,
     },
 }
 

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -12,7 +12,7 @@ use std::{
 use custom_debug_derive::Debug;
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
-    data_types::{Blob, BlockHeight, Timestamp, UserApplicationDescription},
+    data_types::{ApplicationDescription, Blob, BlockHeight, Timestamp},
     hashed::Hashed,
     identifiers::{ApplicationId, BlobId, ChainId},
 };
@@ -78,7 +78,7 @@ where
     DescribeApplication {
         application_id: ApplicationId,
         #[debug(skip)]
-        callback: oneshot::Sender<Result<UserApplicationDescription, WorkerError>>,
+        callback: oneshot::Sender<Result<ApplicationDescription, WorkerError>>,
     },
 
     /// Execute a block but discard any changes to the chain state.

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -14,7 +14,7 @@ use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{Blob, BlockHeight, Timestamp, UserApplicationDescription},
     hashed::Hashed,
-    identifiers::{BlobId, ChainId, UserApplicationId},
+    identifiers::{ApplicationId, BlobId, ChainId},
 };
 use linera_chain::{
     data_types::{BlockProposal, ExecutedBlock, MessageBundle, Origin, ProposedBlock, Target},
@@ -76,7 +76,7 @@ where
 
     /// Describe an application.
     DescribeApplication {
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         #[debug(skip)]
         callback: oneshot::Sender<Result<UserApplicationDescription, WorkerError>>,
     },

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -14,7 +14,7 @@ use std::{
 
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
-    data_types::{Blob, BlockHeight, UserApplicationDescription},
+    data_types::{ApplicationDescription, Blob, BlockHeight},
     ensure,
     hashed::Hashed,
     identifiers::{ApplicationId, BlobId, ChainId},
@@ -170,7 +170,7 @@ where
     pub(super) async fn describe_application(
         &mut self,
         application_id: ApplicationId,
-    ) -> Result<UserApplicationDescription, WorkerError> {
+    ) -> Result<ApplicationDescription, WorkerError> {
         ChainWorkerStateWithTemporaryChanges::new(self)
             .await
             .describe_application(application_id)

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -17,7 +17,7 @@ use linera_base::{
     data_types::{Blob, BlockHeight, UserApplicationDescription},
     ensure,
     hashed::Hashed,
-    identifiers::{BlobId, ChainId, UserApplicationId},
+    identifiers::{ApplicationId, BlobId, ChainId},
 };
 use linera_chain::{
     data_types::{
@@ -169,7 +169,7 @@ where
     /// Returns an application's description.
     pub(super) async fn describe_application(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
     ) -> Result<UserApplicationDescription, WorkerError> {
         ChainWorkerStateWithTemporaryChanges::new(self)
             .await

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use linera_base::{
-    data_types::{ArithmeticError, Blob, Timestamp, UserApplicationDescription},
+    data_types::{ApplicationDescription, ArithmeticError, Blob, Timestamp},
     ensure,
     identifiers::{AccountOwner, ApplicationId, ChannelFullName, GenericApplicationId, Owner},
 };
@@ -114,7 +114,7 @@ where
     pub(super) async fn describe_application(
         &mut self,
         application_id: ApplicationId,
-    ) -> Result<UserApplicationDescription, WorkerError> {
+    ) -> Result<ApplicationDescription, WorkerError> {
         self.0.ensure_is_active()?;
         let response = self.0.chain.describe_application(application_id).await?;
         Ok(response)

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use linera_base::{
     data_types::{ArithmeticError, Blob, Timestamp, UserApplicationDescription},
     ensure,
-    identifiers::{AccountOwner, ChannelFullName, GenericApplicationId, Owner, UserApplicationId},
+    identifiers::{AccountOwner, ApplicationId, ChannelFullName, GenericApplicationId, Owner},
 };
 use linera_chain::{
     data_types::{
@@ -113,7 +113,7 @@ where
     /// Returns an application's description.
     pub(super) async fn describe_application(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
     ) -> Result<UserApplicationDescription, WorkerError> {
         self.0.ensure_is_active()?;
         let response = self.0.chain.describe_application(application_id).await?;

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -35,7 +35,7 @@ use linera_base::{
     hashed::Hashed,
     identifiers::{
         Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, EventId, MessageId,
-        ModuleId, Owner, StreamId, UserApplicationId,
+        ModuleId, Owner, StreamId,
     },
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -2946,7 +2946,7 @@ where
         module_id: ModuleId<A, Parameters, InstantiationArgument>,
         parameters: &Parameters,
         instantiation_argument: &InstantiationArgument,
-        required_application_ids: Vec<UserApplicationId>,
+        required_application_ids: Vec<ApplicationId>,
     ) -> Result<ClientOutcome<(ApplicationId<A>, ConfirmedBlockCertificate)>, ChainClientError>
     {
         let instantiation_argument = serde_json::to_vec(instantiation_argument)?;
@@ -2978,9 +2978,8 @@ where
         module_id: ModuleId,
         parameters: Vec<u8>,
         instantiation_argument: Vec<u8>,
-        required_application_ids: Vec<UserApplicationId>,
-    ) -> Result<ClientOutcome<(UserApplicationId, ConfirmedBlockCertificate)>, ChainClientError>
-    {
+        required_application_ids: Vec<ApplicationId>,
+    ) -> Result<ClientOutcome<(ApplicationId, ConfirmedBlockCertificate)>, ChainClientError> {
         self.execute_operation(SystemOperation::CreateApplication {
             module_id,
             parameters,

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -10,7 +10,7 @@ use std::{
 use futures::{future::Either, stream, StreamExt as _, TryStreamExt as _};
 use linera_base::{
     crypto::ValidatorPublicKey,
-    data_types::{ArithmeticError, Blob, BlockHeight, UserApplicationDescription},
+    data_types::{ApplicationDescription, ArithmeticError, Blob, BlockHeight},
     identifiers::{ApplicationId, BlobId, ChainId, MessageId},
 };
 use linera_chain::{
@@ -285,7 +285,7 @@ where
         &self,
         chain_id: ChainId,
         application_id: ApplicationId,
-    ) -> Result<UserApplicationDescription, LocalNodeError> {
+    ) -> Result<ApplicationDescription, LocalNodeError> {
         let response = self
             .node
             .state

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -11,7 +11,7 @@ use futures::{future::Either, stream, StreamExt as _, TryStreamExt as _};
 use linera_base::{
     crypto::ValidatorPublicKey,
     data_types::{ArithmeticError, Blob, BlockHeight, UserApplicationDescription},
-    identifiers::{BlobId, ChainId, MessageId, UserApplicationId},
+    identifiers::{ApplicationId, BlobId, ChainId, MessageId},
 };
 use linera_chain::{
     data_types::{BlockProposal, ExecutedBlock, ProposedBlock},
@@ -284,7 +284,7 @@ where
     pub async fn describe_application(
         &self,
         chain_id: ChainId,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
     ) -> Result<UserApplicationDescription, LocalNodeError> {
         let response = self
             .node

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -16,7 +16,7 @@ use assert_matches::assert_matches;
 use linera_base::{
     crypto::AccountSecretKey,
     data_types::{
-        Amount, Blob, BlockHeight, Bytecode, OracleResponse, Timestamp, UserApplicationDescription,
+        Amount, ApplicationDescription, Blob, BlockHeight, Bytecode, OracleResponse, Timestamp,
     },
     hashed::Hashed,
     identifiers::{ChainDescription, ChainId, ModuleId},
@@ -197,7 +197,7 @@ where
         instantiation_argument: initial_value_bytes.clone(),
         required_application_ids: vec![],
     };
-    let application_description = UserApplicationDescription {
+    let application_description = ApplicationDescription {
         module_id,
         creator_chain_id: creator_chain.into(),
         block_height: BlockHeight::from(0),

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -19,7 +19,7 @@ use linera_base::{
     },
     doc_scalar,
     hashed::Hashed,
-    identifiers::{BlobId, ChainId, EventId, Owner, UserApplicationId},
+    identifiers::{ApplicationId, BlobId, ChainId, EventId, Owner},
     time::timer::{sleep, timeout},
 };
 use linera_chain::{
@@ -530,7 +530,7 @@ where
     pub async fn describe_application(
         &self,
         chain_id: ChainId,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
     ) -> Result<UserApplicationDescription, WorkerError> {
         self.query_chain_worker(chain_id, move |callback| {
             ChainWorkerRequest::DescribeApplication {

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -15,7 +15,7 @@ use linera_base::crypto::AccountPublicKey;
 use linera_base::{
     crypto::{AccountSecretKey, CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSecretKey},
     data_types::{
-        ArithmeticError, Blob, BlockHeight, DecompressionError, Round, UserApplicationDescription,
+        ApplicationDescription, ArithmeticError, Blob, BlockHeight, DecompressionError, Round,
     },
     doc_scalar,
     hashed::Hashed,
@@ -531,7 +531,7 @@ where
         &self,
         chain_id: ChainId,
         application_id: ApplicationId,
-    ) -> Result<UserApplicationDescription, WorkerError> {
+    ) -> Result<ApplicationDescription, WorkerError> {
         self.query_chain_worker(chain_id, move |callback| {
             ChainWorkerRequest::DescribeApplication {
                 application_id,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -27,11 +27,11 @@ use {
 
 use super::{runtime::ServiceRuntimeRequest, ExecutionRequest};
 use crate::{
-    resources::ResourceController, system::SystemExecutionStateView, ApplicationId,
-    ContractSyncRuntime, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message,
-    MessageContext, MessageKind, Operation, OperationContext, OutgoingMessage, Query, QueryContext,
-    QueryOutcome, ServiceSyncRuntime, SystemMessage, TransactionTracker,
-    UserApplicationDescription,
+    resources::ResourceController, system::SystemExecutionStateView, ApplicationDescription,
+    ApplicationId, ContractSyncRuntime, ExecutionError, ExecutionRuntimeConfig,
+    ExecutionRuntimeContext, Message, MessageContext, MessageKind, Operation, OperationContext,
+    OutgoingMessage, Query, QueryContext, QueryOutcome, ServiceSyncRuntime, SystemMessage,
+    TransactionTracker,
 };
 
 /// A view accessing the execution state of a chain.
@@ -61,7 +61,7 @@ where
         &mut self,
         contract: UserContractCode,
         local_time: Timestamp,
-        application_description: UserApplicationDescription,
+        application_description: ApplicationDescription,
         instantiation_argument: Vec<u8>,
         contract_blob: Blob,
         service_blob: Blob,
@@ -487,12 +487,12 @@ where
 
     pub async fn list_applications(
         &self,
-    ) -> Result<Vec<(ApplicationId, UserApplicationDescription)>, ExecutionError> {
+    ) -> Result<Vec<(ApplicationId, ApplicationDescription)>, ExecutionError> {
         let mut applications = vec![];
         for blob_id in self.system.used_blobs.indices().await? {
             if blob_id.blob_type == BlobType::ApplicationDescription {
                 let blob_content = self.system.read_blob_content(blob_id).await?;
-                let application_description: UserApplicationDescription =
+                let application_description: ApplicationDescription =
                     bcs::from_bytes(blob_content.bytes())?;
                 let app_id = ApplicationId::from(&application_description);
                 applications.push((app_id, application_description));

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -27,11 +27,11 @@ use {
 
 use super::{runtime::ServiceRuntimeRequest, ExecutionRequest};
 use crate::{
-    resources::ResourceController, system::SystemExecutionStateView, ContractSyncRuntime,
-    ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message, MessageContext,
-    MessageKind, Operation, OperationContext, OutgoingMessage, Query, QueryContext, QueryOutcome,
-    ServiceSyncRuntime, SystemMessage, TransactionTracker, UserApplicationDescription,
-    UserApplicationId,
+    resources::ResourceController, system::SystemExecutionStateView, ApplicationId,
+    ContractSyncRuntime, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message,
+    MessageContext, MessageKind, Operation, OperationContext, OutgoingMessage, Query, QueryContext,
+    QueryOutcome, ServiceSyncRuntime, SystemMessage, TransactionTracker,
+    UserApplicationDescription,
 };
 
 /// A view accessing the execution state of a chain.
@@ -40,7 +40,7 @@ pub struct ExecutionStateView<C> {
     /// System application.
     pub system: SystemExecutionStateView<C>,
     /// User applications.
-    pub users: HashedReentrantCollectionView<C, UserApplicationId, KeyValueStoreView<C>>,
+    pub users: HashedReentrantCollectionView<C, ApplicationId, KeyValueStoreView<C>>,
 }
 
 /// How to interact with a long-lived service runtime.
@@ -166,7 +166,7 @@ where
     #[expect(clippy::too_many_arguments)]
     async fn run_user_action(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         chain_id: ChainId,
         local_time: Timestamp,
         action: UserAction,
@@ -192,7 +192,7 @@ where
     #[expect(clippy::too_many_arguments)]
     async fn run_user_action_with_runtime(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         chain_id: ChainId,
         local_time: Timestamp,
         action: UserAction,
@@ -420,7 +420,7 @@ where
 
     async fn query_user_application(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         context: QueryContext,
         query: Vec<u8>,
     ) -> Result<QueryOutcome<Vec<u8>>, ExecutionError> {
@@ -451,7 +451,7 @@ where
 
     async fn query_user_application_with_long_lived_service(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         context: QueryContext,
         query: Vec<u8>,
         incoming_execution_requests: &mut futures::channel::mpsc::UnboundedReceiver<
@@ -487,14 +487,14 @@ where
 
     pub async fn list_applications(
         &self,
-    ) -> Result<Vec<(UserApplicationId, UserApplicationDescription)>, ExecutionError> {
+    ) -> Result<Vec<(ApplicationId, UserApplicationDescription)>, ExecutionError> {
         let mut applications = vec![];
         for blob_id in self.system.used_blobs.indices().await? {
             if blob_id.blob_type == BlobType::ApplicationDescription {
                 let blob_content = self.system.read_blob_content(blob_id).await?;
                 let application_description: UserApplicationDescription =
                     bcs::from_bytes(blob_content.bytes())?;
-                let app_id = UserApplicationId::from(&application_description);
+                let app_id = ApplicationId::from(&application_description);
                 applications.push((app_id, application_description));
             }
         }

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -29,8 +29,8 @@ use reqwest::{header::HeaderMap, Client, Url};
 use crate::{
     system::{CreateApplicationResult, OpenChainConfig, Recipient},
     util::RespondExt,
-    ApplicationId, ExecutionError, ExecutionRuntimeContext, ExecutionStateView, ModuleId,
-    OutgoingMessage, ResourceController, TransactionTracker, UserApplicationDescription,
+    ApplicationDescription, ApplicationId, ExecutionError, ExecutionRuntimeContext,
+    ExecutionStateView, ModuleId, OutgoingMessage, ResourceController, TransactionTracker,
     UserContractCode, UserServiceCode,
 };
 
@@ -67,7 +67,7 @@ where
         &mut self,
         id: ApplicationId,
         txn_tracker: &mut TransactionTracker,
-    ) -> Result<(UserContractCode, UserApplicationDescription), ExecutionError> {
+    ) -> Result<(UserContractCode, ApplicationDescription), ExecutionError> {
         #[cfg(with_metrics)]
         let _latency = LOAD_CONTRACT_LATENCY.measure_latency();
         let blob_id = id.description_blob_id();
@@ -94,7 +94,7 @@ where
         &mut self,
         id: ApplicationId,
         txn_tracker: Option<&mut TransactionTracker>,
-    ) -> Result<(UserServiceCode, UserApplicationDescription), ExecutionError> {
+    ) -> Result<(UserServiceCode, ApplicationDescription), ExecutionError> {
         #[cfg(with_metrics)]
         let _latency = LOAD_SERVICE_LATENCY.measure_latency();
         let blob_id = id.description_blob_id();
@@ -516,11 +516,7 @@ pub enum ExecutionRequest {
     LoadContract {
         id: ApplicationId,
         #[debug(skip)]
-        callback: Sender<(
-            UserContractCode,
-            UserApplicationDescription,
-            TransactionTracker,
-        )>,
+        callback: Sender<(UserContractCode, ApplicationDescription, TransactionTracker)>,
         #[debug(skip)]
         txn_tracker: TransactionTracker,
     },
@@ -529,11 +525,7 @@ pub enum ExecutionRequest {
     LoadService {
         id: ApplicationId,
         #[debug(skip)]
-        callback: Sender<(
-            UserServiceCode,
-            UserApplicationDescription,
-            TransactionTracker,
-        )>,
+        callback: Sender<(UserServiceCode, ApplicationDescription, TransactionTracker)>,
         #[debug(skip)]
         txn_tracker: TransactionTracker,
     },

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -29,8 +29,8 @@ use reqwest::{header::HeaderMap, Client, Url};
 use crate::{
     system::{CreateApplicationResult, OpenChainConfig, Recipient},
     util::RespondExt,
-    ExecutionError, ExecutionRuntimeContext, ExecutionStateView, ModuleId, OutgoingMessage,
-    ResourceController, TransactionTracker, UserApplicationDescription, UserApplicationId,
+    ApplicationId, ExecutionError, ExecutionRuntimeContext, ExecutionStateView, ModuleId,
+    OutgoingMessage, ResourceController, TransactionTracker, UserApplicationDescription,
     UserContractCode, UserServiceCode,
 };
 
@@ -65,7 +65,7 @@ where
 {
     pub(crate) async fn load_contract(
         &mut self,
-        id: UserApplicationId,
+        id: ApplicationId,
         txn_tracker: &mut TransactionTracker,
     ) -> Result<(UserContractCode, UserApplicationDescription), ExecutionError> {
         #[cfg(with_metrics)]
@@ -92,7 +92,7 @@ where
 
     pub(crate) async fn load_service(
         &mut self,
-        id: UserApplicationId,
+        id: ApplicationId,
         txn_tracker: Option<&mut TransactionTracker>,
     ) -> Result<(UserServiceCode, UserApplicationDescription), ExecutionError> {
         #[cfg(with_metrics)]
@@ -514,7 +514,7 @@ where
 pub enum ExecutionRequest {
     #[cfg(not(web))]
     LoadContract {
-        id: UserApplicationId,
+        id: ApplicationId,
         #[debug(skip)]
         callback: Sender<(
             UserContractCode,
@@ -527,7 +527,7 @@ pub enum ExecutionRequest {
 
     #[cfg(not(web))]
     LoadService {
-        id: UserApplicationId,
+        id: ApplicationId,
         #[debug(skip)]
         callback: Sender<(
             UserServiceCode,
@@ -565,7 +565,7 @@ pub enum ExecutionRequest {
         amount: Amount,
         #[debug(skip_if = Option::is_none)]
         signer: Option<Owner>,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         #[debug(skip)]
         callback: Sender<Option<OutgoingMessage>>,
     },
@@ -576,7 +576,7 @@ pub enum ExecutionRequest {
         amount: Amount,
         #[debug(skip_if = Option::is_none)]
         signer: Option<Owner>,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         #[debug(skip)]
         callback: Sender<OutgoingMessage>,
     },
@@ -592,7 +592,7 @@ pub enum ExecutionRequest {
     },
 
     ReadValueBytes {
-        id: UserApplicationId,
+        id: ApplicationId,
         #[debug(with = hex_debug)]
         key: Vec<u8>,
         #[debug(skip)]
@@ -600,21 +600,21 @@ pub enum ExecutionRequest {
     },
 
     ContainsKey {
-        id: UserApplicationId,
+        id: ApplicationId,
         key: Vec<u8>,
         #[debug(skip)]
         callback: Sender<bool>,
     },
 
     ContainsKeys {
-        id: UserApplicationId,
+        id: ApplicationId,
         #[debug(with = hex_vec_debug)]
         keys: Vec<Vec<u8>>,
         callback: Sender<Vec<bool>>,
     },
 
     ReadMultiValuesBytes {
-        id: UserApplicationId,
+        id: ApplicationId,
         #[debug(with = hex_vec_debug)]
         keys: Vec<Vec<u8>>,
         #[debug(skip)]
@@ -622,7 +622,7 @@ pub enum ExecutionRequest {
     },
 
     FindKeysByPrefix {
-        id: UserApplicationId,
+        id: ApplicationId,
         #[debug(with = hex_debug)]
         key_prefix: Vec<u8>,
         #[debug(skip)]
@@ -630,7 +630,7 @@ pub enum ExecutionRequest {
     },
 
     FindKeyValuesByPrefix {
-        id: UserApplicationId,
+        id: ApplicationId,
         #[debug(with = hex_debug)]
         key_prefix: Vec<u8>,
         #[debug(skip)]
@@ -638,7 +638,7 @@ pub enum ExecutionRequest {
     },
 
     WriteBatch {
-        id: UserApplicationId,
+        id: ApplicationId,
         batch: Batch,
         #[debug(skip)]
         callback: Sender<()>,
@@ -655,13 +655,13 @@ pub enum ExecutionRequest {
     },
 
     CloseChain {
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         #[debug(skip)]
         callback: Sender<Result<(), ExecutionError>>,
     },
 
     ChangeApplicationPermissions {
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         application_permissions: ApplicationPermissions,
         #[debug(skip)]
         callback: Sender<Result<(), ExecutionError>>,
@@ -672,7 +672,7 @@ pub enum ExecutionRequest {
         block_height: BlockHeight,
         module_id: ModuleId,
         parameters: Vec<u8>,
-        required_application_ids: Vec<UserApplicationId>,
+        required_application_ids: Vec<ApplicationId>,
         #[debug(skip)]
         txn_tracker: TransactionTracker,
         #[debug(skip)]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -37,8 +37,8 @@ use linera_base::{
     abi::Abi,
     crypto::{BcsHashable, CryptoHash},
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, DecompressionError,
-        Resources, SendMessageRequest, Timestamp, UserApplicationDescription,
+        Amount, ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlockHeight,
+        DecompressionError, Resources, SendMessageRequest, Timestamp,
     },
     doc_scalar, hex_debug, http,
     identifiers::{
@@ -218,7 +218,7 @@ pub enum ExecutionError {
     #[error("Attempt to write to storage from a contract")]
     ServiceWriteAttempt,
     #[error("Failed to load bytecode from storage {0:?}")]
-    ApplicationBytecodeNotFound(Box<UserApplicationDescription>),
+    ApplicationBytecodeNotFound(Box<ApplicationDescription>),
     // TODO(#2927): support dynamic loading of modules on the Web
     #[error("Unsupported dynamic application load: {0:?}")]
     UnsupportedDynamicApplicationLoad(Box<ApplicationId>),
@@ -400,12 +400,12 @@ pub trait ExecutionRuntimeContext {
 
     async fn get_user_contract(
         &self,
-        description: &UserApplicationDescription,
+        description: &ApplicationDescription,
     ) -> Result<UserContractCode, ExecutionError>;
 
     async fn get_user_service(
         &self,
-        description: &UserApplicationDescription,
+        description: &ApplicationDescription,
     ) -> Result<UserServiceCode, ExecutionError>;
 
     async fn get_blob(&self, blob_id: BlobId) -> Result<Blob, ViewError>;
@@ -1056,7 +1056,7 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
 
     async fn get_user_contract(
         &self,
-        description: &UserApplicationDescription,
+        description: &ApplicationDescription,
     ) -> Result<UserContractCode, ExecutionError> {
         let application_id = description.into();
         Ok(self
@@ -1070,7 +1070,7 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
 
     async fn get_user_service(
         &self,
-        description: &UserApplicationDescription,
+        description: &ApplicationDescription,
     ) -> Result<UserServiceCode, ExecutionError> {
         let application_id = description.into();
         Ok(self

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -32,9 +32,9 @@ use crate::{
     resources::ResourceController,
     system::CreateApplicationResult,
     util::{ReceiverExt, UnboundedSenderExt},
-    BaseRuntime, ContractRuntime, ExecutionError, FinalizeContext, Message, MessageContext,
-    MessageKind, ModuleId, Operation, OperationContext, OutgoingMessage, QueryContext,
-    QueryOutcome, ServiceRuntime, TransactionTracker, UserApplicationDescription, UserContractCode,
+    ApplicationDescription, BaseRuntime, ContractRuntime, ExecutionError, FinalizeContext, Message,
+    MessageContext, MessageKind, ModuleId, Operation, OperationContext, OutgoingMessage,
+    QueryContext, QueryOutcome, ServiceRuntime, TransactionTracker, UserContractCode,
     UserContractInstance, UserServiceCode, UserServiceInstance, MAX_EVENT_KEY_LEN,
     MAX_STREAM_NAME_LEN,
 };
@@ -122,7 +122,7 @@ struct ApplicationStatus {
     /// The application ID.
     id: ApplicationId,
     /// The application description.
-    description: UserApplicationDescription,
+    description: ApplicationDescription,
     /// The authenticated signer for the execution thread, if any.
     signer: Option<Owner>,
 }
@@ -131,12 +131,12 @@ struct ApplicationStatus {
 #[derive(Debug)]
 struct LoadedApplication<Instance> {
     instance: Arc<Mutex<Instance>>,
-    description: UserApplicationDescription,
+    description: ApplicationDescription,
 }
 
 impl<Instance> LoadedApplication<Instance> {
     /// Creates a new [`LoadedApplication`] entry from the `instance` and its `description`.
-    fn new(instance: Instance, description: UserApplicationDescription) -> Self {
+    fn new(instance: Instance, description: ApplicationDescription) -> Self {
         LoadedApplication {
             instance: Arc::new(Mutex::new(instance)),
             description,
@@ -986,7 +986,7 @@ impl ContractSyncRuntime {
         &self,
         id: ApplicationId,
         code: UserContractCode,
-        description: UserApplicationDescription,
+        description: ApplicationDescription,
     ) -> Result<(), ExecutionError> {
         let this = self
             .0
@@ -1531,7 +1531,7 @@ impl ServiceSyncRuntime {
         &self,
         id: ApplicationId,
         code: UserServiceCode,
-        description: UserApplicationDescription,
+        description: ApplicationDescription,
     ) -> Result<(), ExecutionError> {
         let this = self
             .runtime

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -43,9 +43,9 @@ use {linera_base::prometheus_util::register_int_counter_vec, prometheus::IntCoun
 use crate::test_utils::SystemExecutionState;
 use crate::{
     committee::{Committee, Epoch},
-    ApplicationId, ChannelName, ChannelSubscription, ExecutionError, ExecutionRuntimeContext,
-    MessageContext, MessageKind, OperationContext, OutgoingMessage, QueryContext, QueryOutcome,
-    ResourceController, TransactionTracker, UserApplicationDescription,
+    ApplicationDescription, ApplicationId, ChannelName, ChannelSubscription, ExecutionError,
+    ExecutionRuntimeContext, MessageContext, MessageKind, OperationContext, OutgoingMessage,
+    QueryContext, QueryOutcome, ResourceController, TransactionTracker,
 };
 
 /// The relative index of the `OpenChain` message created by the `OpenChain` operation.
@@ -901,7 +901,7 @@ where
         self.blob_used(Some(&mut txn_tracker), service_bytecode_blob_id)
             .await?;
 
-        let application_description = UserApplicationDescription {
+        let application_description = ApplicationDescription {
             module_id,
             creator_chain_id: chain_id,
             block_height,
@@ -922,7 +922,7 @@ where
 
     async fn check_required_applications(
         &mut self,
-        application_description: &UserApplicationDescription,
+        application_description: &ApplicationDescription,
         mut txn_tracker: Option<&mut TransactionTracker>,
     ) -> Result<(), ExecutionError> {
         // Make sure that referenced applications IDs have been registered.
@@ -937,7 +937,7 @@ where
         &mut self,
         id: ApplicationId,
         mut txn_tracker: Option<&mut TransactionTracker>,
-    ) -> Result<UserApplicationDescription, ExecutionError> {
+    ) -> Result<ApplicationDescription, ExecutionError> {
         let blob_id = id.description_blob_id();
         let blob_content = match txn_tracker
             .as_ref()
@@ -947,7 +947,7 @@ where
             None => self.read_blob_content(blob_id).await?,
         };
         self.blob_used(txn_tracker.as_deref_mut(), blob_id).await?;
-        let description: UserApplicationDescription = bcs::from_bytes(blob_content.bytes())?;
+        let description: ApplicationDescription = bcs::from_bytes(blob_content.bytes())?;
 
         let (contract_bytecode_blob_id, service_bytecode_blob_id) =
             self.check_bytecode_blobs(&description.module_id).await?;

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -32,16 +32,15 @@ pub use self::{
     system_execution_state::SystemExecutionState,
 };
 use crate::{
-    ExecutionRequest, ExecutionRuntimeContext, ExecutionStateView, MessageContext,
-    OperationContext, QueryContext, ServiceRuntimeEndpoint, ServiceRuntimeRequest,
+    ApplicationDescription, ExecutionRequest, ExecutionRuntimeContext, ExecutionStateView,
+    MessageContext, OperationContext, QueryContext, ServiceRuntimeEndpoint, ServiceRuntimeRequest,
     ServiceSyncRuntime, SystemExecutionStateView, TestExecutionRuntimeContext,
-    UserApplicationDescription,
 };
 
-/// Creates a dummy [`UserApplicationDescription`] for use in tests.
+/// Creates a dummy [`ApplicationDescription`] for use in tests.
 pub fn create_dummy_user_application_description(
     index: u32,
-) -> (UserApplicationDescription, Blob, Blob) {
+) -> (ApplicationDescription, Blob, Blob) {
     let chain_id = ChainId::root(1);
     let mut contract_bytes = b"contract".to_vec();
     let mut service_bytes = b"service".to_vec();
@@ -56,7 +55,7 @@ pub fn create_dummy_user_application_description(
 
     let vm_runtime = VmRuntime::Wasm;
     (
-        UserApplicationDescription {
+        ApplicationDescription {
             module_id: ModuleId::new(contract_blob.id().hash, service_blob.id().hash, vm_runtime),
             creator_chain_id: chain_id,
             block_height: 0.into(),
@@ -137,11 +136,11 @@ pub trait RegisterMockApplication {
         ))
     }
 
-    /// Registers a new [`MockApplication`] associated with a [`UserApplicationDescription`] and
+    /// Registers a new [`MockApplication`] associated with a [`ApplicationDescription`] and
     /// its bytecode [`Blob`]s.
     async fn register_mock_application_with(
         &mut self,
-        description: UserApplicationDescription,
+        description: ApplicationDescription,
         contract: Blob,
         service: Blob,
     ) -> anyhow::Result<(ApplicationId, MockApplication)>;
@@ -158,7 +157,7 @@ where
 
     async fn register_mock_application_with(
         &mut self,
-        description: UserApplicationDescription,
+        description: ApplicationDescription,
         contract: Blob,
         service: Blob,
     ) -> anyhow::Result<(ApplicationId, MockApplication)> {
@@ -181,7 +180,7 @@ where
 
     async fn register_mock_application_with(
         &mut self,
-        description: UserApplicationDescription,
+        description: ApplicationDescription,
         contract: Blob,
         service: Blob,
     ) -> anyhow::Result<(ApplicationId, MockApplication)> {
@@ -209,7 +208,7 @@ where
 
 pub async fn create_dummy_user_application_registrations(
     count: u32,
-) -> anyhow::Result<Vec<(ApplicationId, UserApplicationDescription, Blob, Blob)>> {
+) -> anyhow::Result<Vec<(ApplicationId, ApplicationDescription, Blob, Blob)>> {
     let mut ids = Vec::with_capacity(count as usize);
 
     for index in 0..count {

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -35,7 +35,7 @@ use crate::{
     ExecutionRequest, ExecutionRuntimeContext, ExecutionStateView, MessageContext,
     OperationContext, QueryContext, ServiceRuntimeEndpoint, ServiceRuntimeRequest,
     ServiceSyncRuntime, SystemExecutionStateView, TestExecutionRuntimeContext,
-    UserApplicationDescription, UserApplicationId,
+    UserApplicationDescription,
 };
 
 /// Creates a dummy [`UserApplicationDescription`] for use in tests.
@@ -116,12 +116,12 @@ pub trait RegisterMockApplication {
     /// This is included in the mocked [`ApplicationId`].
     fn creator_chain_id(&self) -> ChainId;
 
-    /// Registers a new [`MockApplication`] and returns it with the [`UserApplicationId`] that was
+    /// Registers a new [`MockApplication`] and returns it with the [`ApplicationId`] that was
     /// used for it.
     async fn register_mock_application(
         &mut self,
         index: u32,
-    ) -> anyhow::Result<(UserApplicationId, MockApplication, [BlobId; 3])> {
+    ) -> anyhow::Result<(ApplicationId, MockApplication, [BlobId; 3])> {
         let (description, contract, service) = create_dummy_user_application_description(index);
         let description_blob_id = Blob::new_application_description(&description).id();
         let contract_blob_id = contract.id();
@@ -144,7 +144,7 @@ pub trait RegisterMockApplication {
         description: UserApplicationDescription,
         contract: Blob,
         service: Blob,
-    ) -> anyhow::Result<(UserApplicationId, MockApplication)>;
+    ) -> anyhow::Result<(ApplicationId, MockApplication)>;
 }
 
 impl<C> RegisterMockApplication for ExecutionStateView<C>
@@ -161,7 +161,7 @@ where
         description: UserApplicationDescription,
         contract: Blob,
         service: Blob,
-    ) -> anyhow::Result<(UserApplicationId, MockApplication)> {
+    ) -> anyhow::Result<(ApplicationId, MockApplication)> {
         self.system
             .register_mock_application_with(description, contract, service)
             .await
@@ -184,7 +184,7 @@ where
         description: UserApplicationDescription,
         contract: Blob,
         service: Blob,
-    ) -> anyhow::Result<(UserApplicationId, MockApplication)> {
+    ) -> anyhow::Result<(ApplicationId, MockApplication)> {
         let id = From::from(&description);
         let extra = self.context().extra();
         let mock_application = MockApplication::default();
@@ -209,7 +209,7 @@ where
 
 pub async fn create_dummy_user_application_registrations(
     count: u32,
-) -> anyhow::Result<Vec<(UserApplicationId, UserApplicationDescription, Blob, Blob)>> {
+) -> anyhow::Result<Vec<(ApplicationId, UserApplicationDescription, Blob, Blob)>> {
     let mut ids = Vec::with_capacity(count as usize);
 
     for index in 0..count {

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -25,9 +25,9 @@ use crate::{
     committee::{Committee, Epoch},
     execution::UserAction,
     system::SystemChannel,
-    ChannelSubscription, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext,
-    ExecutionStateView, OperationContext, ResourceControlPolicy, ResourceController,
-    ResourceTracker, TestExecutionRuntimeContext, UserApplicationDescription, UserContractCode,
+    ApplicationDescription, ChannelSubscription, ExecutionError, ExecutionRuntimeConfig,
+    ExecutionRuntimeContext, ExecutionStateView, OperationContext, ResourceControlPolicy,
+    ResourceController, ResourceTracker, TestExecutionRuntimeContext, UserContractCode,
 };
 
 /// A system execution state, not represented as a view but as a simple struct.
@@ -160,7 +160,7 @@ impl RegisterMockApplication for SystemExecutionState {
 
     async fn register_mock_application_with(
         &mut self,
-        description: UserApplicationDescription,
+        description: ApplicationDescription,
         contract: Blob,
         service: Blob,
     ) -> anyhow::Result<(ApplicationId, MockApplication)> {

--- a/linera-execution/src/unit_tests/applications_tests.rs
+++ b/linera-execution/src/unit_tests/applications_tests.rs
@@ -9,7 +9,7 @@ use linera_base::{
 };
 
 use super::{
-    ApplicationRegistry, ApplicationRegistryView, UserApplicationDescription, UserApplicationId,
+    ApplicationRegistry, ApplicationRegistryView, UserApplicationDescription, ApplicationId,
 };
 
 fn message_id(index: u32) -> MessageId {
@@ -28,8 +28,8 @@ fn module_id() -> ModuleId {
     )
 }
 
-fn app_id(index: u32) -> UserApplicationId {
-    UserApplicationId {
+fn app_id(index: u32) -> ApplicationId {
+    ApplicationId {
         module_id: module_id(),
         creation: message_id(index),
     }

--- a/linera-execution/src/unit_tests/applications_tests.rs
+++ b/linera-execution/src/unit_tests/applications_tests.rs
@@ -9,7 +9,7 @@ use linera_base::{
 };
 
 use super::{
-    ApplicationRegistry, ApplicationRegistryView, UserApplicationDescription, ApplicationId,
+    ApplicationRegistry, ApplicationRegistryView, ApplicationDescription, ApplicationId,
 };
 
 fn message_id(index: u32) -> MessageId {
@@ -35,8 +35,8 @@ fn app_id(index: u32) -> ApplicationId {
     }
 }
 
-fn app_description(index: u32, deps: Vec<u32>) -> UserApplicationDescription {
-    UserApplicationDescription {
+fn app_description(index: u32, deps: Vec<u32>) -> ApplicationDescription {
+    ApplicationDescription {
         module_id: module_id(),
         creation: message_id(index),
         parameters: vec![],

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -39,9 +39,9 @@ fn expected_application_id(
     context: &OperationContext,
     module_id: &ModuleId,
     parameters: Vec<u8>,
-    required_application_ids: Vec<UserApplicationId>,
+    required_application_ids: Vec<ApplicationId>,
     application_index: u32,
-) -> UserApplicationId {
+) -> ApplicationId {
     let description = UserApplicationDescription {
         module_id: *module_id,
         creator_chain_id: context.chain_id,

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -42,7 +42,7 @@ fn expected_application_id(
     required_application_ids: Vec<ApplicationId>,
     application_index: u32,
 ) -> ApplicationId {
-    let description = UserApplicationDescription {
+    let description = ApplicationDescription {
         module_id: *module_id,
         creator_chain_id: context.chain_id,
         block_height: context.height,

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -12,8 +12,8 @@ use assert_matches::assert_matches;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
-        Amount, ApplicationPermissions, Blob, BlockHeight, CompressedBytecode, OracleResponse,
-        Timestamp, UserApplicationDescription,
+        Amount, ApplicationDescription, ApplicationPermissions, Blob, BlockHeight,
+        CompressedBytecode, OracleResponse, Timestamp,
     },
     http,
     identifiers::{
@@ -702,13 +702,13 @@ impl TransferTestEndpoint {
         ApplicationId::from(&Self::sender_application_description())
     }
 
-    /// Returns the [`UserApplicationDescription`] used to represent a sender that's an application.
-    fn sender_application_description() -> UserApplicationDescription {
+    /// Returns the [`ApplicationDescription`] used to represent a sender that's an application.
+    fn sender_application_description() -> ApplicationDescription {
         let contract_id = Self::sender_application_contract_blob().id().hash;
         let service_id = Self::sender_application_service_blob().id().hash;
         let vm_runtime = VmRuntime::Wasm;
 
-        UserApplicationDescription {
+        ApplicationDescription {
             module_id: ModuleId::new(contract_id, service_id, vm_runtime),
             creator_chain_id: ChainId::root(1000),
             block_height: BlockHeight(0),

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -15,9 +15,7 @@ use std::{
 use cargo_toml::Manifest;
 use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey},
-    data_types::{
-        Amount, Blob, BlockHeight, Bytecode, CompressedBytecode, UserApplicationDescription,
-    },
+    data_types::{Amount, ApplicationDescription, Blob, BlockHeight, Bytecode, CompressedBytecode},
     identifiers::{AccountOwner, ApplicationId, ChainDescription, ChainId, ModuleId},
     vm::VmRuntime,
 };
@@ -505,7 +503,7 @@ impl ActiveChain {
         assert_eq!(block.messages().len(), 1);
         assert!(block.messages()[0].is_empty());
 
-        let description = UserApplicationDescription {
+        let description = ApplicationDescription {
             module_id: module_id.forget_abi(),
             creator_chain_id: block.header.chain_id,
             block_height: block.header.height,

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -20,7 +20,7 @@ scalar ApplicationId
 
 type ApplicationOverview {
 	id: ApplicationId!
-	description: UserApplicationDescription!
+	description: ApplicationDescription!
 	link: String!
 }
 
@@ -1246,7 +1246,7 @@ type TimestampedBundleInInbox {
 """
 Description of the necessary information to run a user application
 """
-scalar UserApplicationDescription
+scalar ApplicationDescription
 
 scalar VersionInfo
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -14,7 +14,7 @@ A non-negative amount of tokens.
 scalar Amount
 
 """
-Description of the necessary information to run a user application
+Description of a user application
 """
 scalar ApplicationDescription
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -14,6 +14,11 @@ A non-negative amount of tokens.
 scalar Amount
 
 """
+Description of the necessary information to run a user application
+"""
+scalar ApplicationDescription
+
+"""
 A unique identifier for a user application
 """
 scalar ApplicationId
@@ -1242,11 +1247,6 @@ type TimestampedBundleInInbox {
 	"""
 	seen: Timestamp!
 }
-
-"""
-Description of the necessary information to run a user application
-"""
-scalar ApplicationDescription
 
 scalar VersionInfo
 

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -32,7 +32,7 @@ mod types {
     pub type Operation = Value;
     pub type Origin = Value;
     pub type Target = Value;
-    pub type UserApplicationDescription = Value;
+    pub type ApplicationDescription = Value;
     pub type OperationResult = Value;
 
     #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -62,8 +62,7 @@ mod types {
 #[cfg(not(target_arch = "wasm32"))]
 mod types {
     pub use linera_base::{
-        data_types::UserApplicationDescription, identifiers::ChannelFullName,
-        ownership::ChainOwnership,
+        data_types::ApplicationDescription, identifiers::ChannelFullName, ownership::ChainOwnership,
     };
     pub use linera_chain::{
         data_types::{MessageAction, MessageBundle, OperationResult, Origin, Target},

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -12,7 +12,7 @@ use axum::{extract::Path, http::StatusCode, response, response::IntoResponse, Ex
 use futures::{lock::Mutex, Future};
 use linera_base::{
     crypto::{CryptoError, CryptoHash},
-    data_types::{Amount, ApplicationPermissions, Bytecode, TimeDelta, UserApplicationDescription},
+    data_types::{Amount, ApplicationDescription, ApplicationPermissions, Bytecode, TimeDelta},
     hashed::Hashed,
     identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
@@ -762,14 +762,14 @@ where
 #[derive(SimpleObject)]
 pub struct ApplicationOverview {
     id: ApplicationId,
-    description: UserApplicationDescription,
+    description: ApplicationDescription,
     link: String,
 }
 
 impl ApplicationOverview {
     fn new(
         id: ApplicationId,
-        description: UserApplicationDescription,
+        description: ApplicationDescription,
         port: NonZeroU16,
         chain_id: ChainId,
     ) -> Self {

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -14,7 +14,7 @@ use linera_base::{
     crypto::{CryptoError, CryptoHash},
     data_types::{Amount, ApplicationPermissions, Bytecode, TimeDelta, UserApplicationDescription},
     hashed::Hashed,
-    identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId, Owner, UserApplicationId},
+    identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
     BcsHexParseError,
@@ -575,7 +575,7 @@ where
         module_id: ModuleId,
         parameters: String,
         instantiation_argument: String,
-        required_application_ids: Vec<UserApplicationId>,
+        required_application_ids: Vec<ApplicationId>,
     ) -> Result<ApplicationId, Error> {
         self.apply_client_command(&chain_id, move |client| {
             let parameters = parameters.as_bytes().to_vec();
@@ -761,14 +761,14 @@ where
 
 #[derive(SimpleObject)]
 pub struct ApplicationOverview {
-    id: UserApplicationId,
+    id: ApplicationId,
     description: UserApplicationDescription,
     link: String,
 }
 
 impl ApplicationOverview {
     fn new(
-        id: UserApplicationId,
+        id: ApplicationId,
         description: UserApplicationDescription,
         port: NonZeroU16,
         chain_id: ChainId,
@@ -889,7 +889,7 @@ where
     /// Handles service queries for user applications (including mutations).
     async fn handle_service_request(
         &self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         request: Vec<u8>,
         chain_id: ChainId,
     ) -> Result<Vec<u8>, NodeServiceError> {
@@ -932,7 +932,7 @@ where
     /// Queries a user application, returning the raw [`QueryOutcome`].
     async fn query_user_application(
         &self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         bytes: Vec<u8>,
         chain_id: ChainId,
     ) -> Result<QueryOutcome<Vec<u8>>, NodeServiceError> {
@@ -982,7 +982,7 @@ where
         request: String,
     ) -> Result<Vec<u8>, NodeServiceError> {
         let chain_id: ChainId = chain_id.parse().map_err(NodeServiceError::InvalidChainId)?;
-        let application_id: UserApplicationId = application_id.parse()?;
+        let application_id: ApplicationId = application_id.parse()?;
 
         debug!(
             "Processing request for application {application_id} on chain {chain_id}:\n{:?}",

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -11,7 +11,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Blob, TimeDelta, Timestamp},
     hashed::Hashed,
-    identifiers::{BlobId, ChainId, EventId, UserApplicationId},
+    identifiers::{ApplicationId, BlobId, ChainId, EventId},
 };
 use linera_chain::{
     types::{ConfirmedBlock, ConfirmedBlockCertificate, LiteCertificate},
@@ -263,8 +263,8 @@ pub struct DbStorage<Store, Clock> {
     store: Arc<Store>,
     clock: Clock,
     wasm_runtime: Option<WasmRuntime>,
-    user_contracts: Arc<DashMap<UserApplicationId, UserContractCode>>,
-    user_services: Arc<DashMap<UserApplicationId, UserServiceCode>>,
+    user_contracts: Arc<DashMap<ApplicationId, UserContractCode>>,
+    user_services: Arc<DashMap<ApplicationId, UserServiceCode>>,
     execution_runtime_config: ExecutionRuntimeConfig,
 }
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -18,7 +18,7 @@ use linera_base::{
         UserApplicationDescription,
     },
     hashed::Hashed,
-    identifiers::{BlobId, BlobType, ChainDescription, ChainId, EventId, Owner, UserApplicationId},
+    identifiers::{ApplicationId, BlobId, BlobType, ChainDescription, ChainId, EventId, Owner},
     ownership::ChainOwnership,
     vm::VmRuntime,
 };
@@ -378,8 +378,8 @@ pub struct ChainRuntimeContext<S> {
     storage: S,
     chain_id: ChainId,
     execution_runtime_config: ExecutionRuntimeConfig,
-    user_contracts: Arc<DashMap<UserApplicationId, UserContractCode>>,
-    user_services: Arc<DashMap<UserApplicationId, UserServiceCode>>,
+    user_contracts: Arc<DashMap<ApplicationId, UserContractCode>>,
+    user_services: Arc<DashMap<ApplicationId, UserServiceCode>>,
 }
 
 #[cfg_attr(not(web), async_trait)]
@@ -396,11 +396,11 @@ where
         self.execution_runtime_config
     }
 
-    fn user_contracts(&self) -> &Arc<DashMap<UserApplicationId, UserContractCode>> {
+    fn user_contracts(&self) -> &Arc<DashMap<ApplicationId, UserContractCode>> {
         &self.user_contracts
     }
 
-    fn user_services(&self) -> &Arc<DashMap<UserApplicationId, UserServiceCode>> {
+    fn user_services(&self) -> &Arc<DashMap<ApplicationId, UserServiceCode>> {
         &self.user_services
     }
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -14,8 +14,7 @@ use dashmap::{mapref::entry::Entry, DashMap};
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
-        Amount, Blob, BlockHeight, CompressedBytecode, TimeDelta, Timestamp,
-        UserApplicationDescription,
+        Amount, ApplicationDescription, Blob, BlockHeight, CompressedBytecode, TimeDelta, Timestamp,
     },
     hashed::Hashed,
     identifiers::{ApplicationId, BlobId, BlobType, ChainDescription, ChainId, EventId, Owner},
@@ -257,7 +256,7 @@ pub trait Storage: Sized {
     /// by the `application_description`.
     async fn load_contract(
         &self,
-        application_description: &UserApplicationDescription,
+        application_description: &ApplicationDescription,
     ) -> Result<UserContractCode, ExecutionError> {
         let contract_bytecode_blob_id = BlobId::new(
             application_description.module_id.contract_blob_hash,
@@ -317,7 +316,7 @@ pub trait Storage: Sized {
     /// by the `application_description`.
     async fn load_service(
         &self,
-        application_description: &UserApplicationDescription,
+        application_description: &ApplicationDescription,
     ) -> Result<UserServiceCode, ExecutionError> {
         let service_bytecode_blob_id = BlobId::new(
             application_description.module_id.service_blob_hash,
@@ -406,7 +405,7 @@ where
 
     async fn get_user_contract(
         &self,
-        description: &UserApplicationDescription,
+        description: &ApplicationDescription,
     ) -> Result<UserContractCode, ExecutionError> {
         match self.user_contracts.entry(description.into()) {
             Entry::Occupied(entry) => Ok(entry.get().clone()),
@@ -420,7 +419,7 @@ where
 
     async fn get_user_service(
         &self,
-        description: &UserApplicationDescription,
+        description: &ApplicationDescription,
     ) -> Result<UserServiceCode, ExecutionError> {
         match self.user_services.entry(description.into()) {
             Entry::Occupied(entry) => Ok(entry.get().clone()),


### PR DESCRIPTION
## Motivation

Attempts to use different types for `ApplicationId<A>` from `ApplicationId<()>` show that the problem is more complicated than we thought. In the meantime, we have the "worst of both worlds".

## Proposal

* Remove the alias `UserApplicationId` and enjoy the short names.
* Rename `UserApplicationDescription` into `ApplicationDescription`.

## Test Plan

CI