### PR TITLE
Store network information in DB

### DIFF
--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -20,7 +20,7 @@ use linera_execution::{
     ResourceControlPolicy,
 };
 use linera_rpc::config::{ValidatorInternalNetworkConfig, ValidatorPublicNetworkConfig};
-use linera_storage::Storage;
+use linera_storage::{NetworkDescription, Storage};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, thiserror::Error)]
@@ -233,6 +233,15 @@ impl GenesisConfig {
                 )
                 .await?;
         }
+        let network_description = NetworkDescription {
+            name: self.network_name.clone(),
+            genesis_config_hash: CryptoHash::new(self),
+            timestamp: self.timestamp,
+        };
+        storage
+            .write_network_description(&network_description)
+            .await
+            .map_err(linera_chain::ChainError::from)?;
         Ok(())
     }
 

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -19,7 +19,6 @@ use anyhow::Result;
 use async_trait::async_trait;
 use futures::{future::BoxFuture, FutureExt as _};
 use linera_base::identifiers::ChainId;
-use linera_client::config::GenesisConfig;
 use linera_core::{notifier::ChannelNotifier, JoinSetExt as _};
 use linera_rpc::{
     config::{
@@ -150,7 +149,6 @@ pub struct GrpcProxy<S>(Arc<GrpcProxyInner<S>>);
 struct GrpcProxyInner<S> {
     public_config: ValidatorPublicNetworkConfig,
     internal_config: ValidatorInternalNetworkConfig,
-    genesis_config: GenesisConfig,
     worker_connection_pool: GrpcConnectionPool,
     notifier: ChannelNotifier<Result<Notification, Status>>,
     tls: TlsConfig,
@@ -164,7 +162,6 @@ where
     pub fn new(
         public_config: ValidatorPublicNetworkConfig,
         internal_config: ValidatorInternalNetworkConfig,
-        genesis_config: GenesisConfig,
         connect_timeout: Duration,
         timeout: Duration,
         tls: TlsConfig,
@@ -173,7 +170,6 @@ where
         Self(Arc::new(GrpcProxyInner {
             public_config,
             internal_config,
-            genesis_config,
             worker_connection_pool: GrpcConnectionPool::default()
                 .with_connect_timeout(connect_timeout)
                 .with_timeout(timeout),
@@ -474,7 +470,16 @@ where
         &self,
         _request: Request<()>,
     ) -> Result<Response<CryptoHash>, Status> {
-        Ok(Response::new(self.0.genesis_config.hash().into()))
+        let description = self
+            .0
+            .storage
+            .read_network_description()
+            .await
+            .map_err(Self::error_to_status)?
+            .ok_or(Status::not_found(
+                "Cannot find network description in the database",
+            ))?;
+        Ok(Response::new(description.genesis_config_hash.into()))
     }
 
     #[instrument(skip_all, err(Display))]

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -5,7 +5,7 @@
 
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
-use anyhow::{bail, ensure, Result};
+use anyhow::{anyhow, bail, ensure, Result};
 use async_trait::async_trait;
 use futures::{FutureExt as _, SinkExt, StreamExt};
 use linera_base::listen_for_shutdown_signals;
@@ -106,7 +106,6 @@ where
 
 struct ProxyContext {
     config: ValidatorServerConfig,
-    genesis_config: GenesisConfig,
     send_timeout: Duration,
     recv_timeout: Duration,
 }
@@ -114,12 +113,10 @@ struct ProxyContext {
 impl ProxyContext {
     pub fn from_options(options: &ProxyOptions) -> Result<Self> {
         let config = util::read_json(&options.config_path)?;
-        let genesis_config = util::read_json(&options.genesis_config_path)?;
         Ok(Self {
             config,
             send_timeout: options.send_timeout,
             recv_timeout: options.recv_timeout,
-            genesis_config,
         })
     }
 }
@@ -155,7 +152,6 @@ where
                 Self::Grpc(GrpcProxy::new(
                     context.config.validator.network,
                     context.config.internal_network,
-                    context.genesis_config,
                     context.send_timeout,
                     context.recv_timeout,
                     tls,
@@ -175,7 +171,6 @@ where
                     .validator
                     .network
                     .clone_with_protocol(public_transport),
-                genesis_config: context.genesis_config,
                 send_timeout: context.send_timeout,
                 recv_timeout: context.recv_timeout,
                 storage,
@@ -200,7 +195,6 @@ where
 {
     public_config: ValidatorPublicNetworkPreConfig<TransportProtocol>,
     internal_config: ValidatorInternalNetworkPreConfig<TransportProtocol>,
-    genesis_config: GenesisConfig,
     send_timeout: Duration,
     recv_timeout: Duration,
     storage: S,
@@ -312,9 +306,16 @@ where
                     linera_version::VersionInfo::default().into(),
                 )))
             }
-            GenesisConfigHashQuery => Ok(Some(RpcMessage::GenesisConfigHashResponse(Box::new(
-                self.genesis_config.hash(),
-            )))),
+            GenesisConfigHashQuery => {
+                let description = self
+                    .storage
+                    .read_network_description()
+                    .await?
+                    .ok_or(anyhow!("Cannot find network description in the database"))?;
+                Ok(Some(RpcMessage::GenesisConfigHashResponse(Box::new(
+                    description.genesis_config_hash,
+                ))))
+            }
             UploadBlob(content) => {
                 let blob = Blob::new(*content);
                 let id = blob.id();

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -43,7 +43,7 @@ use {
     prometheus::{HistogramVec, IntCounterVec},
 };
 
-use crate::{ChainRuntimeContext, Clock, Storage};
+use crate::{ChainRuntimeContext, Clock, NetworkDescription, Storage};
 
 /// The metric counting how often a blob is tested for existence from storage
 #[cfg(with_metrics)]
@@ -207,6 +207,28 @@ pub static WRITE_EVENT_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
     )
 });
 
+/// The metric counting how often the network description is read from storage.
+#[cfg(with_metrics)]
+#[doc(hidden)]
+pub static READ_NETWORK_DESCRIPTION: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec(
+        "network_description",
+        "The metric counting how often the network description is read from storage",
+        &[],
+    )
+});
+
+/// The metric counting how often the network description is written to storage.
+#[cfg(with_metrics)]
+#[doc(hidden)]
+pub static WRITE_NETWORK_DESCRIPTION: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec(
+        "write_event",
+        "The metric counting how often the network description is written to storage",
+        &[],
+    )
+});
+
 trait BatchExt {
     fn add_blob(&mut self, blob: &Blob) -> Result<(), ViewError>;
 
@@ -216,6 +238,11 @@ trait BatchExt {
         -> Result<(), ViewError>;
 
     fn add_event(&mut self, event_id: EventId, value: Vec<u8>) -> Result<(), ViewError>;
+
+    fn add_network_description(
+        &mut self,
+        information: &NetworkDescription,
+    ) -> Result<(), ViewError>;
 }
 
 impl BatchExt for Batch {
@@ -254,6 +281,17 @@ impl BatchExt for Batch {
         self.put_key_value_bytes(event_key.to_vec(), value);
         Ok(())
     }
+
+    fn add_network_description(
+        &mut self,
+        information: &NetworkDescription,
+    ) -> Result<(), ViewError> {
+        #[cfg(with_metrics)]
+        WRITE_NETWORK_DESCRIPTION.with_label_values(&[]).inc();
+        let key = bcs::to_bytes(&BaseKey::NetworkDescription)?;
+        self.put_key_value(key, information)?;
+        Ok(())
+    }
 }
 
 /// Main implementation of the [`Storage`] trait.
@@ -276,6 +314,7 @@ enum BaseKey {
     BlobState(BlobId),
     Event(EventId),
     BlockExporterState(u32),
+    NetworkDescription,
 }
 
 const INDEX_CHAIN_ID: u8 = 0;
@@ -793,6 +832,24 @@ where
             batch.add_event(event_id, value)?;
         }
         self.write_batch(batch).await
