### PR TITLE
Ask confirmation to start benchmark

### DIFF
--- a/linera-service/src/linera/command.rs
+++ b/linera-service/src/linera/command.rs
@@ -388,6 +388,10 @@ pub enum ClientCommand {
         /// closing chains.
         #[arg(long, default_value = "5")]
         wrap_up_max_in_flight: usize,
+
+        /// Confirm before starting the benchmark.
+        #[arg(long)]
+        confirm_before_start: bool,
     },
 
     /// Create genesis configuration for a Linera deployment.


### PR DESCRIPTION
## Motivation

When benchmarking, it's better to not have chain creation blocks having to be executed in the middle of the benchmark. So we might as well add a confirmation so that we can get all the processes ready, and then start them as we please.

## Proposal

Add confirmation to start the benchmark, after preparing.

## Test Plan

Ran this a few times already while benchmarking.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
