### PR TITLE
Extract process of signing into a trait

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -72,4 +72,4 @@ jobs:
           max_attempts: 10
           timeout_minutes: 2
           retry_wait_seconds: 10
-          command: linera --wallet docker/wallet.json --storage rocksdb:docker/linera.db sync-balance
+          command: linera --wallet docker/wallet.json --keystore docker/keystore.json --storage rocksdb:docker/linera.db sync-balance

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,7 @@ env:
   RUST_LOG_FORMAT: plain
   LINERA_STORAGE_SERVICE: 127.0.0.1:1235
   LINERA_WALLET: /tmp/local-linera-net/wallet_0.json
+  LINERA_KEYSTORE: /tmp/local-linera-net/keystore_0.json
   LINERA_STORAGE: rocksdb:/tmp/local-linera-net/client_0.db
   LINERA_FAUCET_URL: http://localhost:8079
 

--- a/CLI.md
+++ b/CLI.md
@@ -9,6 +9,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera open-chain`↴](#linera-open-chain)
 * [`linera open-multi-owner-chain`↴](#linera-open-multi-owner-chain)
 * [`linera change-ownership`↴](#linera-change-ownership)
+* [`linera set-preferred-owner`↴](#linera-set-preferred-owner)
 * [`linera change-application-permissions`↴](#linera-change-application-permissions)
 * [`linera close-chain`↴](#linera-close-chain)
 * [`linera local-balance`↴](#linera-local-balance)
@@ -71,6 +72,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `open-chain` — Open (i.e. activate) a new chain deriving the UID from an existing one
 * `open-multi-owner-chain` — Open (i.e. activate) a new multi-owner chain deriving the UID from an existing one
 * `change-ownership` — Change who owns the chain, and how the owners work together proposing blocks
+* `set-preferred-owner` — Change the preferred owner of a chain
 * `change-application-permissions` — Changes the application permissions configuration
 * `close-chain` — Close an existing chain
 * `local-balance` — Read the current native-token balance of the given account directly from the local state
@@ -95,7 +97,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `create-application` — Create an application
 * `publish-and-create` — Create an application, and publish the required module
 * `keygen` — Create an unassigned key pair
-* `assign` — Link an owner with a key pair in the wallet to a chain that was created for that owner
+* `assign` — Link the owner to the chain. Expects that the caller has a private key corresponding to the `public_key`, otherwise block proposals will fail when signing with it
 * `retry-pending-block` — Retry a block we unsuccessfully tried to propose earlier
 * `wallet` — Show the contents of the wallet
 * `project` — Manage Linera projects
@@ -106,6 +108,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 
 * `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
 * `--wallet <WALLET_STATE_PATH>` — Sets the file storing the private state of user chains (an empty one will be created if missing)
+* `--keystore <KEYSTORE_PATH>` — Sets the file storing the keystore state
 * `-w`, `--with-wallet <WITH_WALLET>` — Given an ASCII alphanumeric parameter `X`, read the wallet state and the wallet storage config from the environment variables `LINERA_WALLET_{X}` and `LINERA_STORAGE_{X}` instead of `LINERA_WALLET` and `LINERA_STORAGE`
 * `--send-timeout-ms <SEND_TIMEOUT>` — Timeout for sending queries (milliseconds)
 
@@ -264,6 +267,19 @@ Specify the complete set of new owners, by public key. Existing owners that are 
 * `--fallback-duration-ms <FALLBACK_DURATION>` — The age of an incoming tracked or protected message after which the validators start transitioning the chain to fallback mode, in milliseconds
 
   Default value: `86400000`
+
+
+
+## `linera set-preferred-owner`
+
+Change the preferred owner of a chain
+
+**Usage:** `linera set-preferred-owner [OPTIONS] --owner <OWNER>`
+
+###### **Options:**
+
+* `--chain-id <CHAIN_ID>` — The ID of the chain whose preferred owner will be changed
+* `--owner <OWNER>` — The new preferred owner
 
 
 
@@ -718,7 +734,7 @@ Create an unassigned key pair
 
 ## `linera assign`
 
