### PR TITLE
Add tracking of memory use in the caching.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -125,7 +125,13 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `--max-stream-queries <MAX_STREAM_QUERIES>` — The maximal number of simultaneous stream queries to the database
 
   Default value: `10`
-* `--cache-size <CACHE_SIZE>` — The maximal number of entries in the storage cache
+* `--max-cache-size <MAX_CACHE_SIZE>` — The maximal memory used in the storage cache
+
+  Default value: `10000000`
+* `--max-entry-size <MAX_ENTRY_SIZE>` — The maximal size of an entry in the storage cache
+
+  Default value: `1000000`
+* `--max-cache-entries <MAX_CACHE_ENTRIES>` — The maximal number of entries in the storage cache
 
   Default value: `1000`
 * `--retry-delay-ms <RETRY_DELAY>` — Delay increment for retrying to connect to a validator

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -19,10 +19,7 @@ use linera_base::{
 };
 use linera_core::{client::BlanketMessagePolicy, DEFAULT_GRACE_PERIOD};
 use linera_execution::{ResourceControlPolicy, WasmRuntime, WithWasmDefault as _};
-use linera_views::{
-    lru_caching::StorageCacheConfig,
-    store::CommonStoreConfig,
-};
+use linera_views::{lru_caching::StorageCacheConfig, store::CommonStoreConfig};
 
 #[cfg(feature = "fs")]
 use crate::config::GenesisConfig;

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -447,7 +447,7 @@ impl StorageConfigNamespace {
                 };
                 let config = ServiceStoreConfig {
                     inner_config,
-                    cache_size: common_config.cache_size,
+                    storage_cache_config: common_config.storage_cache_config,
                 };
                 Ok(StoreConfig::Service(config, namespace))
             }

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_views::{
+    lru_caching::StorageCacheConfig,
     scylla_db::{ScyllaDbStore, ScyllaDbStoreConfig},
     store::{AdminKeyValueStore, CommonStoreConfig},
 };
@@ -17,17 +18,29 @@ pub struct ScyllaDbConfig {
     /// ScyllaDB address
     #[arg(long, default_value = "localhost:9042")]
     pub uri: String,
+
     #[arg(long, default_value = "linera")]
     pub table: String,
+
     /// The maximal number of simultaneous queries to the database
     #[arg(long)]
     max_concurrent_queries: Option<usize>,
+
     /// The maximal number of simultaneous stream queries to the database
     #[arg(long, default_value = "10")]
     pub max_stream_queries: usize,
+
+    /// The maximal memory used in the storage cache.
+    #[arg(long, default_value = "10000000")]
+    pub max_cache_size: usize,
+
+    /// The maximal size of an entry in the storage cache.
+    #[arg(long, default_value = "1000000")]
+    pub max_entry_size: usize,
+
     /// The maximal number of entries in the storage cache.
     #[arg(long, default_value = "1000")]
-    cache_size: usize,
+    pub max_cache_entries: usize,
 }
 
 pub type ScyllaDbRunner = Runner<ScyllaDbStore, ScyllaDbConfig>;
