### PR TITLE
make the block exporter context visible in the Storage trait

### DIFF
--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -456,6 +456,7 @@ where
 {
     type Context = ViewContext<ChainRuntimeContext<Self>, Store>;
     type Clock = C;
+    type BlockExporterContext = ViewContext<u32, Store>;
 
     fn clock(&self) -> &C {
         &self.clock
@@ -797,6 +798,15 @@ where
     fn wasm_runtime(&self) -> Option<WasmRuntime> {
         self.wasm_runtime
     }
+
+    async fn block_exporter_context(
+        &self,
+        block_exporter_id: u32,
+    ) -> Result<Self::BlockExporterContext, ViewError> {
+        let root_key = bcs::to_bytes(&BaseKey::BlockExporterState(block_exporter_id))?;
+        let store = self.store.clone_with_root_key(&root_key)?;
+        Ok(ViewContext::create_root_context(store, block_exporter_id).await?)
+    }
 }
 
 impl<Store, C> DbStorage<Store, C>
@@ -891,15 +901,6 @@ where
             blob_ids.push(blob_id);
         }
         Ok(blob_ids)
-    }
-
-    pub async fn block_exporter_context(
-        &self,
-        block_exporter_id: u32,
-    ) -> Result<ViewContext<u32, Store>, ViewError> {
-        let root_key = bcs::to_bytes(&BaseKey::BlockExporterState(block_exporter_id))?;
-        let store = self.store.clone_with_root_key(&root_key)?;
-        Ok(ViewContext::create_root_context(store, block_exporter_id).await?)
     }
 }
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -56,11 +56,14 @@ pub const DEFAULT_NAMESPACE: &str = "table_linera";
 #[cfg_attr(not(web), async_trait)]
 #[cfg_attr(web, async_trait(?Send))]
 pub trait Storage: Sized {
-    /// The low-level storage implementation in use.
+    /// The low-level storage implementation in use by the core protocol (chain workers etc).
     type Context: Context<Extra = ChainRuntimeContext<Self>> + Clone + Send + Sync + 'static;
 
     /// The clock type being used.
     type Clock: Clock;
+
+    /// The low-level storage implementation in use by the block exporter.
+    type BlockExporterContext: Context<Extra = u32> + Clone + Send + Sync + 'static;
 
     /// Returns the current wall clock time.
     fn clock(&self) -> &Self::Clock;
@@ -329,6 +332,11 @@ pub trait Storage: Sized {
             }
         }
     }
+
+    async fn block_exporter_context(
+        &self,
+        block_exporter_id: u32,
+    ) -> Result<Self::BlockExporterContext, ViewError>;
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Motivation

#3729 was not enough to re-use `run_with_storage` in the block exporter

## Proposal

* Move the new definition to the trait.
* Add the necessary associated type.

This is a little ugly but the alternative is to have different variants of the `Storage` trait depending on the app using it. This could be done later.

## Test Plan

CI
