### PR TITLE
Remove `ExecutedBlock`.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -475,7 +475,7 @@ View or update the resource control policy
 * `--http-request <HTTP_REQUEST>` — Set the price for performing an HTTP request
 * `--maximum-fuel-per-block <MAXIMUM_FUEL_PER_BLOCK>` — Set the maximum amount of fuel per block
 * `--maximum-service-oracle-execution-ms <MAXIMUM_SERVICE_ORACLE_EXECUTION_MS>` — Set the maximum time in milliseconds that a block can spend executing services as oracles
-* `--maximum-executed-block-size <MAXIMUM_EXECUTED_BLOCK_SIZE>` — Set the maximum size of an executed block, in bytes
+* `--maximum-block-size <MAXIMUM_BLOCK_SIZE>` — Set the maximum size of a block, in bytes
 * `--maximum-blob-size <MAXIMUM_BLOB_SIZE>` — Set the maximum size of data blobs, compressed bytecode and other binary blobs, in bytes
 * `--maximum-published-blobs <MAXIMUM_PUBLISHED_BLOBS>` — Set the maximum number of published blobs per block
 * `--maximum-bytecode-size <MAXIMUM_BYTECODE_SIZE>` — Set the maximum size of decompressed contract or service bytecode, in bytes
@@ -535,7 +535,7 @@ Create genesis configuration for a Linera deployment. Create initial user chains
 * `--http-request-price <HTTP_REQUEST_PRICE>` — Set the price for performing an HTTP request
 * `--maximum-fuel-per-block <MAXIMUM_FUEL_PER_BLOCK>` — Set the maximum amount of fuel per block. (This will overwrite value from `--policy-config`)
 * `--maximum-service-oracle-execution-ms <MAXIMUM_SERVICE_ORACLE_EXECUTION_MS>` — Set the maximum time in milliseconds that a block can spend executing services as oracles
