### PR TITLE
Add --build-mode to net up --kubernetes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,8 @@
 # - `target` is a Rust target quadruple. Currently known to be
 #   supported are `x86_64-unknown-linux-gnu` and
 #   `aarch64-unknown-linux-gnu`.
+# - `build_flag` is either "--release" or an empty string.
+# - `build_folder` is either "release" or "debug".
 
 # Stage 1 - Generate recipe file for dependencies
 
@@ -20,10 +22,14 @@ ARG build_date
 ARG target=x86_64-unknown-linux-gnu
 ARG binaries=
 ARG copy=${binaries:+_copy}
+ARG build_flag=
+ARG build_folder=
 
 FROM rust:1.74-slim-bookworm AS builder
 ARG git_commit
 ARG target
+ARG build_flag
+ARG build_folder
 
 RUN apt-get update && apt-get install -y \
     pkg-config \
@@ -58,7 +64,7 @@ COPY rust-toolchain* Cargo.* ./
 
 ENV GIT_COMMIT=${git_commit}
 
-RUN cargo build --release \
+RUN cargo build ${build_flag:+"$build_flag"} \
     --target "$target" \
     --bin linera \
     --bin linera-proxy \
@@ -66,9 +72,9 @@ RUN cargo build --release \
     --features scylladb,metrics
 
 RUN mv \
-    target/"$target"/release/linera \
-    target/"$target"/release/linera-proxy \
-    target/"$target"/release/linera-server \
+    target/"$target"/"$build_folder"/linera \
+    target/"$target"/"$build_folder"/linera-proxy \
+    target/"$target"/"$build_folder"/linera-server \
     ./
 
 RUN strip linera linera-proxy linera-server

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -36,11 +36,11 @@ cd "$ROOT_DIR"
 GIT_COMMIT=$(git rev-parse --short HEAD)
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    docker build --build-arg git_commit="$GIT_COMMIT" -f docker/Dockerfile . -t linera || exit 1
+    docker build --build-arg git_commit="$GIT_COMMIT" --build-arg build_flag="--release" --build-arg build_folder="release" -f docker/Dockerfile . -t linera || exit 1
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     CPU_ARCH=$(sysctl -n machdep.cpu.brand_string)
     if [[ "$CPU_ARCH" == *"Apple"* ]]; then
-        docker build --build-arg git_commit="$GIT_COMMIT" --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera . || exit 1
+        docker build --build-arg git_commit="$GIT_COMMIT" --build-arg target=aarch64-unknown-linux-gnu --build-arg build_flag="--release" --build-arg build_folder="release" -f docker/Dockerfile -t linera . || exit 1
     else
         echo "Unsupported Architecture: $CPU_ARCH"
         exit 1

--- a/linera-service/src/cli_wrappers/docker.rs
+++ b/linera-service/src/cli_wrappers/docker.rs
@@ -17,7 +17,12 @@ impl DockerImage {
         &self.name
     }
 
