### PR TITLE
Improve the developer experience of the `linera-sdk` and the solidity compiler.

### DIFF
--- a/linera-execution/src/test_utils/solidity.rs
+++ b/linera-execution/src/test_utils/solidity.rs
@@ -59,7 +59,7 @@ fn get_bytecode_path(path: &Path, file_name: &str, contract_name: &str) -> anyho
     let json_data: serde_json::Value = serde_json::from_str(&contents)?;
     let contracts = json_data
         .get("contracts")
-        .context("failed to get contracts")?;
+        .with_context(|| format!("failed to get contracts in json_data={}", json_data))?;
     let file_name_contract = contracts
         .get(file_name)
         .context("failed to get {file_name}")?;

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -48,7 +48,7 @@ macro_rules! contract {
                     unsafe { &mut CONTRACT },
                     move |contract| {
                         let argument = $crate::serde_json::from_slice(&argument)
-                            .expect("Failed to deserialize instantiation argument");
+                            .unwrap_or_else(|_| panic!("Failed to deserialize instantiation argument {argument:?}"));
 
                         contract.instantiate(argument).blocking_wait()
                     },
@@ -62,7 +62,7 @@ macro_rules! contract {
                     move |contract| {
                         let operation: <$contract as $crate::abi::ContractAbi>::Operation =
                             $crate::bcs::from_bytes(&operation)
-                                .expect("Failed to deserialize operation");
+                            .unwrap_or_else(|_| panic!("Failed to deserialize operation {operation:?}"));
 
                         let response = contract.execute_operation(operation).blocking_wait();
 


### PR DESCRIPTION
## Motivation

There are a few ways to improve the developer experience of apps on Linera.

## Proposal

The following is done:
* Add the printing of the `Vec<u8>` that cannot be deserialized in `execute_operation` and `instantiate`. This is done in the same way as for `handle_query`.
* Print the actual compilation error in `get_bytecode_path` if it fails.

In both cases, the error message is built only if something goes wrong.

## Test Plan

The CI.

## Release Plan

Normal release schedule.

## Links

None.