### PR TITLE
Introduce the `{de}serialize_{operation,response}` to the ContractAbi.

### DIFF
--- a/linera-base/src/abi.rs
+++ b/linera-base/src/abi.rs
@@ -29,6 +29,30 @@ pub trait ContractAbi {
 
     /// The response type of an application call.
     type Response: Serialize + DeserializeOwned + Send + Sync + Debug + 'static;
+
+    /// How the `Operation` is deserialized
+    fn deserialize_operation(operation: Vec<u8>) -> Result<Self::Operation, String> {
+        bcs::from_bytes(&operation)
+            .map_err(|e| format!("BCS deserialization error {e:?} for operation {operation:?}"))
+    }
+
+    /// How the `Operation` is serialized
+    fn serialize_operation(operation: &Self::Operation) -> Result<Vec<u8>, String> {
+        bcs::to_bytes(operation)
+            .map_err(|e| format!("BCS serialization error {e:?} for operation {operation:?}"))
+    }
+
+    /// How the `Response` is deserialized
+    fn deserialize_response(response: Vec<u8>) -> Result<Self::Response, String> {
+        bcs::from_bytes(&response)
+            .map_err(|e| format!("BCS deserialization error {e:?} for response {response:?}"))
+    }
+
+    /// How the `Response` is serialized
+    fn serialize_response(response: Self::Response) -> Result<Vec<u8>, String> {
+        bcs::to_bytes(&response)
+            .map_err(|e| format!("BCS serialization error {e:?} for response {response:?}"))
+    }
 }
 // ANCHOR_END: contract_abi
 

