### PR TITLE
Implement the `EvmQuery` for the EVM contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5008,7 +5008,6 @@ dependencies = [
  "fungible",
  "futures",
  "heck 0.4.1",
- "hex",
  "http 1.2.0",
  "k8s-openapi",
  "kube",

--- a/linera-base/src/vm.rs
+++ b/linera-base/src/vm.rs
@@ -57,11 +57,11 @@ scalar!(VmRuntime);
 #[error("{0:?} is not a valid virtual machine runtime")]
 pub struct InvalidVmRuntime(String);
 
-/// The possible types of queries for an Evm contract
+/// The possible types of queries for an EVM contract
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum EvmQuery {
-    /// The ordinary queries.
+    /// A read-only query.
     Query(Vec<u8>),
-    /// The operation being scheduled.
-    Operation(Vec<u8>),
+    /// A request to schedule an operation that can mutate the application state.
+    Mutation(Vec<u8>),
 }

--- a/linera-base/src/vm.rs
+++ b/linera-base/src/vm.rs
@@ -56,3 +56,12 @@ scalar!(VmRuntime);
 #[derive(Clone, Debug, Error)]
 #[error("{0:?} is not a valid virtual machine runtime")]
 pub struct InvalidVmRuntime(String);
+
+/// The possible types of queries for an Evm contract
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum EvmQuery {
+    /// The ordinary queries.
+    Query(Vec<u8>),
+    /// The operation being scheduled.
+    Operation(Vec<u8>),
+}

--- a/linera-execution/src/revm.rs
+++ b/linera-execution/src/revm.rs
@@ -472,7 +472,6 @@ where
         _context: OperationContext,
         operation: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
-        let operation = bcs::from_bytes::<Vec<u8>>(&operation)?;
         ensure!(
             operation.len() >= 4,
             ExecutionError::EvmError(EvmExecutionError::OperationIsTooShort)
@@ -489,7 +488,6 @@ where
             unreachable!("It is impossible for a Choice::Call to lead to an Output::Create");
         };
         let output = output.as_ref().to_vec();
-        let output = bcs::to_bytes(&output)?;
         Ok(output)
     }
 
@@ -608,7 +606,6 @@ where
             EvmQuery::Query(vec) => vec,
             EvmQuery::Operation(operation) => {
                 let mut runtime = self.db.runtime.lock().expect("The lock should be possible");
-                let operation = bcs::to_bytes(&operation)?;
                 runtime.schedule_operation(operation)?;
                 return Ok(Vec::new());
             }

--- a/linera-execution/src/revm.rs
+++ b/linera-execution/src/revm.rs
@@ -603,9 +603,7 @@ where
         _context: QueryContext,
         argument: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
-        tracing::info!("revm::handle_query, step 1");
         let evm_query: EvmQuery = serde_json::from_slice(&argument)?;
-        tracing::info!("revm::handle_query, step 2");
         let query = match evm_query {
             EvmQuery::Query(vec) => vec,
             EvmQuery::Operation(operation) => {
@@ -615,9 +613,7 @@ where
                 return Ok(Vec::new());
             }
         };
-        tracing::info!("revm::handle_query, step 3");
         let tx_data = Bytes::copy_from_slice(&query);
-        tracing::info!("revm::handle_query, step 4");
         let address = self.db.contract_address;
         let mut evm: Evm<'_, (), _> = Evm::builder()
             .with_ref_db(&mut self.db)

--- a/linera-execution/src/revm.rs
+++ b/linera-execution/src/revm.rs
@@ -601,7 +601,7 @@ where
         _context: QueryContext,
         argument: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
