### PR TITLE
Implement event stream subscriptions; port social example.

### DIFF
--- a/examples/social/src/lib.rs
+++ b/examples/social/src/lib.rs
@@ -41,25 +41,6 @@ pub enum Operation {
     Comment { key: Key, comment: String },
 }
 
-/// A message of the application on one chain, to be handled on another chain.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub enum Message {
-    /// The origin chain wants to subscribe to the target chain.
-    Subscribe,
-    /// The origin chain wants to unsubscribe from the target chain.
-    Unsubscribe,
-    /// The origin chain made a post, and the target chain is subscribed.
-    Post { index: u32, post: OwnPost },
-    /// A Chain liked a post
-    Like { key: Key },
-    /// A Chain commented on a post
-    Comment {
-        key: Key,
-        chain_id: ChainId,
-        comment: String,
-    },
-}
-
 /// A post's text and timestamp, to use in contexts where author and index are known.
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize, SimpleObject)]
 pub struct OwnPost {

--- a/examples/social/src/state.rs
+++ b/examples/social/src/state.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_sdk::views::{linera_views, CustomMapView, LogView, RootView, ViewStorageContext};
+use linera_sdk::{
+    linera_base_types::ChainId,
+    views::{linera_views, CustomMapView, LogView, MapView, RootView, ViewStorageContext},
+};
 use social::{Key, OwnPost, Post};
 
 /// The application state.
@@ -12,4 +15,6 @@ pub struct SocialState {
     pub own_posts: LogView<OwnPost>,
     /// Posts we received from authors we subscribed to.
     pub received_posts: CustomMapView<Key, Post>,
+    /// Other chains events we have already processed.
+    pub processed_events: MapView<ChainId, u32>,
 }

--- a/examples/social/src/state.rs
+++ b/examples/social/src/state.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_sdk::{
-    linera_base_types::ChainId,
-    views::{linera_views, CustomMapView, LogView, MapView, RootView, ViewStorageContext},
-};
+use linera_sdk::views::{linera_views, CustomMapView, LogView, RootView, ViewStorageContext};
 use social::{Key, OwnPost, Post};
 
 /// The application state.
@@ -15,6 +12,4 @@ pub struct SocialState {
     pub own_posts: LogView<OwnPost>,
     /// Posts we received from authors we subscribed to.
     pub received_posts: CustomMapView<Key, Post>,
-    /// Other chains events we have already processed.
-    pub processed_events: MapView<ChainId, u32>,
 }

--- a/examples/social/tests/cross_chain.rs
+++ b/examples/social/tests/cross_chain.rs
@@ -35,9 +35,6 @@ async fn test_cross_chain_posting() {
         })
         .await;
 
-    // Make chain2 handle that fact.
-    chain2.handle_received_messages().await;
-
     // Post on chain2
     chain2
         .add_block(|block| {
@@ -51,8 +48,8 @@ async fn test_cross_chain_posting() {
         })
         .await;
 
-    // Now make chain1 handle that fact.
-    chain1.handle_received_messages().await;
+    // Now make chain1 handle the post.
+    chain1.handle_new_events().await;
 
     // Querying the own posts
     let query = "query { ownPosts { entries(start: 0, end: 1) { timestamp, text } } }";

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1315,6 +1315,26 @@ impl Event {
     }
 }
 
+/// An update for a stream with new events.
+#[derive(Clone, Debug, Serialize, Deserialize, WitType, WitLoad, WitStore)]
+pub struct StreamUpdate {
+    /// The publishing chain.
+    pub chain_id: ChainId,
+    /// The stream ID.
+    pub stream_id: StreamId,
+    /// The lowest index of a new event.
+    pub previous_index: u32,
+    /// The index of the next event, i.e. the lowest for which no event is known yet.
+    pub next_index: u32,
+}
+
+impl StreamUpdate {
+    /// Returns the indices of all new events in the stream.
+    pub fn new_indices(&self) -> impl Iterator<Item = u32> {
+        self.previous_index..self.next_index
+    }
+}
+
 impl BcsHashable<'_> for Event {}
 
 doc_scalar!(Bytecode, "A WebAssembly module's bytecode");

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1322,7 +1322,7 @@ pub struct StreamUpdate {
     pub chain_id: ChainId,
     /// The stream ID.
     pub stream_id: StreamId,
-    /// The lowest index of a new event.
+    /// The lowest index of a new event. See [`StreamUpdate::new_indices`].
     pub previous_index: u32,
     /// The index of the next event, i.e. the lowest for which no event is known yet.
     pub next_index: u32,

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -3,7 +3,6 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    iter,
     sync::Arc,
     time::Duration,
 };
@@ -140,6 +139,8 @@ pub struct ChainListener<C: ClientContext> {
     storage: C::Storage,
     config: Arc<ChainListenerConfig>,
     listening: BTreeMap<ChainId, ListeningClient<C>>,
+    /// The set of chains that subscribe to at least one event stream on the given chain.
+    event_subscribers: BTreeMap<ChainId, BTreeSet<ChainId>>,
     cancellation_token: CancellationToken,
 }
 
@@ -156,6 +157,7 @@ impl<C: ClientContext> ChainListener<C> {
             context,
             config: Arc::new(config),
             listening: Default::default(),
+            event_subscribers: Default::default(),
             cancellation_token,
         }
     }
