### PR TITLE
Extract some logic from `select` in the chain listener.

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -278,6 +278,13 @@ impl ChainListener {
         }
     }
 
+    /// Processes the inbox, unless `skip_process_inbox` is set.
+    ///
+    /// If no block can be produced because we are not the round leader, a timeout is returned
+    /// for when to retry; otherwise `u64::MAX` is returned.
+    ///
+    /// The wallet is persisted with any blocks that processing the inbox added. An error
+    /// is returned if persisting the wallet fails.
     async fn maybe_process_inbox<C>(
         config: &ChainListenerConfig,
         client: &ChainClient<C::ValidatorNodeProvider, C::Storage>,

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -172,7 +172,7 @@ impl ChainListener {
         let mut admin_listener = admin_listener.fuse();
         client.synchronize_from_validators().await?;
         drop(linera_base::task::spawn(listener.in_current_span()));
-        let mut timeout = storage.clock().current_time();
+        let mut timeout = Self::maybe_process_inbox(&config, &client, &context).await?;
         loop {
             let mut sleep = Box::pin(futures::FutureExt::fuse(
                 storage.clock().sleep_until(timeout),
@@ -191,33 +191,12 @@ impl ChainListener {
                     if let Some(
                         Notification { reason: Reason::NewBlock { .. }, .. }
                     ) = maybe_notification {
-                        timeout = storage.clock().current_time();
+                        timeout = Self::maybe_process_inbox(&config, &client, &context).await?;
                     }
                     continue;
                 }
                 () = sleep => {
-                    timeout = Timestamp::from(u64::MAX);
-                    if config.skip_process_inbox {
-                        debug!("Not processing inbox due to listener configuration");
-                        continue;
-                    }
-                    debug!("Processing inbox");
-                    match client.process_inbox_without_prepare().await {
-                        Err(ChainClientError::CannotFindKeyForChain(_)) => {}
-                        Err(error) => warn!(%error, "Failed to process inbox."),
-                        Ok((certs, None)) => {
-                            info!("Done processing inbox. {} blocks created.", certs.len());
-                        }
-                        Ok((certs, Some(new_timeout))) => {
-                            info!(
-                                "{} blocks created. Will try processing the inbox later based \
-                                 on the given round timeout: {new_timeout:?}",
-                                certs.len(),
-                            );
-                            timeout = new_timeout.timestamp;
-                        }
-                    }
-                    context.lock().await.update_wallet(&client).await?;
+                    timeout = Self::maybe_process_inbox(&config, &client, &context).await?;
                     continue;
                 }
             };
@@ -296,5 +275,38 @@ impl ChainListener {
         if delay_ms > 0 {
             linera_base::time::timer::sleep(Duration::from_millis(delay_ms)).await;
         }
+    }
+
+    async fn maybe_process_inbox<C>(
+        config: &ChainListenerConfig,
+        client: &ChainClient<C::ValidatorNodeProvider, C::Storage>,
+        context: &Arc<Mutex<C>>,
+    ) -> Result<Timestamp, Error>
+    where
+        C: ClientContext,
+    {
+        let mut timeout = Timestamp::from(u64::MAX);
+        if config.skip_process_inbox {
+            debug!("Not processing inbox due to listener configuration");
+            return Ok(timeout);
+        }
+        debug!("Processing inbox");
+        match client.process_inbox_without_prepare().await {
+            Err(ChainClientError::CannotFindKeyForChain(_)) => {}
+            Err(error) => warn!(%error, "Failed to process inbox."),
+            Ok((certs, None)) => {
+                info!("Done processing inbox. {} blocks created.", certs.len());
+            }
+            Ok((certs, Some(new_timeout))) => {
+                info!(
+                    "{} blocks created. Will try processing the inbox later based \
+                     on the given round timeout: {new_timeout:?}",
+                    certs.len(),
+                );
+                timeout = new_timeout.timestamp;
+            }
+        }
+        context.lock().await.update_wallet(client).await?;
+        Ok(timeout)
     }
 }


### PR DESCRIPTION
## Motivation

The `select!` statement in the chain listener is very long and hard to read. It is also counterintuitive that we set `timeout` to "now" to process the inbox. (Thank Mateusz for pointing this out!)

## Proposal

Extract processing the inbox from the code, and call the new function instead of setting the timeout to now.

To remove some more code from the macro, filter the admin chain notifications using `StreamExt::filter`.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- 
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
