### PR TITLE
Fix minor `resolve_binary` feature flag issues.

### DIFF
--- a/linera-indexer/example/Cargo.toml
+++ b/linera-indexer/example/Cargo.toml
@@ -34,7 +34,7 @@ tracing-subscriber = { workspace = true, features = ["fmt"] }
 [dev-dependencies]
 anyhow.workspace = true
 async-graphql.workspace = true
-linera-base.workspace = true
+linera-base = { workspace = true, features = ["test"] }
 linera-indexer-graphql-client.workspace = true
 linera-service = { workspace = true, features = ["rocksdb", "test"] }
 linera-service-graphql-client.workspace = true

--- a/linera-indexer/graphql-client/Cargo.toml
+++ b/linera-indexer/graphql-client/Cargo.toml
@@ -21,6 +21,7 @@ serde_json.workspace = true
 linera-execution.workspace = true
 
 [dev-dependencies]
+linera-base = { workspace = true, features = ["test"] }
 linera-service.workspace = true
 tempfile.workspace = true
 test-log = { workspace = true, features = ["trace"] }

--- a/linera-service-graphql-client/Cargo.toml
+++ b/linera-service-graphql-client/Cargo.toml
@@ -32,6 +32,7 @@ linera-core.workspace = true
 linera-execution.workspace = true
 
 [dev-dependencies]
+linera-base = { workspace = true, features = ["test"] }
 fungible.workspace = true
 linera-service = { workspace = true, features = ["test"] }
 tempfile.workspace = true

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -26,7 +26,6 @@ use futures::{
 };
 use guard::INTEGRATION_TEST_GUARD;
 use linera_base::{
-    command::resolve_binary,
     crypto::CryptoHash,
     data_types::Amount,
     identifiers::{Account, AccountOwner, ApplicationId, ChainId},
@@ -2475,17 +2474,6 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
     Ok(())
 }
 
-#[test_log::test(tokio::test)]
-async fn test_resolve_binary() -> Result<()> {
-    resolve_binary("linera", env!("CARGO_PKG_NAME")).await?;
-    resolve_binary("linera-proxy", env!("CARGO_PKG_NAME")).await?;
-    assert!(resolve_binary("linera-spaceship", env!("CARGO_PKG_NAME"))
-        .await
-        .is_err());
-
-    Ok(())
-}
-
 #[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
@@ -3015,7 +3003,8 @@ async fn test_end_to_end_fungible_client_benchmark(config: impl LineraNetConfig)
     let mut faucet_service = client1.run_faucet(None, chain1, Amount::ONE).await?;
     let faucet = faucet_service.instance();
 
-    let path = resolve_binary("linera-benchmark", env!("CARGO_PKG_NAME")).await?;
+    let path =
+        linera_base::command::resolve_binary("linera-benchmark", env!("CARGO_PKG_NAME")).await?;
     // The benchmark looks for examples/fungible, so it needs to run in the project root.
     let current_dir = std::env::current_exe()?;
     let dir = current_dir.ancestors().nth(4).unwrap();

--- a/linera-service/tests/local.rs
+++ b/linera-service/tests/local.rs
@@ -4,6 +4,7 @@
 use std::{path::PathBuf, process::Command};
 
 use anyhow::Result;
+use linera_base::command::resolve_binary;
 use linera_service::cli_wrappers::{local_net::PathProvider, ClientWrapper, Network, OnClientDrop};
 
 mod common;
@@ -59,6 +60,17 @@ async fn test_project_test() -> Result<()> {
     client
         .project_test(&ClientWrapper::example_path("counter")?)
         .await?;
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_resolve_binary() -> Result<()> {
+    resolve_binary("linera", env!("CARGO_PKG_NAME")).await?;
+    resolve_binary("linera-proxy", env!("CARGO_PKG_NAME")).await?;
+    assert!(resolve_binary("linera-spaceship", env!("CARGO_PKG_NAME"))
+        .await
+        .is_err());
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

`resolve_binary` doesn't strip the `dep` directory if it isn't built `with_testing`. This causes some tests to fail if they are run locally in isolation. (In CI, since they are being run together with the other tests, they _do_ use `linera-base/test`, so this doesn't cause issues.)

Also, `test_resolve_binary` is needlessly behind feature flags.

## Proposal

Make test dependencies explicit and move `test_resolve_binary` to the `local` tests.

## Test Plan

It fixed e.g. `cargo test -p linera-indexer-graphql-client` for me locally, and makes `cargo test -p linera-service test_resolve_binary` actually run the test.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