-* `--maximum-executed-block-size <MAXIMUM_EXECUTED_BLOCK_SIZE>` — Set the maximum size of an executed block. (This will overwrite value from `--policy-config`)
+* `--maximum-block-size <MAXIMUM_BLOCK_SIZE>` — Set the maximum size of a block. (This will overwrite value from `--policy-config`)
 * `--maximum-bytecode-size <MAXIMUM_BYTECODE_SIZE>` — Set the maximum size of decompressed contract or service bytecode, in bytes. (This will overwrite value from `--policy-config`)
 * `--maximum-blob-size <MAXIMUM_BLOB_SIZE>` — Set the maximum size of data blobs, compressed bytecode and other binary blobs, in bytes. (This will overwrite value from `--policy-config`)
 * `--maximum-published-blobs <MAXIMUM_PUBLISHED_BLOBS>` — Set the maximum number of published blobs per block. (This will overwrite value from `--policy-config`)

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -67,7 +67,7 @@ impl Contract for MetaCounterContract {
             message = message.with_tracking();
         }
         if query_service {
-            // Make a service query: The result will be logged in the executed block.
+            // Make a service query: The result will be logged in the block.
             let counter_id = self.counter_id();
             let _ = self
                 .runtime

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1193,7 +1193,7 @@ impl<'a> Deserialize<'a> for Blob {
 
 impl BcsHashable<'_> for Blob {}
 
-/// An event recorded in an executed block.
+/// An event recorded in a block.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
 pub struct Event {
     /// The ID of the stream this event belongs to.

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -36,7 +36,7 @@ use crate::{
 pub struct ValidatedBlock(Hashed<Block>);
 
 impl ValidatedBlock {
-    /// Creates a new `ValidatedBlock` from an `Block`.
+    /// Creates a new `ValidatedBlock` from a `Block`.
     pub fn new(block: Block) -> Self {
         Self(Hashed::new(block))
     }

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -15,28 +15,30 @@ use linera_base::{
     hashed::Hashed,
     identifiers::{AccountOwner, BlobId, ChainId, MessageId},
 };
-use linera_execution::{committee::Epoch, BlobState, Operation, OutgoingMessage};
+use linera_execution::{
+    committee::Epoch, system::OpenChainConfig, BlobState, Operation, OutgoingMessage,
+};
 use serde::{ser::SerializeStruct, Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
     data_types::{
-        BlockExecutionOutcome, ExecutedBlock, IncomingBundle, Medium, MessageBundle,
-        OperationResult, OutgoingMessageExt, ProposedBlock,
+        BlockExecutionOutcome, IncomingBundle, Medium, MessageAction, MessageBundle,
+        OperationResult, OutgoingMessageExt, PostedMessage, ProposedBlock,
     },
     types::CertificateValue,
     ChainError,
 };
 
-/// Wrapper around an `ExecutedBlock` that has been validated.
+/// Wrapper around a `Block` that has been validated.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct ValidatedBlock(Hashed<Block>);
 
 impl ValidatedBlock {
-    /// Creates a new `ValidatedBlock` from an `ExecutedBlock`.
-    pub fn new(block: ExecutedBlock) -> Self {
-        Self(Hashed::new(Block::new(block.block, block.outcome)))
+    /// Creates a new `ValidatedBlock` from an `Block`.
+    pub fn new(block: Block) -> Self {
+        Self(Hashed::new(block))
     }
 
     pub fn from_hashed(block: Hashed<Block>) -> Self {
@@ -76,7 +78,7 @@ impl ValidatedBlock {
 
 impl BcsHashable<'_> for ValidatedBlock {}
 
-/// Wrapper around an `ExecutedBlock` that has been confirmed.
+/// Wrapper around a `Block` that has been confirmed.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct ConfirmedBlock(Hashed<Block>);
@@ -96,8 +98,8 @@ impl ConfirmedBlock {
 impl BcsHashable<'_> for ConfirmedBlock {}
 
 impl ConfirmedBlock {
-    pub fn new(block: ExecutedBlock) -> Self {
-        Self(Hashed::new(Block::new(block.block, block.outcome)))
+    pub fn new(block: Block) -> Self {
+        Self(Hashed::new(block))
     }
 
     pub fn from_hashed(block: Hashed<Block>) -> Self {
@@ -112,12 +114,12 @@ impl ConfirmedBlock {
         self.0
     }
 
-    /// Returns a reference to the `ExecutedBlock` contained in this `ConfirmedBlock`.
+    /// Returns a reference to the `Block` contained in this `ConfirmedBlock`.
     pub fn block(&self) -> &Block {
         self.0.inner()
     }
 
-    /// Consumes this `ConfirmedBlock`, returning the `ExecutedBlock` it contains.
+    /// Consumes this `ConfirmedBlock`, returning the `Block` it contains.
     pub fn into_block(self) -> Block {
         self.0.into_inner()
     }
@@ -159,24 +161,7 @@ impl ConfirmedBlock {
 
     /// Returns whether this block matches the proposal.
     pub fn matches_proposed_block(&self, block: &ProposedBlock) -> bool {
-        let ProposedBlock {
-            chain_id,
-            epoch,
-            incoming_bundles,
-            operations,
-            height,
-            timestamp,
-            authenticated_signer,
-            previous_block_hash,
-        } = block;
-        *chain_id == self.chain_id()
-            && *epoch == self.epoch()
-            && *incoming_bundles == self.block().body.incoming_bundles
-            && *operations == self.block().body.operations
-            && *height == self.block().header.height
-            && *timestamp == self.block().header.timestamp
-            && *authenticated_signer == self.block().header.authenticated_signer
-            && *previous_block_hash == self.block().header.previous_block_hash
+        self.block().matches_proposed_block(block)
     }
 
     /// Returns a blob state that applies to all blobs used by this block.
@@ -539,7 +524,7 @@ impl Block {
     }
 
     /// Returns all the published blob IDs in this block's operations.
-    fn published_blob_ids(&self) -> BTreeSet<BlobId> {
+    pub fn published_blob_ids(&self) -> BTreeSet<BlobId> {
         self.body
             .operations
             .iter()
@@ -585,54 +570,40 @@ impl Block {
     pub fn messages(&self) -> &Vec<Vec<OutgoingMessage>> {
         &self.body.messages
     }
-}
 
-impl From<Block> for ExecutedBlock {
-    fn from(block: Block) -> Self {
-        let Block {
-            header:
-                BlockHeader {
-                    chain_id,
-                    epoch,
-                    height,
-                    timestamp,
-                    state_hash,
-                    previous_block_hash,
-                    authenticated_signer,
-                    bundles_hash: _,
-                    operations_hash: _,
-                    messages_hash: _,
-                    previous_message_blocks_hash: _,
-                    oracle_responses_hash: _,
-                    events_hash: _,
-                    blobs_hash: _,
-                    operation_results_hash: _,
-                },
-            body:
-                BlockBody {
-                    incoming_bundles,
-                    operations,
-                    messages,
-                    previous_message_blocks,
-                    oracle_responses,
-                    events,
-                    blobs,
-                    operation_results,
-                },
-        } = block;
+    /// Returns whether there are any oracle responses in this block.
+    pub fn has_oracle_responses(&self) -> bool {
+        self.body
+            .oracle_responses
+            .iter()
+            .any(|responses| !responses.is_empty())
+    }
 
-        let block = ProposedBlock {
+    /// Returns whether this block matches the proposal.
+    pub fn matches_proposed_block(&self, block: &ProposedBlock) -> bool {
+        let ProposedBlock {
             chain_id,
             epoch,
-            height,
-            timestamp,
             incoming_bundles,
             operations,
+            height,
+            timestamp,
             authenticated_signer,
             previous_block_hash,
-        };
+        } = block;
+        *chain_id == self.header.chain_id
+            && *epoch == self.header.epoch
+            && *incoming_bundles == self.body.incoming_bundles
+            && *operations == self.body.operations
+            && *height == self.header.height
+            && *timestamp == self.header.timestamp
+            && *authenticated_signer == self.header.authenticated_signer
+            && *previous_block_hash == self.header.previous_block_hash
+    }
 
-        let outcome = BlockExecutionOutcome {
+    /// Returns whether this block matches the execution outcome.
+    pub fn matches_outcome(&self, outcome: &BlockExecutionOutcome) -> bool {
+        let BlockExecutionOutcome {
             state_hash,
             messages,
             previous_message_blocks,
@@ -640,9 +611,59 @@ impl From<Block> for ExecutedBlock {
             events,
             blobs,
             operation_results,
-        };
+        } = outcome;
+        *state_hash == self.header.state_hash
+            && *messages == self.body.messages
+            && *previous_message_blocks == self.body.previous_message_blocks
+            && *oracle_responses == self.body.oracle_responses
+            && *events == self.body.events
+            && *blobs == self.body.blobs
+            && *operation_results == self.body.operation_results
+    }
 
-        ExecutedBlock { block, outcome }
+    pub fn into_proposal(self) -> (ProposedBlock, BlockExecutionOutcome) {
+        let proposed_block = ProposedBlock {
+            chain_id: self.header.chain_id,
+            epoch: self.header.epoch,
+            incoming_bundles: self.body.incoming_bundles,
+            operations: self.body.operations,
+            height: self.header.height,
+            timestamp: self.header.timestamp,
+            authenticated_signer: self.header.authenticated_signer,
+            previous_block_hash: self.header.previous_block_hash,
+        };
+        let outcome = BlockExecutionOutcome {
+            state_hash: self.header.state_hash,
+            messages: self.body.messages,
+            previous_message_blocks: self.body.previous_message_blocks,
+            oracle_responses: self.body.oracle_responses,
+            events: self.body.events,
+            blobs: self.body.blobs,
+            operation_results: self.body.operation_results,
+        };
+        (proposed_block, outcome)
+    }
+
+    pub fn iter_created_blobs(&self) -> impl Iterator<Item = (BlobId, Blob)> + '_ {
+        self.body
+            .blobs
+            .iter()
+            .flatten()
+            .map(|blob| (blob.id(), blob.clone()))
+    }
+
+    /// If the block's first message is `OpenChain`, returns the bundle, the message and
+    /// the configuration for the new chain.
+    pub fn starts_with_open_chain_message(
+        &self,
+    ) -> Option<(&IncomingBundle, &PostedMessage, &OpenChainConfig)> {
+        let in_bundle = self.body.incoming_bundles.first()?;
+        if in_bundle.action != MessageAction::Accept {
+            return None;
+        }
+        let posted_message = in_bundle.bundle.messages.first()?;
+        let config = posted_message.message.matches_open_chain()?;
+        Some((in_bundle, posted_message, config))
     }
 }
 

--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 impl GenericCertificate<ConfirmedBlock> {
-    /// Returns reference to the `ExecutedBlock` contained in this certificate.
+    /// Returns reference to the `Block` contained in this certificate.
     pub fn block(&self) -> &Block {
         self.inner().block()
     }

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -158,7 +158,7 @@ pub enum ChainError {
     MissingMandatoryApplications(Vec<ApplicationId>),
     #[error("Can't use grant across different broadcast messages")]
     GrantUseOnBroadcast,
-    #[error("ExecutedBlock contains fewer oracle responses than requests")]
+    #[error("Executed block contains fewer oracle responses than requests")]
     MissingOracleResponseList,
     #[error("Unexpected hash for CertificateValue! Expected: {expected:?}, Actual: {actual:?}")]
     CertificateValueHashMismatch {

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -121,7 +121,7 @@ async fn test_block_size_limit() {
     let mut chain = ChainStateView::new(chain_id).await;
 
     // The size of the executed valid block below.
-    let maximum_executed_block_size = 857;
+    let maximum_block_size = 857;
 
     // Initialize the chain.
     let mut config = make_open_chain_config();
@@ -137,7 +137,7 @@ async fn test_block_size_limit() {
                 },
             )]),
             ResourceControlPolicy {
-                maximum_executed_block_size,
+                maximum_block_size,
                 ..ResourceControlPolicy::default()
             },
         ),
@@ -179,7 +179,7 @@ async fn test_block_size_limit() {
         Err(ChainError::ExecutionError(
             execution_error,
             ChainExecutionContext::Operation(1),
-        )) if matches!(*execution_error, ExecutionError::ExecutedBlockTooLarge)
+        )) if matches!(*execution_error, ExecutionError::BlockTooLarge)
     );
 
     // The valid block is accepted...
@@ -192,7 +192,7 @@ async fn test_block_size_limit() {
     // ...because its size is at the allowed limit.
     assert_eq!(
         bcs::serialized_size(&block).unwrap(),
-        maximum_executed_block_size as usize
+        maximum_block_size as usize
     );
 }
 
@@ -263,11 +263,11 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     let valid_block = make_first_block(chain_id)
         .with_incoming_bundle(bundle)
         .with_operation(app_operation.clone());
-    let executed_block = chain
+    let block = chain
         .execute_and_apply_block(&valid_block, time, None, &[], None)
         .await?
         .with(valid_block);
-    let value = Hashed::new(ConfirmedBlock::new(executed_block));
+    let value = Hashed::new(ConfirmedBlock::new(block));
 
     // In the second block, other operations are still not allowed.
     let invalid_block = make_child_block(&value.clone())

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -18,9 +18,7 @@ fn test_signed_values() {
     let validator1_key_pair = ValidatorKeypair::generate();
     let validator2_key_pair = ValidatorKeypair::generate();
 
-    let block =
-        make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(2), Amount::ONE);
-    let executed_block = BlockExecutionOutcome {
+    let block = BlockExecutionOutcome {
         messages: vec![Vec::new()],
         previous_message_blocks: BTreeMap::new(),
         state_hash: CryptoHash::test_hash("state"),
@@ -29,8 +27,8 @@ fn test_signed_values() {
         blobs: vec![Vec::new()],
         operation_results: vec![OperationResult::default()],
     }
-    .with(block);
-    let confirmed_value = Hashed::new(ConfirmedBlock::new(executed_block.clone()));
+    .with(make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(2), Amount::ONE));
+    let confirmed_value = Hashed::new(ConfirmedBlock::new(block.clone()));
 
     let confirmed_vote = LiteVote::new(
         LiteValue::new(&confirmed_value),
@@ -39,7 +37,7 @@ fn test_signed_values() {
     );
     assert!(confirmed_vote.check().is_ok());
 
-    let validated_value = Hashed::new(ValidatedBlock::new(executed_block));
+    let validated_value = Hashed::new(ValidatedBlock::new(block));
     let validated_vote = LiteVote::new(
         LiteValue::new(&validated_value),
         Round::Fast,
@@ -47,7 +45,7 @@ fn test_signed_values() {
     );
     assert_ne!(
         confirmed_vote.value, validated_vote.value,
-        "Confirmed and validated votes should be different, even if for the same executed block"
+        "Confirmed and validated votes should be different, even if for the same block"
     );
 
     let mut v = LiteVote::new(
@@ -81,9 +79,7 @@ fn test_signed_values() {
 fn test_hashes() {
     // Test that hash of confirmed and validated blocks are different,
     // even if the blocks are the same.
-    let block =
-        make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(2), Amount::ONE);
-    let executed_block = BlockExecutionOutcome {
+    let block = BlockExecutionOutcome {
         messages: vec![Vec::new()],
         previous_message_blocks: BTreeMap::new(),
         state_hash: CryptoHash::test_hash("state"),
@@ -92,9 +88,9 @@ fn test_hashes() {
         blobs: vec![Vec::new()],
         operation_results: vec![OperationResult::default()],
     }
-    .with(block);
-    let confirmed_hashed = Hashed::new(ConfirmedBlock::new(executed_block.clone()));
-    let validated_hashed = Hashed::new(ValidatedBlock::new(executed_block));
+    .with(make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(2), Amount::ONE));
+    let confirmed_hashed = Hashed::new(ConfirmedBlock::new(block.clone()));
+    let validated_hashed = Hashed::new(ValidatedBlock::new(block));
 
     assert_eq!(confirmed_hashed.hash(), validated_hashed.hash());
 }
@@ -112,9 +108,7 @@ fn test_certificates() {
         (validator2_key_pair.public_key, account2_secret.public()),
     ]);
 
-    let block =
-        make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(1), Amount::ONE);
-    let executed_block = BlockExecutionOutcome {
+    let block = BlockExecutionOutcome {
         messages: vec![Vec::new()],
         previous_message_blocks: BTreeMap::new(),
         state_hash: CryptoHash::test_hash("state"),
@@ -123,8 +117,8 @@ fn test_certificates() {
         blobs: vec![Vec::new()],
         operation_results: vec![OperationResult::default()],
     }
-    .with(block);
-    let value = Hashed::new(ConfirmedBlock::new(executed_block));
+    .with(make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(1), Amount::ONE));
+    let value = Hashed::new(ConfirmedBlock::new(block));
 
     let v1 = LiteVote::new(
         LiteValue::new(&value),

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -499,7 +499,7 @@ where
                 info!("Shutdown signal received, stopping benchmark");
                 break;
             }
-            let block = ProposedBlock {
+            let proposed_block = ProposedBlock {
                 epoch,
                 chain_id,
                 incoming_bundles: Vec::new(),
@@ -509,15 +509,18 @@ where
                 authenticated_signer,
                 timestamp: chain_client.timestamp().max(Timestamp::now()),
             };
-            let executed_block = local_node
-                .stage_block_execution(block.clone(), None, Vec::new())
+            let block = local_node
+                .stage_block_execution(proposed_block.clone(), None, Vec::new())
                 .await
                 .map_err(BenchmarkError::LocalNode)?
                 .0;
 
-            let value = Hashed::new(ConfirmedBlock::new(executed_block));
-            let proposal =
-                BlockProposal::new_initial(linera_base::data_types::Round::Fast, block, &key_pair);
+            let value = Hashed::new(ConfirmedBlock::new(block));
+            let proposal = BlockProposal::new_initial(
+                linera_base::data_types::Round::Fast,
+                proposed_block,
+                &key_pair,
+            );
 
             chain_client
                 .submit_block_proposal(&committee, Box::new(proposal), value)

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -441,10 +441,8 @@ where
             .certificate_for(&message_id)
             .await
             .context("looking for `OpenChain` message")?;
-        let executed_block = certificate.block();
-        let message = executed_block
-            .message_by_id(&message_id)
-            .map(|msg| &msg.message);
+        let block = certificate.block();
+        let message = block.message_by_id(&message_id).map(|msg| &msg.message);
         let Some(Message::System(SystemMessage::OpenChain(config))) = message else {
             tracing::error!(
                 "The message with the ID returned by the faucet is not OpenChain. \
@@ -462,9 +460,7 @@ where
         }
 
         self.wallet_mut()
-            .mutate(|w| {
-                w.assign_new_chain_to_owner(owner, chain_id, executed_block.header.timestamp)
-            })
+            .mutate(|w| w.assign_new_chain_to_owner(owner, chain_id, block.header.timestamp))
             .await
             .map_err(|e| error::Inner::Persistence(Box::new(e)))?
             .context("assigning new chain")?;

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -596,9 +596,9 @@ pub enum ClientCommand {
         #[arg(long)]
         maximum_service_oracle_execution_ms: Option<u64>,
 
-        /// Set the maximum size of an executed block, in bytes.
+        /// Set the maximum size of a block, in bytes.
         #[arg(long)]
-        maximum_executed_block_size: Option<u64>,
+        maximum_block_size: Option<u64>,
 
         /// Set the maximum size of data blobs, compressed bytecode and other binary blobs,
         /// in bytes.
@@ -810,10 +810,10 @@ pub enum ClientCommand {
         #[arg(long)]
         maximum_service_oracle_execution_ms: Option<u64>,
 
-        /// Set the maximum size of an executed block.
+        /// Set the maximum size of a block.
         /// (This will overwrite value from `--policy-config`)
         #[arg(long)]
-        maximum_executed_block_size: Option<u64>,
+        maximum_block_size: Option<u64>,
 
         /// Set the maximum size of decompressed contract or service bytecode, in bytes.
         /// (This will overwrite value from `--policy-config`)

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -17,7 +17,7 @@ use linera_base::{
     identifiers::{ApplicationId, BlobId, ChainId},
 };
 use linera_chain::{
-    data_types::{BlockProposal, ExecutedBlock, MessageBundle, Origin, ProposedBlock, Target},
+    data_types::{BlockProposal, MessageBundle, Origin, ProposedBlock, Target},
     types::{Block, ConfirmedBlockCertificate, TimeoutCertificate, ValidatedBlockCertificate},
     ChainStateView,
 };
@@ -87,7 +87,7 @@ where
         round: Option<u32>,
         published_blobs: Vec<Blob>,
         #[debug(skip)]
-        callback: oneshot::Sender<Result<(ExecutedBlock, ChainInfoResponse), WorkerError>>,
+        callback: oneshot::Sender<Result<(Block, ChainInfoResponse), WorkerError>>,
     },
 
     /// Process a leader timeout issued for this multi-owner chain.
@@ -184,7 +184,7 @@ where
     pub async fn run(
         config: ChainWorkerConfig,
         storage: StorageClient,
-        executed_block_cache: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
+        block_cache: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
         tracked_chains: Option<Arc<RwLock<HashSet<ChainId>>>>,
         delivery_notifier: DeliveryNotifier,
         chain_id: ChainId,
@@ -197,7 +197,7 @@ where
             let load_result = Self::load(
                 config.clone(),
                 storage.clone(),
-                executed_block_cache.clone(),
+                block_cache.clone(),
                 tracked_chains.clone(),
                 delivery_notifier.clone(),
                 chain_id,
@@ -222,7 +222,7 @@ where
     pub async fn load(
         config: ChainWorkerConfig,
         storage: StorageClient,
-        executed_block_cache: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
+        block_cache: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
         tracked_chains: Option<Arc<RwLock<HashSet<ChainId>>>>,
         delivery_notifier: DeliveryNotifier,
         chain_id: ChainId,
@@ -239,7 +239,7 @@ where
         let worker = ChainWorkerState::load(
             config,
             storage,
-            executed_block_cache,
+            block_cache,
             tracked_chains,
             delivery_notifier,
             chain_id,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2177,11 +2177,12 @@ where
         };
         let (block, _) = self
             .stage_block_execution_and_discard_failing_messages(
-                proposed_block.clone(),
+                proposed_block,
                 round,
                 blobs.clone(),
             )
             .await?;
+        let (proposed_block, _) = block.clone().into_proposal();
         self.state_mut().set_pending_proposal(proposed_block, blobs);
         Ok(Hashed::new(ConfirmedBlock::new(block)))
     }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -43,12 +43,11 @@ use linera_base::{
 use linera_base::{data_types::Bytecode, vm::VmRuntime};
 use linera_chain::{
     data_types::{
-        BlockProposal, ChainAndHeight, ExecutedBlock, IncomingBundle, LiteVote, MessageAction,
-        ProposedBlock,
+        BlockProposal, ChainAndHeight, IncomingBundle, LiteVote, MessageAction, ProposedBlock,
     },
     manager::LockingBlock,
     types::{
-        CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate,
+        Block, CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate,
         LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock, ValidatedBlockCertificate,
     },
     ChainError, ChainExecutionContext, ChainStateView,
@@ -1074,9 +1073,7 @@ where
         committee: &Committee,
         certificate: ValidatedBlockCertificate,
     ) -> Result<ConfirmedBlockCertificate, ChainClientError> {
-        let hashed_value = Hashed::new(ConfirmedBlock::new(
-            certificate.inner().block().clone().into(),
-        ));
+        let hashed_value = Hashed::new(ConfirmedBlock::new(certificate.inner().block().clone()));
         let finalize_action = CommunicateAction::FinalizeBlock {
             certificate: Box::new(certificate),
             delivery: self.options.cross_chain_message_delivery,
@@ -1985,7 +1982,7 @@ where
         mut block: ProposedBlock,
         round: Option<u32>,
         published_blobs: Vec<Blob>,
-    ) -> Result<(ExecutedBlock, ChainInfoResponse), ChainClientError> {
+    ) -> Result<(Block, ChainInfoResponse), ChainClientError> {
         loop {
             let result = self
                 .stage_block_execution(block.clone(), round, published_blobs.clone())
@@ -2030,7 +2027,7 @@ where
         block: ProposedBlock,
         round: Option<u32>,
         published_blobs: Vec<Blob>,
-    ) -> Result<(ExecutedBlock, ChainInfoResponse), ChainClientError> {
+    ) -> Result<(Block, ChainInfoResponse), ChainClientError> {
         loop {
             let result = self
                 .client
@@ -2156,7 +2153,7 @@ where
                 self.next_timestamp(&incoming_bundles, state.timestamp()),
             )
         };
-        let block = ProposedBlock {
+        let proposed_block = ProposedBlock {
             epoch: self.epoch().await?,
             chain_id: self.chain_id,
             incoming_bundles,
@@ -2174,19 +2171,19 @@ where
         // Using the round number during execution counts as an oracle.
         // Accessing the round number in single-leader rounds where we are not the leader
         // is not currently supported.
-        let round = match Self::round_for_new_proposal(&info, &identity, &block, true)? {
+        let round = match Self::round_for_new_proposal(&info, &identity, &proposed_block, true)? {
             Either::Left(round) => round.multi_leader(),
             Either::Right(_) => None,
         };
-        let (executed_block, _) = self
-            .stage_block_execution_and_discard_failing_messages(block, round, blobs.clone())
+        let (block, _) = self
+            .stage_block_execution_and_discard_failing_messages(
+                proposed_block.clone(),
+                round,
+                blobs.clone(),
+            )
             .await?;
-        let block = &executed_block.block;
-        let committee = self.local_committee().await?;
-        let max_size = committee.policy().maximum_block_proposal_size;
-        block.check_proposal_size(max_size)?;
-        self.state_mut().set_pending_proposal(block.clone(), blobs);
-        Ok(Hashed::new(ConfirmedBlock::new(executed_block)))
+        self.state_mut().set_pending_proposal(proposed_block, blobs);
+        Ok(Hashed::new(ConfirmedBlock::new(block)))
     }
 
     /// Returns a suitable timestamp for the next block.
@@ -2496,8 +2493,8 @@ where
         let local_node = &self.client.local_node;
         // Otherwise we have to re-propose the highest validated block, if there is one.
         let pending_proposal = self.state().pending_proposal().clone();
-        let (executed_block, blobs) = if let Some(locking) = &info.manager.requested_locking {
-            let (executed_block, blobs) = match &**locking {
+        let (block, blobs) = if let Some(locking) = &info.manager.requested_locking {
+            let (block, blobs) = match &**locking {
                 LockingBlock::Regular(certificate) => {
                     let blob_ids = certificate.block().required_blob_ids();
                     let blobs = local_node
@@ -2506,47 +2503,50 @@ where
                         .ok_or_else(|| {
                             ChainClientError::InternalError("Missing local locking blobs")
                         })?;
-                    (certificate.block().clone().into(), blobs)
+                    (certificate.block().clone(), blobs)
                 }
                 LockingBlock::Fast(proposal) => {
-                    let block = proposal.content.block.clone();
-                    let blob_ids = block.published_blob_ids();
+                    let proposed_block = proposal.content.block.clone();
+                    let blob_ids = proposed_block.published_blob_ids();
                     let blobs = local_node
                         .get_locking_blobs(&blob_ids, self.chain_id)
                         .await?
                         .ok_or_else(|| {
                             ChainClientError::InternalError("Missing local locking blobs")
                         })?;
-                    let executed_block = self
-                        .stage_block_execution(block, None, blobs.clone())
+                    let block = self
+                        .stage_block_execution(proposed_block, None, blobs.clone())
                         .await?
                         .0;
-                    (executed_block, blobs)
+                    (block, blobs)
                 }
             };
-            (executed_block, blobs)
+            (block, blobs)
         } else if let Some(pending_proposal) = pending_proposal {
             // Otherwise we are free to propose our own pending block.
             // Use the round number assuming there are oracle responses.
             // Using the round number during execution counts as an oracle.
-            let block = pending_proposal.block;
-            let round = match Self::round_for_new_proposal(&info, &identity, &block, true)? {
+            let proposed_block = pending_proposal.block;
+            let round = match Self::round_for_new_proposal(&info, &identity, &proposed_block, true)?
+            {
                 Either::Left(round) => round.multi_leader(),
                 Either::Right(_) => None,
             };
-            let (executed_block, _) = self
-                .stage_block_execution(block, round, pending_proposal.blobs.clone())
+            let (block, _) = self
+                .stage_block_execution(proposed_block, round, pending_proposal.blobs.clone())
                 .await?;
-            (executed_block, pending_proposal.blobs)
+            (block, pending_proposal.blobs)
         } else {
             return Ok(ClientOutcome::Committed(None)); // Nothing to do.
         };
 
+        let has_oracle_responses = block.has_oracle_responses();
+        let (proposed_block, outcome) = block.into_proposal();
         let round = match Self::round_for_new_proposal(
             &info,
             &identity,
-            &executed_block.block,
-            executed_block.outcome.has_oracle_responses(),
+            &proposed_block,
+            has_oracle_responses,
         )? {
             Either::Left(round) => round,
             Either::Right(timeout) => return Ok(ClientOutcome::WaitForTimeout(timeout)),
@@ -2554,7 +2554,7 @@ where
 
         let already_handled_locally = info
             .manager
-            .already_handled_proposal(round, &executed_block.block);
+            .already_handled_proposal(round, &proposed_block);
         let key_pair = self.key_pair().await?;
         // Create the final block proposal.
         let proposal = if let Some(locking) = info.manager.requested_locking {
@@ -2565,8 +2565,11 @@ where
                 }
             })
         } else {
-            let block = executed_block.block.clone();
-            Box::new(BlockProposal::new_initial(round, block, &key_pair))
+            Box::new(BlockProposal::new_initial(
+                round,
+                proposed_block.clone(),
+                &key_pair,
+            ))
         };
         if !already_handled_locally {
             // Check the final block proposal. This will be cheaper after #1401.
@@ -2583,13 +2586,14 @@ where
             }
         }
         let committee = self.local_committee().await?;
+        let block = Block::new(proposed_block, outcome);
         // Send the query to validators.
         let certificate = if round.is_fast() {
-            let hashed_value = Hashed::new(ConfirmedBlock::new(executed_block));
+            let hashed_value = Hashed::new(ConfirmedBlock::new(block));
             self.submit_block_proposal(&committee, proposal, hashed_value)
                 .await?
         } else {
-            let hashed_value = Hashed::new(ValidatedBlock::new(executed_block));
+            let hashed_value = Hashed::new(ValidatedBlock::new(block));
             let certificate = self
                 .submit_block_proposal(&committee, proposal, hashed_value.clone())
                 .await?;

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -14,8 +14,8 @@ use linera_base::{
     identifiers::{ApplicationId, BlobId, ChainId, MessageId},
 };
 use linera_chain::{
-    data_types::{BlockProposal, ExecutedBlock, ProposedBlock},
-    types::{ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
+    data_types::{BlockProposal, ProposedBlock},
+    types::{Block, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
     ChainStateView,
 };
 use linera_execution::{Query, QueryOutcome};
@@ -177,7 +177,7 @@ where
         block: ProposedBlock,
         round: Option<u32>,
         published_blobs: Vec<Blob>,
-    ) -> Result<(ExecutedBlock, ChainInfoResponse), LocalNodeError> {
+    ) -> Result<(Block, ChainInfoResponse), LocalNodeError> {
         Ok(self
             .node
             .state

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2343,9 +2343,9 @@ where
     let result = client1.publish_data_blobs(blob_bytes).await;
     assert_matches!(
         result,
-        Err(ChainClientError::ChainError(
-            ChainError::BlockProposalTooLarge
-        ))
+        Err(ChainClientError::LocalNodeError(
+            LocalNodeError::WorkerError(WorkerError::ChainError(chain_error))
+        )) if matches!(*chain_error, ChainError::BlockProposalTooLarge)
     );
 
     assert_matches!(

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2327,9 +2327,9 @@ where
         .unwrap();
     // This read a new blob, so it cannot be a fast block.
     assert_eq!(certificate.round, Round::MultiLeader(0));
-    let executed_block = certificate.block();
-    assert_eq!(executed_block.body.incoming_bundles.len(), 1);
-    assert_eq!(executed_block.required_blob_ids().len(), 1);
+    let block = certificate.block();
+    assert_eq!(block.body.incoming_bundles.len(), 1);
+    assert_eq!(block.required_blob_ids().len(), 1);
 
     // This will go way over the limit, because of the different overheads.
     let blob_bytes = (0..100)

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -361,8 +361,8 @@ where
         .await
         .unwrap()
         .unwrap();
-    let executed_block = cert.block();
-    let responses = &executed_block.body.oracle_responses;
+    let block = cert.block();
+    let responses = &block.body.oracle_responses;
     let [_, responses] = &responses[..] else {
         panic!("Unexpected oracle responses: {:?}", responses);
     };

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -230,8 +230,8 @@ pub enum ExecutionError {
     MaximumServiceOracleExecutionTimeExceeded,
     #[error("Service running as an oracle produced a response that's too large")]
     ServiceOracleResponseTooLarge,
-    #[error("Serialized size of the executed block exceeds limit")]
-    ExecutedBlockTooLarge,
+    #[error("Serialized size of the block exceeds limit")]
+    BlockTooLarge,
     #[error("HTTP response exceeds the size limit of {limit} bytes, having at least {size} bytes")]
     HttpResponseSizeLimitExceeded { limit: u64, size: u64 },
     #[error("Runtime failed to respond to application")]

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -60,9 +60,9 @@ pub struct ResourceControlPolicy {
     pub maximum_fuel_per_block: u64,
     /// The maximum time in milliseconds that a block can spend executing services as oracles.
     pub maximum_service_oracle_execution_ms: u64,
-    /// The maximum size of an executed block. This includes the block proposal itself as well as
+    /// The maximum size of a block. This includes the block proposal itself as well as
     /// the execution outcome.
-    pub maximum_executed_block_size: u64,
+    pub maximum_block_size: u64,
     /// The maximum size of decompressed contract or service bytecode, in bytes.
     pub maximum_bytecode_size: u64,
     /// The maximum size of a blob.
@@ -107,7 +107,7 @@ impl fmt::Display for ResourceControlPolicy {
             http_request,
             maximum_fuel_per_block,
             maximum_service_oracle_execution_ms,
-            maximum_executed_block_size,
+            maximum_block_size,
             maximum_blob_size,
             maximum_published_blobs,
             maximum_bytecode_size,
@@ -142,7 +142,7 @@ impl fmt::Display for ResourceControlPolicy {
             {maximum_fuel_per_block} maximum fuel per block\n\
             {maximum_service_oracle_execution_ms} ms maximum service-as-oracle execution time per \
                 block\n\
-            {maximum_executed_block_size} maximum size of an executed block\n\
+            {maximum_block_size} maximum size of a block\n\
             {maximum_blob_size} maximum size of a data blob, bytecode or other binary blob\n\
             {maximum_published_blobs} maximum number of blobs published per block\n\
             {maximum_bytecode_size} maximum size of service and contract bytecode\n\
@@ -189,7 +189,7 @@ impl ResourceControlPolicy {
             http_request: Amount::ZERO,
             maximum_fuel_per_block: u64::MAX,
             maximum_service_oracle_execution_ms: u64::MAX,
-            maximum_executed_block_size: u64::MAX,
+            maximum_block_size: u64::MAX,
             maximum_blob_size: u64::MAX,
             maximum_published_blobs: u64::MAX,
             maximum_bytecode_size: u64::MAX,
@@ -269,7 +269,7 @@ impl ResourceControlPolicy {
             http_request: Amount::from_micros(50),
             maximum_fuel_per_block: 100_000_000,
             maximum_service_oracle_execution_ms: 10_000,
-            maximum_executed_block_size: 1_000_000,
+            maximum_block_size: 1_000_000,
             maximum_blob_size: 1_000_000,
             maximum_published_blobs: 10,
             maximum_bytecode_size: 10_000_000,

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -31,7 +31,7 @@ pub struct ResourceController<Account = Amount, Tracker = ResourceTracker> {
 pub struct ResourceTracker {
     /// The number of blocks created.
     pub blocks: u32,
-    /// The total size of the executed block so far.
+    /// The total size of the block so far.
     pub block_size: u64,
     /// The fuel used so far.
     pub fuel: u64,
@@ -384,21 +384,21 @@ impl<Account, Tracker> ResourceController<Account, Tracker>
 where
     Tracker: AsMut<ResourceTracker>,
 {
-    /// Tracks the serialized size of an executed block, or parts of it.
+    /// Tracks the serialized size of a block, or parts of it.
     pub fn track_block_size_of(&mut self, data: &impl Serialize) -> Result<(), ExecutionError> {
         self.track_block_size(bcs::serialized_size(data)?)
     }
 
-    /// Tracks the serialized size of an executed block, or parts of it.
+    /// Tracks the serialized size of a block, or parts of it.
     pub fn track_block_size(&mut self, size: usize) -> Result<(), ExecutionError> {
         let tracker = self.tracker.as_mut();
         tracker.block_size = u64::try_from(size)
             .ok()
             .and_then(|size| tracker.block_size.checked_add(size))
-            .ok_or(ExecutionError::ExecutedBlockTooLarge)?;
+            .ok_or(ExecutionError::BlockTooLarge)?;
         ensure!(
-            tracker.block_size <= self.policy.maximum_executed_block_size,
-            ExecutionError::ExecutedBlockTooLarge
+            tracker.block_size <= self.policy.maximum_block_size,
+            ExecutionError::BlockTooLarge
         );
         Ok(())
     }

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -216,7 +216,7 @@ async fn test_fee_consumption(
         service_as_oracle_query: Amount::from_millis(37),
         http_request: Amount::from_tokens(41),
         maximum_fuel_per_block: 4_868_145_137,
-        maximum_executed_block_size: 43,
+        maximum_block_size: 43,
         maximum_service_oracle_execution_ms: 47,
         maximum_blob_size: 53,
         maximum_published_blobs: 59,

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -887,7 +887,7 @@ ResourceControlPolicy:
         TYPENAME: Amount
     - maximum_fuel_per_block: U64
     - maximum_service_oracle_execution_ms: U64
-    - maximum_executed_block_size: U64
+    - maximum_block_size: U64
     - maximum_bytecode_size: U64
     - maximum_blob_size: U64
     - maximum_published_blobs: U64

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -217,13 +217,13 @@ impl BlockBuilder {
                     .clone()
             })
             .collect();
-        let (executed_block, _) = self
+        let (block, _) = self
             .validator
             .worker()
             .stage_block_execution(self.block, None, published_blobs)
             .await?;
 
-        let value = Hashed::new(ConfirmedBlock::new(executed_block));
+        let value = Hashed::new(ConfirmedBlock::new(block));
         let vote = LiteVote::new(
             LiteValue::new(&value),
             Round::Fast,

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -349,9 +349,9 @@ impl ActiveChain {
             )
             .await;
 
-        let executed_block = certificate.inner().block();
-        assert_eq!(executed_block.messages().len(), 1);
-        assert_eq!(executed_block.messages()[0].len(), 0);
+        let block = certificate.inner().block();
+        assert_eq!(block.messages().len(), 1);
+        assert_eq!(block.messages()[0].len(), 0);
 
         module_id.with_abi()
     }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -525,7 +525,7 @@ A number identifying the configuration of the chain (aka the committee)
 scalar Epoch
 
 """
-An event recorded in an executed block.
+An event recorded in a block.
 """
 type Event {
 	"""
@@ -1118,10 +1118,10 @@ input ResourceControlPolicy {
 	"""
 	maximumServiceOracleExecutionMs: Int!
 	"""
-	The maximum size of an executed block. This includes the block proposal itself as well as
+	The maximum size of a block. This includes the block proposal itself as well as
 	the execution outcome.
 	"""
-	maximumExecutedBlockSize: Int!
+	maximumBlockSize: Int!
 	"""
 	The maximum size of decompressed contract or service bytecode, in bytes.
 	"""

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -145,7 +145,7 @@ mod from {
     use linera_base::{data_types::Event, hashed::Hashed, identifiers::StreamId};
     use linera_chain::{
         block::{Block, BlockBody, BlockHeader},
-        data_types::{ExecutedBlock, IncomingBundle, MessageBundle, PostedMessage},
+        data_types::{IncomingBundle, MessageBundle, PostedMessage},
         types::ConfirmedBlock,
     };
     use linera_execution::OutgoingMessage;
@@ -229,7 +229,7 @@ mod from {
         }
     }
 
-    impl TryFrom<block::BlockBlockValueBlock> for ExecutedBlock {
+    impl TryFrom<block::BlockBlockValueBlock> for Block {
         type Error = serde_json::Error;
 
         fn try_from(val: block::BlockBlockValueBlock) -> Result<Self, Self::Error> {
@@ -305,8 +305,7 @@ mod from {
             Ok(Block {
                 header: block_header,
                 body: block_body,
-            }
-            .into())
+            })
         }
     }
 

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -606,7 +606,7 @@ impl Runnable for Job {
                                     http_request,
                                     maximum_fuel_per_block,
                                     maximum_service_oracle_execution_ms,
-                                    maximum_executed_block_size,
+                                    maximum_block_size,
                                     maximum_blob_size,
                                     maximum_published_blobs,
                                     maximum_bytecode_size,
@@ -654,8 +654,8 @@ impl Runnable for Job {
                                             maximum_service_oracle_execution_ms.unwrap_or(
                                                 existing_policy.maximum_service_oracle_execution_ms,
                                             ),
-                                        maximum_executed_block_size: maximum_executed_block_size
-                                            .unwrap_or(existing_policy.maximum_executed_block_size),
+                                        maximum_block_size: maximum_block_size
+                                            .unwrap_or(existing_policy.maximum_block_size),
                                         maximum_bytecode_size: maximum_bytecode_size
                                             .unwrap_or(existing_policy.maximum_bytecode_size),
                                         maximum_blob_size: maximum_blob_size
@@ -1408,7 +1408,7 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
             http_request_price,
             maximum_fuel_per_block,
             maximum_service_oracle_execution_ms,
-            maximum_executed_block_size,
+            maximum_block_size,
             maximum_blob_size,
             maximum_published_blobs,
             maximum_bytecode_size,
@@ -1450,8 +1450,8 @@ async fn run(options: &ClientOptions) -> Result<i32, anyhow::Error> {
                     .unwrap_or(existing_policy.maximum_fuel_per_block),
                 maximum_service_oracle_execution_ms: maximum_service_oracle_execution_ms
                     .unwrap_or(existing_policy.maximum_service_oracle_execution_ms),
-                maximum_executed_block_size: maximum_executed_block_size
-                    .unwrap_or(existing_policy.maximum_executed_block_size),
+                maximum_block_size: maximum_block_size
+                    .unwrap_or(existing_policy.maximum_block_size),
                 maximum_bytecode_size: maximum_bytecode_size
                     .unwrap_or(existing_policy.maximum_bytecode_size),
                 maximum_blob_size: maximum_blob_size.unwrap_or(existing_policy.maximum_blob_size),

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -716,8 +716,8 @@ impl<T> GrpcMessageLimiter<T> {
 mod proto_message_cap {
     use linera_base::hashed::Hashed;
     use linera_chain::{
-        data_types::{BlockExecutionOutcome, ExecutedBlock},
-        types::{Certificate, ConfirmedBlock, ConfirmedBlockCertificate},
+        data_types::BlockExecutionOutcome,
+        types::{Block, Certificate, ConfirmedBlock, ConfirmedBlockCertificate},
     };
     use linera_sdk::linera_base_types::{
         ChainId, TestString, ValidatorKeypair, ValidatorSignature,
@@ -729,13 +729,13 @@ mod proto_message_cap {
         let keypair = ValidatorKeypair::generate();
         let validator = keypair.public_key;
         let signature = ValidatorSignature::new(&TestString::new("Test"), &keypair.secret_key);
-        let executed_block = ExecutedBlock {
-            block: linera_chain::test::make_first_block(ChainId::root(0)),
-            outcome: BlockExecutionOutcome::default(),
-        };
+        let block = Block::new(
+            linera_chain::test::make_first_block(ChainId::root(0)),
+            BlockExecutionOutcome::default(),
+        );
         let signatures = vec![(validator, signature)];
         Certificate::Confirmed(ConfirmedBlockCertificate::new(
-            Hashed::new(ConfirmedBlock::new(executed_block)),
+            Hashed::new(ConfirmedBlock::new(block)),
             Default::default(),
             signatures,
         ))


### PR DESCRIPTION
## Motivation

`ExecutedBlock` was basically replaced by the new `Block` type, but it is still used in some parts of the code.

## Proposal

Replace every usage of `ExecutedBlock` with `Block`, or, in a few cases, with `ProposedBlock` and `BlockExecutionOutcome`.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
