### PR TITLE
Fix How To Perform HTTP Requests readme test in CI

### DIFF
--- a/examples/how-to/perform-http-requests/README.md
+++ b/examples/how-to/perform-http-requests/README.md
@@ -65,6 +65,7 @@ For the test, a simple HTTP server will be executed in the background.
 ```bash
 HTTP_PORT=9090
 cd examples
+cargo build --bin test_http_server
 cargo run --bin test_http_server -- "$HTTP_PORT" &
 cd ..
 ```

--- a/linera-service/tests/readme_test.rs
+++ b/linera-service/tests/readme_test.rs
@@ -25,8 +25,7 @@ use tokio::process::Command;
 #[test_case::test_case("../examples/crowd-funding" ; "crowd funding")]
 #[test_case::test_case("../examples/fungible" ; "fungible")]
 #[test_case::test_case("../examples/gen-nft" ; "gen-nft")]
-// TODO(#3743): Fix this test and re-enable it.
-// #[test_case::test_case("../examples/how-to/perform-http-requests" ; "how-to-perform-http-requests")]
+#[test_case::test_case("../examples/how-to/perform-http-requests" ; "how-to-perform-http-requests")]
 #[test_case::test_case("../examples/hex-game" ; "hex-game")]
 #[test_case::test_case("../examples/llm" ; "llm")]
 #[test_case::test_case("../examples/native-fungible" ; "native-fungible")]


### PR DESCRIPTION
## Motivation

The README test for the How To Perform HTTP Requests example was failing in CI, but not locally. After investigating the issue, the cause seems to be a race condition by running `cargo run --bin test_http_server &` in the background. This command didn't immediately start the test HTTP server, because it had to be built first, and that meant that on some computers (like in the CI) it could end up starting too late.

## Proposal

Build the `test_http_server` binary in the foreground, so that the `cargo run` command in the background is guaranteed to start the test HTTP server right afterwards.

## Test Plan

CI now passes, whereas it previously failed without this fix.

## Release Plan

- Nothing to do, because this only refactors a step in the README.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Closes #3743
