### PR TITLE
Remove system channels.

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -418,7 +418,7 @@ pub struct ChannelName(
 /// A channel name together with its application ID.
 pub struct ChannelFullName {
     /// The application owning the channel.
-    pub application_id: GenericApplicationId,
+    pub application_id: ApplicationId,
     /// The name of the channel.
     pub name: ChannelName,
 }
@@ -426,26 +426,16 @@ pub struct ChannelFullName {
 impl fmt::Display for ChannelFullName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = hex::encode(&self.name);
-        match self.application_id {
-            GenericApplicationId::System => write!(f, "system channel {name}"),
-            GenericApplicationId::User(app_id) => write!(f, "user channel {name} for app {app_id}"),
-        }
+        let app_id = self.application_id;
+        write!(f, "user channel {name} for app {app_id}")
     }
 }
 
 impl ChannelFullName {
-    /// Creates a full system channel name.
-    pub fn system(name: ChannelName) -> Self {
-        Self {
-            application_id: GenericApplicationId::System,
-            name,
-        }
-    }
-
     /// Creates a full user channel name.
-    pub fn user(name: ChannelName, application_id: ApplicationId) -> Self {
+    pub fn new(name: ChannelName, application_id: ApplicationId) -> Self {
         Self {
-            application_id: application_id.into(),
+            application_id,
             name,
         }
     }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -18,7 +18,8 @@ use linera_base::{
     },
     ensure,
     identifiers::{
-        AccountOwner, ApplicationId, BlobType, ChainId, ChannelFullName, Destination, MessageId,
+        AccountOwner, ApplicationId, BlobType, ChainId, ChannelFullName, Destination,
+        GenericApplicationId, MessageId,
     },
     ownership::ChainOwnership,
 };
@@ -506,7 +507,7 @@ where
         bundle: MessageBundle,
         local_time: Timestamp,
         add_to_received_log: bool,
-    ) -> Result<bool, ChainError> {
+    ) -> Result<(), ChainError> {
         assert!(!bundle.messages.is_empty());
         let chain_id = self.chain_id();
         tracing::trace!(
@@ -517,8 +518,6 @@ where
             chain_id: origin.sender,
             height: bundle.height,
         };
-        let mut subscribe_names_and_ids = Vec::new();
-        let mut unsubscribe_names_and_ids = Vec::new();
 
         // Handle immediate messages.
         for posted_message in &bundle.messages {
@@ -528,17 +527,8 @@ where
                     self.execute_init_message(message_id, config, bundle.timestamp, local_time)
                         .await?;
                 }
-            } else if let Some((id, subscription)) = posted_message.message.matches_subscribe() {
-                let name = ChannelFullName::system(subscription.name.clone());
-                subscribe_names_and_ids.push((name, *id));
-            }
-            if let Some((id, subscription)) = posted_message.message.matches_unsubscribe() {
-                let name = ChannelFullName::system(subscription.name.clone());
-                unsubscribe_names_and_ids.push((name, *id));
             }
         }
-        self.process_unsubscribes(unsubscribe_names_and_ids).await?;
-        let new_outbox_entries = self.process_subscribes(subscribe_names_and_ids).await?;
 
         if bundle.goes_to_inbox() {
             // Process the inbox bundle and update the inbox state.
@@ -569,7 +559,7 @@ where
         if add_to_received_log {
             self.received_log.push(chain_and_height);
         }
-        Ok(new_outbox_entries)
+        Ok(())
     }
 
     /// Updates the `received_log` trackers.
@@ -1167,8 +1157,15 @@ where
                         message.grant == Amount::ZERO,
                         ChainError::GrantUseOnBroadcast
                     );
+                    let GenericApplicationId::User(application_id) =
+                        message.message.application_id()
+                    else {
+                        return Err(ChainError::InternalError(
+                            "System messages cannot be sent to channels".to_string(),
+                        ));
+                    };
                     channel_broadcasts.insert(ChannelFullName {
-                        application_id: message.message.application_id(),
+                        application_id,
                         name: name.clone(),
                     });
                 }

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -20,7 +20,8 @@ use linera_base::{
     hashed::Hashed,
     hex_debug,
     identifiers::{
-        Account, AccountOwner, BlobId, ChainId, ChannelFullName, Destination, MessageId,
+        Account, AccountOwner, BlobId, ChainId, ChannelFullName, Destination, GenericApplicationId,
+        MessageId,
     },
 };
 use linera_execution::{
@@ -330,7 +331,10 @@ impl OutgoingMessageExt for OutgoingMessage {
                     application_id,
                     name,
                 }),
