### PR TITLE
Instead of a key, use an incrementing `index` for events.

### DIFF
--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -40,11 +40,8 @@ impl Contract for MetaCounterContract {
         // Send a no-op message to ourselves. This is only for testing contracts that send messages
         // on initialization. Since the value is 0 it does not change the counter value.
         let this_chain = self.runtime.chain_id();
-        self.runtime.emit(
-            StreamName(b"announcements".to_vec()),
-            b"updates",
-            b"instantiated",
-        );
+        self.runtime
+            .emit(StreamName(b"announcements".to_vec()), 0, b"instantiated");
         self.runtime.send_message(this_chain, Message::Increment(0));
     }
 

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -41,7 +41,7 @@ impl Contract for MetaCounterContract {
         // on initialization. Since the value is 0 it does not change the counter value.
         let this_chain = self.runtime.chain_id();
         self.runtime
-            .emit(StreamName(b"announcements".to_vec()), 0, b"instantiated");
+            .emit(StreamName(b"announcements".to_vec()), b"instantiated");
         self.runtime.send_message(this_chain, Message::Increment(0));
     }
 

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1188,10 +1188,8 @@ impl BcsHashable<'_> for Blob {}
 pub struct Event {
     /// The ID of the stream this event belongs to.
     pub stream_id: StreamId,
-    /// The event key.
-    #[debug(with = "hex_debug")]
-    #[serde(with = "serde_bytes")]
-    pub key: Vec<u8>,
+    /// The event index, i.e. the number of events in the stream before this one.
+    pub index: u32,
     /// The payload data.
     #[debug(with = "hex_debug")]
     #[serde(with = "serde_bytes")]
@@ -1204,7 +1202,7 @@ impl Event {
         EventId {
             chain_id,
             stream_id: self.stream_id.clone(),
-            key: self.key.clone(),
+            index: self.index,
         }
     }
 }

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -523,8 +523,8 @@ pub struct EventId {
     pub chain_id: ChainId,
     /// The ID of the stream this event belongs to.
     pub stream_id: StreamId,
-    /// The event key.
-    pub key: Vec<u8>,
+    /// The event index, i.e. the number of events in the stream before this one.
+    pub index: u32,
 }
 
 /// The destination of a message, relative to a particular application.

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -349,7 +349,7 @@ where
                 application_id: application_id2.forget_abi().into(),
                 stream_name: StreamName(b"announcements".to_vec()),
             },
-            key: b"updates".to_vec(),
+            index: 0,
             value: b"instantiated".to_vec(),
         }]]
     );

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2450,7 +2450,7 @@ where
     let event_id = EventId {
         chain_id: admin_id,
         stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
-        key: bcs::to_bytes(&Epoch::from(1)).unwrap(),
+        index: 1,
     };
     let committee_blob = Blob::new(BlobContent::new_committee(bcs::to_bytes(&committee)?));
     // `PublishCommitteeBlob` is tested e.g. in `client_tests::test_change_voting_rights`, so we
@@ -2470,7 +2470,7 @@ where
                 events: vec![
                     vec![Event {
                         stream_id: event_id.stream_id.clone(),
-                        key: event_id.key.clone(),
+                        index: event_id.index,
                         value: bcs::to_bytes(&blob_hash).unwrap(),
                     }],
                     Vec::new(),
@@ -2560,7 +2560,7 @@ where
                             EventId {
                                 chain_id: admin_id,
                                 stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
-                                key: bcs::to_bytes(&Epoch::from(1)).unwrap(),
+                                index: 1,
                             },
                             bcs::to_bytes(&blob_hash).unwrap(),
                         ),
@@ -2698,7 +2698,7 @@ where
                 previous_message_blocks: BTreeMap::new(),
                 events: vec![vec![Event {
                     stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
-                    key: bcs::to_bytes(&Epoch::from(1)).unwrap(),
+                    index: 1,
                     value: bcs::to_bytes(&committee_blob.id().hash).unwrap(),
                 }]],
                 blobs: vec![Vec::new()],
