### PR TITLE
Count messages, not transactions, in the outgoing message counter.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -324,7 +324,8 @@ impl ChainTipState {
             .ok_or(ArithmeticError::Overflow)?;
 
         let num_outgoing_messages =
-            u32::try_from(outcome.messages.len()).map_err(|_| ArithmeticError::Overflow)?;
+            u32::try_from(outcome.messages.iter().map(Vec::len).sum::<usize>())
+                .map_err(|_| ArithmeticError::Overflow)?;
         self.num_outgoing_messages = self
             .num_outgoing_messages
             .checked_add(num_outgoing_messages)


### PR DESCRIPTION
## Motivation

The message counter currently counts how many `Vec<OutgoingMessage>` vectors there are in a block, which is the number of transactions.

## Proposal

Count the number of messages instead.
(Edit: This isn't actually used in Linera itself at all, but it it exposed as part of the chain state, e.g. for block explorers.)

## Test Plan

The change is small and only affects metrics, so there is no dedicated test.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
