### PR TITLE
Merge `stream_trackers` into `event_subscriptions` map.

### DIFF
--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -459,12 +459,12 @@ where
                 subscriber_app_id,
                 callback,
             } => {
-                let subscribers = self
+                let subscriptions = self
                     .system
                     .event_subscriptions
                     .get_mut_or_default(&(chain_id, stream_id))
                     .await?;
-                subscribers.insert(subscriber_app_id);
+                subscriptions.applications.insert(subscriber_app_id);
                 callback.respond(());
             }
 
@@ -475,15 +475,14 @@ where
                 callback,
             } => {
                 let key = (chain_id, stream_id);
-                let subscribers = self
+                let subscriptions = self
                     .system
                     .event_subscriptions
                     .get_mut_or_default(&key)
                     .await?;
-                subscribers.remove(&subscriber_app_id);
-                if subscribers.is_empty() {
+                subscriptions.applications.remove(&subscriber_app_id);
+                if subscriptions.applications.is_empty() {
                     self.system.event_subscriptions.remove(&key)?;
-                    self.system.stream_trackers.remove(&key)?;
                 }
                 callback.respond(());
             }


### PR DESCRIPTION
## Motivation

`event_subscriptions` and `stream_trackers` always have exactly the same keys.

## Proposal

Merge them into a single map. The value is a new struct that contains both the event count and the subscribers.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
