### PR TITLE
Add max blocking threads option to client/server/proxy

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -161,6 +161,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
   Default value: `1000`
 * `--wasm-runtime <WASM_RUNTIME>` — The WebAssembly runtime to use
 * `--tokio-threads <TOKIO_THREADS>` — The number of Tokio worker threads to use
+* `--tokio-blocking-threads <TOKIO_BLOCKING_THREADS>` — The number of Tokio blocking threads to use
 
 
 

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1320,6 +1320,10 @@ struct ClientOptions {
     #[arg(long, env = "LINERA_CLIENT_TOKIO_THREADS")]
     tokio_threads: Option<usize>,
 
+    /// The number of Tokio blocking threads to use.
+    #[arg(long, env = "LINERA_CLIENT_TOKIO_BLOCKING_THREADS")]
+    tokio_blocking_threads: Option<usize>,
+
     /// Subcommand.
     #[command(subcommand)]
     command: ClientCommand,
@@ -1571,6 +1575,10 @@ fn main() -> anyhow::Result<()> {
 
         builder
     };
+
+    if let Some(blocking_threads) = options.tokio_blocking_threads {
+        runtime.max_blocking_threads(blocking_threads);
+    }
 
     let span = tracing::info_span!("linera::main");
     if let Some(wallet_id) = &options.inner.with_wallet {

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -64,6 +64,10 @@ pub struct ProxyOptions {
     #[arg(long, env = "LINERA_PROXY_TOKIO_THREADS")]
     tokio_threads: Option<usize>,
 
+    /// The number of Tokio blocking threads to use.
+    #[arg(long, env = "LINERA_PROXY_TOKIO_BLOCKING_THREADS")]
+    tokio_blocking_threads: Option<usize>,
+
     /// Storage configuration for the blockchain history, chain states and binary blobs.
     #[arg(long = "storage")]
     storage_config: StorageConfigNamespace,
@@ -385,6 +389,10 @@ fn main() -> Result<()> {
 
         builder
     };
+
+    if let Some(blocking_threads) = options.tokio_blocking_threads {
+        runtime.max_blocking_threads(blocking_threads);
+    }
 
     runtime.enable_all().build()?.block_on(options.run())
 }

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -249,6 +249,10 @@ struct ServerOptions {
     /// The number of Tokio worker threads to use.
     #[arg(long, env = "LINERA_SERVER_TOKIO_THREADS")]
     tokio_threads: Option<usize>,
+
+    /// The number of Tokio blocking threads to use.
+    #[arg(long, env = "LINERA_SERVER_TOKIO_BLOCKING_THREADS")]
+    tokio_blocking_threads: Option<usize>,
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize)]
@@ -475,6 +479,10 @@ fn main() {
 
         builder
     };
+
+    if let Some(blocking_threads) = options.tokio_blocking_threads {
+        runtime.max_blocking_threads(blocking_threads);
+    }
 
     runtime
         .enable_all()


### PR DESCRIPTION
## Motivation

The default limit is 512 blocking threads I believe. We might want more for benchmarks.

## Proposal

Add option to alter that number

## Test Plan

CI + tested with benchmarks

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
