### PR TITLE
Provide access to consumed resources in integration tests

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -728,6 +728,7 @@ where
     ) -> Result<
         (
             BlockExecutionOutcome,
+            ResourceTracker,
             Vec<(ChannelFullName, ChainId)>,
             Vec<(ChannelFullName, ChainId)>,
         ),
@@ -974,7 +975,7 @@ where
             operation_results,
         };
 
-        Ok((outcome, subscribe, unsubscribe))
+        Ok((outcome, resource_controller.tracker, subscribe, unsubscribe))
     }
 
     /// Executes a block: first the incoming messages, then the main operation.
@@ -989,6 +990,7 @@ where
     ) -> Result<
         (
             BlockExecutionOutcome,
+            ResourceTracker,
             Vec<(ChannelFullName, ChainId)>,
             Vec<(ChannelFullName, ChainId)>,
         ),

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -182,7 +182,7 @@ async fn test_block_size_limit() {
     );
 
     // The valid block is accepted...
-    let (outcome, _, _) = chain
+    let (outcome, _, _, _) = chain
         .execute_block(&valid_block, time, None, &[], None)
         .await
         .unwrap();
@@ -262,7 +262,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     let valid_block = make_first_block(chain_id)
         .with_incoming_bundle(bundle)
         .with_operation(app_operation.clone());
-    let (outcome, _, _) = chain
+    let (outcome, _, _, _) = chain
         .execute_block(&valid_block, time, None, &[], None)
         .await?;
     let value = ConfirmedBlock::new(outcome.with(valid_block));
@@ -292,7 +292,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     application.expect_call(ExpectedCall::execute_operation(|_, _, _| Ok(vec![])));
     application.expect_call(ExpectedCall::default_finalize());
     let valid_block = make_child_block(&value).with_operation(app_operation);
-    let (outcome, _, _) = chain
+    let (outcome, _, _, _) = chain
         .execute_block(&valid_block, time, None, &[], None)
         .await?;
     let value = ConfirmedBlock::new(outcome.with(valid_block));
@@ -502,7 +502,7 @@ async fn test_service_as_oracle_response_size_limit(
     chain
         .execute_block(&block, time, None, &[], None)
         .await
-        .map(|(outcome, _, _)| outcome)
+        .map(|(outcome, _, _, _)| outcome)
 }
 
 /// Tests contract HTTP response size limit.
@@ -561,7 +561,7 @@ async fn test_contract_http_response_size_limit(
     chain
         .execute_block(&block, time, None, &[], None)
         .await
-        .map(|(outcome, _, _)| outcome)
+        .map(|(outcome, _, _, _)| outcome)
 }
 
 /// Tests service HTTP response size limit.
@@ -620,7 +620,7 @@ async fn test_service_http_response_size_limit(
     chain
         .execute_block(&block, time, None, &[], None)
         .await
-        .map(|(outcome, _, _)| outcome)
+        .map(|(outcome, _, _, _)| outcome)
 }
 
 /// Sets up a test with a dummy [`MockApplication`].

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -22,7 +22,7 @@ use linera_chain::{
     ChainStateView,
 };
 use linera_execution::{
-    committee::Epoch, ExecutionStateView, Query, QueryContext, QueryOutcome,
+    committee::Epoch, ExecutionStateView, Query, QueryContext, QueryOutcome, ResourceTracker,
     ServiceRuntimeEndpoint, ServiceSyncRuntime,
 };
 use linera_storage::Storage;
@@ -88,7 +88,7 @@ where
         round: Option<u32>,
         published_blobs: Vec<Blob>,
         #[debug(skip)]
-        callback: oneshot::Sender<Result<(Block, ChainInfoResponse), WorkerError>>,
+        callback: oneshot::Sender<Result<(Block, ResourceTracker, ChainInfoResponse), WorkerError>>,
     },
 
     /// Process a leader timeout issued for this multi-owner chain.

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -375,7 +375,7 @@ where
             chain.execution_state = execution_state;
             (outcome.clone(), Vec::new(), Vec::new())
         } else {
-            chain
+            let (outcome, _resources, subscribe, unsubscribe) = chain
                 .execute_block(
                     &proposed_block,
                     local_time,
@@ -383,7 +383,8 @@ where
                     &published_blobs,
                     oracle_responses,
                 )
-                .await?
+                .await?;
+            (outcome, subscribe, unsubscribe)
         };
         // We should always agree on the messages and state hash.
         ensure!(

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -29,7 +29,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::Epoch, ExecutionStateView, Message, Query, QueryContext, QueryOutcome,
-    ServiceRuntimeEndpoint, SystemMessage,
+    ResourceTracker, ServiceRuntimeEndpoint, SystemMessage,
 };
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::{ClonableView, ViewError};
@@ -189,12 +189,12 @@ where
         block: ProposedBlock,
         round: Option<u32>,
         published_blobs: &[Blob],