-        let evm_query: EvmQuery = serde_json::from_slice(&argument)?;
+        let evm_query = serde_json::from_slice(&argument)?;
         let query = match evm_query {
             EvmQuery::Query(vec) => vec,
             EvmQuery::Operation(operation) => {

--- a/linera-execution/src/revm.rs
+++ b/linera-execution/src/revm.rs
@@ -604,7 +604,7 @@ where
         let evm_query = serde_json::from_slice(&argument)?;
         let query = match evm_query {
             EvmQuery::Query(vec) => vec,
-            EvmQuery::Operation(operation) => {
+            EvmQuery::Mutation(operation) => {
                 let mut runtime = self.db.runtime.lock().expect("The lock should be possible");
                 runtime.schedule_operation(operation)?;
                 return Ok(Vec::new());

--- a/linera-execution/src/test_utils/solidity.rs
+++ b/linera-execution/src/test_utils/solidity.rs
@@ -122,3 +122,21 @@ pub fn get_contract_service_paths(module: Vec<u8>) -> anyhow::Result<(PathBuf, P
     let evm_service = app_path.to_path_buf();
     Ok((evm_contract, evm_service, dir))
 }
+
+fn value_to_vec_u8(value: Value) -> Vec<u8> {
+    let mut vec: Vec<u8> = Vec::new();
+    for val in value.as_array().unwrap() {
+        let val = val.as_u64().unwrap();
+        let val = val as u8;
+        vec.push(val);
+    }
+    vec
+}
+
+fn read_evm_u64_entry(value: Value) -> anyhow::Result<u64> {
+    let vec = value_to_vec_u8(value);
+    let mut arr = [0_u8; 8];
+    arr.copy_from_slice(&vec[24..]);
+    let counter_value = u64::from_be_bytes(arr);
+    Ok(counter_value)
+}

--- a/linera-execution/src/test_utils/solidity.rs
+++ b/linera-execution/src/test_utils/solidity.rs
@@ -134,10 +134,9 @@ pub fn value_to_vec_u8(value: Value) -> Vec<u8> {
     vec
 }
 
-pub fn read_evm_u64_entry(value: Value) -> anyhow::Result<u64> {
+pub fn read_evm_u64_entry(value: Value) -> u64 {
     let vec = value_to_vec_u8(value);
     let mut arr = [0_u8; 8];
     arr.copy_from_slice(&vec[24..]);
-    let counter_value = u64::from_be_bytes(arr);
-    Ok(counter_value)
+    u64::from_be_bytes(arr)
 }

--- a/linera-execution/src/test_utils/solidity.rs
+++ b/linera-execution/src/test_utils/solidity.rs
@@ -124,7 +124,7 @@ pub fn get_contract_service_paths(module: Vec<u8>) -> anyhow::Result<(PathBuf, P
     Ok((evm_contract, evm_service, dir))
 }
 
-fn value_to_vec_u8(value: Value) -> Vec<u8> {
+pub fn value_to_vec_u8(value: Value) -> Vec<u8> {
     let mut vec: Vec<u8> = Vec::new();
     for val in value.as_array().unwrap() {
         let val = val.as_u64().unwrap();
@@ -134,7 +134,7 @@ fn value_to_vec_u8(value: Value) -> Vec<u8> {
     vec
 }
 
-fn read_evm_u64_entry(value: Value) -> anyhow::Result<u64> {
+pub fn read_evm_u64_entry(value: Value) -> anyhow::Result<u64> {
     let vec = value_to_vec_u8(value);
     let mut arr = [0_u8; 8];
     arr.copy_from_slice(&vec[24..]);

--- a/linera-execution/src/test_utils/solidity.rs
+++ b/linera-execution/src/test_utils/solidity.rs
@@ -6,12 +6,12 @@
 use std::{
     fs::File,
     io::Write,
-    path::Path,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 
 use anyhow::Context;
-use tempfile::tempdir;
+use tempfile::{tempdir, TempDir};
 
 fn write_compilation_json(path: &Path, file_name: &str) -> anyhow::Result<()> {
     let mut source = File::create(path).unwrap();
@@ -84,23 +84,23 @@ pub fn get_bytecode(source_code: &str, contract_name: &str) -> anyhow::Result<Ve
     get_bytecode_path(path, file_name, contract_name)
 }
 
-pub fn get_example_counter() -> anyhow::Result<Vec<u8>> {
+pub fn get_evm_example_counter() -> anyhow::Result<Vec<u8>> {
     let source_code = r#"
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 contract ExampleCounter {
-  uint256 value;
-  constructor(uint256 start_value) {
+  uint64 value;
+  constructor(uint64 start_value) {
     value = start_value;
   }
 
-  function increment(uint256 input) external returns (uint256) {
+  function increment(uint64 input) external returns (uint64) {
     value = value + input;
     return value;
   }
 
-  function get_value() external view returns (uint256) {
+  function get_value() external view returns (uint64) {
     return value;
   }
 
@@ -108,4 +108,17 @@ contract ExampleCounter {
 "#
     .to_string();
     get_bytecode(&source_code, "ExampleCounter")
+}
+
+pub fn get_contract_service_paths(module: Vec<u8>) -> anyhow::Result<(PathBuf, PathBuf, TempDir)> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path();
+    let app_file = "app.json";
+    let app_path = path.join(app_file);
+    {
+        std::fs::write(app_path.clone(), &module)?;
+    }
+    let evm_contract = app_path.to_path_buf();
+    let evm_service = app_path.to_path_buf();
+    Ok((evm_contract, evm_service, dir))
 }

--- a/linera-execution/src/test_utils/solidity.rs
+++ b/linera-execution/src/test_utils/solidity.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use anyhow::Context;
+use serde_json::Value;
 use tempfile::{tempdir, TempDir};
 
 fn write_compilation_json(path: &Path, file_name: &str) -> anyhow::Result<()> {

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -115,8 +115,7 @@ async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
         ]);
         value += increment;
         let operation = incrementCall { input: *increment };
-        let operation = operation.abi_encode();
-        let bytes = bcs::to_bytes(&operation)?;
+        let bytes = operation.abi_encode();
         let operation = Operation::User {
             application_id: app_id,
             bytes,

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -23,7 +23,6 @@ use linera_execution::{
     TransactionTracker,
 };
 use linera_views::{context::Context as _, views::View};
-use serde_json::Value;
 
 #[tokio::test]
 async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -144,7 +144,7 @@ async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
             anyhow::bail!("Wrong QueryResponse result");
         };
         let result: serde_json::Value = serde_json::from_slice(&result).unwrap();
-        let result = read_evm_u64_entry(result)?;
+        let result = read_evm_u64_entry(result);
         assert_eq!(result, value);
     }
     Ok(())

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -14,7 +14,8 @@ use linera_base::{
 use linera_execution::{
     revm::{EvmContractModule, EvmServiceModule},
     test_utils::{
-        create_dummy_user_application_description, solidity::{get_evm_example_counter, read_evm_u64_entry},
+        create_dummy_user_application_description,
+        solidity::{get_evm_example_counter, read_evm_u64_entry},
         SystemExecutionState,
     },
     ExecutionRuntimeConfig, ExecutionRuntimeContext, Operation, OperationContext, Query,

--- a/linera-sdk/src/abis/evm.rs
+++ b/linera-sdk/src/abis/evm.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! An ABI for applications that implement an EVM runtime.
-use linera_base::abi::{ContractAbi, ServiceAbi};
+use linera_base::{
+    abi::{ContractAbi, ServiceAbi},
+    vm::EvmQuery,
+};
 
 /// An ABI for applications that implement an EVM runtime.
 pub struct EvmAbi;
@@ -29,6 +32,6 @@ impl ContractAbi for EvmAbi {
 }
 
 impl ServiceAbi for EvmAbi {
-    type Query = Vec<u8>;
+    type Query = EvmQuery;
     type QueryResponse = Vec<u8>;
 }

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -96,7 +96,6 @@ fs-err = { workspace = true, features = ["tokio"] }
 fs_extra = { workspace = true, optional = true }
 futures.workspace = true
 heck.workspace = true
-hex.workspace = true
 http.workspace = true
 k8s-openapi = { workspace = true, optional = true }
 kube = { workspace = true, optional = true }

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -397,16 +397,16 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
     let query = EvmQuery::Query(query);
     let result = application.run_json_query(query.clone()).await?;
 
-    let counter_value = read_evm_u64_entry(result)?;
+    let counter_value = read_evm_u64_entry(result);
     assert_eq!(counter_value, original_counter_value);
 
     let mutation = incrementCall { input: increment };
     let mutation = mutation.abi_encode();
-    let mutation = EvmQuery::Operation(mutation);
+    let mutation = EvmQuery::Mutation(mutation);
     application.run_json_query(mutation).await?;
 
     let result = application.run_json_query(query).await?;
-    let counter_value = read_evm_u64_entry(result)?;
+    let counter_value = read_evm_u64_entry(result);
     assert_eq!(counter_value, original_counter_value + increment);
 
     net.ensure_is_running().await?;

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -397,7 +397,6 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
     let query = EvmQuery::Query(query);
     let result = application.run_json_query(query.clone()).await?;
 
-
     let counter_value = read_evm_u64_entry(result)?;
     assert_eq!(counter_value, original_counter_value);
 

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -331,24 +331,6 @@ impl AmmApp {
     }
 }
 
-fn value_to_vec_u8(value: Value) -> Vec<u8> {
-    let mut vec: Vec<u8> = Vec::new();
-    for val in value.as_array().unwrap() {
-        let val = val.as_u64().unwrap();
-        let val = val as u8;
-        vec.push(val);
-    }
-    vec
-}
-
-fn read_evm_u64_entry(value: Value) -> Result<u64> {
-    let vec = value_to_vec_u8(value);
-    let mut arr = [0_u8; 8];
-    arr.copy_from_slice(&vec[24..]);
-    let counter_value = u64::from_be_bytes(arr);
-    Ok(counter_value)
-}
-
 #[cfg(with_revm)]
 #[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
@@ -360,7 +342,7 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
     use alloy_sol_types::{sol, SolCall, SolValue};
     use linera_base::vm::EvmQuery;
     use linera_execution::test_utils::solidity::{
-        get_contract_service_paths, get_evm_example_counter,
+        get_contract_service_paths, get_evm_example_counter, read_evm_u64_entry,
     };
     use linera_sdk::abis::evm::EvmAbi;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;


### PR DESCRIPTION
## Motivation

We use a hacky system for the processing of the query in `handle_query` of REVM. We want to streamline the
mechanism.

## Proposal

The code is adapted from a separate branch that implements the calls `EVM->{EVM,Wasm}` and `Wasm->EVM`
and the changes reflect that.

The following is done:
* The `EvmQuery` is introduced as a type for the input of queries, which reflects what it is.
* The `EvmQuery` is introduced in `linera-base` instead of `linera-execution` since this would force a dependency on `linera-execution` for `linera-sdk`.
* The tests `test_fuel_for_counter_revm_application` and `test_evm_end_to_end_counter` are simplified accordingly.
* The Query type of `EvmAbi` is changed to `EvmQuery`.

## Test Plan

No tests are added, CI suffices.

## Release Plan

Normal release schedule.

## Links

None.