@@ -35,10 +48,15 @@ pub type ScyllaDbRunner = Runner<ScyllaDbStore, ScyllaDbConfig>;
 impl ScyllaDbRunner {
     pub async fn load() -> Result<Self, IndexerError> {
         let config = <IndexerConfig<ScyllaDbConfig> as clap::Parser>::parse();
+        let storage_cache_config = StorageCacheConfig {
+            max_cache_size: config.client.max_cache_size,
+            max_entry_size: config.client.max_entry_size,
+            max_cache_entries: config.client.max_cache_entries,
+        };
         let common_config = CommonStoreConfig {
             max_concurrent_queries: config.client.max_concurrent_queries,
             max_stream_queries: config.client.max_stream_queries,
-            cache_size: config.client.cache_size,
+            storage_cache_config,
         };
         let namespace = config.client.table.clone();
         let store_config = ScyllaDbStoreConfig::new(config.client.uri.clone(), common_config);

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -27,10 +27,7 @@ use linera_service::util;
 #[cfg(with_metrics)]
 use linera_service::{prometheus_server, pyroscope_server};
 use linera_storage::Storage;
-use linera_views::{
-    lru_caching::StorageCacheConfig,
-    store::CommonStoreConfig,
-};
+use linera_views::{lru_caching::StorageCacheConfig, store::CommonStoreConfig};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -37,10 +37,7 @@ use linera_service::util;
 #[cfg(with_metrics)]
 use linera_service::{prometheus_server, pyroscope_server};
 use linera_storage::Storage;
-use linera_views::{
-    lru_caching::StorageCacheConfig,
-    store::CommonStoreConfig,
-};
+use linera_views::{lru_caching::StorageCacheConfig, store::CommonStoreConfig};
 use serde::Deserialize;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -607,7 +604,9 @@ async fn run(options: ServerOptions) {
             };
             let wasm_runtime = wasm_runtime.with_wasm_default();
             let storage_cache_config = StorageCacheConfig {
-                max_cache_size, max_entry_size, max_cache_entries,
+                max_cache_size,
+                max_entry_size,
+                max_cache_entries,
             };
             let common_config = CommonStoreConfig {
                 max_concurrent_queries,
@@ -678,7 +677,9 @@ async fn run(options: ServerOptions) {
             let genesis_config: GenesisConfig =
                 util::read_json(&genesis_config_path).expect("Failed to read initial chain config");
             let storage_cache_config = StorageCacheConfig {
-                max_cache_size, max_entry_size, max_cache_entries,
+                max_cache_size,
+                max_entry_size,
+                max_cache_entries,
             };
             let common_config = CommonStoreConfig {
                 max_concurrent_queries,

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -1203,7 +1203,7 @@ impl DynamoDbStoreConfig {
         };
         DynamoDbStoreConfig {
             inner_config,
-            cache_size: common_config.cache_size,
+            storage_cache_config: common_config.storage_cache_config,
         }
     }
 }

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -27,12 +27,12 @@ pub struct IndexedDbStoreConfig {
 }
 
 impl IndexedDbStoreConfig {
-    /// Creates a `IndexedDbStoreConfig`. `max_concurrent_queries` and `cache_size` are not used.
+    /// Creates a `IndexedDbStoreConfig`. `max_concurrent_queries` and `storage_cache_config` are not used.
     pub fn new(max_stream_queries: usize) -> Self {
         let common_config = CommonStoreConfig {
             max_concurrent_queries: None,
             max_stream_queries,
-            cache_size: 1000,
+            storage_cache_config: DEFAULT_STORAGE_CACHE_POLICY,
         };
         Self { common_config }
     }

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, WriteOperation},
     common::get_upper_bound_option,
+    lru_caching::DEFAULT_STORAGE_CACHE_CONFIG,
     store::{
         CommonStoreConfig, KeyValueStoreError, LocalAdminKeyValueStore, LocalReadableKeyValueStore,
         LocalWritableKeyValueStore, WithError,
@@ -32,7 +33,7 @@ impl IndexedDbStoreConfig {
         let common_config = CommonStoreConfig {
             max_concurrent_queries: None,
             max_stream_queries,
-            storage_cache_config: DEFAULT_STORAGE_CACHE_POLICY,
+            storage_cache_config: DEFAULT_STORAGE_CACHE_CONFIG,
         };
         Self { common_config }
     }

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -662,7 +662,7 @@ impl RocksDbStoreConfig {
         };
         RocksDbStoreConfig {
             inner_config,
-            cache_size: common_config.cache_size,
+            storage_cache_config: common_config.storage_cache_config,
         }
     }
 }

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -921,7 +921,7 @@ impl ScyllaDbStoreConfig {
         };
         ScyllaDbStoreConfig {
             inner_config,
-            cache_size: common_config.cache_size,
+            storage_cache_config: common_config.storage_cache_config,
         }
     }
 }

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -9,8 +9,12 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 #[cfg(with_testing)]
 use crate::random::generate_test_namespace;