-    ) -> Result<(Block, ChainInfoResponse), WorkerError> {
-        let (block, _resources, response) = ChainWorkerStateWithTemporaryChanges::new(self)
+    ) -> Result<(Block, ResourceTracker, ChainInfoResponse), WorkerError> {
+        let (block, resources, response) = ChainWorkerStateWithTemporaryChanges::new(self)
             .await
             .stage_block_execution(block, round, published_blobs)
             .await?;
-        Ok((block, response))
+        Ok((block, resources, response))
     }
 
     /// Processes a leader timeout issued for this multi-owner chain.

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -190,7 +190,7 @@ where
         round: Option<u32>,
         published_blobs: &[Blob],
     ) -> Result<(Block, ChainInfoResponse), WorkerError> {
-        let (block, response) = ChainWorkerStateWithTemporaryChanges::new(self)
+        let (block, _resources, response) = ChainWorkerStateWithTemporaryChanges::new(self)
             .await
             .stage_block_execution(block, round, published_blobs)
             .await?;

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -125,13 +125,13 @@ where
         block: ProposedBlock,
         round: Option<u32>,
         published_blobs: &[Blob],
-    ) -> Result<(Block, ChainInfoResponse), WorkerError> {
+    ) -> Result<(Block, ResourceTracker, ChainInfoResponse), WorkerError> {
         let local_time = self.0.storage.clock().current_time();
         let signer = block.authenticated_signer;
         let (_, committee) = self.0.chain.current_committee()?;
         block.check_proposal_size(committee.policy().maximum_block_proposal_size)?;
 
-        let (outcome, _resources) = self
+        let (outcome, resources) = self
             .execute_block(&block, local_time, round, published_blobs)
             .await?;
 
@@ -147,7 +147,7 @@ where
                 .await?;
         }
 
-        Ok((outcome.with(block), response))
+        Ok((outcome.with(block), resources, response))
     }
 
     /// Validates a proposal's signatures; returns `manager::Outcome::Skip` if we already voted

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -318,7 +318,7 @@ where
         round: Option<u32>,
         published_blobs: &[Blob],
     ) -> Result<BlockExecutionOutcome, WorkerError> {
-        let (outcome, subscribe, unsubscribe) =
+        let (outcome, _resources, subscribe, unsubscribe) =
             Box::pin(
                 self.0
                     .chain

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -178,11 +178,13 @@ where
         round: Option<u32>,
         published_blobs: Vec<Blob>,
     ) -> Result<(Block, ChainInfoResponse), LocalNodeError> {
-        Ok(self
+        let (block, _resources, response) = self
             .node
             .state
             .stage_block_execution(block, round, published_blobs)
-            .await?)
+            .await?;
+
+        Ok((block, response))
     }
 
     /// Reads blobs from storage.

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3198,7 +3198,7 @@ where
             timeout_config: TimeoutConfig::default(),
         })
         .with_authenticated_signer(Some(owner0));
-    let (block0, _) = worker
+    let (block0, _, _) = worker
         .stage_block_execution(proposed_block0, None, vec![])
         .await?;
     let value0 = ConfirmedBlock::new(block0);
@@ -3249,7 +3249,7 @@ where
 
     // Now owner 0 can propose a block, but owner 1 can't.
     let proposed_block1 = make_child_block(&value0.clone());
-    let (block1, _) = worker
+    let (block1, _, _) = worker
         .stage_block_execution(proposed_block1.clone(), None, vec![])
         .await?;
     let proposal1_wrong_owner = proposed_block1
@@ -3291,7 +3291,7 @@ where
     let amount = Amount::from_tokens(1);
     let proposed_block2 =
         make_child_block(&value0.clone()).with_simple_transfer(ChainId::root(1), amount);
-    let (block2, _) = worker
+    let (block2, _, _) = worker
         .stage_block_execution(proposed_block2.clone(), None, vec![])
         .await?;
 
@@ -3407,7 +3407,7 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (block0, _) = worker
+    let (block0, _, _) = worker
         .stage_block_execution(proposed_block0, None, vec![])
         .await?;
     let value0 = ConfirmedBlock::new(block0);
