### PR TITLE
Simplify block execution code; remove redundant arguments.

### DIFF
--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -282,12 +282,13 @@ where
     creator_state
         .execute_operation(
             operation_context,
-            Timestamp::from(3),
             Operation::User {
                 application_id,
                 bytes: user_operation,
             },
             &mut TransactionTracker::new(
+                Timestamp::from(3),
+                0,
                 0,
                 0,
                 Some(vec![OracleResponse::Blob(application_description_blob_id)]),

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -350,10 +350,17 @@ where
         &self,
         context: MessageContext,
         amount: Amount,
-        account: Account,
         txn_tracker: &mut TransactionTracker,
     ) -> Result<(), ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());
+        if amount.is_zero() {
+            return Ok(());
+        }
+        let Some(account) = context.refund_grant_to else {
+            return Err(ExecutionError::InternalError(
+                "Messages with grants should have a non-empty `refund_grant_to`",
+            ));
+        };
         let message = SystemMessage::Credit {
             amount,
             source: context.authenticated_signer.unwrap_or(AccountOwner::CHAIN),

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -330,6 +330,8 @@ pub enum ExecutionError {
     InactiveChain,
     #[error("No recorded response for oracle query")]
     MissingOracleResponse,
+    #[error("Internal error: {0}")]
+    InternalError(&'static str),
 }
 
 impl From<ViewError> for ExecutionError {

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1483,12 +1483,9 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
 impl ServiceSyncRuntime {
     /// Creates a new [`ServiceSyncRuntime`] ready to execute using a provided [`QueryContext`].
     pub fn new(execution_state_sender: ExecutionStateSender, context: QueryContext) -> Self {
-        Self::new_with_txn_tracker(
-            execution_state_sender,
-            context,
-            None,
-            TransactionTracker::default(),
-        )
+        let mut txn_tracker = TransactionTracker::default();
+        txn_tracker.set_local_time(context.local_time);
+        Self::new_with_txn_tracker(execution_state_sender, context, None, txn_tracker)
     }
 
     /// Creates a new [`ServiceSyncRuntime`] ready to execute using a provided [`QueryContext`].

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -69,8 +69,6 @@ pub struct SyncRuntimeInternal<UserInstance> {
     height: BlockHeight,
     /// The current consensus round. Only available during block validation in multi-leader rounds.
     round: Option<u32>,
-    /// The current local time.
-    local_time: Timestamp,
     /// The authenticated signer of the operation or message, if any.
     #[debug(skip_if = Option::is_none)]
     authenticated_signer: Option<AccountOwner>,
@@ -293,7 +291,6 @@ impl<UserInstance> SyncRuntimeInternal<UserInstance> {
         chain_id: ChainId,
         height: BlockHeight,
         round: Option<u32>,
-        local_time: Timestamp,
         authenticated_signer: Option<AccountOwner>,
         executing_message: Option<ExecutingMessage>,
         execution_state_sender: ExecutionStateSender,
@@ -306,7 +303,6 @@ impl<UserInstance> SyncRuntimeInternal<UserInstance> {
             chain_id,
             height,
             round,
-            local_time,
             authenticated_signer,
             executing_message,
             execution_state_sender,
@@ -478,7 +474,7 @@ impl SyncRuntimeInternal<UserContractInstance> {
         let context = QueryContext {
             chain_id: self.chain_id,
             next_block_height: self.height,
-            local_time: self.local_time,
+            local_time: self.transaction_tracker.local_time(),
         };
         let sender = self.execution_state_sender.clone();
 
@@ -886,11 +882,12 @@ where
             .replay_oracle_response(OracleResponse::Assert)?
         {
             // There are no recorded oracle responses, so we check the local time.
+            let local_time = this.transaction_tracker.local_time();
             ensure!(
-                this.local_time < timestamp,
+                local_time < timestamp,
                 ExecutionError::AssertBefore {
                     timestamp,
-                    local_time: this.local_time,
+                    local_time,
                 }
             );
         }
@@ -955,7 +952,6 @@ impl ContractSyncRuntime {
     pub(crate) fn new(
         execution_state_sender: ExecutionStateSender,
         chain_id: ChainId,
-        local_time: Timestamp,
         refund_grant_to: Option<Account>,
         resource_controller: ResourceController,
         action: &UserAction,
@@ -966,7 +962,6 @@ impl ContractSyncRuntime {
                 chain_id,
                 action.height(),
                 action.round(),
-                local_time,
                 action.signer(),
                 if let UserAction::Message(context, _) = action {
                     Some(context.into())
@@ -1508,7 +1503,6 @@ impl ServiceSyncRuntime {
                 context.chain_id,
                 context.next_block_height,
                 None,
-                context.local_time,
                 None,
                 None,
                 execution_state_sender,
@@ -1579,7 +1573,10 @@ impl ServiceSyncRuntime {
             let execution_state_sender = self.handle_mut().inner().execution_state_sender.clone();
             *self = ServiceSyncRuntime::new(execution_state_sender, new_context);
         } else {
-            self.handle_mut().inner().local_time = new_context.local_time;
+            self.handle_mut()
+                .inner()
+                .transaction_tracker
+                .set_local_time(new_context.local_time);
         }
     }
 
@@ -1623,7 +1620,7 @@ impl ServiceRuntime for ServiceSyncRuntimeHandle {
             let query_context = QueryContext {
                 chain_id: this.chain_id,
                 next_block_height: this.height,
-                local_time: this.local_time,
+                local_time: this.transaction_tracker.local_time(),
             };
             this.push_application(ApplicationStatus {
                 caller_id: None,

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -232,3 +232,28 @@ impl TransactionTracker {
         })
     }
 }
+
+#[cfg(with_testing)]
+impl TransactionTracker {
+    /// Creates a new [`TransactionTracker`] for testing, with default values and the given
+    /// oracle responses.
+    pub fn new_replaying(oracle_responses: Vec<OracleResponse>) -> Self {
+        TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(oracle_responses))
+    }
+
+    /// Creates a new [`TransactionTracker`] for testing, with default values and oracle responses
+    /// for the given blobs.
+    pub fn new_replaying_blobs<T>(blob_ids: T) -> Self
+    where
+        T: IntoIterator,
+        T::Item: std::borrow::Borrow<BlobId>,
+    {
+        use std::borrow::Borrow;
+
+        let oracle_responses = blob_ids
+            .into_iter()
+            .map(|blob_id| OracleResponse::Blob(*blob_id.borrow()))
+            .collect();
+        TransactionTracker::new_replaying(oracle_responses)
+    }
+}

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeMap, vec};
 
 use custom_debug_derive::Debug;
 use linera_base::{
-    data_types::{ArithmeticError, Blob, Event, OracleResponse},
+    data_types::{ArithmeticError, Blob, Event, OracleResponse, Timestamp},
     ensure,
     identifiers::{BlobId, ChainId, ChannelFullName, StreamId},
 };
@@ -22,6 +22,10 @@ pub struct TransactionTracker {
     oracle_responses: Vec<OracleResponse>,
     #[debug(skip_if = Vec::is_empty)]
     outgoing_messages: Vec<OutgoingMessage>,
+    /// The current local time.
+    local_time: Timestamp,
+    /// The index of the current transaction in the block.
+    transaction_index: u32,
     next_message_index: u32,
     next_application_index: u32,
     /// Events recorded by contracts' `emit` calls.
@@ -59,14 +63,18 @@ pub struct TransactionOutcome {
 
 impl TransactionTracker {
     pub fn new(
+        local_time: Timestamp,
+        transaction_index: u32,
         next_message_index: u32,
         next_application_index: u32,
         oracle_responses: Option<Vec<OracleResponse>>,
     ) -> Self {
         TransactionTracker {
-            replaying_oracle_responses: oracle_responses.map(Vec::into_iter),
+            local_time,
+            transaction_index,
             next_message_index,
             next_application_index,
+            replaying_oracle_responses: oracle_responses.map(Vec::into_iter),
             ..Self::default()
         }
     }
@@ -74,6 +82,18 @@ impl TransactionTracker {
     pub fn with_blobs(mut self, blobs: BTreeMap<BlobId, Blob>) -> Self {
         self.blobs = blobs;
         self
+    }
+
+    pub fn local_time(&self) -> Timestamp {
+        self.local_time
+    }
+
+    pub fn set_local_time(&mut self, local_time: Timestamp) {
+        self.local_time = local_time;
+    }
+
+    pub fn transaction_index(&self) -> u32 {
+        self.transaction_index
     }
 
     pub fn next_message_index(&self) -> u32 {
@@ -183,6 +203,8 @@ impl TransactionTracker {
             replaying_oracle_responses,
             oracle_responses,
             outgoing_messages,
+            local_time: _,
+            transaction_index: _,
             next_message_index,
             next_application_index,
             events,

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -180,14 +180,13 @@ fn create_runtime<Application>() -> (
         chain_id,
         BlockHeight(0),
         Some(0),
-        Timestamp::from(0),
         None,
         None,
         execution_state_sender,
         None,
         None,
         resource_controller,
-        TransactionTracker::new(0, 0, Some(Vec::new())),
+        TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(Vec::new())),
     );
 
     (runtime, execution_state_receiver)

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -13,7 +13,7 @@ use std::{
 use futures::{channel::mpsc, StreamExt};
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{BlockHeight, Timestamp},
+    data_types::BlockHeight,
     identifiers::{ApplicationId, ChainDescription},
 };
 use linera_views::batch::Batch;
@@ -186,7 +186,7 @@ fn create_runtime<Application>() -> (
         None,
         None,
         resource_controller,
-        TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(Vec::new())),
+        TransactionTracker::new_replaying(Vec::new()),
     );
 
     (runtime, execution_state_receiver)

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -85,6 +85,8 @@ async fn test_transfer_system_api(
         bytes: vec![],
     };
     let mut tracker = TransactionTracker::new(
+        Timestamp::from(0),
+        0,
         0,
         0,
         Some(vec![
@@ -93,14 +95,8 @@ async fn test_transfer_system_api(
             OracleResponse::Blob(service_blob_id),
         ]),
     );
-    view.execute_operation(
-        context,
-        Timestamp::from(0),
-        operation,
-        &mut tracker,
-        &mut controller,
-    )
-    .await?;
+    view.execute_operation(context, operation, &mut tracker, &mut controller)
+        .await?;
 
     let TransactionOutcome {
         outgoing_messages,
@@ -115,10 +111,9 @@ async fn test_transfer_system_api(
 
     view.execute_message(
         create_dummy_message_context(None),
-        Timestamp::from(0),
         outgoing_messages[0].message.clone(),
         None,
-        &mut TransactionTracker::new(0, 0, Some(Vec::new())),
+        &mut TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(Vec::new())),
         &mut controller,
     )
     .await?;
@@ -182,9 +177,10 @@ async fn test_unauthorized_transfer_system_api(
     let result = view
         .execute_operation(
             context,
-            Timestamp::from(0),
             operation,
             &mut TransactionTracker::new(
+                Timestamp::from(0),
+                0,
                 0,
                 0,
                 Some(vec![
@@ -274,6 +270,8 @@ async fn test_claim_system_api(
         bytes: vec![],
     };
     let mut tracker = TransactionTracker::new(
+        Timestamp::from(0),
+        0,
         0,
         0,
         Some(vec![
@@ -283,13 +281,7 @@ async fn test_claim_system_api(
         ]),
     );
     claimer_view
-        .execute_operation(
-            context,
-            Timestamp::from(0),
-            operation,
-            &mut tracker,
-            &mut controller,
-        )
+        .execute_operation(context, operation, &mut tracker, &mut controller)
         .await?;
 
     let TransactionOutcome {
@@ -303,11 +295,10 @@ async fn test_claim_system_api(
     assert_eq!(next_message_index, 1);
     assert!(matches!(outgoing_messages[0].message, Message::System(_)));
 
-    let mut tracker = TransactionTracker::new(0, 0, Some(Vec::new()));
+    let mut tracker = TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(Vec::new()));
     source_view
         .execute_message(
             create_dummy_message_context(None),
-            Timestamp::from(0),
             outgoing_messages[0].message.clone(),
             None,
             &mut tracker,
@@ -338,7 +329,7 @@ async fn test_claim_system_api(
     assert_eq!(next_message_index, 1);
     assert!(matches!(outgoing_messages[0].message, Message::System(_)));
 
-    let mut tracker = TransactionTracker::new(0, 0, Some(Vec::new()));
+    let mut tracker = TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(Vec::new()));
     let context = MessageContext {
         chain_id: claimer_chain_id,
         ..create_dummy_message_context(None)
@@ -346,7 +337,6 @@ async fn test_claim_system_api(
     claimer_view
         .execute_message(
             context,
-            Timestamp::from(0),
             outgoing_messages[0].message.clone(),
             None,
             &mut tracker,
@@ -427,6 +417,8 @@ async fn test_unauthorized_claims(
         bytes: vec![],
     };
     let mut tracker = TransactionTracker::new(
+        Timestamp::from(0),
+        0,
         0,
         0,
         Some(vec![
@@ -436,13 +428,7 @@ async fn test_unauthorized_claims(
         ]),
     );
     let result = claimer_view
-        .execute_operation(
-            context,
-            Timestamp::from(0),
-            operation,
-            &mut tracker,
-            &mut controller,
-        )
+        .execute_operation(context, operation, &mut tracker, &mut controller)
         .await;
 
     assert_matches!(result, Err(ExecutionError::UnauthenticatedClaimOwner));
@@ -492,9 +478,10 @@ async fn test_read_chain_balance_system_api(chain_balance: Amount) {
 
     view.execute_operation(
         context,
-        Timestamp::from(0),
         operation,
         &mut TransactionTracker::new(
+            Timestamp::from(0),
+            0,
             0,
             0,
             Some(vec![
@@ -543,9 +530,14 @@ async fn test_read_owner_balance_system_api(
 
     view.execute_operation(
         context,
-        Timestamp::from(0),
         operation,
-        &mut TransactionTracker::new(0, 0, Some(blob_oracle_responses(blobs.iter()))),
+        &mut TransactionTracker::new(
+            Timestamp::from(0),
+            0,
+            0,
+            0,
+            Some(blob_oracle_responses(blobs.iter())),
+        ),
         &mut controller,
     )
     .await
@@ -584,9 +576,14 @@ async fn test_read_owner_balance_returns_zero_for_missing_accounts(missing_accou
 
     view.execute_operation(
         context,
-        Timestamp::from(0),
         operation,
-        &mut TransactionTracker::new(0, 0, Some(blob_oracle_responses(blobs.iter()))),
+        &mut TransactionTracker::new(
+            Timestamp::from(0),
+            0,
+            0,
+            0,
+            Some(blob_oracle_responses(blobs.iter())),
+        ),
         &mut controller,
     )
     .await
@@ -628,9 +625,14 @@ async fn test_read_owner_balances_system_api(
 
     view.execute_operation(
         context,
-        Timestamp::from(0),
         operation,
-        &mut TransactionTracker::new(0, 0, Some(blob_oracle_responses(blobs.iter()))),
+        &mut TransactionTracker::new(
+            Timestamp::from(0),
+            0,
+            0,
+            0,
+            Some(blob_oracle_responses(blobs.iter())),
+        ),
         &mut controller,
     )
     .await
@@ -672,9 +674,14 @@ async fn test_read_balance_owners_system_api(
 
     view.execute_operation(
         context,
-        Timestamp::from(0),
         operation,
-        &mut TransactionTracker::new(0, 0, Some(blob_oracle_responses(blobs.iter()))),
+        &mut TransactionTracker::new(
+            Timestamp::from(0),
+            0,
+            0,
+            0,
+            Some(blob_oracle_responses(blobs.iter())),
+        ),
         &mut controller,
     )
     .await
@@ -905,9 +912,10 @@ async fn test_query_service(authorized_apps: Option<Vec<()>>) -> Result<(), Exec
 
     view.execute_operation(
         context,
-        Timestamp::from(0),
         operation,
         &mut TransactionTracker::new(
+            Timestamp::from(0),
+            0,
             0,
             0,
             Some(vec![
@@ -981,9 +989,10 @@ async fn test_perform_http_request(authorized_apps: Option<Vec<()>>) -> Result<(
 
     view.execute_operation(
         context,
-        Timestamp::from(0),
         operation,
         &mut TransactionTracker::new(
+            Timestamp::from(0),
+            0,
             0,
             0,
             Some(vec![

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -13,7 +13,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{
         Amount, ApplicationDescription, ApplicationPermissions, Blob, BlockHeight,
-        CompressedBytecode, OracleResponse, Timestamp,
+        CompressedBytecode, OracleResponse,
     },
     http,
     identifiers::{Account, AccountOwner, ApplicationId, ChainDescription, ChainId, ModuleId},
@@ -22,8 +22,8 @@ use linera_base::{
 };
 use linera_execution::{
     test_utils::{
-        blob_oracle_responses, create_dummy_message_context, create_dummy_operation_context,
-        test_accounts_strategy, ExpectedCall, RegisterMockApplication, SystemExecutionState,
+        create_dummy_message_context, create_dummy_operation_context, test_accounts_strategy,
+        ExpectedCall, RegisterMockApplication, SystemExecutionState,
     },
     BaseRuntime, ContractRuntime, ExecutionError, Message, MessageContext, Operation,
     OperationContext, ResourceController, SystemExecutionStateView, TestExecutionRuntimeContext,
@@ -84,17 +84,11 @@ async fn test_transfer_system_api(
         application_id,
         bytes: vec![],
     };
-    let mut tracker = TransactionTracker::new(
-        Timestamp::from(0),
-        0,
-        0,
-        0,
-        Some(vec![
-            OracleResponse::Blob(app_desc_blob_id),
-            OracleResponse::Blob(contract_blob_id),
-            OracleResponse::Blob(service_blob_id),
-        ]),
-    );
+    let mut tracker = TransactionTracker::new_replaying_blobs([
+        app_desc_blob_id,
+        contract_blob_id,
+        service_blob_id,
+    ]);
     view.execute_operation(context, operation, &mut tracker, &mut controller)
         .await?;
 
@@ -113,7 +107,7 @@ async fn test_transfer_system_api(
         create_dummy_message_context(None),
         outgoing_messages[0].message.clone(),
         None,
-        &mut TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(Vec::new())),
+        &mut TransactionTracker::new_replaying(Vec::new()),
         &mut controller,
     )
     .await?;
@@ -178,17 +172,11 @@ async fn test_unauthorized_transfer_system_api(
         .execute_operation(
             context,
             operation,
-            &mut TransactionTracker::new(
-                Timestamp::from(0),
-                0,
-                0,
-                0,
-                Some(vec![
-                    OracleResponse::Blob(app_desc_blob_id),
-                    OracleResponse::Blob(contract_blob_id),
-                    OracleResponse::Blob(service_blob_id),
-                ]),
-            ),
+            &mut TransactionTracker::new_replaying_blobs([
+                app_desc_blob_id,
+                contract_blob_id,
+                service_blob_id,
+            ]),
             &mut controller,
         )
         .await;
@@ -269,17 +257,11 @@ async fn test_claim_system_api(
         application_id,
         bytes: vec![],
     };
-    let mut tracker = TransactionTracker::new(
-        Timestamp::from(0),
-        0,
-        0,
-        0,
-        Some(vec![
-            OracleResponse::Blob(app_desc_blob_id),
-            OracleResponse::Blob(contract_blob_id),
-            OracleResponse::Blob(service_blob_id),
-        ]),
-    );
+    let mut tracker = TransactionTracker::new_replaying_blobs([
+        app_desc_blob_id,
+        contract_blob_id,
+        service_blob_id,
+    ]);
     claimer_view
         .execute_operation(context, operation, &mut tracker, &mut controller)
         .await?;
@@ -295,7 +277,7 @@ async fn test_claim_system_api(
     assert_eq!(next_message_index, 1);
     assert!(matches!(outgoing_messages[0].message, Message::System(_)));
 
-    let mut tracker = TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(Vec::new()));
+    let mut tracker = TransactionTracker::new_replaying(Vec::new());
     source_view
         .execute_message(
             create_dummy_message_context(None),
@@ -329,7 +311,7 @@ async fn test_claim_system_api(
     assert_eq!(next_message_index, 1);
     assert!(matches!(outgoing_messages[0].message, Message::System(_)));
 
-    let mut tracker = TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(Vec::new()));
+    let mut tracker = TransactionTracker::new_replaying(Vec::new());
     let context = MessageContext {
         chain_id: claimer_chain_id,
         ..create_dummy_message_context(None)
@@ -416,17 +398,11 @@ async fn test_unauthorized_claims(
         application_id,
         bytes: vec![],
     };
-    let mut tracker = TransactionTracker::new(
-        Timestamp::from(0),
-        0,
-        0,
-        0,
-        Some(vec![
-            OracleResponse::Blob(app_desc_blob_id),
-            OracleResponse::Blob(contract_blob_id),
-            OracleResponse::Blob(service_blob_id),
-        ]),
-    );
+    let mut tracker = TransactionTracker::new_replaying_blobs([
+        app_desc_blob_id,
+        contract_blob_id,
+        service_blob_id,
+    ]);
     let result = claimer_view
         .execute_operation(context, operation, &mut tracker, &mut controller)
         .await;
@@ -479,17 +455,11 @@ async fn test_read_chain_balance_system_api(chain_balance: Amount) {
     view.execute_operation(
         context,
         operation,
-        &mut TransactionTracker::new(
-            Timestamp::from(0),
-            0,
-            0,
-            0,
-            Some(vec![
-                OracleResponse::Blob(app_desc_blob_id),
-                OracleResponse::Blob(contract_blob_id),
-                OracleResponse::Blob(service_blob_id),
-            ]),
-        ),
+        &mut TransactionTracker::new_replaying_blobs([
+            app_desc_blob_id,
+            contract_blob_id,
+            service_blob_id,
+        ]),
         &mut controller,
     )
     .await
@@ -531,13 +501,7 @@ async fn test_read_owner_balance_system_api(
     view.execute_operation(
         context,
         operation,
-        &mut TransactionTracker::new(
-            Timestamp::from(0),
-            0,
-            0,
-            0,
-            Some(blob_oracle_responses(blobs.iter())),
-        ),
+        &mut TransactionTracker::new_replaying_blobs(blobs),
         &mut controller,
     )
     .await
@@ -577,13 +541,7 @@ async fn test_read_owner_balance_returns_zero_for_missing_accounts(missing_accou
     view.execute_operation(
         context,
         operation,
-        &mut TransactionTracker::new(
-            Timestamp::from(0),
-            0,
-            0,
-            0,
-            Some(blob_oracle_responses(blobs.iter())),
-        ),
+        &mut TransactionTracker::new_replaying_blobs(blobs),
         &mut controller,
     )
     .await
@@ -626,13 +584,7 @@ async fn test_read_owner_balances_system_api(
     view.execute_operation(
         context,
         operation,
-        &mut TransactionTracker::new(
-            Timestamp::from(0),
-            0,
-            0,
-            0,
-            Some(blob_oracle_responses(blobs.iter())),
-        ),
+        &mut TransactionTracker::new_replaying_blobs(blobs),
         &mut controller,
     )
     .await
@@ -675,13 +627,7 @@ async fn test_read_balance_owners_system_api(
     view.execute_operation(
         context,
         operation,
-        &mut TransactionTracker::new(
-            Timestamp::from(0),
-            0,
-            0,
-            0,
-            Some(blob_oracle_responses(blobs.iter())),
-        ),
+        &mut TransactionTracker::new_replaying_blobs(blobs),
         &mut controller,
     )
     .await
@@ -913,18 +859,12 @@ async fn test_query_service(authorized_apps: Option<Vec<()>>) -> Result<(), Exec
     view.execute_operation(
         context,
         operation,
-        &mut TransactionTracker::new(
-            Timestamp::from(0),
-            0,
-            0,
-            0,
-            Some(vec![
-                OracleResponse::Blob(app_desc_blob_id),
-                OracleResponse::Blob(contract_blob_id),
-                OracleResponse::Blob(service_blob_id),
-                OracleResponse::Service(vec![]),
-            ]),
-        ),
+        &mut TransactionTracker::new_replaying(vec![
+            OracleResponse::Blob(app_desc_blob_id),
+            OracleResponse::Blob(contract_blob_id),
+            OracleResponse::Blob(service_blob_id),
+            OracleResponse::Service(vec![]),
+        ]),
         &mut controller,
     )
     .await?;
@@ -990,18 +930,12 @@ async fn test_perform_http_request(authorized_apps: Option<Vec<()>>) -> Result<(
     view.execute_operation(
         context,
         operation,
-        &mut TransactionTracker::new(
-            Timestamp::from(0),
-            0,
-            0,
-            0,
-            Some(vec![
-                OracleResponse::Blob(app_desc_blob_id),
-                OracleResponse::Blob(contract_blob_id),
-                OracleResponse::Blob(service_blob_id),
-                OracleResponse::Http(http::Response::ok(vec![])),
-            ]),
-        ),
+        &mut TransactionTracker::new_replaying(vec![
+            OracleResponse::Blob(app_desc_blob_id),
+            OracleResponse::Blob(contract_blob_id),
+            OracleResponse::Blob(service_blob_id),
+            OracleResponse::Http(http::Response::ok(vec![])),
+        ]),
         &mut controller,
     )
     .await?;

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -283,10 +283,10 @@ async fn test_fee_consumption(
         message_id: MessageId::default(),
     };
     let mut grant = initial_grant.unwrap_or_default();
-    let mut txn_tracker = TransactionTracker::new(0, 0, Some(oracle_responses));
+    let mut txn_tracker =
+        TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(oracle_responses));
     view.execute_message(
         context,
-        Timestamp::from(0),
         Message::User {
             application_id,
             bytes: vec![],

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -9,7 +9,7 @@ use std::{collections::BTreeSet, sync::Arc, vec};
 
 use linera_base::{
     crypto::{AccountPublicKey, CryptoHash},
-    data_types::{Amount, BlockHeight, OracleResponse, Timestamp},
+    data_types::{Amount, BlockHeight, OracleResponse},
     http,
     identifiers::{Account, AccountOwner, ChainDescription, ChainId, MessageId},
 };
@@ -283,8 +283,7 @@ async fn test_fee_consumption(
         message_id: MessageId::default(),
     };
     let mut grant = initial_grant.unwrap_or_default();
-    let mut txn_tracker =
-        TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(oracle_responses));
+    let mut txn_tracker = TransactionTracker::new_replaying(oracle_responses);
     view.execute_message(
         context,
         Message::User {

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -112,6 +112,8 @@ async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
     };
     for increment in &increments {
         let mut txn_tracker = TransactionTracker::new(
+            Timestamp::from(0),
+            0,
             0,
             0,
             Some(vec![
@@ -129,7 +131,6 @@ async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
         };
         view.execute_operation(
             operation_context,
-            Timestamp::from(0),
             operation,
             &mut txn_tracker,
             &mut controller,

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use alloy_sol_types::{sol, SolCall, SolValue};
 use linera_base::{
     data_types::{Amount, Blob, BlockHeight, Timestamp},
-    identifiers::{ChainDescription, ChainId},
+    identifiers::ChainDescription,
 };
 use linera_execution::{
     revm::{EvmContractModule, EvmServiceModule},
@@ -45,10 +45,11 @@ async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
         description: Some(ChainDescription::Root(0)),
         ..Default::default()
     };
-    let mut view = state
-        .into_view_with(ChainId::root(0), ExecutionRuntimeConfig::default())
-        .await;
     let (app_desc, contract_blob, service_blob) = create_dummy_user_application_description(1);
+    let chain_id = app_desc.creator_chain_id;
+    let mut view = state
+        .into_view_with(chain_id, ExecutionRuntimeConfig::default())
+        .await;
     let app_id = From::from(&app_desc);
     let app_desc_blob_id = Blob::new_application_description(&app_desc).id();
     let contract_blob_id = contract_blob.id();
@@ -79,7 +80,7 @@ async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
     .await?;
 
     let operation_context = OperationContext {
-        chain_id: ChainId::root(0),
+        chain_id,
         height: BlockHeight(0),
         round: Some(0),
         index: Some(0),
@@ -88,7 +89,7 @@ async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
     };
 
     let query_context = QueryContext {
-        chain_id: ChainId::root(0),
+        chain_id,
         next_block_height: BlockHeight(0),
         local_time: Timestamp::from(0),
     };

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use alloy_sol_types::{sol, SolCall, SolValue};
 use linera_base::{
-    data_types::{Amount, Blob, BlockHeight, OracleResponse, Timestamp},
+    data_types::{Amount, Blob, BlockHeight, Timestamp},
     identifiers::{ChainDescription, ChainId},
 };
 use linera_execution::{
@@ -111,17 +111,11 @@ async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
         account: None,
     };
     for increment in &increments {
-        let mut txn_tracker = TransactionTracker::new(
-            Timestamp::from(0),
-            0,
-            0,
-            0,
-            Some(vec![
-                OracleResponse::Blob(app_desc_blob_id),
-                OracleResponse::Blob(contract_blob_id),
-                OracleResponse::Blob(service_blob_id),
-            ]),
-        );
+        let mut txn_tracker = TransactionTracker::new_replaying_blobs([
+            app_desc_blob_id,
+            contract_blob_id,
+            service_blob_id,
+        ]);
         value += increment;
         let operation = incrementCall { input: *increment };
         let bytes = operation.abi_encode();

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -52,12 +52,13 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
     let result = view
         .execute_operation(
             context,
-            Timestamp::from(0),
             Operation::User {
                 application_id: *app_id,
                 bytes: vec![],
             },
             &mut TransactionTracker::new(
+                Timestamp::from(0),
+                0,
                 0,
                 0,
                 Some(vec![
@@ -149,6 +150,8 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
     };
     let mut controller = ResourceController::default();
     let mut txn_tracker = TransactionTracker::new(
+        Timestamp::from(0),
+        0,
         0,
         0,
         Some(blob_oracle_responses(
@@ -157,7 +160,6 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
     );
     view.execute_operation(
         context,
-        Timestamp::from(0),
         Operation::User {
             application_id: caller_id,
             bytes: dummy_operation.clone(),
@@ -299,6 +301,8 @@ async fn test_simulated_session() -> anyhow::Result<()> {
     let context = create_dummy_operation_context();
     let mut controller = ResourceController::default();
     let mut txn_tracker = TransactionTracker::new(
+        Timestamp::from(0),
+        0,
         0,
         0,
         Some(blob_oracle_responses(
@@ -307,7 +311,6 @@ async fn test_simulated_session() -> anyhow::Result<()> {
     );
     view.execute_operation(
         context,
-        Timestamp::from(0),
         Operation::User {
             application_id: caller_id,
             bytes: vec![],
@@ -376,12 +379,13 @@ async fn test_simulated_session_leak() -> anyhow::Result<()> {
     let result = view
         .execute_operation(
             context,
-            Timestamp::from(0),
             Operation::User {
                 application_id: caller_id,
                 bytes: vec![],
             },
             &mut TransactionTracker::new(
+                Timestamp::from(0),
+                0,
                 0,
                 0,
                 Some(blob_oracle_responses(
@@ -420,12 +424,17 @@ async fn test_rejecting_block_from_finalize() -> anyhow::Result<()> {
     let result = view
         .execute_operation(
             context,
-            Timestamp::from(0),
             Operation::User {
                 application_id: id,
                 bytes: vec![],
             },
-            &mut TransactionTracker::new(0, 0, Some(blob_oracle_responses(blobs.iter()))),
+            &mut TransactionTracker::new(
+                Timestamp::from(0),
+                0,
+                0,
+                0,
+                Some(blob_oracle_responses(blobs.iter())),
+            ),
             &mut controller,
         )
         .await;
@@ -484,12 +493,13 @@ async fn test_rejecting_block_from_called_applications_finalize() -> anyhow::Res
     let result = view
         .execute_operation(
             context,
-            Timestamp::from(0),
             Operation::User {
                 application_id: first_id,
                 bytes: vec![],
             },
             &mut TransactionTracker::new(
+                Timestamp::from(0),
+                0,
                 0,
                 0,
                 Some(blob_oracle_responses(
@@ -620,6 +630,8 @@ async fn test_sending_message_from_finalize() -> anyhow::Result<()> {
     let context = create_dummy_operation_context();
     let mut controller = ResourceController::default();
     let mut txn_tracker = TransactionTracker::new(
+        Timestamp::from(0),
+        0,
         0,
         0,
         Some(blob_oracle_responses(
@@ -632,7 +644,6 @@ async fn test_sending_message_from_finalize() -> anyhow::Result<()> {
     );
     view.execute_operation(
         context,
-        Timestamp::from(0),
         Operation::User {
             application_id: first_id,
             bytes: vec![],
@@ -683,12 +694,13 @@ async fn test_cross_application_call_from_finalize() -> anyhow::Result<()> {
     let result = view
         .execute_operation(
             context,
-            Timestamp::from(0),
             Operation::User {
                 application_id: caller_id,
                 bytes: vec![],
             },
             &mut TransactionTracker::new(
+                Timestamp::from(0),
+                0,
                 0,
                 0,
                 Some(blob_oracle_responses(
@@ -744,12 +756,13 @@ async fn test_cross_application_call_from_finalize_of_called_application() -> an
     let result = view
         .execute_operation(
             context,
-            Timestamp::from(0),
             Operation::User {
                 application_id: caller_id,
                 bytes: vec![],
             },
             &mut TransactionTracker::new(
+                Timestamp::from(0),
+                0,
                 0,
                 0,
                 Some(blob_oracle_responses(
@@ -804,12 +817,13 @@ async fn test_calling_application_again_from_finalize() -> anyhow::Result<()> {
     let result = view
         .execute_operation(
             context,
-            Timestamp::from(0),
             Operation::User {
                 application_id: caller_id,
                 bytes: vec![],
             },
             &mut TransactionTracker::new(
+                Timestamp::from(0),
+                0,
                 0,
                 0,
                 Some(blob_oracle_responses(
@@ -862,13 +876,12 @@ async fn test_cross_application_error() -> anyhow::Result<()> {
     assert_matches!(
         view.execute_operation(
             context,
-            Timestamp::from(0),
             Operation::User {
                 application_id: caller_id,
                 bytes: vec![],
             },
             &mut TransactionTracker::new(
-                0, 0, Some(blob_oracle_responses(caller_blobs
+                Timestamp::from(0), 0, 0, 0, Some(blob_oracle_responses(caller_blobs
                     .iter()
                     .chain(target_blobs.iter())))
                 ),
@@ -918,10 +931,15 @@ async fn test_simple_message() -> anyhow::Result<()> {
 
     let context = create_dummy_operation_context();
     let mut controller = ResourceController::default();
-    let mut txn_tracker = TransactionTracker::new(0, 0, Some(blob_oracle_responses(blobs.iter())));
+    let mut txn_tracker = TransactionTracker::new(
+        Timestamp::from(0),
+        0,
+        0,
+        0,
+        Some(blob_oracle_responses(blobs.iter())),
+    );
     view.execute_operation(
         context,
-        Timestamp::from(0),
         Operation::User {
             application_id,
             bytes: vec![],
@@ -990,6 +1008,8 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
     let context = create_dummy_operation_context();
     let mut controller = ResourceController::default();
     let mut txn_tracker = TransactionTracker::new(
+        Timestamp::from(0),
+        0,
         0,
         0,
         Some(blob_oracle_responses(
@@ -998,7 +1018,6 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
     );
     view.execute_operation(
         context,
-        Timestamp::from(0),
         Operation::User {
             application_id: caller_id,
             bytes: vec![],
@@ -1075,6 +1094,8 @@ async fn test_message_from_deeper_call() -> anyhow::Result<()> {
     let context = create_dummy_operation_context();
     let mut controller = ResourceController::default();
     let mut txn_tracker = TransactionTracker::new(
+        Timestamp::from(0),
+        0,
         0,
         0,
         Some(blob_oracle_responses(
@@ -1086,7 +1107,6 @@ async fn test_message_from_deeper_call() -> anyhow::Result<()> {
     );
     view.execute_operation(
         context,
-        Timestamp::from(0),
         Operation::User {
             application_id: caller_id,
             bytes: vec![],
@@ -1192,6 +1212,8 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
     let context = create_dummy_operation_context();
     let mut controller = ResourceController::default();
     let mut txn_tracker = TransactionTracker::new(
+        Timestamp::from(0),
+        0,
         0,
         0,
         Some(blob_oracle_responses(
@@ -1203,7 +1225,6 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
     );
     view.execute_operation(
         context,
-        Timestamp::from(0),
         Operation::User {
             application_id: caller_id,
             bytes: vec![],
@@ -1304,18 +1325,14 @@ async fn test_open_chain() -> anyhow::Result<()> {
         bytes: vec![],
     };
     let mut txn_tracker = TransactionTracker::new(
+        Timestamp::from(0),
+        1,
         first_message_index,
         0,
         Some(blob_oracle_responses(blobs.iter())),
     );
-    view.execute_operation(
-        context,
-        Timestamp::from(0),
-        operation,
-        &mut txn_tracker,
-        &mut controller,
-    )
-    .await?;
+    view.execute_operation(context, operation, &mut txn_tracker, &mut controller)
+        .await?;
 
     assert_eq!(*view.system.balance.get(), Amount::from_tokens(3));
     let txn_outcome = txn_tracker.into_outcome().unwrap();
@@ -1389,9 +1406,14 @@ async fn test_close_chain() -> anyhow::Result<()> {
     };
     view.execute_operation(
         context,
-        Timestamp::from(0),
         operation,
-        &mut TransactionTracker::new(0, 0, Some(blob_oracle_responses(blobs.iter()))),
+        &mut TransactionTracker::new(
+            Timestamp::from(0),
+            0,
+            0,
+            0,
+            Some(blob_oracle_responses(blobs.iter())),
+        ),
         &mut controller,
     )
     .await?;
@@ -1402,9 +1424,8 @@ async fn test_close_chain() -> anyhow::Result<()> {
     let operation = SystemOperation::ChangeApplicationPermissions(permissions);
     view.execute_operation(
         context,
-        Timestamp::from(0),
         operation.into(),
-        &mut TransactionTracker::new(0, 0, Some(Vec::new())),
+        &mut TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(Vec::new())),
         &mut controller,
     )
     .await?;
@@ -1423,9 +1444,8 @@ async fn test_close_chain() -> anyhow::Result<()> {
     };
     view.execute_operation(
         context,
-        Timestamp::from(0),
         operation,
-        &mut TransactionTracker::new(0, 0, Some(Vec::new())),
+        &mut TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(Vec::new())),
         &mut controller,
     )
     .await?;
@@ -1500,12 +1520,17 @@ async fn test_message_receipt_spending_chain_balance(
 
     let context = create_dummy_message_context(authenticated_signer);
     let mut controller = ResourceController::default();
-    let mut txn_tracker = TransactionTracker::new(0, 0, Some(blob_oracle_responses(blobs.iter())));
+    let mut txn_tracker = TransactionTracker::new(
+        Timestamp::from(0),
+        0,
+        0,
+        0,
+        Some(blob_oracle_responses(blobs.iter())),
+    );
 
     let execution_result = view
         .execute_message(
             context,
-            Timestamp::from(0),
             Message::User {
                 application_id,
                 bytes: vec![],

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -43,10 +43,9 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         authenticated_caller_id: None,
     };
     let mut controller = ResourceController::default();
-    let mut txn_tracker = TransactionTracker::new(0, 0, Some(Vec::new()));
+    let mut txn_tracker = TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(Vec::new()));
     view.execute_operation(
         context,
-        Timestamp::from(0),
         Operation::system(operation),
         &mut txn_tracker,
         &mut controller,
@@ -84,10 +83,9 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         refund_grant_to: None,
     };
     let mut controller = ResourceController::default();
-    let mut txn_tracker = TransactionTracker::new(0, 0, Some(Vec::new()));
+    let mut txn_tracker = TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(Vec::new()));
     view.execute_message(
         context,
-        Timestamp::from(0),
         Message::System(message),
         None,
         &mut txn_tracker,

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -43,7 +43,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         authenticated_caller_id: None,
     };
     let mut controller = ResourceController::default();
-    let mut txn_tracker = TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(Vec::new()));
+    let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
     view.execute_operation(
         context,
         Operation::system(operation),
@@ -83,7 +83,7 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         refund_grant_to: None,
     };
     let mut controller = ResourceController::default();
-    let mut txn_tracker = TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(Vec::new()));
+    let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
     view.execute_message(
         context,
         Message::System(message),

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use linera_base::{
-    data_types::{Amount, Blob, BlockHeight, OracleResponse, Timestamp},
+    data_types::{Amount, Blob, BlockHeight, Timestamp},
     identifiers::{ChainDescription, ChainId},
 };
 use linera_execution::{
@@ -90,21 +90,11 @@ async fn test_fuel_for_counter_wasm_application(
     };
 
     for (index, increment) in increments.iter().enumerate() {
-        let mut txn_tracker = TransactionTracker::new(
-            Timestamp::from(0),
-            0,
-            0,
-            0,
-            Some(if index == 0 {
-                vec![
-                    OracleResponse::Blob(app_desc_blob_id),
-                    OracleResponse::Blob(contract_blob_id),
-                    OracleResponse::Blob(service_blob_id),
-                ]
-            } else {
-                vec![]
-            }),
-        );
+        let mut txn_tracker = TransactionTracker::new_replaying_blobs(if index == 0 {
+            vec![app_desc_blob_id, contract_blob_id, service_blob_id]
+        } else {
+            vec![]
+        });
         view.execute_operation(
             context,
             Operation::user_without_abi(app_id, increment).unwrap(),

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -91,6 +91,8 @@ async fn test_fuel_for_counter_wasm_application(
 
     for (index, increment) in increments.iter().enumerate() {
         let mut txn_tracker = TransactionTracker::new(
+            Timestamp::from(0),
+            0,
             0,
             0,
             Some(if index == 0 {
@@ -105,7 +107,6 @@ async fn test_fuel_for_counter_wasm_application(
         );
         view.execute_operation(
             context,
-            Timestamp::from(0),
             Operation::user_without_abi(app_id, increment).unwrap(),
             &mut txn_tracker,
             &mut controller,


### PR DESCRIPTION
## Motivation

There are several methods in the block execution code with too many arguments (according to Clippy), and some with redundant arguments.

## Proposal

Remove the redundant arguments; move more information into the `TransactionTracker`; add `TransactionTracker` test constructors to deduplicate some code.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
