### PR TITLE
Remove the Localstack word from the source code

### DIFF
--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -58,6 +58,6 @@ jobs:
         AWS_REGION: us-east-1
         AWS_ACCESS_KEY_ID: test
         AWS_SECRET_ACCESS_KEY: test
-        LOCALSTACK_ENDPOINT: http://localhost:8000
+        DYNAMODB_LOCAL_ENDPOINT: http://localhost:8000
       run: |
         cargo test --locked --features dynamodb -- dynamo

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -79,8 +79,8 @@ async fn make_testing_config(database: Database) -> Result<StorageConfig> {
         Database::DynamoDb => {
             #[cfg(feature = "dynamodb")]
             {
-                let use_localstack = true;
-                Ok(StorageConfig::DynamoDb { use_localstack })
+                let use_dynamodb_local = true;
+                Ok(StorageConfig::DynamoDb { use_dynamodb_local })
             }
             #[cfg(not(feature = "dynamodb"))]
             panic!("Database::DynamoDb is selected without the feature dynamodb");

--- a/spellcheck-dictionary.txt
+++ b/spellcheck-dictionary.txt
@@ -61,7 +61,6 @@ KiB
 Kubernetes
 Linera
 liveness
-LocalStack
 LRU
 memoize
 memoizing


### PR DESCRIPTION
## Motivation

We have not been using Localstack for several years and instead we use DynamoDB local.

Fixes #932 

## Proposal

The renaming is done in a straightforward way.

## Test Plan

The CI

## Release Plan

Normal release schedule.

## Links

None.