### PR TITLE
Remove unused account key from validator config

### DIFF
--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -60,7 +60,6 @@ pub struct ValidatorConfig {
 pub struct ValidatorServerConfig {
     pub validator: ValidatorConfig,
     pub validator_secret: ValidatorSecretKey,
-    pub account_secret: AccountSecretKey,
     pub internal_network: ValidatorInternalNetworkConfig,
 }
 

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -5,10 +5,7 @@
 
 use std::sync::Arc;
 
-use linera_base::{
-    crypto::{AccountSecretKey, ValidatorSecretKey},
-    time::Duration,
-};
+use linera_base::{crypto::ValidatorSecretKey, time::Duration};
 
 /// Configuration parameters for the [`ChainWorkerState`][`super::state::ChainWorkerState`].
 #[derive(Clone, Default)]
@@ -16,8 +13,6 @@ pub struct ChainWorkerConfig {
     /// The signature key pair of the validator. The key may be missing for replicas
     /// without voting rights (possibly with a partial view of chains).
     pub key_pair: Option<Arc<ValidatorSecretKey>>,
-    /// The account secret key of the validator. Can be used to sign blocks as chain owner.
-    pub account_key: Option<Arc<AccountSecretKey>>,
     /// Whether inactive chains are allowed in storage.
     pub allow_inactive_chains: bool,
     /// Whether new messages from deprecated epochs are allowed.
@@ -31,18 +26,13 @@ pub struct ChainWorkerConfig {
 
 impl ChainWorkerConfig {
     /// Configures the `key_pair` in this [`ChainWorkerConfig`].
-    pub fn with_key_pair(
-        mut self,
-        key_pair: Option<(ValidatorSecretKey, AccountSecretKey)>,
-    ) -> Self {
+    pub fn with_key_pair(mut self, key_pair: Option<ValidatorSecretKey>) -> Self {
         match key_pair {
-            Some((validator_secret, account_secret)) => {
+            Some(validator_secret) => {
                 self.key_pair = Some(Arc::new(validator_secret));
-                self.account_key = Some(Arc::new(account_secret));
             }
             None => {
                 self.key_pair = None;
-                self.account_key = None;
             }
         }
         self
@@ -51,10 +41,5 @@ impl ChainWorkerConfig {
     /// Gets a reference to the [`ValidatorSecretKey`], if available.
     pub fn key_pair(&self) -> Option<&ValidatorSecretKey> {
         self.key_pair.as_ref().map(Arc::as_ref)
-    }
-
-    /// Gets a reference to the [`AccountSecretKey`], if available.
-    pub fn account_key(&self) -> Option<&AccountSecretKey> {
-        self.account_key.as_ref().map(Arc::as_ref)
     }
 }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -735,18 +735,18 @@ where
             let validator_keypair = ValidatorKeypair::generate();
             let account_secret = AccountSecretKey::generate();
             validators.push((validator_keypair.public_key, account_secret.public()));
-            key_pairs.push((validator_keypair.secret_key, account_secret));
+            key_pairs.push(validator_keypair.secret_key);
         }
         let initial_committee = Committee::make_simple(validators);
         let mut validator_clients = Vec::new();
         let mut validator_storages = HashMap::new();
         let mut faulty_validators = HashSet::new();
-        for (i, (validator_secret, account_secret)) in key_pairs.into_iter().enumerate() {
+        for (i, validator_secret) in key_pairs.into_iter().enumerate() {
             let validator_public_key = validator_secret.public();
             let storage = storage_builder.build().await?;
             let state = WorkerState::new(
                 format!("Node {}", i),
-                Some((validator_secret, account_secret)),
+                Some(validator_secret),
                 storage.clone(),
                 NonZeroUsize::new(100).expect("Chain worker limit should not be zero"),
             )

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -99,7 +99,7 @@ where
     )]);
     let worker = WorkerState::new(
         "Single validator node".to_string(),
-        Some((validator_keypair.secret_key, account_secret)),
+        Some(validator_keypair.secret_key),
         storage,
         NonZeroUsize::new(10).expect("Chain worker limit should not be zero"),
     )
@@ -3681,7 +3681,9 @@ where
     let (committee, worker) = init_worker_with_chains(storage, balances).await;
 
     // At time 0 we don't vote for fallback mode.
-    let query = ChainInfoQuery::new(chain_id).with_fallback();
+    let query = ChainInfoQuery::new(chain_id)
+        .with_fallback()
+        .with_committees();
     let (response, _) = worker.handle_chain_info_query(query.clone()).await?;
     let manager = response.info.manager;
     assert!(manager.fallback_vote.is_none());
@@ -3723,9 +3725,18 @@ where
     // Now we are in fallback mode, and the validator is the leader.
     let (response, _) = worker.handle_chain_info_query(query.clone()).await?;
     let manager = response.info.manager;
-    let account_key = worker.account_key();
+    let expected_key = response
+        .info
+        .requested_committees
+        .unwrap()
+        .get(&response.info.epoch.unwrap())
+        .unwrap()
+        .validators
+        .get(&vote.public_key)
+        .unwrap()
+        .account_public_key;
     assert_eq!(manager.current_round, Round::Validator(0));
-    assert_eq!(manager.leader, Some(AccountOwner::from(account_key)));
+    assert_eq!(manager.leader, Some(AccountOwner::from(expected_key)));
     Ok(())
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -10,10 +10,8 @@ use std::{
 };
 
 use futures::future::Either;
-#[cfg(with_testing)]
-use linera_base::crypto::AccountPublicKey;
 use linera_base::{
-    crypto::{AccountSecretKey, CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSecretKey},
+    crypto::{CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSecretKey},
     data_types::{
         ApplicationDescription, ArithmeticError, Blob, BlockHeight, DecompressionError, Round,
     },
@@ -290,7 +288,7 @@ where
     #[instrument(level = "trace", skip(nickname, key_pair, storage))]
     pub fn new(
         nickname: String,
-        key_pair: Option<(ValidatorSecretKey, AccountSecretKey)>,
+        key_pair: Option<ValidatorSecretKey>,
         storage: StorageClient,
         chain_worker_limit: NonZeroUsize,
     ) -> Self {
@@ -1075,22 +1073,6 @@ where
             .expect(
                 "Test validator should have a key pair assigned to it \
                 in order to obtain it's public key",
-            )
-            .public()
-    }
-
-    /// Gets a reference to the validator's [`AccountPublicKey`].
-    ///
-    /// # Panics
-    ///
-    /// If the validator doesn't have an account secret key assigned to it.
-    #[instrument(level = "trace", skip(self))]
-    pub fn account_key(&self) -> AccountPublicKey {
-        self.chain_worker_config
-            .account_key()
-            .expect(
-                "Test validator should have a key pair assigned to it \
-                in order to obtain it's account key",
             )
             .public()
     }

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -105,7 +105,7 @@ pub struct ValidatorState {
 #[derive(Eq, PartialEq, Hash, Clone, Debug, Default, InputObject)]
 pub struct Committee {
     /// The validators in the committee.
-    validators: BTreeMap<ValidatorPublicKey, ValidatorState>,
+    pub validators: BTreeMap<ValidatorPublicKey, ValidatorState>,
     /// The sum of all voting rights.
     total_votes: u64,
     /// The threshold to form a quorum.

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -88,7 +88,7 @@ impl TestValidator {
         let clock = storage.clock().clone();
         let worker = WorkerState::new(
             "Single validator node".to_string(),
-            Some((validator_keypair.secret_key.copy(), account_secret.copy())),
+            Some(validator_keypair.secret_key.copy()),
             storage.clone(),
             NonZeroUsize::new(40).expect("Chain worker limit should not be zero"),
         );

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -70,10 +70,7 @@ impl ServerContext {
         );
         let state = WorkerState::new(
             format!("Shard {} @ {}:{}", shard_id, local_ip_addr, shard.port),
-            Some((
-                self.server_config.validator_secret.copy(),
-                self.server_config.account_secret.copy(),
-            )),
+            Some(self.server_config.validator_secret.copy()),
             storage,
             self.max_loaded_chains,
         )
@@ -358,7 +355,6 @@ fn make_server_config<R: CryptoRng>(
         ValidatorServerConfig {
             validator,
             validator_secret: validator_keypair.secret_key,
-            account_secret,
             internal_network,
         },
     )?)


### PR DESCRIPTION
## Motivation

Fallback chain owners (validators) will be done in a separate client process.

## Proposal

Remove unused (and not planned) account key from validator config.

## Test Plan

CI

## Release Plan


- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
