### PR TITLE
Ignore small bounded values in block size limit.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -751,12 +751,6 @@ where
         resource_controller
             .track_block_size(EMPTY_BLOCK_SIZE)
             .with_execution_context(ChainExecutionContext::Block)?;
-        resource_controller
-            .track_executed_block_size_sequence_extension(0, block.incoming_bundles.len())
-            .with_execution_context(ChainExecutionContext::Block)?;
-        resource_controller
-            .track_executed_block_size_sequence_extension(0, block.operations.len())
-            .with_execution_context(ChainExecutionContext::Block)?;
         for blob in published_blobs {
             let blob_type = blob.content().blob_type();
             if blob_type == BlobType::Data
@@ -900,18 +894,6 @@ where
                         .with_execution_context(chain_execution_context)?;
                 }
             }
-            resource_controller
-                .track_executed_block_size_sequence_extension(oracle_responses.len(), 1)
-                .with_execution_context(chain_execution_context)?;
-            resource_controller
-                .track_executed_block_size_sequence_extension(messages.len(), 1)
-                .with_execution_context(chain_execution_context)?;
-            resource_controller
-                .track_executed_block_size_sequence_extension(events.len(), 1)
-                .with_execution_context(chain_execution_context)?;
-            resource_controller
-                .track_executed_block_size_sequence_extension(blobs.len(), 1)
-                .with_execution_context(chain_execution_context)?;
             oracle_responses.push(txn_outcome.oracle_responses);
             messages.push(txn_outcome.outgoing_messages);
             events.push(txn_outcome.events);
@@ -920,9 +902,6 @@ where
             if let Transaction::ExecuteOperation(_) = transaction {
                 resource_controller
                     .track_block_size_of(&(&txn_outcome.operation_result))
-                    .with_execution_context(chain_execution_context)?;
-                resource_controller
-                    .track_executed_block_size_sequence_extension(operation_results.len(), 1)
                     .with_execution_context(chain_execution_context)?;
                 operation_results.push(OperationResult(txn_outcome.operation_result));
             }

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -189,7 +189,7 @@ async fn test_block_size_limit() {
         .unwrap();
     let block = Block::new(valid_block, outcome);
 
-    // ...because its size is exactly at the allowed limit.
+    // ...because its size is at the allowed limit.
     assert_eq!(
         bcs::serialized_size(&block).unwrap(),
         maximum_executed_block_size as usize

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -384,27 +384,6 @@ impl<Account, Tracker> ResourceController<Account, Tracker>
 where
     Tracker: AsMut<ResourceTracker>,
 {
-    /// Tracks the extension of a sequence in an executed block.
-    ///
-    /// The sequence length is ULEB128-encoded, so extending a sequence can add an additional byte.
-    pub fn track_executed_block_size_sequence_extension(
-        &mut self,
-        old_len: usize,
-        delta: usize,
-    ) -> Result<(), ExecutionError> {
-        if delta == 0 {
-            return Ok(());
-        }
-        let new_len = old_len + delta;
-        // ULEB128 uses one byte per 7 bits of the number. It always uses at least one byte.
-        let old_size = ((usize::BITS - old_len.leading_zeros()) / 7).max(1);
-        let new_size = ((usize::BITS - new_len.leading_zeros()) / 7).max(1);
-        if new_size > old_size {
-            self.track_block_size((new_size - old_size) as usize)?;
-        }
-        Ok(())
-    }
-
     /// Tracks the serialized size of an executed block, or parts of it.
     pub fn track_block_size_of(&mut self, data: &impl Serialize) -> Result<(), ExecutionError> {
         self.track_block_size(bcs::serialized_size(data)?)


### PR DESCRIPTION
## Motivation

The current way of computing the block size during execution is complicated (e.g. due to ULEB128 sequence lengths) and doesn't fully take into account the new block structure anyway: It computes the size of `ExecutedBlock`, not `Block`.

## Proposal

Remove the ULEB128 sequence length size tracking.

## Test Plan

CI

The block size limit test still passes, because the small transaction that is used to push it past the size limit is bigger than the few sequence length bytes we are not taking into account, plus the hashes in the `BlockHeader`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #3652.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
