### PR TITLE
Implement the calls from the EVM to `{EVM,Wasm}`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4718,6 +4718,8 @@ dependencies = [
  "proptest",
  "reqwest 0.11.27",
  "revm",
+ "revm-interpreter",
+ "revm-precompile",
  "revm-primitives",
  "serde",
  "serde_bytes",
@@ -6187,6 +6189,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7014,9 +7058,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "19.4.0"
+version = "19.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1538aea4d103a8044820eede9b1254e1b5a2a2abaf3f9a67bef19f8865cf1826"
+checksum = "c175ecec83bba464aa8406502fe5bf670491c2ace81a153264891d43bc7fa332"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -7029,19 +7073,21 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "15.1.0"
+version = "15.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f632e761f171fb2f6ace8d1552a5793e0350578d4acec3e79ade1489f4c2a6"
+checksum = "7dcab7ef2064057acfc84731205f4bc77f4ec1b35630800b26ff6a185731c5ab"
 dependencies = [
+ "paste",
+ "phf",
  "revm-primitives",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "16.0.0"
+version = "16.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6542fb37650dfdbf4b9186769e49c4a8bc1901a3280b2ebf32f915b6c8850f36"
+checksum = "99743c3a2cac341084cc15ac74286c4bf34a0941ebf60aa420cfdb9f81f72f9f"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -7058,9 +7104,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "15.1.0"
+version = "15.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48faea1ecf2c9f80d9b043bbde0db9da616431faed84c4cfa3dd7393005598e6"
+checksum = "f0f987564210317706def498421dfba2ae1af64a8edce82c6102758b48133fcb"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -7944,6 +7990,12 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,10 +143,10 @@ rcgen = "0.12.1"
 reqwest = { version = "0.11.24", default-features = false, features = [
     "rustls-tls",
 ] }
-revm = "19.4.0"
-revm-interpreter = { version = "15.1.0", features = ["serde"] }
-revm-precompile = "16.0.0"
-revm-primitives = "15.1.0"
+revm = "19.7.0"
+revm-interpreter = { version = "15.2.0", features = ["serde"] }
+revm-precompile = "16.2.0"
+revm-primitives = "15.2.0"
 rocksdb = "0.21.0"
 ruzstd = "0.7.1"
 scylla = "0.15.1"

--- a/linera-base/src/crypto/hash.rs
+++ b/linera-base/src/crypto/hash.rs
@@ -58,11 +58,6 @@ impl CryptoHash {
 
         CryptoHash::new(&TestString::new(s))
     }
-
-    /// Build a raw CryptoHash
-    pub fn build_from_b256(v: B256) -> Self {
-        Self(v)
-    }
 }
 
 /// Temporary struct to extend `Keccak256` with `io::Write`.

--- a/linera-base/src/crypto/hash.rs
+++ b/linera-base/src/crypto/hash.rs
@@ -58,6 +58,11 @@ impl CryptoHash {
 
         CryptoHash::new(&TestString::new(s))
     }
+
+    /// Build a raw CryptoHash
+    pub fn build_from_b256(v: B256) -> Self {
+        Self(v)
+    }
 }
 
 /// Temporary struct to extend `Keccak256` with `io::Write`.

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -10,6 +10,7 @@ use std::{
     str::FromStr,
 };
 
+use alloy_primitives::{Address, B256};
 use anyhow::{anyhow, Context};
 use async_graphql::SimpleObject;
 use custom_debug_derive::Debug;
@@ -944,6 +945,18 @@ impl<A> ApplicationId<A> {
             application_description_hash: self.application_description_hash,
             _phantom: PhantomData,
         }
+    }
+
+    /// Convert the `ApplicationId` into an Ethereum Address.
+    pub fn evm_address(&self) -> Address {
+        let bytes = self.application_description_hash.as_bytes();
+        let bytes = bytes.0.as_ref();
+        Address::from_slice(&bytes[0..20])
+    }
+
+    /// Convert the `ApplicationId` into an Ethereum Address.
+    pub fn bytes32(&self) -> B256 {
+        *self.application_description_hash.as_bytes()
     }
 }
 

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -16,6 +16,8 @@ test = ["tokio/macros", "linera-base/test", "linera-views/test", "proptest"]
 revm = [
     "dep:revm",
     "dep:revm-primitives",
+    "dep:revm-precompile",
+    "dep:revm-interpreter",
     "dep:alloy",
     "dep:alloy-sol-types",
     "dep:hex",
@@ -55,6 +57,8 @@ prometheus = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["blocking", "json", "stream"] }
 revm = { workspace = true, optional = true, features = ["serde"] }