@@ -165,12 +167,9 @@ impl<C: ClientContext> ChainListener<C> {
     pub async fn run(mut self) -> Result<(), Error> {
         let chain_ids = {
             let guard = self.context.lock().await;
-            let chain_ids = guard.wallet().chain_ids().into_iter();
-            chain_ids.chain(iter::once(guard.wallet().genesis_admin_chain()))
+            BTreeSet::from_iter(guard.wallet().chain_ids())
         };
-        for chain_id in chain_ids {
-            self.listen(chain_id).await?;
-        }
+        self.listen_recursively(chain_ids).await?;
         loop {
             match self.next_action().await? {
                 Action::ProcessInbox(chain_id) => self.maybe_process_inbox(chain_id).await?,
@@ -196,6 +195,8 @@ impl<C: ClientContext> ChainListener<C> {
                 self.update_validators(&notification).await?;
                 self.update_wallet(notification.chain_id).await?;
                 self.add_new_chains(*hash).await?;
+                self.update_event_subscriptions(notification.chain_id)
+                    .await?;
                 self.process_new_events(notification.chain_id).await?;
             }
         }
@@ -240,31 +241,36 @@ impl<C: ClientContext> ChainListener<C> {
             }
         }
         drop(context_guard);
-        for new_id in new_ids {
-            self.listen(new_id).await?;
-        }
+        self.listen_recursively(new_ids).await?;
         Ok(())
     }
 
     /// Processes the inboxes of all chains that are subscribed to streams with new events.
     async fn process_new_events(&mut self, chain_id: ChainId) -> Result<(), Error> {
-        // TODO(#365): Support subscriptions to chains other than the admin chain.
-        let admin_id = self.context.lock().await.wallet().genesis_admin_chain();
-        if chain_id == admin_id {
-            let chain_ids = self.listening.keys().cloned().collect::<Vec<_>>();
-            for chain_id in chain_ids {
-                if chain_id != admin_id {
-                    self.maybe_process_inbox(chain_id).await?;
-                }
-            }
+        let Some(subscribers) = self.event_subscribers.get(&chain_id).cloned() else {
+            return Ok(());
+        };
+        for subscriber_id in subscribers {
+            self.maybe_process_inbox(subscriber_id).await?;
         }
         Ok(())
     }
 
-    /// Start listening for notifications about the given chain.
-    async fn listen(&mut self, chain_id: ChainId) -> Result<(), Error> {
+    /// Starts listening for notifications about the given chains, and any event stream publisher
+    /// chains.
+    async fn listen_recursively(&mut self, mut chain_ids: BTreeSet<ChainId>) -> Result<(), Error> {
+        while let Some(chain_id) = chain_ids.pop_first() {
+            chain_ids.extend(self.listen(chain_id).await?);
+        }
+        Ok(())
+    }
+
+    /// Starts listening for notifications about the given chain.
+    ///
+    /// Returns all publisher chains, that we also need to listen to.
+    async fn listen(&mut self, chain_id: ChainId) -> Result<BTreeSet<ChainId>, Error> {
         if self.listening.contains_key(&chain_id) {
-            return Ok(());
+            return Ok(BTreeSet::new());
         }
         let client = self.context.lock().await.make_chain_client(chain_id)?;
         let (listener, abort_handle, notification_stream) = client.listen().await?;
@@ -277,8 +283,28 @@ impl<C: ClientContext> ChainListener<C> {
         let listening_client =
             ListeningClient::new(client, abort_handle, join_handle, notification_stream);
         self.listening.insert(chain_id, listening_client);
+        let publishers = self.update_event_subscriptions(chain_id).await?;
         self.maybe_process_inbox(chain_id).await?;
-        Ok(())
+        Ok(publishers)
+    }
+
+    /// Updates the event subscribers map, and returns all publisher chains we need to listen to.
+    async fn update_event_subscriptions(
+        &mut self,
+        chain_id: ChainId,
+    ) -> Result<BTreeSet<ChainId>, Error> {
+        let listening_client = self.listening.get_mut(&chain_id).expect("missing client");
+        if !listening_client.client.is_tracked() {
+            return Ok(BTreeSet::new());
+        }
+        let publishers = listening_client.client.event_stream_publishers().await?;
+        for publisher_id in &publishers {
+            self.event_subscribers
+                .entry(*publisher_id)
+                .or_default()
+                .insert(chain_id);
+        }
+        Ok(publishers)
     }
 
     /// Returns the next notification or timeout to process.
@@ -360,6 +386,10 @@ impl<C: ClientContext> ChainListener<C> {
             return Ok(());
         }
         let listening_client = self.listening.get_mut(&chain_id).expect("missing client");
+        if !listening_client.client.is_tracked() {
+            debug!("Not processing inbox for non-tracked chain");
+            return Ok(());
+        }
         debug!("Processing inbox");
         listening_client.timeout = Timestamp::from(u64::MAX);
         match listening_client

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -249,10 +249,7 @@ where
         // We only create clients for chains we have in the wallet, or for the admin chain.
         let chain = match self.wallet.get(chain_id) {
             Some(chain) => chain.clone(),
-            None if chain_id == self.wallet.genesis_admin_chain() => {
-                UserChain::make_other(self.wallet.genesis_admin_chain(), Timestamp::from(0))
-            }
-            None => return Err(error::Inner::NonexistentChain(chain_id).into()),
+            None => UserChain::make_other(chain_id, Timestamp::from(0)),
         };
         let known_key_pairs = chain.key_pair.into_iter().collect();
         Ok(self.make_chain_client_internal(

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -865,6 +865,51 @@ where
             .collect())
     }
 
+    /// Returns an `UpdateStreams` operation that updates this client's chain about new events
+    /// in any of the streams its applications are subscribing to. Returns `None` if there are no
+    /// new events.
+    #[instrument(level = "trace")]
+    async fn update_streams_operation(&self) -> Result<Option<Operation>, ChainClientError> {
+        // Load all our subscriptions.
+        let subscription_map = self
+            .chain_state_view()
+            .await?
+            .execution_state
+            .system
+            .event_subscriptions
+            .index_values()
+            .await?;
+        // Collect the indices of all new events.
+        let futures = subscription_map
+            .into_iter()
+            .map(|((chain_id, stream_id), subscriptions)| {
+                let client = self.client.clone();
+                async move {
+                    let chain = client.local_node.chain_state_view(chain_id).await?;
+                    if let Some(next_index) = chain
+                        .execution_state
+                        .stream_event_counts
+                        .get(&stream_id)
+                        .await?
+                        .filter(|next_index| *next_index > subscriptions.next_index)
+                    {
+                        Ok(Some((chain_id, stream_id, next_index)))
+                    } else {
+                        Ok::<_, ChainClientError>(None)
+                    }
+                }
+            });
+        let updates = future::try_join_all(futures)
+            .await?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        if updates.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(SystemOperation::UpdateStreams(updates).into()))
+    }
+
     /// Obtains the current epoch of the given chain as well as its set of trusted committees.
     #[instrument(level = "trace")]
     pub async fn epoch_and_committees(
@@ -1524,6 +1569,29 @@ where
                 self.chain_id
             );
         }
+    }
+
+    /// Synchronizes all chains that any application on this chain subscribes to.
+    async fn synchronize_publisher_chains(&self) -> Result<(), ChainClientError> {
+        let chain_ids = self
+            .chain_state_view()
+            .await?
+            .execution_state
+            .system
+            .event_subscriptions
+            .indices()
+            .await?
+            .iter()
+            .map(|(chain_id, _)| *chain_id)
+            .filter(|chain_id| *chain_id != self.chain_id && *chain_id != self.admin_id)
+            .collect::<BTreeSet<_>>();
+        try_join_all(
+            chain_ids
+                .into_iter()
+                .map(|chain_id| self.synchronize_chain_state(chain_id)),
+        )
+        .await?;
+        Ok(())
     }
 
     /// Attempts to download new received certificates.
@@ -2443,6 +2511,7 @@ where
             self.synchronize_chain_state(self.admin_id).await?;
         }
         let info = self.prepare_chain().await?;
+        self.synchronize_publisher_chains().await?;
         self.find_received_certificates().await?;
         Ok(info)
     }
