### PR TITLE
Create key space for block exporters

### DIFF
--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -275,6 +275,7 @@ enum BaseKey {
     Blob(BlobId),
     BlobState(BlobId),
     Event(EventId),
+    BlockExporterState(u32),
 }
 
 const INDEX_CHAIN_ID: u8 = 0;
@@ -903,6 +904,15 @@ where
     ) -> Result<Self, Store::Error> {
         let store = Store::connect(&config, namespace).await?;
         Ok(Self::create(store, wasm_runtime, WallClock))
+    }
+
+    pub async fn block_exporter_context(
+        &self,
+        block_exporter_id: u32,
+    ) -> Result<ViewContext<u32, Store>, ViewError> {
+        let root_key = bcs::to_bytes(&BaseKey::BlockExporterState(block_exporter_id))?;
+        let store = self.store.clone_with_root_key(&root_key)?;
+        Ok(ViewContext::create_root_context(store, block_exporter_id).await?)
     }
 }
 


### PR DESCRIPTION
## Motivation

Help with #3665

## Proposal

* Create a key prefix for block exporters (each identified by a `u32`)
* Create a method `block_exporter_context` in `linera_storage::DbStorage`

## Test Plan

CI