+revm-interpreter = { workspace = true, optional = true, features = ["serde"] }
+revm-precompile = { workspace = true, optional = true }
 revm-primitives = { workspace = true, optional = true }
 serde.workspace = true
 serde_bytes.workspace = true

--- a/linera-execution/src/revm.rs
+++ b/linera-execution/src/revm.rs
@@ -282,6 +282,8 @@ pub enum KeyCategory {
     Storage,
 }
 
+// This is the precompile address that contains the LINERA specific
+// functionalities accessed from the EVM.
 fn precompile_address() -> Address {
     address!("000000000000000000000000000000000000000b")
 }

--- a/linera-execution/src/revm.rs
+++ b/linera-execution/src/revm.rs
@@ -401,7 +401,6 @@ impl<Runtime: ContractRuntime> CallInterceptorContract<Runtime> {
         inputs: &mut CallInputs,
     ) -> Result<Option<CallOutcome>, ExecutionError> {
         let contract_address = Address::ZERO.create(0);
-
         if inputs.target_address != precompile_address()
             && inputs.target_address != contract_address
         {
@@ -411,7 +410,6 @@ impl<Runtime: ContractRuntime> CallInterceptorContract<Runtime> {
             argument.extend(&vec);
             let authenticated = true;
             let result = {
-                let argument = bcs::to_bytes(&argument)?;
                 let mut runtime = self.db.runtime.lock().expect("The lock should be possible");
                 runtime.try_call_application(authenticated, target, argument)?
             };

--- a/linera-execution/src/test_utils/solidity.rs
+++ b/linera-execution/src/test_utils/solidity.rs
@@ -111,6 +111,183 @@ contract ExampleCounter {
     get_bytecode(&source_code, "ExampleCounter")
 }
 
+
+
+
+
+pub fn get_evm_call_wasm_example_counter() -> anyhow::Result<Vec<u8>> {
+    let source_code = r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ExampleCallWasmCounter {
+  bytes32 universal_address;
+  constructor(bytes32 _universal_address) {
+    universal_address = _universal_address;
+  }
+
+
+  struct CounterOperation {
+    uint8 choice;
+    // choice=0 corresponds to Increment
+    uint64 increment;
+  }
+  function bcs_serialize_CounterOperation(CounterOperation memory input) internal pure returns (bytes memory) {
+    bytes memory result = abi.encodePacked(input.choice);
+    if (input.choice == 0) {
+      return abi.encodePacked(result, bcs_serialize_uint64(input.increment));
+    }
+    return result;
+  }
+
+
+  struct CounterRequest {
+    uint8 choice;
+    // choice=0 corresponds to Query
+    // choice=1 corresponds to Increment
+    uint64 increment;
+  }
+
+
+
+
+  function bcs_serialize_uint64(uint64 input) internal pure returns (bytes memory) {
+    bytes memory result = new bytes(8);
+    uint64 value = input;
+    result[0] = bytes1(uint8(value));
+    for (uint i=1; i<8; i++) {
+      value = value >> 8;
+      result[i] = bytes1(uint8(value));
+    }
+    return result;
+  }
+  function bcs_deserialize_offset_uint64(uint256 pos, bytes memory input) internal pure returns (uint256, uint64) {
+    require(pos + 7 < input.length, "Position out of bound");
+    uint64 value = uint8(input[pos + 7]);
+    for (uint256 i=0; i<7; i++) {
+      value = value << 8;
+      value += uint8(input[pos + 6 - i]);
+    }
+    return (pos + 8, value);
+  }
+
+  function bcs_deserialize_offset_uint8(uint256 pos, bytes memory input) internal pure returns (uint256, uint8) {
+    require(pos < input.length, "Position out of bound");
+    uint8 value = uint8(input[pos]);
+    return (pos + 1, value);
+  }
+
+
+
+  function bcs_deserialize_uint64(bytes memory input) public pure returns (uint64) {
+    uint256 new_pos;
+    uint64 value;
+    (new_pos, value) = bcs_deserialize_offset_uint64(0, input);
+    require(new_pos == input.length, "incomplete deserialization");
+    return value;
+  }
+
+  function serde_json_serialize_uint64(uint64 input) public pure returns (bytes memory) {
+    if (input < 10) {
+      bytes memory data = abi.encodePacked(uint8(48 + input));
+      return data;
+    }
+    if (input < 100) {
+      uint64 val1 = input % 10;
+      uint64 val2 = (input - val1) / 10;
+      bytes memory data = abi.encodePacked(uint8(48 + val2), uint8(48 + val1));
+      return data;
+    }
+    require(false);
+  }
+
+
+  function serde_json_serialize_CounterRequest(CounterRequest memory input) public pure returns (bytes memory) {
+    if (input.choice == 0) {
+      bytes memory data = abi.encodePacked(uint8(34), uint8(81), uint8(117), uint8(101), uint8(114), uint8(121), uint8(34));
+      return data;
+    }
+    bytes memory blk1 = abi.encodePacked(uint8(123), uint8(34), uint8(73), uint8(110), uint8(99), uint8(114), uint8(101), uint8(109), uint8(101), uint8(110), uint8(116), uint8(34), uint8(58));
+    bytes memory blk2 = serde_json_serialize_uint64(input.increment);
+    bytes memory blk3 = abi.encodePacked(uint8(125));
+    return abi.encodePacked(blk1, blk2, blk3);
+  }
+
+  function serde_json_deserialize_u64(bytes memory input) public pure returns (uint64) {
+    uint64 value = 0;
+    uint256 len = input.length;
+    uint64 pow = 1;
+    for (uint256 idx=0; idx<len; idx++) {
+      uint256 jdx = len - 1 - idx;
+      uint8 val_idx = uint8(input[jdx]) - 48;
+      value = value + uint64(val_idx) * pow;
+      pow = pow * 10;
+    }
+    return value;
+  }
+
+
+  function nest_increment(uint64 input1) external returns (uint64) {
+    address precompile = address(0x0b);
+    CounterOperation memory input2 = CounterOperation({choice: 0, increment: input1});
+    bytes memory input3 = bcs_serialize_CounterOperation(input2);
+    bytes memory input4 = abi.encodePacked(universal_address, input3);
+    (bool success, bytes memory return1) = precompile.call(input4);
+    require(success);
+    uint64 return2 = bcs_deserialize_uint64(return1);
+    return return2;
+  }
+
+  function nest_get_value() external returns (uint64) {
+    address precompile = address(0x0b);
+    CounterRequest memory input2 = CounterRequest({choice:0, increment: 0});
+    bytes memory input3 = serde_json_serialize_CounterRequest(input2);
+    bytes memory input4 = abi.encodePacked(universal_address, input3);
+    (bool success, bytes memory return1) = precompile.call(input4);
+    require(success);
+    uint64 return2 = serde_json_deserialize_u64(return1);
+    return return2;
+  }
+
+}
+"#
+    .to_string();
+    get_bytecode(&source_code, "ExampleCallWasmCounter")
+}
+
+
+
+
+pub fn get_evm_call_evm_example_counter() -> anyhow::Result<Vec<u8>> {
+    let source_code = r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IExternalContract {
+  function increment(uint64 value) external returns (uint64);
+  function get_value() external returns (uint64);
+}
+
+
+contract ExampleCallEvmCounter {
+  address evm_address;
+  constructor(address _evm_address) {
+    evm_address = _evm_address;
+  }
+  function nest_increment(uint64 input) external returns (uint64) {
+    IExternalContract externalContract = IExternalContract(evm_address);
+    return externalContract.increment(input);
+  }
+  function nest_get_value() external returns (uint64) {
+    IExternalContract externalContract = IExternalContract(evm_address);
+    return externalContract.get_value();
+  }
+}
+"#
+    .to_string();
+    get_bytecode(&source_code, "ExampleCallEvmCounter")
+}
+
 pub fn get_contract_service_paths(module: Vec<u8>) -> anyhow::Result<(PathBuf, PathBuf, TempDir)> {
     let dir = tempfile::tempdir()?;
     let path = dir.path();

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -508,6 +508,226 @@ async fn test_wasm_call_evm_end_to_end_counter(config: impl LineraNetConfig) -> 
     Ok(())
 }
 
+
+
+#[cfg(with_revm)]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
+#[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_evm_call_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()> {
+    use alloy_sol_types::{sol, SolCall, SolValue};
+    use linera_base::vm::EvmQuery;
+    use linera_execution::test_utils::solidity::{
+        get_contract_service_paths, get_evm_call_evm_example_counter, get_evm_example_counter, read_evm_u64_entry,
+    };
+    use linera_sdk::abis::evm::EvmAbi;
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let (mut net, client) = config.instantiate().await?;
+    let chain = client.load_wallet()?.default_chain().unwrap();
+    let original_counter_value = 35;
+    let increment = 5;
+
+    // Creating the EVM contract
+
+    let module = get_evm_example_counter()?;
+    let (contract, service, _dir) = get_contract_service_paths(module)?;
+
+    let evm_instantiation_argument = {
+        sol! {
+            struct ConstructorArgs {
+                uint64 initial_value;
+            }
+        }
+
+        let evm_instantiation_argument = ConstructorArgs {
+            initial_value: original_counter_value,
+        };
+        evm_instantiation_argument.abi_encode()
+    };
+
+    type InstantiationArgument = Vec<u8>;
+
+    let evm_application_id = client
+        .publish_and_create::<EvmAbi, (), InstantiationArgument>(
+            contract,
+            service,
+            VmRuntime::Evm,
+            &(),
+            &evm_instantiation_argument,
+            &[],
+            None,
+        )
+        .await?;
+
+    // Creating the nesting contract
+
+    sol! {
+        struct ConstructorArgs {
+            address evm_contract;
+        }
+        function nest_increment(uint64 input);
+        function nest_get_value();
+    }
+
+    let evm_contract = evm_application_id.evm_address();
+    let nest_instantiation_argument = ConstructorArgs { evm_contract };
+    let nest_instantiation_argument = nest_instantiation_argument.abi_encode();
+
+    let module = get_evm_call_evm_example_counter()?;
+    let (nest_contract, nest_service, _dir) = get_contract_service_paths(module)?;
+
+    type NestInstantiationArgument = Vec<u8>;
+    let nest_application_id = client
+        .publish_and_create::<EvmAbi, (), NestInstantiationArgument>(
+            nest_contract,
+            nest_service,
+            VmRuntime::Evm,
+            &(),
+            &nest_instantiation_argument,
+            &[],
+            None,
+        )
+        .await?;
+
+    let port = get_node_port().await;
+    let mut node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
+
+    let nest_application = node_service
+        .make_application(&chain, &nest_application_id)
+        .await?;
+
+    let query = nest_get_valueCall {};
+    let query = query.abi_encode();
+    let query = EvmQuery::Query(query);
+    let result = nest_application.run_json_query(query.clone()).await?;
+    let counter_value = read_evm_u64_entry(result);
+    assert_eq!(counter_value, original_counter_value);
+
+    let mutation = nest_incrementCall { input: increment };
+    let mutation = mutation.abi_encode();
+    let mutation = EvmQuery::Mutation(mutation);
+    nest_application.run_json_query(mutation).await?;
+
+    let result = nest_application.run_json_query(query).await?;
+    let counter_value = read_evm_u64_entry(result);
+    assert_eq!(counter_value, original_counter_value + increment);
+
+    node_service.ensure_is_running()?;
+
+    net.ensure_is_running().await?;
+    net.terminate().await?;
+
+    Ok(())
+}
+
+#[cfg(with_revm)]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
+#[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_evm_call_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()> {
+    use alloy_sol_types::{sol, SolCall, SolValue};
+    use counter_no_graphql::CounterNoGraphQlAbi;
+    use linera_base::vm::EvmQuery;
+    use linera_execution::test_utils::solidity::{
+        get_contract_service_paths, get_evm_call_wasm_example_counter, read_evm_u64_entry,
+    };
+    use linera_sdk::abis::evm::EvmAbi;
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let (mut net, client) = config.instantiate().await?;
+    let chain = client.load_wallet()?.default_chain().unwrap();
+
+    // Creating the WASM smart contract
+
+    let original_counter_value = 35;
+    let increment = 5;
+    let (contract, service) = client.build_example("counter-no-graphql").await?;
+    let wasm_application_id = client
+        .publish_and_create::<CounterNoGraphQlAbi, (), u64>(
+            contract,
+            service,
+            VmRuntime::Wasm,
+            &(),
+            &original_counter_value,
+            &[],
+            None,
+        )
+        .await?;
+
+    // Creating the EVM smart contract
+
+    sol! {
+        struct ConstructorArgs {
+            bytes32 wasm_contract;
+        }
+        function nest_increment(uint64 input);
+        function nest_get_value();
+    }
+
+    let wasm_contract = wasm_application_id.bytes32();
+    let nest_instantiation_argument = ConstructorArgs { wasm_contract };
+    let nest_instantiation_argument = nest_instantiation_argument.abi_encode();
+
+    let module = get_evm_call_wasm_example_counter()?;
+    let (nest_contract, nest_service, _dir) = get_contract_service_paths(module)?;
+
+    type NestInstantiationArgument = Vec<u8>;
+    let nest_application_id = client
+        .publish_and_create::<EvmAbi, (), NestInstantiationArgument>(
+            nest_contract,
+            nest_service,
+            VmRuntime::Evm,
+            &(),
+            &nest_instantiation_argument,
+            &[],
+            None,
+        )
+        .await?;
+
+    let port = get_node_port().await;
+    let mut node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
+
+    let nest_application = node_service
+        .make_application(&chain, &nest_application_id)
+        .await?;
+
+    let query = nest_get_valueCall {};
+    let query = query.abi_encode();
+    let query = EvmQuery::Query(query);
+    let result = nest_application.run_json_query(query.clone()).await?;
+
+    let counter_value = read_evm_u64_entry(result);
+    assert_eq!(counter_value, original_counter_value);
+
+    let mutation = nest_incrementCall { input: increment };
+    let mutation = mutation.abi_encode();
+    let mutation = EvmQuery::Mutation(mutation);
+    nest_application.run_json_query(mutation).await?;
+
+    let result = nest_application.run_json_query(query).await?;
+    let counter_value = read_evm_u64_entry(result);
+    assert_eq!(counter_value, original_counter_value + increment);
+
+    node_service.ensure_is_running()?;
+
+    net.ensure_is_running().await?;
+    net.terminate().await?;
+
+    Ok(())
+}
+
+
+
+
 #[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(all(feature = "rocksdb", feature = "scylladb"), test_case(LocalNetConfig::new_test(Database::DualRocksDbScyllaDb, Network::Grpc) ; "dualrocksdbscylladb_grpc"))]


### PR DESCRIPTION
## Motivation

We have the EVM application, but not the function calls from the EVM to EVM/Wasm.

## Proposal

We have two cases to cover and the implementation is distinct for both cases.

Call to EVM:
* The EVM itself has cross-application calls and it has a well established system for doing application calls.
* We want to reproduce that system and the canonical technique in REVM is to use a Call interceptor that implements the inspector trait. We need a Contract version and a Service version.
* That call is thus bypassed and send to a `try_call_application/try_query_application`.
* However, for the inspector trait, we need more than just the output, we need the full `InterpreterResult`. This forces adding a specific selector named `INTERPRETER_RESULT_SELECTOR`. This hack has the same cryptographic assumption as the use of selectors by the EVM.
* Depending on the case, we return differently.
* The EVM addresses are converted to ApplicationId by adding 12 values 0.

Call to Wasm:
* Calling the Wasm is done by using the precompile. This address returns the `bytes` output, which is then processed.
* Of course we need precompile for contract and for service. They call `try_call_application/try_query_application`.
* The calls are done directly with the serialization/deserialization being done in the solidity code.
* The implementation is straightforward.

Next steps:
* Implement the fuel consumption.
* Implement the transfer.
* Implement further LINERA APIs in the EVM. Implement the code by using solidity code.

## Test Plan

The testing framework is done in parallel to the test in `test_wasm_call_evm_end_to_end_counter` with the same values and the same APIs.

For the `test_evm_call_evm_end_to_end_counter` this is rather straightforward in term of contract code and it would be the same if one write something in ethereum.

For the `test_evm_call_wasm_end_to_end_counter` this is far more problematic:
* The serialization for `execute_operation` is done with BCS. We wrote the code as generated by `serde-reflection`. 
* The serialization for `query_operation` is done with `serde_json`. So far, there is no code for generating this code in `serde-reflection`.

## Release Plan

This should be significant for next TestNet.

## Links

None.