+    }
+
+    async fn read_network_description(&self) -> Result<Option<NetworkDescription>, ViewError> {
+        let key = bcs::to_bytes(&BaseKey::NetworkDescription)?;
+        let maybe_value = self.store.read_value(&key).await?;
+        #[cfg(with_metrics)]
+        READ_NETWORK_DESCRIPTION.with_label_values(&[]).inc();
+        Ok(maybe_value)
+    }
+
+    async fn write_network_description(
+        &self,
+        information: &NetworkDescription,
+    ) -> Result<(), ViewError> {
+        let mut batch = Batch::new();
+        batch.add_network_description(information)?;
+        self.write_batch(batch).await?;
+        Ok(())
     }
 
     fn wasm_runtime(&self) -> Option<WasmRuntime> {

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -40,6 +40,7 @@ use linera_views::{
     context::Context,
     views::{CryptoHashView, RootView, ViewError},
 };
+use serde::{Deserialize, Serialize};
 
 #[cfg(with_testing)]
 pub use crate::db_storage::TestClock;
@@ -169,6 +170,15 @@ pub trait Storage: Sized {
     async fn write_events(
         &self,
         events: impl IntoIterator<Item = (EventId, Vec<u8>)> + Send,
+    ) -> Result<(), ViewError>;
+
+    /// Reads the network description.
+    async fn read_network_description(&self) -> Result<Option<NetworkDescription>, ViewError>;
+
+    /// Writes the network description.
+    async fn write_network_description(
+        &self,
+        information: &NetworkDescription,
     ) -> Result<(), ViewError>;
 
     /// Initializes a chain in a simple way (used for testing and to create a genesis state).
@@ -339,6 +349,15 @@ pub trait Storage: Sized {
     ) -> Result<Self::BlockExporterContext, ViewError>;
 }
 
+/// A description of the current Linera network to be stored in every node's database.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NetworkDescription {
+    pub name: String,
+    pub genesis_config_hash: CryptoHash,
+    pub timestamp: Timestamp,
+}
+
+/// An implementation of `ExecutionRuntimeContext` suitable for the core protocol.
 #[derive(Clone)]
 pub struct ChainRuntimeContext<S> {
     storage: S,


### PR DESCRIPTION
## Motivation

We currently pass around a genesis configuration when deploying a validator but this is not really needed.
This is the first step to simplify things.

## Proposal

* Create a notion of network description to be persisted in DB
* Use it in the proxy

Incidentally, we won't compute the genesis config hash over and over again.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
