### PR TITLE
Increase the durations in `test_service_as_oracle_timeout_early_stop`.

### DIFF
--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -400,17 +400,17 @@ async fn test_service_as_oracle_exceeding_time_limit(
 }
 
 /// Tests if execution fails early if services call `check_execution_time`.
-#[test_case(&[120]; "single service as oracle call")]
-#[test_case(&[60, 60]; "two service as oracle calls")]
-#[test_case(&[105, 15]; "long and short service as oracle calls")]
-#[test_case(&[50, 50, 50]; "three service as oracle calls")]
-#[test_case(&[60, 60, 60]; "first two service as oracle calls exceeds limit")]
+#[test_case(&[1200]; "single service as oracle call")]
+#[test_case(&[600, 600]; "two service as oracle calls")]
+#[test_case(&[1050, 150]; "long and short service as oracle calls")]
+#[test_case(&[500, 500, 500]; "three service as oracle calls")]
+#[test_case(&[600, 600, 600]; "first two service as oracle calls exceeds limit")]
 #[tokio::test]
 async fn test_service_as_oracle_timeout_early_stop(
     service_oracle_execution_times_ms: &[u64],
 ) -> anyhow::Result<()> {
-    let maximum_service_oracle_execution_ms = 70;
-    let poll_interval = Duration::from_millis(10);
+    let maximum_service_oracle_execution_ms = 700;
+    let poll_interval = Duration::from_millis(100);
     let maximum_expected_execution_time =
         Duration::from_millis(maximum_service_oracle_execution_ms) + 2 * poll_interval;
 


### PR DESCRIPTION
## Motivation

`cargo test -p linera-chain` fails for me locally most of the time.

(Note that it only fails if I run _all_ the `linera-chain` tests. If it's _only_ `test_service_as_oracle_timeout_early_stop`, it passes.)

## Proposal

Multiply the durations in the test by 10, to make them less flaky.

## Test Plan

With this change, `cargo test -p linera-chain` works for me, even in debug mode.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #3766.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
