### PR TITLE
Remove unused `Subscribe` and `Unsubscribe` messages.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -558,15 +558,6 @@ impl MessageBundle {
     pub fn is_protected(&self) -> bool {
         self.messages.iter().any(PostedMessage::is_protected)
     }
-
-    /// Returns whether this bundle must be added to the inbox.
-    ///
-    /// If this is `false`, it gets handled immediately and should never be received in a block.
-    pub fn goes_to_inbox(&self) -> bool {
-        self.messages
-            .iter()
-            .any(|posted_message| posted_message.message.goes_to_inbox())
-    }
 }
 
 impl PostedMessage {

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -444,22 +444,10 @@ where
         let mut heights_by_recipient = BTreeMap::<_, BTreeMap<_, _>>::new();
         let mut targets = self.chain.outboxes.indices().await?;
         if let Some(tracked_chains) = self.tracked_chains.as_ref() {
-            let publishers = self
-                .chain
-                .execution_state
-                .system
-                .subscriptions
-                .indices()
-                .await?
-                .iter()
-                .map(|subscription| subscription.chain_id)
-                .collect::<HashSet<_>>();
             let tracked_chains = tracked_chains
                 .read()
                 .expect("Panics should not happen while holding a lock to `tracked_chains`");
-            targets.retain(|target| {
-                tracked_chains.contains(&target.recipient) || publishers.contains(&target.recipient)
-            });
+            targets.retain(|target| tracked_chains.contains(&target.recipient));
         }
         let outboxes = self.chain.outboxes.try_load_entries(&targets).await?;
         for (target, outbox) in targets.into_iter().zip(outboxes) {
@@ -544,20 +532,8 @@ where
         };
         let mut targets = self.chain.outboxes.indices().await?;
         {
-            let publishers = self
-                .chain
-                .execution_state
-                .system
-                .subscriptions
-                .indices()
-                .await?
-                .iter()
-                .map(|subscription| subscription.chain_id)
-                .collect::<HashSet<_>>();
             let tracked_chains = tracked_chains.read().unwrap();
-            targets.retain(|target| {
-                tracked_chains.contains(&target.recipient) || publishers.contains(&target.recipient)
-            });
+            targets.retain(|target| tracked_chains.contains(&target.recipient));
         }
         let outboxes = self.chain.outboxes.try_load_entries(&targets).await?;
         for outbox in outboxes {

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2510,16 +2510,6 @@ where
             *user_chain.execution_state.system.admin_id.get(),
             Some(admin_id)
         );
-        assert_eq!(
-            user_chain
-                .execution_state
-                .system
-                .subscriptions
-                .indices()
-                .await?
-                .len(),
-            0
-        );
         user_chain.validate_incoming_bundles().await?;
         matches!(
             &user_chain
@@ -2628,16 +2618,6 @@ where
         assert_eq!(
             *user_chain.execution_state.system.admin_id.get(),
             Some(admin_id)
-        );
-        assert_eq!(
-            user_chain
-                .execution_state
-                .system
-                .subscriptions
-                .indices()
-                .await?
-                .len(),
-            0
         );
         assert_eq!(user_chain.execution_state.system.committees.get().len(), 2);
         user_chain.validate_incoming_bundles().await?;

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -311,8 +311,7 @@ where
                 if !app_permissions.can_close_chain(&application_id) {
                     callback.respond(Err(ExecutionError::UnauthorizedApplication(application_id)));
                 } else {
-                    let chain_id = self.context().extra().chain_id();
-                    self.system.close_chain(chain_id).await?;
+                    self.system.close_chain().await?;
                     callback.respond(Ok(()));
                 }
             }

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -15,7 +15,7 @@ use linera_views::{context::Context, map_view::MapView};
 use crate::{
     committee::{Committee, Epoch, ValidatorState},
     system::{Recipient, UserData},
-    ChannelSubscription, ExecutionStateView, SystemExecutionStateView,
+    ExecutionStateView, SystemExecutionStateView,
 };
 
 doc_scalar!(
@@ -71,11 +71,6 @@ impl<C: Send + Sync + Context> SystemExecutionStateView<C> {
     #[graphql(derived(name = "admin_id"))]
     async fn _admin_id(&self) -> &Option<ChainId> {
         self.admin_id.get()
-    }
-
-    #[graphql(derived(name = "subscription"))]
-    async fn _subscriptions(&self) -> Result<Vec<ChannelSubscription>, async_graphql::Error> {
-        Ok(self.subscriptions.indices().await?)
     }
 
     #[graphql(derived(name = "committees"))]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -976,17 +976,6 @@ impl OutgoingMessage {
     }
 }
 
-/// The identifier of a channel, relative to a particular application.
-#[derive(
-    Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Hash, Serialize, Deserialize, SimpleObject,
-)]
-pub struct ChannelSubscription {
-    /// The chain ID broadcasting on this channel.
-    pub chain_id: ChainId,
-    /// The name of the channel.
-    pub name: ChannelName,
-}
-
 impl OperationContext {
     /// Returns an account for the refund.
     /// Returns `None` if there is no authenticated signer of the [`OperationContext`].
@@ -1220,32 +1209,6 @@ impl Message {
         match self {
             Self::System(_) => GenericApplicationId::System,
             Self::User { application_id, .. } => GenericApplicationId::User(*application_id),
-        }
-    }
-
-    /// Returns whether this message must be added to the inbox.
-    pub fn goes_to_inbox(&self) -> bool {
-        !matches!(
-            self,
-            Message::System(SystemMessage::Subscribe { .. } | SystemMessage::Unsubscribe { .. })
-        )
-    }
-
-    pub fn matches_subscribe(&self) -> Option<(&ChainId, &ChannelSubscription)> {
-        match self {
-            Message::System(SystemMessage::Subscribe { id, subscription }) => {
-                Some((id, subscription))
-            }
-            _ => None,
-        }
-    }
-
-    pub fn matches_unsubscribe(&self) -> Option<(&ChainId, &ChannelSubscription)> {
-        match self {
-            Message::System(SystemMessage::Unsubscribe { id, subscription }) => {
-                Some((id, subscription))
-            }
-            _ => None,
         }
     }
 

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -24,9 +24,9 @@ use super::{MockApplication, RegisterMockApplication};
 use crate::{
     committee::{Committee, Epoch},
     execution::UserAction,
-    ApplicationDescription, ChannelSubscription, ExecutionError, ExecutionRuntimeConfig,
-    ExecutionRuntimeContext, ExecutionStateView, OperationContext, ResourceControlPolicy,
-    ResourceController, ResourceTracker, TestExecutionRuntimeContext, UserContractCode,
+    ApplicationDescription, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext,
+    ExecutionStateView, OperationContext, ResourceControlPolicy, ResourceController,
+    ResourceTracker, TestExecutionRuntimeContext, UserContractCode,
 };
 
 /// A system execution state, not represented as a view but as a simple struct.
@@ -35,7 +35,6 @@ pub struct SystemExecutionState {
     pub description: Option<ChainDescription>,
     pub epoch: Option<Epoch>,
     pub admin_id: Option<ChainId>,
-    pub subscriptions: BTreeSet<ChannelSubscription>,
     pub committees: BTreeMap<Epoch, Committee>,
     pub ownership: ChainOwnership,
     pub balance: Amount,
@@ -88,7 +87,6 @@ impl SystemExecutionState {
             description,
             epoch,
             admin_id,
-            subscriptions,
             committees,
             ownership,
             balance,
@@ -120,12 +118,6 @@ impl SystemExecutionState {
         view.system.description.set(description);
         view.system.epoch.set(epoch);
         view.system.admin_id.set(admin_id);
-        for subscription in subscriptions {
-            view.system
-                .subscriptions
-                .insert(&subscription)
-                .expect("serialization of subscription should not fail");
-        }
         view.system.committees.set(committees);
         view.system.ownership.set(ownership);
         view.system.balance.set(balance);

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -381,12 +381,6 @@ ChannelFullName:
         TYPENAME: ChannelName
 ChannelName:
   NEWTYPESTRUCT: BYTES
-ChannelSubscription:
-  STRUCT:
-    - chain_id:
-        TYPENAME: ChainId
-    - name:
-        TYPENAME: ChannelName
 Committee:
   STRUCT:
     - validators:
@@ -1085,20 +1079,6 @@ SystemMessage:
         NEWTYPE:
           TYPENAME: OpenChainConfig
     3:
-      Subscribe:
-        STRUCT:
-          - id:
-              TYPENAME: ChainId
-          - subscription:
-              TYPENAME: ChannelSubscription
-    4:
-      Unsubscribe:
-        STRUCT:
-          - id:
-              TYPENAME: ChainId
-          - subscription:
-              TYPENAME: ChannelSubscription
-    5:
       ApplicationCreated: UNIT
 SystemOperation:
   ENUM:

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -103,10 +103,6 @@ query Chain(
         description
         epoch
         adminId
-        subscriptions {
-          chainId
-          name
-        }
         ownership
         balance
         timestamp

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -396,11 +396,6 @@ A channel name together with its application ID.
 scalar ChannelFullName
 
 """
-The name of a subscription channel
-"""
-scalar ChannelName
-
-"""
 The state of a channel followed by subscribers.
 """
 type ChannelStateView {
@@ -412,20 +407,6 @@ type ChannelStateView {
 	The block heights so far, to be sent to future subscribers.
 	"""
 	blockHeights: LogView_BlockHeight_e824a938!
-}
-
-"""
-The identifier of a channel, relative to a particular application.
-"""
-type ChannelSubscription {
-	"""
-	The chain ID broadcasting on this channel.
-	"""
-	chainId: ChainId!
-	"""
-	The name of the channel.
-	"""
-	name: ChannelName!
 }
 
 """
@@ -1219,7 +1200,6 @@ type SystemExecutionStateView {
 	description: ChainDescription
 	epoch: Epoch
 	adminId: ChainId
-	subscriptions: [ChannelSubscription!]!
 	committees: JSONObject!
 	ownership: ChainOwnership!
 	balance: Amount!

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -6,7 +6,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, Blob, BlockHeight, OracleResponse, Round, Timestamp},
     identifiers::{
-        Account, AccountOwner, BlobId, ChainDescription, ChainId, ChannelName, Destination,
+        Account, AccountOwner, BlobId, ChainDescription, ChainId, Destination,
         GenericApplicationId, StreamName,
     },
 };


### PR DESCRIPTION
## Motivation

`SystemMessage::Subscribe` and `Unsubscribe` were only used for system channels, which are now gone.

## Proposal

Remove them, and the `subscribers` collection in the system execution state view.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- System channels were removed in https://github.com/linera-io/linera-protocol/pull/3634.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