@@ -3498,7 +3498,7 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (change_ownership_block, _) = worker
+    let (change_ownership_block, _, _) = worker
         .stage_block_execution(change_ownership_block, None, vec![])
         .await?;
     let change_ownership_value = ConfirmedBlock::new(change_ownership_block);
@@ -3522,7 +3522,7 @@ where
     // Without the transfer, a random key pair can propose a block.
     let proposal = make_child_block(&change_ownership_value)
         .into_proposal_with_round(&AccountSecretKey::generate(), Round::MultiLeader(0));
-    let (block, _) = worker
+    let (block, _, _) = worker
         .stage_block_execution(proposal.content.block.clone(), None, vec![])
         .await?;
     let value = ConfirmedBlock::new(block);
@@ -3563,7 +3563,7 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (block0, _) = worker
+    let (block0, _, _) = worker
         .stage_block_execution(proposed_block0, None, vec![])
         .await?;
     let value0 = ConfirmedBlock::new(block0);
@@ -3581,7 +3581,7 @@ where
     let proposal1 = proposed_block1
         .clone()
         .into_proposal_with_round(&key_pairs[0], Round::Fast);
-    let (block1, _) = worker
+    let (block1, _, _) = worker
         .stage_block_execution(proposed_block1.clone(), None, vec![])
         .await?;
     let value1 = ConfirmedBlock::new(block1);
@@ -3629,7 +3629,7 @@ where
     worker.handle_block_proposal(proposal3).await?;
 
     // A validated block certificate from a later round can override the locked fast block.
-    let (block2, _) = worker
+    let (block2, _, _) = worker
         .stage_block_execution(proposed_block2.clone(), None, vec![])
         .await?;
     let value2 = ValidatedBlock::new(block2.clone());
@@ -3688,7 +3688,7 @@ where
     let proposed_block = make_first_block(chain_id)
         .with_simple_transfer(chain_id, Amount::ONE)
         .with_authenticated_signer(Some(key_pair.public().into()));
-    let (block, _) = worker
+    let (block, _, _) = worker
         .stage_block_execution(proposed_block, None, vec![])
         .await?;
     let value = ConfirmedBlock::new(block);

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -542,15 +542,17 @@ where
         round: Option<u32>,
         published_blobs: Vec<Blob>,
     ) -> Result<(Block, ChainInfoResponse), WorkerError> {
-        self.query_chain_worker(block.chain_id, move |callback| {
-            ChainWorkerRequest::StageBlockExecution {
-                block,
-                round,
-                published_blobs,
-                callback,
-            }
-        })
-        .await
+        let (block, _resources, response) = self
+            .query_chain_worker(block.chain_id, move |callback| {
+                ChainWorkerRequest::StageBlockExecution {
+                    block,
+                    round,
+                    published_blobs,
+                    callback,
+                }
+            })
+            .await?;
+        Ok((block, response))
     }
 
     /// Executes a [`Query`] for an application's state on a specific chain.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -32,7 +32,9 @@ use linera_chain::{
     },
     ChainError, ChainStateView,
 };
-use linera_execution::{committee::Epoch, ExecutionError, ExecutionStateView, Query, QueryOutcome};
+use linera_execution::{
+    committee::Epoch, ExecutionError, ExecutionStateView, Query, QueryOutcome, ResourceTracker,
+};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
 use lru::LruCache;
@@ -541,18 +543,16 @@ where
         block: ProposedBlock,
         round: Option<u32>,
         published_blobs: Vec<Blob>,
