### PR TITLE
Make `ConfirmedBlock` not `BcsHashable`.

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera/storage.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/storage.json
@@ -1938,7 +1938,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(linera_read_hashed_confirmed_block[1m])",
+          "expr": "rate(linera_read_confirmed_block[1m])",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"

--- a/linera-chain/src/certificate/lite.rs
+++ b/linera-chain/src/certificate/lite.rs
@@ -7,7 +7,6 @@ use std::borrow::Cow;
 use linera_base::{
     crypto::{ValidatorPublicKey, ValidatorSignature},
     data_types::Round,
-    hashed::Hashed,
 };
 use linera_execution::committee::Committee;
 use serde::{Deserialize, Serialize};
@@ -79,8 +78,8 @@ impl LiteCertificate<'_> {
     }
 
     /// Checks whether the value matches this certificate.
-    pub fn check_value<T: CertificateValue>(&self, value: &Hashed<T>) -> bool {
-        self.value.chain_id == value.inner().chain_id()
+    pub fn check_value<T: CertificateValue>(&self, value: &T) -> bool {
+        self.value.chain_id == value.chain_id()
             && T::KIND == self.value.kind
             && self.value.value_hash == value.hash()
     }

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -16,9 +16,7 @@ use linera_base::{
         CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSecretKey, ValidatorSignature,
     },
     data_types::{Amount, Blob, BlockHeight, Event, OracleResponse, Round, Timestamp},
-    doc_scalar, ensure,
-    hashed::Hashed,
-    hex_debug,
+    doc_scalar, ensure, hex_debug,
     identifiers::{
         Account, AccountOwner, BlobId, ChainId, ChannelFullName, Destination, GenericApplicationId,
         MessageId,
@@ -411,7 +409,7 @@ struct VoteValue(CryptoHash, Round, CertificateKind);
 
 /// A vote on a statement from a validator.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(bound(deserialize = "T: BcsHashable<'de>"))]
+#[serde(bound(deserialize = "T: Deserialize<'de>"))]
 pub struct Vote<T> {
     pub value: T,
     pub round: Round,
@@ -686,7 +684,7 @@ impl BlockProposal {
             }
             (Some(lite_certificate), Some(outcome)) => {
                 let block = outcome.clone().with(self.content.block.clone());
-                let value = Hashed::new(ValidatedBlock::new(block));
+                let value = ValidatedBlock::new(block);
                 ensure!(
                     lite_certificate.check_value(&value),
                     "Lite certificate must match the given block and execution outcome"

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -76,26 +76,6 @@ fn test_signed_values() {
 }
 
 #[test]
-fn test_hashes() {
-    // Test that hash of confirmed and validated blocks are different,
-    // even if the blocks are the same.
-    let block = BlockExecutionOutcome {
-        messages: vec![Vec::new()],
-        previous_message_blocks: BTreeMap::new(),
-        state_hash: CryptoHash::test_hash("state"),
-        oracle_responses: vec![Vec::new()],
-        events: vec![Vec::new()],
-        blobs: vec![Vec::new()],
-        operation_results: vec![OperationResult::default()],
-    }
-    .with(make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(2), Amount::ONE));
-    let confirmed_hashed = Hashed::new(ConfirmedBlock::new(block.clone()));
-    let validated_hashed = Hashed::new(ValidatedBlock::new(block));
-
-    assert_eq!(confirmed_hashed.hash(), validated_hashed.hash());
-}
-
-#[test]
 fn test_certificates() {
     let validator1_key_pair = ValidatorKeypair::generate();
     let account1_secret = AccountSecretKey::Ed25519(Ed25519SecretKey::generate());

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -222,8 +222,8 @@ impl ChainListener {
             {
                 context.lock().await.update_wallet(&client).await?;
             }
-            let value = storage.read_hashed_confirmed_block(hash).await?;
-            let block = value.inner().block();
+            let value = storage.read_confirmed_block(hash).await?;
+            let block = value.block();
             let new_chains = block
                 .messages()
                 .iter()

--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -13,7 +13,7 @@ use linera_core::{
 };
 use linera_execution::system::Recipient;
 use linera_storage::{
-    READ_CERTIFICATE_COUNTER, READ_HASHED_CONFIRMED_BLOCK_COUNTER, WRITE_CERTIFICATE_COUNTER,
+    READ_CERTIFICATE_COUNTER, READ_CONFIRMED_BLOCK_COUNTER, WRITE_CERTIFICATE_COUNTER,
 };
 use linera_views::metrics::{LOAD_VIEW_COUNTER, SAVE_VIEW_COUNTER};
 use prometheus::core::Collector;
@@ -114,7 +114,7 @@ criterion_group!(
     config = Criterion::default()
         .measurement_time(Duration::from_secs(40))
         .with_measurement(BenchRecorderMeasurement::new(vec![
-            READ_HASHED_CONFIRMED_BLOCK_COUNTER.desc()[0].fq_name.as_str(),
+            READ_CONFIRMED_BLOCK_COUNTER.desc()[0].fq_name.as_str(),
             READ_CERTIFICATE_COUNTER.desc()[0].fq_name.as_str(), WRITE_CERTIFICATE_COUNTER.desc()[0].fq_name.as_str(),
             LOAD_VIEW_COUNTER.desc()[0].fq_name.as_str(), SAVE_VIEW_COUNTER.desc()[0].fq_name.as_str(),
         ]));

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -32,7 +32,6 @@ use linera_base::{
         Timestamp,
     },
     ensure,
-    hashed::Hashed,
     identifiers::{
         Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, EventId, MessageId,
         ModuleId, StreamId,
@@ -2125,7 +2124,7 @@ where
 
         match self.process_pending_block_without_prepare().await? {
             ClientOutcome::Committed(Some(certificate))
-                if certificate.block() == confirmed_value.inner().block() =>
+                if certificate.block() == confirmed_value.block() =>
             {
                 Ok(ExecuteBlockOutcome::Executed(certificate))
             }
@@ -2152,7 +2151,7 @@ where
         operations: Vec<Operation>,
         blobs: Vec<Blob>,
         identity: AccountOwner,
-    ) -> Result<Hashed<ConfirmedBlock>, ChainClientError> {
+    ) -> Result<ConfirmedBlock, ChainClientError> {
         let (previous_block_hash, height, timestamp) = {
             let state = self.state();
             ensure!(
@@ -2199,7 +2198,7 @@ where
             .await?;
         let (proposed_block, _) = block.clone().into_proposal();
         self.state_mut().set_pending_proposal(proposed_block, blobs);
-        Ok(Hashed::new(ConfirmedBlock::new(block)))
+        Ok(ConfirmedBlock::new(block))
     }
 
     /// Returns a suitable timestamp for the next block.
@@ -3210,13 +3209,13 @@ where
     }
 
     #[instrument(level = "trace", skip(hash))]
-    pub async fn read_hashed_confirmed_block(
+    pub async fn read_confirmed_block(
         &self,
         hash: CryptoHash,
-    ) -> Result<Hashed<ConfirmedBlock>, ViewError> {
+    ) -> Result<ConfirmedBlock, ViewError> {
         self.client
             .storage_client()
-            .read_hashed_confirmed_block(hash)
+            .read_confirmed_block(hash)
             .await
     }
 
@@ -3231,14 +3230,14 @@ where
     }
 
     #[instrument(level = "trace", skip(from, limit))]
-    pub async fn read_hashed_confirmed_blocks_downward(
+    pub async fn read_confirmed_blocks_downward(
         &self,
         from: CryptoHash,
         limit: u32,
-    ) -> Result<Vec<Hashed<ConfirmedBlock>>, ViewError> {
+    ) -> Result<Vec<ConfirmedBlock>, ViewError> {
         self.client
             .storage_client()
-            .read_hashed_confirmed_blocks_downward(from, limit)
+            .read_confirmed_blocks_downward(from, limit)
             .await
     }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1429,14 +1429,13 @@ where
         .unwrap()
         .unwrap();
 
-    let hashed_certificate_values = client2_b
-        .read_hashed_confirmed_blocks_downward(bt_certificate.hash(), 2)
+    let certificate_values = client2_b
+        .read_confirmed_blocks_downward(bt_certificate.hash(), 2)
         .await
         .unwrap();
 
     // Latest block should be the burn
-    assert!(hashed_certificate_values[0]
-        .inner()
+    assert!(certificate_values[0]
         .block()
         .body
         .operations
@@ -1448,7 +1447,7 @@ where
 
     // Block before that should be b0
     assert_eq!(
-        hashed_certificate_values[1].inner().block().body.operations,
+        certificate_values[1].block().body.operations,
         blob_0_1_operations,
     );
 
@@ -1556,14 +1555,13 @@ where
         .unwrap()
         .unwrap();
 
-    let hashed_certificate_values = client2_b
-        .read_hashed_confirmed_blocks_downward(bt_certificate.hash(), 2)
+    let certificate_values = client2_b
+        .read_confirmed_blocks_downward(bt_certificate.hash(), 2)
         .await
         .unwrap();
 
     // Latest block should be the burn
-    assert!(hashed_certificate_values[0]
-        .inner()
+    assert!(certificate_values[0]
         .block()
         .body
         .operations
@@ -1574,8 +1572,7 @@ where
         })));
 
     // Previous should be the `ChangeOwnership` operation, as the blob operations shouldn't be executed here.
-    assert!(hashed_certificate_values[1]
-        .inner()
+    assert!(certificate_values[1]
         .block()
         .body
         .operations
@@ -1799,14 +1796,13 @@ where
         .unwrap()
         .unwrap();
 
-    let hashed_certificate_values = client3_c
-        .read_hashed_confirmed_blocks_downward(bt_certificate.hash(), 3)
+    let certificate_values = client3_c
+        .read_confirmed_blocks_downward(bt_certificate.hash(), 3)
         .await
         .unwrap();
 
     // Latest block should be the burn
-    assert!(hashed_certificate_values[0]
-        .inner()
+    assert!(certificate_values[0]
         .block()
         .body
         .operations
@@ -1816,13 +1812,12 @@ where
 
     // Block before that should be b1
     assert_eq!(
-        hashed_certificate_values[1].inner().block().body.operations,
+        certificate_values[1].block().body.operations,
         blob_2_3_operations,
     );
 
     // Previous should be the `ChangeOwnership` operation
-    assert!(hashed_certificate_values[2]
-        .inner()
+    assert!(certificate_values[2]
         .block()
         .body
         .operations

--- a/linera-explorer/src/components/Block.test.ts
+++ b/linera-explorer/src/components/Block.test.ts
@@ -7,73 +7,71 @@ test('Block mounting', () => {
       title: 'Block',
       block: {
         hash: "1fe0d0bb557f1a9057a2fca119566b439aa70d04918b71ea1485d5da2c7566b5",
-        value: {
-          status: "confirmed",
-          block: {
-            header: {
-              chainId: "aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8",
-              epoch: "0",
-              height: 6,
-              timestamp: 1694097511817833,
-              authenticatedSigner: "a36c72207a7c3cef20eb254978c0947d7cf28c9c7d7c62de42a0ed9db901cf3f",
-              previousBlockHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
-              stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-              messagesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-              previousMessageBlocksHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-              eventsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-              bundlesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-              operationsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-              oracleResponsesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-              blobsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-              operationResultsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-            },
-            body: {
-              messages: [[{
-                destination: { Subscribers: [1] },
-                authenticatedSigner: null,
-                kind: "Protected",
-                grant: 0,
-                message: {
-                  System: {
-                    BytecodeLocations: {
-                      locations: [
-                        [
-                          "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65020000000000000000000000",
-                          { certificateHash: "a4167c67ce9c94c301fd5cbbefeccf6c8e56d568a4c75ed85e93bfacee66bac5", operation_index: 0 }],
-                        [
-                          "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65050000000000000000000000",
-                          { certificateHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a", operation_index: 0 }]]
-                    }
+        status: "confirmed",
+        block: {
+          header: {
+            chainId: "aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8",
+            epoch: "0",
+            height: 6,
+            timestamp: 1694097511817833,
+            authenticatedSigner: "a36c72207a7c3cef20eb254978c0947d7cf28c9c7d7c62de42a0ed9db901cf3f",
+            previousBlockHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
+            stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+            messagesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+            previousMessageBlocksHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+            eventsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+            bundlesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+            operationsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+            oracleResponsesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+            blobsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+            operationResultsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+          },
+          body: {
+            messages: [[{
+              destination: { Subscribers: [1] },
+              authenticatedSigner: null,
+              kind: "Protected",
+              grant: 0,
+              message: {
+                System: {
+                  BytecodeLocations: {
+                    locations: [
+                      [
+                        "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65020000000000000000000000",
+                        { certificateHash: "a4167c67ce9c94c301fd5cbbefeccf6c8e56d568a4c75ed85e93bfacee66bac5", operation_index: 0 }],
+                      [
+                        "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65050000000000000000000000",
+                        { certificateHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a", operation_index: 0 }]]
                   }
                 }
-              }]],
-              previousMessageBlocks: {},
-              events: [[]],
-              oracleResponses: [],
-              blobs: [[]],
-              operationResults: [],
-              incomingBundles: [{
-                origin: {
-                  medium: "Direct",
-                  sender: "aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8"
-                },
-                bundle: {
-                  certificateHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
-                  height: 5,
-                  messages: [{
-                    authenticatedSigner: null,
-                    message: { System: { BytecodePublished: { operation_index: 0 } } },
-                    grant: "0.01",
-                    index: 4,
-                    kind: "Tracked"
-                  }],
-                  transactionIndex: 0,
-                  timestamp: 1694097510206912
-                },
-                action: "Accept",
-              }],
-              operations: []
-            }
+              }
+            }]],
+            previousMessageBlocks: {},
+            events: [[]],
+            oracleResponses: [],
+            blobs: [[]],
+            operationResults: [],
+            incomingBundles: [{
+              origin: {
+                medium: "Direct",
+                sender: "aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8"
+              },
+              bundle: {
+                certificateHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
+                height: 5,
+                messages: [{
+                  authenticatedSigner: null,
+                  message: { System: { BytecodePublished: { operation_index: 0 } } },
+                  grant: "0.01",
+                  index: 4,
+                  kind: "Tracked"
+                }],
+                transactionIndex: 0,
+                timestamp: 1694097510206912
+              },
+              action: "Accept",
+            }],
+            operations: []
           }
         }
       }

--- a/linera-explorer/src/components/Block.vue
+++ b/linera-explorer/src/components/Block.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { HashedConfirmedBlock } from '../../gql/service'
+import { ConfirmedBlock } from '../../gql/service'
 import Json from './Json.vue'
 import Op from './Op.vue'
 
-defineProps<{block: HashedConfirmedBlock, title: string}>()
+defineProps<{block: ConfirmedBlock, title: string}>()
 </script>
 
 <template>
@@ -35,44 +35,44 @@ defineProps<{block: HashedConfirmedBlock, title: string}>()
         </li>
         <li class="list-group-item d-flex justify-content-between">
           <span><strong>Epoch</strong></span>
-          <span>{{ block.value.block.header.epoch }}</span>
+          <span>{{ block.block.header.epoch }}</span>
         </li>
         <li class="list-group-item d-flex justify-content-between">
           <span><strong>Height</strong></span>
-          <span>{{ block.value.block.header.height }}</span>
+          <span>{{ block.block.header.height }}</span>
         </li>
         <li class="list-group-item d-flex justify-content-between">
           <span><strong>Timestamp</strong></span>
-          <span>{{ (new Date(block.value.block.header.timestamp/1000)).toLocaleString() }}</span>
+          <span>{{ (new Date(block.block.header.timestamp/1000)).toLocaleString() }}</span>
         </li>
         <li class="list-group-item d-flex justify-content-between">
           <span><strong>Signer</strong></span>
-          <span>{{ block.value.block.header.authenticatedSigner }}</span>
+          <span>{{ block.block.header.authenticatedSigner }}</span>
         </li>
         <li class="list-group-item d-flex justify-content-between">
           <span><strong>Previous Block</strong></span>
-          <a v-if="block.value.block.header.previousBlockHash!==undefined" @click="$root.route('block', [['block', block.value.block.header.previousBlockHash]])" class="btn btn-link">{{ block.value.block.header.previousBlockHash }}</a>
+          <a v-if="block.block.header.previousBlockHash!==undefined" @click="$root.route('block', [['block', block.block.header.previousBlockHash]])" class="btn btn-link">{{ block.block.header.previousBlockHash }}</a>
           <span v-else>--</span>
         </li>
         <li class="list-group-item d-flex justify-content-between">
           <span><strong>State Hash</strong></span>
-          <span>{{ block.value.block.header.stateHash }}</span>
+          <span>{{ block.block.header.stateHash }}</span>
         </li>
         <li class="list-group-item d-flex justify-content-between">
           <span><strong>Status</strong></span>
-          <span>{{ block.value.status }}</span>
+          <span>{{ block.status }}</span>
         </li>
-        <li v-if="block.value.block.body.incomingBundles.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#in-messages-collapse-'+block.hash">
-          <span><strong>Incoming Messages</strong> ({{ block.value.block.body.incomingBundles.length }})</span>
+        <li v-if="block.block.body.incomingBundles.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#in-messages-collapse-'+block.hash">
+          <span><strong>Incoming Messages</strong> ({{ block.block.body.incomingBundles.length }})</span>
           <i class="bi bi-caret-down-fill"></i>
         </li>
         <li v-else class="list-group-item d-flex justify-content-between">
           <span><strong>Incoming Messages</strong> (0)</span>
           <span></span>
         </li>
-        <div v-if="block.value.block.body.incomingBundles.length!==0" class="collapse" :id="'in-messages-collapse-'+block.hash">
+        <div v-if="block.block.body.incomingBundles.length!==0" class="collapse" :id="'in-messages-collapse-'+block.hash">
           <ul class="list-group">
-            <li v-for="(m, i) in block.value.block.body.incomingBundles" class="list-group-item p-0" key="block.hash+'-inmessage-'+i">
+            <li v-for="(m, i) in block.block.body.incomingBundles" class="list-group-item p-0" key="block.hash+'-inmessage-'+i">
               <div class="card">
                 <div class="card-header">Message {{ i+1 }}</div>
                 <div class="card-body">
@@ -82,34 +82,34 @@ defineProps<{block: HashedConfirmedBlock, title: string}>()
             </li>
           </ul>
         </div>
-        <li v-if="block.value.block.body.operations.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#operations-collapse-'+block.hash">
-          <span><strong>Operations</strong> ({{ block.value.block.body.operations.length }})</span>
+        <li v-if="block.block.body.operations.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#operations-collapse-'+block.hash">
+          <span><strong>Operations</strong> ({{ block.block.body.operations.length }})</span>
           <i class="bi bi-caret-down-fill"></i>
         </li>
         <li v-else class="list-group-item d-flex justify-content-between">
           <span><strong>Operations</strong> (0)</span>
           <span></span>
         </li>
-        <div v-if="block.value.block.body.operations.length!==0" class="collapse" :id="'operations-collapse-'+block.hash">
+        <div v-if="block.block.body.operations.length!==0" class="collapse" :id="'operations-collapse-'+block.hash">
           <ul class="list-group">
-            <li v-for="(o, i) in block.value.block.body.operations" class="list-group-item p-0" key="block.hash+'-operation-'+i">
+            <li v-for="(o, i) in block.block.body.operations" class="list-group-item p-0" key="block.hash+'-operation-'+i">
               <div class="card card-body p-0">
                 <Op :op="o" :id="block.hash+'-operation-'+i" :index="i"/>
               </div>
             </li>
           </ul>
         </div>
-        <li v-if="block.value.block.body.messages.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#out-messages-collapse-'+block.hash">
-          <span><strong>Outgoing Messages</strong> ({{ block.value.block.body.messages.length }})</span>
+        <li v-if="block.block.body.messages.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#out-messages-collapse-'+block.hash">
+          <span><strong>Outgoing Messages</strong> ({{ block.block.body.messages.length }})</span>
           <i class="bi bi-caret-down-fill"></i>
         </li>
         <li v-else class="list-group-item d-flex justify-content-between">
           <span><strong>Outgoing Messages</strong> (0)</span>
           <span></span>
         </li>
-        <div v-if="block.value.block.body.messages.length!==0" class="collapse" :id="'out-messages-collapse-'+block.hash">
+        <div v-if="block.block.body.messages.length!==0" class="collapse" :id="'out-messages-collapse-'+block.hash">
           <ul class="list-group">
-            <li v-for="(m, i) in block.value.block.body.messages" class="list-group-item p-0" key="block.hash+'-outmessage-'+i">
+            <li v-for="(m, i) in block.block.body.messages" class="list-group-item p-0" key="block.hash+'-outmessage-'+i">
               <div class="card">
                 <div class="card-header">Messages for transaction {{ i+1 }}</div>
                 <div class="card-body">
@@ -119,17 +119,17 @@ defineProps<{block: HashedConfirmedBlock, title: string}>()
             </li>
           </ul>
         </div>
-        <li v-if="Object.keys(block.value.block.body.previousMessageBlocks).length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#previous-message-blocks-collapse-'+block.hash">
-          <span><strong>Previous Message Blocks</strong> ({{ Object.keys(block.value.block.body.previousMessageBlocks).length }})</span>
+        <li v-if="Object.keys(block.block.body.previousMessageBlocks).length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#previous-message-blocks-collapse-'+block.hash">
+          <span><strong>Previous Message Blocks</strong> ({{ Object.keys(block.block.body.previousMessageBlocks).length }})</span>
           <i class="bi bi-caret-down-fill"></i>
         </li>
         <li v-else class="list-group-item d-flex justify-content-between">
           <span><strong>Previous Message Blocks</strong> (0)</span>
           <span></span>
         </li>
-        <div v-if=" Object.keys(block.value.block.body.previousMessageBlocks).length!==0" class="collapse" :id="'previous-message-blocks-collapse-'+block.hash">
+        <div v-if=" Object.keys(block.block.body.previousMessageBlocks).length!==0" class="collapse" :id="'previous-message-blocks-collapse-'+block.hash">
           <ul class="list-group">
-            <li v-for="(hash, id) in block.value.block.body.previousMessageBlocks" class="list-group-item p-0" key="block.hash+'-previousmessageblock-'+id">
+            <li v-for="(hash, id) in block.block.body.previousMessageBlocks" class="list-group-item p-0" key="block.hash+'-previousmessageblock-'+id">
               <div class="card">
                 <div class="card-header">Previous message from chain {{ id }} was sent at block</div>
                 <div class="card-body">
@@ -139,17 +139,17 @@ defineProps<{block: HashedConfirmedBlock, title: string}>()
             </li>
           </ul>
         </div>
-        <li v-if="block.value.block.body.oracleResponses.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#oracle-responses-collapse-'+block.hash">
-          <span><strong>Oracle Responses</strong> ({{ block.value.block.body.oracleResponses.length }})</span>
+        <li v-if="block.block.body.oracleResponses.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#oracle-responses-collapse-'+block.hash">
+          <span><strong>Oracle Responses</strong> ({{ block.block.body.oracleResponses.length }})</span>
           <i class="bi bi-caret-down-fill"></i>
         </li>
         <li v-else class="list-group-item d-flex justify-content-between">
           <span><strong>Oracle Responses</strong> (0)</span>
           <span></span>
         </li>
-        <div v-if="block.value.block.body.oracleResponses.length!==0" class="collapse" :id="'oracle-responses-collapse-'+block.hash">
+        <div v-if="block.block.body.oracleResponses.length!==0" class="collapse" :id="'oracle-responses-collapse-'+block.hash">
           <ul class="list-group">
-            <li v-for="(m, i) in block.value.block.body.oracleResponses" class="list-group-item p-0" key="block.hash+'-oracleresponse-'+i">
+            <li v-for="(m, i) in block.block.body.oracleResponses" class="list-group-item p-0" key="block.hash+'-oracleresponse-'+i">
               <div class="card">
                 <div class="card-header">Oracle Response {{ i+1 }}</div>
                 <div class="card-body">
@@ -159,17 +159,17 @@ defineProps<{block: HashedConfirmedBlock, title: string}>()
             </li>
           </ul>
         </div>
-        <li v-if="block.value.block.body.events.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#events-collapse-'+block.hash">
-          <span><strong>Events</strong> ({{ block.value.block.body.events.length }})</span>
+        <li v-if="block.block.body.events.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#events-collapse-'+block.hash">
+          <span><strong>Events</strong> ({{ block.block.body.events.length }})</span>
           <i class="bi bi-caret-down-fill"></i>
         </li>
         <li v-else class="list-group-item d-flex justify-content-between">
           <span><strong>Events</strong> (0)</span>
           <span></span>
         </li>
-        <div v-if="block.value.block.body.events.length!==0" class="collapse" :id="'events-collapse-'+block.hash">
+        <div v-if="block.block.body.events.length!==0" class="collapse" :id="'events-collapse-'+block.hash">
           <ul class="list-group">
-            <li v-for="(m, i) in block.value.block.body.events" class="list-group-item p-0" key="block.hash+'-event-'+i">
+            <li v-for="(m, i) in block.block.body.events" class="list-group-item p-0" key="block.hash+'-event-'+i">
               <div class="card">
                 <div class="card-header">Event {{ i+1 }}</div>
                 <div class="card-body">
@@ -179,17 +179,17 @@ defineProps<{block: HashedConfirmedBlock, title: string}>()
             </li>
           </ul>
         </div>
-        <li v-if="block.value.block.body.blobs.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#blobs-collapse-'+block.hash">
-          <span><strong>Blobs</strong> ({{ block.value.block.body.blobs.length }})</span>
+        <li v-if="block.block.body.blobs.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#blobs-collapse-'+block.hash">
+          <span><strong>Blobs</strong> ({{ block.block.body.blobs.length }})</span>
           <i class="bi bi-caret-down-fill"></i>
         </li>
         <li v-else class="list-group-item d-flex justify-content-between">
           <span><strong>Blobs</strong> (0)</span>
           <span></span>
         </li>
-        <div v-if="block.value.block.body.blobs.length!==0" class="collapse" :id="'blobs-collapse-'+block.hash">
+        <div v-if="block.block.body.blobs.length!==0" class="collapse" :id="'blobs-collapse-'+block.hash">
           <ul class="list-group">
-            <li v-for="(m, i) in block.value.block.body.blobs" class="list-group-item p-0" key="block.hash+'-blob-'+i">
+            <li v-for="(m, i) in block.block.body.blobs" class="list-group-item p-0" key="block.hash+'-blob-'+i">
               <div class="card">
                 <div class="card-header">Blob {{ i+1 }}</div>
                 <div class="card-body">
@@ -199,17 +199,17 @@ defineProps<{block: HashedConfirmedBlock, title: string}>()
             </li>
           </ul>
         </div>
-        <li v-if="block.value.block.body.operationResults.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#operation-results-collapse-'+block.hash">
-          <span><strong>Operation Results</strong> ({{ block.value.block.body.operationResults.length }})</span>
+        <li v-if="block.block.body.operationResults.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#operation-results-collapse-'+block.hash">
+          <span><strong>Operation Results</strong> ({{ block.block.body.operationResults.length }})</span>
           <i class="bi bi-caret-down-fill"></i>
         </li>
         <li v-else class="list-group-item d-flex justify-content-between">
           <span><strong>Operation Results</strong> (0)</span>
           <span></span>
         </li>
-        <div v-if="block.value.block.body.operationResults.length!==0" class="collapse" :id="'operation-results-collapse-'+block.hash">
+        <div v-if="block.block.body.operationResults.length!==0" class="collapse" :id="'operation-results-collapse-'+block.hash">
           <ul class="list-group">
-            <li v-for="(m, i) in block.value.block.body.operationResults" class="list-group-item p-0" key="block.hash+'-operationresult-'+i">
+            <li v-for="(m, i) in block.block.body.operationResults" class="list-group-item p-0" key="block.hash+'-operationresult-'+i">
               <div class="card">
                 <div class="card-header">Operation Result {{ i+1 }}</div>
                 <div class="card-body">

--- a/linera-explorer/src/components/Blocks.test.ts
+++ b/linera-explorer/src/components/Blocks.test.ts
@@ -9,73 +9,71 @@ test('Blocks mounting', () => {
         blocks: [
           {
             hash: "1fe0d0bb557f1a9057a2fca119566b439aa70d04918b71ea1485d5da2c7566b5",
-            value: {
-              status: "confirmed",
-              block: {
-                header: {
-                  chainId: "aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8",
-                  epoch: "0",
-                  height: 6,
-                  stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-                  timestamp: 1694097511817833,
-                  authenticatedSigner: "a36c72207a7c3cef20eb254978c0947d7cf28c9c7d7c62de42a0ed9db901cf3f",
-                  previousBlockHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
-                  messagesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-                  previousMessageBlocksHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-                  eventsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-                  bundlesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-                  operationsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-                  oracleResponsesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-                  blobsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-                  operationResultsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-                },
-                body: {
-                  messages: [[{
-                    destination: { Subscribers: [1] },
-                    authenticatedSigner: null,
-                    kind: "Protected",
-                    grant: 0,
-                    message: {
-                      System: {
-                        BytecodeLocations: {
-                          locations: [
-                            [
-                              "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65020000000000000000000000",
-                              { certificateHash: "a4167c67ce9c94c301fd5cbbefeccf6c8e56d568a4c75ed85e93bfacee66bac5", operation_index: 0 }],
-                            [
-                              "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65050000000000000000000000",
-                              { certificateHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a", operation_index: 0 }]]
-                        }
+            status: "confirmed",
+            block: {
+              header: {
+                chainId: "aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8",
+                epoch: "0",
+                height: 6,
+                stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+                timestamp: 1694097511817833,
+                authenticatedSigner: "a36c72207a7c3cef20eb254978c0947d7cf28c9c7d7c62de42a0ed9db901cf3f",
+                previousBlockHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
+                messagesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+                previousMessageBlocksHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+                eventsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+                bundlesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+                operationsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+                oracleResponsesHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+                blobsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+                operationResultsHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
+              },
+              body: {
+                messages: [[{
+                  destination: { Subscribers: [1] },
+                  authenticatedSigner: null,
+                  kind: "Protected",
+                  grant: 0,
+                  message: {
+                    System: {
+                      BytecodeLocations: {
+                        locations: [
+                          [
+                            "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65020000000000000000000000",
+                            { certificateHash: "a4167c67ce9c94c301fd5cbbefeccf6c8e56d568a4c75ed85e93bfacee66bac5", operation_index: 0 }],
+                          [
+                            "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65050000000000000000000000",
+                            { certificateHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a", operation_index: 0 }]]
                       }
                     }
-                  }]],
-                  previousMessageBlocks: {},
-                  events: [[]],
-                  oracleResponses: [],
-                  blobs: [[]],
-                  operationResults: [],
-                  incomingBundles: [{
-                    origin: {
-                      medium: "Direct",
-                      sender: "aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8"
-                    },
-                    bundle: {
-                      certificateHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
-                      height: 5,
-                      messages: [{
-                        authenticatedSigner: null,
-                        message: { System: { BytecodePublished: { operation_index: 0 } } },
-                        grant: "0.01",
-                        index: 4,
-                        kind: "Tracked"
-                      }],
-                      transactionIndex: 0,
-                      timestamp: 1694097510206912
-                    },
-                    action: "Accept",
-                  }],
-                  operations: []
-                }
+                  }
+                }]],
+                previousMessageBlocks: {},
+                events: [[]],
+                oracleResponses: [],
+                blobs: [[]],
+                operationResults: [],
+                incomingBundles: [{
+                  origin: {
+                    medium: "Direct",
+                    sender: "aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8"
+                  },
+                  bundle: {
+                    certificateHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
+                    height: 5,
+                    messages: [{
+                      authenticatedSigner: null,
+                      message: { System: { BytecodePublished: { operation_index: 0 } } },
+                      grant: "0.01",
+                      index: 4,
+                      kind: "Tracked"
+                    }],
+                    transactionIndex: 0,
+                    timestamp: 1694097510206912
+                  },
+                  action: "Accept",
+                }],
+                operations: []
               }
             }
           }

--- a/linera-explorer/src/components/Blocks.vue
+++ b/linera-explorer/src/components/Blocks.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { HashedConfirmedBlock } from '../../gql/service'
+import { ConfirmedBlock } from '../../gql/service'
 
-defineProps<{blocks: HashedConfirmedBlock[]}>()
+defineProps<{blocks: ConfirmedBlock[]}>()
 </script>
 
 <template>
@@ -23,16 +23,16 @@ defineProps<{blocks: HashedConfirmedBlock[]}>()
       </thead>
       <tbody>
         <tr v-for="b in blocks" :key="'blocks-block-'+b.hash">
-          <td>{{ b.value.block.header.height }}</td>
+          <td>{{ b.block.header.height }}</td>
           <td :title="b.hash">
             <a @click="$root.route('block', [['block', b.hash]])" class="btn btn-link">{{ short_hash(b.hash) }}</a>
           </td>
-          <td>{{ (new Date(b.value.block.header.timestamp/1000)).toLocaleString() }}</td>
-          <td :title="b.value.block.header.authenticatedSigner">{{ b.value.block.header.authenticatedSigner }}</td>
-          <td>{{ b.value.status }}</td>
-          <td>{{ b.value.block.body.incomingBundles.length }}</td>
-          <td>{{ b.value.block.body.messages.length }}</td>
-          <td>{{ b.value.block.body.operations.length }}</td>
+          <td>{{ (new Date(b.block.header.timestamp/1000)).toLocaleString() }}</td>
+          <td :title="b.block.header.authenticatedSigner">{{ b.block.header.authenticatedSigner }}</td>
+          <td>{{ b.status }}</td>
+          <td>{{ b.block.body.incomingBundles.length }}</td>
+          <td>{{ b.block.body.messages.length }}</td>
+          <td>{{ b.block.body.operations.length }}</td>
           <td>
             <button class="btn btn-link btn-sm" data-bs-toggle="modal" :data-bs-target="'#'+b.hash+'-modal'" @click="json_load(b.hash+'-json', b)">
               <i class="bi bi-braces"></i>

--- a/linera-indexer/example/tests/test.rs
+++ b/linera-indexer/example/tests/test.rs
@@ -155,7 +155,7 @@ async fn test_end_to_end_operations_indexer(config: impl LineraNetConfig) {
     );
 
     // checking indexer operation
-    let last_operation = last_block.value.block.body.operations[0].clone();
+    let last_operation = last_block.block.body.operations[0].clone();
     let variables = get_operation::Variables {
         key: get_operation::OperationKeyKind::Last(chain0),
     };
@@ -177,7 +177,7 @@ async fn test_end_to_end_operations_indexer(config: impl LineraNetConfig) {
                 (
                     OperationKey {
                         chain_id: chain0,
-                        height: last_block.value.block.header.height,
+                        height: last_block.block.header.height,
                         index: 0
                     },
                     last_hash,

--- a/linera-indexer/lib/src/plugin.rs
+++ b/linera-indexer/lib/src/plugin.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 
 use async_graphql::{EmptyMutation, EmptySubscription, ObjectType, Schema};
 use axum::Router;
-use linera_base::hashed::Hashed;
 use linera_chain::types::ConfirmedBlock;
 use linera_views::{context::ViewContext, store::KeyValueStore, views::View};
 use tokio::sync::Mutex;
@@ -31,7 +30,7 @@ where
         Self: Sized;
 
     /// Main function of the plugin: registers the information required for a hashed value
-    async fn register(&self, value: &Hashed<ConfirmedBlock>) -> Result<(), IndexerError>;
+    async fn register(&self, value: &ConfirmedBlock) -> Result<(), IndexerError>;
 
     /// Produces the GraphQL schema for the plugin
     fn sdl(&self) -> String;

--- a/linera-indexer/lib/src/service.rs
+++ b/linera-indexer/lib/src/service.rs
@@ -14,8 +14,7 @@ use futures::{
 use graphql_client::reqwest::post_graphql;
 use graphql_ws_client::{graphql::StreamingOperation, GraphQLClientClientBuilder};
 use linera_base::{
-    crypto::CryptoHash, data_types::BlockHeight, hashed::Hashed, identifiers::ChainId,
-    time::Duration,
+    crypto::CryptoHash, data_types::BlockHeight, identifiers::ChainId, time::Duration,
 };
 use linera_chain::types::ConfirmedBlock;
 use linera_core::worker::Reason;
@@ -87,7 +86,7 @@ impl Service {
         &self,
         chain_id: ChainId,
         hash: Option<CryptoHash>,
-    ) -> Result<Hashed<ConfirmedBlock>, IndexerError> {
+    ) -> Result<ConfirmedBlock, IndexerError> {
         let client = reqwest_client();
         let variables = block::Variables { hash, chain_id };
         let response = post_graphql::<Block, _>(&client, &self.http(), variables).await?;

--- a/linera-indexer/plugins/src/operations.rs
+++ b/linera-indexer/plugins/src/operations.rs
@@ -8,10 +8,8 @@ use std::{
 
 use async_graphql::{OneofObject, SimpleObject};
 use axum::Router;
-use linera_base::{
-    crypto::CryptoHash, data_types::BlockHeight, doc_scalar, hashed::Hashed, identifiers::ChainId,
-};
-use linera_chain::types::ConfirmedBlock;
+use linera_base::{crypto::CryptoHash, data_types::BlockHeight, doc_scalar, identifiers::ChainId};
+use linera_chain::types::{CertificateValue as _, ConfirmedBlock};
 use linera_execution::Operation;
 use linera_indexer::{
     common::IndexerError,
@@ -128,13 +126,13 @@ where
         Ok(Self(load(store, NAME).await?))
     }
 
-    async fn register(&self, value: &Hashed<ConfirmedBlock>) -> Result<(), IndexerError> {
+    async fn register(&self, value: &ConfirmedBlock) -> Result<(), IndexerError> {
         let mut plugin = self.0.lock().await;
-        let chain_id = value.inner().chain_id();
-        for (index, content) in value.inner().block().body.operations.iter().enumerate() {
+        let chain_id = value.chain_id();
+        for (index, content) in value.block().body.operations.iter().enumerate() {
             let key = OperationKey {
                 chain_id,
-                height: value.inner().height(),
+                height: value.height(),
                 index,
             };
             match plugin

--- a/linera-rpc/tests/format.rs
+++ b/linera-rpc/tests/format.rs
@@ -5,7 +5,6 @@
 use linera_base::{
     crypto::{AccountPublicKey, AccountSignature, TestString},
     data_types::{BlobContent, OracleResponse, Round},
-    hashed::Hashed,
     identifiers::{AccountOwner, BlobType, ChainDescription, Destination, GenericApplicationId},
     ownership::ChainOwnership,
     vm::VmRuntime,
@@ -58,7 +57,6 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<MessageKind>(&samples)?;
     tracer.trace_type::<CertificateKind>(&samples)?;
     tracer.trace_type::<Certificate>(&samples)?;
-    tracer.trace_type::<Hashed<ConfirmedBlock>>(&samples)?;
     tracer.trace_type::<ConfirmedBlock>(&samples)?;
     tracer.trace_type::<ValidatedBlock>(&samples)?;
     tracer.trace_type::<Timeout>(&samples)?;

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -226,68 +226,66 @@ query Applications($chainId: ChainId!) {
 
 query Block($hash: CryptoHash, $chainId: ChainId!) {
   block(hash: $hash, chainId: $chainId) {
+    status
     hash
-    value {
-      status
-      block {
-        header {
-          chainId
-          epoch
-          height
-          timestamp
-          stateHash
-          previousBlockHash
+    block {
+      header {
+        chainId
+        epoch
+        height
+        timestamp
+        stateHash
+        previousBlockHash
+        authenticatedSigner
+        bundlesHash
+        operationsHash
+        messagesHash
+        previousMessageBlocksHash
+        oracleResponsesHash
+        eventsHash
+        blobsHash
+        operationResultsHash
+      }
+      body {
+        incomingBundles {
+          origin
+          bundle {
+            height
+            timestamp
+            certificateHash
+            transactionIndex
+            messages {
+              authenticatedSigner
+              grant
+              refundGrantTo
+              kind
+              index
+              message
+            }
+          }
+          action
+        }
+        operations
+        messages {
+          destination
           authenticatedSigner
-          bundlesHash
-          operationsHash
-          messagesHash
-          previousMessageBlocksHash
-          oracleResponsesHash
-          eventsHash
-          blobsHash
-          operationResultsHash
+          grant
+          refundGrantTo
+          kind
+          message
         }
-        body {
-          incomingBundles {
-            origin
-            bundle {
-              height
-              timestamp
-              certificateHash
-              transactionIndex
-              messages {
-                authenticatedSigner
-                grant
-                refundGrantTo
-                kind
-                index
-                message
-              }
-            }
-            action
+        previousMessageBlocks
+        oracleResponses
+        events {
+          streamId {
+            applicationId
+            streamName
           }
-          operations
-          messages {
-            destination
-            authenticatedSigner
-            grant
-            refundGrantTo
-            kind
-            message
-          }
-          previousMessageBlocks
-          oracleResponses
-          events {
-            streamId {
-              applicationId
-              streamName
-            }
-            index
-            value
-          }
-          blobs
-          operationResults
+          index
+          value
         }
+        blobs
+        operationResults
       }
     }
   }
@@ -295,68 +293,66 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
 
 query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
   blocks(from: $from, chainId: $chainId, limit: $limit) {
+    status
     hash
-    value {
-      status
-      block {
-        header {
-          chainId
-          epoch
-          height
-          timestamp
-          stateHash
-          previousBlockHash
+    block {
+      header {
+        chainId
+        epoch
+        height
+        timestamp
+        stateHash
+        previousBlockHash
+        authenticatedSigner
+        bundlesHash
+        operationsHash
+        messagesHash
+        previousMessageBlocksHash
+        oracleResponsesHash
+        eventsHash
+        blobsHash
+        operationResultsHash
+      }
+      body {
+        incomingBundles {
+          origin
+          bundle {
+            height
+            timestamp
+            certificateHash
+            transactionIndex
+            messages {
+              authenticatedSigner
+              grant
+              refundGrantTo
+              kind
+              index
+              message
+            }
+          }
+          action
+        }
+        operations
+        messages {
+          destination
           authenticatedSigner
-          bundlesHash
-          operationsHash
-          messagesHash
-          previousMessageBlocksHash
-          oracleResponsesHash
-          eventsHash
-          blobsHash
-          operationResultsHash
+          grant
+          refundGrantTo
+          kind
+          message
         }
-        body {
-          incomingBundles {
-            origin
-            bundle {
-              height
-              timestamp
-              certificateHash
-              transactionIndex
-              messages {
-                authenticatedSigner
-                grant
-                refundGrantTo
-                kind
-                index
-                message
-              }
-            }
-            action
+        previousMessageBlocks
+        oracleResponses
+        events {
+          streamId {
+            applicationId
+            streamName
           }
-          operations
-          messages {
-            destination
-            authenticatedSigner
-            grant
-            refundGrantTo
-            kind
-            message
-          }
-          previousMessageBlocks
-          oracleResponses
-          events {
-            streamId {
-              applicationId
-              streamName
-            }
-            index
-            value
-          }
-          blobs
-          operationResults
+          index
+          value
         }
+        blobs
+        operationResults
       }
     }
   }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -438,6 +438,7 @@ input Committee {
 type ConfirmedBlock {
 	block: Block!
 	status: String!
+	hash: CryptoHash!
 }
 
 """
@@ -551,11 +552,6 @@ type ExecutionStateView {
 A unique identifier for a user application or for the system application
 """
 scalar GenericApplicationId
-
-type HashedConfirmedBlock {
-	hash: CryptoHash!
-	value: ConfirmedBlock!
-}
 
 
 """
@@ -988,8 +984,8 @@ type QueryRoot {
 	chain(chainId: ChainId!): ChainStateExtendedView!
 	applications(chainId: ChainId!): [ApplicationOverview!]!
 	chains: Chains!
-	block(hash: CryptoHash, chainId: ChainId!): HashedConfirmedBlock
-	blocks(from: CryptoHash, chainId: ChainId!, limit: Int): [HashedConfirmedBlock!]!
+	block(hash: CryptoHash, chainId: ChainId!): ConfirmedBlock
+	blocks(from: CryptoHash, chainId: ChainId!, limit: Int): [ConfirmedBlock!]!
 	"""
 	Returns the version information on this node service.
 	"""

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -142,7 +142,7 @@ pub enum ConversionError {
 
 #[cfg(not(target_arch = "wasm32"))]
 mod from {
-    use linera_base::{data_types::Event, hashed::Hashed, identifiers::StreamId};
+    use linera_base::{data_types::Event, identifiers::StreamId};
     use linera_chain::{
         block::{Block, BlockBody, BlockHeader},
         data_types::{IncomingBundle, MessageBundle, PostedMessage},
@@ -152,9 +152,9 @@ mod from {
 
     use super::*;
 
-    impl From<block::BlockBlockValueBlockBodyIncomingBundles> for IncomingBundle {
-        fn from(val: block::BlockBlockValueBlockBodyIncomingBundles) -> Self {
-            let block::BlockBlockValueBlockBodyIncomingBundles {
+    impl From<block::BlockBlockBlockBodyIncomingBundles> for IncomingBundle {
+        fn from(val: block::BlockBlockBlockBodyIncomingBundles) -> Self {
+            let block::BlockBlockBlockBodyIncomingBundles {
                 origin,
                 bundle,
                 action,
@@ -167,9 +167,9 @@ mod from {
         }
     }
 
-    impl From<block::BlockBlockValueBlockBodyIncomingBundlesBundle> for MessageBundle {
-        fn from(val: block::BlockBlockValueBlockBodyIncomingBundlesBundle) -> Self {
-            let block::BlockBlockValueBlockBodyIncomingBundlesBundle {
+    impl From<block::BlockBlockBlockBodyIncomingBundlesBundle> for MessageBundle {
+        fn from(val: block::BlockBlockBlockBodyIncomingBundlesBundle) -> Self {
+            let block::BlockBlockBlockBodyIncomingBundlesBundle {
                 height,
                 timestamp,
                 certificate_hash,
@@ -187,9 +187,9 @@ mod from {
         }
     }
 
-    impl From<block::BlockBlockValueBlockBodyIncomingBundlesBundleMessages> for PostedMessage {
-        fn from(val: block::BlockBlockValueBlockBodyIncomingBundlesBundleMessages) -> Self {
-            let block::BlockBlockValueBlockBodyIncomingBundlesBundleMessages {
+    impl From<block::BlockBlockBlockBodyIncomingBundlesBundleMessages> for PostedMessage {
+        fn from(val: block::BlockBlockBlockBodyIncomingBundlesBundleMessages) -> Self {
+            let block::BlockBlockBlockBodyIncomingBundlesBundleMessages {
                 authenticated_signer,
                 grant,
                 refund_grant_to,
@@ -208,9 +208,9 @@ mod from {
         }
     }
 
-    impl From<block::BlockBlockValueBlockBodyMessages> for OutgoingMessage {
-        fn from(val: block::BlockBlockValueBlockBodyMessages) -> Self {
-            let block::BlockBlockValueBlockBodyMessages {
+    impl From<block::BlockBlockBlockBodyMessages> for OutgoingMessage {
+        fn from(val: block::BlockBlockBlockBodyMessages) -> Self {
+            let block::BlockBlockBlockBodyMessages {
                 destination,
                 authenticated_signer,
                 grant,
@@ -229,12 +229,12 @@ mod from {
         }
     }
 
-    impl TryFrom<block::BlockBlockValueBlock> for Block {
+    impl TryFrom<block::BlockBlockBlock> for Block {
         type Error = serde_json::Error;
 
-        fn try_from(val: block::BlockBlockValueBlock) -> Result<Self, Self::Error> {
-            let block::BlockBlockValueBlock { header, body } = val;
-            let block::BlockBlockValueBlockHeader {
+        fn try_from(val: block::BlockBlockBlock) -> Result<Self, Self::Error> {
+            let block::BlockBlockBlock { header, body } = val;
+            let block::BlockBlockBlockHeader {
                 chain_id,
                 epoch,
                 height,
@@ -251,7 +251,7 @@ mod from {
                 blobs_hash,
                 operation_results_hash,
             } = header;
-            let block::BlockBlockValueBlockBody {
+            let block::BlockBlockBlockBody {
                 incoming_bundles,
                 messages,
                 previous_message_blocks,
@@ -309,8 +309,8 @@ mod from {
         }
     }
 
-    impl From<block::BlockBlockValueBlockBodyEvents> for Event {
-        fn from(event: block::BlockBlockValueBlockBodyEvents) -> Self {
+    impl From<block::BlockBlockBlockBodyEvents> for Event {
+        fn from(event: block::BlockBlockBlockBodyEvents) -> Self {
             Event {
                 stream_id: event.stream_id.into(),
                 index: event.index as u32,
@@ -319,8 +319,8 @@ mod from {
         }
     }
 
-    impl From<block::BlockBlockValueBlockBodyEventsStreamId> for StreamId {
-        fn from(stream_id: block::BlockBlockValueBlockBodyEventsStreamId) -> Self {
+    impl From<block::BlockBlockBlockBodyEventsStreamId> for StreamId {
+        fn from(stream_id: block::BlockBlockBlockBodyEventsStreamId) -> Self {
             StreamId {
                 application_id: stream_id.application_id,
                 stream_name: stream_id.stream_name,
@@ -328,13 +328,13 @@ mod from {
         }
     }
 
-    impl TryFrom<block::BlockBlock> for Hashed<ConfirmedBlock> {
+    impl TryFrom<block::BlockBlock> for ConfirmedBlock {
         type Error = ConversionError;
 
         fn try_from(val: block::BlockBlock) -> Result<Self, Self::Error> {
-            match (val.value.status.as_str(), val.value.block) {
-                ("confirmed", block) => Ok(Hashed::new(ConfirmedBlock::new(block.try_into()?))),
-                _ => Err(ConversionError::UnexpectedCertificateType(val.value.status)),
+            match (val.status.as_str(), val.block) {
+                ("confirmed", block) => Ok(ConfirmedBlock::new(block.try_into()?)),
+                _ => Err(ConversionError::UnexpectedCertificateType(val.status)),
             }
         }
     }

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -13,7 +13,6 @@ use futures::{lock::Mutex, Future};
 use linera_base::{
     crypto::{CryptoError, CryptoHash},
     data_types::{Amount, ApplicationDescription, ApplicationPermissions, Bytecode, TimeDelta},
-    hashed::Hashed,
     identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId},
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
@@ -614,7 +613,7 @@ where
         &self,
         hash: Option<CryptoHash>,
         chain_id: ChainId,
-    ) -> Result<Option<Hashed<ConfirmedBlock>>, Error> {
+    ) -> Result<Option<ConfirmedBlock>, Error> {
         let client = self.context.lock().await.make_chain_client(chain_id)?;
         let hash = match hash {
             Some(hash) => Some(hash),
@@ -624,7 +623,7 @@ where
             }
         };
         if let Some(hash) = hash {
-            let block = client.read_hashed_confirmed_block(hash).await?;
+            let block = client.read_confirmed_block(hash).await?;
             Ok(Some(block))
         } else {
             Ok(None)
@@ -636,7 +635,7 @@ where
         from: Option<CryptoHash>,
         chain_id: ChainId,
         limit: Option<u32>,
-    ) -> Result<Vec<Hashed<ConfirmedBlock>>, Error> {
+    ) -> Result<Vec<ConfirmedBlock>, Error> {
         let client = self.context.lock().await.make_chain_client(chain_id)?;
         let limit = limit.unwrap_or(10);
         let from = match from {
@@ -647,9 +646,7 @@ where
             }
         };
         if let Some(from) = from {
-            let values = client
-                .read_hashed_confirmed_blocks_downward(from, limit)
-                .await?;
+            let values = client.read_confirmed_blocks_downward(from, limit).await?;
             Ok(values)
         } else {
             Ok(vec![])

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -335,14 +335,9 @@ where
                 let content = self.storage.read_blob(*blob_id).await?.into_content();
                 Ok(Some(RpcMessage::DownloadBlobResponse(Box::new(content))))
             }
-            DownloadConfirmedBlock(hash) => {
-                Ok(Some(RpcMessage::DownloadConfirmedBlockResponse(Box::new(
-                    self.storage
-                        .read_hashed_confirmed_block(*hash)
-                        .await?
-                        .into_inner(),
-                ))))
-            }
+            DownloadConfirmedBlock(hash) => Ok(Some(RpcMessage::DownloadConfirmedBlockResponse(
+                Box::new(self.storage.read_confirmed_block(*hash).await?),
+            ))),
             DownloadCertificates(hashes) => {
                 let certificates = self.storage.read_certificates(hashes).await?;
                 Ok(Some(RpcMessage::DownloadCertificatesResponse(certificates)))

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -3271,13 +3271,13 @@ async fn test_end_to_end_repeated_transfers(config: impl LineraNetConfig) -> Res
         let mut block2 = node_service2
             .query_node(&format!(
                 "query {{ block(hash: \"{hash2}\", chainId: \"{chain_id2}\") {{ \
-                    value {{ block {{ body {{ incomingBundles {{ \
+                    block {{ body {{ incomingBundles {{ \
                         origin bundle {{ height }} \
-                    }} }} }} }} \
+                    }} }} }} \
                 }} }}"
             ))
             .await?;
-        let mut bundle = block2["block"]["value"]["block"]["body"]["incomingBundles"][0].take();
+        let mut bundle = block2["block"]["block"]["body"]["incomingBundles"][0].take();
         let origin = serde_json::from_value::<Origin>(bundle["origin"].take())?;
         assert_eq!(origin.sender, chain_id1);
         assert_eq!(origin.medium, Medium::Direct);

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -16,7 +16,6 @@ use linera_base::{
     data_types::{
         Amount, ApplicationDescription, Blob, BlockHeight, CompressedBytecode, TimeDelta, Timestamp,
     },
-    hashed::Hashed,
     identifiers::{AccountOwner, ApplicationId, BlobId, ChainDescription, ChainId, EventId},
     ownership::ChainOwnership,
     vm::VmRuntime,
@@ -49,7 +48,7 @@ pub use crate::db_storage::{
 };
 #[cfg(with_metrics)]
 pub use crate::db_storage::{
-    READ_CERTIFICATE_COUNTER, READ_HASHED_CONFIRMED_BLOCK_COUNTER, WRITE_CERTIFICATE_COUNTER,
+    READ_CERTIFICATE_COUNTER, READ_CONFIRMED_BLOCK_COUNTER, WRITE_CERTIFICATE_COUNTER,
 };
 
 /// The default namespace to be used when none is specified
@@ -87,10 +86,7 @@ pub trait Storage: Sized {
     async fn contains_blob_state(&self, blob_id: BlobId) -> Result<bool, ViewError>;
 
     /// Reads the hashed certificate value with the given hash.
-    async fn read_hashed_confirmed_block(
-        &self,
-        hash: CryptoHash,
-    ) -> Result<Hashed<ConfirmedBlock>, ViewError>;
+    async fn read_confirmed_block(&self, hash: CryptoHash) -> Result<ConfirmedBlock, ViewError>;
 
     /// Reads the blob with the given blob ID.
     async fn read_blob(&self, blob_id: BlobId) -> Result<Blob, ViewError>;
@@ -105,11 +101,11 @@ pub trait Storage: Sized {
     async fn read_blob_states(&self, blob_ids: &[BlobId]) -> Result<Vec<BlobState>, ViewError>;
 
     /// Reads the hashed certificate values in descending order from the given hash.
-    async fn read_hashed_confirmed_blocks_downward(
+    async fn read_confirmed_blocks_downward(
         &self,
         from: CryptoHash,
         limit: u32,
-    ) -> Result<Vec<Hashed<ConfirmedBlock>>, ViewError>;
+    ) -> Result<Vec<ConfirmedBlock>, ViewError>;
 
     /// Writes the given blob.
     async fn write_blob(&self, blob: &Blob) -> Result<(), ViewError>;


### PR DESCRIPTION
## Motivation

We are not using the hash of `ConfirmedBlock` anymore, only the `Block` hash.

## Proposal

Make `ConfirmedBlock` not `BcsHashable`, remove uses of `Hashed<ConfirmedBlock>`.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