@@ -2837,13 +2837,13 @@ where
                 events: vec![
                     vec![Event {
                         stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
-                        key: bcs::to_bytes(&Epoch::from(1)).unwrap(),
+                        index: 1,
                         value: bcs::to_bytes(&committee_blob.id().hash).unwrap(),
                     }],
                     vec![Event {
-                        value: Vec::new(),
                         stream_id: StreamId::system(REMOVED_EPOCH_STREAM_NAME),
-                        key: bcs::to_bytes(&Epoch::from(0)).unwrap(),
+                        index: 0,
+                        value: Vec::new(),
                     }],
                 ],
                 blobs: vec![Vec::new(); 2],

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -19,7 +19,7 @@ use linera_base::{
     },
     doc_scalar,
     hashed::Hashed,
-    identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, EventId},
+    identifiers::{AccountOwner, ApplicationId, BlobId, ChainId},
     time::timer::{sleep, timeout},
 };
 use linera_chain::{
@@ -210,8 +210,6 @@ pub enum WorkerError {
     BlobsNotFound(Vec<BlobId>),
     #[error("The block proposal is invalid: {0}")]
     InvalidBlockProposal(String),
-    #[error("Trying to overwrite an event: {0:?}")]
-    OverwritingEvent(Box<EventId>),
     #[error("The worker is too busy to handle new chains")]
     FullChainWorkerCache,
     #[error("Failed to join spawned worker task")]

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -6,11 +6,12 @@ use std::{mem, vec};
 use futures::{FutureExt, StreamExt};
 use linera_base::{
     data_types::{Amount, BlockHeight},
-    identifiers::{Account, AccountOwner, BlobType, Destination},
+    identifiers::{Account, AccountOwner, BlobType, Destination, StreamId},
 };
 use linera_views::{
     context::Context,
     key_value_store_view::KeyValueStoreView,
+    map_view::MapView,
     reentrant_collection_view::HashedReentrantCollectionView,
     views::{ClonableView, View},
 };
@@ -41,6 +42,8 @@ pub struct ExecutionStateView<C> {
     pub system: SystemExecutionStateView<C>,
     /// User applications.
     pub users: HashedReentrantCollectionView<C, ApplicationId, KeyValueStoreView<C>>,
+    /// The number of events in the streams that this chain is writing to.
+    pub stream_event_counts: MapView<C, StreamId, u32>,
 }
 
 /// How to interact with a long-lived service runtime.

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -15,7 +15,9 @@ use linera_base::prometheus_util::{
     exponential_bucket_latencies, register_histogram_vec, MeasureLatency as _,
 };
 use linera_base::{
-    data_types::{Amount, ApplicationPermissions, BlobContent, BlockHeight, Timestamp},
+    data_types::{
+        Amount, ApplicationPermissions, ArithmeticError, BlobContent, BlockHeight, Timestamp,
+    },
     ensure, hex_debug, hex_vec_debug, http,
     identifiers::{Account, AccountOwner, BlobId, BlobType, ChainId, MessageId, StreamId},
     ownership::ChainOwnership,
@@ -442,7 +444,7 @@ where
                     .get_mut_or_default(&stream_id)
                     .await?;
                 let index = *count;
-                *count += 1;
+                *count = count.checked_add(1).ok_or(ArithmeticError::Overflow)?;
                 callback.respond(index)
             }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -77,8 +77,6 @@ pub use crate::{
     transaction_tracker::{TransactionOutcome, TransactionTracker},
 };
 
-/// The maximum length of an event key in bytes.
-const MAX_EVENT_KEY_LEN: usize = 64;
 /// The maximum length of a stream name.
 const MAX_STREAM_NAME_LEN: usize = 64;
 
@@ -262,8 +260,6 @@ pub enum ExecutionError {
         local_time: Timestamp,
     },
 
-    #[error("Event keys can be at most {MAX_EVENT_KEY_LEN} bytes.")]
-    EventKeyTooLong,
     #[error("Stream names can be at most {MAX_STREAM_NAME_LEN} bytes.")]
     StreamNameTooLong,
     #[error("Blob exceeds size limit")]
@@ -733,12 +729,7 @@ pub trait ContractRuntime: BaseRuntime {
     ) -> Result<Vec<u8>, ExecutionError>;
 
     /// Adds a new item to an event stream.
-    fn emit(
-        &mut self,
-        name: StreamName,
-        key: Vec<u8>,
-        value: Vec<u8>,
-    ) -> Result<(), ExecutionError>;
+    fn emit(&mut self, name: StreamName, index: u32, value: Vec<u8>) -> Result<(), ExecutionError>;
 
     /// Queries a service.
     fn query_service(

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -728,7 +728,7 @@ pub trait ContractRuntime: BaseRuntime {
         argument: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError>;
 
-    /// Adds a new item to an event stream.
+    /// Adds a new item to an event stream. Returns the new event's index in the stream.
     fn emit(&mut self, name: StreamName, value: Vec<u8>) -> Result<u32, ExecutionError>;
 
     /// Queries a service.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -729,7 +729,7 @@ pub trait ContractRuntime: BaseRuntime {
     ) -> Result<Vec<u8>, ExecutionError>;
 
     /// Adds a new item to an event stream.
-    fn emit(&mut self, name: StreamName, index: u32, value: Vec<u8>) -> Result<(), ExecutionError>;
+    fn emit(&mut self, name: StreamName, value: Vec<u8>) -> Result<u32, ExecutionError>;
 
     /// Queries a service.
     fn query_service(

--- a/linera-execution/src/revm.rs
+++ b/linera-execution/src/revm.rs
@@ -569,12 +569,9 @@ where
             let mut runtime = self.db.runtime.lock().expect("The lock should be possible");
             let stream_name = bcs::to_bytes("ethereum_event")?;
             let stream_name = StreamName(stream_name);
-            for (log, index) in logs.iter().enumerate() {
-                let mut key = bcs::to_bytes(&contract_address)?;
-                bcs::serialize_into(&mut key, origin)?;
-                bcs::serialize_into(&mut key, index)?;
-                let value = bcs::to_bytes(&log)?;
-                runtime.emit(stream_name.clone(), key, value)?;
+            for (index, log) in logs.iter().enumerate() {
+                let value = bcs::to_bytes(&(origin, contract_address, log))?;
+                runtime.emit(stream_name.clone(), index as u32, value)?;
             }
         }
         Ok(())

--- a/linera-execution/src/revm.rs
+++ b/linera-execution/src/revm.rs
@@ -569,9 +569,9 @@ where
             let mut runtime = self.db.runtime.lock().expect("The lock should be possible");
             let stream_name = bcs::to_bytes("ethereum_event")?;
             let stream_name = StreamName(stream_name);
-            for (index, log) in logs.iter().enumerate() {
+            for log in &logs {
                 let value = bcs::to_bytes(&(origin, contract_address, log))?;
-                runtime.emit(stream_name.clone(), index as u32, value)?;
+                runtime.emit(stream_name.clone(), value)?;
             }
         }
         Ok(())

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -36,7 +36,7 @@ use crate::{
     FinalizeContext, Message, MessageContext, MessageKind, ModuleId, Operation, OperationContext,
     OutgoingMessage, QueryContext, QueryOutcome, ServiceRuntime, TransactionTracker,
     UserContractCode, UserContractInstance, UserServiceCode, UserServiceInstance,
-    MAX_EVENT_KEY_LEN, MAX_STREAM_NAME_LEN,
+    MAX_STREAM_NAME_LEN,
 };
 
 #[cfg(test)]
@@ -1287,14 +1287,10 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
     fn emit(
         &mut self,
         stream_name: StreamName,
-        key: Vec<u8>,
+        index: u32,
         value: Vec<u8>,
     ) -> Result<(), ExecutionError> {
         let mut this = self.inner();
-        ensure!(
-            key.len() <= MAX_EVENT_KEY_LEN,
-            ExecutionError::EventKeyTooLong
-        );
         ensure!(
             stream_name.0.len() <= MAX_STREAM_NAME_LEN,
             ExecutionError::StreamNameTooLong
@@ -1304,7 +1300,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             stream_name,
             application_id,
         };
-        this.transaction_tracker.add_event(stream_id, key, value);
+        this.transaction_tracker.add_event(stream_id, index, value);
         Ok(())
     }
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -389,7 +389,7 @@ where
                         self.epoch.set(Some(epoch));
                         txn_tracker.add_event(
                             StreamId::system(EPOCH_STREAM_NAME),
-                            bcs::to_bytes(&epoch)?,
+                            epoch.0,
                             bcs::to_bytes(&blob_hash)?,
                         );
                     }
@@ -400,7 +400,7 @@ where
                         );
                         txn_tracker.add_event(
                             StreamId::system(REMOVED_EPOCH_STREAM_NAME),
-                            bcs::to_bytes(&epoch)?,
+                            epoch.0,
                             vec![],
                         );
                     }
@@ -461,7 +461,7 @@ where
                 let event_id = EventId {
                     chain_id: admin_id,
                     stream_id: StreamId::system(EPOCH_STREAM_NAME),
-                    key: bcs::to_bytes(&epoch)?,
+                    index: epoch.0,
                 };
                 let bytes = match txn_tracker.next_replayed_oracle_response()? {
                     None => self.context().extra().get_event(event_id.clone()).await?,
@@ -491,7 +491,7 @@ where
                 let event_id = EventId {
                     chain_id: admin_id,
                     stream_id: StreamId::system(REMOVED_EPOCH_STREAM_NAME),
-                    key: bcs::to_bytes(&epoch)?,
+                    index: epoch.0,
                 };
                 let bytes = match txn_tracker.next_replayed_oracle_response()? {
                     None => self.context().extra().get_event(event_id.clone()).await?,

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -128,10 +128,10 @@ impl TransactionTracker {
         Ok(())
     }
 
-    pub fn add_event(&mut self, stream_id: StreamId, key: Vec<u8>, value: Vec<u8>) {
+    pub fn add_event(&mut self, stream_id: StreamId, index: u32, value: Vec<u8>) {
         self.events.push(Event {
             stream_id,
-            key,
+            index,
             value,
         });
     }

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -576,13 +576,13 @@ where
     fn emit(
         caller: &mut Caller,
         name: StreamName,
-        key: Vec<u8>,
+        index: u32,
         value: Vec<u8>,
     ) -> Result<(), RuntimeError> {
         caller
             .user_data_mut()
             .runtime
-            .emit(name, key, value)
+            .emit(name, index, value)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -573,16 +573,11 @@ where
     }
 
     /// Adds an item to an event stream.
-    fn emit(
-        caller: &mut Caller,
-        name: StreamName,
-        index: u32,
-        value: Vec<u8>,
-    ) -> Result<(), RuntimeError> {
+    fn emit(caller: &mut Caller, name: StreamName, value: Vec<u8>) -> Result<u32, RuntimeError> {
         caller
             .user_data_mut()
             .runtime
-            .emit(name, index, value)
+            .emit(name, value)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -572,7 +572,7 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
-    /// Adds an item to an event stream.
+    /// Adds a new item to an event stream. Returns the new event's index in the stream.
     fn emit(caller: &mut Caller, name: StreamName, value: Vec<u8>) -> Result<u32, RuntimeError> {
         caller
             .user_data_mut()

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -467,7 +467,7 @@ Event:
   STRUCT:
     - stream_id:
         TYPENAME: StreamId
-    - key: BYTES
+    - index: U32
     - value: BYTES
 EventId:
   STRUCT:
@@ -475,8 +475,7 @@ EventId:
         TYPENAME: ChainId
     - stream_id:
         TYPENAME: StreamId
-    - key:
-        SEQ: U8
+    - index: U32
 GenericApplicationId:
   ENUM:
     0:

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -276,8 +276,8 @@ where
     }
 
     /// Adds a new item to an event stream.
-    pub fn emit(&mut self, name: StreamName, key: &[u8], value: &[u8]) {
-        contract_wit::emit(&name.into(), key, value);
+    pub fn emit(&mut self, name: StreamName, index: u32, value: &[u8]) {
+        contract_wit::emit(&name.into(), index, value);
     }
 
     /// Queries an application service as an oracle and returns the response.

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -276,8 +276,8 @@ where
     }
 
     /// Adds a new item to an event stream.
-    pub fn emit(&mut self, name: StreamName, index: u32, value: &[u8]) {
-        contract_wit::emit(&name.into(), index, value);
+    pub fn emit(&mut self, name: StreamName, value: &[u8]) -> u32 {
+        contract_wit::emit(&name.into(), value)
     }
 
     /// Queries an application service as an oracle and returns the response.

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -275,7 +275,7 @@ where
             .expect("Failed to deserialize `Response` type from cross-application call")
     }
 
-    /// Adds a new item to an event stream.
+    /// Adds a new item to an event stream. Returns the new event's index in the stream.
     pub fn emit(&mut self, name: StreamName, value: &[u8]) -> u32 {
         contract_wit::emit(&name.into(), value)
     }

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -809,7 +809,7 @@ where
             .expect("Failed to deserialize `Response` type from cross-application call")
     }
 
-    /// Adds a new item to an event stream.
+    /// Adds a new item to an event stream. Returns the new event's index in the stream.
     pub fn emit(&mut self, name: StreamName, value: &[u8]) -> u32 {
         let entry = self.events.entry(name).or_default();
         entry.push(value.to_vec());

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -4,7 +4,7 @@
 //! Runtime types to simulate interfacing with the host executing the contract.
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, VecDeque},
     sync::{Arc, Mutex, MutexGuard},
 };
 
@@ -60,7 +60,7 @@ where
     subscribe_requests: Vec<(ChainId, ChannelName)>,
     unsubscribe_requests: Vec<(ChainId, ChannelName)>,
     outgoing_transfers: HashMap<Account, Amount>,
-    events: Vec<(StreamName, Vec<u8>, Vec<u8>)>,
+    events: BTreeMap<StreamName, Vec<Vec<u8>>>,
     claim_requests: Vec<ClaimRequest>,
     expected_service_queries: VecDeque<(ApplicationId, String, String)>,
     expected_http_requests: VecDeque<(http::Request, http::Response)>,
@@ -109,7 +109,7 @@ where
             subscribe_requests: Vec::new(),
             unsubscribe_requests: Vec::new(),
             outgoing_transfers: HashMap::new(),
-            events: Vec::new(),
+            events: BTreeMap::new(),
             claim_requests: Vec::new(),
             expected_service_queries: VecDeque::new(),
             expected_http_requests: VecDeque::new(),
@@ -810,8 +810,10 @@ where
     }
 
     /// Adds a new item to an event stream.
-    pub fn emit(&mut self, name: StreamName, key: &[u8], value: &[u8]) {
-        self.events.push((name, key.to_vec(), value.to_vec()));
+    pub fn emit(&mut self, name: StreamName, value: &[u8]) -> u32 {
+        let entry = self.events.entry(name).or_default();
+        entry.push(value.to_vec());
+        entry.len() as u32 - 1
     }
 
     /// Adds an expected `query_service` call`, and the response it should return in the test.

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -15,7 +15,7 @@ interface contract-runtime-api {
     change-application-permissions: func(application-permissions: application-permissions) -> result<tuple<>, change-application-permissions-error>;
     create-application: func(module-id: module-id, parameters: list<u8>, argument: list<u8>, required-application-ids: list<application-id>) -> application-id;
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
-    emit: func(name: stream-name, key: list<u8>, value: list<u8>);
+    emit: func(name: stream-name, index: u32, value: list<u8>);
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     consume-fuel: func(fuel: u64);
     validation-round: func() -> option<u32>;

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -15,7 +15,7 @@ interface contract-runtime-api {
     change-application-permissions: func(application-permissions: application-permissions) -> result<tuple<>, change-application-permissions-error>;
     create-application: func(module-id: module-id, parameters: list<u8>, argument: list<u8>, required-application-ids: list<application-id>) -> application-id;
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
-    emit: func(name: stream-name, index: u32, value: list<u8>);
+    emit: func(name: stream-name, value: list<u8>) -> u32;
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     consume-fuel: func(fuel: u64);
     validation-round: func() -> option<u32>;

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -282,7 +282,7 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
               applicationId
               streamName
             }
-            key
+            index
             value
           }
           blobs
@@ -351,7 +351,7 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
               applicationId
               streamName
             }
-            key
+            index
             value
           }
           blobs

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -533,9 +533,9 @@ type Event {
 	"""
 	streamId: StreamId!
 	"""
-	The event key.
+	The event index, i.e. the number of events in the stream before this one.
 	"""
-	key: [Int!]!
+	index: Int!
 	"""
 	The payload data.
 	"""

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -314,7 +314,7 @@ mod from {
         fn from(event: block::BlockBlockValueBlockBodyEvents) -> Self {
             Event {
                 stream_id: event.stream_id.into(),
-                key: event.key.into_iter().map(|byte| byte as u8).collect(),
+                index: event.index as u32,
                 value: event.value.into_iter().map(|byte| byte as u8).collect(),
             }
         }


### PR DESCRIPTION
## Motivation

The system needs to enforce that events are never overwritten anyway. It makes them much harder to use for applications if the applications need to keep track of that.

## Proposal

Replace the general `key: Vec<u8>` with `index: u32`. Instead of the application, the system now chooses the index, and always uses the next available number.

## Test Plan

The tests have been updated, and already use system events.

The user application events will be tested more thoroughly later, when we have an example (probably `social`) that uses them.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
