### PR TITLE
Rewrite the chain listener as a single loop.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4765,6 +4765,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
  "tower-http 0.5.2",
  "tracing",
 ]

--- a/linera-base/src/task.rs
+++ b/linera-base/src/task.rs
@@ -138,10 +138,10 @@ mod implementation {
     }
 
     /// The type of a future awaiting another task.
-    pub type NonblockingFuture<R> = oneshot::Receiver<R>;
+    pub type NonBlockingFuture<R> = oneshot::Receiver<R>;
 
     /// Spawns a new task on the current thread.
-    pub fn spawn<F: Future + 'static>(future: F) -> NonblockingFuture<F::Output> {
+    pub fn spawn<F: Future + 'static>(future: F) -> NonBlockingFuture<F::Output> {
         let (send, recv) = oneshot::channel();
         wasm_bindgen_futures::spawn_local(async {
             let _ = send.send(future.await);

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -16,7 +16,6 @@ test = ["linera-views/test", "linera-execution/test"]
 benchmark = [
     "linera-base/test",
     "dep:linera-sdk",
-    "dep:tokio-util",
     "dep:crossbeam-channel",
     "dep:num-format",
     "dep:reqwest",
@@ -80,7 +79,7 @@ thiserror.workspace = true
 thiserror-context.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
-tokio-util = { workspace = true, optional = true }
+tokio-util.workspace = true
 tracing.workspace = true
 trait-variant.workspace = true
 

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -147,13 +147,6 @@ impl<C: ClientContext> ChainListener<C> {
         for chain_id in chain_ids {
             self.listen(chain_id).await?;
         }
-        let _handler = linera_base::task::spawn(self.run_notification_loop().in_current_span());
-        Ok(())
-    }
-
-    /// Processes notifications and timeouts in a loop.
-    #[instrument(skip(self))]
-    async fn run_notification_loop(mut self) -> Result<(), Error> {
         loop {
             match self.next_action().await? {
                 Action::ProcessInbox(chain_id) => self.maybe_process_inbox(chain_id).await?,

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -84,10 +84,19 @@ pub trait ClientContext: 'static {
     }
 }
 
+/// A chain client together with the stream of notifications from the local node.
+///
+/// A background task listens to the validators and updates the local node, so any updates to
+/// this chain will trigger a notification. The background task is terminated when this gets
+/// dropped.
 struct ListeningClient<C: ClientContext> {
+    /// The chain client.
     client: ContextChainClient<C>,
+    /// The abort handle for the task that listens to the validators.
     _abort_handle: AbortOnDrop,
+    /// The stream of notifications from the local node.
     notification_stream: Arc<Mutex<NotificationStream>>,
+    /// This is only `< u64::MAX` when the client is waiting for a timeout to process the inbox.
     timeout: Timestamp,
 }
 

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -109,6 +109,7 @@ impl<C: ClientContext> ListeningClient<C> {
         Self {
             client,
             _abort_handle,
+            #[allow(clippy::arc_with_non_send_sync)] // Only `Send` with `futures-util/alloc`.
             notification_stream: Arc::new(Mutex::new(notification_stream)),
             timeout: Timestamp::from(u64::MAX),
         }

--- a/linera-client/src/error.rs
+++ b/linera-client/src/error.rs
@@ -39,6 +39,8 @@ pub(crate) enum Inner {
     #[cfg(feature = "benchmark")]
     #[error("Benchmark error: {0}")]
     Benchmark(#[from] BenchmarkError),
+    #[error("internal error; this is a bug: {0}")]
+    Internal(String),
 }
 
 thiserror_context::impl_context!(Error(Inner));

--- a/linera-client/src/error.rs
+++ b/linera-client/src/error.rs
@@ -39,8 +39,6 @@ pub(crate) enum Inner {
     #[cfg(feature = "benchmark")]
     #[error("Benchmark error: {0}")]
     Benchmark(#[from] BenchmarkError),
-    #[error("internal error; this is a bug: {0}")]
-    Internal(String),
 }
 
 thiserror_context::impl_context!(Error(Inner));

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -142,8 +142,12 @@ async fn test_chain_listener() -> anyhow::Result<()> {
         .update_wallet_for_new_chain(chain_id0, Some(key_pair), clock.current_time())
         .await?;
     let context = Arc::new(Mutex::new(context));
-    let listener = ChainListener::new(config, context, storage);
-    listener.run().await?;
+    let _handle = linera_base::task::spawn(async move {
+        ChainListener::new(config, context, storage)
+            .run()
+            .await
+            .unwrap()
+    });
 
     // Transfer ownership of chain 0 to the chain listener and some other key. The listener will
     // be leader in ~10% of the rounds.

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -143,7 +143,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
         .await?;
     let context = Arc::new(Mutex::new(context));
     let listener = ChainListener::new(config, context, storage);
-    listener.run().await;
+    listener.run().await?;
 
     // Transfer ownership of chain 0 to the chain listener and some other key. The listener will
     // be leader in ~10% of the rounds.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1695,7 +1695,7 @@ where
 
     /// Downloads and processes any certificates we are missing for the given chain.
     #[instrument(level = "trace", skip_all)]
-    async fn synchronize_chain_state(
+    pub async fn synchronize_chain_state(
         &self,
         chain_id: ChainId,
     ) -> Result<Box<ChainInfo>, ChainClientError> {
@@ -3312,6 +3312,15 @@ where
                 }
             }
         }
+    }
+
+    /// Returns whether this chain is tracked by the client, i.e. we are updating its inbox.
+    pub fn is_tracked(&self) -> bool {
+        self.client
+            .tracked_chains
+            .read()
+            .unwrap()
+            .contains(&self.chain_id)
     }
 
     /// Spawns a task that listens to notifications about the current chain from all validators,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -3560,7 +3560,7 @@ enum ExecuteBlockOutcome {
 
 /// Wrapper for `AbortHandle` that aborts when its dropped.
 #[must_use]
-pub struct AbortOnDrop(AbortHandle);
+pub struct AbortOnDrop(pub AbortHandle);
 
 impl Drop for AbortOnDrop {
     #[instrument(level = "trace", skip(self))]

--- a/linera-faucet/server/Cargo.toml
+++ b/linera-faucet/server/Cargo.toml
@@ -21,6 +21,7 @@ linera-version.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 tower-http = { workspace = true, features = ["cors"] }
 tracing.workspace = true
 

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -286,7 +286,7 @@ where
 
         let context = Arc::clone(&self.context);
         let listener = ChainListener::new(self.config.clone(), context, self.storage.clone());
-        listener.run().await;
+        listener.run().await?;
 
         axum::serve(
             tokio::net::TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], port))).await?,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -843,9 +843,9 @@ where
             .layer(CorsLayer::permissive());
 
         info!("GraphiQL IDE: http://localhost:{}", port);
-        ChainListener::new(self.config, Arc::clone(&self.context), self.storage.clone())
-            .run()
-            .await;
+        let listener =
+            ChainListener::new(self.config, Arc::clone(&self.context), self.storage.clone());
+        listener.run().await?;
         let serve_fut = axum::serve(
             tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], port))).await?,
             app,

--- a/scripts/linera_net_helper.sh
+++ b/scripts/linera_net_helper.sh
@@ -38,7 +38,7 @@ function linera_spawn_and_read_wallet_variables() {
 function linera_spawn() {
     LINERA_TMP_DIR=$(mktemp -d) || exit 1
 
-    trap 'jobs -p | xargs -r kill; rm -rf "$LINERA_TMP_DIR"' EXIT
+    trap 'jobs -p | xargs -r kill || true; rm -rf "$LINERA_TMP_DIR"' EXIT
 
     LINERA_TMP_OUT="$LINERA_TMP_DIR/out"
     LINERA_TMP_ERR="$LINERA_TMP_DIR/err"


### PR DESCRIPTION
## Motivation

For https://github.com/linera-io/linera-protocol/issues/365 the chain listener will need to react to new block notifications on a publisher chain by processing the inboxes of all subscriber chains. That is difficult to implement with the current approach: we run a notification processing loop in a separate task for each chain.

## Proposal

Rewrite the chain listener so that there is a single top-level loop processing all events on all chains. That will make it easier to update chains based on events from _other_ chains.

`process_new_events` already does this, to update all non-admin chains for new epochs.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Preparation for #365.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
