### PR TITLE
Change the way that `UserApplicationId` is computed for `ApplicationDescription` of EVM smart contracts.

### DIFF
--- a/linera-base/src/crypto/hash.rs
+++ b/linera-base/src/crypto/hash.rs
@@ -46,6 +46,13 @@ impl CryptoHash {
         &self.0
     }
 
+    /// set the hash as the one from EVM by setting the last 12 bytes to zero.
+    pub fn set_as_evm(&mut self) {
+        for index in 20..32 {
+            self.0 .0[index] = 0;
+        }
+    }
+
     /// Returns the hash of `TestString(s)`, for testing purposes.
     #[cfg(with_testing)]
     pub fn test_hash(s: impl Into<String>) -> Self {

--- a/linera-base/src/crypto/hash.rs
+++ b/linera-base/src/crypto/hash.rs
@@ -46,11 +46,9 @@ impl CryptoHash {
         &self.0
     }
 
-    /// set the hash as the one from EVM by setting the last 12 bytes to zero.
-    pub fn set_as_evm(&mut self) {
-        for index in 20..32 {
-            self.0 .0[index] = 0;
-        }
+    /// Force the last 12 bytes of the hash to be zeroes. This is currently used for EVM compatibility
+    pub fn make_evm_compatible(&mut self) {
+        self.0[20..32].fill(0);
     }
 
     /// Returns the hash of `TestString(s)`, for testing purposes.

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -848,7 +848,7 @@ impl From<&ApplicationDescription> for ApplicationId {
     fn from(description: &ApplicationDescription) -> Self {
         let mut hash = CryptoHash::new(&BlobContent::new_application_description(description));
         if matches!(description.module_id.vm_runtime, VmRuntime::Evm) {
-            hash.set_as_evm();
+            hash.make_evm_compatible();
         }
         ApplicationId::new(hash)
     }
@@ -1084,7 +1084,7 @@ impl Blob {
             let application_description = bcs::from_bytes::<ApplicationDescription>(&content.bytes)
                 .expect("to obtain an application description");
             if matches!(application_description.module_id.vm_runtime, VmRuntime::Evm) {
-                hash.set_as_evm();
+                hash.make_evm_compatible();
             }
         }
         Blob { hash, content }

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -39,6 +39,7 @@ use crate::{
     },
     limited_writer::{LimitedWriter, LimitedWriterError},
     time::{Duration, SystemTime},
+    vm::VmRuntime,
 };
 
 /// A non-negative amount of tokens.
@@ -845,9 +846,11 @@ pub struct ApplicationDescription {
 
 impl From<&ApplicationDescription> for ApplicationId {
     fn from(description: &ApplicationDescription) -> Self {
-        ApplicationId::new(CryptoHash::new(&BlobContent::new_application_description(
-            description,
-        )))
+        let mut hash = CryptoHash::new(&BlobContent::new_application_description(description));
+        if matches!(description.module_id.vm_runtime, VmRuntime::Evm) {
+            hash.set_as_evm();
+        }
+        ApplicationId::new(hash)
     }
 }
 
@@ -1076,7 +1079,14 @@ pub struct Blob {
 impl Blob {
     /// Computes the hash and returns the hashed blob for the given content.
     pub fn new(content: BlobContent) -> Self {
-        let hash = CryptoHash::new(&content);
+        let mut hash = CryptoHash::new(&content);
+        if matches!(content.blob_type, BlobType::ApplicationDescription) {
+            let application_description = bcs::from_bytes::<ApplicationDescription>(&content.bytes)
+                .expect("to obtain an application description");
+            if matches!(application_description.module_id.vm_runtime, VmRuntime::Evm) {
+                hash.set_as_evm();
+            }
+        }
         Blob { hash, content }
     }
 


### PR DESCRIPTION
## Motivation

EVM applications should have a hash that is of length 20. We can achieve that by setting the last 12 bytes to 0.

## Proposal

The changes are done to the computation in the hash in the `data_types.rs`. It requires matching the `ApplicationDescription` for the blob type.
In that case, we need to deserialize the description in order to obtain the module_id and whether they are EVM or not.

It has to be done in two places.

## Test Plan

The CI should be doing the adequate test.

## Release Plan

Normal testing release.

## Links

None.