-use crate::{batch::Batch, common::from_bytes_option, views::ViewError};
-use crate::lru_caching::{StorageCacheConfig, DEFAULT_STORAGE_CACHE_CONFIG};
+use crate::{
+    batch::Batch,
+    common::from_bytes_option,
+    lru_caching::{StorageCacheConfig, DEFAULT_STORAGE_CACHE_CONFIG},
+    views::ViewError,
+};
 
 /// The common initialization parameters for the `KeyValueStore`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -10,6 +10,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 #[cfg(with_testing)]
 use crate::random::generate_test_namespace;
 use crate::{batch::Batch, common::from_bytes_option, views::ViewError};
+use crate::lru_caching::{StorageCacheConfig, DEFAULT_STORAGE_CACHE_CONFIG};
 
 /// The common initialization parameters for the `KeyValueStore`
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -28,7 +29,7 @@ pub struct CommonStoreConfig {
     /// The number of streams used for the async streams.
     pub max_stream_queries: usize,
     /// The cache size being used.
-    pub cache_size: usize,
+    pub storage_cache_config: StorageCacheConfig,
 }
 
 impl CommonStoreConfig {
@@ -46,7 +47,7 @@ impl Default for CommonStoreConfig {
         CommonStoreConfig {
             max_concurrent_queries: None,
             max_stream_queries: 10,
-            cache_size: 1000,
+            storage_cache_config: DEFAULT_STORAGE_CACHE_CONFIG,
         }
     }
 }

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -131,8 +131,7 @@ impl StateStorage for LruMemoryStorage {
 
     async fn new() -> Self {
         let store = MemoryStore::new_test_store().await.unwrap();
-        let storage_cache_config = DEFAULT_STORAGE_CACHE_CONFIG;
-        let store = LruCachingStore::new(store, storage_cache_config);
+        let store = LruCachingStore::new(store, DEFAULT_STORAGE_CACHE_CONFIG);
         LruMemoryStorage {
             accessed_chains: BTreeSet::new(),
             store,

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -22,7 +22,7 @@ use linera_views::{
     context::{Context, MemoryContext, ViewContext},
     key_value_store_view::{KeyValueStoreView, ViewContainer},
     log_view::HashedLogView,
-    lru_caching::{DEFAULT_STORAGE_CACHE_CONFIG, LruCachingMemoryStore, LruCachingStore},
+    lru_caching::{LruCachingMemoryStore, LruCachingStore, DEFAULT_STORAGE_CACHE_CONFIG},
     map_view::{ByteMapView, HashedMapView},
     memory::MemoryStore,
     queue_view::HashedQueueView,

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -22,7 +22,7 @@ use linera_views::{
     context::{Context, MemoryContext, ViewContext},
     key_value_store_view::{KeyValueStoreView, ViewContainer},
     log_view::HashedLogView,
-    lru_caching::{LruCachingMemoryStore, LruCachingStore},
+    lru_caching::{DEFAULT_STORAGE_CACHE_CONFIG, LruCachingMemoryStore, LruCachingStore},
     map_view::{ByteMapView, HashedMapView},
     memory::MemoryStore,
     queue_view::HashedQueueView,
@@ -131,8 +131,8 @@ impl StateStorage for LruMemoryStorage {
 
     async fn new() -> Self {
         let store = MemoryStore::new_test_store().await.unwrap();
-        let cache_size = 1000;
-        let store = LruCachingStore::new(store, cache_size);
+        let storage_cache_config = DEFAULT_STORAGE_CACHE_CONFIG;
+        let store = LruCachingStore::new(store, storage_cache_config);
         LruMemoryStorage {
             accessed_chains: BTreeSet::new(),
             store,


### PR DESCRIPTION
## Motivation

The current tracking is limited by the maximal size of the cache. This is a limited way to
control the size of the cache.

## Proposal

Two additional constraints are added:
* A maximal size of the total cache.
* A maximal size of individual entries in the cache.
* Those entries are added to the input parameters of all the relevant functions.


## Test Plan

The CI.

## Release Plan

Normal release plan.

## Links

None.