### PR TITLE
allow controlling proxy timeouts from the environment

### DIFF
--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -47,11 +47,17 @@ pub struct ProxyOptions {
     config_path: PathBuf,
 
     /// Timeout for sending queries (ms)
-    #[arg(long = "send-timeout-ms", default_value = "4000", value_parser = util::parse_millis)]
+    #[arg(long = "send-timeout-ms",
+          default_value = "4000",
+          value_parser = util::parse_millis,
+          env = "LINERA_PROXY_SEND_TIMEOUT")]
     send_timeout: Duration,
 
     /// Timeout for receiving responses (ms)
-    #[arg(long = "recv-timeout-ms", default_value = "4000", value_parser = util::parse_millis)]
+    #[arg(long = "recv-timeout-ms",
+          default_value = "4000",
+          value_parser = util::parse_millis,
+          env = "LINERA_PROXY_RECV_TIMEOUT")]
     recv_timeout: Duration,
 
     /// The number of Tokio worker threads to use.


### PR DESCRIPTION
## Motivation

Useful for debugging and testing certain applications with `linera net up`

## Proposal

Just use environment variables.

## Test Plan

CI
```
cargo build --bins
export LINERA_PROXY_RECV_TIMEOUT=0
target/debug/linera extract-script-from-markdown README.md | bash -e -x   # <-- fails with timeouts
```

## Release Plan

These changes should be backported to the latest `testnet` branch