-    pub async fn build(name: &str, binaries: &BuildArg, github_root: &PathBuf) -> Result<Self> {
+    pub async fn build(
+        name: &str,
+        binaries: &BuildArg,
+        github_root: &PathBuf,
+        build_mode: &str,
+    ) -> Result<Self> {
         let build_arg = match binaries {
             BuildArg::Directory(bin_path) => {
                 // Get the binaries from the specified path
@@ -56,6 +61,19 @@ impl DockerImage {
             .arg("build")
             .args(["-f", "docker/Dockerfile"])
             .args(["--build-arg", &build_arg]);
+
+        match build_mode {
+            "release" => {
+                command.args(["--build-arg", "build_flag=--release"]);
+                command.args(["--build-arg", "build_folder=release"]);
+            }
+            "debug" => {
+                command.args(["--build-arg", "build_folder=debug"]);
+            }
+            _ => {
+                return Err(anyhow::anyhow!("Invalid build mode: {}", build_mode));
+            }
+        }
 
         #[cfg(not(with_testing))]
         command

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -48,6 +48,7 @@ pub struct LocalKubernetesNetConfig {
     pub binaries: BuildArg,
     pub no_build: bool,
     pub docker_image_name: String,
+    pub build_mode: String,
     pub policy_config: ResourceControlPolicyConfig,
 }
 
@@ -66,6 +67,7 @@ pub struct LocalKubernetesNet {
     binaries: BuildArg,
     no_build: bool,
     docker_image_name: String,
+    build_mode: String,
     kubectl_instance: Arc<Mutex<KubectlInstance>>,
     kind_clusters: Vec<KindCluster>,
     num_initial_validators: usize,
@@ -102,6 +104,7 @@ impl SharedLocalKubernetesNetTestingConfig {
             binaries,
             no_build: false,
             docker_image_name: String::from("linera:latest"),
+            build_mode: String::from("release"),
             policy_config: ResourceControlPolicyConfig::Testnet,
         })
     }
@@ -130,6 +133,7 @@ impl LineraNetConfig for LocalKubernetesNetConfig {
             self.binaries,
             self.no_build,
             self.docker_image_name,
+            self.build_mode,
             KubectlInstance::new(Vec::new()),
             clusters,
             self.num_initial_validators,
@@ -308,6 +312,7 @@ impl LocalKubernetesNet {
         binaries: BuildArg,
         no_build: bool,
         docker_image_name: String,
+        build_mode: String,
         kubectl_instance: KubectlInstance,
         kind_clusters: Vec<KindCluster>,
         num_initial_validators: usize,
@@ -321,6 +326,7 @@ impl LocalKubernetesNet {
             binaries,
             no_build,
             docker_image_name,
+            build_mode,
             kubectl_instance: Arc::new(Mutex::new(kubectl_instance)),
             kind_clusters,
             num_initial_validators,
@@ -401,7 +407,13 @@ impl LocalKubernetesNet {
         let docker_image_name = if self.no_build {
             self.docker_image_name.clone()
         } else {
-            DockerImage::build(&self.docker_image_name, &self.binaries, &github_root).await?;
+            DockerImage::build(
+                &self.docker_image_name,
+                &self.binaries,
+                &github_root,
+                &self.build_mode,
+            )
+            .await?;
             self.docker_image_name.clone()
         };
 

--- a/linera-service/src/linera/command.rs
+++ b/linera-service/src/linera/command.rs
@@ -918,6 +918,11 @@ pub enum NetCommand {
         #[arg(long, default_value = "linera:latest")]
         docker_image_name: String,
 
+        /// The build mode to use.
+        #[cfg(feature = "kubernetes")]
+        #[arg(long, default_value = "release")]
+        build_mode: String,
+
         /// Run with a specific path where the wallet and validator input files are.
         /// If none, then a temporary directory is created.
         #[arg(long)]

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1807,17 +1807,16 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                 shards,
                 testing_prng_seed,
                 policy_config,
-                cross_chain_config: _,
                 kubernetes: true,
                 binaries,
                 no_build,
                 docker_image_name,
-                path: _,
-                external_protocol: _,
+                build_mode,
                 with_faucet,
                 faucet_chain,
                 faucet_port,
                 faucet_amount,
+                ..
             } => {
                 net_up_utils::handle_net_up_kubernetes(
                     *other_initial_chains,
@@ -1828,6 +1827,7 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                     binaries,
                     *no_build,
                     docker_image_name.clone(),
+                    build_mode.clone(),
                     *policy_config,
                     *with_faucet,
                     *faucet_chain,

--- a/linera-service/src/linera/net_up_utils.rs
+++ b/linera-service/src/linera/net_up_utils.rs
@@ -115,6 +115,7 @@ pub async fn handle_net_up_kubernetes(
     binaries: &Option<Option<PathBuf>>,
     no_build: bool,
     docker_image_name: String,
+    build_mode: String,
     policy_config: ResourceControlPolicyConfig,
     with_faucet: bool,
     faucet_chain: Option<u32>,
@@ -147,6 +148,7 @@ pub async fn handle_net_up_kubernetes(
         binaries: binaries.clone().into(),
         no_build,
         docker_image_name,
+        build_mode,
         policy_config,
     };
     let (mut net, client) = config.instantiate().await?;


### PR DESCRIPTION
## Motivation

While debugging the deadlock last week, it was evident that building an image for a local `kind` deployment in debug mode was not straight forward

## Proposal

Added `--build-mode` option to make this easier

## Test Plan

Deployed locally, it works

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
