### PR TITLE
Do not drop notifiers silently if the query may succeed

### DIFF
--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -299,6 +299,12 @@ where
         }
         if tip.next_block_height > height {
             // Block was already confirmed.
+            if let Some(notifier) = notify_when_messages_are_delivered {
+                // Nothing to wait for.
+                if let Err(()) = notifier.send(()) {
+                    warn!("Failed to notify message delivery to caller");
+                }
+            }
             let info = ChainInfoResponse::new(&self.state.chain, self.state.config.key_pair());
             let actions = self.state.create_network_actions().await?;
             return Ok((info, actions));

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -808,7 +808,15 @@ where
                 self.handle_confirmed_certificate(confirmed, notify_when_messages_are_delivered)
                     .await
             }
-            Either::Right(validated) => self.handle_validated_certificate(validated).await,
+            Either::Right(validated) => {
+                if let Some(notifier) = notify_when_messages_are_delivered {
+                    // Nothing to wait for.
+                    if let Err(()) = notifier.send(()) {
+                        warn!("Failed to notify message delivery to caller");
+                    }
+                }
+                self.handle_validated_certificate(validated).await
+            }
         }
     }
 


### PR DESCRIPTION
## Motivation

Resolve suspicious `ERROR`s in logs

## Proposal

* Do not drop notifiers silently if the query may succeed
* The error is still useful and should never happen.

## Test Plan

Run tests locally => no more errors

## Release Plan

- These changes should be backported to the latest `testnet` branch