### PR TITLE
Introduce the `EvmBytecode` as `BlobType`.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -865,18 +865,11 @@ impl ApplicationDescription {
     /// Gets the `BlobId` of the contract
     pub fn contract_bytecode_blob_id(&self) -> BlobId {
         match self.module_id.vm_runtime {
-            VmRuntime::Wasm => {
-                BlobId::new(
-                    self.module_id.contract_blob_hash,
-                    BlobType::ContractBytecode,
-                )
-            },
-            VmRuntime::Evm => {
-                BlobId::new(
-                    self.module_id.contract_blob_hash,
-                    BlobType::EvmBytecode,
-                )
-            },
+            VmRuntime::Wasm => BlobId::new(
+                self.module_id.contract_blob_hash,
+                BlobType::ContractBytecode,
+            ),
+            VmRuntime::Evm => BlobId::new(self.module_id.contract_blob_hash, BlobType::EvmBytecode),
         }
     }
 
@@ -884,17 +877,9 @@ impl ApplicationDescription {
     pub fn service_bytecode_blob_id(&self) -> BlobId {
         match self.module_id.vm_runtime {
             VmRuntime::Wasm => {
-                BlobId::new(
-                    self.module_id.service_blob_hash,
-                    BlobType::ServiceBytecode,
-                )
-            },
-            VmRuntime::Evm => {
-                BlobId::new(
-                    self.module_id.contract_blob_hash,
-                    BlobType::EvmBytecode,
-                )
-            },
+                BlobId::new(self.module_id.service_blob_hash, BlobType::ServiceBytecode)
+            }
+            VmRuntime::Evm => BlobId::new(self.module_id.contract_blob_hash, BlobType::EvmBytecode),
         }
     }
 }
@@ -1064,10 +1049,7 @@ impl BlobContent {
 
     /// Creates a new contract bytecode [`BlobContent`] from the provided bytes.
     pub fn new_evm_bytecode(compressed_bytecode: CompressedBytecode) -> Self {
-        BlobContent::new(
-            BlobType::EvmBytecode,
-            compressed_bytecode.compressed_bytes,
-        )
+        BlobContent::new(BlobType::EvmBytecode, compressed_bytecode.compressed_bytes)
     }
 
     /// Creates a new service bytecode [`BlobContent`] from the provided bytes.

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -861,6 +861,42 @@ impl ApplicationDescription {
     pub fn to_bytes(&self) -> Vec<u8> {
         bcs::to_bytes(self).expect("Serializing blob bytes should not fail!")
     }
+
+    /// Gets the `BlobId` of the contract
+    pub fn contract_bytecode_blob_id(&self) -> BlobId {
+        match self.module_id.vm_runtime {
+            VmRuntime::Wasm => {
+                BlobId::new(
+                    self.module_id.contract_blob_hash,
+                    BlobType::ContractBytecode,
+                )
+            },
+            VmRuntime::Evm => {
+                BlobId::new(
+                    self.module_id.contract_blob_hash,
+                    BlobType::EvmBytecode,
+                )
+            },
+        }
+    }
+
+    /// Gets the `BlobId` of the service
+    pub fn service_bytecode_blob_id(&self) -> BlobId {
+        match self.module_id.vm_runtime {
+            VmRuntime::Wasm => {
+                BlobId::new(
+                    self.module_id.service_blob_hash,
+                    BlobType::ServiceBytecode,
+                )
+            },
+            VmRuntime::Evm => {
+                BlobId::new(
+                    self.module_id.contract_blob_hash,
+                    BlobType::EvmBytecode,
+                )
+            },
+        }
+    }
 }
 
 /// A WebAssembly module's bytecode.

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1026,6 +1026,14 @@ impl BlobContent {
         )
     }
 
