### PR TITLE
Create function "check_account_permission" to remove duplicated code

### DIFF
--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -66,7 +66,9 @@ impl Contract for AmmContract {
                 input_token_idx,
                 input_amount,
             } => {
-                self.check_account_authentication(owner);
+                self.runtime
+                    .check_account_permission(owner)
+                    .expect("Permission for Swap message");
                 // It's assumed that the tokens have already been transferred here at this point
                 assert!(
                     input_amount > Amount::ZERO,
@@ -103,7 +105,9 @@ impl Contract for AmmContract {
                 max_token0_amount,
                 max_token1_amount,
             } => {
-                self.check_account_authentication(owner);
+                self.runtime
+                    .check_account_permission(owner)
+                    .expect("Permission for AddLiquidity message");
 
                 assert!(
                     max_token0_amount > Amount::ZERO && max_token1_amount > Amount::ZERO,
@@ -220,7 +224,9 @@ impl Contract for AmmContract {
                 token_to_remove_idx,
                 mut token_to_remove_amount,
             } => {
-                self.check_account_authentication(owner);
+                self.runtime
+                    .check_account_permission(owner)
+                    .expect("Permission for RemoveLiquidity message");
 
                 assert!(token_to_remove_idx < 2, "Invalid token index");
 
@@ -283,7 +289,9 @@ impl Contract for AmmContract {
             }
 
             Message::RemoveAllAddedLiquidity { owner } => {
-                self.check_account_authentication(owner);
+                self.runtime
+                    .check_account_permission(owner)
+                    .expect("Permission for RemoveAllAddedLiquidity message");
 
                 let message_origin_account = self.get_message_origin_account(owner);
                 let current_shares = self
@@ -309,29 +317,6 @@ impl Contract for AmmContract {
 }
 
 impl AmmContract {
-    /// authenticate the originator of the message
-    fn check_account_authentication(&mut self, owner: AccountOwner) {
-        match owner {
-            AccountOwner::User(address) => {
-                assert_eq!(
-                    self.runtime.authenticated_signer(),
-                    Some(address),
-                    "Unauthorized"
-                )
-            }
-            AccountOwner::Application(id) => {
-                assert_eq!(
-                    self.runtime.authenticated_caller_id(),
-                    Some(id),
-                    "Unauthorized"
-                )
-            }
-            AccountOwner::Chain => {
-                panic!("Using chain balance is not authorized")
-            }
-        }
-    }
-
     /// Obtains the current shares for an `account`.
     async fn current_shares_or_default(&self, account: &Account) -> Amount {
         self.state
@@ -545,7 +530,9 @@ impl AmmContract {
                 input_token_idx,
                 input_amount,
             } => {
-                self.check_account_authentication(owner);
+                self.runtime
+                    .check_account_permission(owner)
+                    .expect("Permission for Swap operation");
 
                 let account_on_amm_chain = self.get_account_on_amm_chain(owner);
                 self.transfer(owner, input_amount, account_on_amm_chain, input_token_idx);
@@ -567,7 +554,9 @@ impl AmmContract {
                 max_token0_amount,
                 max_token1_amount,
             } => {
-                self.check_account_authentication(owner);
+                self.runtime
+                    .check_account_permission(owner)
+                    .expect("Permission for AddLiquidity operation");
 
                 let account_on_amm_chain = self.get_account_on_amm_chain(owner);
                 self.transfer(owner, max_token0_amount, account_on_amm_chain, 0);
@@ -592,7 +581,9 @@ impl AmmContract {
                 token_to_remove_idx,
                 token_to_remove_amount,
             } => {
-                self.check_account_authentication(owner);
+                self.runtime
+                    .check_account_permission(owner)
+                    .expect("Permission for RemoveLiquidity operation");
 
                 let message = Message::RemoveLiquidity {
                     owner,
@@ -606,7 +597,9 @@ impl AmmContract {
             }
 
             Operation::RemoveAllAddedLiquidity { owner } => {
-                self.check_account_authentication(owner);
+                self.runtime
+                    .check_account_permission(owner)
+                    .expect("Permission for RemoveAllAddedLiquidity operation");
 
                 let message = Message::RemoveAllAddedLiquidity { owner };
                 self.runtime

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -58,7 +58,9 @@ impl Contract for NativeFungibleTokenContract {
                 amount,
                 target_account,
             } => {
-                self.check_account_authentication(owner);
+                self.runtime
+                    .check_account_permission(owner)
+                    .expect("Permission for Transfer operation");
 
                 let fungible_target_account = target_account;
                 let target_account = self.normalize_account(target_account);
@@ -74,7 +76,9 @@ impl Contract for NativeFungibleTokenContract {
                 amount,
                 target_account,
             } => {
-                self.check_account_authentication(source_account.owner);
+                self.runtime
+                    .check_account_permission(source_account.owner)
+                    .expect("Permission for Claim operation");
 
                 let fungible_source_account = source_account;
                 let fungible_target_account = target_account;
@@ -130,23 +134,6 @@ impl NativeFungibleTokenContract {
         Account {
             chain_id: account.chain_id,
             owner: account.owner,
-        }
-    }
-
-    /// Verifies that a transfer is authenticated for this local account.
-    fn check_account_authentication(&mut self, owner: AccountOwner) {
-        match owner {
-            AccountOwner::User(address) => {
-                assert_eq!(
-                    self.runtime.authenticated_signer(),
-                    Some(address),
-                    "The requested transfer is not correctly authenticated."
-                );
-            }
-            AccountOwner::Application(_) => panic!("Applications not supported yet"),
-            AccountOwner::Chain => {
-                panic!("Chain accounts are not supported")
-            }
         }
     }
 }

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -195,7 +195,7 @@ pub enum ChangeApplicationPermissionsError {
     NotPermitted,
 }
 
-/// Errors that can happen when verification the authentication of an operation over an
+/// Errors that can happen when verifying the authentication of an operation over an
 /// account.
 #[derive(Clone, Copy, Debug, Error, WitStore, WitType)]
 pub enum AccountPermissionError {

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 use crate::{
     data_types::{Round, TimeDelta},
     doc_scalar,
-    identifiers::Owner,
+    identifiers::{AccountOwner, Owner},
 };
 
 /// The timeout configuration: how long fast, multi-leader and single-leader rounds last.
@@ -193,6 +193,15 @@ pub enum ChangeApplicationPermissionsError {
     /// The application wasn't allowed to change the application permissions.
     #[error("Unauthorized attempt to change the application permissions")]
     NotPermitted,
+}
+
+/// Errors that can happen when verification the authentication of an operation over an
+/// account.
+#[derive(Clone, Copy, Debug, Error, WitStore, WitType)]
+pub enum AccountPermissionError {
+    /// Operations on this account are not permitted in the current execution context.
+    #[error("Unauthorized attempt to access account owned by {0}")]
+    NotPermitted(AccountOwner),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Motivation

We are duplicating this logic in most examples. Probably a sign!

## Proposal

* Make a function `check_account_permission` available in the SDK
* Fix weird permission test in NFT apps

## Test Plan

CI