### PR TITLE
Wait for message delivery even if certificate is already known.

### DIFF
--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -296,15 +296,11 @@ where
             });
         }
         if tip.next_block_height > height {
-            // Block was already confirmed.
-            if let Some(notifier) = notify_when_messages_are_delivered {
-                // Nothing to wait for.
-                if let Err(()) = notifier.send(()) {
-                    warn!("Failed to notify message delivery to caller");
-                }
-            }
-            let info = ChainInfoResponse::new(&self.state.chain, self.state.config.key_pair());
+            // We already processed this block.
             let actions = self.state.create_network_actions().await?;
+            self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
+                .await;
+            let info = ChainInfoResponse::new(&self.state.chain, self.state.config.key_pair());
             return Ok((info, actions));
         }
         let local_time = self.state.storage.clock().current_time();


### PR DESCRIPTION
## Motivation

The `remote_net_grpc` tests fail if message delivery on the validators takes too long.

## Proposal

Wait for message delivery even if the certificate is already known.

## Test Plan

TBD

## Release Plan

- These changes should be backported to the latest `testnet` branch.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
