### PR TITLE
Allow the node service to select arbitrary ports

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -584,8 +584,6 @@ Run a GraphQL service to explore and extend the chains of the wallet
   Default value: `0`
 * `--port <PORT>` — The port on which to run the server
 
-  Default value: `8080`
-
 
 
 ## `linera faucet`

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -890,8 +890,8 @@ pub enum ClientCommand {
         config: ChainListenerConfig,
 
         /// The port on which to run the server
-        #[arg(long, default_value = "8080")]
-        port: NonZeroU16,
+        #[arg(long)]
+        port: Option<NonZeroU16>,
     },
 
     /// Run a GraphQL service that exposes a faucet where users can claim tokens.

--- a/linera-indexer/example/tests/test.rs
+++ b/linera-indexer/example/tests/test.rs
@@ -142,7 +142,7 @@ async fn test_end_to_end_operations_indexer(config: impl LineraNetConfig) {
     .await
     .unwrap()
     .block
-    .unwrap_or_else(|| panic!("no block found"));
+    .expect("no block found");
     let last_hash = last_block.clone().hash;
 
     let indexer_state = request::<State, _>(&req_client, "http://localhost:8081", state::Variables)

--- a/linera-indexer/example/tests/test.rs
+++ b/linera-indexer/example/tests/test.rs
@@ -39,7 +39,7 @@ fn reqwest_client() -> reqwest::Client {
         .unwrap()
 }
 
-async fn run_indexer(path_provider: &PathProvider) -> Child {
+async fn run_indexer(path_provider: &PathProvider, service_port: u16) -> Child {
     let port = 8081;
     let path = resolve_binary("linera-indexer", "linera-indexer-example")
         .await
@@ -48,7 +48,7 @@ async fn run_indexer(path_provider: &PathProvider) -> Child {
     command
         .current_dir(path_provider.path())
         .kill_on_drop(true)
-        .args(["run"]);
+        .args(["run", "--service-port", &service_port.to_string()]);
     let child = command.spawn().unwrap();
     let client = reqwest_client();
     for i in 0..10 {
@@ -73,7 +73,7 @@ fn indexer_running(child: &mut Child) {
     }
 }
 
-async fn transfer(client: &reqwest::Client, from: ChainId, to: Account, amount: &str) {
+async fn transfer(client: &reqwest::Client, port: u16, from: ChainId, to: Account, amount: &str) {
     let variables = transfer::Variables {
         chain_id: from,
         owner: AccountOwner::CHAIN,
@@ -81,7 +81,7 @@ async fn transfer(client: &reqwest::Client, from: ChainId, to: Account, amount: 
         recipient_account: to.owner,
         amount: Amount::from_str(amount).unwrap(),
     };
-    request::<Transfer, _>(client, "http://localhost:8080", variables)
+    request::<Transfer, _>(client, &format!("http://localhost:{port}"), variables)
         .await
         .unwrap();
 }
@@ -105,7 +105,8 @@ async fn test_end_to_end_operations_indexer(config: impl LineraNetConfig) {
         .run_node_service(None, ProcessInbox::Automatic)
         .await
         .unwrap();
-    let mut indexer = run_indexer(&client.path_provider).await;
+    let node_service_port = node_service.port();
+    let mut indexer = run_indexer(&client.path_provider, node_service_port).await;
 
     // check operations plugin
     let req_client = reqwest_client();
@@ -123,7 +124,7 @@ async fn test_end_to_end_operations_indexer(config: impl LineraNetConfig) {
     let chain0 = ChainId::root(0);
     let chain1 = Account::chain(ChainId::root(1));
     for _ in 0..10 {
-        transfer(&req_client, chain0, chain1, "0.1").await;
+        transfer(&req_client, node_service_port, chain0, chain1, "0.1").await;
         linera_base::time::timer::sleep(Duration::from_millis(TRANSFER_DELAY_MILLIS)).await;
     }
     linera_base::time::timer::sleep(Duration::from_secs(2)).await;
@@ -133,11 +134,15 @@ async fn test_end_to_end_operations_indexer(config: impl LineraNetConfig) {
         hash: None,
         chain_id: chain0,
     };
-    let last_block = request::<Block, _>(&req_client, "http://localhost:8080", variables)
-        .await
-        .unwrap()
-        .block
-        .unwrap_or_else(|| panic!("no block found"));
+    let last_block = request::<Block, _>(
+        &req_client,
+        &format!("http://localhost:{node_service_port}"),
+        variables,
+    )
+    .await
+    .unwrap()
+    .block
+    .unwrap_or_else(|| panic!("no block found"));
     let last_hash = last_block.clone().hash;
 
     let indexer_state = request::<State, _>(&req_client, "http://localhost:8081", state::Variables)

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -445,7 +445,6 @@ impl ClientWrapper {
         port: impl Into<Option<u16>>,
         process_inbox: ProcessInbox,
     ) -> Result<NodeService> {
-        let port = port.into().unwrap_or(8080);
         let mut command = self.command().await?;
         command.arg("service");
         if let ProcessInbox::Skip = process_inbox {
@@ -454,10 +453,10 @@ impl ClientWrapper {
         if let Ok(var) = env::var(CLIENT_SERVICE_ENV) {
             command.args(var.split_whitespace());
         }
-        let mut child = command
-            .args(["--port".to_string(), port.to_string()])
-            .stdout(Stdio::piped())
-            .spawn_into()?;
+        if let Some(requested_port) = port.into() {
+            command.args(["--port".to_string(), requested_port.to_string()]);
+        }
+        let mut child = command.stdout(Stdio::piped()).spawn_into()?;
         let port = Self::parse_node_service_port(
             child
                 .stdout

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1348,7 +1348,10 @@ fn log_file_name_for(command: &ClientCommand) -> Cow<'static, str> {
         ClientCommand::Project { .. } => "project".into(),
         ClientCommand::Watch { .. } => "watch".into(),
         ClientCommand::Storage { .. } => "storage".into(),
-        ClientCommand::Service { port, .. } => format!("service-{port}").into(),
+        ClientCommand::Service {
+            port: Some(port), ..
+        } => format!("service-{port}").into(),
+        ClientCommand::Service { port: None, .. } => "service".into(),
         ClientCommand::Faucet { .. } => "faucet".into(),
         ClientCommand::HelpMarkdown | ClientCommand::ExtractScriptFromMarkdown { .. } => {
             "tool".into()

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -766,7 +766,7 @@ where
     C: ClientContext,
 {
     config: ChainListenerConfig,
-    port: NonZeroU16,
+    port: Option<NonZeroU16>,
     default_chain: Option<ChainId>,
     storage: C::Storage,
     context: Arc<Mutex<C>>,
@@ -794,7 +794,7 @@ where
     /// Creates a new instance of the node service given a client chain and a port.
     pub async fn new(
         config: ChainListenerConfig,
-        port: NonZeroU16,
+        port: Option<NonZeroU16>,
         default_chain: Option<ChainId>,
         storage: C::Storage,
         context: C,
@@ -831,7 +831,7 @@ where
     /// Runs the node service.
     #[instrument(name = "node_service", level = "info", skip(self), fields(port = ?self.port))]
     pub async fn run(self) -> Result<(), anyhow::Error> {
-        let requested_port = self.port.get();
+        let requested_port = self.port.map(NonZeroU16::get).unwrap_or_default();
         let listener =
             tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], requested_port)))
                 .await?;

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -838,7 +838,8 @@ where
         let port = NonZeroU16::try_from(listener.local_addr()?.port())
             .expect("Sockets should never bind to port zero");
 
-        info!("GraphiQL IDE: http://localhost:{}", port);
+        info!("Starting GraphQL service");
+        println!("http://localhost:{port}");
 
         let schema = self.schema(port);
         let index_handler = axum::routing::get(util::graphiql).post({

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -216,15 +216,9 @@ async fn main() -> std::io::Result<()> {
     let context = DummyContext::<DummyValidatorNodeProvider, _> {
         _phantom: std::marker::PhantomData,
     };
-    let service = NodeService::new(
-        config,
-        std::num::NonZeroU16::new(8080).unwrap(),
-        None,
-        storage,
-        context,
-    )
-    .await;
-    let schema = service.schema().sdl();
+    let port = std::num::NonZeroU16::new(8080).unwrap();
+    let service = NodeService::new(config, port, None, storage, context).await;
+    let schema = service.schema(port).sdl();
     print!("{}", schema);
     Ok(())
 }

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -217,7 +217,7 @@ async fn main() -> std::io::Result<()> {
         _phantom: std::marker::PhantomData,
     };
     let port = std::num::NonZeroU16::new(8080).unwrap();
-    let service = NodeService::new(config, port, None, storage, context).await;
+    let service = NodeService::new(config, Some(port), None, storage, context).await;
     let schema = service.schema(port).sdl();
     print!("{}", schema);
     Ok(())


### PR DESCRIPTION
## Motivation

Tests currently rely on a port finder to find an available port for the node service to listen on. However, this prevents the integration tests to run in parallel because the tests race to find available ports.

## Proposal

Change the node service to support using port `0` when binding, allowing the operating system to assign an arbitrary available port. The tests must then read the node service's output until it finds the port number.

## Test Plan

Manually ran the integration tests, and then ran them in parallel.

## Release Plan

- These changes follow the usual release cycle, because this changes the `linera service` CLI command in a non-backwards compatible way. Now not specifying the port forces the node service to listen on an arbitrary port, not the fallback `8080` port.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
