### PR TITLE
Add links to previous blocks with the same message recipients.

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -564,6 +564,14 @@ impl Destination {
     pub fn is_channel(&self) -> bool {
         matches!(self, Destination::Subscribers(_))
     }
+
+    /// Returns the recipient chain, or `None` if it is `Subscribers`.
+    pub fn recipient(&self) -> Option<ChainId> {
+        match self {
+            Destination::Recipient(chain_id) => Some(*chain_id),
+            Destination::Subscribers(_) => None,
+        }
+    }
 }
 
 impl From<ChainId> for Destination {

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     fmt,
 };
 
@@ -383,6 +383,8 @@ pub struct ExecutedBlock {
 pub struct BlockExecutionOutcome {
     /// The list of outgoing messages for each transaction.
     pub messages: Vec<Vec<OutgoingMessage>>,
+    /// The hashes of previous blocks that sent messages to the same recipients.
+    pub previous_message_blocks: BTreeMap<ChainId, CryptoHash>,
     /// The hash of the chain's execution state after this block.
     pub state_hash: CryptoHash,
     /// The record of oracle responses for each transaction.

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -121,7 +121,7 @@ async fn test_block_size_limit() {
     let mut chain = ChainStateView::new(chain_id).await;
 
     // The size of the executed valid block below.
-    let maximum_executed_block_size = 856;
+    let maximum_executed_block_size = 857;
 
     // Initialize the chain.
     let mut config = make_open_chain_config();

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -22,6 +22,7 @@ fn test_signed_values() {
         make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(2), Amount::ONE);
     let executed_block = BlockExecutionOutcome {
         messages: vec![Vec::new()],
+        previous_message_blocks: BTreeMap::new(),
         state_hash: CryptoHash::test_hash("state"),
         oracle_responses: vec![Vec::new()],
         events: vec![Vec::new()],
@@ -84,6 +85,7 @@ fn test_hashes() {
         make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(2), Amount::ONE);
     let executed_block = BlockExecutionOutcome {
         messages: vec![Vec::new()],
+        previous_message_blocks: BTreeMap::new(),
         state_hash: CryptoHash::test_hash("state"),
         oracle_responses: vec![Vec::new()],
         events: vec![Vec::new()],
@@ -114,6 +116,7 @@ fn test_certificates() {
         make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(1), Amount::ONE);
     let executed_block = BlockExecutionOutcome {
         messages: vec![Vec::new()],
+        previous_message_blocks: BTreeMap::new(),
         state_hash: CryptoHash::test_hash("state"),
         oracle_responses: vec![Vec::new()],
         events: vec![Vec::new()],

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::large_futures)]
 #![cfg(any(feature = "wasmer", feature = "wasmtime"))]
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use assert_matches::assert_matches;
 use linera_base::{
@@ -149,6 +149,7 @@ where
     let publish_block_proposal = Hashed::new(ConfirmedBlock::new(
         BlockExecutionOutcome {
             messages: vec![Vec::new()],
+            previous_message_blocks: BTreeMap::new(),
             events: vec![Vec::new()],
             blobs: vec![Vec::new()],
             state_hash: publisher_state_hash,
@@ -226,6 +227,7 @@ where
     let create_block_proposal = Hashed::new(ConfirmedBlock::new(
         BlockExecutionOutcome {
             messages: vec![vec![]],
+            previous_message_blocks: BTreeMap::new(),
             events: vec![Vec::new()],
             state_hash: creator_state.crypto_hash().await?,
             oracle_responses: vec![vec![
@@ -297,6 +299,7 @@ where
     let run_block_proposal = Hashed::new(ConfirmedBlock::new(
         BlockExecutionOutcome {
             messages: vec![Vec::new()],
+            previous_message_blocks: BTreeMap::new(),
             events: vec![Vec::new()],
             blobs: vec![Vec::new()],
             state_hash: creator_state.crypto_hash().await?,

--- a/linera-explorer/src/components/Block.test.ts
+++ b/linera-explorer/src/components/Block.test.ts
@@ -19,6 +19,7 @@ test('Block mounting', () => {
               previousBlockHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
               stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
               messagesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+              previousMessageBlocksHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
               eventsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
               bundlesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
               operationsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
@@ -46,6 +47,7 @@ test('Block mounting', () => {
                   }
                 }
               }]],
+              previousMessageBlocks: {},
               events: [[]],
               oracleResponses: [],
               blobs: [[]],

--- a/linera-explorer/src/components/Blocks.test.ts
+++ b/linera-explorer/src/components/Blocks.test.ts
@@ -21,6 +21,7 @@ test('Blocks mounting', () => {
                   authenticatedSigner: "a36c72207a7c3cef20eb254978c0947d7cf28c9c7d7c62de42a0ed9db901cf3f",
                   previousBlockHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
                   messagesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+                  previousMessageBlocksHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
                   eventsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
                   bundlesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
                   operationsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
@@ -48,6 +49,7 @@ test('Blocks mounting', () => {
                       }
                     }
                   }]],
+                  previousMessageBlocks: {},
                   events: [[]],
                   oracleResponses: [],
                   blobs: [[]],

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -178,6 +178,7 @@ async fn get_chain(node: &str, chain_id: ChainId) -> Result<Chain> {
         channels_input: None,
         inboxes_input: None,
         outboxes_input: None,
+        previous_message_blocks_input: None,
     };
     let chain = request::<gql_service::Chain, _>(&client, node, variables)
         .await?

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -126,6 +126,12 @@ BlockBody:
         SEQ:
           SEQ:
             TYPENAME: OutgoingMessage
+    - previous_message_blocks:
+        MAP:
+          KEY:
+            TYPENAME: ChainId
+          VALUE:
+            TYPENAME: CryptoHash
     - oracle_responses:
         SEQ:
           SEQ:
@@ -147,6 +153,12 @@ BlockExecutionOutcome:
         SEQ:
           SEQ:
             TYPENAME: OutgoingMessage
+    - previous_message_blocks:
+        MAP:
+          KEY:
+            TYPENAME: ChainId
+          VALUE:
+            TYPENAME: CryptoHash
     - state_hash:
         TYPENAME: CryptoHash
     - oracle_responses:

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -94,6 +94,7 @@ query Chain(
   $inboxesInput: MapInput_Origin_742d451b,
   $outboxesInput: MapInput_Target_7aac1e1c,
   $channelsInput: MapInput_ChannelFullName_7b67e184,
+  $previousMessageBlocksInput: MapInput_ChainId_37f83aa9,
 ) {
   chain(chainId: $chainId) {
     chainId
@@ -196,6 +197,13 @@ query Chain(
       }
     }
     outboxCounters
+    previousMessageBlocks {
+      keys
+      entries(input: $previousMessageBlocksInput) {
+        key
+        value
+      }
+    }
     channels {
       keys
       entries(input: $channelsInput) {
@@ -237,6 +245,7 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
           bundlesHash
           operationsHash
           messagesHash
+          previousMessageBlocksHash
           oracleResponsesHash
           eventsHash
           blobsHash
@@ -270,6 +279,7 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
             kind
             message
           }
+          previousMessageBlocks
           oracleResponses
           events {
             streamId {
@@ -304,6 +314,7 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
           bundlesHash
           operationsHash
           messagesHash
+          previousMessageBlocksHash
           oracleResponsesHash
           eventsHash
           blobsHash
@@ -337,6 +348,7 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
             kind
             message
           }
+          previousMessageBlocks
           oracleResponses
           events {
             streamId {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -109,6 +109,10 @@ type BlockBody {
 	"""
 	messages: [[OutgoingMessage!]!]!
 	"""
+	The hashes of previous blocks that sent messages to the same recipients.
+	"""
+	previousMessageBlocks: JSONObject!
+	"""
 	The record of oracle responses for each transaction.
 	"""
 	oracleResponses: [[OracleResponse!]!]!
@@ -175,6 +179,10 @@ type BlockHeader {
 	Cryptographic hash of all the messages in the block.
 	"""
 	messagesHash: CryptoHash!
+	"""
+	Cryptographic hash of the lookup table for previous sending blocks.
+	"""
+	previousMessageBlocksHash: CryptoHash!
 	"""
 	Cryptographic hash of all the oracle responses in the block.
 	"""
@@ -332,6 +340,10 @@ type ChainStateExtendedView {
 	Unskippable bundles that have been removed but are still in the queue.
 	"""
 	removedUnskippableBundles: [BundleInInbox!]!
+	"""
+	The heights of previous blocks that sent messages to the same recipients.
+	"""
+	previousMessageBlocks: MapView_ChainId_BlockHeight_f2e56e12!
 	"""
 	Mailboxes used to send messages, indexed by their target.
 	"""
@@ -497,6 +509,14 @@ type Entry_BlobId_Blob_9f0b41f3 {
 """
 A GraphQL-visible map item, complete with key.
 """
+type Entry_ChainId_BlockHeight_2fe78645 {
+	key: ChainId!
+	value: BlockHeight
+}
+
+"""
+A GraphQL-visible map item, complete with key.
+"""
 type Entry_ChannelFullName_ChannelStateView_bd1de7ae {
 	key: ChannelFullName!
 	value: ChannelStateView!
@@ -635,6 +655,10 @@ input MapFilters_BlobId_4d2a0555 {
 	keys: [BlobId!]
 }
 
+input MapFilters_ChainId_37f83aa9 {
+	keys: [ChainId!]
+}
+
 input MapFilters_ChannelFullName_7b67e184 {
 	keys: [ChannelFullName!]
 }
@@ -653,6 +677,10 @@ input MapInput_AccountOwner_d6668c53 {
 
 input MapInput_BlobId_4d2a0555 {
 	filters: MapFilters_BlobId_4d2a0555
+}
+
+input MapInput_ChainId_37f83aa9 {
+	filters: MapFilters_ChainId_37f83aa9
 }
 
 input MapInput_ChannelFullName_7b67e184 {
@@ -683,6 +711,12 @@ type MapView_BlobId_Blob_9f0b41f3 {
 	keys(count: Int): [BlobId!]!
 	entry(key: BlobId!): Entry_BlobId_Blob_50b95aa1!
 	entries(input: MapInput_BlobId_4d2a0555): [Entry_BlobId_Blob_50b95aa1!]!
+}
+
+type MapView_ChainId_BlockHeight_f2e56e12 {
+	keys(count: Int): [ChainId!]!
+	entry(key: ChainId!): Entry_ChainId_BlockHeight_2fe78645!
+	entries(input: MapInput_ChainId_37f83aa9): [Entry_ChainId_BlockHeight_2fe78645!]!
 }
 
 """

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -233,6 +233,7 @@ mod from {
                 state_hash,
                 bundles_hash,
                 messages_hash,
+                previous_message_blocks_hash,
                 operations_hash,
                 oracle_responses_hash,
                 events_hash,
@@ -242,6 +243,7 @@ mod from {
             let block::BlockBlockValueBlockBody {
                 incoming_bundles,
                 messages,
+                previous_message_blocks,
                 operations,
                 oracle_responses,
                 events,
@@ -259,6 +261,7 @@ mod from {
                 state_hash,
                 bundles_hash,
                 messages_hash,
+                previous_message_blocks_hash,
                 operations_hash,
                 oracle_responses_hash,
                 events_hash,
@@ -274,6 +277,7 @@ mod from {
                     .into_iter()
                     .map(|messages| messages.into_iter().map(Into::into).collect())
                     .collect::<Vec<Vec<_>>>(),
+                previous_message_blocks: serde_json::from_value(previous_message_blocks).unwrap(),
                 operations,
                 oracle_responses: oracle_responses.into_iter().map(Into::into).collect(),
                 events: events


### PR DESCRIPTION
## Motivation

We are planning to optimize the client so it does not download all message sender chains (https://github.com/linera-io/linera-protocol/issues/3630). This requires adding data to the `Block` structure itself.

## Proposal

Add the new data to the blocks now, so the optimization is a client-side change and can be added even after the next testnet launch.

## Test Plan

The tests were updated to expect the new entries.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #3630.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
