### PR TITLE
Cache execution states.

### DIFF
--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -22,7 +22,8 @@ use linera_chain::{
     ChainStateView,
 };
 use linera_execution::{
-    committee::Epoch, Query, QueryContext, QueryOutcome, ServiceRuntimeEndpoint, ServiceSyncRuntime,
+    committee::Epoch, ExecutionStateView, Query, QueryContext, QueryOutcome,
+    ServiceRuntimeEndpoint, ServiceSyncRuntime,
 };
 use linera_storage::Storage;
 use tokio::sync::{mpsc, oneshot, OwnedRwLockReadGuard};
@@ -181,10 +182,14 @@ where
     ///
     /// If loading the chain state fails the next request will receive the error reported by the
     /// `storage`, and the actor will then try again to load the state.
+    #[allow(clippy::too_many_arguments)]
     pub async fn run(
         config: ChainWorkerConfig,
         storage: StorageClient,
         block_cache: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
+        execution_state_cache: Arc<
+            ValueCache<CryptoHash, ExecutionStateView<StorageClient::Context>>,
+        >,
         tracked_chains: Option<Arc<RwLock<HashSet<ChainId>>>>,
         delivery_notifier: DeliveryNotifier,
         chain_id: ChainId,
@@ -198,6 +203,7 @@ where
                 config.clone(),
                 storage.clone(),
                 block_cache.clone(),
+                execution_state_cache.clone(),
                 tracked_chains.clone(),
                 delivery_notifier.clone(),
                 chain_id,
@@ -223,6 +229,9 @@ where
         config: ChainWorkerConfig,
         storage: StorageClient,
         block_cache: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
+        execution_state_cache: Arc<
+            ValueCache<CryptoHash, ExecutionStateView<StorageClient::Context>>,
+        >,
         tracked_chains: Option<Arc<RwLock<HashSet<ChainId>>>>,
         delivery_notifier: DeliveryNotifier,
         chain_id: ChainId,
@@ -240,6 +249,7 @@ where
             config,
             storage,
             block_cache,
+            execution_state_cache,
             tracked_chains,
             delivery_notifier,
             chain_id,

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -28,8 +28,8 @@ use linera_chain::{
     ChainError, ChainStateView,
 };
 use linera_execution::{
-    committee::Epoch, Message, Query, QueryContext, QueryOutcome, ServiceRuntimeEndpoint,
-    SystemMessage,
+    committee::Epoch, ExecutionStateView, Message, Query, QueryContext, QueryOutcome,
+    ServiceRuntimeEndpoint, SystemMessage,
 };
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::{ClonableView, ViewError};
@@ -59,6 +59,7 @@ where
     shared_chain_view: Option<Arc<RwLock<ChainStateView<StorageClient::Context>>>>,
     service_runtime_endpoint: Option<ServiceRuntimeEndpoint>,
     block_values: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
+    execution_state_cache: Arc<ValueCache<CryptoHash, ExecutionStateView<StorageClient::Context>>>,
     tracked_chains: Option<Arc<sync::RwLock<HashSet<ChainId>>>>,
     delivery_notifier: DeliveryNotifier,
     knows_chain_is_active: bool,
@@ -74,6 +75,10 @@ where
         config: ChainWorkerConfig,
         storage: StorageClient,
         block_values: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
+
+        execution_state_cache: Arc<
+            ValueCache<CryptoHash, ExecutionStateView<StorageClient::Context>>,
+        >,
         tracked_chains: Option<Arc<sync::RwLock<HashSet<ChainId>>>>,
         delivery_notifier: DeliveryNotifier,
         chain_id: ChainId,
@@ -88,6 +93,7 @@ where
             shared_chain_view: None,
             service_runtime_endpoint,
             block_values,
+            execution_state_cache,
             tracked_chains,
             delivery_notifier,
             knows_chain_is_active: false,


### PR DESCRIPTION
## Motivation

Currently chain workers executes almost every block twice, both in the client's local node and the validators: Once when handling the proposal, and then again when handling the confirmed block.

## Proposal

Cache the `ExecutionStateView` when handling the proposal, and use the cached value for the confirmed block.

This is only done for blocks where no pub-sub channel subscribers are added or removed. (But these will be replaced by event streams soon anyway.)

The second part of https://github.com/linera-io/linera-protocol/issues/1401, caching intermediate states when _staging_ a block, is not part of this PR yet.

## Test Plan

Most existing tests will use this, so CI would fail if it broke anything.

I locally added some logging to verify that a client test (`test_re_propose_locked_block_with_blobs`) has a lot of cache hits. Metrics are already in place for the `ValueCache`, so we should be able to observe the numbers in production, too.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Partly addresses https://github.com/linera-io/linera-protocol/issues/1401.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