--- a/linera-sdk/src/abis/evm.rs
+++ b/linera-sdk/src/abis/evm.rs
@@ -10,6 +10,22 @@ pub struct EvmAbi;
 impl ContractAbi for EvmAbi {
     type Operation = Vec<u8>;
     type Response = Vec<u8>;
+
+    fn deserialize_operation(operation: Vec<u8>) -> Result<Self::Operation, String> {
+        Ok(operation)
+    }
+
+    fn serialize_operation(operation: &Self::Operation) -> Result<Vec<u8>, String> {
+        Ok(operation.to_vec())
+    }
+
+    fn deserialize_response(response: Vec<u8>) -> Result<Self::Response, String> {
+        Ok(response)
+    }
+
+    fn serialize_response(response: Self::Response) -> Result<Vec<u8>, String> {
+        Ok(response)
+    }
 }
 
 impl ServiceAbi for EvmAbi {

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -60,14 +60,11 @@ macro_rules! contract {
                 $crate::contract::run_async_entrypoint::<$contract, _, _>(
                     unsafe { &mut CONTRACT },
                     move |contract| {
-                        let operation: <$contract as $crate::abi::ContractAbi>::Operation =
-                            $crate::bcs::from_bytes(&operation)
-                            .unwrap_or_else(|_| panic!("Failed to deserialize operation {operation:?}"));
+                        let operation = <$contract as $crate::abi::ContractAbi>::deserialize_operation(operation).unwrap();
 
                         let response = contract.execute_operation(operation).blocking_wait();
 
-                        $crate::bcs::to_bytes(&response)
-                            .expect("Failed to serialize contract's `Response`")
+                        <$contract as $crate::abi::ContractAbi>::serialize_response(response).unwrap()
                     },
                 )
             }

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -60,11 +60,13 @@ macro_rules! contract {
                 $crate::contract::run_async_entrypoint::<$contract, _, _>(
                     unsafe { &mut CONTRACT },
                     move |contract| {
-                        let operation = <$contract as $crate::abi::ContractAbi>::deserialize_operation(operation).unwrap();
+                        let operation = <$contract as $crate::abi::ContractAbi>::deserialize_operation(operation)
+                            .expect("Failed to deserialize `Operation` in execute_operation");
 
                         let response = contract.execute_operation(operation).blocking_wait();
 
-                        <$contract as $crate::abi::ContractAbi>::serialize_response(response).unwrap()
+                        <$contract as $crate::abi::ContractAbi>::serialize_response(response)
+                            .expect("Failed to serialize `Response` in execute_operation")
                     },
                 )
             }

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -262,8 +262,7 @@ where
         application: ApplicationId<A>,
         call: &A::Operation,
     ) -> A::Response {
-        let call_bytes = bcs::to_bytes(call)
-            .expect("Failed to serialize `Operation` type for a cross-application call");
+        let call_bytes = A::serialize_operation(call).unwrap();
 
         let response_bytes = contract_wit::try_call_application(
             authenticated,
@@ -271,8 +270,7 @@ where
             &call_bytes,
         );
 
-        bcs::from_bytes(&response_bytes)
-            .expect("Failed to deserialize `Response` type from cross-application call")
+        A::deserialize_response(response_bytes).unwrap()
     }
 
     /// Adds a new item to an event stream. Returns the new event's index in the stream.

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -262,7 +262,8 @@ where
         application: ApplicationId<A>,
         call: &A::Operation,
     ) -> A::Response {
-        let call_bytes = A::serialize_operation(call).unwrap();
+        let call_bytes = A::serialize_operation(call)
+            .expect("Failed to serialize `Operation` in cross-application call");
 
         let response_bytes = contract_wit::try_call_application(
             authenticated,
@@ -270,7 +271,8 @@ where
             &call_bytes,
         );
 
-        A::deserialize_response(response_bytes).unwrap()
+        A::deserialize_response(response_bytes)
+            .expect("Failed to deserialize `Response` in cross-application call")
     }
 
     /// Adds a new item to an event stream. Returns the new event's index in the stream.

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -796,7 +796,8 @@ where
         application: ApplicationId<A>,
         call: &A::Operation,
     ) -> A::Response {
-        let call_bytes = A::serialize_operation(call).unwrap();
+        let call_bytes = A::serialize_operation(call)
+            .expect("Failed to serialize `Operation` in test runtime cross-application call");
 
         let handler = self.call_application_handler.as_mut().expect(
             "Handler for `call_application` has not been mocked, \
@@ -804,7 +805,8 @@ where
         );
         let response_bytes = handler(authenticated, application.forget_abi(), call_bytes);
 
-        A::deserialize_response(response_bytes).unwrap()
+        A::deserialize_response(response_bytes)
+            .expect("Failed to deserialize `Response` in test runtime cross-application call")
     }
 
     /// Adds a new item to an event stream. Returns the new event's index in the stream.

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -796,8 +796,7 @@ where
         application: ApplicationId<A>,
         call: &A::Operation,
     ) -> A::Response {
-        let call_bytes = bcs::to_bytes(call)
-            .expect("Failed to serialize `Operation` type for a cross-application call");
+        let call_bytes = A::serialize_operation(call).unwrap();
 
         let handler = self.call_application_handler.as_mut().expect(
             "Handler for `call_application` has not been mocked, \
@@ -805,8 +804,7 @@ where
         );
         let response_bytes = handler(authenticated, application.forget_abi(), call_bytes);
 
-        bcs::from_bytes(&response_bytes)
-            .expect("Failed to deserialize `Response` type from cross-application call")
+        A::deserialize_response(response_bytes).unwrap()
     }
 
     /// Adds a new item to an event stream. Returns the new event's index in the stream.

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -143,7 +143,8 @@ impl BlockBuilder {
     where
         Abi: ContractAbi,
     {
-        let operation = Abi::serialize_operation(&operation).unwrap();
+        let operation = Abi::serialize_operation(&operation)
+            .expect("Failed to serialize `Operation` in BlockBuilder");
         self.with_raw_operation(application_id.forget_abi(), operation)
     }
 

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -26,7 +26,6 @@ use linera_execution::{
 };
 
 use super::TestValidator;
-use crate::ToBcsBytes;
 
 /// A helper type to build a block proposal using the builder pattern, and then signing them into
 /// [`ConfirmedBlockCertificate`]s using a [`TestValidator`].
@@ -144,12 +143,8 @@ impl BlockBuilder {
     where
         Abi: ContractAbi,
     {
-        self.with_raw_operation(
-            application_id.forget_abi(),
-            operation
-                .to_bcs_bytes()
-                .expect("Failed to serialize operation"),
-        )
+        let operation = Abi::serialize_operation(&operation).unwrap();
+        self.with_raw_operation(application_id.forget_abi(), operation)
     }
 
     /// Adds an already serialized user `operation` to this block.


### PR DESCRIPTION
## Motivation

The EVM apps do not have a type associated with them, instead, the `Operation` / `Response` are `Vec<u8>`.
Using BCS for them is not adequate as it leads to some serialization followed by deserialization situations which
are suboptimal.

## Proposal

The following is done:
* The `{de}serialization_{operation,response}` is introduced in the `ContractAbi`.
* They use strings as error types. Using `bcs::Error` is not the point. And `anyhow::Error` is for tests and binaries.
* There is a standard implementation in the trait, which is overloaded in the `EvmAbi`.
* The use of BCS serialization is removed in the place of the code where it was and replaced by the introduced functions. They `unwrap()` as the use case of those functions always panics in case of errors.
* Whenever a serialization error occurs, the error and the input are printed in the error message.

## Test Plan

The CI.

## Release Plan

Normal release plan.

## Links

None