+    /// Creates a new contract bytecode [`BlobContent`] from the provided bytes.
+    pub fn new_evm_bytecode(compressed_bytecode: CompressedBytecode) -> Self {
+        BlobContent::new(
+            BlobType::EvmBytecode,
+            compressed_bytecode.compressed_bytes,
+        )
+    }
+
     /// Creates a new service bytecode [`BlobContent`] from the provided bytes.
     pub fn new_service_bytecode(compressed_bytecode: CompressedBytecode) -> Self {
         BlobContent::new(
@@ -1109,6 +1117,11 @@ impl Blob {
     /// Creates a new contract bytecode [`BlobContent`] from the provided bytes.
     pub fn new_contract_bytecode(compressed_bytecode: CompressedBytecode) -> Self {
         Blob::new(BlobContent::new_contract_bytecode(compressed_bytecode))
+    }
+
+    /// Creates a new contract bytecode [`BlobContent`] from the provided bytes.
+    pub fn new_evm_bytecode(compressed_bytecode: CompressedBytecode) -> Self {
+        Blob::new(BlobContent::new_evm_bytecode(compressed_bytecode))
     }
 
     /// Creates a new service bytecode [`BlobContent`] from the provided bytes.

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -864,23 +864,12 @@ impl ApplicationDescription {
 
     /// Gets the `BlobId` of the contract
     pub fn contract_bytecode_blob_id(&self) -> BlobId {
-        match self.module_id.vm_runtime {
-            VmRuntime::Wasm => BlobId::new(
-                self.module_id.contract_blob_hash,
-                BlobType::ContractBytecode,
-            ),
-            VmRuntime::Evm => BlobId::new(self.module_id.contract_blob_hash, BlobType::EvmBytecode),
-        }
+        self.module_id.contract_bytecode_blob_id()
     }
 
     /// Gets the `BlobId` of the service
     pub fn service_bytecode_blob_id(&self) -> BlobId {
-        match self.module_id.vm_runtime {
-            VmRuntime::Wasm => {
-                BlobId::new(self.module_id.service_blob_hash, BlobType::ServiceBytecode)
-            }
-            VmRuntime::Evm => BlobId::new(self.module_id.contract_blob_hash, BlobType::EvmBytecode),
-        }
+        self.module_id.service_bytecode_blob_id()
     }
 }
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -169,9 +169,9 @@ pub enum BlobType {
     /// A generic data blob.
     #[default]
     Data,
-    /// A blob containing compressed contract bytecode.
+    /// A blob containing compressed contract Wasm bytecode.
     ContractBytecode,
-    /// A blob containing compressed service bytecode.
+    /// A blob containing compressed service Wasm bytecode.
     ServiceBytecode,
     /// A blob containing compressed EVM bytecode.
     EvmBytecode,
@@ -770,6 +770,36 @@ impl ModuleId {
             _phantom: PhantomData,
         }
     }
+
+    /// Gets the `BlobId` of the contract
+    pub fn contract_bytecode_blob_id(&self) -> BlobId {
+        match self.vm_runtime {
+            VmRuntime::Wasm => BlobId::new(self.contract_blob_hash, BlobType::ContractBytecode),
+            VmRuntime::Evm => BlobId::new(self.contract_blob_hash, BlobType::EvmBytecode),
+        }
+    }
+
+    /// Gets the `BlobId` of the service
+    pub fn service_bytecode_blob_id(&self) -> BlobId {
+	match self.vm_runtime {
+            VmRuntime::Wasm => BlobId::new(self.service_blob_hash, BlobType::ServiceBytecode),
+            VmRuntime::Evm => BlobId::new(self.contract_blob_hash, BlobType::EvmBytecode),
+        }
+    }
+
+    /// Gets the relevant `BlobId` of the module
+    pub fn bytecode_blob_ids(&self) -> Vec<BlobId> {
+	match self.vm_runtime {
+            VmRuntime::Wasm => vec![
+                BlobId::new(self.contract_blob_hash, BlobType::ContractBytecode),
+                BlobId::new(self.service_blob_hash, BlobType::ServiceBytecode),
+            ],
+            VmRuntime::Evm => vec![
+                BlobId::new(self.contract_blob_hash, BlobType::EvmBytecode),
+            ],
+        }
+    }
+
 }
 
 impl<Abi, Parameters, InstantiationArgument> ModuleId<Abi, Parameters, InstantiationArgument> {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -781,7 +781,7 @@ impl ModuleId {
 
     /// Gets the `BlobId` of the service
     pub fn service_bytecode_blob_id(&self) -> BlobId {
-	match self.vm_runtime {
+        match self.vm_runtime {
             VmRuntime::Wasm => BlobId::new(self.service_blob_hash, BlobType::ServiceBytecode),
             VmRuntime::Evm => BlobId::new(self.contract_blob_hash, BlobType::EvmBytecode),
         }
@@ -789,17 +789,14 @@ impl ModuleId {
 
     /// Gets the relevant `BlobId` of the module
     pub fn bytecode_blob_ids(&self) -> Vec<BlobId> {
-	match self.vm_runtime {
+        match self.vm_runtime {
             VmRuntime::Wasm => vec![
                 BlobId::new(self.contract_blob_hash, BlobType::ContractBytecode),
                 BlobId::new(self.service_blob_hash, BlobType::ServiceBytecode),
             ],
-            VmRuntime::Evm => vec![
-                BlobId::new(self.contract_blob_hash, BlobType::EvmBytecode),
-            ],
+            VmRuntime::Evm => vec![BlobId::new(self.contract_blob_hash, BlobType::EvmBytecode)],
         }
     }
-
 }
 
 impl<Abi, Parameters, InstantiationArgument> ModuleId<Abi, Parameters, InstantiationArgument> {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -787,7 +787,7 @@ impl ModuleId {
         }
     }
 
-    /// Gets the relevant `BlobId` of the module
+    /// Gets all bytecode `BlobId`s of the module
     pub fn bytecode_blob_ids(&self) -> Vec<BlobId> {
         match self.vm_runtime {
             VmRuntime::Wasm => vec![

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -173,6 +173,8 @@ pub enum BlobType {
     ContractBytecode,
     /// A blob containing compressed service bytecode.
     ServiceBytecode,
+    /// A blob containing compressed EVM bytecode.
+    EvmBytecode,
     /// A blob containing an application description.
     ApplicationDescription,
     /// A blob containing a committee of validators.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -756,6 +756,7 @@ where
             if blob_type == BlobType::Data
                 || blob_type == BlobType::ContractBytecode
                 || blob_type == BlobType::ServiceBytecode
+                || blob_type == BlobType::EvmBytecode
             {
                 resource_controller
                     .with_state(&mut self.execution_state.system)

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -564,16 +564,15 @@ where
             .with_context(|| format!("failed to load service bytecode from {:?}", &service))?;
 
         info!("Publishing module");
-        let (contract_blob, service_blob, module_id) =
+        let (blobs, module_id) =
             create_bytecode_blobs(contract_bytecode, service_bytecode, vm_runtime).await;
         let (module_id, _) = self
             .apply_client_command(chain_client, |chain_client| {
-                let contract_blob = contract_blob.clone();
-                let service_blob = service_blob.clone();
+                let blobs = blobs.clone();
                 let chain_client = chain_client.clone();
                 async move {
                     chain_client
-                        .publish_module_blobs(contract_blob, service_blob, module_id)
+                        .publish_module_blobs(blobs, module_id)
                         .await
                         .context("Failed to publish module")
                 }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -758,19 +758,24 @@ pub async fn create_bytecode_blobs(
         VmRuntime::Wasm => {
             let (compressed_contract, compressed_service) =
                 tokio::task::spawn_blocking(move || (contract.compress(), service.compress()))
-                .await
-                .expect("Compression should not panic");
+                    .await
+                    .expect("Compression should not panic");
             let contract_blob = Blob::new_contract_bytecode(compressed_contract);
             let service_blob = Blob::new_service_bytecode(compressed_service);
-            let module_id = ModuleId::new(contract_blob.id().hash, service_blob.id().hash, vm_runtime);
+            let module_id =
+                ModuleId::new(contract_blob.id().hash, service_blob.id().hash, vm_runtime);
             (vec![contract_blob, service_blob], module_id)
-        },
+        }
         VmRuntime::Evm => {
             let compressed_contract = contract.compress();
             let evm_contract_blob = Blob::new_evm_bytecode(compressed_contract);
-            let module_id = ModuleId::new(evm_contract_blob.id().hash, evm_contract_blob.id().hash, vm_runtime);
+            let module_id = ModuleId::new(
+                evm_contract_blob.id().hash,
+                evm_contract_blob.id().hash,
+                vm_runtime,
+            );
             (vec![evm_contract_blob], module_id)
-        },
+        }
     }
 }
 
@@ -2897,10 +2902,8 @@ where
         service: Bytecode,
         vm_runtime: VmRuntime,
     ) -> Result<ClientOutcome<(ModuleId, ConfirmedBlockCertificate)>, ChainClientError> {
-        let (blobs, module_id) =
-            create_bytecode_blobs(contract, service, vm_runtime).await;
-        self.publish_module_blobs(blobs, module_id)
-            .await
+        let (blobs, module_id) = create_bytecode_blobs(contract, service, vm_runtime).await;
+        self.publish_module_blobs(blobs, module_id).await
     }
 
     /// Publishes some module.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -753,15 +753,25 @@ pub async fn create_bytecode_blobs(
     contract: Bytecode,
     service: Bytecode,
     vm_runtime: VmRuntime,
-) -> (Blob, Blob, ModuleId) {
-    let (compressed_contract, compressed_service) =
-        tokio::task::spawn_blocking(move || (contract.compress(), service.compress()))
-            .await
-            .expect("Compression should not panic");
-    let contract_blob = Blob::new_contract_bytecode(compressed_contract);
-    let service_blob = Blob::new_service_bytecode(compressed_service);
-    let module_id = ModuleId::new(contract_blob.id().hash, service_blob.id().hash, vm_runtime);
-    (contract_blob, service_blob, module_id)
+) -> (Vec<Blob>, ModuleId) {
+    match vm_runtime {
+        VmRuntime::Wasm => {
+            let (compressed_contract, compressed_service) =
+                tokio::task::spawn_blocking(move || (contract.compress(), service.compress()))
+                .await
+                .expect("Compression should not panic");
+            let contract_blob = Blob::new_contract_bytecode(compressed_contract);
+            let service_blob = Blob::new_service_bytecode(compressed_service);
+            let module_id = ModuleId::new(contract_blob.id().hash, service_blob.id().hash, vm_runtime);
+            (vec![contract_blob, service_blob], module_id)
+        },
+        VmRuntime::Evm => {
+            let compressed_contract = contract.compress();
+            let evm_contract_blob = Blob::new_evm_bytecode(compressed_contract);
+            let module_id = ModuleId::new(evm_contract_blob.id().hash, evm_contract_blob.id().hash, vm_runtime);
+            (vec![evm_contract_blob], module_id)
+        },
+    }
 }
 
 impl<P, S> ChainClient<P, S>
@@ -2887,26 +2897,25 @@ where
         service: Bytecode,
         vm_runtime: VmRuntime,
     ) -> Result<ClientOutcome<(ModuleId, ConfirmedBlockCertificate)>, ChainClientError> {
-        let (contract_blob, service_blob, module_id) =
+        let (blobs, module_id) =
             create_bytecode_blobs(contract, service, vm_runtime).await;
-        self.publish_module_blobs(contract_blob, service_blob, module_id)
+        self.publish_module_blobs(blobs, module_id)
             .await
     }
 
     /// Publishes some module.
     #[cfg(not(target_arch = "wasm32"))]
-    #[instrument(level = "trace", skip(contract_blob, service_blob, module_id))]
+    #[instrument(level = "trace", skip(blobs, module_id))]
     pub async fn publish_module_blobs(
         &self,
-        contract_blob: Blob,
-        service_blob: Blob,
+        blobs: Vec<Blob>,
         module_id: ModuleId,
     ) -> Result<ClientOutcome<(ModuleId, ConfirmedBlockCertificate)>, ChainClientError> {
         self.execute_operations(
             vec![Operation::system(SystemOperation::PublishModule {
                 module_id,
             })],
-            vec![contract_blob, service_blob],
+            blobs,
         )
         .await?
         .try_map(|certificate| Ok((module_id, certificate)))

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -46,6 +46,7 @@ use linera_base::{
     },
     ownership::ChainOwnership,
     task,
+    vm::VmRuntime,
 };
 use linera_views::{batch::Batch, views::ViewError};
 use serde::{Deserialize, Serialize};
@@ -1163,10 +1164,17 @@ impl Operation {
             Some(SystemOperation::Admin(AdminOperation::PublishCommitteeBlob { blob_hash })) => {
                 vec![BlobId::new(*blob_hash, BlobType::Committee)]
             }
-            Some(SystemOperation::PublishModule { module_id }) => vec![
-                BlobId::new(module_id.contract_blob_hash, BlobType::ContractBytecode),
-                BlobId::new(module_id.service_blob_hash, BlobType::ServiceBytecode),
-            ],
+            Some(SystemOperation::PublishModule { module_id }) => {
+                match module_id.vm_runtime {
+                    VmRuntime::Wasm => vec![
+                        BlobId::new(module_id.contract_blob_hash, BlobType::ContractBytecode),
+                        BlobId::new(module_id.service_blob_hash, BlobType::ServiceBytecode),
+                    ],
+                    VmRuntime::Evm => vec![
+                        BlobId::new(module_id.contract_blob_hash, BlobType::EvmBytecode),
+                    ]
+                }
+            }
             _ => vec![],
         }
     }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1164,17 +1164,16 @@ impl Operation {
             Some(SystemOperation::Admin(AdminOperation::PublishCommitteeBlob { blob_hash })) => {
                 vec![BlobId::new(*blob_hash, BlobType::Committee)]
             }
-            Some(SystemOperation::PublishModule { module_id }) => {
-                match module_id.vm_runtime {
-                    VmRuntime::Wasm => vec![
-                        BlobId::new(module_id.contract_blob_hash, BlobType::ContractBytecode),
-                        BlobId::new(module_id.service_blob_hash, BlobType::ServiceBytecode),
-                    ],
-                    VmRuntime::Evm => vec![
-                        BlobId::new(module_id.contract_blob_hash, BlobType::EvmBytecode),
-                    ]
-                }
-            }
+            Some(SystemOperation::PublishModule { module_id }) => match module_id.vm_runtime {
+                VmRuntime::Wasm => vec![
+                    BlobId::new(module_id.contract_blob_hash, BlobType::ContractBytecode),
+                    BlobId::new(module_id.service_blob_hash, BlobType::ServiceBytecode),
+                ],
+                VmRuntime::Evm => vec![BlobId::new(
+                    module_id.contract_blob_hash,
+                    BlobType::EvmBytecode,
+                )],
+            },
             _ => vec![],
         }
     }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -46,7 +46,6 @@ use linera_base::{
     },
     ownership::ChainOwnership,
     task,
-    vm::VmRuntime,
 };
 use linera_views::{batch::Batch, views::ViewError};
 use serde::{Deserialize, Serialize};
@@ -1164,16 +1163,7 @@ impl Operation {
             Some(SystemOperation::Admin(AdminOperation::PublishCommitteeBlob { blob_hash })) => {
                 vec![BlobId::new(*blob_hash, BlobType::Committee)]
             }
-            Some(SystemOperation::PublishModule { module_id }) => match module_id.vm_runtime {
-                VmRuntime::Wasm => vec![
-                    BlobId::new(module_id.contract_blob_hash, BlobType::ContractBytecode),
-                    BlobId::new(module_id.service_blob_hash, BlobType::ServiceBytecode),
-                ],
-                VmRuntime::Evm => vec![BlobId::new(
-                    module_id.contract_blob_hash,
-                    BlobType::EvmBytecode,
-                )],
-            },
+            Some(SystemOperation::PublishModule { module_id }) => module_id.bytecode_blob_ids(),
             _ => vec![],
         }
     }

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -388,7 +388,7 @@ impl ResourceControlPolicy {
             ExecutionError::BlobTooLarge
         );
         match content.blob_type() {
-            BlobType::ContractBytecode | BlobType::ServiceBytecode => {
+            BlobType::ContractBytecode | BlobType::ServiceBytecode | BlobType::EvmBytecode => {
                 ensure!(
                     CompressedBytecode::decompressed_size_at_most(
                         content.bytes(),

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -410,7 +410,7 @@ where
                 for blob_id in module_id.bytecode_blob_ids() {
                     self.blob_published(&blob_id)?;
                 }
-            },
+            }
             CreateApplication {
                 module_id,
                 parameters,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -407,26 +407,24 @@ where
                     }
                 }
             }
-            PublishModule { module_id } => {
-                match module_id.vm_runtime {
-                    VmRuntime::Wasm => {
-                        self.blob_published(&BlobId::new(
-                            module_id.contract_blob_hash,
-                            BlobType::ContractBytecode,
-                        ))?;
-                        self.blob_published(&BlobId::new(
-                            module_id.service_blob_hash,
-                            BlobType::ServiceBytecode,
-                        ))?;
-                    },
-                    VmRuntime::Evm => {
-                        self.blob_published(&BlobId::new(
-                            module_id.contract_blob_hash,
-                            BlobType::EvmBytecode,
-                        ))?;
-                    },
+            PublishModule { module_id } => match module_id.vm_runtime {
+                VmRuntime::Wasm => {
+                    self.blob_published(&BlobId::new(
+                        module_id.contract_blob_hash,
+                        BlobType::ContractBytecode,
+                    ))?;
+                    self.blob_published(&BlobId::new(
+                        module_id.service_blob_hash,
+                        BlobType::ServiceBytecode,
+                    ))?;
                 }
-            }
+                VmRuntime::Evm => {
+                    self.blob_published(&BlobId::new(
+                        module_id.contract_blob_hash,
+                        BlobType::EvmBytecode,
+                    ))?;
+                }
+            },
             CreateApplication {
                 module_id,
                 parameters,
@@ -931,20 +929,18 @@ where
                     BlobId::new(module_id.contract_blob_hash, BlobType::ContractBytecode),
                     BlobId::new(module_id.service_blob_hash, BlobType::ServiceBytecode),
                 ]
-            },
+            }
             VmRuntime::Evm => {
-                vec![BlobId::new(module_id.contract_blob_hash, BlobType::EvmBytecode)]
-            },
+                vec![BlobId::new(
+                    module_id.contract_blob_hash,
+                    BlobType::EvmBytecode,
+                )]
+            }
         };
 
         let mut missing_blobs = Vec::new();
         for blob_id in &blob_ids {
-            if !self
-                .context()
-                .extra()
-                .contains_blob(*blob_id)
-                .await?
-            {
+            if !self.context().extra().contains_blob(*blob_id).await? {
                 missing_blobs.push(*blob_id);
             }
         }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -111,8 +111,10 @@ BlobType:
     2:
       ServiceBytecode: UNIT
     3:
-      ApplicationDescription: UNIT
+      EvmBytecode: UNIT
     4:
+      ApplicationDescription: UNIT
+    5:
       Committee: UNIT
 Block:
   STRUCT:

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -17,9 +17,7 @@ use linera_base::{
         Amount, ApplicationDescription, Blob, BlockHeight, CompressedBytecode, TimeDelta, Timestamp,
     },
     hashed::Hashed,
-    identifiers::{
-        AccountOwner, ApplicationId, BlobId, ChainDescription, ChainId, EventId,
-    },
+    identifiers::{AccountOwner, ApplicationId, BlobId, ChainDescription, ChainId, EventId},
     ownership::ChainOwnership,
     vm::VmRuntime,
 };

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -18,7 +18,7 @@ use linera_base::{
     },
     hashed::Hashed,
     identifiers::{
-        AccountOwner, ApplicationId, BlobId, BlobType, ChainDescription, ChainId, EventId,
+        AccountOwner, ApplicationId, BlobId, ChainDescription, ChainId, EventId,
     },
     ownership::ChainOwnership,
     vm::VmRuntime,
@@ -260,10 +260,7 @@ pub trait Storage: Sized {
         &self,
         application_description: &ApplicationDescription,
     ) -> Result<UserContractCode, ExecutionError> {
-        let contract_bytecode_blob_id = BlobId::new(
-            application_description.module_id.contract_blob_hash,
-            BlobType::ContractBytecode,
-        );
+        let contract_bytecode_blob_id = application_description.contract_bytecode_blob_id();
         let contract_blob = self.read_blob(contract_bytecode_blob_id).await?;
         let compressed_contract_bytecode = CompressedBytecode {
             compressed_bytes: contract_blob.into_bytes().to_vec(),
@@ -320,10 +317,7 @@ pub trait Storage: Sized {
         &self,
         application_description: &ApplicationDescription,
     ) -> Result<UserServiceCode, ExecutionError> {
-        let service_bytecode_blob_id = BlobId::new(
-            application_description.module_id.service_blob_hash,
-            BlobType::ServiceBytecode,
-        );
+        let service_bytecode_blob_id = application_description.service_bytecode_blob_id();
         let service_blob = self.read_blob(service_bytecode_blob_id).await?;
         let compressed_service_bytecode = CompressedBytecode {
             compressed_bytes: service_blob.into_bytes().to_vec(),


### PR DESCRIPTION
## Motivation

The EVM Bytecode has only contract, not a service, or if there is a service, it is the same as the contract.
This leads to a duplication of the blobs that is unfortunate.

## Proposal

The changes are made accordingly and this leads to a relatively nice restructuration:
* The pair `(Blob, Blob)` are replaced by `Vec<Blob>`.
* The `load_contract/load_service` are restructured to accedd the `{contract,service}_bytecode_blob_id` from the application description.
* When calling an EVM smart contract, the service is provided but it has no impact on the running.

Coauthored by @afck

## Test Plan

The CI

## Release Plan

Normal release scheme.

## Links

None.