### PR TITLE
Refactor the chain listener

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -8,16 +8,16 @@ use std::{
 };
 
 use async_trait::async_trait;
-use futures::{channel::mpsc, lock::Mutex, SinkExt as _, StreamExt};
+use futures::{channel::mpsc, lock::Mutex, FutureExt as _, SinkExt as _, Stream, StreamExt};
 use linera_base::{
-    crypto::{AccountSecretKey, CryptoHash},
+    crypto::AccountSecretKey,
     data_types::Timestamp,
     identifiers::{ChainId, Destination},
 };
 use linera_core::{
     client::{ChainClient, ChainClientError},
     node::ValidatorNodeProvider,
-    worker::Reason,
+    worker::{Notification, Reason},
 };
 use linera_execution::{Message, OutgoingMessage, SystemMessage};
 use linera_storage::{Clock as _, Storage};
@@ -85,12 +85,11 @@ pub trait ClientContext: 'static {
 
 /// A `ChainListener` is a process that listens to notifications from validators and reacts
 /// appropriately.
-#[derive(Debug)]
 pub struct ChainListener<C: ClientContext> {
     context: Arc<Mutex<C>>,
     storage: C::Storage,
     config: Arc<ChainListenerConfig>,
-    listening: Arc<Mutex<HashSet<ChainId>>>,
+    listening: Arc<std::sync::Mutex<HashSet<ChainId>>>,
 }
 
 impl<C: ClientContext> Clone for ChainListener<C> {
@@ -102,6 +101,13 @@ impl<C: ClientContext> Clone for ChainListener<C> {
             listening: self.listening.clone(),
         }
     }
+}
+
+/// A `ChainListener` together with a specific client.
+pub struct ChainClientListener<C: ClientContext> {
+    client: ContextChainClient<C>,
+    listener: ChainListener<C>,
+    timeout: Timestamp,
 }
 
 impl<C: ClientContext> ChainListener<C> {
@@ -128,8 +134,15 @@ impl<C: ClientContext> ChainListener<C> {
         }
     }
 
