### PR TITLE
Create trait `RunnableWithStore` to simplify the database tool

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
       run: |
         cargo build --features storage-service
         mkdir /tmp/local-linera-net
-        cargo run --features storage-service --bin linera -- net up --storage service:tcp:localhost:1235:table --policy-config testnet --path /tmp/local-linera-net --validators 4 --shards 4 &
+        cargo run --features storage-service --bin linera -- net up --storage service:tcp:$LINERA_STORAGE_SERVICE:table --policy-config testnet --path /tmp/local-linera-net --validators 4 --shards 4 &
     - name: Create two epochs and run the faucet
       run: |
         cargo build --bin linera

--- a/CLI.md
+++ b/CLI.md
@@ -51,14 +51,14 @@ This document contains the help content for the `linera` command-line program.
 * [`linera net up`↴](#linera-net-up)
 * [`linera net helper`↴](#linera-net-helper)
 * [`linera storage`↴](#linera-storage)
-* [`linera storage delete_all`↴](#linera-storage-delete_all)
-* [`linera storage delete_namespace`↴](#linera-storage-delete_namespace)
-* [`linera storage check_existence`↴](#linera-storage-check_existence)
-* [`linera storage check_absence`↴](#linera-storage-check_absence)
+* [`linera storage delete-all`↴](#linera-storage-delete-all)
+* [`linera storage delete-namespace`↴](#linera-storage-delete-namespace)
+* [`linera storage check-existence`↴](#linera-storage-check-existence)
+* [`linera storage check-absence`↴](#linera-storage-check-absence)
 * [`linera storage initialize`↴](#linera-storage-initialize)
-* [`linera storage list_namespaces`↴](#linera-storage-list_namespaces)
-* [`linera storage list_blob_ids`↴](#linera-storage-list_blob_ids)
-* [`linera storage list_chain_ids`↴](#linera-storage-list_chain_ids)
+* [`linera storage list-namespaces`↴](#linera-storage-list-namespaces)
+* [`linera storage list-blob-ids`↴](#linera-storage-list-blob-ids)
+* [`linera storage list-chain-ids`↴](#linera-storage-list-chain-ids)
 
 ## `linera`
 
@@ -1015,62 +1015,46 @@ Operation on the storage
 
 ###### **Subcommands:**
 
-* `delete_all` — Delete all the namespaces in the database
-* `delete_namespace` — Delete a single namespace from the database
-* `check_existence` — Check existence of a namespace in the database
-* `check_absence` — Check absence of a namespace in the database
+* `delete-all` — Delete all the namespaces in the database
+* `delete-namespace` — Delete a single namespace from the database
+* `check-existence` — Check existence of a namespace in the database
+* `check-absence` — Check absence of a namespace in the database
 * `initialize` — Initialize a namespace in the database
-* `list_namespaces` — List the namespaces in the database
-* `list_blob_ids` — List the blob IDs in the database
-* `list_chain_ids` — List the chain IDs in the database
+* `list-namespaces` — List the namespaces in the database
+* `list-blob-ids` — List the blob IDs in the database
+* `list-chain-ids` — List the chain IDs in the database
 
 
 
-## `linera storage delete_all`
+## `linera storage delete-all`
 
 Delete all the namespaces in the database
 
-**Usage:** `linera storage delete_all --storage <STORAGE_CONFIG>`
-
-###### **Options:**
-
-* `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
+**Usage:** `linera storage delete-all`
 
 
 
-## `linera storage delete_namespace`
+## `linera storage delete-namespace`
 
 Delete a single namespace from the database
 
-**Usage:** `linera storage delete_namespace --storage <STORAGE_CONFIG>`
-
-###### **Options:**
-
-* `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
+**Usage:** `linera storage delete-namespace`
 
 
 
-## `linera storage check_existence`
+## `linera storage check-existence`
 
 Check existence of a namespace in the database
 
-**Usage:** `linera storage check_existence --storage <STORAGE_CONFIG>`
-
-###### **Options:**
-
-* `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
+**Usage:** `linera storage check-existence`
 
 
 
-## `linera storage check_absence`
+## `linera storage check-absence`
 
 Check absence of a namespace in the database
 
-**Usage:** `linera storage check_absence --storage <STORAGE_CONFIG>`
-
-###### **Options:**
-
-* `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
+**Usage:** `linera storage check-absence`
 
 
 
@@ -1078,47 +1062,35 @@ Check absence of a namespace in the database
 
 Initialize a namespace in the database
 
-**Usage:** `linera storage initialize --storage <STORAGE_CONFIG>`
+**Usage:** `linera storage initialize <GENESIS_CONFIG_PATH>`
 
-###### **Options:**
+###### **Arguments:**
 
-* `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
+* `<GENESIS_CONFIG_PATH>`
 
 
 
-## `linera storage list_namespaces`
+## `linera storage list-namespaces`
 
 List the namespaces in the database
 
-**Usage:** `linera storage list_namespaces --storage <STORAGE_CONFIG>`
-
-###### **Options:**
-
-* `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
+**Usage:** `linera storage list-namespaces`
 
 
 
-## `linera storage list_blob_ids`
+## `linera storage list-blob-ids`
 
 List the blob IDs in the database
 
-**Usage:** `linera storage list_blob_ids --storage <STORAGE_CONFIG>`
-
-###### **Options:**
-
-* `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
+**Usage:** `linera storage list-blob-ids`
 
 
 
-## `linera storage list_chain_ids`
+## `linera storage list-chain-ids`
 
 List the chain IDs in the database
 
-**Usage:** `linera storage list_chain_ids --storage <STORAGE_CONFIG>`
-
-###### **Options:**
-
-* `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
+**Usage:** `linera storage list-chain-ids`
 
 
 

--- a/CLI.md
+++ b/CLI.md
@@ -1051,11 +1051,11 @@ Check existence of a namespace in the database
 
 Initialize a namespace in the database
 
-**Usage:** `linera storage initialize <GENESIS_CONFIG_PATH>`
+**Usage:** `linera storage initialize --genesis <GENESIS_CONFIG_PATH>`
 
-###### **Arguments:**
+###### **Options:**
 
-* `<GENESIS_CONFIG_PATH>`
+* `--genesis <GENESIS_CONFIG_PATH>`
 
 
 

--- a/CLI.md
+++ b/CLI.md
@@ -982,7 +982,6 @@ Start a Local Linera Network
   Default value: `10`
 * `--testing-prng-seed <TESTING_PRNG_SEED>` — Force this wallet to generate keys using a PRNG and a given seed. USE FOR TESTING ONLY
 * `--path <PATH>` — Run with a specific path where the wallet and validator input files are. If none, then a temporary directory is created
-* `--storage <STORAGE>` — Run with a specific storage. If none, then a linera-storage-service is started on a random free port
 * `--external-protocol <EXTERNAL_PROTOCOL>` — External protocol used, either `grpc` or `grpcs`
 
   Default value: `grpc`

--- a/CLI.md
+++ b/CLI.md
@@ -54,7 +54,6 @@ This document contains the help content for the `linera` command-line program.
 * [`linera storage delete-all`↴](#linera-storage-delete-all)
 * [`linera storage delete-namespace`↴](#linera-storage-delete-namespace)
 * [`linera storage check-existence`↴](#linera-storage-check-existence)
-* [`linera storage check-absence`↴](#linera-storage-check-absence)
 * [`linera storage initialize`↴](#linera-storage-initialize)
 * [`linera storage list-namespaces`↴](#linera-storage-list-namespaces)
 * [`linera storage list-blob-ids`↴](#linera-storage-list-blob-ids)
@@ -1017,7 +1016,6 @@ Operation on the storage
 * `delete-all` — Delete all the namespaces in the database
 * `delete-namespace` — Delete a single namespace from the database
 * `check-existence` — Check existence of a namespace in the database
-* `check-absence` — Check absence of a namespace in the database
 * `initialize` — Initialize a namespace in the database
 * `list-namespaces` — List the namespaces in the database
 * `list-blob-ids` — List the blob IDs in the database
@@ -1046,14 +1044,6 @@ Delete a single namespace from the database
 Check existence of a namespace in the database
 
 **Usage:** `linera storage check-existence`
-
-
-
-## `linera storage check-absence`
-
-Check absence of a namespace in the database
-
-**Usage:** `linera storage check-absence`
 
 
 

--- a/docker/compose-server-init.sh
+++ b/docker/compose-server-init.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 while true; do
-  ./linera storage check_existence --storage "scylladb:tcp:scylla:9042"
+  ./linera storage check-existence --storage "scylladb:tcp:scylla:9042"
   status=$?
 
   if [ $status -eq 0 ]; then

--- a/docker/proxy-init.sh
+++ b/docker/proxy-init.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 while true; do
-  ./linera storage check_existence --storage "scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042"
+  ./linera storage check-existence --storage "scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042"
   status=$?
 
   if [ "$status" -eq 0 ]; then

--- a/docker/server-init.sh
+++ b/docker/server-init.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 while true; do
-  ./linera storage check_existence --storage "scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042"
+  ./linera storage check-existence --storage "scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042"
   status=$?
 
   if [ $status -eq 0 ]; then

--- a/linera-service/src/linera/command.rs
+++ b/linera-service/src/linera/command.rs
@@ -842,7 +842,10 @@ pub enum DatabaseToolCommand {
     CheckExistence,
 
     /// Initialize a namespace in the database
-    Initialize { genesis_config_path: PathBuf },
+    Initialize {
+        #[arg(long = "genesis")]
+        genesis_config_path: PathBuf,
+    },
 
     /// List the namespaces in the database
     ListNamespaces,

--- a/linera-service/src/linera/command.rs
+++ b/linera-service/src/linera/command.rs
@@ -841,9 +841,6 @@ pub enum DatabaseToolCommand {
     /// Check existence of a namespace in the database
     CheckExistence,
 
-    /// Check absence of a namespace in the database
-    CheckAbsence,
-
     /// Initialize a namespace in the database
     Initialize { genesis_config_path: PathBuf },
 

--- a/linera-service/src/linera/command.rs
+++ b/linera-service/src/linera/command.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{num::NonZeroU16, path::PathBuf};
+use std::{borrow::Cow, num::NonZeroU16, path::PathBuf};
 
 use chrono::{DateTime, Utc};
 use linera_base::{
@@ -783,6 +783,53 @@ pub enum ClientCommand {
     },
 }
 
+impl ClientCommand {
+    /// Returns the log file name to use based on the [`ClientCommand`] that will run.
+    pub fn log_file_name(&self) -> Cow<'static, str> {
+        match self {
+            ClientCommand::Transfer { .. }
+            | ClientCommand::OpenChain { .. }
+            | ClientCommand::OpenMultiOwnerChain { .. }
+            | ClientCommand::ChangeOwnership { .. }
+            | ClientCommand::ChangeApplicationPermissions { .. }
+            | ClientCommand::CloseChain { .. }
+            | ClientCommand::LocalBalance { .. }
+            | ClientCommand::QueryBalance { .. }
+            | ClientCommand::SyncBalance { .. }
+            | ClientCommand::Sync { .. }
+            | ClientCommand::ProcessInbox { .. }
+            | ClientCommand::QueryValidator { .. }
+            | ClientCommand::QueryValidators { .. }
+            | ClientCommand::SyncValidator { .. }
+            | ClientCommand::SetValidator { .. }
+            | ClientCommand::RemoveValidator { .. }
+            | ClientCommand::ResourceControlPolicy { .. }
+            | ClientCommand::FinalizeCommittee
+            | ClientCommand::CreateGenesisConfig { .. }
+            | ClientCommand::PublishModule { .. }
+            | ClientCommand::PublishDataBlob { .. }
+            | ClientCommand::ReadDataBlob { .. }
+            | ClientCommand::CreateApplication { .. }
+            | ClientCommand::PublishAndCreate { .. }
+            | ClientCommand::Keygen
+            | ClientCommand::Assign { .. }
+            | ClientCommand::Wallet { .. }
+            | ClientCommand::RetryPendingBlock { .. } => "client".into(),
+            #[cfg(feature = "benchmark")]
+            ClientCommand::Benchmark { .. } => "benchmark".into(),
+            ClientCommand::Net { .. } => "net".into(),
+            ClientCommand::Project { .. } => "project".into(),
+            ClientCommand::Watch { .. } => "watch".into(),
+            ClientCommand::Storage { .. } => "storage".into(),
+            ClientCommand::Service { port, .. } => format!("service-{port}").into(),
+            ClientCommand::Faucet { .. } => "faucet".into(),
+            ClientCommand::HelpMarkdown | ClientCommand::ExtractScriptFromMarkdown { .. } => {
+                "tool".into()
+            }
+        }
+    }
+}
+
 #[derive(Clone, clap::Parser)]
 pub enum DatabaseToolCommand {
     /// Delete all the namespaces in the database
@@ -875,11 +922,6 @@ pub enum NetCommand {
         /// If none, then a temporary directory is created.
         #[arg(long)]
         path: Option<String>,
-
-        /// Run with a specific storage.
-        /// If none, then a linera-storage-service is started on a random free port.
-        #[arg(long)]
-        storage: Option<String>,
 
         /// External protocol used, either `grpc` or `grpcs`.
         #[arg(long, default_value = "grpc")]

--- a/linera-service/src/linera/command.rs
+++ b/linera-service/src/linera/command.rs
@@ -19,9 +19,8 @@ use linera_client::{
     util,
 };
 use linera_rpc::config::CrossChainConfig;
-use linera_service::{
-    storage::StorageConfigNamespace,
-    util::{DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS, DEFAULT_PAUSE_AFTER_LINERA_SERVICE_SECS},
+use linera_service::util::{
+    DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS, DEFAULT_PAUSE_AFTER_LINERA_SERVICE_SECS,
 };
 
 #[derive(Clone, clap::Subcommand)]
@@ -787,84 +786,28 @@ pub enum ClientCommand {
 #[derive(Clone, clap::Parser)]
 pub enum DatabaseToolCommand {
     /// Delete all the namespaces in the database
-    #[command(name = "delete_all")]
-    DeleteAll {
-        /// Storage configuration for the blockchain history.
-        #[arg(long = "storage")]
-        storage_config: String,
-    },
+    DeleteAll,
 
     /// Delete a single namespace from the database
-    #[command(name = "delete_namespace")]
-    DeleteNamespace {
-        /// Storage configuration for the blockchain history.
-        #[arg(long = "storage")]
-        storage_config: String,
-    },
+    DeleteNamespace,
 
     /// Check existence of a namespace in the database
-    #[command(name = "check_existence")]
-    CheckExistence {
-        /// Storage configuration for the blockchain history.
-        #[arg(long = "storage")]
-        storage_config: String,
-    },
+    CheckExistence,
 
     /// Check absence of a namespace in the database
-    #[command(name = "check_absence")]
-    CheckAbsence {
-        /// Storage configuration for the blockchain history.
-        #[arg(long = "storage")]
-        storage_config: String,
-    },
+    CheckAbsence,
 
     /// Initialize a namespace in the database
-    #[command(name = "initialize")]
-    Initialize {
-        /// Storage configuration for the blockchain history.
-        #[arg(long = "storage")]
-        storage_config: String,
-    },
+    Initialize { genesis_config_path: PathBuf },
 
     /// List the namespaces in the database
-    #[command(name = "list_namespaces")]
-    ListNamespaces {
-        /// Storage configuration for the blockchain history.
-        #[arg(long = "storage")]
-        storage_config: String,
-    },
+    ListNamespaces,
 
     /// List the blob IDs in the database
-    #[command(name = "list_blob_ids")]
-    ListBlobIds {
-        /// Storage configuration for the blockchain history.
-        #[arg(long = "storage")]
-        storage_config: String,
-    },
+    ListBlobIds,
 
     /// List the chain IDs in the database
-    #[command(name = "list_chain_ids")]
-    ListChainIds {
-        /// Storage configuration for the blockchain history.
-        #[arg(long = "storage")]
-        storage_config: String,
-    },
-}
-
-impl DatabaseToolCommand {
-    pub fn storage_config(&self) -> Result<StorageConfigNamespace, anyhow::Error> {
-        let storage_config = match self {
-            DatabaseToolCommand::DeleteAll { storage_config } => storage_config,
-            DatabaseToolCommand::DeleteNamespace { storage_config } => storage_config,
-            DatabaseToolCommand::CheckExistence { storage_config } => storage_config,
-            DatabaseToolCommand::CheckAbsence { storage_config } => storage_config,
-            DatabaseToolCommand::Initialize { storage_config } => storage_config,
-            DatabaseToolCommand::ListNamespaces { storage_config } => storage_config,
-            DatabaseToolCommand::ListBlobIds { storage_config } => storage_config,
-            DatabaseToolCommand::ListChainIds { storage_config } => storage_config,
-        };
-        storage_config.parse::<StorageConfigNamespace>()
-    }
+    ListChainIds,
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -23,7 +23,7 @@ use linera_sdk::linera_base_types::Blob;
 #[cfg(with_metrics)]
 use linera_service::prometheus_server;
 use linera_service::{
-    storage::{run_with_storage, Runnable, StorageConfigNamespace},
+    storage::{Runnable, StorageConfigNamespace},
     util,
 };
 use linera_storage::Storage;
@@ -401,15 +401,11 @@ impl ProxyOptions {
             max_stream_queries: self.max_stream_queries,
             storage_cache_config,
         };
-        let full_storage_config = self.storage_config.add_common_config(common_config).await?;
         let genesis_config: GenesisConfig = util::read_json(&self.genesis_config_path)?;
-        run_with_storage(
-            full_storage_config,
-            &genesis_config,
-            None,
-            ProxyContext::from_options(self)?,
-        )
-        .boxed()
-        .await?
+        let store_config = self.storage_config.add_common_config(common_config).await?;
+        store_config
+            .run_with_storage(&genesis_config, None, ProxyContext::from_options(self)?)
+            .boxed()
+            .await?
     }
 }

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -209,9 +209,10 @@ async fn main() -> std::io::Result<()> {
 
     let store_config = MemoryStoreConfig::new(TEST_MEMORY_MAX_STREAM_QUERIES);
     let namespace = "schema_export";
-    let storage = DbStorage::<MemoryStore, _>::initialize(store_config, namespace, None)
-        .await
-        .expect("storage");
+    let storage =
+        DbStorage::<MemoryStore, _>::maybe_create_and_connect(&store_config, namespace, None)
+            .await
+            .expect("storage");
     let config = ChainListenerConfig::default();
     let context = DummyContext::<DummyValidatorNodeProvider, _> {
         _phantom: std::marker::PhantomData,

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -35,7 +35,7 @@ use linera_sdk::linera_base_types::{AccountSecretKey, ValidatorKeypair};
 #[cfg(with_metrics)]
 use linera_service::prometheus_server;
 use linera_service::{
-    storage::{full_initialize_storage, run_with_storage, Runnable, StorageConfigNamespace},
+    storage::{Runnable, StorageConfigNamespace},
     util,
 };
 use linera_storage::Storage;
@@ -552,11 +552,12 @@ async fn run(options: ServerOptions) {
                 max_stream_queries,
                 storage_cache_config,
             };
-            let full_storage_config = storage_config
+            let store_config = storage_config
                 .add_common_config(common_config)
                 .await
                 .unwrap();
-            run_with_storage(full_storage_config, &genesis_config, wasm_runtime, job)
+            store_config
+                .run_with_storage(&genesis_config, wasm_runtime, job)
                 .boxed()
                 .await
                 .unwrap()
@@ -625,7 +626,7 @@ async fn run(options: ServerOptions) {
                 max_stream_queries,
                 storage_cache_config,
             };
-            let full_storage_config = storage_config
+            let store_config = storage_config
                 .add_common_config(common_config)
                 .await
                 .unwrap();
@@ -636,9 +637,7 @@ async fn run(options: ServerOptions) {
             tracing::info!(
                 "server::ServerCommand::Initialize, call full_initialize_storage, step 1"
             );
-            full_initialize_storage(full_storage_config, &genesis_config)
-                .await
-                .unwrap();
+            store_config.initialize(&genesis_config).await.unwrap();
         }
 
         ServerCommand::EditShards {

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -43,9 +43,7 @@ use linera_views::{
 
 #[cfg(with_testing)]
 pub use crate::db_storage::TestClock;
-pub use crate::db_storage::{
-    list_all_blob_ids, list_all_chain_ids, ChainStatesFirstAssignment, DbStorage, WallClock,
-};
+pub use crate::db_storage::{ChainStatesFirstAssignment, DbStorage, WallClock};
 #[cfg(with_metrics)]
 pub use crate::db_storage::{
     READ_CERTIFICATE_COUNTER, READ_CONFIRMED_BLOCK_COUNTER, WRITE_CERTIFICATE_COUNTER,


### PR DESCRIPTION
## Motivation

Minimize boilerplate + clean up names

follows #3724

## Proposal
 
* (light) refactor how `--config` is handled, notably making it a global option
* create a trait `RunnableWithStore` so that the database command can be written in a single match.
* `linera storage initialize` now takes a genesis config (similar to `linera-server initialize` which could be killed next)
* a few minor code improvements

## Test Plan

CI
