### PR TITLE
Separate block execution proper from updating outboxes etc.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -946,10 +946,12 @@ where
         #[cfg(with_metrics)]
         Self::track_block_metrics(&resource_controller.tracker);
 
-        assert_eq!(
-            messages.len(),
-            block.incoming_bundles.len() + block.operations.len()
-        );
+        let txn_count = block.incoming_bundles.len() + block.operations.len();
+        assert_eq!(oracle_responses.len(), txn_count);
+        assert_eq!(messages.len(), txn_count);
+        assert_eq!(events.len(), txn_count);
+        assert_eq!(blobs.len(), txn_count);
+
         let outcome = BlockExecutionOutcome {
             messages,
             previous_message_blocks,

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -371,7 +371,7 @@ where
         let verified_outcome = self
             .state
             .chain
-            .execute_block(block, local_time, None, &published_blobs, oracle_responses)
+            .execute_and_apply_block(block, local_time, None, &published_blobs, oracle_responses)
             .await?;
         // We should always agree on the messages and state hash.
         ensure!(

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -128,14 +128,15 @@ where
         let local_time = self.0.storage.clock().current_time();
         let signer = block.authenticated_signer;
 
-        let executed_block =
-            Box::pin(
-                self.0
-                    .chain
-                    .execute_block(&block, local_time, round, published_blobs, None),
-            )
-            .await?
-            .with(block);
+        let executed_block = Box::pin(self.0.chain.execute_and_apply_block(
+            &block,
+            local_time,
+            round,
+            published_blobs,
+            None,
+        ))
+        .await?
+        .with(block);
 
         let mut response = ChainInfoResponse::new(&self.0.chain, None);
         if let Some(signer) = signer {
@@ -221,7 +222,7 @@ where
         let outcome = if let Some(outcome) = outcome {
             outcome.clone()
         } else {
-            Box::pin(chain.execute_block(
+            Box::pin(chain.execute_and_apply_block(
                 block,
                 local_time,
                 round.multi_leader(),

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -517,12 +517,13 @@ impl ActiveChain {
 
     /// Returns whether this chain has been closed.
     pub async fn is_closed(&self) -> bool {
-        self.validator
+        let chain = self
+            .validator
             .worker()
             .chain_state_view(self.id())
             .await
-            .expect("Failed to load chain")
-            .is_closed()
+            .expect("Failed to load chain");
+        *chain.execution_state.system.closed.get()
     }
 
     /// Executes a `query` on an `application`'s state on this microchain.


### PR DESCRIPTION
## Motivation

In the future we want to cache execution outcomes, i.e. the `ExecutionStateView` associated with a particular state hash, but not the rest of `ChainStateView`.

## Proposal

Separate the first part of block execution, where `ExecutionStateView` is updated, from the rest, where the state hash, outboxes and other parts of the `ChainStateView` are modified.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- 
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
