### PR TITLE
Fix typo in ServiceStoreError enum variant

### DIFF
--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -508,7 +508,7 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
 
     async fn create(config: &Self::Config, namespace: &str) -> Result<(), ServiceStoreError> {
         if ServiceStoreClientInternal::exists(config, namespace).await? {
-            return Err(ServiceStoreError::StoreAlreadyExist);
+            return Err(ServiceStoreError::StoreAlreadyExists);
         }
         let namespace = bcs::to_bytes(namespace)?;
         let query = RequestCreateNamespace { namespace };

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -36,7 +36,7 @@ pub enum KeyPrefix {
 pub enum ServiceStoreError {
     /// Store already exists during a create operation
     #[error("Store already exists during a create operation")]
-    StoreAlreadyExist,
+    StoreAlreadyExists,
 
     /// Not matching entry
     #[error("Not matching entry")]


### PR DESCRIPTION
change the enum variant name from "StoreAlreadyExist" to "StoreAlreadyExists" to use correct English grammar. This affects both the enum definition in common.rs and its usage in client.rs.