### PR TITLE
Network release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Create Network Release
+
+on:
+  push:
+    tags:
+      - 'testnet-*-v[0-9]+.[0-9]+.[0-9]+'
+      - 'devnet-*-v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract Tag Name
+        id: tag
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.TAG_NAME }}
+          name: ${{ steps.tag.outputs.TAG_NAME }}
+          generate_release_notes: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

We'd like to be able to tag git commits on network branches (i.e. `testnet_archimedes`) and trigger new releases to notify validators of hotfixes.

## Proposal

Add a workflow which pattern matches on git tags and triggers releases.

## Test Plan

Need to test manually.