-            ) => *application_id == self.message.application_id() && name == dest_name,
+            ) => {
+                GenericApplicationId::User(*application_id) == self.message.application_id()
+                    && name == dest_name
+            }
         }
     }
 

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -125,7 +125,7 @@ where
         origin: Origin,
         bundles: Vec<(Epoch, MessageBundle)>,
         #[debug(skip)]
-        callback: oneshot::Sender<Result<Option<(BlockHeight, NetworkActions)>, WorkerError>>,
+        callback: oneshot::Sender<Result<Option<BlockHeight>, WorkerError>>,
     },
 
     /// Handle cross-chain request to confirm that the recipient was updated.

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -440,7 +440,7 @@ where
         &mut self,
         origin: Origin,
         bundles: Vec<(Epoch, MessageBundle)>,
-    ) -> Result<Option<(BlockHeight, NetworkActions)>, WorkerError> {
+    ) -> Result<Option<BlockHeight>, WorkerError> {
         // Only process certificates with relevant heights and epochs.
         let next_height_to_receive = self
             .state
@@ -467,19 +467,14 @@ where
         // Process the received messages in certificates.
         let local_time = self.state.storage.clock().current_time();
         let mut previous_height = None;
-        let mut new_outbox_entries = false;
         for bundle in bundles {
             let add_to_received_log = previous_height != Some(bundle.height);
             previous_height = Some(bundle.height);
             // Update the staged chain state with the received block.
-            if self
-                .state
+            self.state
                 .chain
                 .receive_message_bundle(&origin, bundle, local_time, add_to_received_log)
-                .await?
-            {
-                new_outbox_entries = true;
-            }
+                .await?;
         }
         if !self.state.config.allow_inactive_chains && !self.state.chain.is_active() {
             // Refuse to create a chain state if the chain is still inactive by
@@ -491,15 +486,9 @@ where
             );
             return Ok(None);
         }
-        let actions = if new_outbox_entries {
-            self.state.create_network_actions().await?
-        } else {
-            // Don't create network actions, so that old entries don't cause retry loops.
-            NetworkActions::default()
-        };
         // Save the chain.
         self.save().await?;
-        Ok(Some((last_updated_height, actions)))
+        Ok(Some(last_updated_height))
     }
 
     /// Handles the cross-chain request confirming that the recipient was updated.

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -274,7 +274,7 @@ where
         &mut self,
         origin: Origin,
         bundles: Vec<(Epoch, MessageBundle)>,
-    ) -> Result<Option<(BlockHeight, NetworkActions)>, WorkerError> {
+    ) -> Result<Option<BlockHeight>, WorkerError> {
         ChainWorkerStateWithAttemptedChanges::new(self)
             .await
             .process_cross_chain_update(origin, bundles)

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -8,16 +8,16 @@ use std::collections::HashMap;
 use linera_base::{
     data_types::{ApplicationDescription, ArithmeticError, Blob, Timestamp},
     ensure,
-    identifiers::{AccountOwner, ApplicationId, ChannelFullName, GenericApplicationId},
+    identifiers::{AccountOwner, ApplicationId},
 };
 use linera_chain::{
     data_types::{
-        BlockExecutionOutcome, BlockProposal, ExecutedBlock, IncomingBundle, Medium, MessageAction,
+        BlockExecutionOutcome, BlockProposal, ExecutedBlock, IncomingBundle, MessageAction,
         ProposalContent, ProposedBlock,
     },
     manager,
 };
-use linera_execution::{ChannelSubscription, Query, QueryOutcome};
+use linera_execution::{Query, QueryOutcome};
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::{View, ViewError};
 #[cfg(with_testing)]
@@ -305,21 +305,7 @@ where
             } else {
                 MessageAction::Accept
             };