-Link an owner with a key pair in the wallet to a chain that was created for that owner
+Link the owner to the chain. Expects that the caller has a private key corresponding to the `public_key`, otherwise block proposals will fail when signing with it
 
 **Usage:** `linera assign --owner <OWNER> --chain-id <CHAIN_ID>`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4689,7 +4689,6 @@ dependencies = [
  "num-format",
  "prometheus-parse",
  "proptest",
- "rand 0.8.5",
  "reqwest 0.11.27",
  "serde",
  "serde-wasm-bindgen 0.6.5",

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ FAUCET_URL=http://localhost:8080
 
 # Set the path of the future wallet.
 export LINERA_WALLET="$LINERA_TMP_DIR/wallet.json"
+export LINERA_KEYSTORE="$LINERA_TMP_DIR/keystore.json"
 export LINERA_STORAGE="rocksdb:$LINERA_TMP_DIR/client.db"
 
 # Initialize a new user wallet.

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -17,6 +17,7 @@ cleanup() {
     rm -r linera.db
     rm server.json
     rm wallet.json
+    rm keystore.json
     SCYLLA_VOLUME=docker_linera-scylla-data
     SHARED_VOLUME=docker_linera-shared
     docker rm -f $(docker ps -a -q --filter volume=$SCYLLA_VOLUME)
@@ -63,7 +64,7 @@ linera-server generate --validators "$CONF_DIR/validator.toml" --committee commi
 # * Private chain states are stored in one local wallet `wallet.json`.
 # * `genesis.json` will contain the initial balances of chains as well as the initial committee.
 
-linera --wallet wallet.json --storage rocksdb:linera.db create-genesis-config 10 --genesis genesis.json --initial-funding 10 --committee committee.json --testing-prng-seed 2
+linera --wallet wallet.json --keystore keystore.json --storage rocksdb:linera.db create-genesis-config 10 --genesis genesis.json --initial-funding 10 --committee committee.json --testing-prng-seed 2
 
 if [ "${DOCKER_COMPOSE_WAIT:-false}" = "true" ]; then
     docker compose up --wait

--- a/examples/amm/README.md
+++ b/examples/amm/README.md
@@ -54,6 +54,7 @@ Create the user wallet and add chains to it:
 
 ```bash
 export LINERA_WALLET="$LINERA_TMP_DIR/wallet.json"
+export LINERA_KEYSTORE="$LINERA_TMP_DIR/keystore.json"
 export LINERA_STORAGE="rocksdb:$LINERA_TMP_DIR/client.db"
 
 linera wallet init --faucet $FAUCET_URL

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -43,6 +43,7 @@ Create the user wallet and add chains to it:
 
 ```bash
 export LINERA_WALLET="$LINERA_TMP_DIR/wallet.json"
+export LINERA_KEYSTORE="$LINERA_TMP_DIR/keystore.json"
 export LINERA_STORAGE="rocksdb:$LINERA_TMP_DIR/client.db"
 
 linera wallet init --faucet $FAUCET_URL

--- a/examples/crowd-funding/README.md
+++ b/examples/crowd-funding/README.md
@@ -66,8 +66,10 @@ Create the user wallets and add chains to them:
 
 ```bash
 export LINERA_WALLET_1="$LINERA_TMP_DIR/wallet_1.json"
+export LINERA_KEYSTORE_1="$LINERA_TMP_DIR/keystore_1.json"
 export LINERA_STORAGE_1="rocksdb:$LINERA_TMP_DIR/client_1.db"
 export LINERA_WALLET_2="$LINERA_TMP_DIR/wallet_2.json"
+export LINERA_KEYSTORE_2="$LINERA_TMP_DIR/keystore_2.json"
 export LINERA_STORAGE_2="rocksdb:$LINERA_TMP_DIR/client_2.db"
 
 linera --with-wallet 1 wallet init --faucet $FAUCET_URL
@@ -81,7 +83,7 @@ OWNER_1="${INFO_1[2]}"
 OWNER_2="${INFO_2[2]}"
 ```
 
-Note that `linera --with-wallet 1` is equivalent to `linera --wallet "$LINERA_WALLET_1"
+Note that `linera --with-wallet 1` is equivalent to `linera --wallet "$LINERA_WALLET_1" --keystore "$LINERA_KEYSTORE_1"
 --storage "$LINERA_STORAGE_1"`.
 
 The command below can be used to list the chains created for the test as known by each

--- a/examples/fungible/README.md
+++ b/examples/fungible/README.md
@@ -58,6 +58,7 @@ Create the user wallet and add chains to it:
 
 ```bash
 export LINERA_WALLET="$LINERA_TMP_DIR/wallet.json"
+export LINERA_KEYSTORE="$LINERA_TMP_DIR/keystore.json"
 export LINERA_STORAGE="rocksdb:$LINERA_TMP_DIR/client.db"
 
 linera wallet init --faucet $FAUCET_URL

--- a/examples/gen-nft/README.md
+++ b/examples/gen-nft/README.md
@@ -53,6 +53,7 @@ Create the user wallet and add chains to it:
 
 ```bash
 export LINERA_WALLET="$LINERA_TMP_DIR/wallet.json"
+export LINERA_KEYSTORE="$LINERA_TMP_DIR/keystore.json"
 export LINERA_STORAGE="rocksdb:$LINERA_TMP_DIR/client.db"
 
 linera wallet init --faucet $FAUCET_URL

--- a/examples/hex-game/README.md
+++ b/examples/hex-game/README.md
@@ -49,8 +49,10 @@ Create the user wallets and add chains to them:
 
 ```bash
 export LINERA_WALLET_1="$LINERA_TMP_DIR/wallet_1.json"
+export LINERA_KEYSTORE_1="$LINERA_TMP_DIR/keystore_1.json"
 export LINERA_STORAGE_1="rocksdb:$LINERA_TMP_DIR/client_1.db"
 export LINERA_WALLET_2="$LINERA_TMP_DIR/wallet_2.json"
+export LINERA_KEYSTORE_2="$LINERA_TMP_DIR/keystore_2.json"
 export LINERA_STORAGE_2="rocksdb:$LINERA_TMP_DIR/client_2.db"
 
 linera --with-wallet 1 wallet init --faucet $FAUCET_URL
@@ -65,7 +67,7 @@ OWNER_2="${INFO_2[2]}"
 ```
 
 Note that `linera --with-wallet 1` or `linera -w1` is equivalent to `linera --wallet
-"$LINERA_WALLET_1" --storage "$LINERA_STORAGE_1"`.
+"$LINERA_WALLET_1"  --keystore "$LINERA_KEYSTORE_1" --storage "$LINERA_STORAGE_1"`.
 
 ### Creating the Game Chain
 

--- a/examples/how-to/perform-http-requests/README.md
+++ b/examples/how-to/perform-http-requests/README.md
@@ -91,6 +91,7 @@ We then create a wallet and obtain a chain to use with the application.
 
 ```bash
 export LINERA_WALLET="$LINERA_TMP_DIR/wallet.json"
+export LINERA_KEYSTORE="$LINERA_TMP_DIR/keystore.json"
 export LINERA_STORAGE="rocksdb:$LINERA_TMP_DIR/client.db"
 
 linera wallet init --faucet $FAUCET_URL

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -56,6 +56,7 @@ Create the user wallet and add chains to it:
 
 ```bash
 export LINERA_WALLET="$LINERA_TMP_DIR/wallet.json"
+export LINERA_KEYSTORE="$LINERA_TMP_DIR/keystore.json"
 export LINERA_STORAGE="rocksdb:$LINERA_TMP_DIR/client.db"
 
 linera wallet init --faucet $FAUCET_URL

--- a/examples/matching-engine/README.md
+++ b/examples/matching-engine/README.md
@@ -65,6 +65,7 @@ Create the user wallet and add chains to it:
 
 ```bash
 export LINERA_WALLET="$LINERA_TMP_DIR/wallet.json"
+export LINERA_KEYSTORE="$LINERA_TMP_DIR/keystore.json"
 export LINERA_STORAGE="rocksdb:$LINERA_TMP_DIR/client.db"
 
 linera wallet init --faucet $FAUCET_URL

--- a/examples/native-fungible/README.md
+++ b/examples/native-fungible/README.md
@@ -38,6 +38,7 @@ Create the user wallet and add chains to it:
 
 ```bash
 export LINERA_WALLET="$LINERA_TMP_DIR/wallet.json"
+export LINERA_KEYSTORE="$LINERA_TMP_DIR/keystore.json"
 export LINERA_STORAGE="rocksdb:$LINERA_TMP_DIR/client.db"
 
 linera wallet init --faucet $FAUCET_URL

--- a/examples/non-fungible/README.md
+++ b/examples/non-fungible/README.md
@@ -53,6 +53,7 @@ Create the user wallet and add chains to it:
 
 ```bash
 export LINERA_WALLET="$LINERA_TMP_DIR/wallet.json"
+export LINERA_KEYSTORE="$LINERA_TMP_DIR/keystore.json"
 export LINERA_STORAGE="rocksdb:$LINERA_TMP_DIR/client.db"
 
 linera wallet init --faucet $FAUCET_URL

--- a/examples/rfq/README.md
+++ b/examples/rfq/README.md
@@ -66,8 +66,10 @@ Create the user wallets and add chains to them:
 
 ```bash
 export LINERA_WALLET_1="$LINERA_TMP_DIR/wallet_1.json"
+export LINERA_KEYSTORE_1="$LINERA_TMP_DIR/keystore_1.json"
 export LINERA_STORAGE_1="rocksdb:$LINERA_TMP_DIR/client_1.db"
 export LINERA_WALLET_2="$LINERA_TMP_DIR/wallet_2.json"
+export LINERA_KEYSTORE_2="$LINERA_TMP_DIR/keystore_2.json"
 export LINERA_STORAGE_2="rocksdb:$LINERA_TMP_DIR/client_2.db"
 
 linera --with-wallet 1 wallet init --faucet $FAUCET_URL
@@ -81,7 +83,7 @@ OWNER_1="${INFO_1[2]}"
 OWNER_2="${INFO_2[2]}"
 ```
 
-Note that `linera --with-wallet 1` is equivalent to `linera --wallet "$LINERA_WALLET_1"
+Note that `linera --with-wallet 1` is equivalent to `linera --wallet "$LINERA_WALLET_1" --keystore "$LINERA_KEYSTORE_1"
 --storage "$LINERA_STORAGE_1"`.
 
 Now, we can publish the fungible module and create the fungible applications.

--- a/examples/social/README.md
+++ b/examples/social/README.md
@@ -54,8 +54,10 @@ Create the user wallets and add chains to them:
 
 ```bash
 export LINERA_WALLET_1="$LINERA_TMP_DIR/wallet_1.json"
+export LINERA_KEYSTORE_1="$LINERA_TMP_DIR/keystore_1.json"
 export LINERA_STORAGE_1="rocksdb:$LINERA_TMP_DIR/client_1.db"
 export LINERA_WALLET_2="$LINERA_TMP_DIR/wallet_2.json"
+export LINERA_KEYSTORE_2="$LINERA_TMP_DIR/keystore_2.json"
 export LINERA_STORAGE_2="rocksdb:$LINERA_TMP_DIR/client_2.db"
 
 linera --with-wallet 1 wallet init --faucet $FAUCET_URL
@@ -69,7 +71,7 @@ OWNER_1="${INFO_1[3]}"
 OWNER_2="${INFO_2[3]}"
 ```
 
-Note that `linera --with-wallet 1` is equivalent to `linera --wallet "$LINERA_WALLET_1"
+Note that `linera --with-wallet 1` is equivalent to `linera --wallet "$LINERA_WALLET_1" --keystore "$LINERA_KEYSTORE_1"
 --storage "$LINERA_STORAGE_1"`.
 
 Compile the `social` example and create an application with it:

--- a/linera-base/src/crypto/ed25519.rs
+++ b/linera-base/src/crypto/ed25519.rs
@@ -284,8 +284,12 @@ impl Ed25519Signature {
     where
         T: BcsSignable<'de>,
     {
-        let prehash = CryptoHash::new(value).as_bytes().0;
-        let signature = secret.0.sign(&prehash);
+        Self::sign_prehash(secret, CryptoHash::new(value))
+    }
+
+    /// Computes a signature from a prehash.
+    pub fn sign_prehash(secret: &Ed25519SecretKey, prehash: CryptoHash) -> Self {
+        let signature = secret.0.sign(&prehash.as_bytes().0);
         Ed25519Signature(signature)
     }
 

--- a/linera-base/src/crypto/mod.rs
+++ b/linera-base/src/crypto/mod.rs
@@ -8,6 +8,7 @@ mod ed25519;
 mod hash;
 #[allow(dead_code)]
 mod secp256k1;
+mod signer;
 use std::{fmt::Display, io, num::ParseIntError, str::FromStr};
 
 use alloy_primitives::FixedBytes;
@@ -20,6 +21,7 @@ pub use secp256k1::{
     Secp256k1PublicKey, Secp256k1SecretKey, Secp256k1Signature,
 };
 use serde::{Deserialize, Serialize};
+pub use signer::*;
 use thiserror::Error;
 
 /// The public key of a validator.
@@ -133,10 +135,34 @@ impl AccountSecretKey {
         }
     }
 
+    /// Creates a signature for the `value`.
+    pub fn sign_prehash(&self, value: CryptoHash) -> AccountSignature {
+        match self {
+            AccountSecretKey::Ed25519(secret) => {
+                let signature = Ed25519Signature::sign_prehash(secret, value);
+                AccountSignature::Ed25519(signature)
+            }
+            AccountSecretKey::Secp256k1(secret) => {
+                let signature = secp256k1::Secp256k1Signature::sign_prehash(secret, value);
+                AccountSignature::Secp256k1(signature)
+            }
+            AccountSecretKey::EvmSecp256k1(secret) => {
+                let signature = secp256k1::evm::EvmSignature::sign_prehash(secret, value);
+                AccountSignature::EvmSecp256k1(signature)
+            }
+        }
+    }
+
     #[cfg(all(with_testing, with_getrandom))]
     /// Generates a new key pair using the operating system's RNG.
     pub fn generate() -> Self {
         AccountSecretKey::Ed25519(Ed25519SecretKey::generate())
+    }
+
+    #[cfg(with_getrandom)]
+    /// Generates a new key pair from the given RNG. Use with care.
+    pub fn generate_from<R: CryptoRng>(rng: &mut R) -> Self {
+        AccountSecretKey::Ed25519(Ed25519SecretKey::generate_from(rng))
     }
 }
 

--- a/linera-base/src/crypto/secp256k1/evm.rs
+++ b/linera-base/src/crypto/secp256k1/evm.rs
@@ -377,9 +377,14 @@ impl EvmSignature {
     where
         T: BcsSignable<'de>,
     {
+        Self::sign_prehash(secret, CryptoHash::new(value))
+    }
+
+    /// Computes a signature from a prehash.
+    pub fn sign_prehash(secret: &EvmSecretKey, prehash: CryptoHash) -> Self {
         use k256::ecdsa::signature::hazmat::PrehashSigner;
 
-        let message = eip191_hash_message(CryptoHash::new(value).as_bytes().0).0;
+        let message = eip191_hash_message(prehash.as_bytes().0).0;
         let (signature, rid) = secret
             .0
             .sign_prehash(&message)

--- a/linera-base/src/crypto/secp256k1/mod.rs
+++ b/linera-base/src/crypto/secp256k1/mod.rs
@@ -351,12 +351,16 @@ impl Secp256k1Signature {
     where
         T: BcsSignable<'de>,
     {
+        Self::sign_prehash(secret, CryptoHash::new(value))
+    }
+
+    /// Computes a signature from a prehash.
+    pub fn sign_prehash(secret: &Secp256k1SecretKey, prehash: CryptoHash) -> Self {
         use k256::ecdsa::signature::hazmat::PrehashSigner;
 
-        let prehash = CryptoHash::new(value).as_bytes().0;
         let (signature, _rid) = secret
             .0
-            .sign_prehash(&prehash)
+            .sign_prehash(&prehash.as_bytes().0)
             .expect("Failed to sign prehashed data"); // NOTE: This is a critical error we don't control.
         Secp256k1Signature(signature)
     }

--- a/linera-base/src/crypto/signer.rs
+++ b/linera-base/src/crypto/signer.rs
@@ -1,0 +1,315 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+pub use in_mem::InMemorySigner;
+
+use super::CryptoHash;
+use crate::{
+    crypto::{AccountPublicKey, AccountSignature},
+    identifiers::AccountOwner,
+};
+
+/// A trait for signing keys.
+#[async_trait]
+pub trait Signer: Send + Sync {
+    /// Creates a signature for the given `value` using the provided `owner`.
+    // DEV: We sign `CryptoHash` type, rather than `&[u8]` to make sure we don't sign
+    // things accidentally. See [`CryptoHash::new`] for how the type's name is included
+    // in the resulting hash, providing the canonicity of the hashing process.
+    async fn sign(
+        &self,
+        owner: &AccountOwner,
+        value: &CryptoHash,
+    ) -> Result<AccountSignature, Box<dyn std::error::Error>>;
+
+    /// Returns the public key corresponding to the given `owner`.
+    async fn get_public_key(
+        &self,
+        owner: &AccountOwner,
+    ) -> Result<AccountPublicKey, Box<dyn std::error::Error>>;
+
+    /// Returnes whether the given `owner` is a known signer.
+    async fn contains_key(&self, owner: &AccountOwner) -> Result<bool, Box<dyn std::error::Error>>;
+}
+
+#[async_trait]
+impl Signer for Box<dyn Signer> {
+    async fn sign(
+        &self,
+        owner: &AccountOwner,
+        value: &CryptoHash,
+    ) -> Result<AccountSignature, Box<dyn std::error::Error>> {
+        (**self).sign(owner, value).await
+    }
+
+    async fn get_public_key(
+        &self,
+        owner: &AccountOwner,
+    ) -> Result<AccountPublicKey, Box<dyn std::error::Error>> {
+        (**self).get_public_key(owner).await
+    }
+
+    async fn contains_key(&self, owner: &AccountOwner) -> Result<bool, Box<dyn std::error::Error>> {
+        (**self).contains_key(owner).await
+    }
+}
+
+/// In-memory implementatio of the [`Signer`] trait.
+mod in_mem {
+    use std::{
+        collections::BTreeMap,
+        sync::{Arc, RwLock},
+    };
+
+    use async_trait::async_trait;
+    use serde::{Deserialize, Serialize};
+
+    #[cfg(with_getrandom)]
+    use crate::crypto::CryptoRng;
+    use crate::{
+        crypto::{AccountPublicKey, AccountSecretKey, AccountSignature, CryptoHash, Signer},
+        identifiers::AccountOwner,
+    };
+
+    /// In-memory signer.
+    #[derive(Clone)]
+    pub struct InMemorySigner(Arc<RwLock<InMemSignerInner>>);
+
+    impl InMemorySigner {
+        /// Creates a new `InMemSigner` seeded with `prng_seed`.
+        /// If `prng_seed` is `None`, an `OsRng` will be used.
+        #[cfg(with_getrandom)]
+        pub fn new(prng_seed: Option<u64>) -> Self {
+            InMemorySigner(Arc::new(RwLock::new(InMemSignerInner::new(prng_seed))))
+        }
+
+        /// Creates a new `InMemSigner`.
+        #[cfg(not(with_getrandom))]
+        pub fn new() -> Self {
+            InMemorySigner(Arc::new(RwLock::new(InMemSignerInner::new())))
+        }
+
+        /// Generates a new key pair from Signer's RNG. Use with care.
+        #[cfg(with_getrandom)]
+        pub fn generate_new(&mut self) -> AccountPublicKey {
+            let mut inner = self.0.write().unwrap();
+            let secret = AccountSecretKey::generate_from(&mut inner.rng_state.prng);
+            if inner.rng_state.testing_seed.is_some() {
+                // Generate a new testing seed for the case when we need to store the PRNG state.
+                // It provides a "forward-secrecy" property for the testing seed.
+                // We do not do that for the case when `testing_seed` is `None`, because
+                // we default to the usage of OsRng in that case.
+                inner.rng_state.testing_seed = Some(inner.rng_state.prng.next_u64());
+            }
+            let public = secret.public();
+            let owner = AccountOwner::from(public);
+            inner.keys.insert(owner, secret);
+            public
+        }
+
+        /// Returns the public key corresponding to the given `owner`.
+        pub fn keys(&self) -> Vec<(AccountOwner, Vec<u8>)> {
+            let inner = self.0.read().unwrap();
+            inner.keys()
+        }
+    }
+
+    /// In-memory signer.
+    struct InMemSignerInner {
+        keys: BTreeMap<AccountOwner, AccountSecretKey>,
+        #[cfg(with_getrandom)]
+        rng_state: RngState,
+    }
+
+    #[cfg(with_getrandom)]
+    struct RngState {
+        prng: Box<dyn CryptoRng>,
+        #[cfg(with_getrandom)]
+        testing_seed: Option<u64>,
+    }
+
+    #[cfg(with_getrandom)]
+    impl RngState {
+        fn new(prng_seed: Option<u64>) -> Self {
+            let prng: Box<dyn CryptoRng> = prng_seed.into();
+            RngState {
+                prng,
+                #[cfg(with_getrandom)]
+                testing_seed: prng_seed,
+            }
+        }
+    }
+
+    impl InMemSignerInner {
+        /// Creates a new `InMemSignerInner` seeded with `prng_seed`.
+        /// If `prng_seed` is `None`, an `OsRng` will be used.
+        #[cfg(with_getrandom)]
+        pub fn new(prng_seed: Option<u64>) -> Self {
+            InMemSignerInner {
+                keys: BTreeMap::new(),
+                rng_state: RngState::new(prng_seed),
+            }
+        }
+
+        /// Creates a new `InMemSignerInner`.
+        #[cfg(not(with_getrandom))]
+        pub fn new() -> Self {
+            InMemSignerInner {
+                keys: BTreeMap::new(),
+            }
+        }
+
+        pub fn keys(&self) -> Vec<(AccountOwner, Vec<u8>)> {
+            self.keys
+                .iter()
+                .map(|(owner, secret)| {
+                    (
+                        *owner,
+                        serde_json::to_vec(secret).expect("serialization should not fail"),
+                    )
+                })
+                .collect()
+        }
+    }
+
+    #[async_trait]
+    impl Signer for InMemorySigner {
+        /// Creates a signature for the given `value` using the provided `owner`.
+        async fn sign(
+            &self,
+            owner: &AccountOwner,
+            value: &CryptoHash,
+        ) -> Result<AccountSignature, Box<dyn std::error::Error>> {
+            let inner = self.0.read().unwrap();
+            if let Some(secret) = inner.keys.get(owner) {
+                let signature = secret.sign_prehash(*value);
+                Ok(signature)
+            } else {
+                Err("No key found for the given owner".into())
+            }
+        }
+
+        /// Returns the public key corresponding to the given `owner`.
+        async fn get_public_key(
+            &self,
+            owner: &AccountOwner,
+        ) -> Result<AccountPublicKey, Box<dyn std::error::Error>> {
+            let inner = self.0.read().unwrap();
+            match inner.keys.get(owner).map(|s| s.public()) {
+                Some(public) => Ok(public),
+                None => Err("No key found for the given owner".into()),
+            }
+        }
+
+        /// Returnes whether the given `owner` is a known signer.
+        async fn contains_key(
+            &self,
+            owner: &AccountOwner,
+        ) -> Result<bool, Box<dyn std::error::Error>> {
+            let inner = self.0.read().unwrap();
+            Ok(inner.keys.contains_key(owner))
+        }
+    }
+
+    impl FromIterator<(AccountOwner, AccountSecretKey)> for InMemorySigner {
+        fn from_iter<T>(input: T) -> Self
+        where
+            T: IntoIterator<Item = (AccountOwner, AccountSecretKey)>,
+        {
+            InMemorySigner(Arc::new(RwLock::new(InMemSignerInner {
+                keys: BTreeMap::from_iter(input),
+                #[cfg(with_getrandom)]
+                rng_state: RngState::new(None),
+            })))
+        }
+    }
+
+    impl Default for InMemSignerInner {
+        fn default() -> Self {
+            #[cfg(with_getrandom)]
+            let signer = InMemSignerInner::new(None);
+            #[cfg(not(with_getrandom))]
+            let signer = InMemSignerInner::new();
+            signer
+        }
+    }
+
+    impl Serialize for InMemorySigner {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let inner = self.0.read().unwrap();
+            InMemSignerInner::serialize(&*inner, serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for InMemorySigner {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            let inner = InMemSignerInner::deserialize(deserializer)?;
+            Ok(InMemorySigner(Arc::new(RwLock::new(inner))))
+        }
+    }
+
+    impl Serialize for InMemSignerInner {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            #[derive(Serialize, Debug)]
+            struct Inner<'a> {
+                keys: &'a Vec<(AccountOwner, Vec<u8>)>,
+                #[cfg(with_getrandom)]
+                prng_seed: Option<u64>,
+            }
+
+            #[cfg(with_getrandom)]
+            let prng_seed = self.rng_state.testing_seed;
+
+            let inner = Inner {
+                keys: &self.keys(),
+                #[cfg(with_getrandom)]
+                prng_seed,
+            };
+
+            Inner::serialize(&inner, serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for InMemSignerInner {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            #[derive(Deserialize)]
+            struct Inner {
+                keys: Vec<(AccountOwner, Vec<u8>)>,
+                #[cfg(with_getrandom)]
+                prng_seed: Option<u64>,
+            }
+
+            let inner = Inner::deserialize(deserializer)?;
+
+            let keys = inner
+                .keys
+                .into_iter()
+                .map(|(owner, secret)| {
+                    let secret =
+                        serde_json::from_slice(&secret).map_err(serde::de::Error::custom)?;
+                    Ok((owner, secret))
+                })
+                .collect::<Result<BTreeMap<_, _>, _>>()?;
+
+            let signer = InMemSignerInner {
+                keys,
+                #[cfg(with_getrandom)]
+                rng_state: RngState::new(inner.prng_seed),
+            };
+            Ok(signer)
+        }
+    }
+}

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_base::{
-    crypto::{Ed25519SecretKey, Secp256k1SecretKey, ValidatorKeypair},
+    crypto::{AccountSecretKey, Ed25519SecretKey, Secp256k1SecretKey, ValidatorKeypair},
     data_types::Amount,
 };
 

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -71,7 +71,6 @@ linera-storage.workspace = true
 linera-views.workspace = true
 num-format = { workspace = true, optional = true }
 prometheus-parse = { workspace = true, optional = true }
-rand.workspace = true
 reqwest = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -8,7 +8,7 @@ use std::{collections::HashSet, sync::Arc};
 use async_trait::async_trait;
 use futures::Future;
 use linera_base::{
-    crypto::{AccountSecretKey, CryptoHash},
+    crypto::{CryptoHash, Signer},
     data_types::{BlockHeight, ChainDescription, Timestamp},
     identifiers::{Account, AccountOwner, BlobId, BlobType, ChainId},
     ownership::ChainOwnership,
@@ -32,6 +32,7 @@ use {
     crate::benchmark::{Benchmark, BenchmarkError},
     futures::{stream, StreamExt, TryStreamExt},
     linera_base::{
+        crypto::AccountPublicKey,
         data_types::{Amount, Epoch},
         identifiers::ApplicationId,
     },
@@ -100,15 +101,18 @@ where
         self.make_chain_client(chain_id).await
     }
 
+    fn client(&self) -> &Client<Env> {
+        &self.client
+    }
+
     async fn update_wallet_for_new_chain(
         &mut self,
         chain_id: ChainId,
-        key_pair: Option<AccountSecretKey>,
+        owner: Option<AccountOwner>,
         timestamp: Timestamp,
     ) -> Result<(), Error> {
-        self.update_wallet_for_new_chain(chain_id, key_pair, timestamp)
-            .await?;
-        self.save_wallet().await
+        self.update_wallet_for_new_chain(chain_id, owner, timestamp)
+            .await
     }
 
     async fn update_wallet(&mut self, client: &ChainClient<Env>) -> Result<(), Error> {
@@ -121,7 +125,12 @@ where
     S: linera_core::environment::Storage,
     W: Persist<Target = Wallet>,
 {
-    pub fn new(storage: S, wallet: W, options: ClientContextOptions) -> Self {
+    pub fn new(
+        storage: S,
+        options: ClientContextOptions,
+        wallet: W,
+        signer: Box<dyn Signer>,
+    ) -> Self {
         let node_provider = NodeProvider::new(NodeOptions {
             send_timeout: options.send_timeout,
             recv_timeout: options.recv_timeout,
@@ -140,6 +149,7 @@ where
                 network: node_provider,
                 storage,
             },
+            signer,
             options.max_pending_message_bundles,
             delivery,
             options.long_lived_services,
@@ -164,7 +174,7 @@ where
     }
 
     #[cfg(with_testing)]
-    pub fn new_test_client_context(storage: S, wallet: W) -> Self {
+    pub fn new_test_client_context(storage: S, wallet: W, signer: Box<dyn Signer>) -> Self {
         use linera_core::DEFAULT_GRACE_PERIOD;
 
         let send_recv_timeout = Duration::from_millis(4000);
@@ -189,6 +199,7 @@ where
                 storage,
                 network: NodeProvider::new(node_options),
             },
+            signer,
             10,
             delivery,
             false,
@@ -250,20 +261,20 @@ where
             .expect("No chain specified in wallet with no default chain")
     }
 
-    async fn make_chain_client(&self, chain_id: ChainId) -> Result<ChainClient<Env>, Error> {
+    pub async fn make_chain_client(&self, chain_id: ChainId) -> Result<ChainClient<Env>, Error> {
         // We only create clients for chains we have in the wallet, or for the admin chain.
-        let chain = match self.wallet.get(chain_id) {
+        let chain: UserChain = match self.wallet.get(chain_id) {
             Some(chain) => chain.clone(),
             None => UserChain::make_other(chain_id, Timestamp::from(0)),
         };
-        let known_key_pairs = chain.key_pair.into_iter().collect();
+
         self.make_chain_client_internal(
             chain_id,
-            known_key_pairs,
             chain.block_hash,
             chain.timestamp,
             chain.next_block_height,
             chain.pending_proposal,
+            chain.owner,
         )
         .await
     }
@@ -271,22 +282,22 @@ where
     async fn make_chain_client_internal(
         &self,
         chain_id: ChainId,
-        known_key_pairs: Vec<AccountSecretKey>,
         block_hash: Option<CryptoHash>,
         timestamp: Timestamp,
         next_block_height: BlockHeight,
         pending_proposal: Option<PendingProposal>,
+        preferred_owner: Option<AccountOwner>,
     ) -> Result<ChainClient<Env>, Error> {
         let mut chain_client = self
             .client
             .create_chain_client(
                 chain_id,
-                known_key_pairs,
                 self.wallet.genesis_admin_chain(),
                 block_hash,
                 timestamp,
                 next_block_height,
                 pending_proposal,
+                preferred_owner,
             )
             .await?;
         chain_client.options_mut().message_policy = MessagePolicy::new(
@@ -320,32 +331,22 @@ where
         &mut self,
         client: &ChainClient<Env_>,
     ) -> Result<(), Error> {
-        self.wallet.as_mut().update_from_state(client).await;
+        self.wallet.as_mut().update_from_state(client);
         self.save_wallet().await
     }
 
-    /// Remembers the new chain and private key (if any) in the wallet.
+    /// Remembers the new chain and its owner (if any) in the wallet.
     pub async fn update_wallet_for_new_chain(
         &mut self,
         chain_id: ChainId,
-        key_pair: Option<AccountSecretKey>,
-        timestamp: Timestamp,
-    ) -> Result<(), Error> {
-        self.update_wallet_for_new_chain_internal(chain_id, key_pair, timestamp)
-            .await
-    }
-
-    async fn update_wallet_for_new_chain_internal(
-        &mut self,
-        chain_id: ChainId,
-        key_pair: Option<AccountSecretKey>,
+        owner: Option<AccountOwner>,
         timestamp: Timestamp,
     ) -> Result<(), Error> {
         if self.wallet.get(chain_id).is_none() {
             self.mutate_wallet(|w| {
                 w.insert(UserChain {
                     chain_id,
-                    key_pair: key_pair.as_ref().map(|kp| kp.copy()),
+                    owner,
                     block_hash: None,
                     timestamp,
                     next_block_height: BlockHeight::ZERO,
@@ -496,7 +497,7 @@ where
     ) -> Result<(), Error> {
         let chain_id = chain_id.unwrap_or_else(|| self.default_chain());
         let chain_client = self.make_chain_client(chain_id).await?;
-        info!("Changing ownership for chain {}", chain_id);
+        info!(?ownership_config, %chain_id, preferred_owner=?chain_client.preferred_owner(), "Changing ownership of a chain");
         let time_start = Instant::now();
         let ownership = ChainOwnership::try_from(ownership_config)?;
 
@@ -516,6 +517,21 @@ where
         let time_total = time_start.elapsed();
         info!("Operation confirmed after {} ms", time_total.as_millis());
         debug!("{:?}", certificate);
+        Ok(())
+    }
+
+    pub async fn set_preferred_owner(
+        &mut self,
+        chain_id: Option<ChainId>,
+        preferred_owner: AccountOwner,
+    ) -> Result<(), Error> {
+        let chain_id = chain_id.unwrap_or_else(|| self.default_chain());
+        let mut chain_client = self.make_chain_client(chain_id).await?;
+        let old_owner = chain_client.preferred_owner();
+        info!(%chain_id, ?old_owner, %preferred_owner, "Changing preferred owner for chain");
+        chain_client.set_preferred_owner(preferred_owner);
+        self.update_wallet_from_client(&chain_client).await?;
+        info!("New preferred owner set");
         Ok(())
     }
 }
@@ -625,11 +641,12 @@ where
         transactions_per_block: usize,
         tokens_per_chain: Amount,
         fungible_application_id: Option<ApplicationId>,
+        pub_keys: Vec<AccountPublicKey>,
     ) -> Result<
         (
             HashMap<ChainId, ChainClient<Env>>,
             Epoch,
-            Vec<(ChainId, Vec<Operation>, AccountSecretKey)>,
+            Vec<(ChainId, Vec<Operation>, AccountOwner)>,
             Committee,
         ),
         Error,
@@ -646,7 +663,7 @@ where
 
         let start = Instant::now();
         let (key_pairs, chain_clients) = self
-            .make_benchmark_chains(num_chains, tokens_per_chain)
+            .make_benchmark_chains(num_chains, tokens_per_chain, pub_keys)
             .await?;
         info!(
             "Got {} chains in {} ms",
@@ -713,7 +730,7 @@ where
 
             info!("Updating wallet from chain clients...");
             for chain_client in chain_clients.values() {
-                self.wallet.as_mut().update_from_state(chain_client).await;
+                self.wallet.as_mut().update_from_state(chain_client);
             }
             self.save_wallet().await?;
         }
@@ -767,9 +784,10 @@ where
         &mut self,
         num_chains: usize,
         balance: Amount,
+        pub_keys: Vec<AccountPublicKey>,
     ) -> Result<
         (
-            HashMap<ChainId, AccountSecretKey>,
+            HashMap<ChainId, AccountOwner>,
             HashMap<ChainId, ChainClient<Env>>,
         ),
         Error,
@@ -783,17 +801,17 @@ where
             }
             // This should never panic, because `owned_chain_ids` only returns the owned chains that
             // we have a key pair for.
-            let key_pair = self
+            let owner = self
                 .wallet
                 .get(chain_id)
-                .and_then(|chain| chain.key_pair.as_ref().map(|kp| kp.copy()))
+                .and_then(|chain| chain.owner)
                 .unwrap();
             let chain_client = self.make_chain_client(chain_id).await?;
             let ownership = chain_client.chain_info().await?.manager.ownership;
             if !ownership.owners.is_empty() || ownership.super_owners.len() != 1 {
                 continue;
             }
-            benchmark_chains.insert(chain_client.chain_id(), key_pair);
+            benchmark_chains.insert(chain_client.chain_id(), owner);
             chain_client.process_inbox().await?;
             chain_clients.insert(chain_id, chain_client);
         }
@@ -812,22 +830,18 @@ where
             .expect("should have default chain");
         let operations_per_block = 900; // Over this we seem to hit the block size limits.
 
-        let mut key_pairs = Vec::new();
-        for _ in (0..num_chains_to_create).step_by(operations_per_block) {
-            key_pairs.push(self.wallet.generate_key_pair());
-        }
-        let mut key_pairs_iter = key_pairs.into_iter();
+        let mut pub_keys_iter = pub_keys.into_iter().take(num_chains_to_create);
         let default_chain_client = self.make_chain_client(default_chain_id).await?;
 
         for i in (0..num_chains_to_create).step_by(operations_per_block) {
             let num_new_chains = operations_per_block.min(num_chains_to_create - i);
-            let key_pair = key_pairs_iter.next().unwrap();
+            let pub_key = pub_keys_iter.next().unwrap();
 
             let certificate = Self::execute_open_chains_operations(
                 num_new_chains,
                 &default_chain_client,
                 balance,
-                &key_pair,
+                pub_key.into(),
             )
             .await?;
             info!("Block executed successfully");
@@ -839,19 +853,20 @@ where
                     .find(|blob| blob.id().blob_type == BlobType::ChainDescription)
                     .map(|blob| ChainId(blob.id().hash))
                     .expect("failed to create a new chain");
-                benchmark_chains.insert(chain_id, key_pair.copy());
+                benchmark_chains.insert(chain_id, pub_key.into());
                 self.client.track_chain(chain_id);
 
-                let chain_client = self
+                let mut chain_client = self
                     .make_chain_client_internal(
                         chain_id,
-                        vec![key_pair.copy()],
                         None,
                         certificate.block().header.timestamp,
                         BlockHeight::ZERO,
                         None,
+                        Some(pub_key.into()),
                     )
                     .await?;
+                chain_client.set_preferred_owner(pub_key.into());
                 chain_client.process_inbox().await?;
                 chain_clients.insert(chain_id, chain_client);
             }
@@ -883,10 +898,10 @@ where
         num_new_chains: usize,
         chain_client: &ChainClient<Env>,
         balance: Amount,
-        key_pair: &AccountSecretKey,
+        owner: AccountOwner,
     ) -> Result<ConfirmedBlockCertificate, Error> {
         let config = OpenChainConfig {
-            ownership: ChainOwnership::single_super(key_pair.public().into()),
+            ownership: ChainOwnership::single_super(owner),
             balance,
             application_permissions: Default::default(),
         };
@@ -905,30 +920,23 @@ where
     /// Supplies fungible tokens to the chains.
     async fn supply_fungible_tokens(
         &mut self,
-        key_pairs: &HashMap<ChainId, AccountSecretKey>,
+        key_pairs: &HashMap<ChainId, AccountOwner>,
         application_id: ApplicationId,
     ) -> Result<(), Error> {
         let default_chain_id = self
             .wallet
             .default_chain()
             .expect("should have default chain");
-        let default_key = self
-            .wallet
-            .get(default_chain_id)
-            .unwrap()
-            .key_pair
-            .as_ref()
-            .unwrap()
-            .public();
+        let default_key = self.wallet.get(default_chain_id).unwrap().owner.unwrap();
         let amount = Amount::from(1_000_000);
         let operations: Vec<_> = key_pairs
             .iter()
-            .map(|(chain_id, key_pair)| {
+            .map(|(chain_id, owner)| {
                 Benchmark::<Env>::fungible_transfer(
                     application_id,
                     *chain_id,
                     default_key,
-                    key_pair.public(),
+                    *owner,
                     amount,
                 )
             })

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -44,6 +44,10 @@ pub struct ClientContextOptions {
     #[arg(long = "wallet")]
     pub wallet_state_path: Option<PathBuf>,
 
+    /// Sets the file storing the keystore state.
+    #[arg(long = "keystore")]
+    pub keystore_path: Option<PathBuf>,
+
     /// Given an ASCII alphanumeric parameter `X`, read the wallet state and the wallet
     /// storage config from the environment variables `LINERA_WALLET_{X}` and
     /// `LINERA_STORAGE_{X}` instead of `LINERA_WALLET` and

--- a/linera-client/src/persistent/file.rs
+++ b/linera-client/src/persistent/file.rs
@@ -136,7 +136,7 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned> File<T> {
         Self::read_or_create(path, || {
             Err(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
-                format!("path does not exist: {}", path.display()),
+                format!("file is empty or does not exist: {}", path.display()),
             )
             .into())
         })

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -8,7 +8,7 @@ use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use futures::{lock::Mutex, FutureExt as _};
 use linera_base::{
-    crypto::{AccountPublicKey, AccountSecretKey, Secp256k1SecretKey},
+    crypto::{AccountPublicKey, InMemorySigner},
     data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
     identifiers::{AccountOwner, ChainId},
     ownership::{ChainOwnership, TimeoutConfig},
@@ -21,7 +21,6 @@ use linera_core::{
     DEFAULT_GRACE_PERIOD,
 };
 use linera_execution::system::Recipient;
-use rand::SeedableRng as _;
 use tokio_util::sync::CancellationToken;
 
 use super::util::make_genesis_config;
@@ -49,6 +48,10 @@ impl chain_listener::ClientContext for ClientContext {
         self.client.storage_client()
     }
 
+    fn client(&self) -> &linera_core::client::Client<Self::Environment> {
+        &self.client
+    }
+
     async fn make_chain_client(
         &self,
         chain_id: ChainId,
@@ -57,22 +60,16 @@ impl chain_listener::ClientContext for ClientContext {
             .wallet
             .get(chain_id)
             .unwrap_or_else(|| panic!("Unknown chain: {}", chain_id));
-        let known_key_pairs = chain
-            .key_pair
-            .as_ref()
-            .map(|kp| kp.copy())
-            .into_iter()
-            .collect();
         Ok(self
             .client
             .create_chain_client(
                 chain_id,
-                known_key_pairs,
                 self.wallet.genesis_admin_chain(),
                 chain.block_hash,
                 chain.timestamp,
                 chain.next_block_height,
                 chain.pending_proposal.clone(),
+                chain.owner,
             )
             .await?)
     }
@@ -80,13 +77,13 @@ impl chain_listener::ClientContext for ClientContext {
     async fn update_wallet_for_new_chain(
         &mut self,
         chain_id: ChainId,
-        key_pair: Option<AccountSecretKey>,
+        owner: Option<AccountOwner>,
         timestamp: Timestamp,
     ) -> Result<(), Error> {
         if self.wallet.get(chain_id).is_none() {
             self.wallet.insert(UserChain {
                 chain_id,
-                key_pair: key_pair.as_ref().map(|kp| kp.copy()),
+                owner,
                 block_hash: None,
                 timestamp,
                 next_block_height: BlockHeight::ZERO,
@@ -101,7 +98,7 @@ impl chain_listener::ClientContext for ClientContext {
         &mut self,
         client: &ChainClient<environment::Test>,
     ) -> Result<(), Error> {
-        self.wallet.update_from_state(client).await;
+        self.wallet.update_from_state(client);
         Ok(())
     }
 }
@@ -111,26 +108,29 @@ impl chain_listener::ClientContext for ClientContext {
 #[test_log::test(tokio::test)]
 async fn test_chain_listener() -> anyhow::Result<()> {
     // Create two chains.
-    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+    let mut signer = InMemorySigner::new(Some(42));
+    let key_pair = signer.generate_new();
+    let owner: AccountOwner = key_pair.into();
     let config = ChainListenerConfig::default();
     let storage_builder = MemoryStorageBuilder::default();
     let clock = storage_builder.clock().clone();
-    let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, &mut signer).await?;
     let client0 = builder.add_root_chain(0, Amount::ONE).await?;
     let chain_id0 = client0.chain_id();
     let client1 = builder.add_root_chain(1, Amount::ONE).await?;
-
     // Start a chain listener for chain 0 with a new key.
     let genesis_config = make_genesis_config(&builder);
     let storage = builder.make_storage().await?;
     let delivery = CrossChainMessageDelivery::NonBlocking;
+
     let mut context = ClientContext {
-        wallet: Wallet::new(genesis_config, Some(37)),
+        wallet: Wallet::new(genesis_config),
         client: Arc::new(Client::new(
             environment::Impl {
                 storage: storage.clone(),
                 network: builder.make_node_provider(),
             },
+            Box::new(signer),
             10,
             delivery,
             false,
@@ -141,20 +141,16 @@ async fn test_chain_listener() -> anyhow::Result<()> {
             Duration::from_secs(1),
         )),
     };
-    let key_pair = AccountSecretKey::Secp256k1(Secp256k1SecretKey::generate_from(&mut rng));
-    let owner = key_pair.public().into();
     context
-        .update_wallet_for_new_chain(chain_id0, Some(key_pair), clock.current_time())
+        .update_wallet_for_new_chain(chain_id0, Some(owner), clock.current_time())
         .await?;
-    let context = Arc::new(Mutex::new(context));
-    let cancellation_token = CancellationToken::new();
-    let child_token = cancellation_token.child_token();
-    let handle = linera_base::task::spawn(async move {
-        ChainListener::new(config, context, storage, child_token)
-            .run()
-            .await
-            .unwrap()
-    });
+    context
+        .update_wallet_for_new_chain(
+            client1.chain_id(),
+            client1.preferred_owner(),
+            clock.current_time(),
+        )
+        .await?;
 
     // Transfer ownership of chain 0 to the chain listener and some other key. The listener will
     // be leader in ~10% of the rounds.
@@ -168,6 +164,15 @@ async fn test_chain_listener() -> anyhow::Result<()> {
         .change_ownership(ChainOwnership::multiple(owners, 0, timeout_config))
         .await?;
 
+    let context = Arc::new(Mutex::new(context));
+    let cancellation_token = CancellationToken::new();
+    let child_token = cancellation_token.child_token();
+    let handle = linera_base::task::spawn(async move {
+        ChainListener::new(config, context, storage, child_token)
+            .run()
+            .await
+            .unwrap()
+    });
     // Transfer one token to chain 0. The listener should eventually become leader and receive
     // the message.
     let recipient0 = Recipient::chain(chain_id0);

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -1,13 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeMap, HashMap},
-    iter::IntoIterator,
-};
+use std::{collections::BTreeMap, iter::IntoIterator};
 
 use linera_base::{
-    crypto::{AccountSecretKey, CryptoHash, CryptoRng},
+    crypto::CryptoHash,
     data_types::{BlockHeight, ChainDescription, Timestamp},
     ensure,
     identifiers::{AccountOwner, ChainId},
@@ -16,7 +13,6 @@ use linera_core::{
     client::{ChainClient, PendingProposal},
     Environment,
 };
-use rand::Rng as _;
 use serde::{Deserialize, Serialize};
 
 use crate::{config::GenesisConfig, error, Error};
@@ -24,34 +20,24 @@ use crate::{config::GenesisConfig, error, Error};
 #[derive(Serialize, Deserialize)]
 pub struct Wallet {
     pub chains: BTreeMap<ChainId, UserChain>,
-    pub unassigned_key_pairs: HashMap<AccountOwner, AccountSecretKey>,
     pub default: Option<ChainId>,
     pub genesis_config: GenesisConfig,
-    pub testing_prng_seed: Option<u64>,
 }
 
 impl Extend<UserChain> for Wallet {
     fn extend<Chains: IntoIterator<Item = UserChain>>(&mut self, chains: Chains) {
-        let mut chains = chains.into_iter();
-        if let Some(chain) = chains.next() {
-            // Ensures that the default chain gets set appropriately to the first chain,
-            // if it isn't already set.
+        for chain in chains.into_iter() {
             self.insert(chain);
-
-            self.chains
-                .extend(chains.map(|chain| (chain.chain_id, chain)));
         }
     }
 }
 
 impl Wallet {
-    pub fn new(genesis_config: GenesisConfig, testing_prng_seed: Option<u64>) -> Self {
+    pub fn new(genesis_config: GenesisConfig) -> Self {
         Wallet {
             chains: BTreeMap::new(),
-            unassigned_key_pairs: HashMap::new(),
             default: None,
             genesis_config,
-            testing_prng_seed,
         }
     }
 
@@ -67,21 +53,26 @@ impl Wallet {
         self.chains.insert(chain.chain_id, chain);
     }
 
-    pub fn forget_keys(&mut self, chain_id: &ChainId) -> Result<AccountSecretKey, Error> {
+    pub fn forget_keys(&mut self, chain_id: &ChainId) -> Result<AccountOwner, Error> {
         let chain = self
             .chains
             .get_mut(chain_id)
             .ok_or(error::Inner::NonexistentChain(*chain_id))?;
-        chain
-            .key_pair
+
+        let owner = chain
+            .owner
             .take()
-            .ok_or(error::Inner::NonexistentKeypair(*chain_id).into())
+            .ok_or(error::Inner::NonexistentKeypair(*chain_id))?;
+
+        Ok(owner)
     }
 
     pub fn forget_chain(&mut self, chain_id: &ChainId) -> Result<UserChain, Error> {
-        self.chains
+        let user_chain = self
+            .chains
             .remove(chain_id)
-            .ok_or(error::Inner::NonexistentChain(*chain_id).into())
+            .ok_or::<Error>(error::Inner::NonexistentChain(*chain_id).into())?;
+        Ok(user_chain)
     }
 
     pub fn default_chain(&self) -> Option<ChainId> {
@@ -96,7 +87,7 @@ impl Wallet {
     pub fn owned_chain_ids(&self) -> Vec<ChainId> {
         self.chains
             .iter()
-            .filter_map(|(chain_id, chain)| chain.key_pair.is_some().then_some(*chain_id))
+            .filter_map(|(chain_id, chain)| chain.owner.is_some().then_some(*chain_id))
             .collect()
     }
 
@@ -112,39 +103,15 @@ impl Wallet {
         self.chains.values_mut()
     }
 
-    pub fn add_unassigned_key_pair(&mut self, key_pair: AccountSecretKey) {
-        let owner = key_pair.public().into();
-        self.unassigned_key_pairs.insert(owner, key_pair);
-    }
-
-    pub fn key_pair_for_owner(&self, owner: &AccountOwner) -> Option<AccountSecretKey> {
-        if let Some(key_pair) = self
-            .unassigned_key_pairs
-            .get(owner)
-            .map(|key_pair| key_pair.copy())
-        {
-            return Some(key_pair);
-        }
-        self.chains
-            .values()
-            .filter_map(|user_chain| user_chain.key_pair.as_ref())
-            .find(|key_pair| AccountOwner::from(key_pair.public()) == *owner)
-            .map(|key_pair| key_pair.copy())
-    }
-
     pub fn assign_new_chain_to_owner(
         &mut self,
         owner: AccountOwner,
         chain_id: ChainId,
         timestamp: Timestamp,
     ) -> Result<(), Error> {
-        let key_pair = self
-            .unassigned_key_pairs
-            .remove(&owner)
-            .ok_or(error::Inner::NonexistentKeypair(chain_id))?;
         let user_chain = UserChain {
             chain_id,
-            key_pair: Some(key_pair),
+            owner: Some(owner),
             block_hash: None,
             timestamp,
             next_block_height: BlockHeight(0),
@@ -163,20 +130,17 @@ impl Wallet {
         Ok(())
     }
 
-    pub async fn update_from_state<Env: Environment>(&mut self, chain_client: &ChainClient<Env>) {
-        let key_pair = chain_client.key_pair().await.map(|k| k.copy()).ok();
+    pub fn update_from_state<Env: Environment>(&mut self, chain_client: &ChainClient<Env>) {
+        let client_owner = chain_client.preferred_owner();
         let state = chain_client.state();
-        self.chains.insert(
-            chain_client.chain_id(),
-            UserChain {
-                chain_id: chain_client.chain_id(),
-                key_pair,
-                block_hash: state.block_hash(),
-                next_block_height: state.next_block_height(),
-                timestamp: state.timestamp(),
-                pending_proposal: state.pending_proposal().clone(),
-            },
-        );
+        self.insert(UserChain {
+            chain_id: chain_client.chain_id(),
+            owner: client_owner,
+            block_hash: state.block_hash(),
+            next_block_height: state.next_block_height(),
+            timestamp: state.timestamp(),
+            pending_proposal: state.pending_proposal().clone(),
+        });
     }
 
     pub fn genesis_admin_chain(&self) -> ChainId {
@@ -186,22 +150,13 @@ impl Wallet {
     pub fn genesis_config(&self) -> &GenesisConfig {
         &self.genesis_config
     }
-
-    pub fn make_prng(&self) -> Box<dyn CryptoRng> {
-        self.testing_prng_seed.into()
-    }
-
-    pub fn refresh_prng_seed<R: CryptoRng>(&mut self, rng: &mut R) {
-        if self.testing_prng_seed.is_some() {
-            self.testing_prng_seed = Some(rng.gen());
-        }
-    }
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct UserChain {
     pub chain_id: ChainId,
-    pub key_pair: Option<AccountSecretKey>,
+    /// The owner of the chain, if we own it.
+    pub owner: Option<AccountOwner>,
     pub block_hash: Option<CryptoHash>,
     pub timestamp: Timestamp,
     pub next_block_height: BlockHeight,
@@ -212,7 +167,7 @@ impl Clone for UserChain {
     fn clone(&self) -> Self {
         Self {
             chain_id: self.chain_id,
-            key_pair: self.key_pair.as_ref().map(AccountSecretKey::copy),
+            owner: self.owner,
             block_hash: self.block_hash,
             timestamp: self.timestamp,
             next_block_height: self.next_block_height,
@@ -224,13 +179,13 @@ impl Clone for UserChain {
 impl UserChain {
     /// Create a user chain that we own.
     pub fn make_initial(
-        key_pair: AccountSecretKey,
+        owner: AccountOwner,
         description: ChainDescription,
         timestamp: Timestamp,
     ) -> Self {
         Self {
             chain_id: description.into(),
-            key_pair: Some(key_pair),
+            owner: Some(owner),
             block_hash: None,
             timestamp,
             next_block_height: BlockHeight::ZERO,
@@ -243,7 +198,7 @@ impl UserChain {
     pub fn make_other(chain_id: ChainId, timestamp: Timestamp) -> Self {
         Self {
             chain_id,
-            key_pair: None,
+            owner: None,
             block_hash: None,
             timestamp,
             next_block_height: BlockHeight::ZERO,

--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -3,6 +3,7 @@
 
 use criterion::{criterion_group, criterion_main, measurement::Measurement, BatchSize, Criterion};
 use linera_base::{
+    crypto::InMemorySigner,
     data_types::Amount,
     identifiers::{Account, AccountOwner},
     time::Duration,
@@ -25,12 +26,15 @@ where
     B: StorageBuilder + Default,
 {
     let storage_builder = B::default();
+    let mut signer = InMemorySigner::new(None);
     // Criterion doesn't allow setup functions to be async, but it runs them inside an async
     // context. But our setup uses async functions:
     let handle = runtime::Handle::current();
     let _guard = handle.enter();
     futures::executor::block_on(async move {
-        let mut builder = TestBuilder::new(storage_builder, 4, 1).await.unwrap();
+        let mut builder = TestBuilder::new(storage_builder, 4, 1, &mut signer)
+            .await
+            .unwrap();
         let chain1 = builder
             .add_root_chain(1, Amount::from_tokens(10))
             .await

--- a/linera-core/build.rs
+++ b/linera-core/build.rs
@@ -6,5 +6,9 @@ fn main() {
         web: { all(target_arch = "wasm32", feature = "web") },
         with_testing: { any(test, feature = "test") },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
+
+        // the old version of `getrandom` we pin here is available on all targets, but
+        // using it will panic if no suitable source of entropy is found
+        with_getrandom: { any(web, not(target_arch = "wasm32")) },
     };
 }

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -19,8 +19,9 @@ use assert_matches::assert_matches;
 use async_graphql::Request;
 use counter::CounterAbi;
 use linera_base::{
+    crypto::InMemorySigner,
     data_types::{Amount, Bytecode, Event, OracleResponse},
-    identifiers::{AccountOwner, ApplicationId, BlobId, BlobType, StreamId, StreamName},
+    identifiers::{ApplicationId, BlobId, BlobType, StreamId, StreamName},
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
 };
@@ -97,6 +98,7 @@ async fn run_test_create_application<B>(storage_builder: B) -> anyhow::Result<()
 where
     B: StorageBuilder,
 {
+    let mut keys = InMemorySigner::new(None);
     let vm_runtime = VmRuntime::Wasm;
     let (contract_path, service_path) =
         linera_execution::wasm_test::get_example_bytecode_paths("counter")?;
@@ -111,7 +113,7 @@ where
         .len()
         .max(service_bytecode.bytes.len()) as u64;
     policy.maximum_blob_size = contract_compressed_len.max(service_compressed_len) as u64;
-    let mut builder = TestBuilder::new(storage_builder, 4, 1)
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, &mut keys)
         .await?
         .with_policy(policy.clone());
     let publisher = builder.add_root_chain(0, Amount::from_tokens(3)).await?;
@@ -261,8 +263,9 @@ async fn run_test_run_application_with_dependency<B>(storage_builder: B) -> anyh
 where
     B: StorageBuilder,
 {
+    let mut keys = InMemorySigner::new(None);
     let vm_runtime = VmRuntime::Wasm;
-    let mut builder = TestBuilder::new(storage_builder, 4, 1)
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, &mut keys)
         .await?
         .with_policy(ResourceControlPolicy::all_categories());
     // Will publish the module.
@@ -276,6 +279,7 @@ where
     // Handling the message causes an oracle request to the counter service, so no fast blocks
     // are allowed.
     let receiver_key = receiver.public_key().await.unwrap();
+
     receiver
         .change_ownership(ChainOwnership::multiple(
             [(receiver_key.into(), 100)],
@@ -284,6 +288,7 @@ where
         ))
         .await
         .unwrap();
+
     let creator_key = creator.public_key().await.unwrap();
     creator
         .change_ownership(ChainOwnership::multiple(
@@ -528,8 +533,9 @@ async fn run_test_cross_chain_message<B>(storage_builder: B) -> anyhow::Result<(
 where
     B: StorageBuilder,
 {
+    let mut keys = InMemorySigner::new(None);
     let vm_runtime = VmRuntime::Wasm;
-    let mut builder = TestBuilder::new(storage_builder, 4, 1)
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, &mut keys)
         .await?
         .with_policy(ResourceControlPolicy::all_categories());
     let _admin = builder.add_root_chain(0, Amount::ONE).await?;
@@ -554,9 +560,9 @@ where
     let module_id = module_id
         .with_abi::<fungible::FungibleTokenAbi, fungible::Parameters, fungible::InitialState>();
 
-    let sender_owner = AccountOwner::from(sender.key_pair().await?.public());
-    let receiver_owner = AccountOwner::from(receiver.key_pair().await?.public());
-    let receiver2_owner = AccountOwner::from(receiver2.key_pair().await?.public());
+    let sender_owner = sender.preferred_owner.unwrap();
+    let receiver_owner = receiver.preferred_owner.unwrap();
+    let receiver2_owner = receiver2.preferred_owner.unwrap();
 
     let accounts = BTreeMap::from_iter([(sender_owner, Amount::from_tokens(1_000_000))]);
     let state = fungible::InitialState { accounts };
@@ -707,8 +713,9 @@ async fn run_test_event_streams<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
 {
+    let mut keys = InMemorySigner::new(None);
     let vm_runtime = VmRuntime::Wasm;
-    let mut builder = TestBuilder::new(storage_builder, 4, 1)
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, &mut keys)
         .await?
         .with_policy(ResourceControlPolicy::all_categories());
     let sender = builder.add_root_chain(0, Amount::ONE).await?;
@@ -882,7 +889,8 @@ async fn test_memory_fuel_limit(wasm_runtime: WasmRuntime) -> anyhow::Result<()>
         blob_byte_published: Amount::from_attos(1),
         ..ResourceControlPolicy::default()
     };
-    let mut builder = TestBuilder::new(storage_builder, 4, 1)
+    let mut keys = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, &mut keys)
         .await?
         .with_policy(policy.clone());
     let publisher = builder.add_root_chain(0, Amount::from_tokens(3)).await?;

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -18,8 +18,7 @@ use std::{
 use assert_matches::assert_matches;
 use linera_base::{
     crypto::{
-        AccountPublicKey, AccountSecretKey, CryptoHash, Ed25519SecretKey, EvmSecretKey,
-        Secp256k1SecretKey, ValidatorKeypair,
+        AccountPublicKey, AccountSecretKey, CryptoHash, InMemorySigner, Signer, ValidatorKeypair,
     },
     data_types::*,
     identifiers::{Account, AccountOwner, ChainId, EventId, StreamId},
@@ -258,12 +257,11 @@ where
             .unwrap()
             .unwrap()
     }
-
     #[expect(clippy::too_many_arguments)]
     async fn make_simple_transfer_certificate(
         &self,
         chain_description: ChainDescription,
-        key_pair: &AccountSecretKey,
+        chain_owner_pubkey: AccountPublicKey,
         target_id: ChainId,
         amount: Amount,
         incoming_bundles: Vec<IncomingBundle>,
@@ -272,8 +270,8 @@ where
     ) -> ConfirmedBlockCertificate {
         self.make_transfer_certificate_for_epoch(
             chain_description,
-            key_pair,
-            Some(key_pair.public().into()),
+            chain_owner_pubkey,
+            chain_owner_pubkey.into(),
             AccountOwner::CHAIN,
             Recipient::chain(target_id),
             amount,
@@ -290,8 +288,8 @@ where
     async fn make_transfer_certificate(
         &self,
         chain_description: ChainDescription,
-        key_pair: &AccountSecretKey,
-        authenticated_signer: Option<AccountOwner>,
+        chain_owner_pubkey: AccountPublicKey,
+        authenticated_signer: AccountOwner,
         source: AccountOwner,
         recipient: Recipient,
         amount: Amount,
@@ -302,7 +300,7 @@ where
     ) -> ConfirmedBlockCertificate {
         self.make_transfer_certificate_for_epoch(
             chain_description,
-            key_pair,
+            chain_owner_pubkey,
             authenticated_signer,
             source,
             recipient,
@@ -324,8 +322,8 @@ where
     async fn make_transfer_certificate_for_epoch(
         &self,
         chain_description: ChainDescription,
-        key_pair: &AccountSecretKey,
-        authenticated_signer: Option<AccountOwner>,
+        chain_owner_pubkey: AccountPublicKey,
+        authenticated_signer: AccountOwner,
         source: AccountOwner,
         recipient: Recipient,
         amount: Amount,
@@ -338,7 +336,7 @@ where
         let chain_id = chain_description.id();
         let system_state = SystemExecutionState {
             committees: [(epoch, self.committee.clone())].into_iter().collect(),
-            ownership: ChainOwnership::single(key_pair.public().into()),
+            ownership: ChainOwnership::single(chain_owner_pubkey.into()),
             balance,
             balances,
             ..SystemExecutionState::new(chain_description)
@@ -377,7 +375,7 @@ where
         let block = ProposedBlock {
             epoch,
             incoming_bundles,
-            authenticated_signer,
+            authenticated_signer: Some(authenticated_signer),
             ..block_template
         }
         .with_transfer(source, recipient, amount);
@@ -465,16 +463,12 @@ fn direct_credit_message(recipient: ChainId, amount: Amount) -> OutgoingMessage 
 }
 
 /// Creates `count` key pairs and returns them, sorted by the `AccountOwner` created from their public key.
-fn generate_key_pairs(count: usize) -> Vec<AccountSecretKey> {
-    let mut key_pairs: Vec<AccountSecretKey> = (0..count)
-        .map(|idx| match idx % 3 {
-            0 => AccountSecretKey::Ed25519(Ed25519SecretKey::generate()),
-            1 => AccountSecretKey::Secp256k1(Secp256k1SecretKey::generate()),
-            _ => AccountSecretKey::EvmSecp256k1(EvmSecretKey::generate()),
-        })
-        .collect();
-    key_pairs.sort_by_key(|key_pair| AccountOwner::from(key_pair.public()));
-    key_pairs
+fn generate_key_pairs(signer: &mut InMemorySigner, count: usize) -> Vec<AccountPublicKey> {
+    let mut public_keys = iter::repeat_with(|| signer.generate_new())
+        .take(count)
+        .collect::<Vec<_>>();
+    public_keys.sort_by_key(|pk| AccountOwner::from(*pk));
+    public_keys
 }
 
 /// Creates a `CrossChainRequest` with the messages sent by the certificate to the recipient.
@@ -500,10 +494,12 @@ async fn test_handle_block_proposal_bad_signature<B>(mut storage_builder: B) -> 
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountSecretKey::generate();
+    let mut signer = InMemorySigner::new(None);
+    let sender_public_key = signer.generate_new();
+    let sender_owner = sender_public_key.into();
     let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
     let chain_1_desc = env
-        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .add_root_chain(1, sender_owner, Amount::from_tokens(5))
         .await;
     let chain_2_desc = env
         .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ZERO)
@@ -512,7 +508,9 @@ where
     let chain_2 = chain_2_desc.id();
     let block_proposal = make_first_block(chain_1)
         .with_simple_transfer(chain_2, Amount::from_tokens(5))
-        .into_first_proposal(&sender_key_pair);
+        .into_first_proposal(sender_owner, &signer)
+        .await
+        .unwrap();
     let unknown_key_pair = AccountSecretKey::generate();
     let mut bad_signature_block_proposal = block_proposal.clone();
     bad_signature_block_proposal.signature = unknown_key_pair.sign(&block_proposal.content);
@@ -539,10 +537,11 @@ async fn test_handle_block_proposal_zero_amount<B>(mut storage_builder: B) -> an
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountSecretKey::generate();
+    let mut signer = InMemorySigner::new(None);
+    let sender_owner = signer.generate_new().into();
     let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
     let chain_1_desc = env
-        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .add_root_chain(1, sender_owner, Amount::from_tokens(5))
         .await;
     let chain_2_desc = env
         .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ZERO)
@@ -552,8 +551,10 @@ where
     // test block non-positive amount
     let zero_amount_block_proposal = make_first_block(chain_1)
         .with_simple_transfer(chain_2, Amount::ZERO)
-        .with_authenticated_signer(Some(sender_key_pair.public().into()))
-        .into_first_proposal(&sender_key_pair);
+        .with_authenticated_signer(Some(sender_owner))
+        .into_first_proposal(sender_owner, &signer)
+        .await
+        .unwrap();
     assert_matches!(
     env.worker()
         .handle_block_proposal(zero_amount_block_proposal)
@@ -580,21 +581,23 @@ async fn test_handle_block_proposal_ticks<B>(mut storage_builder: B) -> anyhow::
 where
     B: StorageBuilder,
 {
+    let mut signer = InMemorySigner::new(None);
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
-    let key_pair = AccountSecretKey::generate();
+    let public_key = signer.generate_new();
+    let owner = public_key.into();
     let balance = Amount::from_tokens(5);
     let mut env = TestEnvironment::new(storage, false, false).await;
-    let chain_1_desc = env
-        .add_root_chain(1, key_pair.public().into(), balance)
-        .await;
+    let chain_1_desc = env.add_root_chain(1, owner, balance).await;
     let epoch = Epoch::ZERO;
     let chain_id = chain_1_desc.id();
 
     {
         let block_proposal = make_first_block(chain_id)
             .with_timestamp(Timestamp::from(TEST_GRACE_PERIOD_MICROS + 1_000_000))
-            .into_first_proposal(&key_pair);
+            .into_first_proposal(owner, &signer)
+            .await
+            .unwrap();
         // Timestamp too far in the future
         assert_matches!(
             env.worker().handle_block_proposal(block_proposal).await,
@@ -605,14 +608,18 @@ where
     let block_0_time = Timestamp::from(TEST_GRACE_PERIOD_MICROS);
     let certificate = {
         let block = make_first_block(chain_id).with_timestamp(block_0_time);
-        let block_proposal = block.clone().into_first_proposal(&key_pair);
+        let block_proposal = block
+            .clone()
+            .into_first_proposal(owner, &signer)
+            .await
+            .unwrap();
         let future = env.worker().handle_block_proposal(block_proposal);
         clock.set(block_0_time);
         future.await?;
 
         let system_state = SystemExecutionState {
             committees: [(epoch, env.committee().clone())].into_iter().collect(),
-            ownership: ChainOwnership::single(key_pair.public().into()),
+            ownership: ChainOwnership::single(owner),
             balance,
             timestamp: block_0_time,
             ..SystemExecutionState::new(chain_1_desc.clone())
@@ -634,7 +641,9 @@ where
     {
         let block_proposal = make_child_block(&certificate.into_value())
             .with_timestamp(block_0_time.saturating_sub_micros(1))
-            .into_first_proposal(&key_pair);
+            .into_first_proposal(owner, &signer)
+            .await
+            .unwrap();
         // Timestamp older than previous one
         assert_matches!(
             env.worker().handle_block_proposal(block_proposal).await,
@@ -654,10 +663,11 @@ async fn test_handle_block_proposal_unknown_sender<B>(mut storage_builder: B) ->
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountSecretKey::generate();
+    let mut signer = InMemorySigner::new(None);
+    let sender_public_key = signer.generate_new();
     let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
     let chain_1_desc = env
-        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .add_root_chain(1, sender_public_key.into(), Amount::from_tokens(5))
         .await;
     let chain_2_desc = env
         .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ZERO)
@@ -665,9 +675,16 @@ where
     let chain_1 = chain_1_desc.id();
     let chain_2 = chain_2_desc.id();
     let unknown_key = AccountSecretKey::generate();
+    let unknown_owner = unknown_key.public().into();
+    let new_signer: Box<dyn Signer> = Box::new(InMemorySigner::from_iter(vec![(
+        unknown_owner,
+        unknown_key,
+    )]));
     let unknown_sender_block_proposal = make_first_block(chain_1)
         .with_simple_transfer(chain_2, Amount::from_tokens(5))
-        .into_first_proposal(&unknown_key);
+        .into_first_proposal(unknown_owner, &new_signer)
+        .await
+        .unwrap();
     assert_matches!(
         env.worker()
             .handle_block_proposal(unknown_sender_block_proposal)
@@ -690,24 +707,25 @@ async fn test_handle_block_proposal_with_chaining<B>(mut storage_builder: B) -> 
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountSecretKey::generate();
+    let mut signer = InMemorySigner::new(None);
+    let sender_public_key = signer.generate_new();
+    let sender_owner = sender_public_key.into();
     let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
     let chain_desc = env
-        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .add_root_chain(1, sender_owner, Amount::from_tokens(5))
         .await;
     let chain_1 = chain_desc.id();
-    let chain_2 = env
-        .add_root_chain(2, sender_key_pair.public().into(), Amount::ZERO)
-        .await
-        .id();
+    let chain_2 = env.add_root_chain(2, sender_owner, Amount::ZERO).await.id();
     let block_proposal0 = make_first_block(chain_1)
         .with_simple_transfer(chain_2, Amount::ONE)
-        .with_authenticated_signer(Some(sender_key_pair.public().into()))
-        .into_first_proposal(&sender_key_pair);
+        .with_authenticated_signer(Some(sender_owner))
+        .into_first_proposal(sender_owner, &signer)
+        .await
+        .unwrap();
     let certificate0 = env
         .make_simple_transfer_certificate(
             chain_desc.clone(),
-            &sender_key_pair,
+            sender_public_key,
             chain_2,
             Amount::ONE,
             Vec::new(),
@@ -717,7 +735,9 @@ where
         .await;
     let block_proposal1 = make_child_block(certificate0.value())
         .with_simple_transfer(chain_2, Amount::from_tokens(2))
-        .into_first_proposal(&sender_key_pair);
+        .into_first_proposal(sender_owner, &signer)
+        .await
+        .unwrap();
 
     assert_matches!(
         env.worker().handle_block_proposal(block_proposal1.clone()).await,
@@ -746,14 +766,12 @@ where
     let block_certificate0 =
         env.make_certificate(chain.manager.validated_vote().unwrap().value().clone());
     drop(chain);
-
     env.worker()
         .handle_validated_certificate(block_certificate0)
         .await?;
     let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active());
     let block = chain.manager.confirmed_vote().unwrap().value().block();
-
     // Should be confirmed after handling the certificate.
     assert!(block.matches_proposed_block(&block_proposal0.content.block));
     assert!(chain.manager.validated_vote().is_none());
@@ -764,7 +782,6 @@ where
         .await?;
     let chain = env.worker().chain_state_view(chain_1).await?;
     drop(chain);
-
     env.worker()
         .handle_block_proposal(block_proposal1.clone())
         .await?;
@@ -798,22 +815,20 @@ async fn test_handle_block_proposal_with_incoming_bundles<B>(
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountSecretKey::generate();
-    let recipient_key_pair = AccountSecretKey::generate();
+    let mut signer = InMemorySigner::new(None);
+    let sender_public_key = signer.generate_new();
+    let sender_owner = sender_public_key.into();
+    let recipient_public_key = signer.generate_new();
+    let recipient_owner = recipient_public_key.into();
     let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
     let chain_1_desc = env
-        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(6))
+        .add_root_chain(1, sender_owner, Amount::from_tokens(6))
         .await;
-    let chain_2_desc = env
-        .add_root_chain(2, recipient_key_pair.public().into(), Amount::ZERO)
-        .await;
-    let chain_3_desc = env
-        .add_root_chain(3, recipient_key_pair.public().into(), Amount::ZERO)
-        .await;
+    let chain_2_desc = env.add_root_chain(2, recipient_owner, Amount::ZERO).await;
+    let chain_3_desc = env.add_root_chain(3, recipient_owner, Amount::ZERO).await;
     let chain_1 = chain_1_desc.id();
     let chain_2 = chain_2_desc.id();
     let chain_3 = chain_3_desc.id();
-
     let certificate0 = env.make_certificate(ConfirmedBlock::new(
         BlockExecutionOutcome {
             messages: vec![
@@ -836,7 +851,7 @@ where
             make_first_block(chain_1)
                 .with_simple_transfer(chain_2, Amount::ONE)
                 .with_simple_transfer(chain_2, Amount::from_tokens(2))
-                .with_authenticated_signer(Some(sender_key_pair.public().into())),
+                .with_authenticated_signer(Some(sender_owner)),
         ),
     ));
 
@@ -858,7 +873,7 @@ where
         .with(
             make_child_block(&certificate0.clone().into_value())
                 .with_simple_transfer(chain_2, Amount::from_tokens(3))
-                .with_authenticated_signer(Some(sender_key_pair.public().into())),
+                .with_authenticated_signer(Some(sender_owner)),
         ),
     ));
     // Missing earlier blocks
@@ -913,8 +928,10 @@ where
     {
         let block_proposal = make_first_block(chain_2)
             .with_simple_transfer(chain_3, Amount::from_tokens(6))
-            .with_authenticated_signer(Some(recipient_key_pair.public().into()))
-            .into_first_proposal(&recipient_key_pair);
+            .with_authenticated_signer(Some(recipient_owner))
+            .into_first_proposal(recipient_owner, &signer)
+            .await
+            .unwrap();
         // Insufficient funding
         assert_matches!(
                 env.worker().handle_block_proposal(block_proposal).await,
@@ -967,8 +984,10 @@ where
                 },
                 action: MessageAction::Accept,
             })
-            .with_authenticated_signer(Some(recipient_key_pair.public().into()))
-            .into_first_proposal(&recipient_key_pair);
+            .with_authenticated_signer(Some(recipient_owner))
+            .into_first_proposal(recipient_owner, &signer)
+            .await
+            .unwrap();
         // Inconsistent received messages.
         assert_matches!(
             env.worker().handle_block_proposal(block_proposal).await,
@@ -991,8 +1010,10 @@ where
                 },
                 action: MessageAction::Accept,
             })
-            .with_authenticated_signer(Some(recipient_key_pair.public().into()))
-            .into_first_proposal(&recipient_key_pair);
+            .with_authenticated_signer(Some(recipient_owner))
+            .into_first_proposal(recipient_owner, &signer)
+            .await
+            .unwrap();
         // Skipped message.
         assert_matches!(
             env.worker().handle_block_proposal(block_proposal).await,
@@ -1040,8 +1061,10 @@ where
                 },
                 action: MessageAction::Accept,
             })
-            .with_authenticated_signer(Some(recipient_key_pair.public().into()))
-            .into_first_proposal(&recipient_key_pair);
+            .with_authenticated_signer(Some(recipient_owner))
+            .into_first_proposal(recipient_owner, &signer)
+            .await
+            .unwrap();
         // Inconsistent order in received messages (heights).
         assert_matches!(
             env.worker().handle_block_proposal(block_proposal).await,
@@ -1065,8 +1088,10 @@ where
                 },
                 action: MessageAction::Accept,
             })
-            .with_authenticated_signer(Some(recipient_key_pair.public().into()))
-            .into_first_proposal(&recipient_key_pair);
+            .with_authenticated_signer(Some(recipient_owner))
+            .into_first_proposal(recipient_owner, &signer)
+            .await
+            .unwrap();
         // Taking the first message only is ok.
         env.worker()
             .handle_block_proposal(block_proposal.clone())
@@ -1119,7 +1144,9 @@ where
                 },
                 action: MessageAction::Accept,
             })
-            .into_first_proposal(&recipient_key_pair);
+            .into_first_proposal(recipient_owner, &signer)
+            .await
+            .unwrap();
         env.worker()
             .handle_block_proposal(block_proposal.clone())
             .await?;
@@ -1136,10 +1163,11 @@ async fn test_handle_block_proposal_exceed_balance<B>(mut storage_builder: B) ->
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountSecretKey::generate();
+    let mut signer = InMemorySigner::new(None);
+    let sender_owner = signer.generate_new().into();
     let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
     let chain_1_desc = env
-        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .add_root_chain(1, sender_owner, Amount::from_tokens(5))
         .await;
     let chain_2_desc = env
         .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ZERO)
@@ -1148,8 +1176,10 @@ where
     let chain_2 = chain_2_desc.id();
     let block_proposal = make_first_block(chain_1)
         .with_simple_transfer(chain_2, Amount::from_tokens(1000))
-        .with_authenticated_signer(Some(sender_key_pair.public().into()))
-        .into_first_proposal(&sender_key_pair);
+        .with_authenticated_signer(Some(sender_owner))
+        .into_first_proposal(sender_owner, &signer)
+        .await
+        .unwrap();
     assert_matches!(
         env.worker().handle_block_proposal(block_proposal).await,
         Err(
@@ -1174,20 +1204,23 @@ async fn test_handle_block_proposal<B>(mut storage_builder: B) -> anyhow::Result
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountSecretKey::generate();
+    let mut signer = InMemorySigner::new(None);
+    let sender_owner = signer.generate_new().into();
     let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
     let chain_1_desc = env
-        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .add_root_chain(1, sender_owner, Amount::from_tokens(5))
         .await;
     let chain_2_desc = env
-        .add_root_chain(2, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .add_root_chain(2, sender_owner, Amount::from_tokens(5))
         .await;
     let chain_1 = chain_1_desc.id();
     let chain_2 = chain_2_desc.id();
     let block_proposal = make_first_block(chain_1)
         .with_simple_transfer(chain_2, Amount::from_tokens(5))
-        .with_authenticated_signer(Some(sender_key_pair.public().into()))
-        .into_first_proposal(&sender_key_pair);
+        .with_authenticated_signer(Some(sender_owner))
+        .into_first_proposal(sender_owner, &signer)
+        .await
+        .unwrap();
 
     let (chain_info_response, _actions) =
         env.worker().handle_block_proposal(block_proposal).await?;
@@ -1225,10 +1258,11 @@ async fn test_handle_block_proposal_replay<B>(mut storage_builder: B) -> anyhow:
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountSecretKey::generate();
+    let mut signer = InMemorySigner::new(None);
+    let sender_owner = signer.generate_new().into();
     let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
     let chain_1_desc = env
-        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .add_root_chain(1, sender_owner, Amount::from_tokens(5))
         .await;
     let chain_2_desc = env
         .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ZERO)
@@ -1237,8 +1271,10 @@ where
     let chain_2 = chain_2_desc.id();
     let block_proposal = make_first_block(chain_1)
         .with_simple_transfer(chain_2, Amount::from_tokens(5))
-        .with_authenticated_signer(Some(sender_key_pair.public().into()))
-        .into_first_proposal(&sender_key_pair);
+        .with_authenticated_signer(Some(sender_owner))
+        .into_first_proposal(sender_owner, &signer)
+        .await
+        .unwrap();
 
     let (response, _actions) = env
         .worker()
@@ -1263,17 +1299,19 @@ async fn test_handle_certificate_unknown_sender<B>(mut storage_builder: B) -> an
 where
     B: StorageBuilder,
 {
-    let sender_key_pair = AccountSecretKey::generate();
+    let mut signer = InMemorySigner::new(None);
+    let sender_pubkey = signer.generate_new();
+    let test_pubkey = signer.generate_new();
     let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
     let chain_2_desc = env
-        .add_root_chain(2, sender_key_pair.public().into(), Amount::ZERO)
+        .add_root_chain(2, test_pubkey.into(), Amount::ZERO)
         .await;
     let chain_2 = chain_2_desc.id();
     let chain_1_desc = dummy_chain_description(1);
     let certificate = env
         .make_simple_transfer_certificate(
             chain_1_desc.clone(),
-            &sender_key_pair,
+            sender_pubkey,
             chain_2,
             Amount::from_tokens(5),
             Vec::new(),
@@ -1352,8 +1390,8 @@ where
     let certificate = env
         .make_transfer_certificate_for_epoch(
             chain_2_desc.clone(),
-            &sender_key_pair,
-            Some(chain_key_pair.public().into()),
+            sender_key_pair.public(),
+            chain_key_pair.public().into(),
             AccountOwner::CHAIN,
             Recipient::chain(chain_2),
             Amount::from_tokens(5),
@@ -1396,7 +1434,7 @@ where
     let certificate = env
         .make_simple_transfer_certificate(
             chain_1_desc.clone(),
-            &sender_key_pair,
+            sender_key_pair.public(),
             chain_2,
             Amount::from_tokens(5),
             Vec::new(),
@@ -1443,7 +1481,7 @@ where
     let certificate = env
         .make_simple_transfer_certificate(
             chain_1_desc.clone(),
-            &key_pair,
+            key_pair.public(),
             chain_2,
             Amount::from_tokens(1000),
             vec![IncomingBundle {
@@ -1536,7 +1574,7 @@ where
     let certificate = env
         .make_simple_transfer_certificate(
             chain_1_desc.clone(),
-            &sender_key_pair,
+            sender_key_pair.public(),
             chain_2,
             Amount::ONE,
             Vec::new(),
@@ -1592,7 +1630,7 @@ where
     let certificate = env
         .make_simple_transfer_certificate(
             chain_1_desc.clone(),
-            &key_pair,
+            key_pair.public(),
             chain_1,
             Amount::ONE,
             Vec::new(),
@@ -1662,7 +1700,7 @@ where
     let certificate = env
         .make_simple_transfer_certificate(
             chain_1_desc,
-            &sender_key_pair,
+            sender_key_pair.public(),
             chain_2,
             Amount::from_tokens(10),
             Vec::new(),
@@ -1735,7 +1773,7 @@ where
     let certificate = env
         .make_simple_transfer_certificate(
             chain_1_desc,
-            &sender_key_pair,
+            sender_key_pair.public(),
             chain_2,
             Amount::from_tokens(10),
             Vec::new(),
@@ -1777,7 +1815,7 @@ where
     let certificate = env
         .make_simple_transfer_certificate(
             chain_1_desc,
-            &sender_key_pair,
+            sender_key_pair.public(),
             chain_2,
             Amount::from_tokens(10),
             Vec::new(),
@@ -1863,7 +1901,7 @@ where
     let certificate = env
         .make_simple_transfer_certificate(
             chain_1_desc.clone(),
-            &sender_key_pair,
+            sender_key_pair.public(),
             chain_2,
             Amount::from_tokens(5),
             Vec::new(),
@@ -1899,7 +1937,7 @@ where
     let certificate = env
         .make_simple_transfer_certificate(
             chain_2_desc.clone(),
-            &recipient_key_pair,
+            recipient_key_pair.public(),
             chain_3,
             Amount::ONE,
             vec![IncomingBundle {
@@ -1991,7 +2029,7 @@ where
     let certificate = env
         .make_simple_transfer_certificate(
             chain_1_desc.clone(),
-            &sender_key_pair,
+            sender_key_pair.public(),
             chain_2, // the recipient chain does not exist
             Amount::from_tokens(5),
             Vec::new(),
@@ -2025,10 +2063,12 @@ where
     B: StorageBuilder,
 {
     let sender_key_pair = AccountSecretKey::generate();
-    let sender = AccountOwner::from(sender_key_pair.public());
+    let sender_pubkey = sender_key_pair.public();
+    let sender = AccountOwner::from(sender_pubkey);
 
     let recipient_key_pair = AccountSecretKey::generate();
-    let recipient = AccountOwner::from(sender_key_pair.public());
+    let recipient_pubkey = recipient_key_pair.public();
+    let recipient = AccountOwner::from(recipient_pubkey);
 
     let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
     let chain_1_desc = env
@@ -2054,8 +2094,8 @@ where
     let certificate00 = env
         .make_transfer_certificate(
             chain_1_desc.clone(),
-            &sender_key_pair,
-            Some(AccountOwner::from(sender_key_pair.public())),
+            sender_pubkey,
+            sender,
             AccountOwner::CHAIN,
             Recipient::Account(sender_account),
             Amount::from_tokens(5),
@@ -2073,8 +2113,8 @@ where
     let certificate01 = env
         .make_transfer_certificate(
             chain_1_desc.clone(),
-            &sender_key_pair,
-            Some(AccountOwner::from(sender_key_pair.public())),
+            sender_pubkey,
+            sender,
             AccountOwner::CHAIN,
             Recipient::Burn,
             Amount::ONE,
@@ -2114,8 +2154,8 @@ where
     let certificate1 = env
         .make_transfer_certificate(
             chain_1_desc.clone(),
-            &sender_key_pair,
-            Some(sender),
+            sender_pubkey,
+            sender,
             sender,
             Recipient::Account(recipient_account),
             Amount::from_tokens(3),
@@ -2133,8 +2173,8 @@ where
     let certificate2 = env
         .make_transfer_certificate(
             chain_1_desc.clone(),
-            &sender_key_pair,
-            Some(sender),
+            sender_pubkey,
+            sender,
             sender,
             Recipient::Account(recipient_account),
             Amount::from_tokens(2),
@@ -2153,8 +2193,8 @@ where
     let certificate = env
         .make_transfer_certificate(
             chain_2_desc.clone(),
-            &recipient_key_pair,
-            Some(recipient),
+            recipient_pubkey,
+            recipient,
             recipient,
             Recipient::Burn,
             Amount::ONE,
@@ -2212,8 +2252,8 @@ where
     let certificate3 = env
         .make_transfer_certificate(
             chain_1_desc.clone(),
-            &sender_key_pair,
-            Some(sender),
+            sender_pubkey,
+            sender,
             sender,
             Recipient::Burn,
             Amount::from_tokens(3),
@@ -2814,8 +2854,8 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let certificate0 = env
         .make_transfer_certificate_for_epoch(
             chain_0.clone(),
-            &key_pair0,
-            Some(key_pair0.public().into()),
+            key_pair0.public(),
+            key_pair0.public().into(),
             AccountOwner::CHAIN,
             Recipient::chain(id1),
             Amount::ONE,
@@ -2829,8 +2869,8 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let certificate1 = env
         .make_transfer_certificate_for_epoch(
             chain_0.clone(),
-            &key_pair0,
-            Some(key_pair0.public().into()),
+            key_pair0.public(),
+            key_pair0.public().into(),
             AccountOwner::CHAIN,
             Recipient::chain(id1),
             Amount::ONE,
@@ -2844,8 +2884,8 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let certificate2 = env
         .make_transfer_certificate_for_epoch(
             chain_0.clone(),
-            &key_pair0,
-            Some(key_pair0.public().into()),
+            key_pair0.public(),
+            key_pair0.public().into(),
             AccountOwner::CHAIN,
             Recipient::chain(id1),
             Amount::ONE,
@@ -2860,8 +2900,8 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let certificate3 = env
         .make_transfer_certificate_for_epoch(
             chain_0.clone(),
-            &key_pair0,
-            Some(key_pair0.public().into()),
+            key_pair0.public(),
+            key_pair0.public().into(),
             AccountOwner::CHAIN,
             Recipient::chain(id1),
             Amount::ONE,
@@ -2974,10 +3014,11 @@ where
     B: StorageBuilder,
 {
     let storage = storage_builder.build().await?;
+    let mut signer = InMemorySigner::new(None);
     let clock = storage_builder.clock();
-    let key_pairs = generate_key_pairs(2);
-    let owner0 = AccountOwner::from(key_pairs[0].public());
-    let owner1 = AccountOwner::from(key_pairs[1].public());
+    let key_pairs = generate_key_pairs(&mut signer, 2);
+    let owner0 = AccountOwner::from(key_pairs[0]);
+    let owner1 = AccountOwner::from(key_pairs[1]);
     let mut env = TestEnvironment::new(storage, false, false).await;
     let chain_1_desc = env.add_root_chain(1, owner0, Amount::from_tokens(2)).await;
     let chain_1 = chain_1_desc.id();
@@ -3008,12 +3049,17 @@ where
 
     // So owner 0 cannot propose a block in this round. And the next round hasn't started yet.
     let proposal = make_child_block(&value0.clone())
-        .into_proposal_with_round(&key_pairs[0], Round::SingleLeader(0));
+        .into_proposal_with_round(owner0, &signer, Round::SingleLeader(0))
+        .await
+        .unwrap();
     let result = env.worker().handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::InvalidOwner));
     let proposal = make_child_block(&value0.clone())
-        .into_proposal_with_round(&key_pairs[0], Round::SingleLeader(1));
+        .into_proposal_with_round(owner0, &signer, Round::SingleLeader(1))
+        .await
+        .unwrap();
     let result = env.worker().handle_block_proposal(proposal).await;
+
     assert_matches!(result, Err(WorkerError::ChainError(ref error))
         if matches!(**error, ChainError::WrongRound(Round::SingleLeader(0)))
     );
@@ -3053,7 +3099,9 @@ where
     let proposal1_wrong_owner = proposed_block1
         .clone()
         .with_authenticated_signer(Some(owner1))
-        .into_proposal_with_round(&key_pairs[1], Round::SingleLeader(1));
+        .into_proposal_with_round(owner1, &signer, Round::SingleLeader(1))
+        .await
+        .unwrap();
     let result = env
         .worker()
         .handle_block_proposal(proposal1_wrong_owner)
@@ -3061,7 +3109,9 @@ where
     assert_matches!(result, Err(WorkerError::InvalidOwner));
     let proposal1 = proposed_block1
         .clone()
-        .into_proposal_with_round(&key_pairs[0], Round::SingleLeader(1));
+        .into_proposal_with_round(owner0, &signer, Round::SingleLeader(1))
+        .await
+        .unwrap();
     let (response, _) = env.worker().handle_block_proposal(proposal1).await?;
     let value1 = ValidatedBlock::new(block1.clone());
 
@@ -3115,7 +3165,9 @@ where
     let proposal = proposed_block2
         .clone()
         .with_authenticated_signer(Some(owner1))
-        .into_proposal_with_round(&key_pairs[1], Round::SingleLeader(5));
+        .into_proposal_with_round(owner1, &signer, Round::SingleLeader(5))
+        .await
+        .unwrap();
     let result = env.worker().handle_block_proposal(proposal.clone()).await;
     assert_matches!(result, Err(WorkerError::ChainError(error))
          if matches!(*error, ChainError::HasIncompatibleConfirmedVote(_, _))
@@ -3123,8 +3175,15 @@ where
 
     // But with the validated block certificate for block2, it is allowed.
     let certificate2 = env.make_certificate_with_round(value2.clone(), Round::SingleLeader(4));
-    let proposal =
-        BlockProposal::new_retry(Round::SingleLeader(5), certificate2.clone(), &key_pairs[1]);
+
+    let proposal = BlockProposal::new_retry(
+        owner1,
+        Round::SingleLeader(5),
+        certificate2.clone(),
+        &signer,
+    )
+    .await
+    .unwrap();
     let lite_value2 = LiteValue::new(&value2);
     let (_, _) = env.worker().handle_block_proposal(proposal).await?;
     let (response, _) = env
@@ -3150,7 +3209,10 @@ where
     assert_eq!(response.info.manager.current_round, Round::SingleLeader(6));
 
     // Since the validator now voted for block2, it can't vote for block1 anymore.
-    let proposal = proposed_block1.into_proposal_with_round(&key_pairs[0], Round::SingleLeader(6));
+    let proposal = proposed_block1
+        .into_proposal_with_round(owner0, &signer, Round::SingleLeader(6))
+        .await
+        .unwrap();
     let result = env.worker().handle_block_proposal(proposal.clone()).await;
     assert_matches!(result, Err(WorkerError::ChainError(error))
          if matches!(*error, ChainError::HasIncompatibleConfirmedVote(_, _))
@@ -3189,10 +3251,11 @@ where
     B: StorageBuilder,
 {
     let storage = storage_builder.build().await?;
+    let mut signer = InMemorySigner::new(None);
     let clock = storage_builder.clock();
-    let key_pairs = generate_key_pairs(2);
-    let owner0 = AccountOwner::from(key_pairs[0].public());
-    let owner1 = AccountOwner::from(key_pairs[1].public());
+    let key_pairs = generate_key_pairs(&mut signer, 2);
+    let owner0 = AccountOwner::from(key_pairs[0]);
+    let owner1 = AccountOwner::from(key_pairs[1]);
     let mut env = TestEnvironment::new(storage, false, false).await;
     let chain_1_desc = env.add_root_chain(1, owner0, Amount::from_tokens(2)).await;
     let chain_id = chain_1_desc.id();
@@ -3225,11 +3288,16 @@ where
     assert_eq!(response.info.manager.leader, None);
 
     // So owner 1 cannot propose a block in this round. And the next round hasn't started yet.
-    let proposal = make_child_block(&value0).into_proposal_with_round(&key_pairs[1], Round::Fast);
+    let proposal = make_child_block(&value0)
+        .into_proposal_with_round(owner1, &signer, Round::Fast)
+        .await
+        .unwrap();
     let result = env.worker().handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::InvalidOwner));
-    let proposal =
-        make_child_block(&value0).into_proposal_with_round(&key_pairs[1], Round::MultiLeader(0));
+    let proposal = make_child_block(&value0)
+        .into_proposal_with_round(owner1, &signer, Round::MultiLeader(0))
+        .await
+        .unwrap();
     let result = env.worker().handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::ChainError(ref error))
         if matches!(**error, ChainError::WrongRound(Round::Fast))
@@ -3266,7 +3334,9 @@ where
     let proposal1 = block1
         .clone()
         .with_authenticated_signer(Some(owner1))
-        .into_proposal_with_round(&key_pairs[1], Round::MultiLeader(1));
+        .into_proposal_with_round(owner1, &signer, Round::MultiLeader(1))
+        .await
+        .unwrap();
     let _ = env.worker().handle_block_proposal(proposal1).await?;
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
     let (response, _) = env.worker().handle_chain_info_query(query_values).await?;
@@ -3284,8 +3354,9 @@ where
     B: StorageBuilder,
 {
     let storage = storage_builder.build().await?;
-    let key_pair = AccountSecretKey::generate();
-    let owner = key_pair.public().into();
+    let mut signer = InMemorySigner::new(None);
+    let public_key = signer.generate_new();
+    let owner = public_key.into();
     let mut env = TestEnvironment::new(storage, false, false).await;
     let chain_1_desc = env.add_root_chain(1, owner, Amount::from_tokens(2)).await;
     let chain_id = chain_1_desc.id();
@@ -3316,7 +3387,9 @@ where
     // But non-owners are not allowed to transfer the chain's funds.
     let proposal = make_child_block(&change_ownership_value)
         .with_transfer(AccountOwner::CHAIN, Recipient::Burn, Amount::from_tokens(1))
-        .into_proposal_with_round(&AccountSecretKey::generate(), Round::MultiLeader(0));
+        .into_proposal_with_round(owner, &signer, Round::MultiLeader(0))
+        .await
+        .unwrap();
     let result = env.worker().handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::ChainError(error)) if matches!(&*error,
         ChainError::ExecutionError(error, _) if matches!(&**error,
@@ -3325,7 +3398,9 @@ where
 
     // Without the transfer, a random key pair can propose a block.
     let proposal = make_child_block(&change_ownership_value)
-        .into_proposal_with_round(&AccountSecretKey::generate(), Round::MultiLeader(0));
+        .into_proposal_with_round(owner, &signer, Round::MultiLeader(0))
+        .await
+        .unwrap();
     let (block, _) = env
         .worker()
         .stage_block_execution(proposal.content.block.clone(), None, vec![])
@@ -3349,9 +3424,10 @@ where
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
-    let key_pairs = generate_key_pairs(2);
-    let owner0 = AccountOwner::from(key_pairs[0].public());
-    let owner1 = AccountOwner::from(key_pairs[1].public());
+    let mut signer = InMemorySigner::new(None);
+    let key_pairs = generate_key_pairs(&mut signer, 2);
+    let owner0 = AccountOwner::from(key_pairs[0]);
+    let owner1 = AccountOwner::from(key_pairs[1]);
     let mut env = TestEnvironment::new(storage, false, false).await;
     let chain_1_desc = env.add_root_chain(1, owner0, Amount::from_tokens(2)).await;
     let chain_id = chain_1_desc.id();
@@ -3387,7 +3463,9 @@ where
     let proposed_block1 = make_child_block(&value0.clone());
     let proposal1 = proposed_block1
         .clone()
-        .into_proposal_with_round(&key_pairs[0], Round::Fast);
+        .into_proposal_with_round(owner0, &signer, Round::Fast)
+        .await
+        .unwrap();
     let (block1, _) = env
         .worker()
         .stage_block_execution(proposed_block1.clone(), None, vec![])
@@ -3414,7 +3492,9 @@ where
     // Now any owner can propose a block. But block1 is locked. Re-proposing it is allowed.
     let proposal1b = proposed_block1
         .clone()
-        .into_proposal_with_round(&key_pairs[1], Round::MultiLeader(0));
+        .into_proposal_with_round(owner1, &signer, Round::MultiLeader(0))
+        .await
+        .unwrap();
     let (response, _) = env.worker().handle_block_proposal(proposal1b).await?;
     let vote = response.info.manager.pending.as_ref().unwrap();
     assert_eq!(vote.round, Round::MultiLeader(0));
@@ -3426,14 +3506,18 @@ where
         .with_authenticated_signer(Some(owner1));
     let proposal2 = proposed_block2
         .clone()
-        .into_proposal_with_round(&key_pairs[1], Round::MultiLeader(1));
+        .into_proposal_with_round(owner1, &signer, Round::MultiLeader(1))
+        .await
+        .unwrap();
     let result = env.worker().handle_block_proposal(proposal2).await;
     assert_matches!(result, Err(WorkerError::ChainError(err))
         if matches!(*err, ChainError::HasIncompatibleConfirmedVote(_, Round::Fast))
     );
     let proposal3 = proposed_block1
         .clone()
-        .into_proposal_with_round(&key_pairs[1], Round::MultiLeader(2));
+        .into_proposal_with_round(owner0, &signer, Round::MultiLeader(2))
+        .await
+        .unwrap();
     env.worker().handle_block_proposal(proposal3).await?;
 
     // A validated block certificate from a later round can override the locked fast block.
@@ -3444,7 +3528,9 @@ where
     let value2 = ValidatedBlock::new(block2.clone());
     let certificate2 = env.make_certificate_with_round(value2.clone(), Round::MultiLeader(0));
     let proposal =
-        BlockProposal::new_retry(Round::MultiLeader(3), certificate2.clone(), &key_pairs[1]);
+        BlockProposal::new_retry(owner1, Round::MultiLeader(3), certificate2.clone(), &signer)
+            .await
+            .unwrap();
     let lite_value2 = LiteValue::new(&value2);
     let (_, _) = env.worker().handle_block_proposal(proposal).await?;
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
@@ -3470,12 +3556,11 @@ where
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
-    let key_pair = AccountSecretKey::generate();
+    let mut signer = InMemorySigner::new(None);
+    let public_key = signer.generate_new();
     let mut env = TestEnvironment::new(storage, false, false).await;
     let balance = Amount::from_tokens(5);
-    let chain_1_desc = env
-        .add_root_chain(1, key_pair.public().into(), balance)
-        .await;
+    let chain_1_desc = env.add_root_chain(1, public_key.into(), balance).await;
     let chain_id = chain_1_desc.id();
 
     // At time 0 we don't vote for fallback mode.
@@ -3497,7 +3582,7 @@ where
     // Make a tracked message to ourselves. It's in the inbox now.
     let proposed_block = make_first_block(chain_id)
         .with_simple_transfer(chain_id, Amount::ONE)
-        .with_authenticated_signer(Some(key_pair.public().into()));
+        .with_authenticated_signer(Some(public_key.into()));
     let (block, _) = env
         .worker()
         .stage_block_execution(proposed_block, None, vec![])
@@ -3560,6 +3645,7 @@ where
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
     let mut env = TestEnvironment::new(storage, false, true).await;
+
     let chain_description = env
         .add_root_chain(
             1,
@@ -3635,13 +3721,13 @@ where
 
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
-    let key_pair = AccountSecretKey::generate();
+    let mut signer = InMemorySigner::new(None);
+    let public_key = signer.generate_new();
+    let owner = public_key.into();
     let balance = Amount::ZERO;
 
     let mut env = TestEnvironment::new(storage.clone(), false, true).await;
-    let chain_description = env
-        .add_root_chain(1, key_pair.public().into(), balance)
-        .await;
+    let chain_description = env.add_root_chain(1, owner, balance).await;
     let chain_id = chain_description.id();
 
     let (application_id, application);
@@ -3708,7 +3794,11 @@ where
     clock.set(Timestamp::from(BLOCK_TIMESTAMP));
     let block = make_first_block(chain_id).with_timestamp(Timestamp::from(BLOCK_TIMESTAMP));
 
-    let block_proposal = block.clone().into_first_proposal(&key_pair);
+    let block_proposal = block
+        .clone()
+        .into_first_proposal(owner, &signer)
+        .await
+        .unwrap();
     let _ = env.worker().handle_block_proposal(block_proposal).await?;
 
     for local_time in queries_before_confirmation {

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -173,7 +173,7 @@ where
         };
 
         if client.next_block_height() >= self.end_block_height {
-            let key_pair = client.key_pair().await?;
+            let preferred_owner = client.preferred_owner();
             let balance = client.local_balance().await?.try_sub(Amount::ONE)?;
             let ownership = client.chain_state_view().await?.ownership().clone();
             let (chain_id, certificate) = client
@@ -188,7 +188,7 @@ where
                 .await
                 .update_wallet_for_new_chain(
                     chain_id,
-                    Some(key_pair),
+                    preferred_owner,
                     certificate.block().header.timestamp,
                 )
                 .await?;

--- a/linera-service/src/linera/command.rs
+++ b/linera-service/src/linera/command.rs
@@ -88,6 +88,17 @@ pub enum ClientCommand {
         ownership_config: ChainOwnershipConfig,
     },
 
+    /// Change the preferred owner of a chain.
+    SetPreferredOwner {
+        /// The ID of the chain whose preferred owner will be changed.
+        #[clap(long)]
+        chain_id: Option<ChainId>,
+
+        /// The new preferred owner.
+        #[arg(long)]
+        owner: AccountOwner,
+    },
+
     /// Changes the application permissions configuration.
     ChangeApplicationPermissions {
         /// The ID of the chain to which the new permissions will be applied.
@@ -735,7 +746,9 @@ pub enum ClientCommand {
     /// Create an unassigned key pair.
     Keygen,
 
-    /// Link an owner with a key pair in the wallet to a chain that was created for that owner.
+    /// Link the owner to the chain.
+    /// Expects that the caller has a private key corresponding to the `public_key`,
+    /// otherwise block proposals will fail when signing with it.
     Assign {
         /// The owner to assign.
         #[arg(long)]
@@ -800,6 +813,7 @@ impl ClientCommand {
             | ClientCommand::OpenChain { .. }
             | ClientCommand::OpenMultiOwnerChain { .. }
             | ClientCommand::ChangeOwnership { .. }
+            | ClientCommand::SetPreferredOwner { .. }
             | ClientCommand::ChangeApplicationPermissions { .. }
             | ClientCommand::CloseChain { .. }
             | ClientCommand::LocalBalance { .. }

--- a/linera-service/src/linera/net_up_utils.rs
+++ b/linera-service/src/linera/net_up_utils.rs
@@ -277,6 +277,14 @@ async fn print_messages_and_create_faucet(
     );
     println!(
         "{}",
+        format!(
+            "export LINERA_KEYSTORE=\"{}\"",
+            client.keystore_path().display()
+        )
+        .bold()
+    );
+    println!(
+        "{}",
         format!("export LINERA_STORAGE=\"{}\"\n", client.storage_path()).bold()
     );
 

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -3,9 +3,9 @@
 
 use async_trait::async_trait;
 use linera_base::{
-    crypto::{AccountSecretKey, CryptoHash},
+    crypto::CryptoHash,
     data_types::{BlobContent, Timestamp},
-    identifiers::{BlobId, ChainId},
+    identifiers::{AccountOwner, BlobId, ChainId},
 };
 use linera_chain::{
     data_types::BlockProposal,
@@ -182,6 +182,10 @@ impl<P: ValidatorNodeProvider + Send, S: Storage + Clone + Send + Sync + 'static
         unimplemented!()
     }
 
+    fn client(&self) -> &linera_core::client::Client<Self::Environment> {
+        unimplemented!()
+    }
+
     async fn make_chain_client(&self, _: ChainId) -> Result<ChainClient<Self::Environment>, Error> {
         unimplemented!()
     }
@@ -189,7 +193,7 @@ impl<P: ValidatorNodeProvider + Send, S: Storage + Clone + Send + Sync + 'static
     async fn update_wallet_for_new_chain(
         &mut self,
         _: ChainId,
-        _: Option<AccountSecretKey>,
+        _: Option<AccountOwner>,
         _: Timestamp,
     ) -> Result<(), Error> {
         Ok(())


### PR DESCRIPTION
## Motivation

Currently client processes own a private key (`AccountSecretKey`) which is potentially insecure but also prevents implementation of external signers (wallet extensions, hardware wallets, etc.). This PR addresses that.

## Proposal

We achieve that by the introduction of a new `Signer` trait that encapsulates the actions of signing and getting a public key for an `AccountOwner` instance. A couple of other changes were made/introduced to support that:
- `Signer` is passed around as `Box<dyn Signer>` to hide the implementation details of the actual `Signer` instance.
- `Signer::sign` signs a `CryptoHash` (rather than `T: BcsSignable`).
- (required by the above ☝️ ) New `sign_prehash(self, CryptoHash)` methods added on all secret keys types in the `linera-crypto`
- An `InMemSigner` was introduced for backwards-compatibility and intermediate usage in native and web clients.
- Removed `assigned_keys` and `unassignd_keys` from the `Wallet`. Now the `Signer` is the source of truth about which keys are available.

## Test Plan

All tests have been updated to pass.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