-    ) -> Result<(Block, ChainInfoResponse), WorkerError> {
-        let (block, _resources, response) = self
-            .query_chain_worker(block.chain_id, move |callback| {
-                ChainWorkerRequest::StageBlockExecution {
-                    block,
-                    round,
-                    published_blobs,
-                    callback,
-                }
-            })
-            .await?;
-        Ok((block, response))
+    ) -> Result<(Block, ResourceTracker, ChainInfoResponse), WorkerError> {
+        self.query_chain_worker(block.chain_id, move |callback| {
+            ChainWorkerRequest::StageBlockExecution {
+                block,
+                round,
+                published_blobs,
+                callback,
+            }
+        })
+        .await
     }
 
     /// Executes a [`Query`] for an application's state on a specific chain.

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -201,10 +201,7 @@ impl BlockBuilder {
 
     /// Tries to sign the prepared block with the [`TestValidator`]'s keys and return the
     /// resulting [`Certificate`]. Returns an error if block execution fails.
-    pub(crate) async fn try_sign(
-        self,
-        blobs: &[Blob],
-    ) -> Result<ConfirmedBlockCertificate, WorkerError> {
+    pub(crate) async fn try_sign(self, blobs: &[Blob]) -> Result<CertifiedBlock, WorkerError> {
         let published_blobs = self
             .block
             .published_blob_ids()
@@ -217,7 +214,7 @@ impl BlockBuilder {
                     .clone()
             })
             .collect();
-        let (block, _, _) = self
+        let (block, resources, _) = self
             .validator
             .worker()
             .stage_block_execution(self.block, None, published_blobs)
@@ -236,7 +233,10 @@ impl BlockBuilder {
             .expect("Failed to sign block")
             .expect("Committee has more than one test validator");
 
-        Ok(certificate)
+        Ok(CertifiedBlock {
+            certificate,
+            resources,
+        })
     }
 }
 

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -8,7 +8,7 @@
 use linera_base::{
     abi::ContractAbi,
     data_types::{Amount, ApplicationPermissions, Blob, Round, Timestamp},
-    identifiers::{AccountOwner, ApplicationId, ChainId},
+    identifiers::{AccountOwner, ApplicationId, ChainId, MessageId},
     ownership::TimeoutConfig,
 };
 use linera_chain::{
@@ -263,5 +263,22 @@ impl CertifiedBlock {
     /// Returns the number of messages produced by this [`CertifiedBlock`].
     pub fn outgoing_message_count(&self) -> usize {
         self.certificate.outgoing_message_count()
+    }
+
+    /// Returns the [`MessageId`] for the `message_index`th outgoing message produced by the
+    /// `operation_index`th operation in this [`CertifiedBlock`].
+    pub fn message_id_for_operation(
+        &self,
+        operation_index: usize,
+        message_index: u32,
+    ) -> MessageId {
+        self.certificate
+            .inner()
+            .block()
+            .message_id_for_operation(operation_index, message_index)
+            .expect(
+                "Missing {message_index}th outgoing message \
+                produced by {operation_index}th operation",
+            )
     }
 }

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -16,13 +16,13 @@ use linera_chain::{
         IncomingBundle, LiteValue, LiteVote, Medium, MessageAction, Origin, ProposedBlock,
         SignatureAggregator,
     },
-    types::{ConfirmedBlock, ConfirmedBlockCertificate},
+    types::{BlockHeader, ConfirmedBlock, ConfirmedBlockCertificate},
 };
 use linera_core::worker::WorkerError;
 use linera_execution::{
     committee::Epoch,
     system::{Recipient, SystemOperation},
-    Operation,
+    Operation, OutgoingMessage, ResourceTracker,
 };
 
 use super::TestValidator;
@@ -237,5 +237,24 @@ impl BlockBuilder {
             .expect("Committee has more than one test validator");
 
         Ok(certificate)
+    }
+}
+
+/// A block that has been confirmed and certified by the validators.
+#[derive(Clone, Debug)]
+pub struct CertifiedBlock {
+    pub(super) certificate: ConfirmedBlockCertificate,
+    pub(super) resources: ResourceTracker,
+}
+
+impl CertifiedBlock {
+    /// Returns the header of this [`CertifiedBlock`].
+    pub fn header(&self) -> &BlockHeader {
+        &self.certificate.inner().block().header
+    }
+
+    /// Returns the messages in this [`CertifiedBlock`].
+    pub fn messages(&self) -> &[Vec<OutgoingMessage>] {
+        self.certificate.inner().block().messages()
     }
 }

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -259,4 +259,9 @@ impl CertifiedBlock {
     pub fn messages(&self) -> &[Vec<OutgoingMessage>] {
         self.certificate.inner().block().messages()
     }
+
+    /// Returns the number of messages produced by this [`CertifiedBlock`].
+    pub fn outgoing_message_count(&self) -> usize {
+        self.certificate.outgoing_message_count()
+    }
 }

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -174,23 +174,24 @@ impl BlockBuilder {
         self
     }
 
