### PR TITLE
Run Docker workflow on toolchain changes.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,7 @@ on:
       - 'docker/**'
       - 'Cargo.toml'
       - '.github/workflows/docker.yml'
+      - 'toolchains/**'
   workflow_dispatch:
 
 # This allows a subsequently queued workflow run to interrupt previous runs on pull-requests


### PR DESCRIPTION
## Motivation

Changes to the Rust toolchain can break the Linera Docker image.

## Proposal

Run the Docker workflow when there is a change to the Rust toolchain.