### PR TITLE
Add missing metadata so crates can be published. (#3778)

### DIFF
--- a/linera-faucet/Cargo.toml
+++ b/linera-faucet/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
 name = "linera-faucet"
+description = "Common definitions for the Linera faucet."
+readme = "README.md"
+documentation = "https://docs.rs/linera-faucet/latest/linera_faucet/"
+
 version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/linera-faucet/client/Cargo.toml
+++ b/linera-faucet/client/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
 name = "linera-faucet-client"
+description = "The client component of the Linera faucet."
+readme = "README.md"
+documentation = "https://docs.rs/linera-faucet-client/latest/linera_faucet_client/"
+
 version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/linera-faucet/server/Cargo.toml
+++ b/linera-faucet/server/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
 name = "linera-faucet-server"
+description = "The server component of the Linera faucet."
+readme = "README.md"
+documentation = "https://docs.rs/linera-faucet-server/latest/linera_faucet_server/"
+
 version.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Motivation

Publishing the faucet crates fails because of missing metadata.

## Proposal

Add the metadata to `Cargo.toml`.

## Test Plan

`scripts/test_publish.sh packages.txt test-registry`

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Port of https://github.com/linera-io/linera-protocol/pull/3778.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