+    /// Spawns a task running the listener for the given chain, if it is not already running.
     #[instrument(level = "trace", skip_all, fields(?chain_id))]
     fn run_with_chain_id(&self, chain_id: ChainId) {
+        if !self.listening.lock().unwrap().insert(chain_id) {
+            // If we are already listening to notifications, there's nothing to do.
+            // This can happen if we download a child before the parent
+            // chain, and then process the OpenChain message in the parent.
+            return;
+        }
         let listener = self.clone();
         let _handle = linera_base::task::spawn(
             async move {
@@ -142,22 +155,13 @@ impl<C: ClientContext> ChainListener<C> {
     }
 
     #[instrument(level = "trace", skip_all, fields(?chain_id))]
-    async fn run_client_stream(&self, chain_id: ChainId) -> Result<(), Error> {
-        if !self.listening.lock().await.insert(chain_id) {
-            // If we are already listening to notifications, there's nothing to do.
-            // This can happen if we download a child before the parent
-            // chain, and then process the OpenChain message in the parent.
-            return Ok(());
-        }
-        // If the client is not present, we can request it.
+    async fn run_client_stream(self, chain_id: ChainId) -> Result<(), Error> {
         let client = self.context.lock().await.make_chain_client(chain_id)?;
-        let (listener, _listen_handle, local_stream) = client.listen().await?;
-        let mut local_stream = local_stream.fuse();
-        let (event_tx, mut event_rx) = mpsc::channel(1);
-        let mut admin_event_tx = event_tx.clone();
-        let mut admin_stream = client.subscribe_to(client.admin_id()).await?;
+        let (event_tx, event_rx) = mpsc::channel(1);
         if client.admin_id() != chain_id {
-            linera_base::task::spawn(async move {
+            let mut admin_event_tx = event_tx.clone();
+            let mut admin_stream = client.subscribe_to(client.admin_id()).await?;
+            let _handle = linera_base::task::spawn(async move {
                 while let Some(notification) = admin_stream.next().await {
                     if let Reason::NewBlock { .. } = notification.reason {
                         if admin_event_tx.send(()).await.is_err() {
@@ -167,61 +171,84 @@ impl<C: ClientContext> ChainListener<C> {
                 }
             });
         }
+        let (listener, _listen_handle, local_stream) = client.listen().await?;
         client.synchronize_from_validators().await?;
-        drop(linera_base::task::spawn(listener.in_current_span()));
-        let mut timeout = self.maybe_process_inbox(&client).await?;
+        let _handle = linera_base::task::spawn(listener.in_current_span());
+        let client_listener = ChainClientListener::new(client, self);
+        client_listener.run(local_stream, event_rx).await
+    }
+}
+
+impl<C: ClientContext> ChainClientListener<C> {
+    /// Creates a new chain client listener.
+    fn new(client: ContextChainClient<C>, listener: ChainListener<C>) -> Self {
+        Self {
+            client,
+            listener,
+            timeout: Timestamp::from(u64::MAX),
+        }
+    }
+
+    /// Listens to notifications from the local stream and to new events, and processes them.
+    async fn run(
+        mut self,
+        local_stream: impl Stream<Item = Notification> + Unpin,
+        mut event_rx: mpsc::Receiver<()>,
+    ) -> Result<(), Error> {
+        let mut local_stream = local_stream.fuse();
+        self.maybe_process_inbox().await?;
+        let storage = self.listener.storage.clone();
         loop {
-            let mut sleep = Box::pin(futures::FutureExt::fuse(
-                self.storage.clock().sleep_until(timeout),
-            ));
+            let mut sleep = Box::pin(storage.clock().sleep_until(self.timeout).fuse());
             futures::select! {
-                () = sleep => {
-                    timeout = self.maybe_process_inbox(&client).await?;
-                }
-                maybe_event_msg = event_rx.next() => {
-                    if maybe_event_msg == Some(()) {
-                        // A new block on a publisher chain may have created a new event.
-                        timeout = self.maybe_process_inbox(&client).await?;
-                    } else {
-                        break;
-                    }
-                }
                 maybe_notification = local_stream.next() => {
                     let Some(notification) = maybe_notification else {
                         break;
                     };
-                    info!("Received new notification: {:?}", notification);
-                    Self::maybe_sleep(self.config.delay_before_ms).await;
-                    match &notification.reason {
-                        Reason::NewIncomingBundle { .. } => {
-                            timeout = self.maybe_process_inbox(&client).await?;
-                        }
-                        Reason::NewBlock { .. } | Reason::NewRound { .. } => {
-                            if let Err(error) = client.update_validators(None).await {
-                                warn!(
-                                    "Failed to update validators about the local chain after \
-                                     receiving {notification:?} with error: {error:?}"
-                                );
-                            }
-                        }
-                    }
-                    Self::maybe_sleep(self.config.delay_after_ms).await;
-                    if let Reason::NewBlock { hash, .. } = notification.reason {
-                        self.process_new_block(&client, hash).await?;
-                    };
+                    self.process_notification(notification).await?;
                 }
+                maybe_event_msg = event_rx.next() => {
+                    let Some(()) = maybe_event_msg else {
+                        break;
+                    };
+                    // A new block on a publisher chain may have created a new event.
+                    self.maybe_process_inbox().await?;
+                }
+                () = sleep => self.maybe_process_inbox().await?,
             }
         }
         Ok(())
     }
 
-    async fn process_new_block(
-        &self,
-        client: &ContextChainClient<C>,
-        hash: CryptoHash,
-    ) -> Result<(), Error> {
-        self.context.lock().await.update_wallet(client).await?;
-        let value = self.storage.read_confirmed_block(hash).await?;
+    /// Processes a notification from the local stream.
+    /// * If there are incoming messages, the inbox is processed.
+    /// * If there are new blocks or a new round, the validators are updated.
+    /// * If a new block opened a chain that we own, starts listening to it.
+    async fn process_notification(&mut self, notification: Notification) -> Result<(), Error> {
+        info!("Received new notification: {:?}", notification);
+        Self::sleep(self.listener.config.delay_before_ms).await;
+        match &notification.reason {
+            Reason::NewIncomingBundle { .. } => self.maybe_process_inbox().await?,
+            Reason::NewBlock { .. } | Reason::NewRound { .. } => {
+                if let Err(error) = self.client.update_validators(None).await {
+                    warn!(
+                        "Failed to update validators about the local chain after \
+                         receiving {notification:?} with error: {error:?}"
+                    );
+                }
+            }
+        }
+        Self::sleep(self.listener.config.delay_after_ms).await;
+        let Reason::NewBlock { hash, .. } = notification.reason else {
+            return Ok(());
+        };
+        self.listener
+            .context
+            .lock()
+            .await
+            .update_wallet(&self.client)
+            .await?;
+        let value = self.listener.storage.read_confirmed_block(hash).await?;
         let block = value.block();
         let new_chains = block
             .messages()
@@ -234,13 +261,8 @@ impl<C: ClientContext> ChainListener<C> {
                     ..
                 } = outgoing_message
                 {
-                    let owners = open_chain_config
-                        .ownership
-                        .all_owners()
-                        .cloned()
-                        .collect::<Vec<_>>();
-                    let timestamp = block.header.timestamp;
-                    Some((new_id, owners, timestamp))
+                    let owners = open_chain_config.ownership.all_owners().cloned();
+                    Some((new_id, owners.collect::<Vec<_>>()))
                 } else {
                     None
                 }
@@ -249,8 +271,9 @@ impl<C: ClientContext> ChainListener<C> {
         if new_chains.is_empty() {
             return Ok(());
         }
-        let mut context_guard = self.context.lock().await;
-        for (new_id, owners, timestamp) in new_chains {
+        let mut context_guard = self.listener.context.lock().await;
+        let timestamp = block.header.timestamp;
+        for (new_id, owners) in new_chains {
             let key_pair = owners
                 .iter()
                 .find_map(|owner| context_guard.wallet().key_pair_for_owner(owner));
@@ -258,16 +281,10 @@ impl<C: ClientContext> ChainListener<C> {
                 context_guard
                     .update_wallet_for_new_chain(*new_id, key_pair, timestamp)
                     .await?;
-                self.run_with_chain_id(*new_id);
+                self.listener.run_with_chain_id(*new_id);
             }
         }
         Ok(())
-    }
-
-    async fn maybe_sleep(delay_ms: u64) {
-        if delay_ms > 0 {
-            linera_base::time::timer::sleep(Duration::from_millis(delay_ms)).await;
-        }
     }
 
     /// Processes the inbox, unless `skip_process_inbox` is set.
@@ -277,32 +294,35 @@ impl<C: ClientContext> ChainListener<C> {
     ///
     /// The wallet is persisted with any blocks that processing the inbox added. An error
     /// is returned if persisting the wallet fails.
-    async fn maybe_process_inbox(
-        &self,
-        client: &ChainClient<C::ValidatorNodeProvider, C::Storage>,
-    ) -> Result<Timestamp, Error> {
-        let mut timeout = Timestamp::from(u64::MAX);
-        if self.config.skip_process_inbox {
+    async fn maybe_process_inbox(&mut self) -> Result<(), Error> {
+        self.timeout = Timestamp::from(u64::MAX);
+        if self.listener.config.skip_process_inbox {
             debug!("Not processing inbox due to listener configuration");
-            return Ok(timeout);
+            return Ok(());
         }
         debug!("Processing inbox");
-        match client.process_inbox_without_prepare().await {
+        match self.client.process_inbox_without_prepare().await {
             Err(ChainClientError::CannotFindKeyForChain(_)) => {}
             Err(error) => warn!(%error, "Failed to process inbox."),
-            Ok((certs, None)) => {
-                info!("Done processing inbox. {} blocks created.", certs.len());
-            }
+            Ok((certs, None)) => info!("Done processing inbox. {} blocks created.", certs.len()),
             Ok((certs, Some(new_timeout))) => {
                 info!(
                     "{} blocks created. Will try processing the inbox later based \
                      on the given round timeout: {new_timeout:?}",
                     certs.len(),
                 );
-                timeout = new_timeout.timestamp;
+                self.timeout = new_timeout.timestamp;
             }
         }
-        self.context.lock().await.update_wallet(client).await?;
-        Ok(timeout)
+        let mut context_guard = self.listener.context.lock().await;
+        context_guard.update_wallet(&self.client).await?;
+        Ok(())
+    }
+
+    /// Sleeps for the given number of milliseconds, if greater than 0.
+    async fn sleep(delay_ms: u64) {
+        if delay_ms > 0 {
+            linera_base::time::timer::sleep(Duration::from_millis(delay_ms)).await;
+        }
     }
 }

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -142,8 +142,8 @@ async fn test_chain_listener() -> anyhow::Result<()> {
         .update_wallet_for_new_chain(chain_id0, Some(key_pair), clock.current_time())
         .await?;
     let context = Arc::new(Mutex::new(context));
-    let listener = ChainListener::new(config);
-    listener.run(context, storage).await;
+    let listener = ChainListener::new(config, context, storage);
+    listener.run().await;
 
     // Transfer ownership of chain 0 to the chain listener and some other key. The listener will
     // be leader in ~10% of the rounds.

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -284,13 +284,9 @@ where
 
         info!("GraphiQL IDE: http://localhost:{}", port);
 
-        ChainListener::new(
-            self.config.clone(),
-            Arc::clone(&self.context),
-            self.storage.clone(),
-        )
-        .run()
-        .await;
+        let context = Arc::clone(&self.context);
+        let listener = ChainListener::new(self.config.clone(), context, self.storage.clone());
+        listener.run().await;
 
         axum::serve(
             tokio::net::TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], port))).await?,

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -284,9 +284,13 @@ where
 
         info!("GraphiQL IDE: http://localhost:{}", port);
 
-        ChainListener::new(self.config.clone())
-            .run(Arc::clone(&self.context), self.storage.clone())
-            .await;
+        ChainListener::new(
+            self.config.clone(),
+            Arc::clone(&self.context),
+            self.storage.clone(),
+        )
+        .run()
+        .await;
 
         axum::serve(
             tokio::net::TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], port))).await?,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -858,8 +858,8 @@ where
             // TODO(#551): Provide application authentication.
             .layer(CorsLayer::permissive());
 
-        ChainListener::new(self.config)
-            .run(Arc::clone(&self.context), self.storage.clone())
+        ChainListener::new(self.config, Arc::clone(&self.context), self.storage.clone())
+            .run()
             .await;
 
         axum::serve(listener, app).await?;


### PR DESCRIPTION
## Motivation

The chain listener is currently one big complex loop. It is about to get more complicated when we add event stream subscriptions.

## Proposal

Split the loop into smaller methods. Move some of the local variables as fields into `ChainListener`. Introduce a `ChainClientListener` that tracks the local variables that are specific to a single chain.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
