### PR TITLE
Fix the `test_wasm_end_to_end_social_user_pub_sub` flakiness.

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -892,6 +892,7 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
+    client2.sync(chain2).await?;
     let (contract, service) = client1.build_example("social").await?;
     let module_id = client1
         .publish_module::<SocialAbi, (), ()>(contract, service, None)


### PR DESCRIPTION
## Motivation

`test_wasm_end_to_end_social_user_pub_sub` sometimes fails because it's not deterministic when the first block, with the `OpenChain` message, is created on `chain2`.

## Proposal

Synchronize after `open_and_assign`, so the `OpenChain` message is seen in the inbox right away.

## Test Plan

The test passes for me now.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
