### PR TITLE
Pass CertificateValue to Vote::new. Get rid of extra hashing.

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -175,8 +175,13 @@ impl ConfirmedBlock {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Deserialize, Serialize)]
-pub struct Timeout {
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Timeout(Hashed<TimeoutInner>);
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[serde(rename = "Timeout")]
+pub struct TimeoutInner {
     pub chain_id: ChainId,
     pub height: BlockHeight,
     pub epoch: Epoch,
@@ -184,11 +189,12 @@ pub struct Timeout {
 
 impl Timeout {
     pub fn new(chain_id: ChainId, height: BlockHeight, epoch: Epoch) -> Self {
-        Self {
+        let inner = TimeoutInner {
             chain_id,
             height,
             epoch,
-        }
+        };
+        Self(Hashed::new(inner))
     }
 
     pub fn to_log_str(&self) -> &'static str {
@@ -196,19 +202,24 @@ impl Timeout {
     }
 
     pub fn chain_id(&self) -> ChainId {
-        self.chain_id
+        self.0.inner().chain_id
     }
 
     pub fn height(&self) -> BlockHeight {
-        self.height
+        self.0.inner().height
     }
 
     pub fn epoch(&self) -> Epoch {
-        self.epoch
+        self.0.inner().epoch
+    }
+
+    pub fn inner(&self) -> &Hashed<TimeoutInner> {
+        &self.0
     }
 }
 
 impl BcsHashable<'_> for Timeout {}
+impl BcsHashable<'_> for TimeoutInner {}
 
 /// Failure to convert a `Certificate` into one of the expected certificate types.
 #[derive(Clone, Copy, Debug, Error)]

--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -5,7 +5,6 @@
 use linera_base::{
     crypto::{ValidatorPublicKey, ValidatorSignature},
     data_types::Round,
-    hashed::Hashed,
     identifiers::{BlobId, ChainId, MessageId},
 };
 use linera_execution::committee::Epoch;
@@ -90,7 +89,7 @@ impl<'de> Deserialize<'de> for GenericCertificate<ConfirmedBlock> {
         #[derive(Debug, Deserialize)]
         #[serde(rename = "ConfirmedBlockCertificate")]
         struct Helper {
-            value: Hashed<ConfirmedBlock>,
+            value: ConfirmedBlock,
             round: Round,
             signatures: Vec<(ValidatorPublicKey, ValidatorSignature)>,
         }

--- a/linera-chain/src/certificate/generic.rs
+++ b/linera-chain/src/certificate/generic.rs
@@ -139,6 +139,5 @@ impl<T: CertificateValue + Eq + PartialEq> PartialEq for GenericCertificate<T> {
         self.hash() == other.hash()
             && self.round == other.round
             && self.signatures == other.signatures
-        // && self::KIND == other::KIND
     }
 }

--- a/linera-chain/src/certificate/generic.rs
+++ b/linera-chain/src/certificate/generic.rs
@@ -6,7 +6,6 @@ use custom_debug_derive::Debug;
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey, ValidatorSignature},
     data_types::Round,
-    hashed::Hashed,
 };
 use linera_execution::committee::Committee;
 
@@ -15,15 +14,15 @@ use crate::{data_types::LiteValue, ChainError};
 
 /// Generic type representing a certificate for `value` of type `T`.
 #[derive(Debug)]
-pub struct GenericCertificate<T> {
-    value: Hashed<T>,
+pub struct GenericCertificate<T: CertificateValue> {
+    value: T,
     pub round: Round,
     signatures: Vec<(ValidatorPublicKey, ValidatorSignature)>,
 }
 
-impl<T> GenericCertificate<T> {
+impl<T: CertificateValue> GenericCertificate<T> {
     pub fn new(
-        value: Hashed<T>,
+        value: T,
         round: Round,
         mut signatures: Vec<(ValidatorPublicKey, ValidatorSignature)>,
     ) -> Self {
@@ -37,23 +36,23 @@ impl<T> GenericCertificate<T> {
     }
 
     /// Returns a reference to the `Hashed` value contained in this certificate.
-    pub fn value(&self) -> &Hashed<T> {
+    pub fn value(&self) -> &T {
         &self.value
     }
 
     /// Consumes this certificate, returning the value it contains.
-    pub fn into_value(self) -> Hashed<T> {
+    pub fn into_value(self) -> T {
         self.value
     }
 
     /// Returns reference to the value contained in this certificate.
     pub fn inner(&self) -> &T {
-        self.value.inner()
+        &self.value
     }
 
     /// Consumes this certificate, returning the value it contains.
     pub fn into_inner(self) -> T {
-        self.value.into_inner()
+        self.value
     }
 
     /// Returns the certified value's hash.
@@ -61,13 +60,7 @@ impl<T> GenericCertificate<T> {
         self.value.hash()
     }
 
-    pub fn destructure(
-        self,
-    ) -> (
-        Hashed<T>,
-        Round,
-        Vec<(ValidatorPublicKey, ValidatorSignature)>,
-    ) {
+    pub fn destructure(self) -> (T, Round, Vec<(ValidatorPublicKey, ValidatorSignature)>) {
         (self.value, self.round, self.signatures)
     }
 
@@ -128,7 +121,7 @@ impl<T> GenericCertificate<T> {
     }
 }
 
-impl<T: Clone> Clone for GenericCertificate<T> {
+impl<T: CertificateValue> Clone for GenericCertificate<T> {
     fn clone(&self) -> Self {
         Self {
             value: self.value.clone(),
@@ -139,12 +132,13 @@ impl<T: Clone> Clone for GenericCertificate<T> {
 }
 
 #[cfg(with_testing)]
-impl<T: Eq + PartialEq> Eq for GenericCertificate<T> {}
+impl<T: CertificateValue + Eq + PartialEq> Eq for GenericCertificate<T> {}
 #[cfg(with_testing)]
-impl<T: Eq + PartialEq> PartialEq for GenericCertificate<T> {
+impl<T: CertificateValue + Eq + PartialEq> PartialEq for GenericCertificate<T> {
     fn eq(&self, other: &Self) -> bool {
         self.hash() == other.hash()
             && self.round == other.round
             && self.signatures == other.signatures
+        // && self::KIND == other::KIND
     }
 }

--- a/linera-chain/src/certificate/lite.rs
+++ b/linera-chain/src/certificate/lite.rs
@@ -86,11 +86,8 @@ impl LiteCertificate<'_> {
     }
 
     /// Returns the [`GenericCertificate`] with the specified value, if it matches.
-    pub fn with_value<T: CertificateValue>(
-        self,
-        value: Hashed<T>,
-    ) -> Option<GenericCertificate<T>> {
-        if self.value.chain_id != value.inner().chain_id()
+    pub fn with_value<T: CertificateValue>(self, value: T) -> Option<GenericCertificate<T>> {
+        if self.value.chain_id != value.chain_id()
             || T::KIND != self.value.kind
             || self.value.value_hash != value.hash()
         {

--- a/linera-chain/src/certificate/timeout.rs
+++ b/linera-chain/src/certificate/timeout.rs
@@ -5,7 +5,6 @@
 use linera_base::{
     crypto::{ValidatorPublicKey, ValidatorSignature},
     data_types::Round,
-    hashed::Hashed,
 };
 use serde::{
     ser::{Serialize, SerializeStruct, Serializer},
@@ -50,7 +49,7 @@ impl<'de> Deserialize<'de> for GenericCertificate<Timeout> {
         #[derive(Deserialize)]
         #[serde(rename = "TimeoutCertificate")]
         struct Inner {
-            value: Hashed<Timeout>,
+            value: Timeout,
             round: Round,
             signatures: Vec<(ValidatorPublicKey, ValidatorSignature)>,
         }

--- a/linera-chain/src/certificate/validated.rs
+++ b/linera-chain/src/certificate/validated.rs
@@ -5,7 +5,6 @@
 use linera_base::{
     crypto::{ValidatorPublicKey, ValidatorSignature},
     data_types::Round,
-    hashed::Hashed,
     identifiers::BlobId,
 };
 use serde::{
@@ -67,7 +66,7 @@ impl<'de> Deserialize<'de> for GenericCertificate<ValidatedBlock> {
         #[derive(Deserialize)]
         #[serde(rename = "ValidatedBlockCertificate")]
         struct Inner {
-            value: Hashed<ValidatedBlock>,
+            value: ValidatedBlock,
             round: Round,
             signatures: Vec<(ValidatorPublicKey, ValidatorSignature)>,
         }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -17,7 +17,6 @@ use linera_base::{
         OracleResponse, Timestamp,
     },
     ensure,
-    hashed::Hashed,
     identifiers::{
         AccountOwner, ApplicationId, BlobType, ChainId, ChannelFullName, Destination,
         GenericApplicationId, MessageId,
@@ -1007,11 +1006,11 @@ where
     /// manager. This does not touch the execution state itself, which must be updated separately.
     pub async fn apply_confirmed_block(
         &mut self,
-        block: &Hashed<ConfirmedBlock>,
+        block: &ConfirmedBlock,
         local_time: Timestamp,
     ) -> Result<(), ChainError> {
-        let hash = block.hash();
-        let block = block.inner().inner().inner();
+        let hash = block.inner().hash();
+        let block = block.inner().inner();
         self.execution_state_hash.set(Some(block.header.state_hash));
         for txn_messages in &block.body.messages {
             self.process_outgoing_messages(block.header.height, txn_messages)

--- a/linera-chain/src/test/mod.rs
+++ b/linera-chain/src/test/mod.rs
@@ -8,7 +8,6 @@ mod http_server;
 use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey},
     data_types::{Amount, BlockHeight, Round, Timestamp},
-    hashed::Hashed,
     identifiers::{AccountOwner, ChainId},
 };
 use linera_execution::{
@@ -27,9 +26,8 @@ use crate::{
 };
 
 /// Creates a new child of the given block, with the same timestamp.
-pub fn make_child_block(parent: &Hashed<ConfirmedBlock>) -> ProposedBlock {
-    let parent_value = parent.inner();
-    let parent_header = &parent_value.block().header;
+pub fn make_child_block(parent: &ConfirmedBlock) -> ProposedBlock {
+    let parent_header = &parent.block().header;
     ProposedBlock {
         epoch: parent_header.epoch,
         chain_id: parent_header.chain_id,
@@ -132,7 +130,7 @@ impl BlockTestExt for ProposedBlock {
     }
 }
 
-pub trait VoteTestExt<T>: Sized {
+pub trait VoteTestExt<T: CertificateValue>: Sized {
     /// Returns a certificate for a committee consisting only of this validator.
     fn into_certificate(self) -> GenericCertificate<T>;
 }

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -17,7 +17,6 @@ use linera_base::{
         Amount, ApplicationDescription, ApplicationPermissions, Blob, BlockHeight, Bytecode,
         Timestamp,
     },
-    hashed::Hashed,
     http,
     identifiers::{AccountOwner, ApplicationId, ChainId, MessageId, ModuleId},
     ownership::ChainOwnership,
@@ -266,7 +265,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     let (outcome, _, _) = chain
         .execute_block(&valid_block, time, None, &[], None)
         .await?;
-    let value = Hashed::new(ConfirmedBlock::new(outcome.with(valid_block)));
+    let value = ConfirmedBlock::new(outcome.with(valid_block));
     chain.apply_confirmed_block(&value, time).await?;
 
     // In the second block, other operations are still not allowed.
@@ -296,7 +295,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     let (outcome, _, _) = chain
         .execute_block(&valid_block, time, None, &[], None)
         .await?;
-    let value = Hashed::new(ConfirmedBlock::new(outcome.with(valid_block)));
+    let value = ConfirmedBlock::new(outcome.with(valid_block));
     chain.apply_confirmed_block(&value, time).await?;
 
     Ok(())

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -28,7 +28,7 @@ fn test_signed_values() {
         operation_results: vec![OperationResult::default()],
     }
     .with(make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(2), Amount::ONE));
-    let confirmed_value = Hashed::new(ConfirmedBlock::new(block.clone()));
+    let confirmed_value = ConfirmedBlock::new(block.clone());
 
     let confirmed_vote = LiteVote::new(
         LiteValue::new(&confirmed_value),
@@ -37,7 +37,7 @@ fn test_signed_values() {
     );
     assert!(confirmed_vote.check().is_ok());
 
-    let validated_value = Hashed::new(ValidatedBlock::new(block));
+    let validated_value = ValidatedBlock::new(block);
     let validated_vote = LiteVote::new(
         LiteValue::new(&validated_value),
         Round::Fast,
@@ -118,7 +118,7 @@ fn test_certificates() {
         operation_results: vec![OperationResult::default()],
     }
     .with(make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(1), Amount::ONE));
-    let value = Hashed::new(ConfirmedBlock::new(block));
+    let value = ConfirmedBlock::new(block);
 
     let v1 = LiteVote::new(
         LiteValue::new(&value),

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -6,7 +6,6 @@ use std::{collections::HashMap, iter};
 use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey},
     data_types::{Amount, Timestamp},
-    hashed::Hashed,
     identifiers::{AccountOwner, ApplicationId, ChainId},
     listen_for_shutdown_signals,
     time::Instant,
@@ -515,7 +514,7 @@ where
                 .map_err(BenchmarkError::LocalNode)?
                 .0;
 
-            let value = Hashed::new(ConfirmedBlock::new(block));
+            let value = ConfirmedBlock::new(block);
             let proposal = BlockProposal::new_initial(
                 linera_base::data_types::Round::Fast,
                 proposed_block,

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -73,11 +73,11 @@ where
         self.state.ensure_is_active()?;
         let (chain_epoch, committee) = self.state.chain.current_committee()?;
         ensure!(
-            certificate.inner().epoch == chain_epoch,
+            certificate.inner().epoch() == chain_epoch,
             WorkerError::InvalidEpoch {
-                chain_id: certificate.inner().chain_id,
+                chain_id: certificate.inner().chain_id(),
                 chain_epoch,
-                epoch: certificate.inner().epoch
+                epoch: certificate.inner().epoch()
             }
         );
         certificate.check(committee)?;
@@ -87,7 +87,7 @@ where
             .chain
             .tip_state
             .get()
-            .already_validated_block(certificate.inner().height)?
+            .already_validated_block(certificate.inner().height())?
         {
             return Ok((
                 ChainInfoResponse::new(&self.state.chain, self.state.config.key_pair()),
@@ -95,8 +95,8 @@ where
             ));
         }
         let old_round = self.state.chain.manager.current_round();
-        let timeout_chain_id = certificate.inner().chain_id;
-        let timeout_height = certificate.inner().height;
+        let timeout_chain_id = certificate.inner().chain_id();
+        let timeout_height = certificate.inner().height();
         self.state
             .chain
             .manager
@@ -186,12 +186,12 @@ where
             Some(Either::Left(vote)) => {
                 self.state
                     .block_values
-                    .insert(Cow::Borrowed(vote.value.inner().inner()));
+                    .insert(Cow::Borrowed(vote.value.inner()));
             }
             Some(Either::Right(vote)) => {
                 self.state
                     .block_values
-                    .insert(Cow::Borrowed(vote.value.inner().inner()));
+                    .insert(Cow::Borrowed(vote.value.inner()));
             }
             None => (),
         }
@@ -349,7 +349,7 @@ where
         }
 
         // Update the blob state with last used certificate hash.
-        let blob_state = certificate.value().inner().to_blob_state();
+        let blob_state = certificate.value().to_blob_state();
         let overwrite = blobs_result.is_ok(); // Overwrite only if we wrote the certificate.
         let blob_ids = required_blob_ids.into_iter().collect::<Vec<_>>();
         self.state

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1088,7 +1088,7 @@ where
         committee: &Committee,
         certificate: ValidatedBlockCertificate,
     ) -> Result<ConfirmedBlockCertificate, ChainClientError> {
-        let hashed_value = Hashed::new(ConfirmedBlock::new(certificate.inner().block().clone()));
+        let hashed_value = ConfirmedBlock::new(certificate.inner().block().clone());
         let finalize_action = CommunicateAction::FinalizeBlock {
             certificate: Box::new(certificate),
             delivery: self.options.cross_chain_message_delivery,
@@ -1110,11 +1110,11 @@ where
         &self,
         committee: &Committee,
         proposal: Box<BlockProposal>,
-        value: Hashed<T>,
+        value: T,
     ) -> Result<GenericCertificate<T>, ChainClientError> {
         let submit_action = CommunicateAction::SubmitBlock {
             proposal,
-            blob_ids: value.inner().required_blob_ids().into_iter().collect(),
+            blob_ids: value.required_blob_ids().into_iter().collect(),
         };
         let certificate = self
             .communicate_chain_action(committee, submit_action, value)
@@ -1203,7 +1203,7 @@ where
         &self,
         committee: &Committee,
         action: CommunicateAction,
-        value: Hashed<T>,
+        value: T,
     ) -> Result<GenericCertificate<T>, ChainClientError> {
         let local_node = self.client.local_node.clone();
         let nodes = self.make_nodes(committee)?;
@@ -1712,7 +1712,7 @@ where
             round,
             chain_id,
         };
-        let value: Hashed<Timeout> = Hashed::new(Timeout::new(chain_id, height, epoch));
+        let value = Timeout::new(chain_id, height, epoch);
         let certificate = self
             .communicate_chain_action(&committee, action, value)
             .await?;
@@ -2605,11 +2605,11 @@ where
         let block = Block::new(proposed_block, outcome);
         // Send the query to validators.
         let certificate = if round.is_fast() {
-            let hashed_value = Hashed::new(ConfirmedBlock::new(block));
+            let hashed_value = ConfirmedBlock::new(block);
             self.submit_block_proposal(&committee, proposal, hashed_value)
                 .await?
         } else {
-            let hashed_value = Hashed::new(ValidatedBlock::new(block));
+            let hashed_value = ValidatedBlock::new(block);
             let certificate = self
                 .submit_block_proposal(&committee, proposal, hashed_value.clone())
                 .await?;

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -18,7 +18,6 @@ use linera_base::{
     data_types::{
         Amount, ApplicationDescription, Blob, BlockHeight, Bytecode, OracleResponse, Timestamp,
     },
-    hashed::Hashed,
     identifiers::{ChainDescription, ChainId, ModuleId},
     ownership::ChainOwnership,
     vm::VmRuntime,
@@ -146,7 +145,7 @@ where
         ..SystemExecutionState::new(Epoch::ZERO, publisher_chain, admin_id)
     };
     let publisher_state_hash = publisher_system_state.clone().into_hash().await;
-    let publish_block_proposal = Hashed::new(ConfirmedBlock::new(
+    let publish_block_proposal = ConfirmedBlock::new(
         BlockExecutionOutcome {
             messages: vec![Vec::new()],
             previous_message_blocks: BTreeMap::new(),
@@ -157,7 +156,7 @@ where
             operation_results: vec![OperationResult::default()],
         }
         .with(publish_block),
-    ));
+    );
     let publish_certificate = make_certificate(&committee, &worker, publish_block_proposal);
 
     assert_matches!(
@@ -224,7 +223,7 @@ where
             service_blob,
         )
         .await?;
-    let create_block_proposal = Hashed::new(ConfirmedBlock::new(
+    let create_block_proposal = ConfirmedBlock::new(
         BlockExecutionOutcome {
             messages: vec![vec![]],
             previous_message_blocks: BTreeMap::new(),
@@ -238,7 +237,7 @@ where
             operation_results: vec![OperationResult::default()],
         }
         .with(create_block),
-    ));
+    );
     let create_certificate = make_certificate(&committee, &worker, create_block_proposal);
 
     storage
@@ -297,7 +296,7 @@ where
         )
         .await?;
     creator_state.system.timestamp.set(Timestamp::from(3));
-    let run_block_proposal = Hashed::new(ConfirmedBlock::new(
+    let run_block_proposal = ConfirmedBlock::new(
         BlockExecutionOutcome {
             messages: vec![Vec::new()],
             previous_message_blocks: BTreeMap::new(),
@@ -308,7 +307,7 @@ where
             operation_results: vec![OperationResult(bcs::to_bytes(&15u64)?)],
         }
         .with(run_block),
-    ));
+    );
     let run_certificate = make_certificate(&committee, &worker, run_block_proposal);
 
     let info = worker

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -370,7 +370,7 @@ where
             }
         }
         if let Some(cert) = timeout {
-            if cert.inner().chain_id == chain_id {
+            if cert.value().chain_id() == chain_id {
                 // Timeouts are small and don't have blobs, so we can call `handle_certificate`
                 // directly.
                 self.remote_node.handle_timeout_certificate(cert).await?;

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -404,7 +404,7 @@ where
                 let value = ConfirmedBlock::from_hashed(block);
                 Ok(Either::Left(
                     certificate
-                        .with_value(Hashed::new(value))
+                        .with_value(value)
                         .ok_or(WorkerError::InvalidLiteCertificate)?,
                 ))
             }
@@ -412,7 +412,7 @@ where
                 let value = ValidatedBlock::from_hashed(block);
                 Ok(Either::Right(
                     certificate
-                        .with_value(Hashed::new(value))
+                        .with_value(value)
                         .ok_or(WorkerError::InvalidLiteCertificate)?,
                 ))
             }
@@ -587,7 +587,7 @@ where
         &self,
         certificate: TimeoutCertificate,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
-        let chain_id = certificate.inner().chain_id;
+        let chain_id = certificate.value().chain_id();
         self.query_chain_worker(chain_id, move |callback| {
             ChainWorkerRequest::ProcessTimeout {
                 certificate,
@@ -890,8 +890,8 @@ where
     /// Processes a timeout certificate
     #[instrument(skip_all, fields(
         nick = self.nickname,
-        chain_id = format!("{:.8}", certificate.inner().chain_id),
-        height = %certificate.inner().height,
+        chain_id = format!("{:.8}", certificate.inner().chain_id()),
+        height = %certificate.inner().height(),
     ))]
     pub async fn handle_timeout_certificate(
         &self,

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -8,7 +8,6 @@ use linera_base::{
     },
     data_types::{BlobContent, BlockHeight},
     ensure,
-    hashed::Hashed,
     identifiers::{AccountOwner, BlobId, ChainId},
 };
 use linera_chain::{
@@ -448,7 +447,7 @@ impl TryFrom<api::Certificate> for TimeoutCertificate {
         let cert_type = certificate.kind;
 
         if cert_type == api::CertificateKind::Timeout as i32 {
-            let value: Hashed<Timeout> = bincode::deserialize(&certificate.value)?;
+            let value: Timeout = bincode::deserialize(&certificate.value)?;
             Ok(TimeoutCertificate::new(value, round, signatures))
         } else {
             Err(GrpcProtoConversionError::InvalidCertificateType)
@@ -465,7 +464,7 @@ impl TryFrom<api::Certificate> for ValidatedBlockCertificate {
         let cert_type = certificate.kind;
 
         if cert_type == api::CertificateKind::Validated as i32 {
-            let value: Hashed<ValidatedBlock> = bincode::deserialize(&certificate.value)?;
+            let value: ValidatedBlock = bincode::deserialize(&certificate.value)?;
             Ok(ValidatedBlockCertificate::new(value, round, signatures))
         } else {
             Err(GrpcProtoConversionError::InvalidCertificateType)
@@ -482,7 +481,7 @@ impl TryFrom<api::Certificate> for ConfirmedBlockCertificate {
         let cert_type = certificate.kind;
 
         if cert_type == api::CertificateKind::Confirmed as i32 {
-            let value: Hashed<ConfirmedBlock> = bincode::deserialize(&certificate.value)?;
+            let value: ConfirmedBlock = bincode::deserialize(&certificate.value)?;
             Ok(ConfirmedBlockCertificate::new(value, round, signatures))
         } else {
             Err(GrpcProtoConversionError::InvalidCertificateType)
@@ -919,13 +918,13 @@ impl TryFrom<api::Certificate> for Certificate {
         let signatures = bincode::deserialize(&certificate.signatures)?;
 
         let value = if certificate.kind == api::CertificateKind::Confirmed as i32 {
-            let value: Hashed<ConfirmedBlock> = bincode::deserialize(&certificate.value)?;
+            let value: ConfirmedBlock = bincode::deserialize(&certificate.value)?;
             Certificate::Confirmed(ConfirmedBlockCertificate::new(value, round, signatures))
         } else if certificate.kind == api::CertificateKind::Validated as i32 {
-            let value: Hashed<ValidatedBlock> = bincode::deserialize(&certificate.value)?;
+            let value: ValidatedBlock = bincode::deserialize(&certificate.value)?;
             Certificate::Validated(ValidatedBlockCertificate::new(value, round, signatures))
         } else if certificate.kind == api::CertificateKind::Timeout as i32 {
-            let value: Hashed<Timeout> = bincode::deserialize(&certificate.value)?;
+            let value: Timeout = bincode::deserialize(&certificate.value)?;
             Certificate::Timeout(TimeoutCertificate::new(value, round, signatures))
         } else {
             return Err(GrpcProtoConversionError::InvalidCertificateType);
@@ -1152,13 +1151,13 @@ pub mod tests {
     pub fn test_certificate() {
         let key_pair = ValidatorKeypair::generate();
         let certificate = ValidatedBlockCertificate::new(
-            Hashed::new(ValidatedBlock::new(
+            ValidatedBlock::new(
                 BlockExecutionOutcome {
                     state_hash: CryptoHash::new(&Foo("test".into())),
                     ..BlockExecutionOutcome::default()
                 }
                 .with(get_block()),
-            )),
+            ),
             Round::MultiLeader(3),
             vec![(
                 key_pair.public_key,
@@ -1201,7 +1200,7 @@ pub mod tests {
             ..BlockExecutionOutcome::default()
         };
         let cert = ValidatedBlockCertificate::new(
-            Hashed::new(ValidatedBlock::new(outcome.clone().with(get_block()))),
+            ValidatedBlock::new(outcome.clone().with(get_block())),
             Round::SingleLeader(2),
             vec![(
                 key_pair.public_key,

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -8,7 +8,6 @@
 use linera_base::{
     abi::ContractAbi,
     data_types::{Amount, ApplicationPermissions, Blob, Round, Timestamp},
-    hashed::Hashed,
     identifiers::{AccountOwner, ApplicationId, ChainId},
     ownership::TimeoutConfig,
 };
@@ -223,7 +222,7 @@ impl BlockBuilder {
             .stage_block_execution(self.block, None, published_blobs)
             .await?;
 
-        let value = Hashed::new(ConfirmedBlock::new(block));
+        let value = ConfirmedBlock::new(block);
         let vote = LiteVote::new(
             LiteValue::new(&value),
             Round::Fast,

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -714,7 +714,6 @@ impl<T> GrpcMessageLimiter<T> {
 
 #[cfg(test)]
 mod proto_message_cap {
-    use linera_base::hashed::Hashed;
     use linera_chain::{
         data_types::BlockExecutionOutcome,
         types::{Block, Certificate, ConfirmedBlock, ConfirmedBlockCertificate},
@@ -735,7 +734,7 @@ mod proto_message_cap {
         );
         let signatures = vec![(validator, signature)];
         Certificate::Confirmed(ConfirmedBlockCertificate::new(
-            Hashed::new(ConfirmedBlock::new(block)),
+            ConfirmedBlock::new(block),
             Default::default(),
             signatures,
         ))

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -14,7 +14,7 @@ use linera_base::{
     identifiers::{ApplicationId, BlobId, ChainId, EventId},
 };
 use linera_chain::{
-    types::{ConfirmedBlock, ConfirmedBlockCertificate, LiteCertificate},
+    types::{CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, LiteCertificate},
     ChainStateView,
 };
 use linera_execution::{
@@ -864,8 +864,9 @@ where
             .ok_or_else(|| ViewError::not_found("value bytes for hash", hash))?;
         let cert = bcs::from_bytes::<LiteCertificate>(cert_bytes)?;
         let value = bcs::from_bytes::<ConfirmedBlock>(value_bytes)?;
+        assert_eq!(value.hash(), hash);
         let certificate = cert
-            .with_value(value.with_hash_unchecked(hash))
+            .with_value(value)
             .ok_or(ViewError::InconsistentEntries)?;
         Ok(certificate)
     }


### PR DESCRIPTION
## Motivation

Andreas noticed that we're unnecessarily hashing `ConfirmedBlock` before creating a `Vote` for it. Intuitiveily it shouldn't be necessary - `ConfirmedBlock` already contains `Hashed<Block>` and when creating a vote for it we're adding the certificate's kind as well.

## Proposal

Change the code to operate on `T: CertificateValue` rather than `Hashed<T>`. All `CertificateValue` impls are required now to also have a `fn hash() -> CryptoHash`.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