@@ -3056,7 +3125,11 @@ where
         let mut certificates = Vec::new();
         loop {
             let incoming_bundles = self.pending_message_bundles().await?;
-            let block_operations = epoch_change_ops.next().into_iter().collect::<Vec<_>>();
+            let update_streams = self.update_streams_operation().await?;
+            let block_operations = update_streams
+                .into_iter()
+                .chain(epoch_change_ops.next())
+                .collect::<Vec<_>>();
             if incoming_bundles.is_empty() && block_operations.is_empty() {
                 return Ok((certificates, None));
             }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -889,7 +889,7 @@ where
     /// in any of the streams its applications are subscribing to. Returns `None` if there are no
     /// new events.
     #[instrument(level = "trace")]
-    async fn update_streams_operation(&self) -> Result<Option<Operation>, ChainClientError> {
+    async fn collect_stream_updates(&self) -> Result<Option<Operation>, ChainClientError> {
         // Load all our subscriptions.
         let subscription_map = self
             .chain_state_view()
@@ -3143,8 +3143,8 @@ where
         let mut certificates = Vec::new();
         loop {
             let incoming_bundles = self.pending_message_bundles().await?;
-            let update_streams = self.update_streams_operation().await?;
-            let block_operations = update_streams
+            let stream_updates = self.collect_stream_updates().await?;
+            let block_operations = stream_updates
                 .into_iter()
                 .chain(epoch_change_ops.next())
                 .collect::<Vec<_>>();

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -755,6 +755,23 @@ where
         self.client.local_node.chain_state_view(self.chain_id).await
     }
 
+    /// Returns all chain IDs that publish an event stream this chain subscribes to.
+    #[instrument(level = "trace", skip(self))]
+    pub async fn event_stream_publishers(&self) -> Result<BTreeSet<ChainId>, LocalNodeError> {
+        Ok(self
+            .chain_state_view()
+            .await?
+            .execution_state
+            .system
+            .event_subscriptions
+            .indices()
+            .await?
+            .into_iter()
+            .map(|(chain_id, _)| chain_id)
+            .chain((self.chain_id != self.admin_id).then_some(self.admin_id))
+            .collect())
+    }
+
     /// Subscribes to notifications from this client's chain.
     #[instrument(level = "trace")]
     pub async fn subscribe(&self) -> Result<NotificationStream, LocalNodeError> {

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -10,7 +10,7 @@ use alloy::primitives::Address;
 use linera_base::{
     data_types::Bytecode,
     ensure,
-    identifiers::{ApplicationId, StreamName},
+    identifiers::{ApplicationId, ChainId, StreamId, StreamName},
     vm::EvmQuery,
 };
 use num_enum::TryFromPrimitive;
@@ -552,6 +552,14 @@ where
     ) -> Result<(), ExecutionError> {
         // TODO(#3760): Implement execute_message for EVM
         todo!("The execute_message part of the Ethereum smart contract has not yet been coded");
+    }
+
+    fn process_streams(
+        &mut self,
+        _context: OperationContext,
+        _streams: Vec<(ChainId, StreamId, u32)>,
+    ) -> Result<(), ExecutionError> {
+        todo!("Streams are not implemented for Ethereum smart contracts yet.")
     }
 
     fn finalize(&mut self, _context: FinalizeContext) -> Result<(), ExecutionError> {

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -35,9 +35,9 @@ use {
 
 use crate::{
     evm::database::DatabaseRuntime, ContractRuntime, ContractSyncRuntimeHandle, EvmExecutionError,
-    EvmRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext,
-    ProcessStreamsContext, QueryContext, ServiceRuntime, ServiceSyncRuntimeHandle, UserContract,
-    UserContractInstance, UserContractModule, UserService, UserServiceInstance, UserServiceModule,
+    EvmRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext, QueryContext,
+    ServiceRuntime, ServiceSyncRuntimeHandle, UserContract, UserContractInstance,
+    UserContractModule, UserService, UserServiceInstance, UserServiceModule,
 };
 
 /// This is the selector of the `execute_message` that should be called
@@ -554,11 +554,7 @@ where
         todo!("The execute_message part of the Ethereum smart contract has not yet been coded");
     }
 
-    fn process_streams(
-        &mut self,
-        _context: ProcessStreamsContext,
-        _streams: Vec<StreamUpdate>,
-    ) -> Result<(), ExecutionError> {
+    fn process_streams(&mut self, _streams: Vec<StreamUpdate>) -> Result<(), ExecutionError> {
         // TODO(#3785): Implement process_streams for EVM
         todo!("Streams are not implemented for Ethereum smart contracts yet.")
     }

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -35,9 +35,9 @@ use {
 
 use crate::{
     evm::database::DatabaseRuntime, ContractRuntime, ContractSyncRuntimeHandle, EvmExecutionError,
-    EvmRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext, QueryContext,
-    ServiceRuntime, ServiceSyncRuntimeHandle, UserContract, UserContractInstance,
-    UserContractModule, UserService, UserServiceInstance, UserServiceModule,
+    EvmRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext,
+    ProcessStreamsContext, QueryContext, ServiceRuntime, ServiceSyncRuntimeHandle, UserContract,
+    UserContractInstance, UserContractModule, UserService, UserServiceInstance, UserServiceModule,
 };
 
 /// This is the selector of the `execute_message` that should be called
@@ -556,7 +556,7 @@ where
 
     fn process_streams(
         &mut self,
-        _context: OperationContext,
+        _context: ProcessStreamsContext,
         _streams: Vec<(ChainId, StreamId, u32)>,
     ) -> Result<(), ExecutionError> {
         todo!("Streams are not implemented for Ethereum smart contracts yet.")

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -8,9 +8,9 @@ use std::{convert::TryFrom, sync::Arc};
 
 use alloy::primitives::Address;
 use linera_base::{
-    data_types::Bytecode,
+    data_types::{Bytecode, StreamUpdate},
     ensure,
-    identifiers::{ApplicationId, ChainId, StreamId, StreamName},
+    identifiers::{ApplicationId, StreamName},
     vm::EvmQuery,
 };
 use num_enum::TryFromPrimitive;
@@ -557,7 +557,7 @@ where
     fn process_streams(
         &mut self,
         _context: ProcessStreamsContext,
-        _streams: Vec<(ChainId, StreamId, u32)>,
+        _streams: Vec<StreamUpdate>,
     ) -> Result<(), ExecutionError> {
         // TODO(#3785): Implement process_streams for EVM
         todo!("Streams are not implemented for Ethereum smart contracts yet.")

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -559,6 +559,7 @@ where
         _context: ProcessStreamsContext,
         _streams: Vec<(ChainId, StreamId, u32)>,
     ) -> Result<(), ExecutionError> {
+        // TODO(#3785): Implement process_streams for EVM
         todo!("Streams are not implemented for Ethereum smart contracts yet.")
     }
 

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -542,7 +542,7 @@ where
                     .get(&(*chain_id, stream_id.clone()))
                     .unwrap_or(&empty);
                 for app_id in &new.applications {
-                    if !old.applications.contains(app_id) {
+                    if !old.applications.contains(app_id) || old.next_index < new.next_index {
                         to_process.entry(*app_id).or_default().push((
                             *chain_id,
                             stream_id.clone(),

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -517,7 +517,7 @@ where
         let mut processed = BTreeSet::new();
         loop {
             let to_process = txn_tracker
-                .flush_streams_to_process()
+                .take_streams_to_process()
                 .into_iter()
                 .filter_map(|(app_id, updates)| {
                     let updates = updates

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{mem, vec};
+use std::{collections::BTreeMap, mem, vec};
 
 use futures::{FutureExt, StreamExt};
 use linera_base::{
     data_types::{Amount, BlockHeight},
-    identifiers::{Account, AccountOwner, Destination, StreamId},
+    identifiers::{Account, AccountOwner, ChainId, Destination, StreamId},
 };
 use linera_views::{
     context::Context,
@@ -28,11 +28,12 @@ use {
 
 use super::{runtime::ServiceRuntimeRequest, ExecutionRequest};
 use crate::{
-    resources::ResourceController, system::SystemExecutionStateView, ApplicationDescription,
-    ApplicationId, ContractSyncRuntime, ExecutionError, ExecutionRuntimeConfig,
-    ExecutionRuntimeContext, Message, MessageContext, MessageKind, Operation, OperationContext,
-    OutgoingMessage, Query, QueryContext, QueryOutcome, ServiceSyncRuntime, SystemMessage,
-    TransactionTracker,
+    resources::ResourceController,
+    system::{EventSubscriptions, SystemExecutionStateView},
+    ApplicationDescription, ApplicationId, ContractSyncRuntime, ExecutionError,
+    ExecutionRuntimeConfig, ExecutionRuntimeContext, Message, MessageContext, MessageKind,
+    Operation, OperationContext, OutgoingMessage, ProcessStreamsContext, Query, QueryContext,
+    QueryOutcome, ServiceSyncRuntime, SystemMessage, TransactionTracker,
 };
 
 /// A view accessing the execution state of a chain.
@@ -138,6 +139,7 @@ pub enum UserAction {
     Instantiate(OperationContext, Vec<u8>),
     Operation(OperationContext, Vec<u8>),
     Message(MessageContext, Vec<u8>),
+    ProcessStreams(ProcessStreamsContext, Vec<(ChainId, StreamId, u32)>),
 }
 
 impl UserAction {
@@ -146,6 +148,7 @@ impl UserAction {
         match self {
             Instantiate(context, _) => context.authenticated_signer,
             Operation(context, _) => context.authenticated_signer,
+            ProcessStreams(context, _) => context.authenticated_signer,
             Message(context, _) => context.authenticated_signer,
         }
     }
@@ -154,6 +157,7 @@ impl UserAction {
         match self {
             UserAction::Instantiate(context, _) => context.height,
             UserAction::Operation(context, _) => context.height,
+            UserAction::ProcessStreams(context, _) => context.height,
             UserAction::Message(context, _) => context.height,
         }
     }
@@ -162,6 +166,7 @@ impl UserAction {
         match self {
             UserAction::Instantiate(context, _) => context.round,
             UserAction::Operation(context, _) => context.round,
+            UserAction::ProcessStreams(context, _) => context.round,
             UserAction::Message(context, _) => context.round,
         }
     }
@@ -263,6 +268,7 @@ where
         resource_controller: &mut ResourceController<Option<AccountOwner>>,
     ) -> Result<(), ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());
+        let old_subscriptions = self.read_event_subscriptions().await?;
         match operation {
             Operation::System(op) => {
                 let new_application = self
@@ -297,6 +303,13 @@ where
                 .await?;
             }
         }
+        self.process_subscriptions(
+            txn_tracker,
+            resource_controller,
+            context.into(),
+            old_subscriptions,
+        )
+        .await?;
         Ok(())
     }
 
@@ -309,6 +322,7 @@ where
         resource_controller: &mut ResourceController<Option<AccountOwner>>,
     ) -> Result<(), ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());
+        let old_subscriptions = self.read_event_subscriptions().await?;
         match message {
             Message::System(message) => {
                 let outcome = self.system.execute_message(context, message).await?;
@@ -329,6 +343,13 @@ where
                 .await?;
             }
         }
+        self.process_subscriptions(
+            txn_tracker,
+            resource_controller,
+            context.into(),
+            old_subscriptions,
+        )
+        .await?;
         Ok(())
     }
 
@@ -493,5 +514,61 @@ where
             applications.push((app_id, application_description));
         }
         Ok(applications)
+    }
+
+    async fn read_event_subscriptions(
+        &self,
+    ) -> Result<BTreeMap<(ChainId, StreamId), EventSubscriptions>, ExecutionError> {
+        let vec = self.system.event_subscriptions.index_values().await?;
+        Ok(vec.into_iter().collect())
+    }
+
+    async fn process_subscriptions(
+        &mut self,
+        txn_tracker: &mut TransactionTracker,
+        resource_controller: &mut ResourceController<Option<AccountOwner>>,
+        context: ProcessStreamsContext,
+        mut old_subscriptions: BTreeMap<(ChainId, StreamId), EventSubscriptions>,
+    ) -> Result<(), ExecutionError> {
+        let mut new_subscriptions = self.read_event_subscriptions().await?;
+        let empty = EventSubscriptions::default();
+        loop {
+            let mut to_process = BTreeMap::<ApplicationId, Vec<_>>::new();
+            for ((chain_id, stream_id), new) in &new_subscriptions {
+                if new.next_index == 0 {
+                    continue;
+                }
+                let old = old_subscriptions
+                    .get(&(*chain_id, stream_id.clone()))
+                    .unwrap_or(&empty);
+                for app_id in &new.applications {
+                    if !old.applications.contains(app_id) {
+                        to_process.entry(*app_id).or_default().push((
+                            *chain_id,
+                            stream_id.clone(),
+                            new.next_index,
+                        ));
+                    }
+                }
+            }
+            if to_process.is_empty() {
+                return Ok(());
+            }
+            for (app_id, streams) in to_process {
+                self.run_user_action(
+                    app_id,
+                    UserAction::ProcessStreams(context, streams.clone()),
+                    None,
+                    None,
+                    txn_tracker,
+                    resource_controller,
+                )
+                .await?;
+            }
+            old_subscriptions = mem::replace(
+                &mut new_subscriptions,
+                self.read_event_subscriptions().await?,
+            );
+        }
     }
 }

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -150,7 +150,7 @@ impl UserAction {
         match self {
             Instantiate(context, _) => context.authenticated_signer,
             Operation(context, _) => context.authenticated_signer,
-            ProcessStreams(context, _) => context.authenticated_signer,
+            ProcessStreams(_, _) => None,
             Message(context, _) => context.authenticated_signer,
         }
     }
@@ -506,6 +506,8 @@ where
         Ok(applications)
     }
 
+    /// Calls `process_streams` for all applications that are subscribed to streams with new
+    /// events or that have new subscriptions.
     async fn process_subscriptions(
         &mut self,
         txn_tracker: &mut TransactionTracker,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -31,12 +31,11 @@ use {
 
 use super::{runtime::ServiceRuntimeRequest, ExecutionRequest};
 use crate::{
-    resources::ResourceController,
-    system::{EventSubscriptions, SystemExecutionStateView},
-    ApplicationDescription, ApplicationId, ContractSyncRuntime, ExecutionError,
-    ExecutionRuntimeConfig, ExecutionRuntimeContext, Message, MessageContext, MessageKind,
-    Operation, OperationContext, OutgoingMessage, ProcessStreamsContext, Query, QueryContext,
-    QueryOutcome, ServiceSyncRuntime, SystemMessage, TransactionTracker,
+    resources::ResourceController, system::SystemExecutionStateView, ApplicationDescription,
+    ApplicationId, ContractSyncRuntime, ExecutionError, ExecutionRuntimeConfig,
+    ExecutionRuntimeContext, Message, MessageContext, MessageKind, Operation, OperationContext,
+    OutgoingMessage, ProcessStreamsContext, Query, QueryContext, QueryOutcome, ServiceSyncRuntime,
+    SystemMessage, TransactionTracker,
 };
 
 /// A view accessing the execution state of a chain.

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -464,8 +464,12 @@ where
                     .event_subscriptions
                     .get_mut_or_default(&(chain_id, stream_id))
                     .await?;
-                subscriptions.applications.insert(subscriber_app_id);
-                callback.respond(());
+                let next_index = if subscriptions.applications.insert(subscriber_app_id) {
+                    subscriptions.next_index
+                } else {
+                    0
+                };
+                callback.respond(next_index);
             }
 
             UnsubscribeFromEvents {
@@ -759,7 +763,7 @@ pub enum ExecutionRequest {
         stream_id: StreamId,
         subscriber_app_id: ApplicationId,
         #[debug(skip)]
-        callback: Sender<()>,
+        callback: Sender<u32>,
     },
 
     UnsubscribeFromEvents {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -327,6 +327,8 @@ pub enum ExecutionError {
     InactiveChain,
     #[error("No recorded response for oracle query")]
     MissingOracleResponse,
+    #[error("process_streams was not called for all stream updates")]
+    UnprocessedStreams,
     #[error("Internal error: {0}")]
     InternalError(&'static str),
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -368,11 +368,7 @@ pub trait UserContract {
     ) -> Result<(), ExecutionError>;
 
     /// Reacts to new events on streams this application subscribes to.
-    fn process_streams(
-        &mut self,
-        context: ProcessStreamsContext,
-        updates: Vec<StreamUpdate>,
-    ) -> Result<(), ExecutionError>;
+    fn process_streams(&mut self, updates: Vec<StreamUpdate>) -> Result<(), ExecutionError>;
 
     /// Finishes execution of the current transaction.
     fn finalize(&mut self, context: FinalizeContext) -> Result<(), ExecutionError>;

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -366,7 +366,7 @@ pub trait UserContract {
     /// Reacts to new events on streams this application subscribes to.
     fn process_streams(
         &mut self,
-        context: OperationContext,
+        context: ProcessStreamsContext,
         streams: Vec<(ChainId, StreamId, u32)>,
     ) -> Result<(), ExecutionError>;
 
@@ -471,6 +471,41 @@ pub struct MessageContext {
     /// The ID of the message (based on the operation height and index in the remote
     /// certificate).
     pub message_id: MessageId,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ProcessStreamsContext {
+    /// The current chain ID.
+    pub chain_id: ChainId,
+    /// The authenticated signer of the operation that created the message, if any.
+    #[debug(skip_if = Option::is_none)]
+    pub authenticated_signer: Option<AccountOwner>,
+    /// The current block height.
+    pub height: BlockHeight,
+    /// The consensus round number, if this is a block that gets validated in a multi-leader round.
+    pub round: Option<u32>,
+}
+
+impl From<MessageContext> for ProcessStreamsContext {
+    fn from(context: MessageContext) -> Self {
+        Self {
+            chain_id: context.chain_id,
+            authenticated_signer: context.authenticated_signer,
+            height: context.height,
+            round: context.round,
+        }
+    }
+}
+
+impl From<OperationContext> for ProcessStreamsContext {
+    fn from(context: OperationContext) -> Self {
+        Self {
+            chain_id: context.chain_id,
+            authenticated_signer: context.authenticated_signer,
+            height: context.height,
+            round: context.round,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -40,7 +40,7 @@ use linera_base::{
     doc_scalar, hex_debug, http,
     identifiers::{
         Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, ChannelName, Destination,
-        EventId, GenericApplicationId, MessageId, ModuleId, StreamName,
+        EventId, GenericApplicationId, MessageId, ModuleId, StreamId, StreamName,
     },
     ownership::ChainOwnership,
     task,
@@ -361,6 +361,13 @@ pub trait UserContract {
         &mut self,
         context: MessageContext,
         message: Vec<u8>,
+    ) -> Result<(), ExecutionError>;
+
+    /// Reacts to new events on streams this application subscribes to.
+    fn process_streams(
+        &mut self,
+        context: OperationContext,
+        streams: Vec<(ChainId, StreamId, u32)>,
     ) -> Result<(), ExecutionError>;
 
     /// Finishes execution of the current transaction.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -35,12 +35,12 @@ use linera_base::{
     crypto::{BcsHashable, CryptoHash},
     data_types::{
         Amount, ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlockHeight,
-        DecompressionError, Epoch, Resources, SendMessageRequest, Timestamp,
+        DecompressionError, Epoch, Resources, SendMessageRequest, StreamUpdate, Timestamp,
     },
     doc_scalar, hex_debug, http,
     identifiers::{
         Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, ChannelName, Destination,
-        EventId, GenericApplicationId, MessageId, ModuleId, StreamId, StreamName,
+        EventId, GenericApplicationId, MessageId, ModuleId, StreamName,
     },
     ownership::ChainOwnership,
     task,
@@ -371,7 +371,7 @@ pub trait UserContract {
     fn process_streams(
         &mut self,
         context: ProcessStreamsContext,
-        streams: Vec<(ChainId, StreamId, u32)>,
+        updates: Vec<StreamUpdate>,
     ) -> Result<(), ExecutionError>;
 
     /// Finishes execution of the current transaction.

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1054,6 +1054,9 @@ impl ContractSyncRuntimeHandle {
             UserAction::Message(context, message) => {
                 code.execute_message(context, message).map(|()| None)
             }
+            UserAction::ProcessStreams(context, streams) => {
+                code.process_streams(context, streams).map(|()| None)
+            }
         };
 
         let result = self.execute(application_id, signer, closure)?;

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1054,8 +1054,8 @@ impl ContractSyncRuntimeHandle {
             UserAction::Message(context, message) => {
                 code.execute_message(context, message).map(|()| None)
             }
-            UserAction::ProcessStreams(context, updates) => {
-                code.process_streams(context, updates).map(|()| None)
+            UserAction::ProcessStreams(_context, updates) => {
+                code.process_streams(updates).map(|()| None)
             }
         };
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1054,8 +1054,8 @@ impl ContractSyncRuntimeHandle {
             UserAction::Message(context, message) => {
                 code.execute_message(context, message).map(|()| None)
             }
-            UserAction::ProcessStreams(context, streams) => {
-                code.process_streams(context, streams).map(|()| None)
+            UserAction::ProcessStreams(context, updates) => {
+                code.process_streams(context, updates).map(|()| None)
             }
         };
 
@@ -1377,6 +1377,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             subscriber_app_id,
             chain_id,
             stream_id,
+            0,
             next_index,
         );
         Ok(())

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -522,7 +522,6 @@ where
                     if subscriptions.next_index >= next_index {
                         continue;
                     }
-                    subscriptions.next_index = next_index;
                     for application_id in &subscriptions.applications {
                         txn_tracker.add_stream_to_process(
                             *application_id,
@@ -531,17 +530,22 @@ where
                             next_index,
                         );
                     }
+                    subscriptions.next_index = next_index;
                     let index = next_index
                         .checked_sub(1)
                         .ok_or(ArithmeticError::Underflow)?;
-                    self.context()
-                        .extra()
-                        .get_event(EventId {
-                            chain_id,
-                            stream_id: stream_id.clone(),
-                            index,
-                        })
-                        .await?;
+                    let event_id = EventId {
+                        chain_id,
+                        stream_id,
+                        index,
+                    };
+                    ensure!(
+                        self.context()
+                            .extra()
+                            .contains_event(event_id.clone())
+                            .await?,
+                        ExecutionError::EventNotFound(event_id)
+                    );
                 }
             }
         }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -523,6 +523,14 @@ where
                         continue;
                     }
                     subscriptions.next_index = next_index;
+                    for application_id in &subscriptions.applications {
+                        txn_tracker.add_stream_to_process(
+                            *application_id,
+                            chain_id,
+                            stream_id.clone(),
+                            next_index,
+                        );
+                    }
                     let index = next_index
                         .checked_sub(1)
                         .ok_or(ArithmeticError::Underflow)?;
@@ -530,7 +538,7 @@ where
                         .extra()
                         .get_event(EventId {
                             chain_id,
-                            stream_id,
+                            stream_id: stream_id.clone(),
                             index,
                         })
                         .await?;

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -514,7 +514,6 @@ where
                 txn_tracker.add_oracle_response(OracleResponse::Event(event_id, bytes));
             }
             UpdateStreams(streams) => {
-                let mut to_process = BTreeMap::new();
                 for (chain_id, stream_id, next_index) in streams {
                     let subscriptions = self
                         .event_subscriptions
@@ -524,13 +523,6 @@ where
                         continue;
                     }
                     subscriptions.next_index = next_index;
-                    for app_id in &subscriptions.applications {
-                        to_process.entry(*app_id).or_insert_with(Vec::new).push((
-                            chain_id,
-                            stream_id.clone(),
-                            next_index,
-                        ));
-                    }
                     let index = next_index
                         .checked_sub(1)
                         .ok_or(ArithmeticError::Underflow)?;
@@ -543,7 +535,6 @@ where
                         })
                         .await?;
                 }
-                // TODO(#365): Call process_streams.
             }
         }
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -527,6 +527,7 @@ where
                             *application_id,
                             chain_id,
                             stream_id.clone(),
+                            subscriptions.next_index,
                             next_index,
                         );
                     }

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -21,8 +21,8 @@ use linera_base::identifiers::{ChainId, StreamId};
 
 use crate::{
     ContractSyncRuntimeHandle, ExecutionError, FinalizeContext, MessageContext, OperationContext,
-    QueryContext, ServiceSyncRuntimeHandle, UserContract, UserContractModule, UserService,
-    UserServiceModule,
+    ProcessStreamsContext, QueryContext, ServiceSyncRuntimeHandle, UserContract,
+    UserContractModule, UserService, UserServiceModule,
 };
 
 /// A mocked implementation of a user application.
@@ -150,7 +150,7 @@ type ExecuteMessageHandler = Box<
 type ProcessStreamHandler = Box<
     dyn FnOnce(
             &mut ContractSyncRuntimeHandle,
-            OperationContext,
+            ProcessStreamsContext,
             Vec<(ChainId, StreamId, u32)>,
         ) -> Result<(), ExecutionError>
         + Send
@@ -257,7 +257,7 @@ impl ExpectedCall {
     pub fn process_streams(
         handler: impl FnOnce(
                 &mut ContractSyncRuntimeHandle,
-                OperationContext,
+                ProcessStreamsContext,
                 Vec<(ChainId, StreamId, u32)>,
             ) -> Result<(), ExecutionError>
             + Send
@@ -379,12 +379,12 @@ impl UserContract for MockApplicationInstance<ContractSyncRuntimeHandle> {
 
     fn process_streams(
         &mut self,
-        _context: OperationContext,
-        _streams: Vec<(ChainId, StreamId, u32)>,
+        context: ProcessStreamsContext,
+        streams: Vec<(ChainId, StreamId, u32)>,
     ) -> Result<(), ExecutionError> {
         match self.next_expected_call() {
             Some(ExpectedCall::ProcessStreams(handler)) => {
-                handler(&mut self.runtime, _context, _streams)
+                handler(&mut self.runtime, context, streams)
             }
             Some(unexpected_call) => panic!(
                 "Expected a call to `process_streams`, got a call to `{unexpected_call}` instead."

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -17,7 +17,10 @@ use std::{
 
 #[cfg(web)]
 use js_sys::wasm_bindgen;
-use linera_base::identifiers::{ChainId, StreamId};
+use linera_base::{
+    data_types::StreamUpdate,
+    identifiers::{ChainId, StreamId},
+};
 
 use crate::{
     ContractSyncRuntimeHandle, ExecutionError, FinalizeContext, MessageContext, OperationContext,
@@ -151,7 +154,7 @@ type ProcessStreamHandler = Box<
     dyn FnOnce(
             &mut ContractSyncRuntimeHandle,
             ProcessStreamsContext,
-            Vec<(ChainId, StreamId, u32)>,
+            Vec<StreamUpdate>,
         ) -> Result<(), ExecutionError>
         + Send
         + Sync,
@@ -258,7 +261,7 @@ impl ExpectedCall {
         handler: impl FnOnce(
                 &mut ContractSyncRuntimeHandle,
                 ProcessStreamsContext,
-                Vec<(ChainId, StreamId, u32)>,
+                Vec<StreamUpdate>,
             ) -> Result<(), ExecutionError>
             + Send
             + Sync
@@ -380,11 +383,11 @@ impl UserContract for MockApplicationInstance<ContractSyncRuntimeHandle> {
     fn process_streams(
         &mut self,
         context: ProcessStreamsContext,
-        streams: Vec<(ChainId, StreamId, u32)>,
+        updates: Vec<StreamUpdate>,
     ) -> Result<(), ExecutionError> {
         match self.next_expected_call() {
             Some(ExpectedCall::ProcessStreams(handler)) => {
-                handler(&mut self.runtime, context, streams)
+                handler(&mut self.runtime, context, updates)
             }
             Some(unexpected_call) => panic!(
                 "Expected a call to `process_streams`, got a call to `{unexpected_call}` instead."

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -189,10 +189,8 @@ impl TransactionTracker {
         let Some(streams) = self.streams_to_process.get_mut(&application_id) else {
             return;
         };
-        if streams.remove(&(chain_id, stream_id)).is_some() {
-            if streams.is_empty() {
-                self.streams_to_process.remove(&application_id);
-            }
+        if streams.remove(&(chain_id, stream_id)).is_some() && streams.is_empty() {
+            self.streams_to_process.remove(&application_id);
         }
     }
 

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -200,7 +200,7 @@ impl TransactionTracker {
         }
     }
 
-    pub fn flush_streams_to_process(&mut self) -> BTreeMap<ApplicationId, Vec<StreamUpdate>> {
+    pub fn take_streams_to_process(&mut self) -> BTreeMap<ApplicationId, Vec<StreamUpdate>> {
         mem::take(&mut self.streams_to_process)
             .into_iter()
             .map(|(app_id, streams)| {

--- a/linera-execution/src/wasm/entrypoints.rs
+++ b/linera-execution/src/wasm/entrypoints.rs
@@ -3,7 +3,7 @@
 
 //! Wasm entrypoints for contracts and services.
 
-use linera_base::identifiers::{ChainId, StreamId};
+use linera_base::data_types::StreamUpdate;
 use linera_witty::wit_import;
 
 /// WIT entrypoints for application contracts.
@@ -12,7 +12,7 @@ pub trait ContractEntrypoints {
     fn instantiate(argument: Vec<u8>);
     fn execute_operation(operation: Vec<u8>) -> Vec<u8>;
     fn execute_message(message: Vec<u8>);
-    fn process_streams(streams: Vec<(ChainId, StreamId, u32)>);
+    fn process_streams(streams: Vec<StreamUpdate>);
     fn finalize();
 }
 

--- a/linera-execution/src/wasm/entrypoints.rs
+++ b/linera-execution/src/wasm/entrypoints.rs
@@ -3,6 +3,7 @@
 
 //! Wasm entrypoints for contracts and services.
 
+use linera_base::identifiers::{ChainId, StreamId};
 use linera_witty::wit_import;
 
 /// WIT entrypoints for application contracts.
@@ -11,6 +12,7 @@ pub trait ContractEntrypoints {
     fn instantiate(argument: Vec<u8>);
     fn execute_operation(operation: Vec<u8>) -> Vec<u8>;
     fn execute_message(message: Vec<u8>);
+    fn process_streams(streams: Vec<(ChainId, StreamId, u32)>);
     fn finalize();
 }
 

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -5,7 +5,10 @@
 
 use std::{marker::Unpin, sync::LazyLock};
 
-use linera_base::data_types::Bytecode;
+use linera_base::{
+    data_types::Bytecode,
+    identifiers::{ChainId, StreamId},
+};
 use linera_witty::{
     wasmer::{EntrypointInstance, InstanceBuilder},
     ExportTo,
@@ -156,6 +159,17 @@ where
     ) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)
             .execute_message(message)
+            .map_err(WasmExecutionError::from)?;
+        Ok(())
+    }
+
+    fn process_streams(
+        &mut self,
+        _context: OperationContext,
+        streams: Vec<(ChainId, StreamId, u32)>,
+    ) -> Result<(), ExecutionError> {
+        ContractEntrypoints::new(&mut self.instance)
+            .process_streams(streams)
             .map_err(WasmExecutionError::from)?;
         Ok(())
     }

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -20,7 +20,7 @@ use super::{
 use crate::{
     wasm::{WasmContractModule, WasmServiceModule},
     ContractRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext,
-    ProcessStreamsContext, QueryContext, ServiceRuntime,
+    QueryContext, ServiceRuntime,
 };
 
 /// An [`Engine`] instance configured to run application services.
@@ -160,11 +160,7 @@ where
         Ok(())
     }
 
-    fn process_streams(
-        &mut self,
-        _context: ProcessStreamsContext,
-        updates: Vec<StreamUpdate>,
-    ) -> Result<(), ExecutionError> {
+    fn process_streams(&mut self, updates: Vec<StreamUpdate>) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)
             .process_streams(updates)
             .map_err(WasmExecutionError::from)?;

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -23,7 +23,7 @@ use super::{
 use crate::{
     wasm::{WasmContractModule, WasmServiceModule},
     ContractRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext,
-    QueryContext, ServiceRuntime,
+    ProcessStreamsContext, QueryContext, ServiceRuntime,
 };
 
 /// An [`Engine`] instance configured to run application services.
@@ -165,7 +165,7 @@ where
 
     fn process_streams(
         &mut self,
-        _context: OperationContext,
+        _context: ProcessStreamsContext,
         streams: Vec<(ChainId, StreamId, u32)>,
     ) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -5,10 +5,7 @@
 
 use std::{marker::Unpin, sync::LazyLock};
 
-use linera_base::{
-    data_types::Bytecode,
-    identifiers::{ChainId, StreamId},
-};
+use linera_base::data_types::{Bytecode, StreamUpdate};
 use linera_witty::{
     wasmer::{EntrypointInstance, InstanceBuilder},
     ExportTo,
@@ -166,10 +163,10 @@ where
     fn process_streams(
         &mut self,
         _context: ProcessStreamsContext,
-        streams: Vec<(ChainId, StreamId, u32)>,
+        updates: Vec<StreamUpdate>,
     ) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)
-            .process_streams(streams)
+            .process_streams(updates)
             .map_err(WasmExecutionError::from)?;
         Ok(())
     }

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -5,10 +5,7 @@
 
 use std::sync::LazyLock;
 
-use linera_base::{
-    data_types::Bytecode,
-    identifiers::{ChainId, StreamId},
-};
+use linera_base::data_types::{Bytecode, StreamUpdate};
 use linera_witty::{wasmtime::EntrypointInstance, ExportTo};
 use tokio::sync::Mutex;
 use wasmtime::{Config, Engine, Linker, Module, Store};
@@ -171,10 +168,10 @@ where
     fn process_streams(
         &mut self,
         _context: ProcessStreamsContext,
-        streams: Vec<(ChainId, StreamId, u32)>,
+        updates: Vec<StreamUpdate>,
     ) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)
-            .process_streams(streams)
+            .process_streams(updates)
             .map_err(WasmExecutionError::from)?;
         Ok(())
     }

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -21,7 +21,7 @@ use super::{
 use crate::{
     wasm::{WasmContractModule, WasmServiceModule},
     ContractRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext,
-    QueryContext, ServiceRuntime,
+    ProcessStreamsContext, QueryContext, ServiceRuntime,
 };
 
 /// An [`Engine`] instance configured to run application contracts.
@@ -170,7 +170,7 @@ where
 
     fn process_streams(
         &mut self,
-        _context: OperationContext,
+        _context: ProcessStreamsContext,
         streams: Vec<(ChainId, StreamId, u32)>,
     ) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -18,7 +18,7 @@ use super::{
 use crate::{
     wasm::{WasmContractModule, WasmServiceModule},
     ContractRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext,
-    ProcessStreamsContext, QueryContext, ServiceRuntime,
+    QueryContext, ServiceRuntime,
 };
 
 /// An [`Engine`] instance configured to run application contracts.
@@ -165,11 +165,7 @@ where
         Ok(())
     }
 
-    fn process_streams(
-        &mut self,
-        _context: ProcessStreamsContext,
-        updates: Vec<StreamUpdate>,
-    ) -> Result<(), ExecutionError> {
+    fn process_streams(&mut self, updates: Vec<StreamUpdate>) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)
             .process_streams(updates)
             .map_err(WasmExecutionError::from)?;

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -5,7 +5,10 @@
 
 use std::sync::LazyLock;
 
-use linera_base::data_types::Bytecode;
+use linera_base::{
+    data_types::Bytecode,
+    identifiers::{ChainId, StreamId},
+};
 use linera_witty::{wasmtime::EntrypointInstance, ExportTo};
 use tokio::sync::Mutex;
 use wasmtime::{Config, Engine, Linker, Module, Store};
@@ -161,6 +164,17 @@ where
     ) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)
             .execute_message(message)
+            .map_err(WasmExecutionError::from)?;
+        Ok(())
+    }
+
+    fn process_streams(
+        &mut self,
+        _context: OperationContext,
+        streams: Vec<(ChainId, StreamId, u32)>,
+    ) -> Result<(), ExecutionError> {
+        ContractEntrypoints::new(&mut self.instance)
+            .process_streams(streams)
             .map_err(WasmExecutionError::from)?;
         Ok(())
     }

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, BlockHeight},
+    data_types::{Amount, BlockHeight, StreamUpdate},
     identifiers::{
         AccountOwner, ApplicationId, ChainId, GenericApplicationId, MessageId, ModuleId, StreamId,
         StreamName,
@@ -168,6 +168,17 @@ impl From<wit_entrypoints::StreamId> for StreamId {
         StreamId {
             application_id: stream_id.application_id.into(),
             stream_name: stream_id.stream_name.into(),
+        }
+    }
+}
+
+impl From<wit_entrypoints::StreamUpdate> for StreamUpdate {
+    fn from(stream_update: wit_entrypoints::StreamUpdate) -> Self {
+        StreamUpdate {
+            chain_id: stream_update.chain_id.into(),
+            stream_id: stream_update.stream_id.into(),
+            previous_index: stream_update.previous_index,
+            next_index: stream_update.next_index,
         }
     }
 }

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -6,12 +6,18 @@
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, BlockHeight},
-    identifiers::{AccountOwner, ApplicationId, ChainId, MessageId, ModuleId},
+    identifiers::{
+        AccountOwner, ApplicationId, ChainId, GenericApplicationId, MessageId, ModuleId, StreamId,
+        StreamName,
+    },
     ownership::{ChangeApplicationPermissionsError, CloseChainError},
     vm::VmRuntime,
 };
 
-use super::wit::contract_runtime_api as wit_contract_api;
+use super::wit::{
+    contract_runtime_api as wit_contract_api,
+    exports::linera::app::contract_entrypoints as wit_entrypoints,
+};
 
 impl From<wit_contract_api::CryptoHash> for CryptoHash {
     fn from(crypto_hash: wit_contract_api::CryptoHash) -> Self {
@@ -113,6 +119,55 @@ impl From<wit_contract_api::ChangeApplicationPermissionsError>
             wit_contract_api::ChangeApplicationPermissionsError::NotPermitted => {
                 ChangeApplicationPermissionsError::NotPermitted
             }
+        }
+    }
+}
+
+impl From<wit_entrypoints::CryptoHash> for CryptoHash {
+    fn from(crypto_hash: wit_entrypoints::CryptoHash) -> Self {
+        CryptoHash::from([
+            crypto_hash.part1,
+            crypto_hash.part2,
+            crypto_hash.part3,
+            crypto_hash.part4,
+        ])
+    }
+}
+
+impl From<wit_entrypoints::ApplicationId> for ApplicationId {
+    fn from(application_id: wit_entrypoints::ApplicationId) -> Self {
+        ApplicationId::new(application_id.application_description_hash.into())
+    }
+}
+
+impl From<wit_entrypoints::GenericApplicationId> for GenericApplicationId {
+    fn from(generic_application_id: wit_entrypoints::GenericApplicationId) -> Self {
+        match generic_application_id {
+            wit_entrypoints::GenericApplicationId::System => GenericApplicationId::System,
+            wit_entrypoints::GenericApplicationId::User(application_id) => {
+                GenericApplicationId::User(application_id.into())
+            }
+        }
+    }
+}
+
+impl From<wit_entrypoints::ChainId> for ChainId {
+    fn from(chain_id: wit_entrypoints::ChainId) -> Self {
+        ChainId(chain_id.inner0.into())
+    }
+}
+
+impl From<wit_entrypoints::StreamName> for StreamName {
+    fn from(stream_name: wit_entrypoints::StreamName) -> Self {
+        StreamName(stream_name.inner0)
+    }
+}
+
+impl From<wit_entrypoints::StreamId> for StreamId {
+    fn from(stream_id: wit_entrypoints::StreamId) -> Self {
+        StreamId {
+            application_id: stream_id.application_id.into(),
+            stream_name: stream_id.stream_name.into(),
         }
     }
 }

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -85,18 +85,15 @@ macro_rules! contract {
                 )
             }
 
-            fn process_streams(streams: Vec<(
-                $crate::contract::wit::exports::linera::app::contract_entrypoints::ChainId,
-                $crate::contract::wit::exports::linera::app::contract_entrypoints::StreamId,
-                u32,
-            )>) {
+            fn process_streams(updates: Vec<
+                $crate::contract::wit::exports::linera::app::contract_entrypoints::StreamUpdate,
+            >) {
                 use $crate::util::BlockingWait;
                 $crate::contract::run_async_entrypoint::<$contract, _, _>(
                     unsafe { &mut CONTRACT },
                     move |contract| {
-                        contract.process_streams(streams.into_iter().map(|(chain_id, stream_id, next_index)| {
-                            (chain_id.into(), stream_id.into(), next_index)
-                        }).collect()).blocking_wait()
+                        let updates = updates.into_iter().map(Into::into).collect();
+                        contract.process_streams(updates).blocking_wait()
                     },
                 )
             }

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -85,12 +85,18 @@ macro_rules! contract {
                 )
             }
 
-            fn process_streams(streams: Vec<(ChainId, StreamId, u32>)) {
+            fn process_streams(streams: Vec<(
+                $crate::contract::wit::exports::linera::app::contract_entrypoints::ChainId,
+                $crate::contract::wit::exports::linera::app::contract_entrypoints::StreamId,
+                u32,
+            )>) {
                 use $crate::util::BlockingWait;
                 $crate::contract::run_async_entrypoint::<$contract, _, _>(
                     unsafe { &mut CONTRACT },
                     move |contract| {
-                        contract.process_streams(streams).blocking_wait()
+                        contract.process_streams(streams.into_iter().map(|(chain_id, stream_id, next_index)| {
+                            (chain_id.into(), stream_id.into(), next_index)
+                        }).collect()).blocking_wait()
                     },
                 )
             }

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -85,6 +85,16 @@ macro_rules! contract {
                 )
             }
 
+            fn process_streams(streams: Vec<(ChainId, StreamId, u32>)) {
+                use $crate::util::BlockingWait;
+                $crate::contract::run_async_entrypoint::<$contract, _, _>(
+                    unsafe { &mut CONTRACT },
+                    move |contract| {
+                        contract.process_streams(streams).blocking_wait()
+                    },
+                )
+            }
+
             fn finalize() {
                 use $crate::util::BlockingWait;
 

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -296,6 +296,26 @@ where
         bcs::from_bytes(&event).expect("Failed to deserialize event")
     }
 
+    /// Subscribes this application to an event stream.
+    pub fn subscribe_to_events(
+        &mut self,
+        chain_id: ChainId,
+        application_id: ApplicationId,
+        name: StreamName,
+    ) {
+        contract_wit::subscribe_to_events(chain_id.into(), application_id.into(), &name.into())
+    }
+
+    /// Unsubscribes this application from an event stream.
+    pub fn unsubscribe_from_events(
+        &mut self,
+        chain_id: ChainId,
+        application_id: ApplicationId,
+        name: StreamName,
+    ) {
+        contract_wit::unsubscribe_from_events(chain_id.into(), application_id.into(), &name.into())
+    }
+
     /// Queries an application service as an oracle and returns the response.
     ///
     /// Should only be used with queries where it is very likely that all validators will compute

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -840,6 +840,26 @@ where
         bcs::from_bytes(value).expect("Failed to deserialize event value")
     }
 
+    /// Subscribes this application to an event stream.
+    pub fn subscribe_to_events(
+        &mut self,
+        _chain_id: ChainId,
+        _application_id: ApplicationId,
+        _name: StreamName,
+    ) {
+        // This is a no-op in the mock runtime.
+    }
+
+    /// Unsubscribes this application from an event stream.
+    pub fn unsubscribe_from_events(
+        &mut self,
+        _chain_id: ChainId,
+        _application_id: ApplicationId,
+        _name: StreamName,
+    ) {
+        // This is a no-op in the mock runtime.
+    }
+
     /// Adds an expected `query_service` call`, and the response it should return in the test.
     pub fn add_expected_service_query<A: ServiceAbi + Send>(
         &mut self,

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -46,7 +46,6 @@ pub mod views;
 use std::fmt::Debug;
 
 pub use bcs;
-use contract::wit::contract_runtime_api::ChainId;
 pub use linera_base::{
     abi,
     data_types::{Resources, SendMessageRequest},
@@ -56,7 +55,7 @@ use linera_base::{
     abi::{ContractAbi, ServiceAbi, WithContractAbi, WithServiceAbi},
     crypto::CryptoHash,
     doc_scalar,
-    identifiers::StreamId,
+    identifiers::{ChainId, StreamId},
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub use serde_json;

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -54,8 +54,8 @@ pub use linera_base::{
 use linera_base::{
     abi::{ContractAbi, ServiceAbi, WithContractAbi, WithServiceAbi},
     crypto::CryptoHash,
+    data_types::StreamUpdate,
     doc_scalar,
-    identifiers::{ChainId, StreamId},
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub use serde_json;
@@ -137,7 +137,7 @@ pub trait Contract: WithContractAbi + ContractAbi + Sized {
     ///
     /// This is called whenever there is a new event on any stream that this application
     /// subscribes to.
-    async fn process_streams(&mut self, _streams: Vec<(ChainId, StreamId, u32)>) {}
+    async fn process_streams(&mut self, _updates: Vec<StreamUpdate>) {}
 
     /// Finishes the execution of the current transaction.
     ///

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -46,6 +46,7 @@ pub mod views;
 use std::fmt::Debug;
 
 pub use bcs;
+use contract::wit::contract_runtime_api::ChainId;
 pub use linera_base::{
     abi,
     data_types::{Resources, SendMessageRequest},
@@ -55,6 +56,7 @@ use linera_base::{
     abi::{ContractAbi, ServiceAbi, WithContractAbi, WithServiceAbi},
     crypto::CryptoHash,
     doc_scalar,
+    identifiers::StreamId,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub use serde_json;
@@ -131,6 +133,12 @@ pub trait Contract: WithContractAbi + ContractAbi + Sized {
     /// For a message to be executed, a user must mark it to be received in a block of the receiver
     /// chain.
     async fn execute_message(&mut self, message: Self::Message);
+
+    /// Reacts to new events on streams.
+    ///
+    /// This is called whenever there is a new event on any stream that this application
+    /// subscribes to.
+    async fn process_streams(&mut self, _streams: Vec<(ChainId, StreamId, u32)>) {}
 
     /// Finishes the execution of the current transaction.
     ///

--- a/linera-sdk/wit/contract-entrypoints.wit
+++ b/linera-sdk/wit/contract-entrypoints.wit
@@ -4,5 +4,35 @@ interface contract-entrypoints {
     instantiate: func(argument: list<u8>);
     execute-operation: func(operation: list<u8>) -> list<u8>;
     execute-message: func(message: list<u8>);
+    process-streams: func(streams: list<tuple<chain-id, stream-id, u32>>);
     finalize: func();
+
+    record application-id {
+        application-description-hash: crypto-hash,
+    }
+
+    record chain-id {
+        inner0: crypto-hash,
+    }
+
+    record crypto-hash {
+        part1: u64,
+        part2: u64,
+        part3: u64,
+        part4: u64,
+    }
+
+    variant generic-application-id {
+        system,
+        user(application-id),
+    }
+
+    record stream-id {
+        application-id: generic-application-id,
+        stream-name: stream-name,
+    }
+
+    record stream-name {
+        inner0: list<u8>,
+    }
 }

--- a/linera-sdk/wit/contract-entrypoints.wit
+++ b/linera-sdk/wit/contract-entrypoints.wit
@@ -4,7 +4,7 @@ interface contract-entrypoints {
     instantiate: func(argument: list<u8>);
     execute-operation: func(operation: list<u8>) -> list<u8>;
     execute-message: func(message: list<u8>);
-    process-streams: func(streams: list<tuple<chain-id, stream-id, u32>>);
+    process-streams: func(streams: list<stream-update>);
     finalize: func();
 
     record application-id {
@@ -34,5 +34,12 @@ interface contract-entrypoints {
 
     record stream-name {
         inner0: list<u8>,
+    }
+
+    record stream-update {
+        chain-id: chain-id,
+        stream-id: stream-id,
+        previous-index: u32,
+        next-index: u32,
     }
 }

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -826,7 +826,7 @@ where
     }
 
     /// Runs the node service.
-    #[instrument(name = "node_service", level = "info", skip(self), fields(port = ?self.port))]
+    #[instrument(name = "node_service", level = "info", skip_all, fields(port = ?self.port))]
     pub async fn run(self, cancellation_token: CancellationToken) -> Result<(), anyhow::Error> {
         let port = self.port.get();
         let index_handler = axum::routing::get(util::graphiql).post(Self::index_handler);

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -919,18 +919,8 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
     let app2 = node_service2
         .make_application(&chain2, &application_id)
         .await?;
-    let hash = app2
-        .mutate(format!("subscribe(chainId: \"{chain1}\")"))
+    app2.mutate(format!("subscribe(chainId: \"{chain1}\")"))
         .await?;
-
-    node_service1.process_inbox(&chain1).await?;
-
-    // The returned hash should now be the latest one.
-    let query = format!("query {{ chain(chainId: \"{chain2}\") {{ tipState {{ blockHash }} }} }}");
-    for node_service in [&node_service2, &node_service1] {
-        let response = node_service.query_node(&query).await?;
-        assert_eq!(hash, response["chain"]["tipState"]["blockHash"]);
-    }
 
     let mut notifications = Box::pin(node_service2.notifications(chain2).await?);
 

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -885,7 +885,7 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) -> Result<()> {
+async fn test_wasm_end_to_end_social_event_streams(config: impl LineraNetConfig) -> Result<()> {
     use linera_base::time::Instant;
     use social::SocialAbi;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -783,6 +783,14 @@ where
         maybe_value.ok_or_else(|| ViewError::EventsNotFound(vec![event_id]))
     }
 
+    async fn contains_event(&self, event_id: EventId) -> Result<bool, ViewError> {
+        let event_key = bcs::to_bytes(&BaseKey::Event(event_id))?;
+        let exists = self.store.contains_key(&event_key).await?;
+        #[cfg(with_metrics)]
+        CONTAINS_BLOB_COUNTER.with_label_values(&[]).inc();
+        Ok(exists)
+    }
+
     async fn write_events(
         &self,
         events: impl IntoIterator<Item = (EventId, Vec<u8>)> + Send,

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -195,6 +195,16 @@ pub static READ_EVENT_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
     )
 });
 
+/// The metric counting how often an event is tested for existence from storage
+#[cfg(with_metrics)]
+static CONTAINS_EVENT_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec(
+        "contains_event",
+        "The metric counting how often an event is tested for existence from storage",
+        &[],
+    )
+});
+
 /// The metric counting how often an event is written to storage.
 #[cfg(with_metrics)]
 #[doc(hidden)]
@@ -787,7 +797,7 @@ where
         let event_key = bcs::to_bytes(&BaseKey::Event(event_id))?;
         let exists = self.store.contains_key(&event_key).await?;
         #[cfg(with_metrics)]
-        CONTAINS_BLOB_COUNTER.with_label_values(&[]).inc();
+        CONTAINS_EVENT_COUNTER.with_label_values(&[]).inc();
         Ok(exists)
     }
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -165,6 +165,9 @@ pub trait Storage: Sized {
     /// Reads the event with the given ID.
     async fn read_event(&self, id: EventId) -> Result<Vec<u8>, ViewError>;
 
+    /// Tests existence of the event with the given ID.
+    async fn contains_event(&self, id: EventId) -> Result<bool, ViewError>;
+
     /// Writes a vector of events.
     async fn write_events(
         &self,
@@ -408,6 +411,10 @@ where
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {
         self.storage.contains_blob(blob_id).await
+    }
+
+    async fn contains_event(&self, event_id: EventId) -> Result<bool, ViewError> {
+        self.storage.contains_event(event_id).await
     }
 
     #[cfg(with_testing)]


### PR DESCRIPTION
## Motivation

We want to replace pub-sub channels with event streams for better scalability (https://github.com/linera-io/linera-protocol/issues/365).

Events can already be emitted and read; this PR adds subscriptions.

## Proposal

Handle the `UpdateStreams` system operation. Chain owners can inform applications on a chain about new events in streams published by other chains this way. Also add back `subscribe_to_events` and `unsubscribe_from_events`.

Keep a note in the `TransactionTracker` about any changes to event subscriptions or new events in relevant streams. As part of the same transaction, call `process_streams` in all subscriber contracts.

When synchronizing a chain, and in the chain listener, detect new events and commit `UpdateStreams` as appropriate. (This is part of `process_inbox` now.)

Port the `social` example to use event streams instead of pub-sub channels, without changing any of the business logic (which should be fixed, too, but that is a separate issue: https://github.com/linera-io/linera-protocol/issues/3782).

## Test Plan

CI; the two pub-sub channel tests have been adapted.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Part of https://github.com/linera-io/linera-protocol/issues/365.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
