### PR TITLE
Implement the end-to-end test that calls an EVM smart contract.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,6 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "alloy-sol-types",
- "futures",
  "linera-sdk",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,6 +1747,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "call-evm-counter"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "alloy-sol-types",
+ "futures",
+ "linera-sdk",
+ "serde",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4989,6 +5000,7 @@ dependencies = [
  "async-tungstenite",
  "axum",
  "base64 0.22.1",
+ "call-evm-counter",
  "cargo_toml",
  "cfg_aliases",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,6 +251,7 @@ linera-witty-macros = { version = "0.14.0", path = "./linera-witty-macros" }
 
 amm = { path = "./examples/amm" }
 counter = { path = "./examples/counter" }
+call-evm-counter = { path = "./examples/call-evm-counter" }
 counter-no-graphql = { path = "./examples/counter-no-graphql" }
 crowd-funding = { path = "./examples/crowd-funding" }
 ethereum-tracker = { path = "./examples/ethereum-tracker" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,8 +250,8 @@ linera-witty = { version = "0.14.0", path = "./linera-witty" }
 linera-witty-macros = { version = "0.14.0", path = "./linera-witty-macros" }
 
 amm = { path = "./examples/amm" }
-counter = { path = "./examples/counter" }
 call-evm-counter = { path = "./examples/call-evm-counter" }
+counter = { path = "./examples/counter" }
 counter-no-graphql = { path = "./examples/counter-no-graphql" }
 crowd-funding = { path = "./examples/crowd-funding" }
 ethereum-tracker = { path = "./examples/ethereum-tracker" }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1291,7 +1291,6 @@ dependencies = [
  "alloy",
  "alloy-sol-types",
  "assert_matches",
- "futures",
  "linera-sdk",
  "serde",
  "tokio",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
+ "k256",
  "serde",
 ]
 
@@ -984,6 +985,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "aurora-engine-modexp"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
+dependencies = [
+ "hex",
+ "num",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1162,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -1160,6 +1174,7 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
+ "serde",
  "tap",
  "wyz",
 ]
@@ -1267,6 +1282,19 @@ dependencies = [
  "libc",
  "once_cell",
  "serde",
+]
+
+[[package]]
+name = "call-evm-counter"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "alloy-sol-types",
+ "assert_matches",
+ "futures",
+ "linera-sdk",
+ "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -2117,6 +2145,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3355,6 +3394,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128"
@@ -3500,6 +3542,8 @@ dependencies = [
 name = "linera-execution"
 version = "0.14.0"
 dependencies = [
+ "alloy",
+ "alloy-sol-types",
  "anyhow",
  "async-graphql",
  "async-trait",
@@ -3512,6 +3556,7 @@ dependencies = [
  "derive_more",
  "dyn-clone",
  "futures",
+ "hex",
  "linera-base",
  "linera-views",
  "linera-views-derive",
@@ -3524,9 +3569,12 @@ dependencies = [
  "prometheus",
  "proptest",
  "reqwest 0.11.27",
+ "revm",
+ "revm-primitives",
  "serde",
  "serde_bytes",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.65",
  "tokio",
  "tracing",
@@ -4153,6 +4201,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4184,6 +4246,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -5006,6 +5090,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm"
+version = "19.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c175ecec83bba464aa8406502fe5bf670491c2ace81a153264891d43bc7fa332"
+dependencies = [
+ "auto_impl",
+ "cfg-if",
+ "dyn-clone",
+ "revm-interpreter",
+ "revm-precompile",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "15.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcab7ef2064057acfc84731205f4bc77f4ec1b35630800b26ff6a185731c5ab"
+dependencies = [
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "16.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99743c3a2cac341084cc15ac74286c4bf34a0941ebf60aa420cfdb9f81f72f9f"
+dependencies = [
+ "aurora-engine-modexp",
+ "blst",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "once_cell",
+ "revm-primitives",
+ "ripemd",
+ "secp256k1",
+ "sha2",
+ "substrate-bn",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "15.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f987564210317706def498421dfba2ae1af64a8edce82c6102758b48133fcb"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives",
+ "auto_impl",
+ "bitflags 2.6.0",
+ "bitvec",
+ "c-kzg",
+ "cfg-if",
+ "dyn-clone",
+ "enumn",
+ "hex",
+ "serde",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5039,6 +5187,15 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5292,6 +5449,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "rand",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "self_cell"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5386,6 +5562,7 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
+ "indexmap 2.5.0",
  "itoa",
  "memchr",
  "ryu",
@@ -5728,6 +5905,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.95",
+]
+
+[[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand",
+ "rustc-hex",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -197,7 +197,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
- "k256",
  "serde",
 ]
 
@@ -985,16 +984,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "aurora-engine-modexp"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
-dependencies = [
- "hex",
- "num",
-]
-
-[[package]]
 name = "auto_impl"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,9 +1151,6 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitvec"
@@ -1174,7 +1160,6 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
- "serde",
  "tap",
  "wyz",
 ]
@@ -2144,17 +2129,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "enumn"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.95",
 ]
 
 [[package]]
@@ -3393,9 +3367,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128"
@@ -3541,8 +3512,6 @@ dependencies = [
 name = "linera-execution"
 version = "0.14.0"
 dependencies = [
- "alloy",
- "alloy-sol-types",
  "anyhow",
  "async-graphql",
  "async-trait",
@@ -3555,7 +3524,6 @@ dependencies = [
  "derive_more",
  "dyn-clone",
  "futures",
- "hex",
  "linera-base",
  "linera-views",
  "linera-views-derive",
@@ -3568,12 +3536,9 @@ dependencies = [
  "prometheus",
  "proptest",
  "reqwest 0.11.27",
- "revm",
- "revm-primitives",
  "serde",
  "serde_bytes",
  "serde_json",
- "tempfile",
  "thiserror 1.0.65",
  "tokio",
  "tracing",
@@ -4200,20 +4165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4245,28 +4196,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
@@ -5089,70 +5018,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "revm"
-version = "19.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c175ecec83bba464aa8406502fe5bf670491c2ace81a153264891d43bc7fa332"
-dependencies = [
- "auto_impl",
- "cfg-if",
- "dyn-clone",
- "revm-interpreter",
- "revm-precompile",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "revm-interpreter"
-version = "15.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcab7ef2064057acfc84731205f4bc77f4ec1b35630800b26ff6a185731c5ab"
-dependencies = [
- "revm-primitives",
- "serde",
-]
-
-[[package]]
-name = "revm-precompile"
-version = "16.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99743c3a2cac341084cc15ac74286c4bf34a0941ebf60aa420cfdb9f81f72f9f"
-dependencies = [
- "aurora-engine-modexp",
- "blst",
- "c-kzg",
- "cfg-if",
- "k256",
- "once_cell",
- "revm-primitives",
- "ripemd",
- "secp256k1",
- "sha2",
- "substrate-bn",
-]
-
-[[package]]
-name = "revm-primitives"
-version = "15.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f987564210317706def498421dfba2ae1af64a8edce82c6102758b48133fcb"
-dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-primitives",
- "auto_impl",
- "bitflags 2.6.0",
- "bitvec",
- "c-kzg",
- "cfg-if",
- "dyn-clone",
- "enumn",
- "hex",
- "serde",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5186,15 +5051,6 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "ripemd"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
-dependencies = [
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -5448,25 +5304,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
-dependencies = [
- "rand",
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "self_cell"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5561,7 +5398,6 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
- "indexmap 2.5.0",
  "itoa",
  "memchr",
  "ryu",
@@ -5904,19 +5740,6 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.95",
-]
-
-[[package]]
-name = "substrate-bn"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
-dependencies = [
- "byteorder",
- "crunchy",
- "lazy_static",
- "rand",
- "rustc-hex",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "amm",
     "counter",
+    "call-evm-counter",
     "counter-no-graphql",
     "crowd-funding",
     "ethereum-tracker",
@@ -21,6 +22,7 @@ members = [
 
 [workspace.dependencies]
 alloy = { version = "0.9.2", default-features = false }
+alloy-sol-types = "0.8.18"
 anyhow = "1.0.80"
 assert_matches = "1.5.0"
 async-graphql = { version = "=7.0.2", default-features = false }

--- a/examples/call-evm-counter/Cargo.toml
+++ b/examples/call-evm-counter/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "call-evm-counter"
+version = "0.1.0"
+authors = ["Linera <contact@linera.io>"]
+edition = "2021"
+
+[dependencies]
+alloy = { workspace = true, default-features = false, features = [ "rpc-types-eth" ] }
+alloy-sol-types.workspace = true
+futures.workspace = true
+linera-sdk = { workspace = true, features = [ "revm" ] }
+serde.workspace = true
+
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+linera-sdk = { workspace = true, features = ["test", "wasmer"] }
+tokio = { workspace = true, features = ["rt", "sync"] }
+
+[dev-dependencies]
+assert_matches.workspace = true
+linera-sdk = { workspace = true, features = ["test"] }
+
+[[bin]]
+name = "call_evm_counter_contract"
+path = "src/contract.rs"
+
+[[bin]]
+name = "call_evm_counter_service"
+path = "src/service.rs"

--- a/examples/call-evm-counter/Cargo.toml
+++ b/examples/call-evm-counter/Cargo.toml
@@ -9,7 +9,7 @@ alloy = { workspace = true, default-features = false, features = [
     "rpc-types-eth",
 ] }
 alloy-sol-types.workspace = true
-linera-sdk = { workspace = true, features = ["revm"] }
+linera-sdk.workspace = true
 serde.workspace = true
 
 

--- a/examples/call-evm-counter/Cargo.toml
+++ b/examples/call-evm-counter/Cargo.toml
@@ -5,9 +5,11 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dependencies]
-alloy = { workspace = true, default-features = false, features = [ "rpc-types-eth" ] }
+alloy = { workspace = true, default-features = false, features = [
+    "rpc-types-eth",
+] }
 alloy-sol-types.workspace = true
-linera-sdk = { workspace = true, features = [ "revm" ] }
+linera-sdk = { workspace = true, features = ["revm"] }
 serde.workspace = true
 
 

--- a/examples/call-evm-counter/Cargo.toml
+++ b/examples/call-evm-counter/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [dependencies]
 alloy = { workspace = true, default-features = false, features = [ "rpc-types-eth" ] }
 alloy-sol-types.workspace = true
-futures.workspace = true
 linera-sdk = { workspace = true, features = [ "revm" ] }
 serde.workspace = true
 

--- a/examples/call-evm-counter/src/contract.rs
+++ b/examples/call-evm-counter/src/contract.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+use linera_sdk::abis::evm::EvmAbi;
+use call_evm_counter::{CallCounterAbi, CallCounterOperation};
+use alloy_sol_types::{sol, SolCall};
+use linera_sdk::{
+    linera_base_types::{ApplicationId, WithContractAbi},
+    Contract, ContractRuntime,
+};
+
+pub struct CallCounterContract {
+    runtime: ContractRuntime<Self>,
+}
+
+linera_sdk::contract!(CallCounterContract);
+
+impl WithContractAbi for CallCounterContract {
+    type Abi = CallCounterAbi;
+}
+
+impl Contract for CallCounterContract {
+    type Message = ();
+    type InstantiationArgument = ();
+    type Parameters = ApplicationId<EvmAbi>;
+
+    async fn load(runtime: ContractRuntime<Self>) -> Self {
+        CallCounterContract { runtime }
+    }
+
+    async fn instantiate(&mut self, _value: ()) {
+        // Validate that the application parameters were configured correctly.
+        self.runtime.application_parameters();
+    }
+
+    async fn execute_operation(&mut self, operation: CallCounterOperation) -> u64 {
+        let CallCounterOperation::Increment(increment) = operation;
+        sol! {
+            function increment(uint64 input);
+        }
+        let operation = incrementCall { input: increment };
+        let operation = operation.abi_encode();
+        let evm_counter_id = self.runtime.application_parameters();
+        let result = self.runtime.call_application(true, evm_counter_id, &operation);
+        let mut arr = [0_u8; 8];
+        arr.copy_from_slice(&result[24..]);
+        let counter_value = u64::from_be_bytes(arr);
+        counter_value
+    }
+
+    async fn execute_message(&mut self, _message: ()) {
+        panic!("Counter application doesn't support any cross-chain messages");
+    }
+
+    async fn store(self) {
+    }
+}

--- a/examples/call-evm-counter/src/contract.rs
+++ b/examples/call-evm-counter/src/contract.rs
@@ -3,10 +3,10 @@
 
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
-use linera_sdk::abis::evm::EvmAbi;
-use call_evm_counter::{CallCounterAbi, CallCounterOperation};
 use alloy_sol_types::{sol, SolCall};
+use call_evm_counter::{CallCounterAbi, CallCounterOperation};
 use linera_sdk::{
+    abis::evm::EvmAbi,
     linera_base_types::{ApplicationId, WithContractAbi},
     Contract, ContractRuntime,
 };
@@ -43,7 +43,9 @@ impl Contract for CallCounterContract {
         let operation = incrementCall { input: increment };
         let operation = operation.abi_encode();
         let evm_counter_id = self.runtime.application_parameters();
-        let result = self.runtime.call_application(true, evm_counter_id, &operation);
+        let result = self
+            .runtime
+            .call_application(true, evm_counter_id, &operation);
         let mut arr = [0_u8; 8];
         arr.copy_from_slice(&result[24..]);
         let counter_value = u64::from_be_bytes(arr);
@@ -54,6 +56,5 @@ impl Contract for CallCounterContract {
         panic!("Counter application doesn't support any cross-chain messages");
     }
 
-    async fn store(self) {
-    }
+    async fn store(self) {}
 }

--- a/examples/call-evm-counter/src/contract.rs
+++ b/examples/call-evm-counter/src/contract.rs
@@ -3,6 +3,7 @@
 
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
+use alloy::primitives::U256;
 use alloy_sol_types::{sol, SolCall};
 use call_evm_counter::{CallCounterAbi, CallCounterOperation};
 use linera_sdk::{
@@ -46,10 +47,8 @@ impl Contract for CallCounterContract {
         let result = self
             .runtime
             .call_application(true, evm_counter_id, &operation);
-        let mut arr = [0_u8; 8];
-        arr.copy_from_slice(&result[24..]);
-        let counter_value = u64::from_be_bytes(arr);
-        counter_value
+        let arr: [u8; 32] = result.try_into().expect("result should have length 32");
+        U256::from_be_bytes(arr).to::<u64>()
     }
 
     async fn execute_message(&mut self, _message: ()) {

--- a/examples/call-evm-counter/src/lib.rs
+++ b/examples/call-evm-counter/src/lib.rs
@@ -1,0 +1,30 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*! ABI of the Counter Example Application that does not use GraphQL */
+
+use linera_sdk::linera_base_types::{ContractAbi, ServiceAbi};
+use serde::{Deserialize, Serialize};
+
+pub struct CallCounterAbi;
+
+impl ContractAbi for CallCounterAbi {
+    type Operation = CallCounterOperation;
+    type Response = u64;
+}
+
+impl ServiceAbi for CallCounterAbi {
+    type Query = CallCounterRequest;
+    type QueryResponse = u64;
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum CallCounterRequest {
+    Query,
+    Increment(u64),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum CallCounterOperation {
+    Increment(u64),
+}

--- a/examples/call-evm-counter/src/service.rs
+++ b/examples/call-evm-counter/src/service.rs
@@ -5,11 +5,14 @@
 
 use std::sync::Arc;
 
-use linera_sdk::abis::evm::EvmAbi;
+use alloy::primitives::U256;
 use alloy_sol_types::{sol, SolCall};
 use call_evm_counter::{CallCounterOperation, CallCounterRequest};
-use linera_sdk::{linera_base_types::{ApplicationId, WithServiceAbi, EvmQuery}, Service, ServiceRuntime};
-use alloy::primitives::U256;
+use linera_sdk::{
+    abis::evm::EvmAbi,
+    linera_base_types::{ApplicationId, EvmQuery, WithServiceAbi},
+    Service, ServiceRuntime,
+};
 
 pub struct CallCounterService {
     runtime: Arc<ServiceRuntime<Self>>,
@@ -36,14 +39,14 @@ impl Service for CallCounterService {
                 sol! {
                     function get_value();
                 }
-                let query = get_valueCall { };
+                let query = get_valueCall {};
                 let query = query.abi_encode();
                 let query = EvmQuery::Query(query);
                 let evm_counter_id = self.runtime.application_parameters();
                 let result = self.runtime.query_application(evm_counter_id, &query);
-                let arr : [u8; 32] = result.try_into().expect("result should have length 32");
+                let arr: [u8; 32] = result.try_into().expect("result should have length 32");
                 U256::from_be_bytes(arr).to::<u64>()
-            },
+            }
             CallCounterRequest::Increment(value) => {
                 let operation = CallCounterOperation::Increment(value);
                 self.runtime.schedule_operation(&operation);

--- a/examples/call-evm-counter/src/service.rs
+++ b/examples/call-evm-counter/src/service.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+use std::sync::Arc;
+
+use linera_sdk::abis::evm::EvmAbi;
+use alloy_sol_types::{sol, SolCall};
+use call_evm_counter::{CallCounterOperation, CallCounterRequest};
+use linera_sdk::{linera_base_types::{ApplicationId, WithServiceAbi, EvmQuery}, Service, ServiceRuntime};
+use alloy::primitives::U256;
+
+pub struct CallCounterService {
+    runtime: Arc<ServiceRuntime<Self>>,
+}
+
+linera_sdk::service!(CallCounterService);
+
+impl WithServiceAbi for CallCounterService {
+    type Abi = call_evm_counter::CallCounterAbi;
+}
+
+impl Service for CallCounterService {
+    type Parameters = ApplicationId<EvmAbi>;
+
+    async fn new(runtime: ServiceRuntime<Self>) -> Self {
+        CallCounterService {
+            runtime: Arc::new(runtime),
+        }
+    }
+
+    async fn handle_query(&self, request: CallCounterRequest) -> u64 {
+        match request {
+            CallCounterRequest::Query => {
+                sol! {
+                    function get_value();
+                }
+                let query = get_valueCall { };
+                let query = query.abi_encode();
+                let query = EvmQuery::Query(query);
+                let evm_counter_id = self.runtime.application_parameters();
+                let result = self.runtime.query_application(evm_counter_id, &query);
+                let arr : [u8; 32] = result.try_into().expect("result should have length 32");
+                U256::from_be_bytes(arr).to::<u64>()
+            },
+            CallCounterRequest::Increment(value) => {
+                let operation = CallCounterOperation::Increment(value);
+                self.runtime.schedule_operation(&operation);
+                0
+            }
+        }
+    }
+}

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -24,7 +24,6 @@ ignored = ["base64ct"]
 
 [features]
 ethereum = ["async-trait", "linera-ethereum"]
-revm = ["linera-execution/revm"]
 wasmer = [
     "linera-core/wasmer",
     "linera-execution/wasmer",

--- a/linera-sdk/build.rs
+++ b/linera-sdk/build.rs
@@ -3,7 +3,6 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
-        with_revm: { feature = "revm" },
         with_testing: { any(test, feature = "test") },
         with_wasm_runtime: { any(feature = "wasmer", feature = "wasmtime") },
         with_integration_testing: {

--- a/linera-sdk/src/abis/mod.rs
+++ b/linera-sdk/src/abis/mod.rs
@@ -3,6 +3,5 @@
 
 //! Common ABIs that may have multiple implementations.
 
-#[cfg(with_revm)]
 pub mod evm;
 pub mod fungible;

--- a/linera-sdk/src/linera_base_types.rs
+++ b/linera-sdk/src/linera_base_types.rs
@@ -4,5 +4,5 @@
 //! Types reexported from [`linera_base`].
 
 pub use linera_base::{
-    abi::*, crypto::*, data_types::*, identifiers::*, ownership::*, BcsHexParseError,
+    abi::*, crypto::*, data_types::*, identifiers::*, ownership::*, vm::EvmQuery, BcsHexParseError,
 };

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -17,7 +17,6 @@ default = ["wasmer", "rocksdb", "storage-service"]
 revm = [
     "linera-execution/revm",
     "linera-storage/revm",
-    "linera-sdk/revm",
     "dep:alloy-sol-types",
 ]
 test = [

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -14,11 +14,7 @@ version.workspace = true
 [features]
 ethereum = []
 default = ["wasmer", "rocksdb", "storage-service"]
-revm = [
-    "linera-execution/revm",
-    "linera-storage/revm",
-    "dep:alloy-sol-types",
-]
+revm = ["linera-execution/revm", "linera-storage/revm", "dep:alloy-sol-types"]
 test = [
     "linera-base/test",
     "linera-execution/test",

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -147,6 +147,7 @@ alloy = { workspace = true, default-features = false, features = [
 ] }
 amm.workspace = true
 base64.workspace = true
+call-evm-counter.workspace = true
 counter.workspace = true
 counter-no-graphql.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -508,7 +508,6 @@ async fn test_wasm_call_evm_end_to_end_counter(config: impl LineraNetConfig) -> 
     Ok(())
 }
 
-
 #[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(all(feature = "rocksdb", feature = "scylladb"), test_case(LocalNetConfig::new_test(Database::DualRocksDbScyllaDb, Network::Grpc) ; "dualrocksdbscylladb_grpc"))]

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -415,6 +415,100 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
     Ok(())
 }
 
+#[cfg(with_revm)]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
+#[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_wasm_call_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()> {
+    use alloy_sol_types::{sol, SolValue};
+    use call_evm_counter::{CallCounterAbi, CallCounterRequest};
+    use linera_execution::test_utils::solidity::{
+        get_contract_service_paths, get_evm_example_counter,
+    };
+    use linera_sdk::abis::evm::EvmAbi;
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let (mut net, client) = config.instantiate().await?;
+    let chain = client.load_wallet()?.default_chain().unwrap();
+
+    // Creating the EVM contract
+
+    let module = get_evm_example_counter()?;
+
+    sol! {
+        struct ConstructorArgs {
+            uint64 initial_value;
+        }
+    }
+
+    let original_counter_value = 35;
+    let evm_instantiation_argument = ConstructorArgs {
+        initial_value: original_counter_value,
+    };
+    let evm_instantiation_argument = evm_instantiation_argument.abi_encode();
+
+    let (evm_contract, evm_service, _dir) = get_contract_service_paths(module)?;
+    type InstantiationArgument = Vec<u8>;
+
+    let evm_application_id = client
+        .publish_and_create::<EvmAbi, (), InstantiationArgument>(
+            evm_contract,
+            evm_service,
+            VmRuntime::Evm,
+            &(),
+            &evm_instantiation_argument,
+            &[],
+            None,
+        )
+        .await?;
+
+    // Creating the WASM contract
+
+    let (wasm_contract, wasm_service) = client.build_example("call-evm-counter").await?;
+    type WasmParameter = ApplicationId<EvmAbi>;
+    let wasm_application_id = client
+        .publish_and_create::<CallCounterAbi, WasmParameter, ()>(
+            wasm_contract,
+            wasm_service,
+            VmRuntime::Wasm,
+            &evm_application_id,
+            &(),
+            &[],
+            None,
+        )
+        .await?;
+
+    let port = get_node_port().await;
+    let mut node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
+
+    let wasm_application = node_service
+        .make_application(&chain, &wasm_application_id)
+        .await?;
+
+    let query = CallCounterRequest::Query;
+    let counter_value = wasm_application.run_json_query(&query).await?;
+    assert_eq!(counter_value, original_counter_value);
+
+    let increment = 5;
+    let query_increment = CallCounterRequest::Increment(increment);
+    wasm_application.run_json_query(&query_increment).await?;
+
+    let counter_value = wasm_application.run_json_query(&query).await?;
+    assert_eq!(counter_value, original_counter_value + increment);
+
+    node_service.ensure_is_running()?;
+
+    net.ensure_is_running().await?;
+    net.terminate().await?;
+
+    Ok(())
+}
+
+
 #[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(all(feature = "rocksdb", feature = "scylladb"), test_case(LocalNetConfig::new_test(Database::DualRocksDbScyllaDb, Network::Grpc) ; "dualrocksdbscylladb_grpc"))]


### PR DESCRIPTION
## Motivation

The EVM smart contract have the `EvmAbi`. A test is needed to demonstrate on how to call them from Wasm.

## Proposal

The following changes are made:
* The `EvmQuery` is added to the `linera_base_types`.
* The `call-evm-counter` is added, which is a non GraphQL app.
* A demonstration of query and mutation is introduced in the end-to-end test.

There are some changes to the `linera-sdk`:
* The `EvmAbi` should not be protected by a `revm` feature as the fact that we use REVM is incidental.
* The `call-evm-counter` calling for the `revm` feature forces the `revm` feature by default which is unfortunate.

This is the first example of a query to a smart contract that leads to another `query_application` being created in the end-to-end test.

## Test Plan

The introduced test demonstrates the functionality.

## Release Plan

Normal release plan.

## Links

None.