### PR TITLE
Increase upper bound for inbox size metric

### DIFF
--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -39,7 +39,7 @@ static INBOX_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
         "inbox_size",
         "Inbox size",
         &[],
-        exponential_bucket_interval(1.0, 500_000.0),
+        exponential_bucket_interval(1.0, 2_000_000.0),
     )
 });
 


### PR DESCRIPTION
## Motivation

I've seen inbox size p99 reach half a million during benchmarks

## Proposal

Bump it to 2 million

## Test Plan

Will deploy a network with this

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