-    /// Receives all direct messages  that were sent to this chain by the given certificate.
-    pub fn with_messages_from(&mut self, certificate: &ConfirmedBlockCertificate) -> &mut Self {
-        self.with_messages_from_by_medium(certificate, &Medium::Direct, MessageAction::Accept)
+    /// Receives all direct messages that were sent to this chain by the given certificate.
+    pub fn with_messages_from(&mut self, block: &CertifiedBlock) -> &mut Self {
+        self.with_messages_from_by_medium(block, &Medium::Direct, MessageAction::Accept)
     }
 
     /// Receives all messages that were sent to this chain by the given certificate.
     pub fn with_messages_from_by_medium(
         &mut self,
-        certificate: &ConfirmedBlockCertificate,
+        block: &CertifiedBlock,
         medium: &Medium,
         action: MessageAction,
     ) -> &mut Self {
         let origin = Origin {
-            sender: certificate.inner().chain_id(),
+            sender: block.certificate.inner().chain_id(),
             medium: medium.clone(),
         };
-        let bundles = certificate
+        let bundles = block
+            .certificate
             .message_bundles_for(medium, self.block.chain_id)
             .map(|(_epoch, bundle)| IncomingBundle {
                 origin: origin.clone(),

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -50,13 +50,14 @@ impl BlockBuilder {
         chain_id: ChainId,
         owner: AccountOwner,
         epoch: Epoch,
-        previous_block: Option<&ConfirmedBlockCertificate>,
+        previous_block: Option<&CertifiedBlock>,
         validator: TestValidator,
     ) -> Self {
-        let previous_block_hash = previous_block.map(|certificate| certificate.hash());
+        let previous_block_hash = previous_block.map(|block| block.certificate.hash());
         let height = previous_block
-            .map(|certificate| {
-                certificate
+            .map(|block| {
+                block
+                    .certificate
                     .inner()
                     .height()
                     .try_add_one()

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -217,7 +217,7 @@ impl BlockBuilder {
                     .clone()
             })
             .collect();
-        let (block, _) = self
+        let (block, _, _) = self
             .validator
             .worker()
             .stage_block_execution(self.block, None, published_blobs)

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -264,7 +264,7 @@ impl ActiveChain {
         block_builder(&mut block);
 
         // TODO(#2066): Remove boxing once call-stack is shallower
-        let certificate = Box::pin(block.try_sign(&blobs)).await?;
+        let certificate = Box::pin(block.try_sign(&blobs)).await?.certificate;
 
         let result = self
             .validator

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -19,7 +19,7 @@ use linera_base::{
     identifiers::{AccountOwner, ApplicationId, ChainDescription, ChainId, ModuleId},
     vm::VmRuntime,
 };
-use linera_chain::{types::ConfirmedBlockCertificate, ChainExecutionContext};
+use linera_chain::ChainExecutionContext;
 use linera_core::{data_types::ChainInfoQuery, worker::WorkerError};
 use linera_execution::{
     committee::Epoch,
@@ -37,7 +37,7 @@ use crate::{ContractAbi, ServiceAbi};
 pub struct ActiveChain {
     key_pair: AccountSecretKey,
     description: ChainDescription,
-    tip: Arc<Mutex<Option<ConfirmedBlockCertificate>>>,
+    tip: Arc<Mutex<Option<CertifiedBlock>>>,
     validator: TestValidator,
 }
 
@@ -279,7 +279,7 @@ impl ActiveChain {
             result.expect("Rejected certificate");
         }
 
-        *tip = Some(block.certificate.clone());
+        *tip = Some(block.clone());
 
         Ok(block)
     }

--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -33,7 +33,7 @@ pub use {
 pub use self::mock_stubs::*;
 #[cfg(with_integration_testing)]
 pub use self::{
-    block::BlockBuilder,
+    block::{BlockBuilder, CertifiedBlock},
     chain::{ActiveChain, TryGraphQLMutationError, TryGraphQLQueryError, TryQueryError},
     validator::TestValidator,
 };

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -278,16 +278,16 @@ impl TestValidator {
             application_permissions: ApplicationPermissions::default(),
         };
 
-        let certificate = admin_chain
+        let block = admin_chain
             .add_block(|block| {
                 block.with_system_operation(SystemOperation::OpenChain(new_chain_config));
             })
             .await;
-        let block = certificate.inner().block();
+        let block_header = block.header();
 
         ChainDescription::Child(MessageId {
-            chain_id: block.header.chain_id,
-            height: block.header.height,
+            chain_id: block_header.chain_id,
+            height: block_header.height,
             index: OPEN_CHAIN_MESSAGE_INDEX,
         })
     }


### PR DESCRIPTION
## Motivation

Messages may be sent with resource grants so that the message receiver doesn't have to pay any fees to receive the message. However, figuring out how much resources to include in the grant is not trivial.

## Proposal

Allow writing integration tests that assert if a block consumed less resources than those that would be provided for a grant.

## Test Plan

TODO: this needs a test.

## Release Plan

- These changes follow the usual release cycle, because this adds a new breaking change to the SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
