### PR TITLE
Split `execute_and_apply_block`, move more chain logic to `ChainStateView`.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -17,6 +17,7 @@ use linera_base::{
         OracleResponse, Timestamp,
     },
     ensure,
+    hashed::Hashed,
     identifiers::{
         AccountOwner, ApplicationId, BlobType, ChainId, ChannelFullName, Destination,
         GenericApplicationId, MessageId,
@@ -43,7 +44,7 @@ use linera_views::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    block::Block,
+    block::{Block, ConfirmedBlock},
     data_types::{
         BlockExecutionOutcome, ChainAndHeight, IncomingBundle, MessageAction, MessageBundle,
         OperationResult, Origin, PostedMessage, ProposedBlock, Target, Transaction,
@@ -306,26 +307,26 @@ impl ChainTipState {
     /// Checks if the measurement counters would be valid.
     pub fn update_counters(
         &mut self,
-        proposed_block: &ProposedBlock,
-        outcome: &BlockExecutionOutcome,
+        incoming_bundles: &[IncomingBundle],
+        operations: &[Operation],
+        messages: &[Vec<OutgoingMessage>],
     ) -> Result<(), ChainError> {
-        let num_incoming_bundles = u32::try_from(proposed_block.incoming_bundles.len())
-            .map_err(|_| ArithmeticError::Overflow)?;
+        let num_incoming_bundles =
+            u32::try_from(incoming_bundles.len()).map_err(|_| ArithmeticError::Overflow)?;
         self.num_incoming_bundles = self
             .num_incoming_bundles
             .checked_add(num_incoming_bundles)
             .ok_or(ArithmeticError::Overflow)?;
 
-        let num_operations = u32::try_from(proposed_block.operations.len())
-            .map_err(|_| ArithmeticError::Overflow)?;
+        let num_operations =
+            u32::try_from(operations.len()).map_err(|_| ArithmeticError::Overflow)?;
         self.num_operations = self
             .num_operations
             .checked_add(num_operations)
             .ok_or(ArithmeticError::Overflow)?;
 
-        let num_outgoing_messages =
-            u32::try_from(outcome.messages.iter().map(Vec::len).sum::<usize>())
-                .map_err(|_| ArithmeticError::Overflow)?;
+        let num_outgoing_messages = u32::try_from(messages.iter().map(Vec::len).sum::<usize>())
+            .map_err(|_| ArithmeticError::Overflow)?;
         self.num_outgoing_messages = self
             .num_outgoing_messages
             .checked_add(num_outgoing_messages)
@@ -1004,28 +1005,44 @@ where
 
     /// Applies an execution outcome to the chain, updating the outboxes, state hash and chain
     /// manager. This does not touch the execution state itself, which must be updated separately.
-    pub async fn apply_execution_outcome(
+    pub async fn apply_confirmed_block(
         &mut self,
-        outcome: &BlockExecutionOutcome,
-        height: BlockHeight,
+        block: &Hashed<ConfirmedBlock>,
         local_time: Timestamp,
     ) -> Result<(), ChainError> {
-        self.execution_state_hash.set(Some(outcome.state_hash));
-        for txn_messages in &outcome.messages {
-            self.process_outgoing_messages(height, txn_messages).await?;
+        let hash = block.hash();
+        let block = block.inner().inner().inner();
+        self.execution_state_hash.set(Some(block.header.state_hash));
+        for txn_messages in &block.body.messages {
+            self.process_outgoing_messages(block.header.height, txn_messages)
+                .await?;
         }
 
-        let recipients = outcome
+        let recipients = block
+            .body
             .messages
             .iter()
             .flatten()
             .flat_map(|message| message.destination.recipient())
             .collect::<BTreeSet<_>>();
         for recipient in recipients {
-            self.previous_message_blocks.insert(&recipient, height)?;
+            self.previous_message_blocks
+                .insert(&recipient, block.header.height)?;
         }
         // Last, reset the consensus state based on the current ownership.
-        self.reset_chain_manager(height.try_add_one()?, local_time)
+        self.reset_chain_manager(block.header.height.try_add_one()?, local_time)?;
+
+        // Advance to next block height.
+        let tip = self.tip_state.get_mut();
+        tip.block_hash = Some(hash);
+        tip.next_block_height.try_add_assign_one()?;
+        tip.update_counters(
+            &block.body.incoming_bundles,
+            &block.body.operations,
+            &block.body.messages,
+        )?;
+        self.confirmed_log.push(hash);
+        Ok(())
     }
 
     /// Executes a message as part of an incoming bundle in a block.

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -172,7 +172,7 @@ async fn test_block_size_limit() {
         });
 
     let result = chain
-        .execute_and_apply_block(&invalid_block, time, None, &[], None)
+        .execute_block(&invalid_block, time, None, &[], None)
         .await;
     assert_matches!(
         result,
@@ -183,8 +183,8 @@ async fn test_block_size_limit() {
     );
 
     // The valid block is accepted...
-    let outcome = chain
-        .execute_and_apply_block(&valid_block, time, None, &[], None)
+    let (outcome, _, _) = chain
+        .execute_block(&valid_block, time, None, &[], None)
         .await
         .unwrap();
     let block = Block::new(valid_block, outcome);
@@ -247,7 +247,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
         .with_incoming_bundle(bundle.clone())
         .with_simple_transfer(chain_id, Amount::ONE);
     let result = chain
-        .execute_and_apply_block(&invalid_block, time, None, &[], None)
+        .execute_block(&invalid_block, time, None, &[], None)
         .await;
     assert_matches!(result, Err(ChainError::AuthorizedApplications(app_ids))
         if app_ids == vec![application_id]
@@ -263,10 +263,13 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     let valid_block = make_first_block(chain_id)
         .with_incoming_bundle(bundle)
         .with_operation(app_operation.clone());
-    let block = chain
-        .execute_and_apply_block(&valid_block, time, None, &[], None)
-        .await?
-        .with(valid_block);
+    let (outcome, _, _) = chain
+        .execute_block(&valid_block, time, None, &[], None)
+        .await?;
+    chain
+        .apply_execution_outcome(&outcome, valid_block.height, time)
+        .await?;
+    let block = outcome.with(valid_block);
     let value = Hashed::new(ConfirmedBlock::new(block));
 
     // In the second block, other operations are still not allowed.
@@ -274,7 +277,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
         .with_simple_transfer(chain_id, Amount::ONE)
         .with_operation(app_operation.clone());
     let result = chain
-        .execute_and_apply_block(&invalid_block, time, None, &[], None)
+        .execute_block(&invalid_block, time, None, &[], None)
         .await;
     assert_matches!(result, Err(ChainError::AuthorizedApplications(app_ids))
         if app_ids == vec![application_id]
@@ -283,7 +286,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     // Also, blocks without an application operation or incoming message are forbidden.
     let invalid_block = make_child_block(&value.clone());
     let result = chain
-        .execute_and_apply_block(&invalid_block, time, None, &[], None)
+        .execute_block(&invalid_block, time, None, &[], None)
         .await;
     assert_matches!(result, Err(ChainError::MissingMandatoryApplications(app_ids))
         if app_ids == vec![application_id]
@@ -293,8 +296,11 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     application.expect_call(ExpectedCall::execute_operation(|_, _, _| Ok(vec![])));
     application.expect_call(ExpectedCall::default_finalize());
     let valid_block = make_child_block(&value).with_operation(app_operation);
+    let (outcome, _, _) = chain
+        .execute_block(&valid_block, time, None, &[], None)
+        .await?;
     chain
-        .execute_and_apply_block(&valid_block, time, None, &[], None)
+        .apply_execution_outcome(&outcome, valid_block.height, time)
         .await?;
 
     Ok(())
@@ -337,9 +343,7 @@ async fn test_service_as_oracles(service_oracle_execution_times_ms: &[u64]) -> a
 
     application.expect_call(ExpectedCall::default_finalize());
 
-    chain
-        .execute_and_apply_block(&block, time, None, &[], None)
-        .await?;
+    chain.execute_block(&block, time, None, &[], None).await?;
 
     Ok(())
 }
@@ -384,9 +388,7 @@ async fn test_service_as_oracle_exceeding_time_limit(
 
     application.expect_call(ExpectedCall::default_finalize());
 
-    let result = chain
-        .execute_and_apply_block(&block, time, None, &[], None)
-        .await;
+    let result = chain.execute_block(&block, time, None, &[], None).await;
 
     let Err(ChainError::ExecutionError(execution_error, ChainExecutionContext::Operation(0))) =
         result
@@ -451,9 +453,7 @@ async fn test_service_as_oracle_timeout_early_stop(
     application.expect_call(ExpectedCall::default_finalize());
 
     let execution_start = Instant::now();
-    let result = chain
-        .execute_and_apply_block(&block, time, None, &[], None)
-        .await;
+    let result = chain.execute_block(&block, time, None, &[], None).await;
     let execution_time = execution_start.elapsed();
 
     let Err(ChainError::ExecutionError(execution_error, ChainExecutionContext::Operation(0))) =
@@ -505,8 +505,9 @@ async fn test_service_as_oracle_response_size_limit(
     application.expect_call(ExpectedCall::default_finalize());
 
     chain
-        .execute_and_apply_block(&block, time, None, &[], None)
+        .execute_block(&block, time, None, &[], None)
         .await
+        .map(|(outcome, _, _)| outcome)
 }
 
 /// Tests contract HTTP response size limit.
@@ -563,8 +564,9 @@ async fn test_contract_http_response_size_limit(
     application.expect_call(ExpectedCall::default_finalize());
 
     chain
-        .execute_and_apply_block(&block, time, None, &[], None)
+        .execute_block(&block, time, None, &[], None)
         .await
+        .map(|(outcome, _, _)| outcome)
 }
 
 /// Tests service HTTP response size limit.
@@ -621,8 +623,9 @@ async fn test_service_http_response_size_limit(
     application.expect_call(ExpectedCall::default_finalize());
 
     chain
-        .execute_and_apply_block(&block, time, None, &[], None)
+        .execute_block(&block, time, None, &[], None)
         .await
+        .map(|(outcome, _, _)| outcome)
 }
 
 /// Sets up a test with a dummy [`MockApplication`].

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -266,11 +266,8 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     let (outcome, _, _) = chain
         .execute_block(&valid_block, time, None, &[], None)
         .await?;
-    chain
-        .apply_execution_outcome(&outcome, valid_block.height, time)
-        .await?;
-    let block = outcome.with(valid_block);
-    let value = Hashed::new(ConfirmedBlock::new(block));
+    let value = Hashed::new(ConfirmedBlock::new(outcome.with(valid_block)));
+    chain.apply_confirmed_block(&value, time).await?;
 
     // In the second block, other operations are still not allowed.
     let invalid_block = make_child_block(&value.clone())
@@ -299,9 +296,8 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     let (outcome, _, _) = chain
         .execute_block(&valid_block, time, None, &[], None)
         .await?;
-    chain
-        .apply_execution_outcome(&outcome, valid_block.height, time)
-        .await?;
+    let value = Hashed::new(ConfirmedBlock::new(outcome.with(valid_block)));
+    chain.apply_confirmed_block(&value, time).await?;
 
     Ok(())
 }

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -367,15 +367,13 @@ where
             .collect::<Vec<_>>();
 
         // Execute the block and update inboxes.
-        self.state
-            .chain
+        let chain = &mut self.state.chain;
+        chain
             .remove_bundles_from_inboxes(block.header.timestamp, &block.body.incoming_bundles)
             .await?;
         let oracle_responses = Some(block.body.oracle_responses.clone());
         let (proposed_block, outcome) = block.clone().into_proposal();
-        let (verified_outcome, subscribe, unsubscribe) = self
-            .state
-            .chain
+        let (verified_outcome, subscribe, unsubscribe) = chain
             .execute_block(
                 &proposed_block,
                 local_time,
@@ -393,23 +391,16 @@ where
             }
         );
         // Update the rest of the chain state.
-        self.state.chain.process_unsubscribes(unsubscribe).await?;
-        self.state
-            .chain
-            .apply_execution_outcome(&outcome, block.header.height, local_time)
+        chain.process_unsubscribes(unsubscribe).await?;
+        chain
+            .apply_confirmed_block(certificate.value(), local_time)
             .await?;
-        self.state.chain.process_subscribes(subscribe).await?;
-        // Advance to next block height.
-        let tip = self.state.chain.tip_state.get_mut();
-        let hash = certificate.hash();
-        tip.block_hash = Some(hash);
-        tip.next_block_height.try_add_assign_one()?;
-        tip.update_counters(&proposed_block, &outcome)?;
-        self.state.chain.confirmed_log.push(hash);
+        chain.process_subscribes(subscribe).await?;
         self.state
             .track_newly_created_chains(&proposed_block, &outcome);
         let mut actions = self.state.create_network_actions().await?;
         trace!("Processed confirmed block {height} on chain {chain_id:.8}");
+        let hash = certificate.hash();
         actions.notifications.push(Notification {
             chain_id,
             reason: Reason::NewBlock { height, hash },

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -239,7 +239,11 @@ where
             WorkerError::FastBlockUsingOracles
         );
         // Check if the counters of tip_state would be valid.
-        chain.tip_state.get_mut().update_counters(block, &outcome)?;
+        chain.tip_state.get_mut().update_counters(
+            &block.incoming_bundles,
+            &block.operations,
+            &outcome.messages,
+        )?;
         // Verify that the resulting chain would have no unconfirmed incoming messages.
         chain.validate_incoming_bundles().await?;
         Ok(Some((outcome, local_time)))


### PR DESCRIPTION
## Motivation

The code for updating the chain state is somewhat arbitrarily split between `ChainStateView` and the worker.

## Proposal

Move more of it into `ChainStateView`.

Split `execute_and_apply_block` into two methods, and move more application logic into the latter.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
