### PR TITLE
Cleanups after #3625

### DIFF
--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -40,8 +40,7 @@ impl Contract for NativeFungibleTokenContract {
                 chain_id: self.runtime.chain_id(),
                 owner,
             };
-            self.runtime
-                .transfer(AccountOwner::chain(), account, amount);
+            self.runtime.transfer(AccountOwner::CHAIN, account, amount);
         }
     }
 

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -33,7 +33,7 @@ async fn chain_balance_transfers() {
 
     let transfer_certificate = funding_chain
         .add_block(|block| {
-            block.with_native_token_transfer(AccountOwner::chain(), recipient, transfer_amount);
+            block.with_native_token_transfer(AccountOwner::CHAIN, recipient, transfer_amount);
         })
         .await;
 
@@ -69,7 +69,7 @@ async fn transfer_to_owner() {
 
     let transfer_certificate = funding_chain
         .add_block(|block| {
-            block.with_native_token_transfer(AccountOwner::chain(), recipient, transfer_amount);
+            block.with_native_token_transfer(AccountOwner::CHAIN, recipient, transfer_amount);
         })
         .await;
 
@@ -113,7 +113,7 @@ async fn transfer_to_multiple_owners() {
     let transfer_certificate = funding_chain
         .add_block(|block| {
             for (recipient, transfer_amount) in recipients.zip(transfer_amounts.clone()) {
-                block.with_native_token_transfer(AccountOwner::chain(), recipient, transfer_amount);
+                block.with_native_token_transfer(AccountOwner::CHAIN, recipient, transfer_amount);
             }
         })
         .await;
@@ -153,7 +153,7 @@ async fn emptied_account_disappears_from_queries() {
 
     let transfer_certificate = funding_chain
         .add_block(|block| {
-            block.with_native_token_transfer(AccountOwner::chain(), recipient, transfer_amount);
+            block.with_native_token_transfer(AccountOwner::CHAIN, recipient, transfer_amount);
         })
         .await;
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -39,13 +39,11 @@ pub enum AccountOwner {
 
 impl AccountOwner {
     /// Returns the default chain address.
-    pub fn chain() -> Self {
-        AccountOwner::Reserved(0)
-    }
+    pub const CHAIN: AccountOwner = AccountOwner::Reserved(0);
 
     /// Tests if the account is the chain address.
     pub fn is_chain(&self) -> bool {
-        self == &AccountOwner::chain()
+        self == &AccountOwner::CHAIN
     }
 }
 
@@ -77,7 +75,7 @@ impl Account {
     pub fn chain(chain_id: ChainId) -> Self {
         Account {
             chain_id,
-            owner: AccountOwner::chain(),
+            owner: AccountOwner::CHAIN,
         }
     }
 }

--- a/linera-base/src/unit_tests.rs
+++ b/linera-base/src/unit_tests.rs
@@ -97,7 +97,7 @@ fn send_message_request_test_case() -> SendMessageRequest<Vec<u8>> {
 fn account_test_case() -> Account {
     Account {
         chain_id: ChainId::root(10),
-        owner: AccountOwner::Address32(CryptoHash::test_hash("account")),
+        owner: AccountOwner::from(CryptoHash::test_hash("account")),
     }
 }
 

--- a/linera-chain/src/test/mod.rs
+++ b/linera-chain/src/test/mod.rs
@@ -109,7 +109,7 @@ impl BlockTestExt for ProposedBlock {
     }
 
     fn with_simple_transfer(self, chain_id: ChainId, amount: Amount) -> Self {
-        self.with_transfer(AccountOwner::chain(), Recipient::chain(chain_id), amount)
+        self.with_transfer(AccountOwner::CHAIN, Recipient::chain(chain_id), amount)
     }
 
     fn with_incoming_bundle(mut self, incoming_bundle: IncomingBundle) -> Self {

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -166,7 +166,7 @@ async fn test_block_size_limit() {
     let invalid_block = valid_block
         .clone()
         .with_operation(SystemOperation::Transfer {
-            owner: AccountOwner::chain(),
+            owner: AccountOwner::CHAIN,
             recipient: Recipient::root(0),
             amount: Amount::ONE,
         });

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -594,7 +594,7 @@ where
                     amount,
                 ),
                 None => Operation::system(SystemOperation::Transfer {
-                    owner: AccountOwner::chain(),
+                    owner: AccountOwner::CHAIN,
                     recipient: Recipient::chain(previous_chain_id),
                     amount,
                 }),

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -161,7 +161,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     // the message.
     let recipient0 = Recipient::chain(chain_id0);
     client1
-        .transfer(AccountOwner::chain(), Amount::ONE, recipient0)
+        .transfer(AccountOwner::CHAIN, Amount::ONE, recipient0)
         .await?;
     for i in 0.. {
         client0.synchronize_from_validators().boxed().await?;

--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -59,7 +59,7 @@ where
 
     let account = Account::new(chain2.chain_id(), owner1);
     let cert = chain1
-        .transfer_to_account(AccountOwner::chain(), amt, account)
+        .transfer_to_account(AccountOwner::CHAIN, amt, account)
         .await
         .unwrap()
         .unwrap();

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -278,7 +278,7 @@ where
         if query.request_committees {
             info.requested_committees = Some(chain.execution_state.system.committees.get().clone());
         }
-        if query.request_owner_balance == AccountOwner::chain() {
+        if query.request_owner_balance == AccountOwner::CHAIN {
             info.requested_owner_balance = Some(*chain.execution_state.system.balance.get());
         } else {
             info.requested_owner_balance = chain

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2289,9 +2289,7 @@ where
     /// block.
     #[instrument(level = "trace")]
     pub async fn query_balance(&self) -> Result<Amount, ChainClientError> {
-        let (balance, _) = self
-            .query_balances_with_owner(AccountOwner::chain())
-            .await?;
+        let (balance, _) = self.query_balances_with_owner(AccountOwner::CHAIN).await?;
         Ok(balance)
     }
 
@@ -2344,7 +2342,7 @@ where
             operations: Vec::new(),
             previous_block_hash,
             height,
-            authenticated_signer: if owner == AccountOwner::chain() {
+            authenticated_signer: if owner == AccountOwner::CHAIN {
                 None
             } else {
                 Some(owner)
@@ -2384,9 +2382,7 @@ where
     /// Does not process the inbox or attempt to synchronize with validators.
     #[instrument(level = "trace")]
     pub async fn local_balance(&self) -> Result<Amount, ChainClientError> {
-        let (balance, _) = self
-            .local_balances_with_owner(AccountOwner::chain())
-            .await?;
+        let (balance, _) = self.local_balances_with_owner(AccountOwner::CHAIN).await?;
         Ok(balance)
     }
 

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -101,7 +101,7 @@ impl ChainInfoQuery {
             chain_id,
             test_next_block_height: None,
             request_committees: false,
-            request_owner_balance: AccountOwner::chain(),
+            request_owner_balance: AccountOwner::CHAIN,
             request_pending_message_bundles: false,
             request_sent_certificate_hashes_in_range: None,
             request_received_log_excluding_first_n: None,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -104,7 +104,7 @@ where
     {
         let certificate = sender
             .transfer_to_account(
-                AccountOwner::chain(),
+                AccountOwner::CHAIN,
                 Amount::from_tokens(3),
                 Account::chain(ChainId::root(2)),
             )
@@ -155,7 +155,7 @@ where
     let friend = receiver.identity().await?;
     sender
         .transfer_to_account(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::from_tokens(3),
             Account::new(receiver_id, owner),
         )
@@ -164,7 +164,7 @@ where
         .unwrap();
     let cert = sender
         .transfer_to_account(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::from_millis(100),
             Account::new(receiver_id, friend),
         )
@@ -288,7 +288,7 @@ where
     sender.synchronize_from_validators().await.unwrap();
     // Can still use the chain.
     sender
-        .burn(AccountOwner::chain(), Amount::from_tokens(3))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await
         .unwrap();
     Ok(())
@@ -335,7 +335,7 @@ where
     // Cannot use the chain any more.
     assert_matches!(
         sender
-            .burn(AccountOwner::chain(), Amount::from_tokens(3))
+            .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
             .await,
         Err(ChainClientError::CannotFindKeyForChain(_))
     );
@@ -378,7 +378,7 @@ where
     sender.synchronize_from_validators().await.unwrap();
     // Can still use the chain with the old client.
     sender
-        .burn(AccountOwner::chain(), Amount::from_tokens(2))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(2))
         .await
         .unwrap();
     assert_eq!(sender.next_block_height(), BlockHeight::from(2));
@@ -405,7 +405,7 @@ where
 
     // We need at least three validators for making an operation.
     builder.set_fault_type([0, 1], FaultType::Offline).await;
-    let result = client.burn(AccountOwner::chain(), Amount::ONE).await;
+    let result = client.burn(AccountOwner::CHAIN, Amount::ONE).await;
     assert_matches!(
         result,
         Err(ChainClientError::CommunicationError(
@@ -415,7 +415,7 @@ where
     builder.set_fault_type([0, 1], FaultType::Honest).await;
     builder.set_fault_type([2, 3], FaultType::Offline).await;
     assert_matches!(
-        sender.burn(AccountOwner::chain(), Amount::ONE).await,
+        sender.burn(AccountOwner::CHAIN, Amount::ONE).await,
         Err(ChainClientError::CommunicationError(
             CommunicationError::Trusted(ClientIoError { .. })
         ))
@@ -434,7 +434,7 @@ where
     );
     client.clear_pending_proposal();
     client
-        .burn(AccountOwner::chain(), Amount::ONE)
+        .burn(AccountOwner::CHAIN, Amount::ONE)
         .await
         .unwrap()
         .unwrap();
@@ -444,10 +444,7 @@ where
     sender.process_inbox().await.unwrap();
     assert_eq!(sender.local_balance().await.unwrap(), Amount::ONE);
     sender.clear_pending_proposal();
-    sender
-        .burn(AccountOwner::chain(), Amount::ONE)
-        .await
-        .unwrap();
+    sender.burn(AccountOwner::CHAIN, Amount::ONE).await.unwrap();
 
     // That's it, we spent all our money on this test!
     assert_eq!(sender.local_balance().await.unwrap(), Amount::ZERO);
@@ -534,7 +531,7 @@ where
     // Transfer before creating the chain. The validators will ignore the cross-chain messages.
     sender
         .transfer_to_account(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::from_tokens(2),
             Account::chain(new_id),
         )
@@ -581,7 +578,7 @@ where
     // process the cross-chain messages.
     let certificate2 = sender
         .transfer_to_account(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::from_tokens(1),
             Account::chain(new_id),
         )
@@ -597,7 +594,7 @@ where
         Amount::from_tokens(3)
     );
     client
-        .burn(AccountOwner::chain(), Amount::from_tokens(3))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await
         .unwrap();
     Ok(())
@@ -626,7 +623,7 @@ where
     // Transfer before creating the chain.
     sender
         .transfer_to_account(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::from_tokens(3),
             Account::chain(new_id),
         )
@@ -669,7 +666,7 @@ where
         .await
         .unwrap();
     let result = client
-        .burn(AccountOwner::chain(), Amount::from_tokens(3))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await;
     assert_matches!(
         result,
@@ -711,7 +708,7 @@ where
     // Transfer after creating the chain.
     let transfer_certificate = sender
         .transfer_to_account(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::from_tokens(3),
             Account::chain(new_id),
         )
@@ -740,7 +737,7 @@ where
         Amount::from_tokens(3)
     );
     client
-        .burn(AccountOwner::chain(), Amount::from_tokens(3))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await
         .unwrap();
     assert_eq!(client.local_balance().await.unwrap(), Amount::ZERO);
@@ -786,7 +783,7 @@ where
     );
     // Cannot use the chain for operations any more.
     let result = client1
-        .burn(AccountOwner::chain(), Amount::from_tokens(3))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await;
     assert!(
         matches!(
@@ -802,7 +799,7 @@ where
     // Incoming messages now get rejected.
     client2
         .transfer_to_account(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::from_tokens(3),
             Account::chain(client1.chain_id()),
         )
@@ -860,7 +857,7 @@ where
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let result = sender
         .transfer_to_account_unsafe_unconfirmed(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::from_tokens(3),
             Account::chain(ChainId::root(2)),
         )
@@ -910,7 +907,7 @@ where
     );
     let certificate = client1
         .transfer_to_account(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::from_tokens(3),
             Account::chain(client2.chain_id),
         )
@@ -959,7 +956,7 @@ where
     assert_eq!(client2.next_block_height(), BlockHeight::ZERO);
     client2
         .transfer_to_account(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::ONE,
             Account::chain(client1.chain_id),
         )
@@ -1005,7 +1002,7 @@ where
     let client2 = builder.add_root_chain(2, Amount::ZERO).await?;
     let certificate = client1
         .transfer_to_account_unsafe_unconfirmed(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::from_tokens(2),
             Account::chain(client2.chain_id),
         )
@@ -1055,7 +1052,7 @@ where
     // Confirming to a quorum of nodes only at the end.
     client1
         .transfer_to_account_unsafe_unconfirmed(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::ONE,
             Account::chain(client2.chain_id),
         )
@@ -1063,7 +1060,7 @@ where
         .unwrap();
     client1
         .transfer_to_account_unsafe_unconfirmed(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::ONE,
             Account::chain(client2.chain_id),
         )
@@ -1083,7 +1080,7 @@ where
     // Sending money from client2 fails, as a consequence.
     let obtained_error = client2
         .transfer_to_account_unsafe_unconfirmed(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::from_tokens(2),
             Account::chain(client3.chain_id),
         )
@@ -1100,7 +1097,7 @@ where
     client2.synchronize_from_validators().await.unwrap();
     let certificate = client2
         .transfer_to_account(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::from_tokens(2),
             Account::chain(client3.chain_id),
         )
@@ -1176,7 +1173,7 @@ where
     // Sending money from the admin chain is supported.
     let cert = admin
         .transfer_to_account(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::from_tokens(2),
             Account::chain(user.chain_id()),
         )
@@ -1185,7 +1182,7 @@ where
         .unwrap();
     admin
         .transfer_to_account(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::ONE,
             Account::chain(user.chain_id()),
         )
@@ -1211,7 +1208,7 @@ where
     // Try to make a transfer back to the admin chain.
     let cert = user
         .transfer_to_account(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::from_tokens(2),
             Account::chain(admin.chain_id()),
         )
@@ -1227,7 +1224,7 @@ where
     // Try again to make a transfer back to the admin chain.
     let cert = user
         .transfer_to_account(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::ONE,
             Account::chain(admin.chain_id()),
         )
@@ -1257,12 +1254,12 @@ where
     let sender = builder.add_root_chain(1, Amount::from_tokens(3)).await?;
 
     let obtained_error = sender
-        .burn(AccountOwner::chain(), Amount::from_tokens(4))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(4))
         .await;
     assert_insufficient_funding_during_operation(obtained_error, 0);
 
     let obtained_error = sender
-        .burn(AccountOwner::chain(), Amount::from_tokens(3))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await;
     assert_insufficient_funding_fees(obtained_error);
     Ok(())
@@ -1427,7 +1424,7 @@ where
         *info2_b.manager.requested_locking.unwrap()
     );
     let bt_certificate = client2_b
-        .burn(AccountOwner::chain(), Amount::from_tokens(1))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(1))
         .await
         .unwrap()
         .unwrap();
@@ -1444,7 +1441,7 @@ where
         .body
         .operations
         .contains(&Operation::system(SystemOperation::Transfer {
-            owner: AccountOwner::chain(),
+            owner: AccountOwner::CHAIN,
             recipient: Recipient::Burn,
             amount: Amount::from_tokens(1),
         })));
@@ -1554,7 +1551,7 @@ where
 
     client2_b.prepare_chain().await.unwrap();
     let bt_certificate = client2_b
-        .burn(AccountOwner::chain(), Amount::from_tokens(1))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(1))
         .await
         .unwrap()
         .unwrap();
@@ -1571,7 +1568,7 @@ where
         .body
         .operations
         .contains(&Operation::system(SystemOperation::Transfer {
-            owner: AccountOwner::chain(),
+            owner: AccountOwner::CHAIN,
             recipient: Recipient::Burn,
             amount: Amount::from_tokens(1),
         })));
@@ -1903,7 +1900,7 @@ where
 
     // The other owner is leader now. Trying to submit a block should return `WaitForTimeout`.
     let result = client
-        .transfer(AccountOwner::chain(), Amount::ONE, Recipient::root(2))
+        .transfer(AccountOwner::CHAIN, Amount::ONE, Recipient::root(2))
         .await
         .unwrap();
     let timeout = match result {
@@ -1930,7 +1927,7 @@ where
 
     // Now we are the leader, and the transfer should succeed.
     let _certificate = client
-        .transfer(AccountOwner::chain(), Amount::ONE, Recipient::root(2))
+        .transfer(AccountOwner::CHAIN, Amount::ONE, Recipient::root(2))
         .await
         .unwrap()
         .unwrap();
@@ -1988,7 +1985,7 @@ where
         .set_fault_type([2], FaultType::OfflineWithInfo)
         .await;
     let result = client0
-        .burn(AccountOwner::chain(), Amount::from_tokens(3))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await;
     assert!(result.is_err());
 
@@ -2031,7 +2028,7 @@ where
     // Client 0 now only tries to burn 1 token. Before that, they automatically finalize the
     // pending block, which publishes the blob, leaving 10 - 1 = 9.
     client0
-        .burn(AccountOwner::chain(), Amount::from_tokens(1))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(1))
         .await
         .unwrap();
     client0.synchronize_from_validators().await.unwrap();
@@ -2045,7 +2042,7 @@ where
     // Burn another token so Client 1 sees that the blob is already published
     client1.prepare_chain().await.unwrap();
     client1
-        .burn(AccountOwner::chain(), Amount::from_tokens(1))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(1))
         .await
         .unwrap();
     client1.synchronize_from_validators().await.unwrap();
@@ -2077,7 +2074,7 @@ where
         .set_fault_type([2], FaultType::OfflineWithInfo)
         .await;
     let result = client
-        .burn(AccountOwner::chain(), Amount::from_tokens(3))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await;
     assert!(result.is_err());
 
@@ -2086,10 +2083,7 @@ where
 
     // The client tries to burn another token. Before that, they automatically finalize the
     // pending block, which burns 3 tokens, leaving 10 - 3 - 1 = 6.
-    client
-        .burn(AccountOwner::chain(), Amount::ONE)
-        .await
-        .unwrap();
+    client.burn(AccountOwner::CHAIN, Amount::ONE).await.unwrap();
     client.synchronize_from_validators().await.unwrap();
     client.process_inbox().await.unwrap();
     assert_eq!(
@@ -2140,7 +2134,7 @@ where
         .await;
     builder.set_fault_type([3], FaultType::Offline).await;
     let result = client0
-        .burn(AccountOwner::chain(), Amount::from_tokens(3))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await;
     assert!(result.is_err());
     let manager = client0
@@ -2178,7 +2172,7 @@ where
     assert!(manager.requested_locking.is_none());
     assert_eq!(manager.current_round, Round::MultiLeader(0));
     let result = client1
-        .burn(AccountOwner::chain(), Amount::from_tokens(2))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(2))
         .await;
     assert!(result.is_err());
 
@@ -2199,7 +2193,7 @@ where
     assert_eq!(manager.current_round, Round::MultiLeader(1));
     assert!(client1.pending_proposal().is_some());
     client1
-        .burn(AccountOwner::chain(), Amount::from_tokens(4))
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(4))
         .await
         .unwrap();
 
@@ -2226,7 +2220,7 @@ where
     let mut receiver = builder.add_root_chain(2, Amount::ZERO).await?;
     let recipient = Recipient::chain(receiver.chain_id());
     let cert = sender
-        .transfer(AccountOwner::chain(), Amount::ONE, recipient)
+        .transfer(AccountOwner::CHAIN, Amount::ONE, recipient)
         .await
         .unwrap()
         .unwrap();
@@ -2312,7 +2306,7 @@ where
     // Send a message from chain 2 to chain 3.
     let certificate = client2
         .transfer(
-            AccountOwner::chain(),
+            AccountOwner::CHAIN,
             Amount::from_millis(1),
             Recipient::chain(chain_id3),
         )

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -202,7 +202,7 @@ where
         chain_description,
         key_pair,
         Some(key_pair.public().into()),
-        AccountOwner::chain(),
+        AccountOwner::CHAIN,
         Recipient::chain(target_id),
         amount,
         incoming_bundles,
@@ -371,16 +371,16 @@ fn direct_outgoing_message(
 
 fn system_credit_message(amount: Amount) -> Message {
     Message::System(SystemMessage::Credit {
-        source: AccountOwner::chain(),
-        target: AccountOwner::chain(),
+        source: AccountOwner::CHAIN,
+        target: AccountOwner::CHAIN,
         amount,
     })
 }
 
 fn direct_credit_message(recipient: ChainId, amount: Amount) -> OutgoingMessage {
     let message = SystemMessage::Credit {
-        source: AccountOwner::chain(),
-        target: AccountOwner::chain(),
+        source: AccountOwner::CHAIN,
+        target: AccountOwner::CHAIN,
         amount,
     };
     direct_outgoing_message(recipient, MessageKind::Tracked, message)
@@ -1389,7 +1389,7 @@ where
         ChainDescription::Root(2),
         &sender_key_pair,
         Some(chain_key_pair.public().into()),
-        AccountOwner::chain(),
+        AccountOwner::CHAIN,
         Recipient::chain(ChainId::root(2)),
         Amount::from_tokens(5),
         Vec::new(),
@@ -2123,7 +2123,7 @@ where
         ChainDescription::Root(1),
         &sender_key_pair,
         Some(AccountOwner::from(sender_key_pair.public())),
-        AccountOwner::chain(),
+        AccountOwner::CHAIN,
         Recipient::Account(sender_account),
         Amount::from_tokens(5),
         Vec::new(),
@@ -2143,7 +2143,7 @@ where
         ChainDescription::Root(1),
         &sender_key_pair,
         Some(AccountOwner::from(sender_key_pair.public())),
-        AccountOwner::chain(),
+        AccountOwner::CHAIN,
         Recipient::Burn,
         Amount::ONE,
         vec![IncomingBundle {
@@ -2154,7 +2154,7 @@ where
                 timestamp: Timestamp::from(0),
                 transaction_index: 0,
                 messages: vec![Message::System(SystemMessage::Credit {
-                    source: AccountOwner::chain(),
+                    source: AccountOwner::CHAIN,
                     target: sender,
                     amount: Amount::from_tokens(5),
                 })
@@ -2982,7 +2982,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
         ChainDescription::Root(0),
         &key_pair0,
         Some(key_pair0.public().into()),
-        AccountOwner::chain(),
+        AccountOwner::CHAIN,
         Recipient::chain(id1),
         Amount::ONE,
         Vec::new(),
@@ -2998,7 +2998,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
         ChainDescription::Root(0),
         &key_pair0,
         Some(key_pair0.public().into()),
-        AccountOwner::chain(),
+        AccountOwner::CHAIN,
         Recipient::chain(id1),
         Amount::ONE,
         Vec::new(),
@@ -3014,7 +3014,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
         ChainDescription::Root(0),
         &key_pair0,
         Some(key_pair0.public().into()),
-        AccountOwner::chain(),
+        AccountOwner::CHAIN,
         Recipient::chain(id1),
         Amount::ONE,
         Vec::new(),
@@ -3031,7 +3031,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
         ChainDescription::Root(0),
         &key_pair0,
         Some(key_pair0.public().into()),
-        AccountOwner::chain(),
+        AccountOwner::CHAIN,
         Recipient::chain(id1),
         Amount::ONE,
         Vec::new(),
@@ -3514,11 +3514,7 @@ where
     // The first round is the multi-leader round 0. Anyone is allowed to propose.
     // But non-owners are not allowed to transfer the chain's funds.
     let proposal = make_child_block(&change_ownership_value)
-        .with_transfer(
-            AccountOwner::chain(),
-            Recipient::Burn,
-            Amount::from_tokens(1),
-        )
+        .with_transfer(AccountOwner::CHAIN, Recipient::Burn, Amount::from_tokens(1))
         .into_proposal_with_round(&AccountSecretKey::generate(), Round::MultiLeader(0));
     let result = worker.handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::ChainError(error)) if matches!(&*error,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -368,9 +368,7 @@ where
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         let message = SystemMessage::Credit {
             amount,
-            source: context
-                .authenticated_signer
-                .unwrap_or(AccountOwner::chain()),
+            source: context.authenticated_signer.unwrap_or(AccountOwner::CHAIN),
             target: account.owner,
         };
         txn_tracker.add_outgoing_message(

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -628,7 +628,7 @@ where
         recipient: Recipient,
         amount: Amount,
     ) -> Result<Option<OutgoingMessage>, ExecutionError> {
-        if source == AccountOwner::chain() {
+        if source == AccountOwner::CHAIN {
             ensure!(
                 authenticated_signer.is_some()
                     && self
@@ -697,7 +697,7 @@ where
         account: &AccountOwner,
         amount: Amount,
     ) -> Result<(), ExecutionError> {
-        let balance = if account == &AccountOwner::chain() {
+        let balance = if account == &AccountOwner::CHAIN {
             self.balance.get_mut()
         } else {
             self.balances.get_mut(account).await?.ok_or_else(|| {
@@ -715,7 +715,7 @@ where
                 account: *account,
             })?;
 
-        if account != &AccountOwner::chain() && balance.is_zero() {
+        if account != &AccountOwner::CHAIN && balance.is_zero() {
             self.balances.remove(account)?;
         }
 
@@ -737,7 +737,7 @@ where
                 target,
             } => {
                 let receiver = if context.is_bouncing { source } else { target };
-                if receiver == AccountOwner::chain() {
+                if receiver == AccountOwner::CHAIN {
                     let new_balance = self.balance.get().saturating_add(amount);
                     self.balance.set(new_balance);
                 } else {
@@ -842,7 +842,7 @@ where
                 epoch: config.epoch,
             }
         );
-        self.debit(&AccountOwner::chain(), config.balance).await?;
+        self.debit(&AccountOwner::CHAIN, config.balance).await?;
         let message = SystemMessage::OpenChain(config);
         Ok(OutgoingMessage::new(child_id, message).with_kind(MessageKind::Protected))
     }

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -128,7 +128,7 @@ async fn open_chain_message_index() {
 /// Tests if an account is removed from storage if it is drained.
 #[tokio::test]
 async fn empty_accounts_are_removed() -> anyhow::Result<()> {
-    let owner = AccountOwner::Address32(CryptoHash::test_hash("account owner"));
+    let owner = AccountOwner::from(CryptoHash::test_hash("account owner"));
     let amount = Amount::from_tokens(99);
 
     let mut view = SystemExecutionState {

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -734,7 +734,7 @@ impl TransferTestEndpoint {
 
     /// Returns the [`Owner`] used to represent a recipient that's a user.
     fn recipient_owner() -> AccountOwner {
-        AccountOwner::Address32(CryptoHash::test_hash("recipient"))
+        AccountOwner::from(CryptoHash::test_hash("recipient"))
     }
 
     /// Returns the [`ApplicationId`] used to represent a recipient that's an application.
@@ -788,9 +788,7 @@ impl TransferTestEndpoint {
     pub fn unauthorized_sender_account_owner(&self) -> AccountOwner {
         match self {
             TransferTestEndpoint::Chain => AccountOwner::CHAIN,
-            TransferTestEndpoint::User => {
-                AccountOwner::Address32(CryptoHash::test_hash("attacker"))
-            }
+            TransferTestEndpoint::User => AccountOwner::from(CryptoHash::test_hash("attacker")),
             TransferTestEndpoint::Application => Self::recipient_application_id().into(),
         }
     }

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -778,7 +778,7 @@ impl TransferTestEndpoint {
     /// Returns the [`AccountOwner`] to represent this transfer endpoint as a sender.
     pub fn sender_account_owner(&self) -> AccountOwner {
         match self {
-            TransferTestEndpoint::Chain => AccountOwner::chain(),
+            TransferTestEndpoint::Chain => AccountOwner::CHAIN,
             TransferTestEndpoint::User => Self::sender_owner(),
             TransferTestEndpoint::Application => Self::sender_application_id().into(),
         }
@@ -787,7 +787,7 @@ impl TransferTestEndpoint {
     /// Returns the [`AccountOwner`] to represent this transfer endpoint as an unauthorized sender.
     pub fn unauthorized_sender_account_owner(&self) -> AccountOwner {
         match self {
-            TransferTestEndpoint::Chain => AccountOwner::chain(),
+            TransferTestEndpoint::Chain => AccountOwner::CHAIN,
             TransferTestEndpoint::User => {
                 AccountOwner::Address32(CryptoHash::test_hash("attacker"))
             }
@@ -818,7 +818,7 @@ impl TransferTestEndpoint {
     /// Returns the [`AccountOwner`] to represent this transfer endpoint as a recipient.
     pub fn recipient_account_owner(&self) -> AccountOwner {
         match self {
-            TransferTestEndpoint::Chain => AccountOwner::chain(),
+            TransferTestEndpoint::Chain => AccountOwner::CHAIN,
             TransferTestEndpoint::User => Self::recipient_owner(),
             TransferTestEndpoint::Application => Self::recipient_application_id().into(),
         }
@@ -832,8 +832,7 @@ impl TransferTestEndpoint {
         amount: Amount,
     ) -> anyhow::Result<()> {
         let account_owner = self.recipient_account_owner();
-        let (expected_chain_balance, expected_balances) = if account_owner == AccountOwner::chain()
-        {
+        let (expected_chain_balance, expected_balances) = if account_owner == AccountOwner::CHAIN {
             (amount, vec![])
         } else {
             (Amount::ZERO, vec![(account_owner, amount)])

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1286,7 +1286,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
         move |runtime, _context, _operation| {
             assert_eq!(runtime.chain_ownership()?, ownership);
             let destination = Account::chain(ChainId::root(2));
-            runtime.transfer(AccountOwner::chain(), destination, Amount::ONE)?;
+            runtime.transfer(AccountOwner::CHAIN, destination, Amount::ONE)?;
             let id = runtime.application_id()?;
             let application_permissions = ApplicationPermissions::new_single(id);
             let (actual_message_id, chain_id) =
@@ -1483,11 +1483,11 @@ async fn test_message_receipt_spending_chain_balance(
 
     let (application_id, application, blobs) = view.register_mock_application(0).await?;
 
-    let receiver_chain_account = AccountOwner::chain();
+    let receiver_chain_account = AccountOwner::CHAIN;
     let sender_chain_id = ChainId::root(2);
     let recipient = Account {
         chain_id: sender_chain_id,
-        owner: AccountOwner::chain(),
+        owner: AccountOwner::CHAIN,
     };
 
     application.expect_call(ExpectedCall::execute_message(

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -30,7 +30,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
     };
     let mut view = state.into_view().await;
     let operation = SystemOperation::Transfer {
-        owner: AccountOwner::chain(),
+        owner: AccountOwner::CHAIN,
         amount: Amount::from_tokens(4),
         recipient: Recipient::Burn,
     };
@@ -66,8 +66,8 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
     let mut view = state.into_view().await;
     let message = SystemMessage::Credit {
         amount: Amount::from_tokens(4),
-        target: AccountOwner::chain(),
-        source: AccountOwner::chain(),
+        target: AccountOwner::CHAIN,
+        source: AccountOwner::CHAIN,
     };
     let context = MessageContext {
         chain_id: ChainId::root(0),

--- a/linera-indexer/example/tests/test.rs
+++ b/linera-indexer/example/tests/test.rs
@@ -76,7 +76,7 @@ fn indexer_running(child: &mut Child) {
 async fn transfer(client: &reqwest::Client, from: ChainId, to: Account, amount: &str) {
     let variables = transfer::Variables {
         chain_id: from,
-        owner: AccountOwner::chain(),
+        owner: AccountOwner::CHAIN,
         recipient_chain: to.chain_id,
         recipient_account: to.owner,
         amount: Amount::from_str(amount).unwrap(),

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -1087,7 +1087,7 @@ pub mod tests {
             chain_id: ChainId::root(0),
             test_next_block_height: Some(BlockHeight::from(10)),
             request_committees: false,
-            request_owner_balance: AccountOwner::chain(),
+            request_owner_balance: AccountOwner::CHAIN,
             request_pending_message_bundles: false,
             request_sent_certificate_hashes_in_range: Some(
                 linera_core::data_types::BlockHeightRange {

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -530,7 +530,7 @@ where
     /// Debits an `amount` of native tokens from a `source` owner account (or the current
     /// chain's balance).
     fn debit(&mut self, source: AccountOwner, amount: Amount) {
-        let source_balance = if source == AccountOwner::chain() {
+        let source_balance = if source == AccountOwner::CHAIN {
             self.chain_balance_mut()
         } else {
             self.owner_balance_mut(source)
@@ -544,7 +544,7 @@ where
     /// Credits an `amount` of native tokens into a `destination` owner account (or the
     /// current chain's balance).
     fn credit(&mut self, destination: AccountOwner, amount: Amount) {
-        let destination_balance = if destination == AccountOwner::chain() {
+        let destination_balance = if destination == AccountOwner::CHAIN {
             self.chain_balance_mut()
         } else {
             self.owner_balance_mut(destination)

--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -38,7 +38,7 @@ fn reqwest_client() -> reqwest::Client {
 async fn transfer(client: &reqwest::Client, url: &str, from: ChainId, to: Account, amount: &str) {
     let variables = transfer::Variables {
         chain_id: from,
-        owner: AccountOwner::chain(),
+        owner: AccountOwner::CHAIN,
         recipient_chain: to.chain_id,
         recipient_account: to.owner,
         amount: Amount::from_str(amount).unwrap(),

--- a/linera-service/benches/transfers.rs
+++ b/linera-service/benches/transfers.rs
@@ -88,7 +88,7 @@ async fn setup_native_token_balances(
         admin_chain
             .add_block(|block| {
                 block.with_native_token_transfer(
-                    AccountOwner::chain(),
+                    AccountOwner::CHAIN,
                     recipient,
                     Amount::from_tokens(initial_balance),
                 );


### PR DESCRIPTION
## Motivation

Address nits from #3625.

## Proposal

Add `const CHAIN` and use that instead of `fn chain()`. 

Use `AccountOwner::from` (instead of the variant directly) for consistency.

## Test Plan

CI

## Release Plan


- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
