### PR TITLE
Remove event subscription functions from contract runtime.

### DIFF
--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -296,26 +296,6 @@ where
         bcs::from_bytes(&event).expect("Failed to deserialize event")
     }
 
-    /// Subscribes this application to an event stream.
-    pub fn subscribe_to_events(
-        &mut self,
-        chain_id: ChainId,
-        application_id: ApplicationId,
-        name: StreamName,
-    ) {
-        contract_wit::subscribe_to_events(chain_id.into(), application_id.into(), &name.into())
-    }
-
-    /// Unsubscribes this application from an event stream.
-    pub fn unsubscribe_from_events(
-        &mut self,
-        chain_id: ChainId,
-        application_id: ApplicationId,
-        name: StreamName,
-    ) {
-        contract_wit::unsubscribe_from_events(chain_id.into(), application_id.into(), &name.into())
-    }
-
     /// Queries an application service as an oracle and returns the response.
     ///
     /// Should only be used with queries where it is very likely that all validators will compute

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -840,26 +840,6 @@ where
         bcs::from_bytes(value).expect("Failed to deserialize event value")
     }
 
-    /// Subscribes this application to an event stream.
-    pub fn subscribe_to_events(
-        &mut self,
-        _chain_id: ChainId,
-        _application_id: ApplicationId,
-        _name: StreamName,
-    ) {
-        // This is a no-op in the mock runtime.
-    }
-
-    /// Unsubscribes this application from an event stream.
-    pub fn unsubscribe_from_events(
-        &mut self,
-        _chain_id: ChainId,
-        _application_id: ApplicationId,
-        _name: StreamName,
-    ) {
-        // This is a no-op in the mock runtime.
-    }
-
     /// Adds an expected `query_service` call`, and the response it should return in the test.
     pub fn add_expected_service_query<A: ServiceAbi + Send>(
         &mut self,


### PR DESCRIPTION
## Motivation

In https://github.com/linera-io/linera-protocol/pull/3692 I added basic user events, but subscriptions are not implemented yet. However, I optimistically added the contract runtime functions for subscriptions in that PR, too, so they are now user-visible but don't work yet.

## Proposal

Remove them from the contract runtime, so that if we release a new SDK, they don't show up yet.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Reverts a few lines of https://github.com/linera-io/linera-protocol/pull/3692.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
