### PR TITLE
Replace `#[should_panic]` with assertions in HTTP example tests

### DIFF
--- a/examples/how-to/perform-http-requests/tests/http_requests.rs
+++ b/examples/how-to/perform-http-requests/tests/http_requests.rs
@@ -58,7 +58,7 @@ async fn service_query_performs_http_request() -> anyhow::Result<()> {
 
 /// Tests if service query can't perform HTTP requests to hosts that aren't allowed.
 #[test_log::test(tokio::test)]
-#[should_panic(expected = "UnauthorizedHttpRequest")]
+#[should_panic(expected = "Failed to execute service query")]
 async fn service_query_cant_send_http_request_to_unauthorized_host() {
     let url = "http://localhost/".to_owned();
 

--- a/examples/how-to/perform-http-requests/tests/http_requests.rs
+++ b/examples/how-to/perform-http-requests/tests/http_requests.rs
@@ -60,10 +60,10 @@ async fn service_query_performs_http_request() -> anyhow::Result<()> {
 #[test_log::test(tokio::test)]
 #[should_panic(expected = "Failed to execute service query")]
 async fn service_query_cant_send_http_request_to_unauthorized_host() {
-    let url = "http://localhost/".to_owned();
+    let url = "http://localhost/";
 
     let (_validator, application_id, chain) =
-        TestValidator::with_current_application::<Abi, _, _>(url, ()).await;
+        TestValidator::with_current_application::<Abi, _, _>(url.to_owned(), ()).await;
 
     chain
         .graphql_query(application_id, "query { performHttpRequest }")

--- a/examples/how-to/perform-http-requests/tests/http_requests.rs
+++ b/examples/how-to/perform-http-requests/tests/http_requests.rs
@@ -8,7 +8,9 @@
 use assert_matches::assert_matches;
 use axum::{routing::get, Router};
 use how_to_perform_http_requests::Abi;
-use linera_sdk::test::{ExecutionError, HttpServer, QueryOutcome, TestValidator};
+use linera_sdk::test::{
+    ExecutionError, HttpServer, QueryOutcome, TestValidator, WasmExecutionError,
+};
 
 /// Tests if service query performs HTTP request to allowed host.
 #[test_log::test(tokio::test)]
@@ -107,7 +109,6 @@ async fn service_sends_valid_http_response_to_contract() -> anyhow::Result<()> {
 
 /// Tests if the contract rejects an invalid HTTP response sent by the service.
 #[test_log::test(tokio::test)]
-#[should_panic(expected = "Failed to execute service GraphQL mutation")]
 async fn contract_rejects_invalid_http_response_from_service() {
     const HTTP_RESPONSE_BODY: &str = "Untrusted response";
 
@@ -119,7 +120,7 @@ async fn contract_rejects_invalid_http_response_from_service() {
     let url = format!("http://localhost:{port}/");
 
     let (validator, application_id, chain) =
-        TestValidator::with_current_application::<Abi, _, _>(url, ()).await;
+        TestValidator::with_current_application::<Abi, _, _>(url.clone(), ()).await;
 
     validator
         .change_resource_control_policy(|policy| {
@@ -129,9 +130,15 @@ async fn contract_rejects_invalid_http_response_from_service() {
         })
         .await;
 
-    chain
-        .graphql_mutation(application_id, "mutation { performHttpRequest }")
-        .await;
+    let error = chain
+        .try_graphql_mutation(application_id, "mutation { performHttpRequest }")
+        .await
+        .expect_err("Expected GraphQL mutation to fail");
+
+    assert_matches!(
+        error.expect_proposal_execution_error(0),
+        ExecutionError::WasmError(WasmExecutionError::ExecuteModule(_))
+    );
 }
 
 /// Tests if the contract accepts a valid HTTP response it obtains by itself.
@@ -164,7 +171,6 @@ async fn contract_accepts_valid_http_response_it_obtains_by_itself() -> anyhow::
 
 /// Tests if the contract rejects an invalid HTTP response it obtains by itself.
 #[test_log::test(tokio::test)]
-#[should_panic(expected = "Failed to execute service GraphQL mutation")]
 async fn contract_rejects_invalid_http_response_it_obtains_by_itself() {
     const HTTP_RESPONSE_BODY: &str = "Untrusted response";
 
@@ -186,9 +192,15 @@ async fn contract_rejects_invalid_http_response_it_obtains_by_itself() {
         })
         .await;
 
-    chain
-        .graphql_mutation(application_id, "mutation { performHttpRequestInContract }")
-        .await;
+    let error = chain
+        .try_graphql_mutation(application_id, "mutation { performHttpRequestInContract }")
+        .await
+        .expect_err("Expected GraphQL mutation to fail");
+
+    assert_matches!(
+        error.expect_proposal_execution_error(0),
+        ExecutionError::WasmError(WasmExecutionError::ExecuteModule(_))
+    );
 }
 
 /// Tests if the contract accepts a valid HTTP response it obtains from the service acting as an
@@ -223,7 +235,6 @@ async fn contract_accepts_valid_http_response_from_oracle() -> anyhow::Result<()
 /// Tests if the contract rejects an invalid HTTP response it obtains from the service acting as an
 /// oracle.
 #[test_log::test(tokio::test)]
-#[should_panic(expected = "Failed to execute service GraphQL mutation")]
 async fn contract_rejects_invalid_http_response_from_oracle() {
     const HTTP_RESPONSE_BODY: &str = "Invalid response";
 
@@ -245,7 +256,13 @@ async fn contract_rejects_invalid_http_response_from_oracle() {
         })
         .await;
 
-    chain
-        .graphql_mutation(application_id, "mutation { performHttpRequestAsOracle }")
-        .await;
+    let error = chain
+        .try_graphql_mutation(application_id, "mutation { performHttpRequestAsOracle }")
+        .await
+        .expect_err("Expected GraphQL mutation to fail");
+
+    assert_matches!(
+        error.expect_proposal_execution_error(0),
+        ExecutionError::WasmError(WasmExecutionError::ExecuteModule(_))
+    );
 }

--- a/examples/how-to/perform-http-requests/tests/http_requests.rs
+++ b/examples/how-to/perform-http-requests/tests/http_requests.rs
@@ -107,7 +107,7 @@ async fn service_sends_valid_http_response_to_contract() -> anyhow::Result<()> {
 
 /// Tests if the contract rejects an invalid HTTP response sent by the service.
 #[test_log::test(tokio::test)]
-#[should_panic(expected = "Failed to execute block")]
+#[should_panic(expected = "Failed to execute service GraphQL mutation")]
 async fn contract_rejects_invalid_http_response_from_service() {
     const HTTP_RESPONSE_BODY: &str = "Untrusted response";
 
@@ -164,7 +164,7 @@ async fn contract_accepts_valid_http_response_it_obtains_by_itself() -> anyhow::
 
 /// Tests if the contract rejects an invalid HTTP response it obtains by itself.
 #[test_log::test(tokio::test)]
-#[should_panic(expected = "Failed to execute block")]
+#[should_panic(expected = "Failed to execute service GraphQL mutation")]
 async fn contract_rejects_invalid_http_response_it_obtains_by_itself() {
     const HTTP_RESPONSE_BODY: &str = "Untrusted response";
 
@@ -223,7 +223,7 @@ async fn contract_accepts_valid_http_response_from_oracle() -> anyhow::Result<()
 /// Tests if the contract rejects an invalid HTTP response it obtains from the service acting as an
 /// oracle.
 #[test_log::test(tokio::test)]
-#[should_panic(expected = "Failed to execute block")]
+#[should_panic(expected = "Failed to execute service GraphQL mutation")]
 async fn contract_rejects_invalid_http_response_from_oracle() {
     const HTTP_RESPONSE_BODY: &str = "Invalid response";
 

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -179,6 +179,7 @@ impl From<ViewError> for ChainError {
 }
 
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(with_testing, derive(Eq, PartialEq))]
 pub enum ChainExecutionContext {
     Query,
     DescribeApplication,

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -18,6 +18,7 @@ use linera_chain::{
     },
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
 };
+use linera_core::worker::WorkerError;
 use linera_execution::{
     committee::Epoch,
     system::{Recipient, SystemOperation},
@@ -203,7 +204,7 @@ impl BlockBuilder {
     pub(crate) async fn try_sign(
         self,
         blobs: &[Blob],
-    ) -> anyhow::Result<ConfirmedBlockCertificate> {
+    ) -> Result<ConfirmedBlockCertificate, WorkerError> {
         let published_blobs = self
             .block
             .published_blob_ids()

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -236,7 +236,7 @@ impl ActiveChain {
     pub async fn try_add_block(
         &self,
         block_builder: impl FnOnce(&mut BlockBuilder),
-    ) -> anyhow::Result<ConfirmedBlockCertificate> {
+    ) -> Result<ConfirmedBlockCertificate, WorkerError> {
         self.try_add_block_with_blobs(block_builder, vec![]).await
     }
 
@@ -251,7 +251,7 @@ impl ActiveChain {
         &self,
         block_builder: impl FnOnce(&mut BlockBuilder),
         blobs: Vec<Blob>,
-    ) -> anyhow::Result<ConfirmedBlockCertificate> {
+    ) -> Result<ConfirmedBlockCertificate, WorkerError> {
         let mut tip = self.tip.lock().await;
         let mut block = BlockBuilder::new(
             self.description.into(),

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -754,3 +754,18 @@ pub enum TryGraphQLMutationError {
     #[error("Failed to propose block with operations scheduled by the GraphQL mutation")]
     Proposal(#[from] WorkerError),
 }
+
+impl TryGraphQLMutationError {
+    /// Returns the inner [`ExecutionError`] in this [`TryGraphQLMutationError::Proposal`] error.
+    ///
+    /// # Panics
+    ///
+    /// If this is not caused by an [`ExecutionError`] during a block proposal.
+    pub fn expect_proposal_execution_error(self, transaction_index: u32) -> ExecutionError {
+        let TryGraphQLMutationError::Proposal(proposal_error) = self else {
+            panic!("Expected an `ExecutionError` during the block proposal. Got: {self:#?}");
+        };
+
+        proposal_error.expect_execution_error(ChainExecutionContext::Operation(transaction_index))
+    }
+}

--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -30,7 +30,11 @@ pub use {
 #[cfg(with_testing)]
 pub use self::mock_stubs::*;
 #[cfg(with_integration_testing)]
-pub use self::{block::BlockBuilder, chain::ActiveChain, validator::TestValidator};
+pub use self::{
+    block::BlockBuilder,
+    chain::{ActiveChain, TryQueryError},
+    validator::TestValidator,
+};
 use crate::{Contract, ContractRuntime, Service, ServiceRuntime};
 
 /// Creates a [`ContractRuntime`] to use in tests.

--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -23,6 +23,7 @@ pub use {
     linera_chain::{
         data_types::{Medium, MessageAction},
         test::HttpServer,
+        ChainError, ChainExecutionContext,
     },
     linera_execution::{system::Recipient, ExecutionError, QueryOutcome, WasmExecutionError},
 };

--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -24,7 +24,7 @@ pub use {
         data_types::{Medium, MessageAction},
         test::HttpServer,
     },
-    linera_execution::{system::Recipient, QueryOutcome, WasmExecutionError},
+    linera_execution::{system::Recipient, ExecutionError, QueryOutcome, WasmExecutionError},
 };
 
 #[cfg(with_testing)]

--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -34,7 +34,7 @@ pub use self::mock_stubs::*;
 #[cfg(with_integration_testing)]
 pub use self::{
     block::BlockBuilder,
-    chain::{ActiveChain, TryGraphQLQueryError, TryQueryError},
+    chain::{ActiveChain, TryGraphQLMutationError, TryGraphQLQueryError, TryQueryError},
     validator::TestValidator,
 };
 use crate::{Contract, ContractRuntime, Service, ServiceRuntime};

--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -25,6 +25,7 @@ pub use {
         test::HttpServer,
         ChainError, ChainExecutionContext,
     },
+    linera_core::worker::WorkerError,
     linera_execution::{system::Recipient, ExecutionError, QueryOutcome, WasmExecutionError},
 };
 

--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -24,7 +24,7 @@ pub use {
         data_types::{Medium, MessageAction},
         test::HttpServer,
     },
-    linera_execution::{system::Recipient, QueryOutcome},
+    linera_execution::{system::Recipient, QueryOutcome, WasmExecutionError},
 };
 
 #[cfg(with_testing)]

--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -32,7 +32,7 @@ pub use self::mock_stubs::*;
 #[cfg(with_integration_testing)]
 pub use self::{
     block::BlockBuilder,
-    chain::{ActiveChain, TryQueryError},
+    chain::{ActiveChain, TryGraphQLQueryError, TryQueryError},
     validator::TestValidator,
 };
 use crate::{Contract, ContractRuntime, Service, ServiceRuntime};


### PR DESCRIPTION
## Motivation

The integration tests for the HTTP Requests How-To example (#3509) used the `#[should_panic]` attribute for testing failures. However, as [pointed out during review](https://github.com/linera-io/linera-protocol/pull/3509#discussion_r1986888526), these are quite broad and may lead to mistakes. Being able to assert the exact error leads to better tests and a better example for external developers.

## Proposal

Add `try_query`, `try_graphql_query` and `try_graphql_mutation` helper methods to the `ActiveChain` test interface. Use the new methods to replace usages of `#[should_panic]` with error type assertions.

To reduce boilerplate code, a `WorkerError::expect_execution_error` test helper method was added, that dives into the internal `ExecutionError` stored inside a `WorkerError`.

## Test Plan

CI should catch any regressions caused by this refactor to the tests.

## Release Plan

- These changes follow the usual release cycle, because this only includes small backward-compatible API additions to the public API and SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
