### PR TITLE
Backport #3776: Fix the `test_wasm_end_to_end_social_user_pub_sub` flakiness.

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -690,6 +690,7 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
+    client2.sync(chain2).await?;
     let (contract, service) = client1.build_example("social").await?;
     let module_id = client1
         .publish_module::<SocialAbi, (), ()>(contract, service, None)


### PR DESCRIPTION
## Motivation

`test_wasm_end_to_end_social_user_pub_sub` is flaky.

## Proposal

Backport #3776.

## Test Plan

See #3776.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #3776
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