-            let subscriptions = &chain.execution_state.system.subscriptions;
             for (origin, inbox) in pairs {
-                if let Medium::Channel(ChannelFullName {
-                    application_id: GenericApplicationId::System,
-                    name,
-                }) = &origin.medium
-                {
-                    let subscription = ChannelSubscription {
-                        chain_id: origin.sender,
-                        name: name.clone(),
-                    };
-                    if !subscriptions.contains(&subscription).await? {
-                        continue; // We are not subscribed to this channel.
-                    }
-                }
                 for bundle in inbox.added_bundles.elements().await? {
                     messages.push(IncomingBundle {
                         origin: origin.clone(),

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -608,7 +608,7 @@ where
         origin: Origin,
         recipient: ChainId,
         bundles: Vec<(Epoch, MessageBundle)>,
-    ) -> Result<Option<(BlockHeight, NetworkActions)>, WorkerError> {
+    ) -> Result<Option<BlockHeight>, WorkerError> {
         self.query_chain_worker(recipient, move |callback| {
             ChainWorkerRequest::ProcessCrossChainUpdate {
                 origin,
@@ -988,11 +988,10 @@ where
                 let mut actions = NetworkActions::default();
                 for (medium, bundles) in bundle_vecs {
                     let origin = Origin { sender, medium };
-                    if let Some((height, new_actions)) = self
+                    if let Some(height) = self
                         .process_cross_chain_update(origin.clone(), recipient, bundles)
                         .await?
                     {
-                        actions.extend(new_actions);
                         height_by_origin.push((origin, height));
                     }
                 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -50,7 +50,7 @@ use linera_base::{
 };
 use linera_views::{batch::Batch, views::ViewError};
 use serde::{Deserialize, Serialize};
-use system::{AdminOperation, OpenChainConfig, SystemChannel};
+use system::{AdminOperation, OpenChainConfig};
 use thiserror::Error;
 
 #[cfg(with_revm)]
@@ -314,12 +314,6 @@ pub enum ExecutionError {
     InvalidCommitteeEpoch { expected: Epoch, provided: Epoch },
     #[error("Failed to remove committee")]
     InvalidCommitteeRemoval,
-    #[error("Cannot subscribe to a channel ({1}) on the same chain ({0})")]
-    SelfSubscription(ChainId, SystemChannel),
-    #[error("Chain {0} tried to subscribe to channel {1} but it is already subscribed")]
-    AlreadySubscribedToChannel(ChainId, SystemChannel),
-    #[error("Invalid unsubscription request to channel {1} on chain {0}")]
-    InvalidUnsubscription(ChainId, SystemChannel),
     #[error("Amount overflow")]
     AmountOverflow,
     #[error("Amount underflow")]

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1200,7 +1200,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
     fn subscribe(&mut self, chain: ChainId, name: ChannelName) -> Result<(), ExecutionError> {
         let mut this = self.inner();
         let application_id = this.current_application().id;
-        let full_name = ChannelFullName::user(name, application_id);
+        let full_name = ChannelFullName::new(name, application_id);
         this.transaction_tracker.subscribe(full_name, chain);
 
         Ok(())
@@ -1209,7 +1209,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
     fn unsubscribe(&mut self, chain: ChainId, name: ChannelName) -> Result<(), ExecutionError> {
         let mut this = self.inner();
         let application_id = this.current_application().id;
-        let full_name = ChannelFullName::user(name, application_id);
+        let full_name = ChannelFullName::new(name, application_id);
         this.transaction_tracker.unsubscribe(full_name, chain);
 
         Ok(())

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -24,7 +24,6 @@ use super::{MockApplication, RegisterMockApplication};
 use crate::{
     committee::{Committee, Epoch},
     execution::UserAction,
-    system::SystemChannel,
     ApplicationDescription, ChannelSubscription, ExecutionError, ExecutionRuntimeConfig,
     ExecutionRuntimeContext, ExecutionStateView, OperationContext, ResourceControlPolicy,
     ResourceController, ResourceTracker, TestExecutionRuntimeContext, UserContractCode,

--- a/linera-rpc/tests/format.rs
+++ b/linera-rpc/tests/format.rs
@@ -17,7 +17,7 @@ use linera_chain::{
 };
 use linera_core::{data_types::CrossChainRequest, node::NodeError};
 use linera_execution::{
-    system::{AdminOperation, Recipient, SystemChannel, SystemMessage, SystemOperation},
+    system::{AdminOperation, Recipient, SystemMessage, SystemOperation},
     Message, MessageKind, Operation,
 };
 use linera_rpc::RpcMessage;
@@ -48,7 +48,6 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<Round>(&samples)?;
     tracer.trace_type::<OracleResponse>(&samples)?;
     tracer.trace_type::<Recipient>(&samples)?;
-    tracer.trace_type::<SystemChannel>(&samples)?;
     tracer.trace_type::<SystemOperation>(&samples)?;
     tracer.trace_type::<AdminOperation>(&samples)?;
     tracer.trace_type::<SystemMessage>(&samples)?;

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -364,7 +364,7 @@ ChainOwnership:
 ChannelFullName:
   STRUCT:
     - application_id:
-        TYPENAME: GenericApplicationId
+        TYPENAME: ApplicationId
     - name:
         TYPENAME: ChannelName
 ChannelName:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -1048,10 +1048,6 @@ StreamId:
         TYPENAME: StreamName
 StreamName:
   NEWTYPESTRUCT: BYTES
-SystemChannel:
-  ENUM:
-    0:
-      Admin: UNIT
 SystemMessage:
   ENUM:
     0:
@@ -1140,35 +1136,21 @@ SystemOperation:
         NEWTYPE:
           TYPENAME: ApplicationPermissions
     6:
-      Subscribe:
-        STRUCT:
-          - chain_id:
-              TYPENAME: ChainId
-          - channel:
-              TYPENAME: SystemChannel
-    7:
-      Unsubscribe:
-        STRUCT:
-          - chain_id:
-              TYPENAME: ChainId
-          - channel:
-              TYPENAME: SystemChannel
-    8:
       PublishModule:
         STRUCT:
           - module_id:
               TYPENAME: ModuleId
-    9:
+    7:
       PublishDataBlob:
         STRUCT:
           - blob_hash:
               TYPENAME: CryptoHash
-    10:
+    8:
       ReadBlob:
         STRUCT:
           - blob_id:
               TYPENAME: BlobId
-    11:
+    9:
       CreateApplication:
         STRUCT:
           - module_id:
@@ -1178,15 +1160,15 @@ SystemOperation:
           - required_application_ids:
               SEQ:
                 TYPENAME: ApplicationId
-    12:
+    10:
       Admin:
         NEWTYPE:
           TYPENAME: AdminOperation
-    13:
+    11:
       ProcessNewEpoch:
         NEWTYPE:
           TYPENAME: Epoch
-    14:
+    12:
       ProcessRemovedEpoch:
         NEWTYPE:
           TYPENAME: Epoch

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -9,7 +9,7 @@ use linera_base::{
     abi::ContractAbi,
     data_types::{Amount, ApplicationPermissions, Blob, Round, Timestamp},
     hashed::Hashed,
-    identifiers::{AccountOwner, ApplicationId, ChainId, ChannelFullName, GenericApplicationId},
+    identifiers::{AccountOwner, ApplicationId, ChainId},
     ownership::TimeoutConfig,
 };
 use linera_chain::{
@@ -21,7 +21,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::Epoch,
-    system::{Recipient, SystemChannel, SystemOperation},
+    system::{Recipient, SystemOperation},
     Operation,
 };
 
@@ -175,19 +175,6 @@ impl BlockBuilder {
     ) -> &mut Self {
         self.block.incoming_bundles.extend(bundles);
         self
-    }
-
-    /// Receives all admin messages that were sent to this chain by the given certificate.
-    pub fn with_system_messages_from(
-        &mut self,
-        certificate: &ConfirmedBlockCertificate,
-        channel: SystemChannel,
-    ) -> &mut Self {
-        let medium = Medium::Channel(ChannelFullName {
-            application_id: GenericApplicationId::System,
-            name: channel.name(),
-        });
-        self.with_messages_from_by_medium(certificate, &medium, MessageAction::Accept)
     }
 
     /// Receives all direct messages  that were sent to this chain by the given certificate.

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -822,14 +822,6 @@ type MutationRoot {
 	"""
 	createCommittee(chainId: ChainId!, committee: Committee!): CryptoHash!
 	"""
-	Subscribes to a system channel.
-	"""
-	subscribe(subscriberChainId: ChainId!, publisherChainId: ChainId!, channel: SystemChannel!): CryptoHash!
-	"""
-	Unsubscribes from a system channel.
-	"""
-	unsubscribe(subscriberChainId: ChainId!, publisherChainId: ChainId!, channel: SystemChannel!): CryptoHash!
-	"""
 	(admin chain only) Removes a committee. Once this message is accepted by a chain,
 	blocks from the retired epoch will not be accepted until they are followed (hence
 	re-certified) by a block certified by a recent committee.
@@ -1187,16 +1179,6 @@ type SubscriptionRoot {
 	Subscribes to notifications from the specified chain.
 	"""
 	notifications(chainId: ChainId!): Notification!
-}
-
-"""
-The channels available in the system application.
-"""
-enum SystemChannel {
-	"""
-	Channel used to broadcast reconfigurations.
-	"""
-	ADMIN
 }
 
 type SystemExecutionStateView {

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -28,10 +28,7 @@ use linera_base::{
 };
 use linera_client::{client_options::ResourceControlPolicyConfig, wallet::Wallet};
 use linera_core::worker::Notification;
-use linera_execution::{
-    committee::{Committee, Epoch},
-    system::SystemChannel,
-};
+use linera_execution::committee::{Committee, Epoch};
 use linera_faucet::ClaimOutcome;
 use linera_faucet_client::Faucet;
 use serde::{de::DeserializeOwned, ser::Serialize};
@@ -1267,24 +1264,6 @@ impl NodeService {
             .parse::<ApplicationId>()
             .context("invalid application ID")?
             .with_abi())
-    }
-
-    pub async fn subscribe(
-        &self,
-        subscriber_chain_id: ChainId,
-        publisher_chain_id: ChainId,
-        channel: SystemChannel,
-    ) -> Result<()> {
-        let query = format!(
-            "mutation {{ subscribe(\
-                 subscriberChainId: \"{subscriber_chain_id}\", \
-                 publisherChainId: \"{publisher_chain_id}\", \
-                 channel: \"{}\") \
-             }}",
-            channel.to_value(),
-        );
-        self.query_node(query).await?;
-        Ok(())
     }
 
     /// Obtains the hash of the `chain`'s tip block, as known by this node service.

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -31,7 +31,7 @@ use linera_core::{
 };
 use linera_execution::{
     committee::{Committee, Epoch},
-    system::{AdminOperation, Recipient, SystemChannel},
+    system::{AdminOperation, Recipient},
     Operation, Query, QueryOutcome, QueryResponse, SystemOperation,
 };
 use linera_sdk::linera_base_types::BlobContent;
@@ -492,36 +492,6 @@ where
             })
             .await?
             .hash())
-    }
-
-    /// Subscribes to a system channel.
-    async fn subscribe(
-        &self,
-        subscriber_chain_id: ChainId,
-        publisher_chain_id: ChainId,
-        channel: SystemChannel,
-    ) -> Result<CryptoHash, Error> {
-        let operation = SystemOperation::Subscribe {
-            chain_id: publisher_chain_id,
-            channel,
-        };
-        self.execute_system_operation(operation, subscriber_chain_id)
-            .await
-    }
-
-    /// Unsubscribes from a system channel.
-    async fn unsubscribe(
-        &self,
-        subscriber_chain_id: ChainId,
-        publisher_chain_id: ChainId,
-        channel: SystemChannel,
-    ) -> Result<CryptoHash, Error> {
-        let operation = SystemOperation::Unsubscribe {
-            chain_id: publisher_chain_id,
-            channel,
-        };
-        self.execute_system_operation(operation, subscriber_chain_id)
-            .await
     }
 
     /// (admin chain only) Removes a committee. Once this message is accepted by a chain,


### PR DESCRIPTION
## Motivation

As of https://github.com/linera-io/linera-protocol/pull/3432 we are not using system channels anymore.

## Proposal

Remove the `SystemChannel` type and any system channel-specific logic, in particular the "off-chain subscription handling".

## Test Plan

The `social` example tests make sure that _user_ pub-sub channels still work.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
