### PR TITLE
Change ChainDescriptions into blobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,7 +64,7 @@ jobs:
         cargo build --bin linera
         cargo run --bin linera -- resource-control-policy --block 0.0000001
         cargo run --bin linera -- resource-control-policy --block 0.000000
-        cargo run --bin linera -- faucet --amount 1000 --port 8079 a3edc33d8e951a1139333be8a4b56646b5598a8f51216e86592d881808972b07 &
+        cargo run --bin linera -- faucet --amount 1000 --port 8079 &
     - name: Run the remote-net tests
       run: |
         cargo test -p linera-service remote_net_grpc --features remote-net

--- a/CLI.md
+++ b/CLI.md
@@ -720,12 +720,12 @@ Create an unassigned key pair
 
 Link an owner with a key pair in the wallet to a chain that was created for that owner
 
-**Usage:** `linera assign --owner <OWNER> --message-id <MESSAGE_ID>`
+**Usage:** `linera assign --owner <OWNER> --chain-id <CHAIN_ID>`
 
 ###### **Options:**
 
 * `--owner <OWNER>` — The owner to assign
-* `--message-id <MESSAGE_ID>` — The ID of the message that created the chain. (This uniquely describes the chain and where it was created.)
+* `--chain-id <CHAIN_ID>` — The ID of the chain
 
 
 

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ linera wallet init --faucet $FAUCET_URL
 INFO1=($(linera wallet request-chain --faucet $FAUCET_URL))
 INFO2=($(linera wallet request-chain --faucet $FAUCET_URL))
 CHAIN1="${INFO1[0]}"
-ACCOUNT1="${INFO1[3]}"
+ACCOUNT1="${INFO1[2]}"
 CHAIN2="${INFO2[0]}"
-ACCOUNT2="${INFO2[3]}"
+ACCOUNT2="${INFO2[2]}"
 
 # Show the different chains tracked by the wallet.
 linera wallet show

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2981,6 +2981,7 @@ name = "hex-game"
 version = "0.1.0"
 dependencies = [
  "async-graphql",
+ "bcs",
  "linera-sdk",
  "log",
  "serde",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -2,15 +2,15 @@
 resolver = "2"
 members = [
     "amm",
-    "counter",
     "call-evm-counter",
+    "counter",
     "counter-no-graphql",
     "crowd-funding",
     "ethereum-tracker",
     "fungible",
     "gen-nft",
-    "how-to/perform-http-requests",
     "hex-game",
+    "how-to/perform-http-requests",
     "llm",
     "matching-engine",
     "meta-counter",

--- a/examples/amm/README.md
+++ b/examples/amm/README.md
@@ -64,9 +64,9 @@ INFO_2=($(linera wallet request-chain --faucet $FAUCET_URL))
 CHAIN_AMM="${INFO_AMM[0]}"
 CHAIN_1="${INFO_1[0]}"
 CHAIN_2="${INFO_2[0]}"
-OWNER_AMM="${INFO_AMM[3]}"
-OWNER_1="${INFO_1[3]}"
-OWNER_2="${INFO_2[3]}"
+OWNER_AMM="${INFO_AMM[2]}"
+OWNER_1="${INFO_1[2]}"
+OWNER_2="${INFO_2[2]}"
 ```
 
 Now we have to publish and create the fungible applications. The flag `--wait-for-outgoing-messages` waits until a quorum of validators has confirmed that all sent cross-chain messages have been delivered.

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -49,7 +49,7 @@ linera wallet init --faucet $FAUCET_URL
 
 INFO_1=($(linera wallet request-chain --faucet $FAUCET_URL))
 CHAIN_1="${INFO_1[0]}"
-OWNER_1="${INFO_1[3]}"
+OWNER_1="${INFO_1[2]}"
 ```
 
 Now, compile the `counter` application WebAssembly binaries, publish and create an application instance.

--- a/examples/crowd-funding/README.md
+++ b/examples/crowd-funding/README.md
@@ -77,8 +77,8 @@ INFO_1=($(linera --with-wallet 1 wallet request-chain --faucet $FAUCET_URL))
 INFO_2=($(linera --with-wallet 2 wallet request-chain --faucet $FAUCET_URL))
 CHAIN_1="${INFO_1[0]}"
 CHAIN_2="${INFO_2[0]}"
-OWNER_1="${INFO_1[3]}"
-OWNER_2="${INFO_2[3]}"
+OWNER_1="${INFO_1[2]}"
+OWNER_2="${INFO_2[2]}"
 ```
 
 Note that `linera --with-wallet 1` is equivalent to `linera --wallet "$LINERA_WALLET_1"

--- a/examples/fungible/README.md
+++ b/examples/fungible/README.md
@@ -64,10 +64,10 @@ linera wallet init --faucet $FAUCET_URL
 
 INFO_1=($(linera wallet request-chain --faucet $FAUCET_URL))
 CHAIN_1="${INFO_1[0]}"
-OWNER_1="${INFO_1[3]}"
+OWNER_1="${INFO_1[2]}"
 INFO_2=($(linera wallet request-chain --faucet $FAUCET_URL))
 CHAIN_2="${INFO_2[0]}"
-OWNER_2="${INFO_2[3]}"
+OWNER_2="${INFO_2[2]}"
 ```
 
 Now, compile the `fungible` application WebAssembly binaries, and publish them as an application

--- a/examples/gen-nft/README.md
+++ b/examples/gen-nft/README.md
@@ -61,8 +61,8 @@ INFO_1=($(linera wallet request-chain --faucet $FAUCET_URL))
 INFO_2=($(linera wallet request-chain --faucet $FAUCET_URL))
 CHAIN_1="${INFO_1[0]}"
 CHAIN_2="${INFO_2[0]}"
-OWNER_1="${INFO_1[3]}"
-OWNER_2="${INFO_2[3]}"
+OWNER_1="${INFO_1[2]}"
+OWNER_2="${INFO_2[2]}"
 ```
 
 Next, compile the `non-fungible` application WebAssembly binaries, and publish them as an application module:

--- a/examples/hex-game/Cargo.toml
+++ b/examples/hex-game/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 async-graphql.workspace = true
+bcs.workspace = true
 linera-sdk.workspace = true
 log.workspace = true
 serde.workspace = true

--- a/examples/hex-game/README.md
+++ b/examples/hex-game/README.md
@@ -60,8 +60,8 @@ INFO_1=($(linera --with-wallet 1 wallet request-chain --faucet $FAUCET_URL))
 INFO_2=($(linera --with-wallet 2 wallet request-chain --faucet $FAUCET_URL))
 CHAIN_1="${INFO_1[0]}"
 CHAIN_2="${INFO_2[0]}"
-OWNER_1="${INFO_1[3]}"
-OWNER_2="${INFO_2[3]}"
+OWNER_1="${INFO_1[2]}"
+OWNER_2="${INFO_2[2]}"
 ```
 
 Note that `linera --with-wallet 1` or `linera -w1` is equivalent to `linera --wallet
@@ -123,25 +123,24 @@ query {
   gameChains {
     entry(key: "$OWNER_1") {
       value {
-        messageId chainId
+        chainId
       }
     }
   }
 }
 ```
 
-Set the `QUERY_RESULT` variable to have the result returned by the previous query, and `HEX_CHAIN` and `MESSAGE_ID` will be properly set for you.
-Alternatively you can set the variables to the `chainId` and `messageId` values, respectively, returned by the previous query yourself.
-Using the message ID, we can assign the new chain to the key in each wallet:
+Set the `QUERY_RESULT` variable to have the result returned by the previous query, and `HEX_CHAIN` will be properly set for you.
+Alternatively you can set the variable to the `chainId`, returned by the previous query yourself.
+Using the chain ID, we can assign the new chain to the key in each wallet:
 
 ```bash
 kill %% && sleep 1    # Kill the service so we can use CLI commands for wallet 0.
 
 HEX_CHAIN=$(echo "$QUERY_RESULT" | jq -r '.gameChains.entry.value[0].chainId')
-MESSAGE_ID=$(echo "$QUERY_RESULT" | jq -r '.gameChains.entry.value[0].messageId')
 
-linera -w1 assign --owner $OWNER_1 --message-id $MESSAGE_ID
-linera -w2 assign --owner $OWNER_2 --message-id $MESSAGE_ID
+linera -w1 assign --owner $OWNER_1 --chain-id $HEX_CHAIN
+linera -w2 assign --owner $OWNER_2 --chain-id $HEX_CHAIN
 
 linera -w1 service --port 8080 &
 linera -w2 service --port 8081 &

--- a/examples/hex-game/src/contract.rs
+++ b/examples/hex-game/src/contract.rs
@@ -155,17 +155,14 @@ impl HexContract {
         );
         let app_id = self.runtime.application_id();
         let permissions = ApplicationPermissions::new_single(app_id.forget_abi());
-        let (message_id, chain_id) = self.runtime.open_chain(ownership, permissions, fee_budget);
+        let chain_id = self.runtime.open_chain(ownership, permissions, fee_budget);
         for owner in &players {
             self.state
                 .game_chains
                 .get_mut_or_default(owner)
                 .await
                 .unwrap()
-                .insert(GameChain {
-                    message_id,
-                    chain_id,
-                });
+                .insert(GameChain { chain_id });
         }
         self.runtime.send_message(
             chain_id,

--- a/examples/hex-game/src/state.rs
+++ b/examples/hex-game/src/state.rs
@@ -14,8 +14,6 @@ use serde::{Deserialize, Serialize};
 /// The IDs of a temporary chain for a single game of Hex.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, SimpleObject)]
 pub struct GameChain {
-    /// The ID of the `OpenChain` message that created the chain.
-    pub message_id: MessageId,
     /// The ID of the temporary game chain itself.
     pub chain_id: ChainId,
 }

--- a/examples/hex-game/src/state.rs
+++ b/examples/hex-game/src/state.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeSet;
 use async_graphql::SimpleObject;
 use hex_game::{Board, Clock, Timeouts};
 use linera_sdk::{
-    linera_base_types::{AccountOwner, ChainId, MessageId},
+    linera_base_types::{AccountOwner, ChainId},
     views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
 };
 use serde::{Deserialize, Serialize};

--- a/examples/how-to/perform-http-requests/tests/http_requests.rs
+++ b/examples/how-to/perform-http-requests/tests/http_requests.rs
@@ -22,7 +22,7 @@ async fn service_query_performs_http_request() -> anyhow::Result<()> {
     let port = http_server.port();
     let url = format!("http://localhost:{port}/");
 
-    let (validator, application_id, chain) =
+    let (mut validator, application_id, chain) =
         TestValidator::with_current_application::<Abi, _, _>(url, ()).await;
 
     validator
@@ -89,7 +89,7 @@ async fn service_sends_valid_http_response_to_contract() -> anyhow::Result<()> {
     let port = http_server.port();
     let url = format!("http://localhost:{port}/");
 
-    let (validator, application_id, chain) =
+    let (mut validator, application_id, chain) =
         TestValidator::with_current_application::<Abi, _, _>(url, ()).await;
 
     validator
@@ -119,7 +119,7 @@ async fn contract_rejects_invalid_http_response_from_service() {
     let port = http_server.port();
     let url = format!("http://localhost:{port}/");
 
-    let (validator, application_id, chain) =
+    let (mut validator, application_id, chain) =
         TestValidator::with_current_application::<Abi, _, _>(url.clone(), ()).await;
 
     validator
@@ -151,7 +151,7 @@ async fn contract_accepts_valid_http_response_it_obtains_by_itself() -> anyhow::
     let port = http_server.port();
     let url = format!("http://localhost:{port}/");
 
-    let (validator, application_id, chain) =
+    let (mut validator, application_id, chain) =
         TestValidator::with_current_application::<Abi, _, _>(url, ()).await;
 
     validator
@@ -181,7 +181,7 @@ async fn contract_rejects_invalid_http_response_it_obtains_by_itself() {
     let port = http_server.port();
     let url = format!("http://localhost:{port}/");
 
-    let (validator, application_id, chain) =
+    let (mut validator, application_id, chain) =
         TestValidator::with_current_application::<Abi, _, _>(url, ()).await;
 
     validator
@@ -214,7 +214,7 @@ async fn contract_accepts_valid_http_response_from_oracle() -> anyhow::Result<()
     let port = http_server.port();
     let url = format!("http://localhost:{port}/");
 
-    let (validator, application_id, chain) =
+    let (mut validator, application_id, chain) =
         TestValidator::with_current_application::<Abi, _, _>(url, ()).await;
 
     validator
@@ -245,7 +245,7 @@ async fn contract_rejects_invalid_http_response_from_oracle() {
     let port = http_server.port();
     let url = format!("http://localhost:{port}/");
 
-    let (validator, application_id, chain) =
+    let (mut validator, application_id, chain) =
         TestValidator::with_current_application::<Abi, _, _>(url, ()).await;
 
     validator

--- a/examples/matching-engine/README.md
+++ b/examples/matching-engine/README.md
@@ -75,9 +75,9 @@ INFO_3=($(linera wallet request-chain --faucet $FAUCET_URL))
 CHAIN_1="${INFO_1[0]}"
 CHAIN_2="${INFO_2[0]}"
 CHAIN_3="${INFO_3[0]}"
-OWNER_1="${INFO_1[3]}"
-OWNER_2="${INFO_2[3]}"
-OWNER_3="${INFO_3[3]}"
+OWNER_1="${INFO_1[2]}"
+OWNER_2="${INFO_2[2]}"
+OWNER_3="${INFO_3[2]}"
 ```
 
 Publish and create two `fungible` applications whose IDs will be used as a

--- a/examples/native-fungible/README.md
+++ b/examples/native-fungible/README.md
@@ -46,8 +46,8 @@ INFO_1=($(linera wallet request-chain --faucet $FAUCET_URL))
 INFO_2=($(linera wallet request-chain --faucet $FAUCET_URL))
 CHAIN_1="${INFO_1[0]}"
 CHAIN_2="${INFO_2[0]}"
-OWNER_1="${INFO_1[3]}"
-OWNER_2="${INFO_2[3]}"
+OWNER_1="${INFO_1[2]}"
+OWNER_2="${INFO_2[2]}"
 ```
 
 Compile the `native-fungible` application WebAssembly binaries, and publish them as an application

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use fungible::{self, FungibleTokenAbi};
 use linera_sdk::{
-    linera_base_types::{Account, AccountOwner, Amount, ChainId, CryptoHash},
+    linera_base_types::{Account, AccountOwner, Amount, CryptoHash},
     test::{ActiveChain, Recipient, TestValidator},
 };
 
@@ -28,7 +28,7 @@ async fn chain_balance_transfers() {
     .await;
 
     let transfer_amount = Amount::ONE;
-    let funding_chain = validator.get_chain(&ChainId::root(0));
+    let funding_chain = validator.get_chain(&validator.admin_chain_id());
     let recipient = Recipient::chain(recipient_chain.id());
 
     let transfer_certificate = funding_chain
@@ -62,7 +62,7 @@ async fn transfer_to_owner() {
     .await;
 
     let transfer_amount = Amount::from_tokens(2);
-    let funding_chain = validator.get_chain(&ChainId::root(0));
+    let funding_chain = validator.get_chain(&validator.admin_chain_id());
     let owner = AccountOwner::from(CryptoHash::test_hash("owner"));
     let account = Account::new(recipient_chain.id(), owner);
     let recipient = Recipient::Account(account);
@@ -98,7 +98,7 @@ async fn transfer_to_multiple_owners() {
 
     let number_of_owners = 10;
     let transfer_amounts = (1..=number_of_owners).map(Amount::from_tokens);
-    let funding_chain = validator.get_chain(&ChainId::root(0));
+    let funding_chain = validator.get_chain(&validator.admin_chain_id());
 
     let account_owners = (1..=number_of_owners)
         .map(|index| AccountOwner::from(CryptoHash::test_hash(format!("owner{index}"))))
@@ -146,7 +146,7 @@ async fn emptied_account_disappears_from_queries() {
     .await;
 
     let transfer_amount = Amount::from_tokens(100);
-    let funding_chain = validator.get_chain(&ChainId::root(0));
+    let funding_chain = validator.get_chain(&validator.admin_chain_id());
 
     let owner = AccountOwner::from(recipient_chain.public_key());
     let recipient = Recipient::Account(Account::new(recipient_chain.id(), owner));

--- a/examples/non-fungible/README.md
+++ b/examples/non-fungible/README.md
@@ -61,8 +61,8 @@ INFO_1=($(linera wallet request-chain --faucet $FAUCET_URL))
 INFO_2=($(linera wallet request-chain --faucet $FAUCET_URL))
 CHAIN_1="${INFO_1[0]}"
 CHAIN_2="${INFO_2[0]}"
-OWNER_1="${INFO_1[3]}"
-OWNER_2="${INFO_2[3]}"
+OWNER_1="${INFO_1[2]}"
+OWNER_2="${INFO_2[2]}"
 ```
 
 ```bash

--- a/examples/rfq/README.md
+++ b/examples/rfq/README.md
@@ -77,8 +77,8 @@ INFO_1=($(linera --with-wallet 1 wallet request-chain --faucet $FAUCET_URL))
 INFO_2=($(linera --with-wallet 2 wallet request-chain --faucet $FAUCET_URL))
 CHAIN_1="${INFO_1[0]}"
 CHAIN_2="${INFO_2[0]}"
-OWNER_1="${INFO_1[3]}"
-OWNER_2="${INFO_2[3]}"
+OWNER_1="${INFO_1[2]}"
+OWNER_2="${INFO_2[2]}"
 ```
 
 Note that `linera --with-wallet 1` is equivalent to `linera --wallet "$LINERA_WALLET_1"

--- a/examples/rfq/src/contract.rs
+++ b/examples/rfq/src/contract.rs
@@ -334,7 +334,7 @@ impl RfqContract {
         );
         let app_id = self.runtime.application_id();
         let permissions = ApplicationPermissions::new_single(app_id.forget_abi());
-        let (_, temp_chain_id) = self.runtime.open_chain(ownership, permissions, fee_budget);
+        let temp_chain_id = self.runtime.open_chain(ownership, permissions, fee_budget);
 
         // transfer tokens to the new chain
         let transfer = fungible::Operation::Transfer {

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -811,7 +811,7 @@ impl Epoch {
 }
 
 /// The initial configuration for a new chain.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct InitialChainConfig {
     /// The ownership configuration of the new chain.
     pub ownership: ChainOwnership,
@@ -827,8 +827,8 @@ pub struct InitialChainConfig {
     pub application_permissions: ApplicationPermissions,
 }
 
-/// How to create a chain.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Debug, Serialize, Deserialize)]
+/// Initial chain configuration and chain origin.
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Serialize, Deserialize)]
 pub struct ChainDescription {
     origin: ChainOrigin,
     timestamp: Timestamp,
@@ -1459,7 +1459,10 @@ doc_scalar!(
     Round,
     "A number to identify successive attempts to decide a value in a consensus protocol."
 );
-doc_scalar!(ChainDescription, "How to create a chain");
+doc_scalar!(
+    ChainDescription,
+    "Initial chain configuration and chain origin."
+);
 doc_scalar!(OracleResponse, "A record of a single oracle response.");
 doc_scalar!(BlobContent, "A blob of binary data.");
 doc_scalar!(

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -810,16 +810,16 @@ impl Epoch {
     }
 }
 
-/// The configuration for a new chain.
+/// The initial configuration for a new chain.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize)]
-pub struct OpenChainConfig {
+pub struct InitialChainConfig {
     /// The ownership configuration of the new chain.
     pub ownership: ChainOwnership,
     /// The ID of the admin chain.
     pub admin_id: Option<ChainId>,
     /// The epoch in which the chain is created.
     pub epoch: Epoch,
-    /// Blob IDs of the committees corresponding to epochs.
+    /// Serialized committees corresponding to epochs.
     pub committees: BTreeMap<Epoch, Vec<u8>>,
     /// The initial chain balance.
     pub balance: Amount,
@@ -832,12 +832,12 @@ pub struct OpenChainConfig {
 pub struct ChainDescription {
     origin: ChainOrigin,
     timestamp: Timestamp,
-    config: OpenChainConfig,
+    config: InitialChainConfig,
 }
 
 impl ChainDescription {
     /// Creates a new [`ChainDescription`].
-    pub fn new(origin: ChainOrigin, config: OpenChainConfig, timestamp: Timestamp) -> Self {
+    pub fn new(origin: ChainOrigin, config: InitialChainConfig, timestamp: Timestamp) -> Self {
         Self {
             origin,
             config,
@@ -855,8 +855,8 @@ impl ChainDescription {
         self.origin
     }
 
-    /// Returns a reference to the [`OpenChainConfig`] of the chain.
-    pub fn config(&self) -> &OpenChainConfig {
+    /// Returns a reference to the [`InitialChainConfig`] of the chain.
+    pub fn config(&self) -> &InitialChainConfig {
         &self.config
     }
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -994,33 +994,33 @@ mod tests {
     use assert_matches::assert_matches;
 
     use super::{AccountOwner, BlobType};
+    use crate::{
+        data_types::{Amount, ChainDescription, ChainOrigin, Epoch, InitialChainConfig, Timestamp},
+        ownership::ChainOwnership,
+    };
 
-    /* TODO: figure out if this can be fixed.
-    /// Verifies that chain IDs that are explicitly used in some example and test scripts don't
-    /// change.
+    /// Verifies that the way of computing chain IDs doesn't change.
     #[test]
-    fn chain_ids() {
-        assert_eq!(
-            &ChainId::root(0).to_string(),
-            "aee928d4bf3880353b4a3cd9b6f88e6cc6e5ed050860abae439e7782e9b2dfe8"
+    fn chain_id_computing() {
+        let example_chain_origin = ChainOrigin::Root(0);
+        let example_chain_config = InitialChainConfig {
+            admin_id: None,
+            epoch: Epoch::ZERO,
+            ownership: ChainOwnership::single(AccountOwner::Reserved(0)),
+            balance: Amount::ZERO,
+            committees: [(Epoch::ZERO, vec![])].into_iter().collect(),
+            application_permissions: Default::default(),
+        };
+        let description = ChainDescription::new(
+            example_chain_origin,
+            example_chain_config,
+            Timestamp::from(0),
         );
         assert_eq!(
-            &ChainId::root(1).to_string(),
-            "a3edc33d8e951a1139333be8a4b56646b5598a8f51216e86592d881808972b07"
+            description.id().to_string(),
+            "f8c2f02adc0ac763ffd74a32d02aa37490d869605c356a2da55e1d09e7d253bf"
         );
-        assert_eq!(
-            &ChainId::root(2).to_string(),
-            "678e9f66507069d38955b593e93ddf192a23a4087225fd307eadad44e5544ae3"
-        );
-        assert_eq!(
-            &ChainId::root(9).to_string(),
-            "63620ea465af9e9e0e8e4dd8d21593cc3a719feac5f096df8440f90738f4dbd8"
-        );
-        assert_eq!(
-            &ChainId::root(999).to_string(),
-            "5487b70625ce71f7ee29154ad32aefa1c526cb483bdb783dea2e1d17bc497844"
-        );
-    }*/
+    }
 
     #[test]
     fn blob_types() {

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -21,20 +21,7 @@ use crate::{
 };
 
 /// The timeout configuration: how long fast, multi-leader and single-leader rounds last.
-#[derive(
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Clone,
-    Hash,
-    Debug,
-    Serialize,
-    Deserialize,
-    WitLoad,
-    WitStore,
-    WitType,
-)]
+#[derive(PartialEq, Eq, Clone, Hash, Debug, Serialize, Deserialize, WitLoad, WitStore, WitType)]
 pub struct TimeoutConfig {
     /// The duration of the fast round.
     #[debug(skip_if = Option::is_none)]
@@ -61,19 +48,7 @@ impl Default for TimeoutConfig {
 
 /// Represents the owner(s) of a chain.
 #[derive(
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Clone,
-    Hash,
-    Debug,
-    Default,
-    Serialize,
-    Deserialize,
-    WitLoad,
-    WitStore,
-    WitType,
+    PartialEq, Eq, Clone, Hash, Debug, Default, Serialize, Deserialize, WitLoad, WitStore, WitType,
 )]
 pub struct ChainOwnership {
     /// Super owners can propose fast blocks in the first round, and regular blocks in any round.

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -21,7 +21,20 @@ use crate::{
 };
 
 /// The timeout configuration: how long fast, multi-leader and single-leader rounds last.
-#[derive(PartialEq, Eq, Clone, Hash, Debug, Serialize, Deserialize, WitLoad, WitStore, WitType)]
+#[derive(
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Hash,
+    Debug,
+    Serialize,
+    Deserialize,
+    WitLoad,
+    WitStore,
+    WitType,
+)]
 pub struct TimeoutConfig {
     /// The duration of the fast round.
     #[debug(skip_if = Option::is_none)]
@@ -48,7 +61,19 @@ impl Default for TimeoutConfig {
 
 /// Represents the owner(s) of a chain.
 #[derive(
-    PartialEq, Eq, Clone, Hash, Debug, Default, Serialize, Deserialize, WitLoad, WitStore, WitType,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Hash,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    WitLoad,
+    WitStore,
+    WitType,
 )]
 pub struct ChainOwnership {
     /// Super owners can propose fast blocks in the first round, and regular blocks in any round.

--- a/linera-base/src/unit_tests.rs
+++ b/linera-base/src/unit_tests.rs
@@ -67,7 +67,7 @@ fn send_message_request_test_case() -> SendMessageRequest<Vec<u8>> {
     SendMessageRequest {
         authenticated: true,
         is_tracked: false,
-        destination: ChainId::root(0),
+        destination: ChainId(CryptoHash::test_hash("chain_id_0")),
         grant: Resources {
             bytes_to_read: 200,
             bytes_to_write: 0,
@@ -91,7 +91,7 @@ fn send_message_request_test_case() -> SendMessageRequest<Vec<u8>> {
 /// Creates a dummy [`Account`] instance to use for the WIT roundtrip test.
 fn account_test_case() -> Account {
     Account {
-        chain_id: ChainId::root(10),
+        chain_id: ChainId(CryptoHash::test_hash("chain_id_10")),
         owner: AccountOwner::from(CryptoHash::test_hash("account")),
     }
 }
@@ -99,7 +99,7 @@ fn account_test_case() -> Account {
 /// Creates a dummy [`MessageId`] instance to use for the WIT roundtrip test.
 fn message_id_test_case() -> MessageId {
     MessageId {
-        chain_id: ChainId::root(3),
+        chain_id: ChainId(CryptoHash::test_hash("chain_id_3")),
         height: BlockHeight(9_812_394),
         index: 7,
     }

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -512,8 +512,9 @@ impl Block {
         self.oracle_blob_ids().contains(blob_id)
             || self.published_blob_ids().contains(blob_id)
             || self.created_blob_ids().contains(blob_id)
-            || (blob_id.blob_type == BlobType::ChainDescription
-                && blob_id.hash == self.header.chain_id.0)
+            || (self.header.height == BlockHeight(0)
+                && (blob_id.blob_type == BlobType::ChainDescription
+                    && blob_id.hash == self.header.chain_id.0))
     }
 
     /// Returns all the published blob IDs in this block's operations.

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -13,16 +13,16 @@ use linera_base::{
     crypto::{BcsHashable, CryptoHash},
     data_types::{Blob, BlockHeight, Epoch, Event, OracleResponse, Timestamp},
     hashed::Hashed,
-    identifiers::{AccountOwner, BlobId, ChainId, MessageId},
+    identifiers::{AccountOwner, BlobId, BlobType, ChainId, MessageId},
 };
-use linera_execution::{system::OpenChainConfig, BlobState, Operation, OutgoingMessage};
+use linera_execution::{BlobState, Operation, OutgoingMessage};
 use serde::{ser::SerializeStruct, Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
     data_types::{
-        BlockExecutionOutcome, IncomingBundle, MessageAction, MessageBundle, OperationResult,
-        OutgoingMessageExt, PostedMessage, ProposedBlock,
+        BlockExecutionOutcome, IncomingBundle, MessageBundle, OperationResult, OutgoingMessageExt,
+        ProposedBlock,
     },
     types::CertificateValue,
 };
@@ -497,6 +497,13 @@ impl Block {
         let mut blob_ids = self.oracle_blob_ids();
         blob_ids.extend(self.published_blob_ids());
         blob_ids.extend(self.created_blob_ids());
+        if self.header.height == BlockHeight(0) {
+            // the initial block implicitly depends on the chain description blob
+            blob_ids.insert(BlobId::new(
+                self.header.chain_id.0,
+                BlobType::ChainDescription,
+            ));
+        }
         blob_ids
     }
 
@@ -505,6 +512,8 @@ impl Block {
         self.oracle_blob_ids().contains(blob_id)
             || self.published_blob_ids().contains(blob_id)
             || self.created_blob_ids().contains(blob_id)
+            || (blob_id.blob_type == BlobType::ChainDescription
+                && blob_id.hash == self.header.chain_id.0)
     }
 
     /// Returns all the published blob IDs in this block's operations.
@@ -634,20 +643,6 @@ impl Block {
             .iter()
             .flatten()
             .map(|blob| (blob.id(), blob.clone()))
-    }
-
-    /// If the block's first message is `OpenChain`, returns the bundle, the message and
-    /// the configuration for the new chain.
-    pub fn starts_with_open_chain_message(
-        &self,
-    ) -> Option<(&IncomingBundle, &PostedMessage, &OpenChainConfig)> {
-        let in_bundle = self.body.incoming_bundles.first()?;
-        if in_bundle.action != MessageAction::Accept {
-            return None;
-        }
-        let posted_message = in_bundle.bundle.messages.first()?;
-        let config = posted_message.message.matches_open_chain()?;
-        Some((in_bundle, posted_message, config))
     }
 }
 

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -16,9 +16,7 @@ use linera_base::{
     doc_scalar, ensure, hex_debug,
     identifiers::{Account, AccountOwner, BlobId, ChainId, MessageId},
 };
-use linera_execution::{
-    committee::Committee, Message, MessageKind, Operation, OutgoingMessage, SystemMessage,
-};
+use linera_execution::{committee::Committee, Message, MessageKind, Operation, OutgoingMessage};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -183,25 +181,6 @@ impl IncomingBundle {
             let message_id = chain_and_height.to_message_id(posted_message.index);
             (message_id, posted_message)
         })
-    }
-
-    /// Rearranges the messages in the bundle so that the first message is an `OpenChain` message.
-    /// Returns whether the `OpenChain` message was found at all.
-    pub fn put_openchain_at_front(bundles: &mut [IncomingBundle]) -> bool {
-        let Some(index) = bundles.iter().position(|msg| {
-            matches!(
-                msg.bundle.messages.first(),
-                Some(PostedMessage {
-                    message: Message::System(SystemMessage::OpenChain(_)),
-                    ..
-                })
-            )
-        }) else {
-            return false;
-        };
-
-        bundles[0..=index].rotate_right(1);
-        true
     }
 }
 

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -15,7 +15,7 @@ use linera_base::{
     crypto::{AccountPublicKey, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationDescription, ApplicationPermissions, Blob, BlockHeight, Bytecode,
-        ChainDescription, ChainOrigin, Epoch, OpenChainConfig, Timestamp,
+        ChainDescription, ChainOrigin, Epoch, InitialChainConfig, Timestamp,
     },
     http,
     identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId},
@@ -71,7 +71,7 @@ impl TestEnvironment {
             ValidatorPublicKey::test_key(1),
             AccountPublicKey::test_key(1),
         )]);
-        let config = OpenChainConfig {
+        let config = InitialChainConfig {
             ownership: ChainOwnership::single(AccountPublicKey::test_key(0).into()),
             admin_id: None,
             epoch: Epoch::ZERO,
@@ -102,7 +102,7 @@ impl TestEnvironment {
             .map(Blob::new_chain_description)
     }
 
-    fn make_open_chain_config(&self) -> OpenChainConfig {
+    fn make_open_chain_config(&self) -> InitialChainConfig {
         self.admin_chain_description.config().clone()
     }
 
@@ -131,14 +131,14 @@ impl TestEnvironment {
     fn make_child_chain_description_with_config(
         &mut self,
         height: u64,
-        config: OpenChainConfig,
+        config: InitialChainConfig,
     ) -> ChainDescription {
         let origin = ChainOrigin::Child {
             parent: self.admin_id(),
             block_height: BlockHeight(height),
             chain_index: 0,
         };
-        let config = OpenChainConfig {
+        let config = InitialChainConfig {
             admin_id: Some(self.admin_id()),
             ..config
         };
@@ -254,7 +254,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     let application_id = ApplicationId::from(&app_description);
     let application = MockApplication::default();
 
-    let config = OpenChainConfig {
+    let config = InitialChainConfig {
         application_permissions: ApplicationPermissions::new_single(application_id),
         ..env.make_open_chain_config()
     };

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -13,6 +13,10 @@ use crate::{
     test::{make_first_block, BlockTestExt},
 };
 
+fn dummy_chain_id(index: u32) -> ChainId {
+    ChainId(CryptoHash::test_hash(format!("chain{}", index)))
+}
+
 #[test]
 fn test_signed_values() {
     let validator1_key_pair = ValidatorKeypair::generate();
@@ -27,7 +31,7 @@ fn test_signed_values() {
         blobs: vec![Vec::new()],
         operation_results: vec![OperationResult::default()],
     }
-    .with(make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(2), Amount::ONE));
+    .with(make_first_block(dummy_chain_id(1)).with_simple_transfer(dummy_chain_id(2), Amount::ONE));
     let confirmed_value = ConfirmedBlock::new(block.clone());
 
     let confirmed_vote = LiteVote::new(
@@ -97,7 +101,7 @@ fn test_certificates() {
         blobs: vec![Vec::new()],
         operation_results: vec![OperationResult::default()],
     }
-    .with(make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(1), Amount::ONE));
+    .with(make_first_block(dummy_chain_id(1)).with_simple_transfer(dummy_chain_id(1), Amount::ONE));
     let value = ConfirmedBlock::new(block);
 
     let v1 = LiteVote::new(

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -24,6 +24,7 @@ use linera_core::{
     Environment, JoinSetExt,
 };
 use linera_rpc::node_provider::{NodeOptions, NodeProvider};
+use linera_storage::Storage;
 use linera_views::views::ViewError;
 use thiserror_context::Context;
 use tracing::{debug, info};
@@ -96,10 +97,7 @@ where
         self.client.storage_client()
     }
 
-    async fn make_chain_client(
-        &self,
-        chain_id: ChainId,
-    ) -> Result<ChainClient<Env>, Error> {
+    async fn make_chain_client(&self, chain_id: ChainId) -> Result<ChainClient<Env>, Error> {
         self.make_chain_client(chain_id).await
     }
 
@@ -253,10 +251,7 @@ where
             .expect("No chain specified in wallet with no default chain")
     }
 
-    async fn make_chain_client(
-        &self,
-        chain_id: ChainId,
-    ) -> Result<ChainClient<Env>, Error> {
+    async fn make_chain_client(&self, chain_id: ChainId) -> Result<ChainClient<Env>, Error> {
         // We only create clients for chains we have in the wallet, or for the admin chain.
         let chain = match self.wallet.get(chain_id) {
             Some(chain) => chain.clone(),

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -32,7 +32,7 @@ use {
     crate::benchmark::{Benchmark, BenchmarkError},
     futures::{stream, StreamExt, TryStreamExt},
     linera_base::{
-        data_types::{Amount, Epoch, OpenChainConfig},
+        data_types::{Amount, Epoch, InitialChainConfig},
         identifiers::ApplicationId,
     },
     linera_core::client::ChainClientError,
@@ -953,7 +953,7 @@ where
             })
             .collect();
         let epoch = epoch.expect("default chain should be active");
-        let config = OpenChainConfig {
+        let config = InitialChainConfig {
             ownership: ChainOwnership::single_super(key_pair.public().into()),
             committees,
             admin_id: Some(admin_id),

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -13,7 +13,7 @@ use linera_base::{
         AccountPublicKey, AccountSecretKey, BcsSignable, CryptoHash, CryptoRng, Ed25519SecretKey,
         ValidatorPublicKey, ValidatorSecretKey,
     },
-    data_types::{Amount, ChainDescription, ChainOrigin, Epoch, OpenChainConfig, Timestamp},
+    data_types::{Amount, ChainDescription, ChainOrigin, Epoch, InitialChainConfig, Timestamp},
     identifiers::ChainId,
     ownership::ChainOwnership,
 };
@@ -232,7 +232,7 @@ impl GenesisConfig {
         .collect();
         for (chain_number, (public_key, balance)) in (0..).zip(&self.chains) {
             let origin = ChainOrigin::Root(chain_number);
-            let config = OpenChainConfig {
+            let config = InitialChainConfig {
                 admin_id: if chain_number == 0 {
                     None
                 } else {

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
+    collections::BTreeMap,
     iter::IntoIterator,
     ops::{Deref, DerefMut},
 };
@@ -12,8 +13,9 @@ use linera_base::{
         AccountPublicKey, AccountSecretKey, BcsSignable, CryptoHash, CryptoRng, Ed25519SecretKey,
         ValidatorPublicKey, ValidatorSecretKey,
     },
-    data_types::{Amount, Timestamp},
-    identifiers::{ChainDescription, ChainId},
+    data_types::{Amount, ChainDescription, ChainOrigin, Epoch, OpenChainConfig, Timestamp},
+    identifiers::ChainId,
+    ownership::ChainOwnership,
 };
 use linera_execution::{
     committee::{Committee, ValidatorState},
@@ -222,18 +224,28 @@ impl GenesisConfig {
         S: Storage + Clone + Send + Sync + 'static,
     {
         let committee = self.create_committee();
+        let committees: BTreeMap<_, _> = [(
+            Epoch::ZERO,
+            bcs::to_bytes(&committee).expect("serializing a committee should not fail"),
+        )]
+        .into_iter()
+        .collect();
         for (chain_number, (public_key, balance)) in (0..).zip(&self.chains) {
-            let description = ChainDescription::Root(chain_number);
-            storage
-                .create_chain(
-                    committee.clone(),
-                    self.admin_id,
-                    description,
-                    (*public_key).into(),
-                    *balance,
-                    self.timestamp,
-                )
-                .await?;
+            let origin = ChainOrigin::Root(chain_number);
+            let config = OpenChainConfig {
+                admin_id: if chain_number == 0 {
+                    None
+                } else {
+                    Some(self.admin_id)
+                },
+                application_permissions: Default::default(),
+                balance: *balance,
+                committees: committees.clone(),
+                epoch: Epoch::ZERO,
+                ownership: ChainOwnership::single((*public_key).into()),
+            };
+            let description = ChainDescription::new(origin, config, self.timestamp);
+            storage.create_chain(description).await?;
         }
         Ok(())
     }

--- a/linera-client/src/error.rs
+++ b/linera-client/src/error.rs
@@ -32,8 +32,6 @@ pub(crate) enum Inner {
     ChainInfoResponseMissingCommittee,
     #[error("arithmetic error: {0}")]
     Arithmetic(#[from] linera_base::data_types::ArithmeticError),
-    #[error("invalid open message")]
-    InvalidOpenMessage(Option<Box<linera_execution::Message>>),
     #[error("incorrect chain ownership")]
     ChainOwnership,
     #[cfg(feature = "benchmark")]

--- a/linera-client/src/error.rs
+++ b/linera-client/src/error.rs
@@ -28,8 +28,6 @@ pub(crate) enum Inner {
     LocalNode(#[from] linera_core::local_node::LocalNodeError),
     #[error("remote node operation failed: {0}")]
     RemoteNode(#[from] linera_core::node::NodeError),
-    #[error("chain info response missing latest committee")]
-    ChainInfoResponseMissingCommittee,
     #[error("arithmetic error: {0}")]
     Arithmetic(#[from] linera_base::data_types::ArithmeticError),
     #[error("incorrect chain ownership")]

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -49,7 +49,7 @@ impl chain_listener::ClientContext for ClientContext {
         self.client.storage_client()
     }
 
-    fn make_chain_client(
+    async fn make_chain_client(
         &self,
         chain_id: ChainId,
     ) -> Result<ChainClient<environment::Test>, Error> {
@@ -63,15 +63,18 @@ impl chain_listener::ClientContext for ClientContext {
             .map(|kp| kp.copy())
             .into_iter()
             .collect();
-        Ok(self.client.create_chain_client(
-            chain_id,
-            known_key_pairs,
-            self.wallet.genesis_admin_chain(),
-            chain.block_hash,
-            chain.timestamp,
-            chain.next_block_height,
-            chain.pending_proposal.clone(),
-        ))
+        Ok(self
+            .client
+            .create_chain_client(
+                chain_id,
+                known_key_pairs,
+                self.wallet.genesis_admin_chain(),
+                chain.block_hash,
+                chain.timestamp,
+                chain.next_block_height,
+                chain.pending_proposal.clone(),
+            )
+            .await?)
     }
 
     async fn update_wallet_for_new_chain(

--- a/linera-client/src/unit_tests/util.rs
+++ b/linera-client/src/unit_tests/util.rs
@@ -3,7 +3,6 @@
 
 use linera_base::data_types::Timestamp;
 use linera_core::test_utils::{MemoryStorageBuilder, TestBuilder};
-use linera_execution::ResourceControlPolicy;
 use linera_rpc::{
     config::{NetworkProtocol, ValidatorPublicNetworkPreConfig},
     simple::TransportProtocol,
@@ -31,7 +30,7 @@ pub fn make_genesis_config(builder: &TestBuilder<MemoryStorageBuilder>) -> Genes
         CommitteeConfig { validators },
         builder.admin_id(),
         Timestamp::from(0),
-        ResourceControlPolicy::default(),
+        builder.initial_committee.policy().clone(),
         "test network".to_string(),
     );
     genesis_config.chains.extend(builder.genesis_chains());

--- a/linera-client/src/unit_tests/wallet.rs
+++ b/linera-client/src/unit_tests/wallet.rs
@@ -5,7 +5,6 @@ use anyhow::anyhow;
 use linera_base::{
     crypto::{AccountSecretKey, Ed25519SecretKey},
     data_types::{Amount, Blob, BlockHeight, Epoch},
-    identifiers::{ChainDescription, ChainId},
 };
 use linera_chain::data_types::ProposedBlock;
 use linera_core::{
@@ -28,8 +27,8 @@ async fn test_save_wallet_with_pending_blobs() -> anyhow::Result<()> {
     let storage_builder = MemoryStorageBuilder::default();
     let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
-    let chain_id = ChainId::root(0);
     builder.add_root_chain(0, Amount::ONE).await?;
+    let chain_id = builder.admin_id();
     let storage = builder.make_storage().await?;
 
     let genesis_config = make_genesis_config(&builder);
@@ -52,7 +51,7 @@ async fn test_save_wallet_with_pending_blobs() -> anyhow::Result<()> {
     wallet
         .add_chains(Some(UserChain::make_initial(
             key_pair,
-            ChainDescription::Root(0),
+            builder.admin_description().unwrap().clone(),
             clock.current_time(),
         )))
         .await?;

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -8,9 +8,9 @@ use std::{
 
 use linera_base::{
     crypto::{AccountSecretKey, CryptoHash, CryptoRng},
-    data_types::{BlockHeight, Timestamp},
+    data_types::{BlockHeight, ChainDescription, Timestamp},
     ensure,
-    identifiers::{AccountOwner, ChainDescription, ChainId},
+    identifiers::{AccountOwner, ChainId},
 };
 use linera_core::{
     client::{ChainClient, PendingProposal},

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -68,7 +68,7 @@ where
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         // Check that the chain is active and ready for this timeout.
         // Verify the certificate. Returns a catch-all error to make client code more robust.
-        self.state.ensure_is_active()?;
+        self.state.ensure_is_active().await?;
         let (chain_epoch, committee) = self.state.chain.current_committee()?;
         ensure!(
             certificate.inner().epoch() == chain_epoch,
@@ -208,7 +208,7 @@ where
         let height = header.height;
         // Check that the chain is active and ready for this validated block.
         // Verify the certificate. Returns a catch-all error to make client code more robust.
-        self.state.ensure_is_active()?;
+        self.state.ensure_is_active().await?;
         let (epoch, committee) = self.state.chain.current_committee()?;
         check_block_epoch(epoch, header.chain_id, header.epoch)?;
         certificate.check(committee)?;
@@ -303,13 +303,7 @@ where
         }
         let local_time = self.state.storage.clock().current_time();
         // TODO(#2351): This sets the committee and then checks that committee's signatures.
-        if tip.is_first_block() && self.state.chain.is_child() {
-            self.state
-                .chain
-                .execute_init_message_from(block, local_time)
-                .await?;
-        }
-        self.state.ensure_is_active()?;
+        self.state.ensure_is_active().await?;
         // Verify the certificate.
         let (epoch, committee) = self.state.chain.current_committee()?;
         check_block_epoch(epoch, chain_id, block.header.epoch)?;

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -59,7 +59,7 @@ where
         &mut self,
         height: BlockHeight,
     ) -> Result<Option<ConfirmedBlockCertificate>, WorkerError> {
-        self.0.ensure_is_active()?;
+        self.0.ensure_is_active().await?;
         let certificate_hash = match self.0.chain.confirmed_log.get(height.try_into()?).await? {
             Some(hash) => hash,
             None => return Ok(None),
@@ -77,7 +77,7 @@ where
         height: BlockHeight,
         index: u32,
     ) -> Result<Option<MessageBundle>, WorkerError> {
-        self.0.ensure_is_active()?;
+        self.0.ensure_is_active().await?;
 
         let mut inbox = self.0.chain.inboxes.try_load_entry_mut(&inbox_id).await?;
         let mut bundles = inbox.added_bundles.iter_mut().await?;
@@ -96,7 +96,7 @@ where
         &mut self,
         query: Query,
     ) -> Result<QueryOutcome, WorkerError> {
-        self.0.ensure_is_active()?;
+        self.0.ensure_is_active().await?;
         let local_time = self.0.storage.clock().current_time();
         let outcome = self
             .0
@@ -111,7 +111,7 @@ where
         &mut self,
         application_id: ApplicationId,
     ) -> Result<ApplicationDescription, WorkerError> {
-        self.0.ensure_is_active()?;
+        self.0.ensure_is_active().await?;
         let response = self.0.chain.describe_application(application_id).await?;
         Ok(response)
     }
@@ -123,6 +123,7 @@ where
         round: Option<u32>,
         published_blobs: &[Blob],
     ) -> Result<(Block, ChainInfoResponse), WorkerError> {
+        self.0.ensure_is_active().await?;
         let local_time = self.0.storage.clock().current_time();
         let signer = block.authenticated_signer;
         let (_, committee) = self.0.chain.current_committee()?;
@@ -241,6 +242,7 @@ where
         &mut self,
         query: ChainInfoQuery,
     ) -> Result<ChainInfoResponse, WorkerError> {
+        self.0.ensure_is_active().await?;
         let chain = &self.0.chain;
         let mut info = ChainInfo::from(chain);
         if query.request_committees {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -29,7 +29,7 @@ use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey, CryptoHash, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight, Epoch,
-        OpenChainConfig, Round, Timestamp,
+        InitialChainConfig, Round, Timestamp,
     },
     ensure,
     identifiers::{
@@ -2961,7 +2961,7 @@ impl<Env: Environment> ChainClient<Env> {
                 })
                 .collect();
             let epoch = epoch.ok_or(LocalNodeError::InactiveChain(self.chain_id))?;
-            let config = OpenChainConfig {
+            let config = InitialChainConfig {
                 ownership: ownership.clone(),
                 committees,
                 admin_id: Some(self.admin_id),

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -3394,6 +3394,17 @@ impl<Env: Environment> ChainClient<Env> {
     ) {
         match notification.reason {
             Reason::NewIncomingBundle { origin, height } => {
+                if let Err(error) = self
+                    .client
+                    .ensure_has_chain_description(origin, self.admin_id)
+                    .await
+                {
+                    error!(
+                        chain_id = %self.chain_id,
+                        "NewIncomingBundle: could not find blob for sender's chain: {error}"
+                    );
+                    return;
+                }
                 if self.local_next_block_height(origin, &mut local_node).await > Some(height) {
                     debug!(
                         chain_id = %self.chain_id,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1427,6 +1427,12 @@ impl<Env: Environment> ChainClient<Env> {
         let remote_max_heights = Self::max_height_per_chain(&remote_log);
 
         // Obtain the next block height we need in the local node, for each chain.
+        // But first, ensure we have the chain descriptions!
+        for chain in remote_max_heights.keys() {
+            self.client
+                .ensure_has_chain_description(*chain, self.admin_id)
+                .await?;
+        }
         let local_next_heights = self
             .client
             .local_node

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -29,12 +29,12 @@ use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey, CryptoHash, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight, Epoch,
-        Round, Timestamp,
+        OpenChainConfig, Round, Timestamp,
     },
     ensure,
     identifiers::{
-        Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, EventId, MessageId,
-        ModuleId, StreamId,
+        Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, EventId, ModuleId,
+        StreamId,
     },
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -54,8 +54,7 @@ use linera_chain::{
 use linera_execution::{
     committee::Committee,
     system::{
-        AdminOperation, OpenChainConfig, Recipient, SystemOperation, EPOCH_STREAM_NAME,
-        OPEN_CHAIN_MESSAGE_INDEX, REMOVED_EPOCH_STREAM_NAME,
+        AdminOperation, Recipient, SystemOperation, EPOCH_STREAM_NAME, REMOVED_EPOCH_STREAM_NAME,
     },
     ExecutionError, Operation, Query, QueryOutcome, QueryResponse, SystemQuery, SystemResponse,
 };
@@ -240,7 +239,7 @@ impl<Env: Environment> Client<Env> {
     /// Creates a new `ChainClient`.
     #[instrument(level = "trace", skip_all, fields(chain_id, next_block_height))]
     #[expect(clippy::too_many_arguments)]
-    pub fn create_chain_client(
+    pub async fn create_chain_client(
         self: &Arc<Self>,
         chain_id: ChainId,
         known_key_pairs: Vec<AccountSecretKey>,
@@ -249,7 +248,7 @@ impl<Env: Environment> Client<Env> {
         timestamp: Timestamp,
         next_block_height: BlockHeight,
         pending_proposal: Option<PendingProposal>,
-    ) -> ChainClient<Env> {
+    ) -> Result<ChainClient<Env>, ChainClientError> {
         // If the entry already exists we assume that the entry is more up to date than
         // the arguments: If they were read from the wallet file, they might be stale.
         if let dashmap::mapref::entry::Entry::Vacant(e) = self.chains.entry(chain_id) {
@@ -262,7 +261,11 @@ impl<Env: Environment> Client<Env> {
             ));
         }
 
-        ChainClient {
+        let _ = self
+            .ensure_has_chain_description(chain_id, admin_id)
+            .await?;
+
+        Ok(ChainClient {
             client: self.clone(),
             chain_id,
             admin_id,
@@ -273,6 +276,25 @@ impl<Env: Environment> Client<Env> {
                 grace_period: self.grace_period,
                 blob_download_timeout: self.blob_download_timeout,
             },
+        })
+    }
+
+    pub async fn chain_info(
+        &self,
+        chain_id: ChainId,
+        validators: &[RemoteNode<impl ValidatorNode>],
+    ) -> Result<Box<ChainInfo>, LocalNodeError> {
+        match self.local_node.chain_info(chain_id).await {
+            Ok(info) => Ok(info),
+            Err(LocalNodeError::BlobsNotFound(blob_ids)) => {
+                let blobs =
+                    RemoteNode::download_blobs(&blob_ids, validators, self.blob_download_timeout)
+                        .await
+                        .ok_or(LocalNodeError::BlobsNotFound(blob_ids))?;
+                self.local_node.storage_client().write_blobs(&blobs).await?;
+                self.local_node.chain_info(chain_id).await
+            }
+            err => err,
         }
     }
 
@@ -285,10 +307,10 @@ impl<Env: Environment> Client<Env> {
         target_next_block_height: BlockHeight,
     ) -> Result<Box<ChainInfo>, ChainClientError> {
         // Sequentially try each validator in random order.
-        let mut validators = validators.iter().collect::<Vec<_>>();
-        validators.shuffle(&mut rand::thread_rng());
-        for remote_node in validators {
-            let info = self.local_node.chain_info(chain_id).await?;
+        let mut validators_vec = validators.iter().collect::<Vec<_>>();
+        validators_vec.shuffle(&mut rand::thread_rng());
+        for remote_node in validators_vec {
+            let info = self.chain_info(chain_id, validators).await?;
             if target_next_block_height <= info.next_block_height {
                 return Ok(info);
             }
@@ -300,7 +322,7 @@ impl<Env: Environment> Client<Env> {
             )
             .await?;
         }
-        let info = self.local_node.chain_info(chain_id).await?;
+        let info = self.chain_info(chain_id, validators).await?;
         if target_next_block_height <= info.next_block_height {
             Ok(info)
         } else {
@@ -391,6 +413,61 @@ impl<Env: Environment> Client<Env> {
         self.local_node
             .handle_certificate(certificate.clone(), &self.notifier)
             .await
+    }
+
+    /// Obtains the current epoch of the given chain as well as its set of trusted committees.
+    pub async fn epoch_and_committees(
+        &self,
+        chain_id: ChainId,
+    ) -> Result<(Option<Epoch>, BTreeMap<Epoch, Committee>), LocalNodeError> {
+        let query = ChainInfoQuery::new(chain_id).with_committees();
+        let info = self.local_node.handle_chain_info_query(query).await?.info;
+        let epoch = info.epoch;
+        let committees = info
+            .requested_committees
+            .ok_or(LocalNodeError::InvalidChainInfoResponse)?;
+        Ok((epoch, committees))
+    }
+
+    fn make_nodes(&self, committee: &Committee) -> Result<Vec<RemoteNode<Env::ValidatorNode>>, NodeError> {
+        Ok(self
+            .validator_node_provider
+            .make_nodes(committee)?
+            .map(|(public_key, node)| RemoteNode { public_key, node })
+            .collect())
+    }
+
+    /// Ensures that the client has the `ChainDescription` blob corresponding to this
+    /// client's `ChainId`.
+    pub async fn ensure_has_chain_description(
+        &self,
+        chain_id: ChainId,
+        admin_id: ChainId,
+    ) -> Result<Blob, ChainClientError> {
+        let chain_desc_id = BlobId::new(chain_id.0, BlobType::ChainDescription);
+        if let Ok(blob) = self
+            .local_node
+            .storage_client()
+            .read_blob(chain_desc_id)
+            .await
+        {
+            // We have the blob - return it.
+            return Ok(blob);
+        }
+        // We can't get the committee from the chain we're assigned to because we don't
+        // have the description - use the admin chain.
+        let (admin_epoch, admin_committees) = self.epoch_and_committees(admin_id).await?;
+        let admin_epoch = admin_epoch.ok_or(ChainClientError::CommitteeSynchronizationError)?;
+        let remote_committee = admin_committees
+            .get(&admin_epoch)
+            .ok_or_else(|| ChainClientError::CommitteeDeprecationError)?;
+        // Recover history from the network.
+        let nodes = self.make_nodes(remote_committee)?;
+        let blob = RemoteNode::download_blob(&nodes, chain_desc_id, self.blob_download_timeout)
+            .await
+            .ok_or(LocalNodeError::BlobsNotFound(vec![chain_desc_id]))?;
+        self.local_node.storage_client().write_blob(&blob).await?;
+        Ok(blob)
     }
 }
 
@@ -814,6 +891,11 @@ impl<Env: Environment> ChainClient<Env> {
     /// local chain.
     #[instrument(level = "trace")]
     async fn pending_message_bundles(&self) -> Result<Vec<IncomingBundle>, ChainClientError> {
+        if self.options.message_policy.is_ignore() {
+            // Ignore all messages.
+            return Ok(Vec::new());
+        }
+
         let query = ChainInfoQuery::new(self.chain_id).with_pending_message_bundles();
         let info = self
             .client
@@ -829,35 +911,8 @@ impl<Env: Environment> ChainClient<Env> {
                 ChainClientError::WalletSynchronizationError
             );
         }
-        if info.next_block_height != BlockHeight::ZERO && self.options.message_policy.is_ignore() {
-            return Ok(Vec::new()); // OpenChain is already received, others are ignored.
-        }
 
-        let mut rearranged = false;
-        let mut pending_message_bundles = info.requested_pending_message_bundles;
-
-        // The first incoming message of any child chain must be `OpenChain`. We must have it in
-        // our inbox, and include it before all other messages.
-        if info.next_block_height == BlockHeight::ZERO
-            && info
-                .description
-                .ok_or_else(|| LocalNodeError::InactiveChain(self.chain_id))?
-                .is_child()
-        {
-            // The first incoming message of any child chain must be `OpenChain`. We must have it in
-            // our inbox, and include it before all other messages.
-            rearranged = IncomingBundle::put_openchain_at_front(&mut pending_message_bundles);
-            ensure!(rearranged, LocalNodeError::InactiveChain(self.chain_id));
-        }
-
-        if self.options.message_policy.is_ignore() {
-            // Ignore messages other than OpenChain.
-            if rearranged {
-                return Ok(pending_message_bundles[0..1].to_vec());
-            } else {
-                return Ok(Vec::new());
-            }
-        }
+        let pending_message_bundles = info.requested_pending_message_bundles;
 
         Ok(pending_message_bundles
             .into_iter()
@@ -922,31 +977,20 @@ impl<Env: Environment> ChainClient<Env> {
         &self,
         chain_id: ChainId,
     ) -> Result<(Option<Epoch>, BTreeMap<Epoch, Committee>), LocalNodeError> {
-        let query = ChainInfoQuery::new(chain_id).with_committees();
-        let info = self
-            .client
-            .local_node
-            .handle_chain_info_query(query)
-            .await?
-            .info;
-        let epoch = info.epoch;
-        let committees = info
-            .requested_committees
-            .ok_or(LocalNodeError::InvalidChainInfoResponse)?;
-        Ok((epoch, committees))
+        self.client.epoch_and_committees(chain_id).await
     }
 
     /// Obtains the epochs of the committees trusted by the local chain.
     #[instrument(level = "trace")]
     pub async fn epochs(&self) -> Result<Vec<Epoch>, LocalNodeError> {
-        let (_epoch, committees) = self.epoch_and_committees(self.chain_id).await?;
+        let (_epoch, committees) = self.client.epoch_and_committees(self.chain_id).await?;
         Ok(committees.into_keys().collect())
     }
 
     /// Obtains the committee for the current epoch of the local chain.
     #[instrument(level = "trace")]
     pub async fn local_committee(&self) -> Result<Committee, LocalNodeError> {
-        let (epoch, mut committees) = self.epoch_and_committees(self.chain_id).await?;
+        let (epoch, mut committees) = self.client.epoch_and_committees(self.chain_id).await?;
         committees
             .remove(
                 epoch
@@ -971,24 +1015,18 @@ impl<Env: Environment> ChainClient<Env> {
     async fn known_committees(
         &self,
     ) -> Result<(BTreeMap<Epoch, Committee>, Epoch), LocalNodeError> {
-        let (epoch, mut committees) = self.epoch_and_committees(self.chain_id).await?;
-        let (admin_epoch, admin_committees) = self.epoch_and_committees(self.admin_id).await?;
+        let (epoch, mut committees) = match self.client.epoch_and_committees(self.chain_id).await {
+            Ok(result) => result,
+            // We might not be initialized due to a missing blob - just treat this case as
+            // no committees.
+            Err(LocalNodeError::BlobsNotFound(_)) => (None, BTreeMap::new()),
+            err => err?,
+        };
+        let (admin_epoch, admin_committees) =
+            self.client.epoch_and_committees(self.admin_id).await?;
         committees.extend(admin_committees);
         let epoch = std::cmp::max(epoch.unwrap_or_default(), admin_epoch.unwrap_or_default());
         Ok((committees, epoch))
-    }
-
-    #[instrument(level = "trace")]
-    fn make_nodes(
-        &self,
-        committee: &Committee,
-    ) -> Result<Vec<RemoteNode<Env::ValidatorNode>>, NodeError> {
-        Ok(self
-            .client
-            .validator_node_provider()
-            .make_nodes(committee)?
-            .map(|(public_key, node)| RemoteNode { public_key, node })
-            .collect())
     }
 
     /// Obtains the validators for the latest epoch.
@@ -997,7 +1035,7 @@ impl<Env: Environment> ChainClient<Env> {
         &self,
     ) -> Result<Vec<RemoteNode<Env::ValidatorNode>>, ChainClientError> {
         let committee = self.latest_committee().await?;
-        Ok(self.make_nodes(&committee)?)
+        Ok(self.client.make_nodes(&committee)?)
     }
 
     /// Obtains the current epoch of the local chain.
@@ -1193,7 +1231,7 @@ impl<Env: Environment> ChainClient<Env> {
         delivery: CrossChainMessageDelivery,
     ) -> Result<(), ChainClientError> {
         let local_node = self.client.local_node.clone();
-        let nodes = self.make_nodes(committee)?;
+        let nodes = self.client.make_nodes(committee)?;
         let n_validators = nodes.len();
         let chain_worker_count =
             std::cmp::max(1, self.client.max_loaded_chains.get() / n_validators);
@@ -1232,7 +1270,7 @@ impl<Env: Environment> ChainClient<Env> {
         value: T,
     ) -> Result<GenericCertificate<T>, ChainClientError> {
         let local_node = self.client.local_node.clone();
-        let nodes = self.make_nodes(committee)?;
+        let nodes = self.client.make_nodes(committee)?;
         let n_validators = nodes.len();
         let chain_worker_count =
             std::cmp::max(1, self.client.max_loaded_chains.get() / n_validators);
@@ -1331,7 +1369,7 @@ impl<Env: Environment> ChainClient<Env> {
             nodes
         } else {
             // We assume that the committee that signed the certificate is still active.
-            self.make_nodes(remote_committee)?
+            self.client.make_nodes(remote_committee)?
         };
         self.client
             .download_certificates(&nodes, block.header.chain_id, block.header.height)
@@ -1633,7 +1671,7 @@ impl<Env: Environment> ChainClient<Env> {
         // Use network information from the local chain.
         let chain_id = self.chain_id;
         let local_committee = self.local_committee().await?;
-        let nodes = self.make_nodes(&local_committee)?;
+        let nodes = self.client.make_nodes(&local_committee)?;
         let client = self.clone();
         // Proceed to downloading received certificates. Split the available chain workers so that
         // the tasks don't use more than the limit in total.
@@ -1793,11 +1831,11 @@ impl<Env: Environment> ChainClient<Env> {
         #[cfg(with_metrics)]
         let _latency = metrics::SYNCHRONIZE_CHAIN_STATE_LATENCY.measure_latency();
 
-        let (epoch, mut committees) = self.epoch_and_committees(chain_id).await?;
+        let (epoch, mut committees) = self.client.epoch_and_committees(chain_id).await?;
         let committee = committees
             .remove(&epoch.ok_or(LocalNodeError::InvalidChainInfoResponse)?)
             .ok_or(LocalNodeError::InvalidChainInfoResponse)?;
-        let validators = self.make_nodes(&committee)?;
+        let validators = self.client.make_nodes(&committee)?;
         communicate_with_quorum(
             &validators,
             &committee,
@@ -2910,14 +2948,23 @@ impl<Env: Environment> ChainClient<Env> {
         ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
         balance: Amount,
-    ) -> Result<ClientOutcome<(MessageId, ConfirmedBlockCertificate)>, ChainClientError> {
+    ) -> Result<ClientOutcome<(ChainId, ConfirmedBlockCertificate)>, ChainClientError> {
         loop {
-            let (epoch, committees) = self.epoch_and_committees(self.chain_id).await?;
+            let (epoch, committees) = self.client.epoch_and_committees(self.chain_id).await?;
+            let committees = committees
+                .into_iter()
+                .map(|(epoch, committee)| {
+                    (
+                        epoch,
+                        bcs::to_bytes(&committee).expect("Serializing a committee shouldn't fail!"),
+                    )
+                })
+                .collect();
             let epoch = epoch.ok_or(LocalNodeError::InactiveChain(self.chain_id))?;
             let config = OpenChainConfig {
                 ownership: ownership.clone(),
                 committees,
-                admin_id: self.admin_id,
+                admin_id: Some(self.admin_id),
                 epoch,
                 balance,
                 application_permissions: application_permissions.clone(),
@@ -2931,17 +2978,20 @@ impl<Env: Environment> ChainClient<Env> {
                 }
             };
             // The first message of the only operation created the new chain.
-            let message_id = certificate
+            let chain_blob_id = certificate
                 .block()
-                .message_id_for_operation(0, OPEN_CHAIN_MESSAGE_INDEX)
-                .ok_or_else(|| ChainClientError::InternalError("Failed to create new chain"))?;
+                .created_blob_ids()
+                .into_iter()
+                .next()
+                .ok_or_else(|| ChainClientError::InternalError("Failed to create a new chain"))?;
+            let chain_id = ChainId(chain_blob_id.hash);
             // Add the new chain to the list of tracked chains
-            self.client.track_chain(ChainId::child(message_id));
+            self.client.track_chain(chain_id);
             self.client
                 .local_node
                 .retry_pending_cross_chain_requests(self.chain_id)
                 .await?;
-            return Ok(ClientOutcome::Committed((message_id, certificate)));
+            return Ok(ClientOutcome::Committed((chain_id, certificate)));
         }
     }
 
@@ -3242,7 +3292,7 @@ impl<Env: Environment> ChainClient<Env> {
         &self,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
         self.prepare_chain().await?;
-        let (current_epoch, committees) = self.epoch_and_committees(self.chain_id).await?;
+        let (current_epoch, committees) = self.client.epoch_and_committees(self.chain_id).await?;
         let current_epoch = current_epoch.ok_or(LocalNodeError::InactiveChain(self.chain_id))?;
         let operations = committees
             .keys()

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -288,6 +288,7 @@ impl<Env: Environment> Client<Env> {
         match self.local_node.chain_info(chain_id).await {
             Ok(info) => Ok(info),
             Err(LocalNodeError::BlobsNotFound(blob_ids)) => {
+                // TODO(#2351): make sure the blobs are legitimate!
                 let blobs =
                     RemoteNode::download_blobs(&blob_ids, validators, self.blob_download_timeout)
                         .await
@@ -466,6 +467,7 @@ impl<Env: Environment> Client<Env> {
             .get(&admin_epoch)
             .ok_or_else(|| ChainClientError::CommitteeDeprecationError)?;
         // Recover history from the network.
+        // TODO(#2351): make sure that the blob is legitimately created!
         let nodes = self.make_nodes(remote_committee)?;
         let blob = RemoteNode::download_blob(&nodes, chain_desc_id, self.blob_download_timeout)
             .await

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -29,7 +29,7 @@ use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey, CryptoHash, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight, Epoch,
-        InitialChainConfig, Round, Timestamp,
+        Round, Timestamp,
     },
     ensure,
     identifiers::{
@@ -54,7 +54,8 @@ use linera_chain::{
 use linera_execution::{
     committee::Committee,
     system::{
-        AdminOperation, Recipient, SystemOperation, EPOCH_STREAM_NAME, REMOVED_EPOCH_STREAM_NAME,
+        AdminOperation, OpenChainConfig, Recipient, SystemOperation, EPOCH_STREAM_NAME,
+        REMOVED_EPOCH_STREAM_NAME,
     },
     ExecutionError, Operation, Query, QueryOutcome, QueryResponse, SystemQuery, SystemResponse,
 };
@@ -2950,22 +2951,8 @@ impl<Env: Environment> ChainClient<Env> {
         balance: Amount,
     ) -> Result<ClientOutcome<(ChainId, ConfirmedBlockCertificate)>, ChainClientError> {
         loop {
-            let (epoch, committees) = self.client.epoch_and_committees(self.chain_id).await?;
-            let committees = committees
-                .into_iter()
-                .map(|(epoch, committee)| {
-                    (
-                        epoch,
-                        bcs::to_bytes(&committee).expect("Serializing a committee shouldn't fail!"),
-                    )
-                })
-                .collect();
-            let epoch = epoch.ok_or(LocalNodeError::InactiveChain(self.chain_id))?;
-            let config = InitialChainConfig {
+            let config = OpenChainConfig {
                 ownership: ownership.clone(),
-                committees,
-                admin_id: Some(self.admin_id),
-                epoch,
                 balance,
                 application_permissions: application_permissions.clone(),
             };

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -430,9 +430,12 @@ impl<Env: Environment> Client<Env> {
         Ok((epoch, committees))
     }
 
-    fn make_nodes(&self, committee: &Committee) -> Result<Vec<RemoteNode<Env::ValidatorNode>>, NodeError> {
+    fn make_nodes(
+        &self,
+        committee: &Committee,
+    ) -> Result<Vec<RemoteNode<Env::ValidatorNode>>, NodeError> {
         Ok(self
-            .validator_node_provider
+            .validator_node_provider()
             .make_nodes(committee)?
             .map(|(public_key, node)| RemoteNode { public_key, node })
             .collect())

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -10,8 +10,8 @@ use linera_base::{
         BcsSignable, CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSecretKey,
         ValidatorSignature,
     },
-    data_types::{Amount, BlockHeight, Epoch, Round, Timestamp},
-    identifiers::{AccountOwner, ChainDescription, ChainId},
+    data_types::{Amount, BlockHeight, ChainDescription, Epoch, Round, Timestamp},
+    identifiers::{AccountOwner, ChainId},
 };
 use linera_chain::{
     data_types::{ChainAndHeight, IncomingBundle, MessageBundle},
@@ -271,7 +271,7 @@ where
         ChainInfo {
             chain_id: view.chain_id(),
             epoch: *system_state.epoch.get(),
-            description: *system_state.description.get(),
+            description: system_state.description.get().clone(),
             manager: Box::new(ChainManagerInfo::from(&view.manager)),
             chain_balance: *system_state.balance.get(),
             block_hash: tip_state.block_hash,

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -11,7 +11,7 @@ use futures::{future::Either, stream, StreamExt as _, TryStreamExt as _};
 use linera_base::{
     crypto::ValidatorPublicKey,
     data_types::{ApplicationDescription, ArithmeticError, Blob, BlockHeight},
-    identifiers::{ApplicationId, BlobId, ChainId, MessageId},
+    identifiers::{ApplicationId, BlobId, ChainId},
 };
 use linera_chain::{
     data_types::{BlockProposal, ProposedBlock},
@@ -319,28 +319,6 @@ where
                     "could not find certificate with block chain ID and height {}",
                     (chain_id, block_height),
                 )
-            })?;
-        Ok(certificate)
-    }
-
-    /// Obtains the certificate containing the specified message.
-    #[instrument(level = "trace", skip(self))]
-    pub async fn certificate_for(
-        &self,
-        message_id: &MessageId,
-    ) -> Result<ConfirmedBlockCertificate, LocalNodeError> {
-        let query = ChainInfoQuery::new(message_id.chain_id)
-            .with_sent_certificate_hashes_in_range(BlockHeightRange::single(message_id.height));
-        let info = self.handle_chain_info_query(query).await?.info;
-        let certificates = self
-            .storage_client()
-            .read_certificates(info.requested_sent_certificate_hashes)
-            .await?;
-        let certificate = certificates
-            .into_iter()
-            .find(|certificate| certificate.has_message(message_id))
-            .ok_or_else(|| {
-                ViewError::not_found("could not find certificate with message {}", message_id)
             })?;
         Ok(certificate)
     }

--- a/linera-core/src/notifier.rs
+++ b/linera-core/src/notifier.rs
@@ -119,14 +119,16 @@ pub mod tests {
         time::Duration,
     };
 
+    use linera_execution::test_utils::dummy_chain_description;
+
     use super::*;
 
     #[test]
     fn test_concurrent() {
         let notifier = ChannelNotifier::default();
 
-        let chain_a = ChainId::root(0);
-        let chain_b = ChainId::root(1);
+        let chain_a = dummy_chain_description(0).id();
+        let chain_b = dummy_chain_description(1).id();
 
         let a_rec = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let b_rec = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -195,10 +197,10 @@ pub mod tests {
     fn test_eviction() {
         let notifier = ChannelNotifier::default();
 
-        let chain_a = ChainId::root(0);
-        let chain_b = ChainId::root(1);
-        let chain_c = ChainId::root(2);
-        let chain_d = ChainId::root(3);
+        let chain_a = dummy_chain_description(0).id();
+        let chain_b = dummy_chain_description(1).id();
+        let chain_c = dummy_chain_description(2).id();
+        let chain_d = dummy_chain_description(3).id();
 
         // Chain A -> Notify A, Notify B
         // Chain B -> Notify A, Notify B

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -314,7 +314,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
     }
 
     #[instrument(level = "trace", skip(validators))]
-    async fn download_blob(
+    pub async fn download_blob(
         validators: &[Self],
         blob_id: BlobId,
         timeout: Duration,

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -313,6 +313,8 @@ impl<N: ValidatorNode> RemoteNode<N> {
         self.node.download_certificates(hashes).await
     }
 
+    /// Downloads a blob, but does not verify if it has actually been published and
+    /// accepted by a quorum of validators.
     #[instrument(level = "trace", skip(validators))]
     pub async fn download_blob(
         validators: &[Self],

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1905,7 +1905,7 @@ where
     Ok(())
 }
 
-// TODO: this test is currently intermittently failing if the faulty validators respond to
+// TODO(#3860): this test is currently intermittently failing if the faulty validators respond to
 // client0 before the correct ones. Un-ignore when this issue is fixed.
 #[ignore]
 #[test_case(MemoryStorageBuilder::default(); "memory")]

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1905,6 +1905,9 @@ where
     Ok(())
 }
 
+// TODO: this test is currently intermittently failing if the faulty validators respond to
+// client0 before the correct ones. Un-ignore when this issue is fixed.
+#[ignore]
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -513,7 +513,7 @@ where
     let parent = builder.add_root_chain(2, Amount::ZERO).await?;
     let new_key_pair = AccountSecretKey::generate();
 
-    let new_chain_config = OpenChainConfig {
+    let new_chain_config = InitialChainConfig {
         ownership: ChainOwnership::single(new_key_pair.public().into()),
         admin_id: Some(builder.admin_id()),
         epoch: Epoch::ZERO,

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -813,7 +813,7 @@ where
         );
         let key_pair = AccountSecretKey::generate();
         let public_key = key_pair.public();
-        let open_chain_config = OpenChainConfig {
+        let open_chain_config = InitialChainConfig {
             ownership: ChainOwnership::single(public_key.into()),
             admin_id: if index == 0 {
                 None
@@ -839,7 +839,7 @@ where
                 .unwrap();
             if validator.fault_type().await == FaultType::Malicious {
                 let origin = description.origin();
-                let config = OpenChainConfig {
+                let config = InitialChainConfig {
                     balance: Amount::ZERO,
                     ..description.config().clone()
                 };

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -683,20 +683,13 @@ struct GenesisStorageBuilder {
 struct GenesisAccount {
     description: ChainDescription,
     public_key: AccountPublicKey,
-    balance: Amount,
 }
 
 impl GenesisStorageBuilder {
-    fn add(
-        &mut self,
-        description: ChainDescription,
-        public_key: AccountPublicKey,
-        balance: Amount,
-    ) {
+    fn add(&mut self, description: ChainDescription, public_key: AccountPublicKey) {
         self.accounts.push(GenesisAccount {
             description,
             public_key,
-            balance,
         })
     }
 
@@ -831,7 +824,7 @@ where
         }
         // Remember what's in the genesis store for future clients to join.
         self.genesis_storage_builder
-            .add(description.clone(), public_key, balance);
+            .add(description.clone(), public_key);
         for validator in &self.validator_clients {
             let storage = self
                 .validator_storages
@@ -865,7 +858,10 @@ where
                 genesis_account.description.origin(),
                 ChainOrigin::Root(i as u32)
             );
-            result.push((genesis_account.public_key, genesis_account.balance));
+            result.push((
+                genesis_account.public_key,
+                genesis_account.description.config().balance,
+            ));
         }
         result
     }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -20,7 +20,8 @@ use linera_base::{
         AccountPublicKey, AccountSecretKey, CryptoHash, ValidatorKeypair, ValidatorPublicKey,
     },
     data_types::*,
-    identifiers::{BlobId, ChainDescription, ChainId},
+    identifiers::{BlobId, ChainId},
+    ownership::ChainOwnership,
 };
 use linera_chain::{
     data_types::BlockProposal,
@@ -658,7 +659,7 @@ where
 pub struct TestBuilder<B: StorageBuilder> {
     storage_builder: B,
     pub initial_committee: Committee,
-    admin_id: ChainId,
+    admin_description: Option<ChainDescription>,
     genesis_storage_builder: GenesisStorageBuilder,
     validator_clients: Vec<LocalValidatorClient<B::Storage>>,
     validator_storages: HashMap<ValidatorPublicKey, B::Storage>,
@@ -699,20 +700,13 @@ impl GenesisStorageBuilder {
         })
     }
 
-    async fn build<S>(&self, storage: S, initial_committee: Committee, admin_id: ChainId) -> S
+    async fn build<S>(&self, storage: S) -> S
     where
         S: Storage + Clone + Send + Sync + 'static,
     {
         for account in &self.accounts {
             storage
-                .create_chain(
-                    initial_committee.clone(),
-                    admin_id,
-                    account.description,
-                    account.public_key.into(),
-                    account.balance,
-                    Timestamp::from(0),
-                )
+                .create_chain(account.description.clone())
                 .await
                 .unwrap();
         }
@@ -769,7 +763,7 @@ where
         Ok(Self {
             storage_builder,
             initial_committee,
-            admin_id: ChainId::root(0),
+            admin_description: None,
             genesis_storage_builder: GenesisStorageBuilder::default(),
             validator_clients,
             validator_storages,
@@ -807,60 +801,60 @@ where
         balance: Amount,
     ) -> anyhow::Result<ChainClient<B::Storage>> {
         // Make sure the admin chain is initialized.
-        if self.genesis_storage_builder.accounts.is_empty() && index != 0 {
+        if self.admin_description.is_none() && index != 0 {
             Box::pin(self.add_root_chain(0, Amount::ZERO)).await?;
         }
-        let description = ChainDescription::Root(index);
+        let origin = ChainOrigin::Root(index);
+        let mut committees = BTreeMap::new();
+        committees.insert(
+            Epoch(0),
+            bcs::to_bytes(&self.initial_committee)
+                .expect("Serializing a committee should not fail!"),
+        );
         let key_pair = AccountSecretKey::generate();
         let public_key = key_pair.public();
+        let open_chain_config = OpenChainConfig {
+            ownership: ChainOwnership::single(public_key.into()),
+            admin_id: if index == 0 {
+                None
+            } else {
+                Some(self.admin_id())
+            },
+            epoch: Epoch(0),
+            committees,
+            balance,
+            application_permissions: ApplicationPermissions::default(),
+        };
+        let description = ChainDescription::new(origin, open_chain_config, Timestamp::from(0));
+        if index == 0 {
+            self.admin_description = Some(description.clone());
+        }
         // Remember what's in the genesis store for future clients to join.
         self.genesis_storage_builder
-            .add(description, public_key, balance);
+            .add(description.clone(), public_key, balance);
         for validator in &self.validator_clients {
             let storage = self
                 .validator_storages
                 .get_mut(&validator.public_key)
                 .unwrap();
             if validator.fault_type().await == FaultType::Malicious {
+                let origin = description.origin();
+                let config = OpenChainConfig {
+                    balance: Amount::ZERO,
+                    ..description.config().clone()
+                };
                 storage
-                    .create_chain(
-                        self.initial_committee.clone(),
-                        self.admin_id,
-                        description,
-                        public_key.into(),
-                        Amount::ZERO,
-                        Timestamp::from(0),
-                    )
+                    .create_chain(ChainDescription::new(origin, config, Timestamp::from(0)))
                     .await
                     .unwrap();
             } else {
-                storage
-                    .create_chain(
-                        self.initial_committee.clone(),
-                        self.admin_id,
-                        description,
-                        public_key.into(),
-                        balance,
-                        Timestamp::from(0),
-                    )
-                    .await
-                    .unwrap();
+                storage.create_chain(description.clone()).await.unwrap();
             }
         }
         for storage in self.chain_client_storages.iter_mut() {
-            storage
-                .create_chain(
-                    self.initial_committee.clone(),
-                    self.admin_id,
-                    description,
-                    public_key.into(),
-                    balance,
-                    Timestamp::from(0),
-                )
-                .await
-                .unwrap();
+            storage.create_chain(description.clone()).await.unwrap();
         }
-        self.make_client(description.into(), key_pair, None, BlockHeight::ZERO)
+        self.make_client(description.id(), key_pair, None, BlockHeight::ZERO)
             .await
     }
 
@@ -868,8 +862,8 @@ where
         let mut result = Vec::new();
         for (i, genesis_account) in self.genesis_storage_builder.accounts.iter().enumerate() {
             assert_eq!(
-                genesis_account.description,
-                ChainDescription::Root(i as u32)
+                genesis_account.description.origin(),
+                ChainOrigin::Root(i as u32)
             );
             result.push((genesis_account.public_key, genesis_account.balance));
         }
@@ -877,7 +871,14 @@ where
     }
 
     pub fn admin_id(&self) -> ChainId {
-        self.admin_id
+        self.admin_description
+            .as_ref()
+            .expect("admin chain not initialized")
+            .id()
+    }
+
+    pub fn admin_description(&self) -> Option<&ChainDescription> {
+        self.admin_description.as_ref()
     }
 
     pub fn make_node_provider(&self) -> NodeProvider<B::Storage> {
@@ -891,11 +892,7 @@ where
     pub async fn make_storage(&mut self) -> anyhow::Result<B::Storage> {
         Ok(self
             .genesis_storage_builder
-            .build(
-                self.storage_builder.build().await?,
-                self.initial_committee.clone(),
-                self.admin_id,
-            )
+            .build(self.storage_builder.build().await?)
             .await)
     }
 
@@ -924,15 +921,17 @@ where
             DEFAULT_GRACE_PERIOD,
             Duration::from_secs(1),
         ));
-        Ok(builder.create_chain_client(
-            chain_id,
-            vec![key_pair],
-            self.admin_id,
-            block_hash,
-            Timestamp::from(0),
-            block_height,
-            None,
-        ))
+        Ok(builder
+            .create_chain_client(
+                chain_id,
+                vec![key_pair],
+                self.admin_id(),
+                block_hash,
+                Timestamp::from(0),
+                block_height,
+                None,
+            )
+            .await?)
     }
 
     /// Tries to find a (confirmation) certificate for the given chain_id and block height.

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -108,7 +108,13 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     async fn new(storage: S, is_client: bool, has_long_lived_services: bool) -> Self {
-        Self::new_with_amount(storage, is_client, has_long_lived_services, Amount::MAX).await
+        Self::new_with_amount(
+            storage,
+            is_client,
+            has_long_lived_services,
+            Amount::from_tokens(1_000_000),
+        )
+        .await
     }
 
     async fn new_with_amount(

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -22,7 +22,7 @@ use linera_base::{
         Secp256k1SecretKey, ValidatorKeypair,
     },
     data_types::*,
-    identifiers::{Account, AccountOwner, ChainDescription, ChainId, EventId, MessageId, StreamId},
+    identifiers::{Account, AccountOwner, ChainId, EventId, StreamId},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
@@ -42,10 +42,12 @@ use linera_chain::{
 use linera_execution::{
     committee::Committee,
     system::{
-        AdminOperation, OpenChainConfig, Recipient, SystemMessage, SystemOperation,
+        AdminOperation, Recipient, SystemMessage, SystemOperation,
         EPOCH_STREAM_NAME as NEW_EPOCH_STREAM_NAME, REMOVED_EPOCH_STREAM_NAME,
     },
-    test_utils::{ExpectedCall, RegisterMockApplication, SystemExecutionState},
+    test_utils::{
+        dummy_chain_description, ExpectedCall, RegisterMockApplication, SystemExecutionState,
+    },
     ExecutionError, Message, MessageKind, OutgoingMessage, Query, QueryContext, QueryOutcome,
     QueryResponse, SystemQuery, SystemResponse,
 };
@@ -79,294 +81,349 @@ use crate::{
 /// The test worker accepts blocks with a timestamp this far in the future.
 const TEST_GRACE_PERIOD_MICROS: u64 = 500_000;
 
-/// Instantiates the protocol with a single validator. Returns the corresponding committee
-/// and the (non-sharded, in-memory) "worker" that we can interact with.
-fn init_worker<S>(
-    storage: S,
-    is_client: bool,
-    has_long_lived_services: bool,
-) -> (Committee, WorkerState<S>)
-where
-    S: Storage + Clone + Send + Sync + 'static,
-{
-    let validator_keypair = ValidatorKeypair::generate();
-    let account_secret = AccountSecretKey::generate();
-    let committee = Committee::make_simple(vec![(
-        validator_keypair.public_key,
-        account_secret.public(),
-    )]);
-    let worker = WorkerState::new(
-        "Single validator node".to_string(),
-        Some(validator_keypair.secret_key),
-        storage,
-        NonZeroUsize::new(10).expect("Chain worker limit should not be zero"),
-    )
-    .with_allow_inactive_chains(is_client)
-    .with_allow_messages_from_deprecated_epochs(is_client)
-    .with_long_lived_services(has_long_lived_services)
-    .with_grace_period(Duration::from_micros(TEST_GRACE_PERIOD_MICROS));
-    (committee, worker)
+fn serialize_committees(
+    committees: impl IntoIterator<Item = (Epoch, Committee)>,
+) -> BTreeMap<Epoch, Vec<u8>> {
+    committees
+        .into_iter()
+        .map(|(epoch, committee)| {
+            (
+                epoch,
+                bcs::to_bytes(&committee).expect("serializing a committee should not fail"),
+            )
+        })
+        .collect()
 }
 
-/// Same as `init_worker` but also instantiates some initial chains.
-async fn init_worker_with_chains<S, I>(storage: S, balances: I) -> (Committee, WorkerState<S>)
+struct TestEnvironment<S: Storage> {
+    committee: Committee,
+    worker: WorkerState<S>,
+    admin_keypair: AccountSecretKey,
+    admin_description: ChainDescription,
+    other_chains: BTreeMap<ChainId, ChainDescription>,
+}
+
+impl<S> TestEnvironment<S>
 where
-    I: IntoIterator<Item = (ChainDescription, AccountOwner, Amount)>,
     S: Storage + Clone + Send + Sync + 'static,
 {
-    let (committee, worker) = init_worker(
-        storage, /* is_client */ false, /* has_long_lived_services */ false,
-    );
-    for (description, owner, balance) in balances {
-        worker
+    async fn new(storage: S, is_client: bool, has_long_lived_services: bool) -> Self {
+        Self::new_with_amount(storage, is_client, has_long_lived_services, Amount::MAX).await
+    }
+
+    async fn new_with_amount(
+        storage: S,
+        is_client: bool,
+        has_long_lived_services: bool,
+        amount: Amount,
+    ) -> Self {
+        let validator_keypair = ValidatorKeypair::generate();
+        let account_secret = AccountSecretKey::generate();
+        let committee = Committee::make_simple(vec![(
+            validator_keypair.public_key,
+            account_secret.public(),
+        )]);
+
+        let origin = ChainOrigin::Root(0);
+        let config = OpenChainConfig {
+            admin_id: None,
+            balance: amount,
+            ownership: ChainOwnership::single(account_secret.public().into()),
+            epoch: Epoch::ZERO,
+            committees: serialize_committees([(Epoch::ZERO, committee.clone())]),
+            application_permissions: Default::default(),
+        };
+        let admin_description = ChainDescription::new(origin, config, Timestamp::from(0));
+        storage
+            .write_blob(&Blob::new_chain_description(&admin_description))
+            .await
+            .expect("writing a blob should not fail");
+
+        let worker = WorkerState::new(
+            "Single validator node".to_string(),
+            Some(validator_keypair.secret_key),
+            storage,
+            NonZeroUsize::new(10).expect("Chain worker limit should not be zero"),
+        )
+        .with_allow_inactive_chains(is_client)
+        .with_allow_messages_from_deprecated_epochs(is_client)
+        .with_long_lived_services(has_long_lived_services)
+        .with_grace_period(Duration::from_micros(TEST_GRACE_PERIOD_MICROS));
+        Self {
+            committee,
+            worker,
+            admin_description,
+            admin_keypair: account_secret,
+            other_chains: BTreeMap::new(),
+        }
+    }
+
+    fn admin_id(&self) -> ChainId {
+        self.admin_description.id()
+    }
+
+    fn committee(&self) -> &Committee {
+        &self.committee
+    }
+
+    fn worker(&self) -> &WorkerState<S> {
+        &self.worker
+    }
+
+    fn admin_public_key(&self) -> AccountPublicKey {
+        self.admin_keypair.public()
+    }
+
+    async fn add_root_chain(
+        &mut self,
+        index: u32,
+        owner: AccountOwner,
+        balance: Amount,
+    ) -> ChainDescription {
+        let origin = ChainOrigin::Root(index);
+        let config = OpenChainConfig {
+            admin_id: Some(self.admin_id()),
+            epoch: self.admin_description.config().epoch,
+            ownership: ChainOwnership::single(owner),
+            committees: self.admin_description.config().committees.clone(),
+            balance,
+            application_permissions: Default::default(),
+        };
+        let description = ChainDescription::new(origin, config, Timestamp::from(0));
+        self.other_chains
+            .insert(description.id(), description.clone());
+        self.worker
             .storage
-            .create_chain(
-                committee.clone(),
-                ChainId::root(0),
-                description,
-                owner,
-                balance,
-                Timestamp::from(0),
-            )
+            .create_chain(description.clone())
             .await
             .unwrap();
+        description
     }
-    (committee, worker)
-}
 
-/// Same as `init_worker` but also instantiate a single initial chain.
-async fn init_worker_with_chain<S>(
-    storage: S,
-    description: ChainDescription,
-    owner: AccountOwner,
-    balance: Amount,
-) -> (Committee, WorkerState<S>)
-where
-    S: Storage + Clone + Send + Sync + 'static,
-{
-    init_worker_with_chains(storage, [(description, owner, balance)]).await
-}
-
-fn make_certificate<S, T>(
-    committee: &Committee,
-    worker: &WorkerState<S>,
-    value: T,
-) -> GenericCertificate<T>
-where
-    S: Storage,
-    T: CertificateValue,
-{
-    make_certificate_with_round(committee, worker, value, Round::MultiLeader(0))
-}
-
-fn make_certificate_with_round<S, T>(
-    committee: &Committee,
-    worker: &WorkerState<S>,
-    value: T,
-    round: Round,
-) -> GenericCertificate<T>
-where
-    S: Storage,
-    T: CertificateValue,
-{
-    let vote = LiteVote::new(
-        LiteValue::new(&value),
-        round,
-        worker.chain_worker_config.key_pair().unwrap(),
-    );
-    let mut builder = SignatureAggregator::new(value, round, committee);
-    builder
-        .append(vote.public_key, vote.signature)
-        .unwrap()
-        .unwrap()
-}
-
-#[expect(clippy::too_many_arguments)]
-async fn make_simple_transfer_certificate<S>(
-    chain_description: ChainDescription,
-    key_pair: &AccountSecretKey,
-    target_id: ChainId,
-    amount: Amount,
-    incoming_bundles: Vec<IncomingBundle>,
-    committee: &Committee,
-    balance: Amount,
-    worker: &WorkerState<S>,
-    previous_confirmed_block: Option<&ConfirmedBlockCertificate>,
-) -> ConfirmedBlockCertificate
-where
-    S: Storage,
-{
-    make_transfer_certificate_for_epoch(
-        chain_description,
-        key_pair,
-        Some(key_pair.public().into()),
-        AccountOwner::CHAIN,
-        Recipient::chain(target_id),
-        amount,
-        incoming_bundles,
-        Epoch::ZERO,
-        committee,
-        balance,
-        BTreeMap::new(),
-        worker,
-        previous_confirmed_block,
-    )
-    .await
-}
-
-#[expect(clippy::too_many_arguments)]
-async fn make_transfer_certificate<S>(
-    chain_description: ChainDescription,
-    key_pair: &AccountSecretKey,
-    authenticated_signer: Option<AccountOwner>,
-    source: AccountOwner,
-    recipient: Recipient,
-    amount: Amount,
-    incoming_bundles: Vec<IncomingBundle>,
-    committee: &Committee,
-    balance: Amount,
-    balances: BTreeMap<AccountOwner, Amount>,
-    worker: &WorkerState<S>,
-    previous_confirmed_block: Option<&ConfirmedBlockCertificate>,
-) -> ConfirmedBlockCertificate
-where
-    S: Storage,
-{
-    make_transfer_certificate_for_epoch(
-        chain_description,
-        key_pair,
-        authenticated_signer,
-        source,
-        recipient,
-        amount,
-        incoming_bundles,
-        Epoch::ZERO,
-        committee,
-        balance,
-        balances,
-        worker,
-        previous_confirmed_block,
-    )
-    .await
-}
-
-/// Creates a certificate with a transfer.
-///
-/// This does not work for blocks with ancestors that sent a message to the same recipient, unless
-/// the `previous_confirmed_block` also did.
-#[expect(clippy::too_many_arguments)]
-async fn make_transfer_certificate_for_epoch<S>(
-    chain_description: ChainDescription,
-    key_pair: &AccountSecretKey,
-    authenticated_signer: Option<AccountOwner>,
-    source: AccountOwner,
-    recipient: Recipient,
-    amount: Amount,
-    incoming_bundles: Vec<IncomingBundle>,
-    epoch: Epoch,
-    committee: &Committee,
-    balance: Amount,
-    balances: BTreeMap<AccountOwner, Amount>,
-    worker: &WorkerState<S>,
-    previous_confirmed_block: Option<&ConfirmedBlockCertificate>,
-) -> ConfirmedBlockCertificate
-where
-    S: Storage,
-{
-    let chain_id = chain_description.into();
-    let system_state = SystemExecutionState {
-        committees: [(epoch, committee.clone())].into_iter().collect(),
-        ownership: ChainOwnership::single(key_pair.public().into()),
-        balance,
-        balances,
-        ..SystemExecutionState::new(epoch, chain_description, ChainId::root(0))
-    };
-    let block_template = match &previous_confirmed_block {
-        None => make_first_block(chain_id),
-        Some(cert) => make_child_block(cert.value()),
-    };
-
-    let mut messages = incoming_bundles
-        .iter()
-        .flat_map(|incoming_bundle| {
-            incoming_bundle
-                .bundle
-                .messages
-                .iter()
-                .map(|posted_message| {
-                    if matches!(incoming_bundle.action, MessageAction::Reject)
-                        && matches!(posted_message.kind, MessageKind::Tracked)
-                    {
-                        vec![OutgoingMessage {
-                            authenticated_signer: posted_message.authenticated_signer,
-                            destination: incoming_bundle.origin,
-                            grant: Amount::ZERO,
-                            refund_grant_to: None,
-                            kind: MessageKind::Bouncing,
-                            message: posted_message.message.clone(),
-                        }]
-                    } else {
-                        Vec::new()
-                    }
-                })
-        })
-        .collect::<Vec<_>>();
-
-    let block = ProposedBlock {
-        epoch,
-        incoming_bundles,
-        authenticated_signer,
-        ..block_template
+    async fn add_child_chain(
+        &mut self,
+        parent_id: ChainId,
+        owner: AccountOwner,
+        balance: Amount,
+    ) -> ChainDescription {
+        let origin = ChainOrigin::Child {
+            parent: parent_id,
+            block_height: BlockHeight(0),
+            chain_index: 0,
+        };
+        let config = OpenChainConfig {
+            admin_id: Some(self.admin_id()),
+            epoch: self.admin_description.config().epoch,
+            ownership: ChainOwnership::single(owner),
+            committees: self.admin_description.config().committees.clone(),
+            balance,
+            application_permissions: Default::default(),
+        };
+        let description = ChainDescription::new(origin, config, Timestamp::from(0));
+        self.other_chains
+            .insert(description.id(), description.clone());
+        self.worker
+            .storage
+            .create_chain(description.clone())
+            .await
+            .unwrap();
+        description
     }
-    .with_transfer(source, recipient, amount);
-    match recipient {
-        Recipient::Account(account) => {
-            messages.push(vec![direct_outgoing_message(
-                account.chain_id,
-                MessageKind::Tracked,
-                SystemMessage::Credit {
-                    source,
-                    target: account.owner,
-                    amount,
-                },
-            )]);
+
+    fn make_certificate<T>(&self, value: T) -> GenericCertificate<T>
+    where
+        T: CertificateValue,
+    {
+        self.make_certificate_with_round(value, Round::MultiLeader(0))
+    }
+
+    fn make_certificate_with_round<T>(&self, value: T, round: Round) -> GenericCertificate<T>
+    where
+        T: CertificateValue,
+    {
+        let vote = LiteVote::new(
+            LiteValue::new(&value),
+            round,
+            self.worker.chain_worker_config.key_pair().unwrap(),
+        );
+        let mut builder = SignatureAggregator::new(value, round, &self.committee);
+        builder
+            .append(vote.public_key, vote.signature)
+            .unwrap()
+            .unwrap()
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    async fn make_simple_transfer_certificate(
+        &self,
+        chain_description: ChainDescription,
+        key_pair: &AccountSecretKey,
+        target_id: ChainId,
+        amount: Amount,
+        incoming_bundles: Vec<IncomingBundle>,
+        balance: Amount,
+        previous_confirmed_block: Option<&ConfirmedBlockCertificate>,
+    ) -> ConfirmedBlockCertificate {
+        self.make_transfer_certificate_for_epoch(
+            chain_description,
+            key_pair,
+            Some(key_pair.public().into()),
+            AccountOwner::CHAIN,
+            Recipient::chain(target_id),
+            amount,
+            incoming_bundles,
+            Epoch::ZERO,
+            balance,
+            BTreeMap::new(),
+            previous_confirmed_block,
+        )
+        .await
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    async fn make_transfer_certificate(
+        &self,
+        chain_description: ChainDescription,
+        key_pair: &AccountSecretKey,
+        authenticated_signer: Option<AccountOwner>,
+        source: AccountOwner,
+        recipient: Recipient,
+        amount: Amount,
+        incoming_bundles: Vec<IncomingBundle>,
+        balance: Amount,
+        balances: BTreeMap<AccountOwner, Amount>,
+        previous_confirmed_block: Option<&ConfirmedBlockCertificate>,
+    ) -> ConfirmedBlockCertificate {
+        self.make_transfer_certificate_for_epoch(
+            chain_description,
+            key_pair,
+            authenticated_signer,
+            source,
+            recipient,
+            amount,
+            incoming_bundles,
+            Epoch::ZERO,
+            balance,
+            balances,
+            previous_confirmed_block,
+        )
+        .await
+    }
+
+    /// Creates a certificate with a transfer.
+    ///
+    /// This does not work for blocks with ancestors that sent a message to the same recipient, unless
+    /// the `previous_confirmed_block` also did.
+    #[expect(clippy::too_many_arguments)]
+    async fn make_transfer_certificate_for_epoch(
+        &self,
+        chain_description: ChainDescription,
+        key_pair: &AccountSecretKey,
+        authenticated_signer: Option<AccountOwner>,
+        source: AccountOwner,
+        recipient: Recipient,
+        amount: Amount,
+        incoming_bundles: Vec<IncomingBundle>,
+        epoch: Epoch,
+        balance: Amount,
+        balances: BTreeMap<AccountOwner, Amount>,
+        previous_confirmed_block: Option<&ConfirmedBlockCertificate>,
+    ) -> ConfirmedBlockCertificate {
+        let chain_id = chain_description.id();
+        let system_state = SystemExecutionState {
+            committees: [(epoch, self.committee.clone())].into_iter().collect(),
+            ownership: ChainOwnership::single(key_pair.public().into()),
+            balance,
+            balances,
+            ..SystemExecutionState::new(chain_description)
+        };
+        let block_template = match &previous_confirmed_block {
+            None => make_first_block(chain_id),
+            Some(cert) => make_child_block(cert.value()),
+        };
+
+        let mut messages = incoming_bundles
+            .iter()
+            .flat_map(|incoming_bundle| {
+                incoming_bundle
+                    .bundle
+                    .messages
+                    .iter()
+                    .map(|posted_message| {
+                        if matches!(incoming_bundle.action, MessageAction::Reject)
+                            && matches!(posted_message.kind, MessageKind::Tracked)
+                        {
+                            vec![OutgoingMessage {
+                                authenticated_signer: posted_message.authenticated_signer,
+                                destination: incoming_bundle.origin,
+                                grant: Amount::ZERO,
+                                refund_grant_to: None,
+                                kind: MessageKind::Bouncing,
+                                message: posted_message.message.clone(),
+                            }]
+                        } else {
+                            Vec::new()
+                        }
+                    })
+            })
+            .collect::<Vec<_>>();
+
+        let block = ProposedBlock {
+            epoch,
+            incoming_bundles,
+            authenticated_signer,
+            ..block_template
         }
-        Recipient::Burn => messages.push(Vec::new()),
-    }
-    let tx_count = block.operations.len() + block.incoming_bundles.len();
-    let oracle_responses = iter::repeat_with(Vec::new).take(tx_count).collect();
-    let events = iter::repeat_with(Vec::new).take(tx_count).collect();
-    let blobs = iter::repeat_with(Vec::new).take(tx_count).collect();
-    let operation_results = iter::repeat_with(Vec::new)
-        .map(OperationResult)
-        .take(block.operations.len())
-        .collect();
-    let state_hash = system_state.into_hash().await;
-    let previous_message_blocks = messages
-        .iter()
-        .flatten()
-        .map(|message| message.destination)
-        .filter(|recipient| {
-            previous_confirmed_block
-                .iter()
-                .flat_map(|block| block.inner().block().body.messages.iter().flatten())
-                .any(|message| message.destination == *recipient)
-        })
-        .map(|recipient| (recipient, previous_confirmed_block.unwrap().hash()))
-        .collect();
-    let value = ConfirmedBlock::new(
-        BlockExecutionOutcome {
-            messages,
-            previous_message_blocks,
-            events,
-            blobs,
-            state_hash,
-            oracle_responses,
-            operation_results,
+        .with_transfer(source, recipient, amount);
+        match recipient {
+            Recipient::Account(account) => {
+                messages.push(vec![direct_outgoing_message(
+                    account.chain_id,
+                    MessageKind::Tracked,
+                    SystemMessage::Credit {
+                        source,
+                        target: account.owner,
+                        amount,
+                    },
+                )]);
+            }
+            Recipient::Burn => messages.push(Vec::new()),
         }
-        .with(block),
-    );
-    make_certificate(committee, worker, value)
+        let tx_count = block.operations.len() + block.incoming_bundles.len();
+        let oracle_responses = iter::repeat_with(Vec::new).take(tx_count).collect();
+        let events = iter::repeat_with(Vec::new).take(tx_count).collect();
+        let blobs = iter::repeat_with(Vec::new).take(tx_count).collect();
+        let operation_results = iter::repeat_with(Vec::new)
+            .map(OperationResult)
+            .take(block.operations.len())
+            .collect();
+        let state_hash = system_state.into_hash().await;
+        let previous_message_blocks = messages
+            .iter()
+            .flatten()
+            .map(|message| message.destination)
+            .filter(|recipient| {
+                previous_confirmed_block
+                    .iter()
+                    .flat_map(|block| block.inner().block().body.messages.iter().flatten())
+                    .any(|message| message.destination == *recipient)
+            })
+            .map(|recipient| (recipient, previous_confirmed_block.unwrap().hash()))
+            .collect();
+        let value = ConfirmedBlock::new(
+            BlockExecutionOutcome {
+                messages,
+                previous_message_blocks,
+                events,
+                blobs,
+                state_hash,
+                oracle_responses,
+                operation_results,
+            }
+            .with(block),
+        );
+        self.make_certificate(value)
+    }
 }
 
 fn direct_outgoing_message(
@@ -438,35 +495,29 @@ where
     B: StorageBuilder,
 {
     let sender_key_pair = AccountSecretKey::generate();
-    let (_, worker) = init_worker_with_chains(
-        storage_builder.build().await?,
-        vec![
-            (
-                ChainDescription::Root(1),
-                sender_key_pair.public().into(),
-                Amount::from_tokens(5),
-            ),
-            (
-                ChainDescription::Root(2),
-                AccountPublicKey::test_key(2).into(),
-                Amount::ZERO,
-            ),
-        ],
-    )
-    .await;
-    let block_proposal = make_first_block(ChainId::root(1))
-        .with_simple_transfer(ChainId::root(2), Amount::from_tokens(5))
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .await;
+    let chain_2_desc = env
+        .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ZERO)
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = chain_2_desc.id();
+    let block_proposal = make_first_block(chain_1)
+        .with_simple_transfer(chain_2, Amount::from_tokens(5))
         .into_first_proposal(&sender_key_pair);
     let unknown_key_pair = AccountSecretKey::generate();
     let mut bad_signature_block_proposal = block_proposal.clone();
     bad_signature_block_proposal.signature = unknown_key_pair.sign(&block_proposal.content);
     assert_matches!(
-        worker
+        env.worker()
             .handle_block_proposal(bad_signature_block_proposal)
             .await,
-            Err(WorkerError::CryptoError(error)) if matches!(error, linera_base::crypto::CryptoError::InvalidSignature {..})
+            Err(WorkerError::CryptoError(error))
+                if matches!(error, linera_base::crypto::CryptoError::InvalidSignature {..})
     );
-    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active());
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
@@ -483,29 +534,22 @@ where
     B: StorageBuilder,
 {
     let sender_key_pair = AccountSecretKey::generate();
-    let (_, worker) = init_worker_with_chains(
-        storage_builder.build().await?,
-        vec![
-            (
-                ChainDescription::Root(1),
-                sender_key_pair.public().into(),
-                Amount::from_tokens(5),
-            ),
-            (
-                ChainDescription::Root(2),
-                AccountPublicKey::test_key(2).into(),
-                Amount::ZERO,
-            ),
-        ],
-    )
-    .await;
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .await;
+    let chain_2_desc = env
+        .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ZERO)
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = chain_2_desc.id();
     // test block non-positive amount
-    let zero_amount_block_proposal = make_first_block(ChainId::root(1))
-        .with_simple_transfer(ChainId::root(2), Amount::ZERO)
+    let zero_amount_block_proposal = make_first_block(chain_1)
+        .with_simple_transfer(chain_2, Amount::ZERO)
         .with_authenticated_signer(Some(sender_key_pair.public().into()))
         .into_first_proposal(&sender_key_pair);
     assert_matches!(
-    worker
+    env.worker()
         .handle_block_proposal(zero_amount_block_proposal)
         .await,
         Err(
@@ -514,7 +558,7 @@ where
             execution_error, ChainExecutionContext::Operation(_)
         ) if matches!(**execution_error, ExecutionError::IncorrectTransferAmount))
     );
-    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active());
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
@@ -534,35 +578,38 @@ where
     let clock = storage_builder.clock();
     let key_pair = AccountSecretKey::generate();
     let balance = Amount::from_tokens(5);
-    let balances = vec![(ChainDescription::Root(1), key_pair.public().into(), balance)];
+    let mut env = TestEnvironment::new(storage, false, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, key_pair.public().into(), balance)
+        .await;
     let epoch = Epoch::ZERO;
-    let (committee, worker) = init_worker_with_chains(storage, balances).await;
+    let chain_id = chain_1_desc.id();
 
     {
-        let block_proposal = make_first_block(ChainId::root(1))
+        let block_proposal = make_first_block(chain_id)
             .with_timestamp(Timestamp::from(TEST_GRACE_PERIOD_MICROS + 1_000_000))
             .into_first_proposal(&key_pair);
         // Timestamp too far in the future
         assert_matches!(
-            worker.handle_block_proposal(block_proposal).await,
+            env.worker().handle_block_proposal(block_proposal).await,
             Err(WorkerError::InvalidTimestamp)
         );
     }
 
     let block_0_time = Timestamp::from(TEST_GRACE_PERIOD_MICROS);
     let certificate = {
-        let block = make_first_block(ChainId::root(1)).with_timestamp(block_0_time);
+        let block = make_first_block(chain_id).with_timestamp(block_0_time);
         let block_proposal = block.clone().into_first_proposal(&key_pair);
-        let future = worker.handle_block_proposal(block_proposal);
+        let future = env.worker().handle_block_proposal(block_proposal);
         clock.set(block_0_time);
         future.await?;
 
         let system_state = SystemExecutionState {
-            committees: [(epoch, committee.clone())].into_iter().collect(),
+            committees: [(epoch, env.committee().clone())].into_iter().collect(),
             ownership: ChainOwnership::single(key_pair.public().into()),
             balance,
             timestamp: block_0_time,
-            ..SystemExecutionState::new(epoch, ChainDescription::Root(1), ChainId::root(0))
+            ..SystemExecutionState::new(chain_1_desc.clone())
         };
         let state_hash = system_state.into_hash().await;
         let value = ConfirmedBlock::new(
@@ -572,9 +619,9 @@ where
             }
             .with(block),
         );
-        make_certificate(&committee, &worker, value)
+        env.make_certificate(value)
     };
-    worker
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
 
@@ -584,7 +631,7 @@ where
             .into_first_proposal(&key_pair);
         // Timestamp older than previous one
         assert_matches!(
-            worker.handle_block_proposal(block_proposal).await,
+            env.worker().handle_block_proposal(block_proposal).await,
             Err(WorkerError::ChainError(error))
                 if matches!(*error, ChainError::InvalidBlockTimestamp)
         );
@@ -602,33 +649,26 @@ where
     B: StorageBuilder,
 {
     let sender_key_pair = AccountSecretKey::generate();
-    let (_, worker) = init_worker_with_chains(
-        storage_builder.build().await?,
-        vec![
-            (
-                ChainDescription::Root(1),
-                sender_key_pair.public().into(),
-                Amount::from_tokens(5),
-            ),
-            (
-                ChainDescription::Root(2),
-                AccountPublicKey::test_key(2).into(),
-                Amount::ZERO,
-            ),
-        ],
-    )
-    .await;
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .await;
+    let chain_2_desc = env
+        .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ZERO)
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = chain_2_desc.id();
     let unknown_key = AccountSecretKey::generate();
-    let unknown_sender_block_proposal = make_first_block(ChainId::root(1))
-        .with_simple_transfer(ChainId::root(2), Amount::from_tokens(5))
+    let unknown_sender_block_proposal = make_first_block(chain_1)
+        .with_simple_transfer(chain_2, Amount::from_tokens(5))
         .into_first_proposal(&unknown_key);
     assert_matches!(
-        worker
+        env.worker()
             .handle_block_proposal(unknown_sender_block_proposal)
             .await,
         Err(WorkerError::InvalidOwner)
     );
-    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active());
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
@@ -645,35 +685,36 @@ where
     B: StorageBuilder,
 {
     let sender_key_pair = AccountSecretKey::generate();
-    let (committee, worker) = init_worker_with_chain(
-        storage_builder.build().await?,
-        ChainDescription::Root(1),
-        sender_key_pair.public().into(),
-        Amount::from_tokens(5),
-    )
-    .await;
-    let block_proposal0 = make_first_block(ChainId::root(1))
-        .with_simple_transfer(ChainId::root(2), Amount::ONE)
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .await;
+    let chain_1 = chain_desc.id();
+    let chain_2 = env
+        .add_root_chain(2, sender_key_pair.public().into(), Amount::ZERO)
+        .await
+        .id();
+    let block_proposal0 = make_first_block(chain_1)
+        .with_simple_transfer(chain_2, Amount::ONE)
         .with_authenticated_signer(Some(sender_key_pair.public().into()))
         .into_first_proposal(&sender_key_pair);
-    let certificate0 = make_simple_transfer_certificate(
-        ChainDescription::Root(1),
-        &sender_key_pair,
-        ChainId::root(2),
-        Amount::ONE,
-        Vec::new(),
-        &committee,
-        Amount::from_tokens(4),
-        &worker,
-        None,
-    )
-    .await;
+    let certificate0 = env
+        .make_simple_transfer_certificate(
+            chain_desc.clone(),
+            &sender_key_pair,
+            chain_2,
+            Amount::ONE,
+            Vec::new(),
+            Amount::from_tokens(4),
+            None,
+        )
+        .await;
     let block_proposal1 = make_child_block(certificate0.value())
-        .with_simple_transfer(ChainId::root(2), Amount::from_tokens(2))
+        .with_simple_transfer(chain_2, Amount::from_tokens(2))
         .into_first_proposal(&sender_key_pair);
 
     assert_matches!(
-        worker.handle_block_proposal(block_proposal1.clone()).await,
+        env.worker().handle_block_proposal(block_proposal1.clone()).await,
         Err(WorkerError::ChainError(error)) if matches!(
             *error,
             ChainError::UnexpectedBlockHeight {
@@ -681,32 +722,29 @@ where
                 found_block_height: BlockHeight(1)
             })
     );
-    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active());
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
 
     drop(chain);
-    worker
+    env.worker()
         .handle_block_proposal(block_proposal0.clone())
         .await?;
-    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active());
     let block = chain.manager.validated_vote().unwrap().value().block();
     // Multi-leader round - it's not confirmed yet.
     assert!(block.matches_proposed_block(&block_proposal0.content.block));
     assert!(chain.manager.confirmed_vote().is_none());
-    let block_certificate0 = make_certificate(
-        &committee,
-        &worker,
-        chain.manager.validated_vote().unwrap().value().clone(),
-    );
+    let block_certificate0 =
+        env.make_certificate(chain.manager.validated_vote().unwrap().value().clone());
     drop(chain);
 
-    worker
+    env.worker()
         .handle_validated_certificate(block_certificate0)
         .await?;
-    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active());
     let block = chain.manager.confirmed_vote().unwrap().value().block();
 
@@ -715,24 +753,24 @@ where
     assert!(chain.manager.validated_vote().is_none());
     drop(chain);
 
-    worker
+    env.worker()
         .handle_confirmed_certificate(certificate0, None)
         .await?;
-    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    let chain = env.worker().chain_state_view(chain_1).await?;
     drop(chain);
 
-    worker
+    env.worker()
         .handle_block_proposal(block_proposal1.clone())
         .await?;
 
-    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active());
     let block = chain.manager.validated_vote().unwrap().value().block();
     assert!(block.matches_proposed_block(&block_proposal1.content.block));
     assert!(chain.manager.confirmed_vote().is_none());
     drop(chain);
     assert_matches!(
-        worker.handle_block_proposal(block_proposal0).await,
+        env.worker().handle_block_proposal(block_proposal0).await,
         Err(WorkerError::ChainError(error)) if matches!(
             *error,
             ChainError::UnexpectedBlockHeight {
@@ -756,92 +794,70 @@ where
 {
     let sender_key_pair = AccountSecretKey::generate();
     let recipient_key_pair = AccountSecretKey::generate();
-    let (committee, worker) = init_worker_with_chains(
-        storage_builder.build().await?,
-        vec![
-            (
-                ChainDescription::Root(1),
-                sender_key_pair.public().into(),
-                Amount::from_tokens(6),
-            ),
-            (
-                ChainDescription::Root(2),
-                recipient_key_pair.public().into(),
-                Amount::ZERO,
-            ),
-        ],
-    )
-    .await;
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(6))
+        .await;
+    let chain_2_desc = env
+        .add_root_chain(2, recipient_key_pair.public().into(), Amount::ZERO)
+        .await;
+    let chain_3_desc = env
+        .add_root_chain(3, recipient_key_pair.public().into(), Amount::ZERO)
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = chain_2_desc.id();
+    let chain_3 = chain_3_desc.id();
 
-    let epoch = Epoch::ZERO;
-    let admin_id = ChainId::root(0);
-    let certificate0 = make_certificate(
-        &committee,
-        &worker,
-        ConfirmedBlock::new(
-            BlockExecutionOutcome {
-                messages: vec![
-                    vec![direct_credit_message(ChainId::root(2), Amount::ONE)],
-                    vec![direct_credit_message(
-                        ChainId::root(2),
-                        Amount::from_tokens(2),
-                    )],
-                ],
-                previous_message_blocks: BTreeMap::new(),
-                events: vec![Vec::new(); 2],
-                blobs: vec![Vec::new(); 2],
-                state_hash: SystemExecutionState {
-                    committees: [(epoch, committee.clone())].into_iter().collect(),
-                    ownership: ChainOwnership::single(sender_key_pair.public().into()),
-                    balance: Amount::from_tokens(3),
-                    ..SystemExecutionState::new(epoch, ChainDescription::Root(1), admin_id)
-                }
-                .into_hash()
-                .await,
-                oracle_responses: vec![Vec::new(); 2],
-                operation_results: vec![OperationResult::default(); 2],
+    let certificate0 = env.make_certificate(ConfirmedBlock::new(
+        BlockExecutionOutcome {
+            messages: vec![
+                vec![direct_credit_message(chain_2, Amount::ONE)],
+                vec![direct_credit_message(chain_2, Amount::from_tokens(2))],
+            ],
+            previous_message_blocks: BTreeMap::new(),
+            events: vec![Vec::new(); 2],
+            blobs: vec![Vec::new(); 2],
+            state_hash: SystemExecutionState {
+                balance: Amount::from_tokens(3),
+                ..SystemExecutionState::new(chain_1_desc.clone())
             }
-            .with(
-                make_first_block(ChainId::root(1))
-                    .with_simple_transfer(ChainId::root(2), Amount::ONE)
-                    .with_simple_transfer(ChainId::root(2), Amount::from_tokens(2))
-                    .with_authenticated_signer(Some(sender_key_pair.public().into())),
-            ),
+            .into_hash()
+            .await,
+            oracle_responses: vec![Vec::new(); 2],
+            operation_results: vec![OperationResult::default(); 2],
+        }
+        .with(
+            make_first_block(chain_1)
+                .with_simple_transfer(chain_2, Amount::ONE)
+                .with_simple_transfer(chain_2, Amount::from_tokens(2))
+                .with_authenticated_signer(Some(sender_key_pair.public().into())),
         ),
-    );
+    ));
 
-    let certificate1 = make_certificate(
-        &committee,
-        &worker,
-        ConfirmedBlock::new(
-            BlockExecutionOutcome {
-                messages: vec![vec![direct_credit_message(
-                    ChainId::root(2),
-                    Amount::from_tokens(3),
-                )]],
-                previous_message_blocks: BTreeMap::from([(ChainId::root(2), certificate0.hash())]),
-                events: vec![Vec::new()],
-                blobs: vec![Vec::new()],
-                state_hash: SystemExecutionState {
-                    committees: [(epoch, committee.clone())].into_iter().collect(),
-                    ownership: ChainOwnership::single(sender_key_pair.public().into()),
-                    ..SystemExecutionState::new(epoch, ChainDescription::Root(1), admin_id)
-                }
-                .into_hash()
-                .await,
-                oracle_responses: vec![Vec::new()],
-                operation_results: vec![OperationResult::default()],
+    let certificate1 = env.make_certificate(ConfirmedBlock::new(
+        BlockExecutionOutcome {
+            messages: vec![vec![direct_credit_message(chain_2, Amount::from_tokens(3))]],
+            previous_message_blocks: BTreeMap::from([(chain_2, certificate0.hash())]),
+            events: vec![Vec::new()],
+            blobs: vec![Vec::new()],
+            state_hash: SystemExecutionState {
+                balance: Amount::ZERO,
+                ..SystemExecutionState::new(chain_1_desc.clone())
             }
-            .with(
-                make_child_block(&certificate0.clone().into_value())
-                    .with_simple_transfer(ChainId::root(2), Amount::from_tokens(3))
-                    .with_authenticated_signer(Some(sender_key_pair.public().into())),
-            ),
+            .into_hash()
+            .await,
+            oracle_responses: vec![Vec::new()],
+            operation_results: vec![OperationResult::default()],
+        }
+        .with(
+            make_child_block(&certificate0.clone().into_value())
+                .with_simple_transfer(chain_2, Amount::from_tokens(3))
+                .with_authenticated_signer(Some(sender_key_pair.public().into())),
         ),
-    );
+    ));
     // Missing earlier blocks
     assert_matches!(
-        worker
+        env.worker()
             .handle_confirmed_certificate(certificate1.clone(), None)
             .await,
         Err(WorkerError::MissingEarlierBlocks { .. })
@@ -849,53 +865,53 @@ where
 
     // Run transfers
     let notifications = Arc::new(Mutex::new(Vec::new()));
-    worker
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate0.clone(), &notifications)
         .await?;
-    worker
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate1.clone(), &notifications)
         .await?;
     assert_eq!(
         *notifications.lock().unwrap(),
         vec![
             Notification {
-                chain_id: ChainId::root(1),
+                chain_id: chain_1,
                 reason: NewBlock {
                     height: BlockHeight(0),
                     hash: certificate0.hash(),
                 }
             },
             Notification {
-                chain_id: ChainId::root(2),
+                chain_id: chain_2,
                 reason: NewIncomingBundle {
-                    origin: ChainId::root(1),
+                    origin: chain_1,
                     height: BlockHeight(0)
                 }
             },
             Notification {
-                chain_id: ChainId::root(1),
+                chain_id: chain_1,
                 reason: NewBlock {
                     height: BlockHeight(1),
                     hash: certificate1.hash(),
                 }
             },
             Notification {
-                chain_id: ChainId::root(2),
+                chain_id: chain_2,
                 reason: NewIncomingBundle {
-                    origin: ChainId::root(1),
+                    origin: chain_1,
                     height: BlockHeight(1)
                 }
             }
         ]
     );
     {
-        let block_proposal = make_first_block(ChainId::root(2))
-            .with_simple_transfer(ChainId::root(3), Amount::from_tokens(6))
+        let block_proposal = make_first_block(chain_2)
+            .with_simple_transfer(chain_3, Amount::from_tokens(6))
             .with_authenticated_signer(Some(recipient_key_pair.public().into()))
             .into_first_proposal(&recipient_key_pair);
         // Insufficient funding
         assert_matches!(
-                worker.handle_block_proposal(block_proposal).await,
+                env.worker().handle_block_proposal(block_proposal).await,
                 Err(
                     WorkerError::ChainError(error)
                 ) if matches!(&*error, ChainError::ExecutionError(
@@ -904,10 +920,10 @@ where
         );
     }
     {
-        let block_proposal = make_first_block(ChainId::root(2))
-            .with_simple_transfer(ChainId::root(3), Amount::from_tokens(5))
+        let block_proposal = make_first_block(chain_2)
+            .with_simple_transfer(chain_3, Amount::from_tokens(5))
             .with_incoming_bundle(IncomingBundle {
-                origin: ChainId::root(1),
+                origin: chain_1,
                 bundle: MessageBundle {
                     certificate_hash: certificate0.hash(),
                     height: BlockHeight::ZERO,
@@ -920,7 +936,7 @@ where
                 action: MessageAction::Accept,
             })
             .with_incoming_bundle(IncomingBundle {
-                origin: ChainId::root(1),
+                origin: chain_1,
                 bundle: MessageBundle {
                     certificate_hash: certificate0.hash(),
                     height: BlockHeight::ZERO,
@@ -932,7 +948,7 @@ where
                 action: MessageAction::Accept,
             })
             .with_incoming_bundle(IncomingBundle {
-                origin: ChainId::root(1),
+                origin: chain_1,
                 bundle: MessageBundle {
                     certificate_hash: certificate1.hash(),
                     height: BlockHeight::from(1),
@@ -949,16 +965,16 @@ where
             .into_first_proposal(&recipient_key_pair);
         // Inconsistent received messages.
         assert_matches!(
-            worker.handle_block_proposal(block_proposal).await,
+            env.worker().handle_block_proposal(block_proposal).await,
             Err(WorkerError::ChainError(chain_error))
                 if matches!(*chain_error, ChainError::UnexpectedMessage { .. })
         );
     }
     {
-        let block_proposal = make_first_block(ChainId::root(2))
-            .with_simple_transfer(ChainId::root(3), Amount::from_tokens(6))
+        let block_proposal = make_first_block(chain_2)
+            .with_simple_transfer(chain_3, Amount::from_tokens(6))
             .with_incoming_bundle(IncomingBundle {
-                origin: ChainId::root(1),
+                origin: chain_1,
                 bundle: MessageBundle {
                     certificate_hash: certificate0.hash(),
                     height: BlockHeight::ZERO,
@@ -973,16 +989,16 @@ where
             .into_first_proposal(&recipient_key_pair);
         // Skipped message.
         assert_matches!(
-            worker.handle_block_proposal(block_proposal).await,
+            env.worker().handle_block_proposal(block_proposal).await,
             Err(WorkerError::ChainError(chain_error))
                 if matches!(*chain_error, ChainError::CannotSkipMessage { .. })
         );
     }
     {
-        let block_proposal = make_first_block(ChainId::root(2))
-            .with_simple_transfer(ChainId::root(3), Amount::from_tokens(6))
+        let block_proposal = make_first_block(chain_2)
+            .with_simple_transfer(chain_3, Amount::from_tokens(6))
             .with_incoming_bundle(IncomingBundle {
-                origin: ChainId::root(1),
+                origin: chain_1,
                 bundle: MessageBundle {
                     certificate_hash: certificate1.hash(),
                     height: BlockHeight::from(1),
@@ -994,7 +1010,7 @@ where
                 action: MessageAction::Accept,
             })
             .with_incoming_bundle(IncomingBundle {
-                origin: ChainId::root(1),
+                origin: chain_1,
                 bundle: MessageBundle {
                     certificate_hash: certificate0.hash(),
                     height: BlockHeight::ZERO,
@@ -1007,7 +1023,7 @@ where
                 action: MessageAction::Accept,
             })
             .with_incoming_bundle(IncomingBundle {
-                origin: ChainId::root(1),
+                origin: chain_1,
                 bundle: MessageBundle {
                     certificate_hash: certificate0.hash(),
                     height: BlockHeight::ZERO,
@@ -1022,16 +1038,16 @@ where
             .into_first_proposal(&recipient_key_pair);
         // Inconsistent order in received messages (heights).
         assert_matches!(
-            worker.handle_block_proposal(block_proposal).await,
+            env.worker().handle_block_proposal(block_proposal).await,
             Err(WorkerError::ChainError(chain_error))
                 if matches!(*chain_error, ChainError::CannotSkipMessage { .. })
         );
     }
     {
-        let block_proposal = make_first_block(ChainId::root(2))
-            .with_simple_transfer(ChainId::root(3), Amount::ONE)
+        let block_proposal = make_first_block(chain_2)
+            .with_simple_transfer(chain_3, Amount::ONE)
             .with_incoming_bundle(IncomingBundle {
-                origin: ChainId::root(1),
+                origin: chain_1,
                 bundle: MessageBundle {
                     certificate_hash: certificate0.hash(),
                     height: BlockHeight::ZERO,
@@ -1046,41 +1062,35 @@ where
             .with_authenticated_signer(Some(recipient_key_pair.public().into()))
             .into_first_proposal(&recipient_key_pair);
         // Taking the first message only is ok.
-        worker.handle_block_proposal(block_proposal.clone()).await?;
-        let certificate: ConfirmedBlockCertificate = make_certificate(
-            &committee,
-            &worker,
-            ConfirmedBlock::new(
-                BlockExecutionOutcome {
-                    messages: vec![
-                        Vec::new(),
-                        vec![direct_credit_message(ChainId::root(3), Amount::ONE)],
-                    ],
-                    previous_message_blocks: BTreeMap::new(),
-                    events: vec![Vec::new(); 2],
-                    blobs: vec![Vec::new(); 2],
-                    state_hash: SystemExecutionState {
-                        committees: [(epoch, committee.clone())].into_iter().collect(),
-                        ownership: ChainOwnership::single(recipient_key_pair.public().into()),
-                        ..SystemExecutionState::new(epoch, ChainDescription::Root(2), admin_id)
-                    }
+        env.worker()
+            .handle_block_proposal(block_proposal.clone())
+            .await?;
+        let certificate: ConfirmedBlockCertificate = env.make_certificate(ConfirmedBlock::new(
+            BlockExecutionOutcome {
+                messages: vec![
+                    Vec::new(),
+                    vec![direct_credit_message(chain_3, Amount::ONE)],
+                ],
+                previous_message_blocks: BTreeMap::new(),
+                events: vec![Vec::new(); 2],
+                blobs: vec![Vec::new(); 2],
+                state_hash: SystemExecutionState::new(chain_2_desc.clone())
                     .into_hash()
                     .await,
-                    oracle_responses: vec![Vec::new(); 2],
-                    operation_results: vec![OperationResult::default()],
-                }
-                .with(block_proposal.content.block),
-            ),
-        );
-        worker
+                oracle_responses: vec![Vec::new(); 2],
+                operation_results: vec![OperationResult::default()],
+            }
+            .with(block_proposal.content.block),
+        ));
+        env.worker()
             .handle_confirmed_certificate(certificate.clone(), None)
             .await?;
 
         // Then receive the next two messages.
         let block_proposal = make_child_block(&certificate.into_value())
-            .with_simple_transfer(ChainId::root(3), Amount::from_tokens(3))
+            .with_simple_transfer(chain_3, Amount::from_tokens(3))
             .with_incoming_bundle(IncomingBundle {
-                origin: ChainId::root(1),
+                origin: chain_1,
                 bundle: MessageBundle {
                     certificate_hash: certificate0.hash(),
                     height: BlockHeight::from(0),
@@ -1092,7 +1102,7 @@ where
                 action: MessageAction::Accept,
             })
             .with_incoming_bundle(IncomingBundle {
-                origin: ChainId::root(1),
+                origin: chain_1,
                 bundle: MessageBundle {
                     certificate_hash: certificate1.hash(),
                     height: BlockHeight::from(1),
@@ -1104,7 +1114,9 @@ where
                 action: MessageAction::Accept,
             })
             .into_first_proposal(&recipient_key_pair);
-        worker.handle_block_proposal(block_proposal.clone()).await?;
+        env.worker()
+            .handle_block_proposal(block_proposal.clone())
+            .await?;
     }
     Ok(())
 }
@@ -1119,35 +1131,28 @@ where
     B: StorageBuilder,
 {
     let sender_key_pair = AccountSecretKey::generate();
-    let (_, worker) = init_worker_with_chains(
-        storage_builder.build().await?,
-        vec![
-            (
-                ChainDescription::Root(1),
-                sender_key_pair.public().into(),
-                Amount::from_tokens(5),
-            ),
-            (
-                ChainDescription::Root(2),
-                AccountPublicKey::test_key(2).into(),
-                Amount::ZERO,
-            ),
-        ],
-    )
-    .await;
-    let block_proposal = make_first_block(ChainId::root(1))
-        .with_simple_transfer(ChainId::root(2), Amount::from_tokens(1000))
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .await;
+    let chain_2_desc = env
+        .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ZERO)
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = chain_2_desc.id();
+    let block_proposal = make_first_block(chain_1)
+        .with_simple_transfer(chain_2, Amount::from_tokens(1000))
         .with_authenticated_signer(Some(sender_key_pair.public().into()))
         .into_first_proposal(&sender_key_pair);
     assert_matches!(
-        worker.handle_block_proposal(block_proposal).await,
+        env.worker().handle_block_proposal(block_proposal).await,
         Err(
             WorkerError::ChainError(error)
         ) if matches!(&*error, ChainError::ExecutionError(
                 execution_error, ChainExecutionContext::Operation(_)
         ) if matches!(**execution_error, ExecutionError::InsufficientFunding { .. }))
     );
-    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active());
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
@@ -1164,38 +1169,37 @@ where
     B: StorageBuilder,
 {
     let sender_key_pair = AccountSecretKey::generate();
-    let (committee, worker) = init_worker_with_chains(
-        storage_builder.build().await?,
-        vec![(
-            ChainDescription::Root(1),
-            sender_key_pair.public().into(),
-            Amount::from_tokens(5),
-        )],
-    )
-    .await;
-    let block_proposal = make_first_block(ChainId::root(1))
-        .with_simple_transfer(ChainId::root(2), Amount::from_tokens(5))
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .await;
+    let chain_2_desc = env
+        .add_root_chain(2, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = chain_2_desc.id();
+    let block_proposal = make_first_block(chain_1)
+        .with_simple_transfer(chain_2, Amount::from_tokens(5))
         .with_authenticated_signer(Some(sender_key_pair.public().into()))
         .into_first_proposal(&sender_key_pair);
 
-    let (chain_info_response, _actions) = worker.handle_block_proposal(block_proposal).await?;
-    chain_info_response.check(&worker.public_key())?;
-    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    let (chain_info_response, _actions) =
+        env.worker().handle_block_proposal(block_proposal).await?;
+    chain_info_response.check(&env.worker().public_key())?;
+    let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active());
     assert!(chain.manager.confirmed_vote().is_none()); // It was a multi-leader
                                                        // round.
-    let validated_certificate = make_certificate(
-        &committee,
-        &worker,
-        chain.manager.validated_vote().unwrap().value().clone(),
-    );
+    let validated_certificate =
+        env.make_certificate(chain.manager.validated_vote().unwrap().value().clone());
     drop(chain);
 
-    let (chain_info_response, _actions) = worker
+    let (chain_info_response, _actions) = env
+        .worker()
         .handle_validated_certificate(validated_certificate)
         .await?;
-    chain_info_response.check(&worker.public_key())?;
-    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    chain_info_response.check(&env.worker().public_key())?;
+    let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active());
     assert!(chain.manager.validated_vote().is_none()); // Should be confirmed by now.
     let pending_vote = chain.manager.confirmed_vote().unwrap().lite();
@@ -1216,30 +1220,26 @@ where
     B: StorageBuilder,
 {
     let sender_key_pair = AccountSecretKey::generate();
-    let (_, worker) = init_worker_with_chains(
-        storage_builder.build().await?,
-        vec![
-            (
-                ChainDescription::Root(1),
-                sender_key_pair.public().into(),
-                Amount::from_tokens(5),
-            ),
-            (
-                ChainDescription::Root(2),
-                AccountPublicKey::test_key(2).into(),
-                Amount::ZERO,
-            ),
-        ],
-    )
-    .await;
-    let block_proposal = make_first_block(ChainId::root(1))
-        .with_simple_transfer(ChainId::root(2), Amount::from_tokens(5))
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .await;
+    let chain_2_desc = env
+        .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ZERO)
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = chain_2_desc.id();
+    let block_proposal = make_first_block(chain_1)
+        .with_simple_transfer(chain_2, Amount::from_tokens(5))
         .with_authenticated_signer(Some(sender_key_pair.public().into()))
         .into_first_proposal(&sender_key_pair);
 
-    let (response, _actions) = worker.handle_block_proposal(block_proposal.clone()).await?;
-    response.check(&worker.public_key())?;
-    let (replay_response, _actions) = worker.handle_block_proposal(block_proposal).await?;
+    let (response, _actions) = env
+        .worker()
+        .handle_block_proposal(block_proposal.clone())
+        .await?;
+    response.check(&env.worker().public_key())?;
+    let (replay_response, _actions) = env.worker().handle_block_proposal(block_proposal).await?;
     // Workaround lack of equality.
     assert_eq!(
         CryptoHash::new(&*response.info),
@@ -1258,32 +1258,29 @@ where
     B: StorageBuilder,
 {
     let sender_key_pair = AccountSecretKey::generate();
-    let (committee, worker) = init_worker_with_chains(
-        storage_builder.build().await?,
-        vec![(
-            ChainDescription::Root(2),
-            AccountPublicKey::test_key(2).into(),
-            Amount::ZERO,
-        )],
-    )
-    .await;
-    let certificate = make_simple_transfer_certificate(
-        ChainDescription::Root(1),
-        &sender_key_pair,
-        ChainId::root(2),
-        Amount::from_tokens(5),
-        Vec::new(),
-        &committee,
-        Amount::ZERO,
-        &worker,
-        None,
-    )
-    .await;
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_2_desc = env
+        .add_root_chain(2, sender_key_pair.public().into(), Amount::ZERO)
+        .await;
+    let chain_2 = chain_2_desc.id();
+    let chain_1_desc = dummy_chain_description(1);
+    let certificate = env
+        .make_simple_transfer_certificate(
+            chain_1_desc.clone(),
+            &sender_key_pair,
+            chain_2,
+            Amount::from_tokens(5),
+            Vec::new(),
+            Amount::from_tokens(5),
+            None,
+        )
+        .await;
     assert_matches!(
-        worker
+        env.worker()
             .fully_handle_certificate_with_notifications(certificate, &())
             .await,
-        Err(WorkerError::ChainError(error)) if matches!(*error, ChainError::InactiveChain {..})
+        Err(WorkerError::BlobsNotFound(error))
+            if error == vec![Blob::new_chain_description(&chain_1_desc).id()]
     );
     Ok(())
 }
@@ -1298,67 +1295,31 @@ where
     B: StorageBuilder,
 {
     let sender_key_pair = AccountSecretKey::generate();
-    let (committee, worker) = init_worker_with_chains(
-        storage_builder.build().await?,
-        vec![(
-            ChainDescription::Root(2),
-            AccountPublicKey::test_key(2).into(),
-            Amount::ZERO,
-        )],
-    )
-    .await;
-    let admin_id = ChainId::root(0);
-    let epoch = Epoch::ZERO;
-    let description = ChainDescription::Child(MessageId {
-        chain_id: ChainId::root(3),
-        height: BlockHeight::ZERO,
-        index: 0,
-    });
-    let chain_id = ChainId::from(description);
-    let ownership = ChainOwnership::single(sender_key_pair.public().into());
-    let committees = BTreeMap::from_iter([(epoch, committee.clone())]);
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_2_desc = env
+        .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ZERO)
+        .await;
     let balance = Amount::from_tokens(42);
-    let state = SystemExecutionState {
-        committees: committees.clone(),
-        ownership: ownership.clone(),
-        balance,
-        ..SystemExecutionState::new(epoch, description, admin_id)
-    };
-    let open_chain_message = IncomingBundle {
-        origin: ChainId::root(3),
-        bundle: MessageBundle {
-            certificate_hash: CryptoHash::test_hash("certificate"),
-            height: BlockHeight::ZERO,
-            timestamp: Timestamp::from(0),
-            transaction_index: 0,
-            messages: vec![
-                Message::System(SystemMessage::OpenChain(Box::new(OpenChainConfig {
-                    ownership,
-                    admin_id,
-                    epoch,
-                    committees,
-                    balance,
-                    application_permissions: Default::default(),
-                })))
-                .to_posted(0, MessageKind::Protected),
-            ],
-        },
-        action: MessageAction::Accept,
-    };
+    let description = env
+        .add_child_chain(chain_2_desc.id(), sender_key_pair.public().into(), balance)
+        .await;
+    let chain_id = description.id();
+    let state = SystemExecutionState::new(description);
     let value = ConfirmedBlock::new(
         BlockExecutionOutcome {
-            messages: vec![Vec::new()],
+            messages: vec![],
             previous_message_blocks: BTreeMap::new(),
-            events: vec![Vec::new()],
-            blobs: vec![Vec::new()],
+            events: vec![],
+            blobs: vec![],
             state_hash: state.into_hash().await,
-            oracle_responses: vec![Vec::new()],
+            oracle_responses: vec![],
             operation_results: vec![],
         }
-        .with(make_first_block(chain_id).with_incoming_bundle(open_chain_message)),
+        .with(make_first_block(chain_id)),
     );
-    let certificate = make_certificate(&committee, &worker, value);
-    let info = worker
+    let certificate = env.make_certificate(value);
+    let info = env
+        .worker()
         .fully_handle_certificate_with_notifications(certificate, &())
         .await?
         .info;
@@ -1377,35 +1338,30 @@ where
 {
     let sender_key_pair = AccountSecretKey::generate();
     let chain_key_pair = AccountSecretKey::generate();
-    let (committee, worker) = init_worker_with_chains(
-        storage_builder.build().await?,
-        vec![(
-            ChainDescription::Root(2),
-            chain_key_pair.public().into(),
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_2_desc = env
+        .add_root_chain(2, chain_key_pair.public().into(), Amount::from_tokens(5))
+        .await;
+    let chain_2 = chain_2_desc.id();
+    let certificate = env
+        .make_transfer_certificate_for_epoch(
+            chain_2_desc.clone(),
+            &sender_key_pair,
+            Some(chain_key_pair.public().into()),
+            AccountOwner::CHAIN,
+            Recipient::chain(chain_2),
             Amount::from_tokens(5),
-        )],
-    )
-    .await;
-    let certificate = make_transfer_certificate_for_epoch(
-        ChainDescription::Root(2),
-        &sender_key_pair,
-        Some(chain_key_pair.public().into()),
-        AccountOwner::CHAIN,
-        Recipient::chain(ChainId::root(2)),
-        Amount::from_tokens(5),
-        Vec::new(),
-        Epoch::ZERO,
-        &committee,
-        Amount::ZERO,
-        BTreeMap::new(),
-        &worker,
-        None,
-    )
-    .await;
+            Vec::new(),
+            Epoch::ZERO,
+            Amount::ZERO,
+            BTreeMap::new(),
+            None,
+        )
+        .await;
     // This fails because `make_simple_transfer_certificate` uses `sender_key_pair.public()` to
     // compute the hash of the execution state.
     assert_matches!(
-        worker
+        env.worker()
             .fully_handle_certificate_with_notifications(certificate, &())
             .await,
         Err(WorkerError::IncorrectOutcome { .. })
@@ -1423,39 +1379,30 @@ where
     B: StorageBuilder,
 {
     let sender_key_pair = AccountSecretKey::generate();
-    let (committee, worker) = init_worker_with_chains(
-        storage_builder.build().await?,
-        vec![
-            (
-                ChainDescription::Root(1),
-                sender_key_pair.public().into(),
-                Amount::from_tokens(5),
-            ),
-            (
-                ChainDescription::Root(2),
-                AccountPublicKey::test_key(2).into(),
-                Amount::ZERO,
-            ),
-        ],
-    )
-    .await;
-    let certificate = make_simple_transfer_certificate(
-        ChainDescription::Root(1),
-        &sender_key_pair,
-        ChainId::root(2),
-        Amount::from_tokens(5),
-        Vec::new(),
-        &committee,
-        Amount::ZERO,
-        &worker,
-        None,
-    )
-    .await;
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .await;
+    let chain_2_desc = env
+        .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ZERO)
+        .await;
+    let chain_2 = chain_2_desc.id();
+    let certificate = env
+        .make_simple_transfer_certificate(
+            chain_1_desc.clone(),
+            &sender_key_pair,
+            chain_2,
+            Amount::from_tokens(5),
+            Vec::new(),
+            Amount::ZERO,
+            None,
+        )
+        .await;
     // Replays are ignored.
-    worker
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
-    worker
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate, &())
         .await?;
     Ok(())
@@ -1473,50 +1420,46 @@ where
     B: StorageBuilder,
 {
     let key_pair = AccountSecretKey::generate();
-    let (committee, worker) = init_worker_with_chains(
-        storage_builder.build().await?,
-        vec![
-            (
-                ChainDescription::Root(1),
-                key_pair.public().into(),
-                Amount::from_tokens(5),
-            ),
-            (
-                ChainDescription::Root(2),
-                AccountPublicKey::test_key(2).into(),
-                Amount::ZERO,
-            ),
-        ],
-    )
-    .await;
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, key_pair.public().into(), Amount::from_tokens(5))
+        .await;
+    let chain_2_desc = env
+        .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ZERO)
+        .await;
+    let chain_3_desc = env
+        .add_root_chain(3, AccountPublicKey::test_key(3).into(), Amount::ZERO)
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = chain_2_desc.id();
+    let chain_3 = chain_3_desc.id();
 
-    let certificate = make_simple_transfer_certificate(
-        ChainDescription::Root(1),
-        &key_pair,
-        ChainId::root(2),
-        Amount::from_tokens(1000),
-        vec![IncomingBundle {
-            origin: ChainId::root(3),
-            bundle: MessageBundle {
-                certificate_hash: CryptoHash::test_hash("certificate"),
-                height: BlockHeight::ZERO,
-                timestamp: Timestamp::from(0),
-                transaction_index: 0,
-                messages: vec![system_credit_message(Amount::from_tokens(995))
-                    .to_posted(0, MessageKind::Tracked)],
-            },
-            action: MessageAction::Accept,
-        }],
-        &committee,
-        Amount::ZERO,
-        &worker,
-        None,
-    )
-    .await;
-    worker
+    let certificate = env
+        .make_simple_transfer_certificate(
+            chain_1_desc.clone(),
+            &key_pair,
+            chain_2,
+            Amount::from_tokens(1000),
+            vec![IncomingBundle {
+                origin: chain_3,
+                bundle: MessageBundle {
+                    certificate_hash: CryptoHash::test_hash("certificate"),
+                    height: BlockHeight::ZERO,
+                    timestamp: Timestamp::from(0),
+                    transaction_index: 0,
+                    messages: vec![system_credit_message(Amount::from_tokens(995))
+                        .to_posted(0, MessageKind::Tracked)],
+                },
+                action: MessageAction::Accept,
+            }],
+            Amount::ZERO,
+            None,
+        )
+        .await;
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
-    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active());
     assert_eq!(Amount::ZERO, *chain.execution_state.system.balance.get());
     assert_eq!(
@@ -1525,9 +1468,9 @@ where
     );
     let inbox = chain
         .inboxes
-        .try_load_entry(&ChainId::root(3))
+        .try_load_entry(&chain_3)
         .await?
-        .expect("Missing inbox for `ChainId::root(3)` in `ChainId::root(1)`");
+        .expect("Missing inbox for `chain_3` in `ChainId::root(1)`");
     assert_eq!(BlockHeight::ZERO, inbox.next_block_height_to_receive()?);
     assert_eq!(inbox.added_bundles.count(), 0);
     assert_matches!(
@@ -1557,7 +1500,7 @@ where
     );
     assert_eq!(chain.confirmed_log.count(), 1);
     assert_eq!(Some(certificate.hash()), chain.tip_state.get().block_hash);
-    let chain = worker.chain_state_view(ChainId::root(2)).await?;
+    let chain = env.worker().chain_state_view(chain_2).await?;
     assert!(chain.is_active());
     Ok(())
 }
@@ -1574,39 +1517,31 @@ where
     B: StorageBuilder,
 {
     let sender_key_pair = AccountSecretKey::generate();
-    let (committee, worker) = init_worker_with_chains(
-        storage_builder.build().await?,
-        vec![
-            (
-                ChainDescription::Root(1),
-                sender_key_pair.public().into(),
-                Amount::ONE,
-            ),
-            (
-                ChainDescription::Root(2),
-                AccountPublicKey::test_key(2).into(),
-                Amount::MAX,
-            ),
-        ],
-    )
-    .await;
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::ONE)
+        .await;
+    let chain_2_desc = env
+        .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::MAX)
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = chain_2_desc.id();
 
-    let certificate = make_simple_transfer_certificate(
-        ChainDescription::Root(1),
-        &sender_key_pair,
-        ChainId::root(2),
-        Amount::ONE,
-        Vec::new(),
-        &committee,
-        Amount::ZERO,
-        &worker,
-        None,
-    )
-    .await;
-    worker
+    let certificate = env
+        .make_simple_transfer_certificate(
+            chain_1_desc.clone(),
+            &sender_key_pair,
+            chain_2,
+            Amount::ONE,
+            Vec::new(),
+            Amount::ZERO,
+            None,
+        )
+        .await;
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
-    let new_sender_chain = worker.chain_state_view(ChainId::root(1)).await?;
+    let new_sender_chain = env.worker().chain_state_view(chain_1).await?;
     assert!(new_sender_chain.is_active());
     assert_eq!(
         Amount::ZERO,
@@ -1621,7 +1556,7 @@ where
         Some(certificate.hash()),
         new_sender_chain.tip_state.get().block_hash
     );
-    let new_recipient_chain = worker.chain_state_view(ChainId::root(2)).await?;
+    let new_recipient_chain = env.worker().chain_state_view(chain_2).await?;
     assert!(new_recipient_chain.is_active());
     assert_eq!(
         Amount::MAX,
@@ -1644,30 +1579,30 @@ where
     let storage = storage_builder.build().await?;
     let key_pair = AccountSecretKey::generate();
     let owner = key_pair.public().into();
-    let (committee, worker) =
-        init_worker_with_chain(storage, ChainDescription::Root(1), owner, Amount::ONE).await;
+    let mut env = TestEnvironment::new(storage, false, false).await;
+    let chain_1_desc = env.add_root_chain(1, owner, Amount::ONE).await;
+    let chain_1 = chain_1_desc.id();
 
-    let certificate = make_simple_transfer_certificate(
-        ChainDescription::Root(1),
-        &key_pair,
-        ChainId::root(1),
-        Amount::ONE,
-        Vec::new(),
-        &committee,
-        Amount::ZERO,
-        &worker,
-        None,
-    )
-    .await;
-    worker
+    let certificate = env
+        .make_simple_transfer_certificate(
+            chain_1_desc.clone(),
+            &key_pair,
+            chain_1,
+            Amount::ONE,
+            Vec::new(),
+            Amount::ZERO,
+            None,
+        )
+        .await;
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
-    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active());
     assert_eq!(Amount::ZERO, *chain.execution_state.system.balance.get());
     let inbox = chain
         .inboxes
-        .try_load_entry(&ChainId::root(1))
+        .try_load_entry(&chain_1)
         .await?
         .expect("Missing inbox for `ChainId::root(1)` in `ChainId::root(1)`");
     assert_eq!(BlockHeight::from(1), inbox.next_block_height_to_receive()?);
@@ -1711,40 +1646,36 @@ where
     B: StorageBuilder,
 {
     let sender_key_pair = AccountSecretKey::generate();
-    let (committee, worker) = init_worker_with_chain(
-        storage_builder.build().await?,
-        ChainDescription::Root(2),
-        AccountPublicKey::test_key(2).into(),
-        Amount::ONE,
-    )
-    .await;
-    let certificate = make_simple_transfer_certificate(
-        ChainDescription::Root(1),
-        &sender_key_pair,
-        ChainId::root(2),
-        Amount::from_tokens(10),
-        Vec::new(),
-        &committee,
-        Amount::ZERO,
-        &worker,
-        None,
-    )
-    .await;
-    worker
-        .handle_cross_chain_request(update_recipient_direct(
-            ChainId::root(2),
-            &certificate.clone(),
-        ))
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_2_desc = env
+        .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ONE)
+        .await;
+    let chain_2 = chain_2_desc.id();
+    let chain_1_desc = dummy_chain_description(1);
+    let chain_1 = chain_1_desc.id();
+    let certificate = env
+        .make_simple_transfer_certificate(
+            chain_1_desc,
+            &sender_key_pair,
+            chain_2,
+            Amount::from_tokens(10),
+            Vec::new(),
+            Amount::ZERO,
+            None,
+        )
+        .await;
+    env.worker()
+        .handle_cross_chain_request(update_recipient_direct(chain_2, &certificate.clone()))
         .await?;
-    let chain = worker.chain_state_view(ChainId::root(2)).await?;
+    let chain = env.worker().chain_state_view(chain_2).await?;
     assert!(chain.is_active());
     assert_eq!(Amount::ONE, *chain.execution_state.system.balance.get());
     assert_eq!(BlockHeight::ZERO, chain.tip_state.get().next_block_height);
     let inbox = chain
         .inboxes
-        .try_load_entry(&ChainId::root(1))
+        .try_load_entry(&chain_1)
         .await?
-        .expect("Missing inbox for `ChainId::root(1)` in `ChainId::root(2)`");
+        .expect("Missing inbox for `ChainId::root(1)` in `chain_2`");
     assert_eq!(BlockHeight::from(1), inbox.next_block_height_to_receive()?);
     assert_matches!(
         inbox
@@ -1790,27 +1721,29 @@ where
 {
     let storage = storage_builder.build().await?;
     let sender_key_pair = AccountSecretKey::generate();
-    let (committee, worker) = init_worker(
-        storage, /* is_client */ false, /* has_long_lived_services */ false,
-    );
-    let certificate = make_simple_transfer_certificate(
-        ChainDescription::Root(1),
-        &sender_key_pair,
-        ChainId::root(2),
-        Amount::from_tokens(10),
-        Vec::new(),
-        &committee,
-        Amount::ZERO,
-        &worker,
-        None,
-    )
-    .await;
-    assert!(worker
-        .handle_cross_chain_request(update_recipient_direct(ChainId::root(2), &certificate))
+    let mut env = TestEnvironment::new(storage, false, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(10))
+        .await;
+    let chain_2 = dummy_chain_description(2).id();
+    let certificate = env
+        .make_simple_transfer_certificate(
+            chain_1_desc,
+            &sender_key_pair,
+            chain_2,
+            Amount::from_tokens(10),
+            Vec::new(),
+            Amount::ZERO,
+            None,
+        )
+        .await;
+    assert!(env
+        .worker()
+        .handle_cross_chain_request(update_recipient_direct(chain_2, &certificate))
         .await?
         .cross_chain_requests
         .is_empty());
-    let chain = worker.chain_state_view(ChainId::root(2)).await?;
+    let chain = env.worker().chain_state_view(chain_2).await?;
     // The target chain did not receive the message
     assert!(chain.inboxes.indices().await?.is_empty());
     Ok(())
@@ -1829,24 +1762,27 @@ where
 {
     let storage = storage_builder.build().await?;
     let sender_key_pair = AccountSecretKey::generate();
-    let (committee, worker) = init_worker(
-        storage, /* is_client */ true, /* has_long_lived_services */ false,
-    );
-    let certificate = make_simple_transfer_certificate(
-        ChainDescription::Root(1),
-        &sender_key_pair,
-        ChainId::root(2),
-        Amount::from_tokens(10),
-        Vec::new(),
-        &committee,
-        Amount::ZERO,
-        &worker,
-        None,
-    )
-    .await;
+    let mut env = TestEnvironment::new(storage, true, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(10))
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = dummy_chain_description(2).id();
+    let certificate = env
+        .make_simple_transfer_certificate(
+            chain_1_desc,
+            &sender_key_pair,
+            chain_2,
+            Amount::from_tokens(10),
+            Vec::new(),
+            Amount::ZERO,
+            None,
+        )
+        .await;
     // An inactive target chain is created and it acknowledges the message.
-    let actions = worker
-        .handle_cross_chain_request(update_recipient_direct(ChainId::root(2), &certificate))
+    let actions = env
+        .worker()
+        .handle_cross_chain_request(update_recipient_direct(chain_2, &certificate))
         .await?;
     assert_matches!(
         actions.cross_chain_requests.as_slice(),
@@ -1855,14 +1791,14 @@ where
     assert_eq!(
         actions.notifications,
         vec![Notification {
-            chain_id: ChainId::root(2),
+            chain_id: chain_2,
             reason: Reason::NewIncomingBundle {
-                origin: ChainId::root(1),
+                origin: chain_1,
                 height: BlockHeight::ZERO,
             }
         }]
     );
-    let chain = worker.chain_state_view(ChainId::root(2)).await?;
+    let chain = env.worker().chain_state_view(chain_2).await?;
     assert!(!chain.inboxes.indices().await?.is_empty());
     Ok(())
 }
@@ -1880,76 +1816,73 @@ where
 {
     let sender_key_pair = AccountSecretKey::generate();
     let recipient_key_pair = AccountSecretKey::generate();
-    let (committee, worker) = init_worker_with_chains(
-        storage_builder.build().await?,
-        vec![
-            (
-                ChainDescription::Root(1),
-                sender_key_pair.public().into(),
-                Amount::from_tokens(5),
-            ),
-            (
-                ChainDescription::Root(2),
-                recipient_key_pair.public().into(),
-                Amount::ZERO,
-            ),
-        ],
-    )
-    .await;
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .await;
+    let chain_2_desc = env
+        .add_root_chain(2, recipient_key_pair.public().into(), Amount::ZERO)
+        .await;
+    let chain_3_desc = env
+        .add_root_chain(3, recipient_key_pair.public().into(), Amount::ZERO)
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = chain_2_desc.id();
+    let chain_3 = chain_3_desc.id();
     assert_eq!(
-        worker
-            .query_application(ChainId::root(1), Query::System(SystemQuery))
+        env.worker()
+            .query_application(chain_1, Query::System(SystemQuery))
             .await?,
         QueryOutcome {
             response: QueryResponse::System(SystemResponse {
-                chain_id: ChainId::root(1),
+                chain_id: chain_1,
                 balance: Amount::from_tokens(5),
             }),
             operations: vec![],
         }
     );
     assert_eq!(
-        worker
-            .query_application(ChainId::root(2), Query::System(SystemQuery))
+        env.worker()
+            .query_application(chain_2, Query::System(SystemQuery))
             .await?,
         QueryOutcome {
             response: QueryResponse::System(SystemResponse {
-                chain_id: ChainId::root(2),
+                chain_id: chain_2,
                 balance: Amount::ZERO,
             }),
             operations: vec![],
         }
     );
 
-    let certificate = make_simple_transfer_certificate(
-        ChainDescription::Root(1),
-        &sender_key_pair,
-        ChainId::root(2),
-        Amount::from_tokens(5),
-        Vec::new(),
-        &committee,
-        Amount::ZERO,
-        &worker,
-        None,
-    )
-    .await;
+    let certificate = env
+        .make_simple_transfer_certificate(
+            chain_1_desc.clone(),
+            &sender_key_pair,
+            chain_2,
+            Amount::from_tokens(5),
+            Vec::new(),
+            Amount::ZERO,
+            None,
+        )
+        .await;
 
-    let info = worker
+    let info = env
+        .worker()
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?
         .info;
-    assert_eq!(ChainId::root(1), info.chain_id);
+    assert_eq!(chain_1, info.chain_id);
     assert_eq!(Amount::ZERO, info.chain_balance);
     assert_eq!(BlockHeight::from(1), info.next_block_height);
     assert_eq!(Some(certificate.hash()), info.block_hash);
     assert!(info.manager.pending.is_none());
     assert_eq!(
-        worker
-            .query_application(ChainId::root(1), Query::System(SystemQuery))
+        env.worker()
+            .query_application(chain_1, Query::System(SystemQuery))
             .await?,
         QueryOutcome {
             response: QueryResponse::System(SystemResponse {
-                chain_id: ChainId::root(1),
+                chain_id: chain_1,
                 balance: Amount::ZERO,
             }),
             operations: vec![],
@@ -1957,40 +1890,39 @@ where
     );
 
     // Try to use the money. This requires selecting the incoming message in a next block.
-    let certificate = make_simple_transfer_certificate(
-        ChainDescription::Root(2),
-        &recipient_key_pair,
-        ChainId::root(3),
-        Amount::ONE,
-        vec![IncomingBundle {
-            origin: ChainId::root(1),
-            bundle: MessageBundle {
-                certificate_hash: certificate.hash(),
-                height: BlockHeight::ZERO,
-                timestamp: Timestamp::from(0),
-                transaction_index: 0,
-                messages: vec![system_credit_message(Amount::from_tokens(5))
-                    .to_posted(0, MessageKind::Tracked)],
-            },
-            action: MessageAction::Accept,
-        }],
-        &committee,
-        Amount::from_tokens(4),
-        &worker,
-        None,
-    )
-    .await;
-    worker
+    let certificate = env
+        .make_simple_transfer_certificate(
+            chain_2_desc.clone(),
+            &recipient_key_pair,
+            chain_3,
+            Amount::ONE,
+            vec![IncomingBundle {
+                origin: chain_1,
+                bundle: MessageBundle {
+                    certificate_hash: certificate.hash(),
+                    height: BlockHeight::ZERO,
+                    timestamp: Timestamp::from(0),
+                    transaction_index: 0,
+                    messages: vec![system_credit_message(Amount::from_tokens(5))
+                        .to_posted(0, MessageKind::Tracked)],
+                },
+                action: MessageAction::Accept,
+            }],
+            Amount::from_tokens(4),
+            None,
+        )
+        .await;
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
 
     assert_eq!(
-        worker
-            .query_application(ChainId::root(2), Query::System(SystemQuery))
+        env.worker()
+            .query_application(chain_2, Query::System(SystemQuery))
             .await?,
         QueryOutcome {
             response: QueryResponse::System(SystemResponse {
-                chain_id: ChainId::root(2),
+                chain_id: chain_2,
                 balance: Amount::from_tokens(4),
             }),
             operations: vec![],
@@ -1998,7 +1930,7 @@ where
     );
 
     {
-        let recipient_chain = worker.chain_state_view(ChainId::root(2)).await?;
+        let recipient_chain = env.worker().chain_state_view(chain_2).await?;
         assert!(recipient_chain.is_active());
         assert_eq!(
             *recipient_chain.execution_state.system.balance.get(),
@@ -2019,13 +1951,13 @@ where
         );
         assert_eq!(recipient_chain.received_log.count(), 1);
     }
-    let query = ChainInfoQuery::new(ChainId::root(2)).with_received_log_excluding_first_n(0);
-    let (response, _actions) = worker.handle_chain_info_query(query).await?;
+    let query = ChainInfoQuery::new(chain_2).with_received_log_excluding_first_n(0);
+    let (response, _actions) = env.worker().handle_chain_info_query(query).await?;
     assert_eq!(response.info.requested_received_log.len(), 1);
     assert_eq!(
         response.info.requested_received_log[0],
         ChainAndHeight {
-            chain_id: ChainId::root(1),
+            chain_id: chain_1,
             height: BlockHeight::ZERO
         }
     );
@@ -2044,31 +1976,30 @@ where
     B: StorageBuilder,
 {
     let sender_key_pair = AccountSecretKey::generate();
-    let (committee, worker) = init_worker_with_chain(
-        storage_builder.build().await?,
-        ChainDescription::Root(1),
-        sender_key_pair.public().into(),
-        Amount::from_tokens(5),
-    )
-    .await;
-    let certificate = make_simple_transfer_certificate(
-        ChainDescription::Root(1),
-        &sender_key_pair,
-        ChainId::root(2), // the recipient chain does not exist
-        Amount::from_tokens(5),
-        Vec::new(),
-        &committee,
-        Amount::ZERO,
-        &worker,
-        None,
-    )
-    .await;
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(5))
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = dummy_chain_description(2).id();
+    let certificate = env
+        .make_simple_transfer_certificate(
+            chain_1_desc.clone(),
+            &sender_key_pair,
+            chain_2, // the recipient chain does not exist
+            Amount::from_tokens(5),
+            Vec::new(),
+            Amount::ZERO,
+            None,
+        )
+        .await;
 
-    let info = worker
+    let info = env
+        .worker()
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?
         .info;
-    assert_eq!(ChainId::root(1), info.chain_id);
+    assert_eq!(chain_1, info.chain_id);
     assert_eq!(Amount::ZERO, info.chain_balance);
     assert_eq!(BlockHeight::from(1), info.next_block_height);
     assert_eq!(Some(certificate.hash()), info.block_hash);
@@ -2089,153 +2020,202 @@ where
 {
     let sender_key_pair = AccountSecretKey::generate();
     let sender = AccountOwner::from(sender_key_pair.public());
-    let sender_account = Account {
-        chain_id: ChainId::root(1),
-        owner: sender,
-    };
 
     let recipient_key_pair = AccountSecretKey::generate();
     let recipient = AccountOwner::from(sender_key_pair.public());
+
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(6))
+        .await;
+    let chain_2_desc = env
+        .add_root_chain(2, recipient_key_pair.public().into(), Amount::ZERO)
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = chain_2_desc.id();
+
+    let sender_account = Account {
+        chain_id: chain_1,
+        owner: sender,
+    };
     let recipient_account = Account {
-        chain_id: ChainId::root(2),
+        chain_id: chain_2,
         owner: recipient,
     };
 
-    let (committee, worker) = init_worker_with_chains(
-        storage_builder.build().await?,
-        vec![
-            (
-                ChainDescription::Root(1),
-                sender_key_pair.public().into(),
-                Amount::from_tokens(6),
-            ),
-            (
-                ChainDescription::Root(2),
-                recipient_key_pair.public().into(),
-                Amount::ZERO,
-            ),
-        ],
-    )
-    .await;
-
     // First move the money from the public balance to the sender's account.
     // This takes two certificates (sending, receiving) sadly.
-    let certificate00 = make_transfer_certificate(
-        ChainDescription::Root(1),
-        &sender_key_pair,
-        Some(AccountOwner::from(sender_key_pair.public())),
-        AccountOwner::CHAIN,
-        Recipient::Account(sender_account),
-        Amount::from_tokens(5),
-        Vec::new(),
-        &committee,
-        Amount::ONE,
-        BTreeMap::new(),
-        &worker,
-        None,
-    )
-    .await;
+    let certificate00 = env
+        .make_transfer_certificate(
+            chain_1_desc.clone(),
+            &sender_key_pair,
+            Some(AccountOwner::from(sender_key_pair.public())),
+            AccountOwner::CHAIN,
+            Recipient::Account(sender_account),
+            Amount::from_tokens(5),
+            Vec::new(),
+            Amount::ONE,
+            BTreeMap::new(),
+            None,
+        )
+        .await;
 
-    worker
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate00.clone(), &())
         .await?;
 
-    let certificate01 = make_transfer_certificate(
-        ChainDescription::Root(1),
-        &sender_key_pair,
-        Some(AccountOwner::from(sender_key_pair.public())),
-        AccountOwner::CHAIN,
-        Recipient::Burn,
-        Amount::ONE,
-        vec![IncomingBundle {
-            origin: ChainId::root(1),
-            bundle: MessageBundle {
-                certificate_hash: certificate00.hash(),
-                height: BlockHeight::from(0),
-                timestamp: Timestamp::from(0),
-                transaction_index: 0,
-                messages: vec![Message::System(SystemMessage::Credit {
-                    source: AccountOwner::CHAIN,
-                    target: sender,
-                    amount: Amount::from_tokens(5),
-                })
-                .to_posted(0, MessageKind::Tracked)],
-            },
-            action: MessageAction::Accept,
-        }],
-        &committee,
-        Amount::ZERO,
-        BTreeMap::from_iter([(sender, Amount::from_tokens(5))]),
-        &worker,
-        Some(&certificate00),
-    )
-    .await;
+    let certificate01 = env
+        .make_transfer_certificate(
+            chain_1_desc.clone(),
+            &sender_key_pair,
+            Some(AccountOwner::from(sender_key_pair.public())),
+            AccountOwner::CHAIN,
+            Recipient::Burn,
+            Amount::ONE,
+            vec![IncomingBundle {
+                origin: chain_1,
+                bundle: MessageBundle {
+                    certificate_hash: certificate00.hash(),
+                    height: BlockHeight::from(0),
+                    timestamp: Timestamp::from(0),
+                    transaction_index: 0,
+                    messages: vec![Message::System(SystemMessage::Credit {
+                        source: AccountOwner::CHAIN,
+                        target: sender,
+                        amount: Amount::from_tokens(5),
+                    })
+                    .to_posted(0, MessageKind::Tracked)],
+                },
+                action: MessageAction::Accept,
+            }],
+            Amount::ZERO,
+            BTreeMap::from_iter([(sender, Amount::from_tokens(5))]),
+            Some(&certificate00),
+        )
+        .await;
 
-    worker
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate01.clone(), &())
         .await?;
 
     {
-        let chain = worker.chain_state_view(ChainId::root(1)).await?;
+        let chain = env.worker.chain_state_view(chain_1).await?;
         assert!(chain.is_active());
         chain.validate_incoming_bundles().await?;
     }
 
     // Then, make two transfers to the recipient.
-    let certificate1 = make_transfer_certificate(
-        ChainDescription::Root(1),
-        &sender_key_pair,
-        Some(sender),
-        sender,
-        Recipient::Account(recipient_account),
-        Amount::from_tokens(3),
-        Vec::new(),
-        &committee,
-        Amount::ZERO,
-        BTreeMap::from_iter([(sender, Amount::from_tokens(2))]),
-        &worker,
-        Some(&certificate01),
-    )
-    .await;
+    let certificate1 = env
+        .make_transfer_certificate(
+            chain_1_desc.clone(),
+            &sender_key_pair,
+            Some(sender),
+            sender,
+            Recipient::Account(recipient_account),
+            Amount::from_tokens(3),
+            Vec::new(),
+            Amount::ZERO,
+            BTreeMap::from_iter([(sender, Amount::from_tokens(2))]),
+            Some(&certificate01),
+        )
+        .await;
 
-    worker
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate1.clone(), &())
         .await?;
 
-    let certificate2 = make_transfer_certificate(
-        ChainDescription::Root(1),
-        &sender_key_pair,
-        Some(sender),
-        sender,
-        Recipient::Account(recipient_account),
-        Amount::from_tokens(2),
-        Vec::new(),
-        &committee,
-        Amount::ZERO,
-        BTreeMap::new(),
-        &worker,
-        Some(&certificate1),
-    )
-    .await;
+    let certificate2 = env
+        .make_transfer_certificate(
+            chain_1_desc.clone(),
+            &sender_key_pair,
+            Some(sender),
+            sender,
+            Recipient::Account(recipient_account),
+            Amount::from_tokens(2),
+            Vec::new(),
+            Amount::ZERO,
+            BTreeMap::new(),
+            Some(&certificate1),
+        )
+        .await;
 
-    worker
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate2.clone(), &())
         .await?;
 
     // Reject the first transfer and try to use the money of the second one.
-    let certificate = make_transfer_certificate(
-        ChainDescription::Root(2),
-        &recipient_key_pair,
-        Some(recipient),
-        recipient,
-        Recipient::Burn,
-        Amount::ONE,
-        vec![
-            IncomingBundle {
-                origin: ChainId::root(1),
+    let certificate = env
+        .make_transfer_certificate(
+            chain_2_desc.clone(),
+            &recipient_key_pair,
+            Some(recipient),
+            recipient,
+            Recipient::Burn,
+            Amount::ONE,
+            vec![
+                IncomingBundle {
+                    origin: chain_1,
+                    bundle: MessageBundle {
+                        certificate_hash: certificate1.hash(),
+                        height: BlockHeight::from(2),
+                        timestamp: Timestamp::from(0),
+                        transaction_index: 0,
+                        messages: vec![Message::System(SystemMessage::Credit {
+                            source: sender,
+                            target: recipient,
+                            amount: Amount::from_tokens(3),
+                        })
+                        .to_posted(0, MessageKind::Tracked)],
+                    },
+                    action: MessageAction::Reject,
+                },
+                IncomingBundle {
+                    origin: chain_1,
+                    bundle: MessageBundle {
+                        certificate_hash: certificate2.hash(),
+                        height: BlockHeight::from(3),
+                        timestamp: Timestamp::from(0),
+                        transaction_index: 0,
+                        messages: vec![Message::System(SystemMessage::Credit {
+                            source: sender,
+                            target: recipient,
+                            amount: Amount::from_tokens(2),
+                        })
+                        .to_posted(0, MessageKind::Tracked)],
+                    },
+                    action: MessageAction::Accept,
+                },
+            ],
+            Amount::ZERO,
+            BTreeMap::from_iter([(recipient, Amount::from_tokens(1))]),
+            None,
+        )
+        .await;
+
+    env.worker()
+        .fully_handle_certificate_with_notifications(certificate.clone(), &())
+        .await?;
+
+    {
+        let chain = env.worker().chain_state_view(chain_2).await?;
+        assert!(chain.is_active());
+        chain.validate_incoming_bundles().await?;
+    }
+
+    // Process the bounced message and try to use the refund.
+    let certificate3 = env
+        .make_transfer_certificate(
+            chain_1_desc.clone(),
+            &sender_key_pair,
+            Some(sender),
+            sender,
+            Recipient::Burn,
+            Amount::from_tokens(3),
+            vec![IncomingBundle {
+                origin: chain_2,
                 bundle: MessageBundle {
-                    certificate_hash: certificate1.hash(),
-                    height: BlockHeight::from(2),
+                    certificate_hash: certificate.hash(),
+                    height: BlockHeight::from(0),
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
                     messages: vec![Message::System(SystemMessage::Credit {
@@ -2243,83 +2223,22 @@ where
                         target: recipient,
                         amount: Amount::from_tokens(3),
                     })
-                    .to_posted(0, MessageKind::Tracked)],
-                },
-                action: MessageAction::Reject,
-            },
-            IncomingBundle {
-                origin: ChainId::root(1),
-                bundle: MessageBundle {
-                    certificate_hash: certificate2.hash(),
-                    height: BlockHeight::from(3),
-                    timestamp: Timestamp::from(0),
-                    transaction_index: 0,
-                    messages: vec![Message::System(SystemMessage::Credit {
-                        source: sender,
-                        target: recipient,
-                        amount: Amount::from_tokens(2),
-                    })
-                    .to_posted(0, MessageKind::Tracked)],
+                    .to_posted(0, MessageKind::Bouncing)],
                 },
                 action: MessageAction::Accept,
-            },
-        ],
-        &committee,
-        Amount::ZERO,
-        BTreeMap::from_iter([(recipient, Amount::from_tokens(1))]),
-        &worker,
-        None,
-    )
-    .await;
+            }],
+            Amount::ZERO,
+            BTreeMap::new(),
+            Some(&certificate2),
+        )
+        .await;
 
-    worker
-        .fully_handle_certificate_with_notifications(certificate.clone(), &())
-        .await?;
-
-    {
-        let chain = worker.chain_state_view(ChainId::root(2)).await?;
-        assert!(chain.is_active());
-        chain.validate_incoming_bundles().await?;
-    }
-
-    // Process the bounced message and try to use the refund.
-    let certificate3 = make_transfer_certificate(
-        ChainDescription::Root(1),
-        &sender_key_pair,
-        Some(sender),
-        sender,
-        Recipient::Burn,
-        Amount::from_tokens(3),
-        vec![IncomingBundle {
-            origin: ChainId::root(2),
-            bundle: MessageBundle {
-                certificate_hash: certificate.hash(),
-                height: BlockHeight::from(0),
-                timestamp: Timestamp::from(0),
-                transaction_index: 0,
-                messages: vec![Message::System(SystemMessage::Credit {
-                    source: sender,
-                    target: recipient,
-                    amount: Amount::from_tokens(3),
-                })
-                .to_posted(0, MessageKind::Bouncing)],
-            },
-            action: MessageAction::Accept,
-        }],
-        &committee,
-        Amount::ZERO,
-        BTreeMap::new(),
-        &worker,
-        Some(&certificate2),
-    )
-    .await;
-
-    worker
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate3.clone(), &())
         .await?;
 
     {
-        let chain = worker.chain_state_view(ChainId::root(1)).await?;
+        let chain = env.worker.chain_state_view(chain_1).await?;
         assert!(chain.is_active());
         chain.validate_incoming_bundles().await?;
     }
@@ -2338,74 +2257,51 @@ where
     B: StorageBuilder,
 {
     let storage = storage_builder.build().await?;
-    let key_pair = AccountSecretKey::generate();
-    let (committee, worker) = init_worker_with_chain(
-        storage.clone(),
-        ChainDescription::Root(0),
-        key_pair.public().into(),
-        Amount::from_tokens(2),
-    )
-    .await;
+    let mut env =
+        TestEnvironment::new_with_amount(storage.clone(), false, false, Amount::from_tokens(2))
+            .await;
     let mut committees = BTreeMap::new();
+    let committee = env.committee().clone();
     committees.insert(Epoch::ZERO, committee.clone());
-    let admin_id = ChainId::root(0);
+    let admin_id = env.admin_id();
     // Have the admin chain create a user chain.
-    let user_description = ChainDescription::Child(MessageId {
-        chain_id: admin_id,
-        height: BlockHeight::ZERO,
-        index: 0,
-    });
-    let user_id = ChainId::from(user_description);
-    let certificate0 = make_certificate(
-        &committee,
-        &worker,
-        ConfirmedBlock::new(
-            BlockExecutionOutcome {
-                messages: vec![vec![direct_outgoing_message(
-                    user_id,
-                    MessageKind::Protected,
-                    SystemMessage::OpenChain(Box::new(OpenChainConfig {
-                        ownership: ChainOwnership::single(key_pair.public().into()),
-                        epoch: Epoch::ZERO,
-                        committees: committees.clone(),
-                        admin_id,
-                        balance: Amount::ZERO,
-                        application_permissions: Default::default(),
-                    })),
-                )]],
-                previous_message_blocks: BTreeMap::new(),
-                events: vec![Vec::new()],
-                blobs: vec![Vec::new()],
-                state_hash: SystemExecutionState {
-                    committees: committees.clone(),
-                    ownership: ChainOwnership::single(key_pair.public().into()),
-                    balance: Amount::from_tokens(2),
-                    ..SystemExecutionState::new(Epoch::ZERO, ChainDescription::Root(0), admin_id)
-                }
-                .into_hash()
-                .await,
-                oracle_responses: vec![Vec::new()],
-                operation_results: vec![OperationResult::default()],
+    let user_description = env
+        .add_child_chain(admin_id, env.admin_public_key().into(), Amount::ZERO)
+        .await;
+    let user_id = user_description.id();
+    let certificate0 = env.make_certificate(ConfirmedBlock::new(
+        BlockExecutionOutcome {
+            messages: vec![vec![]],
+            previous_message_blocks: BTreeMap::new(),
+            events: vec![Vec::new()],
+            blobs: vec![vec![Blob::new_chain_description(&user_description)]],
+            state_hash: SystemExecutionState {
+                admin_id: Some(admin_id),
+                ..SystemExecutionState::new(env.admin_description.clone())
             }
-            .with(
-                make_first_block(admin_id)
-                    .with_operation(SystemOperation::OpenChain(OpenChainConfig {
-                        ownership: ChainOwnership::single(key_pair.public().into()),
-                        epoch: Epoch::ZERO,
-                        committees: committees.clone(),
-                        admin_id,
-                        balance: Amount::ZERO,
-                        application_permissions: Default::default(),
-                    }))
-                    .with_authenticated_signer(Some(key_pair.public().into())),
-            ),
+            .into_hash()
+            .await,
+            oracle_responses: vec![Vec::new()],
+            operation_results: vec![OperationResult::default()],
+        }
+        .with(
+            make_first_block(admin_id)
+                .with_operation(SystemOperation::OpenChain(OpenChainConfig {
+                    ownership: ChainOwnership::single(env.admin_public_key().into()),
+                    epoch: Epoch::ZERO,
+                    committees: serialize_committees(committees.clone()),
+                    admin_id: Some(admin_id),
+                    balance: Amount::ZERO,
+                    application_permissions: Default::default(),
+                }))
+                .with_authenticated_signer(Some(env.admin_public_key().into())),
         ),
-    );
-    worker
+    ));
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate0.clone(), &())
         .await?;
     {
-        let admin_chain = worker.chain_state_view(admin_id).await?;
+        let admin_chain = env.worker().chain_state_view(admin_id).await?;
         assert!(admin_chain.is_active());
         admin_chain.validate_incoming_bundles().await?;
         assert_eq!(
@@ -2434,53 +2330,51 @@ where
     // just write it directly to storage here for simplicity.
     storage.write_blob(&committee_blob).await?;
     let blob_hash = committee_blob.id().hash;
-    let certificate1 = make_certificate(
-        &committee,
-        &worker,
-        ConfirmedBlock::new(
-            BlockExecutionOutcome {
-                messages: vec![
-                    vec![],
-                    vec![direct_credit_message(user_id, Amount::from_tokens(2))],
-                ],
-                previous_message_blocks: BTreeMap::from([(user_id, certificate0.hash())]),
-                events: vec![
-                    vec![Event {
-                        stream_id: event_id.stream_id.clone(),
-                        index: event_id.index,
-                        value: bcs::to_bytes(&blob_hash).unwrap(),
-                    }],
-                    Vec::new(),
-                ],
-                blobs: vec![Vec::new(); 2],
-                state_hash: SystemExecutionState {
-                    // The root chain knows both committees at the end.
-                    committees: committees2.clone(),
-                    ownership: ChainOwnership::single(key_pair.public().into()),
-                    used_blobs: BTreeSet::from([committee_blob.id()]),
-                    ..SystemExecutionState::new(Epoch::from(1), ChainDescription::Root(0), admin_id)
-                }
-                .into_hash()
-                .await,
-                oracle_responses: vec![vec![OracleResponse::Blob(committee_blob.id())], vec![]],
-                operation_results: vec![OperationResult::default(); 2],
+    let certificate1 = env.make_certificate(ConfirmedBlock::new(
+        BlockExecutionOutcome {
+            messages: vec![
+                vec![],
+                vec![direct_credit_message(user_id, Amount::from_tokens(2))],
+            ],
+            previous_message_blocks: BTreeMap::new(),
+            events: vec![
+                vec![Event {
+                    stream_id: event_id.stream_id.clone(),
+                    index: event_id.index,
+                    value: bcs::to_bytes(&blob_hash).unwrap(),
+                }],
+                Vec::new(),
+            ],
+            blobs: vec![Vec::new(); 2],
+            state_hash: SystemExecutionState {
+                // The root chain knows both committees at the end.
+                committees: committees2.clone(),
+                used_blobs: BTreeSet::from([committee_blob.id()]),
+                epoch: Some(Epoch::from(1)),
+                admin_id: Some(admin_id),
+                balance: Amount::ZERO,
+                ..SystemExecutionState::new(env.admin_description.clone())
             }
-            .with(
-                make_child_block(&certificate0.clone().into_value())
-                    .with_operation(SystemOperation::Admin(AdminOperation::CreateCommittee {
-                        epoch: Epoch::from(1),
-                        blob_hash,
-                    }))
-                    .with_simple_transfer(user_id, Amount::from_tokens(2)),
-            ),
+            .into_hash()
+            .await,
+            oracle_responses: vec![vec![OracleResponse::Blob(committee_blob.id())], vec![]],
+            operation_results: vec![OperationResult::default(); 2],
+        }
+        .with(
+            make_child_block(&certificate0.clone().into_value())
+                .with_operation(SystemOperation::Admin(AdminOperation::CreateCommittee {
+                    epoch: Epoch::from(1),
+                    blob_hash,
+                }))
+                .with_simple_transfer(user_id, Amount::from_tokens(2)),
         ),
-    );
-    worker
+    ));
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate1.clone(), &())
         .await?;
     {
         // The child is active and has not migrated yet.
-        let user_chain = worker.chain_state_view(user_id).await?;
+        let user_chain = env.worker().chain_state_view(user_id).await?;
         assert!(user_chain.is_active());
         assert_eq!(
             BlockHeight::ZERO,
@@ -2500,96 +2394,68 @@ where
                 .added_bundles
                 .read_front(10)
                 .await?[..],
-            [bundle1, bundle2]
+            [bundle1]
             if matches!(bundle1.messages[..], [PostedMessage {
-                 message: Message::System(SystemMessage::OpenChain(_)), ..
-            }]) && matches!(bundle2.messages[..], [PostedMessage {
                 message: Message::System(SystemMessage::Credit { .. }), ..
             }])
         );
         assert_eq!(user_chain.execution_state.system.committees.get().len(), 1);
     }
     // Make the child receive the pending messages.
-    let certificate3 = make_certificate(
-        &committee,
-        &worker,
-        ConfirmedBlock::new(
-            BlockExecutionOutcome {
-                messages: vec![Vec::new(); 3],
-                previous_message_blocks: BTreeMap::new(),
-                events: vec![Vec::new(); 3],
-                blobs: vec![Vec::new(); 3],
-                state_hash: SystemExecutionState {
-                    // Finally the child knows about both committees and has the money.
-                    committees: committees2.clone(),
-                    ownership: ChainOwnership::single(key_pair.public().into()),
-                    balance: Amount::from_tokens(2),
-                    used_blobs: BTreeSet::from([committee_blob.id()]),
-                    ..SystemExecutionState::new(Epoch::from(1), user_description, admin_id)
-                }
-                .into_hash()
-                .await,
-                oracle_responses: vec![
-                    vec![],
-                    vec![],
-                    vec![
-                        OracleResponse::Event(
-                            EventId {
-                                chain_id: admin_id,
-                                stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
-                                index: 1,
-                            },
-                            bcs::to_bytes(&blob_hash).unwrap(),
-                        ),
-                        OracleResponse::Blob(committee_blob.id()),
-                    ],
-                ],
-                operation_results: vec![OperationResult::default()],
+    let certificate3 = env.make_certificate(ConfirmedBlock::new(
+        BlockExecutionOutcome {
+            messages: vec![Vec::new(); 2],
+            previous_message_blocks: BTreeMap::new(),
+            events: vec![Vec::new(); 2],
+            blobs: vec![Vec::new(); 2],
+            state_hash: SystemExecutionState {
+                // Finally the child knows about both committees and has the money.
+                committees: committees2.clone(),
+                balance: Amount::from_tokens(2),
+                used_blobs: BTreeSet::from([committee_blob.id()]),
+                epoch: Some(Epoch::from(1)),
+                ..SystemExecutionState::new(user_description)
             }
-            .with(
-                make_first_block(user_id)
-                    .with_incoming_bundle(IncomingBundle {
-                        origin: admin_id,
-                        bundle: MessageBundle {
-                            certificate_hash: certificate0.hash(),
-                            height: BlockHeight::from(0),
-                            timestamp: Timestamp::from(0),
-                            transaction_index: 0,
-                            messages: vec![Message::System(SystemMessage::OpenChain(Box::new(
-                                OpenChainConfig {
-                                    ownership: ChainOwnership::single(key_pair.public().into()),
-                                    epoch: Epoch::from(0),
-                                    committees: committees.clone(),
-                                    admin_id,
-                                    balance: Amount::ZERO,
-                                    application_permissions: Default::default(),
-                                },
-                            )))
-                            .to_posted(0, MessageKind::Protected)],
+            .into_hash()
+            .await,
+            oracle_responses: vec![
+                vec![],
+                vec![
+                    OracleResponse::Event(
+                        EventId {
+                            chain_id: admin_id,
+                            stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
+                            index: 1,
                         },
-                        action: MessageAction::Accept,
-                    })
-                    .with_incoming_bundle(IncomingBundle {
-                        origin: admin_id,
-                        bundle: MessageBundle {
-                            certificate_hash: certificate1.hash(),
-                            height: BlockHeight::from(1),
-                            timestamp: Timestamp::from(0),
-                            transaction_index: 1,
-                            messages: vec![system_credit_message(Amount::from_tokens(2))
-                                .to_posted(0, MessageKind::Tracked)],
-                        },
-                        action: MessageAction::Accept,
-                    })
-                    .with_operation(SystemOperation::ProcessNewEpoch(Epoch::from(1))),
-            ),
+                        bcs::to_bytes(&blob_hash).unwrap(),
+                    ),
+                    OracleResponse::Blob(committee_blob.id()),
+                ],
+            ],
+            operation_results: vec![OperationResult::default()],
+        }
+        .with(
+            make_first_block(user_id)
+                .with_incoming_bundle(IncomingBundle {
+                    origin: admin_id,
+                    bundle: MessageBundle {
+                        certificate_hash: certificate1.hash(),
+                        height: BlockHeight::from(1),
+                        timestamp: Timestamp::from(0),
+                        transaction_index: 1,
+                        messages: vec![system_credit_message(Amount::from_tokens(2))
+                            .to_posted(0, MessageKind::Tracked)],
+                    },
+                    action: MessageAction::Accept,
+                })
+                .with_operation(SystemOperation::ProcessNewEpoch(Epoch::from(1))),
         ),
-    );
-    worker
+    ));
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate3, &())
         .await?;
     {
-        let user_chain = worker.chain_state_view(user_id).await?;
+        let user_chain = env.worker().chain_state_view(user_id).await?;
         assert!(user_chain.is_active());
         assert_eq!(
             BlockHeight::from(1),
@@ -2614,50 +2480,40 @@ async fn test_transfers_and_committee_creation<B>(mut storage_builder: B) -> any
 where
     B: StorageBuilder,
 {
-    let owner0 = AccountSecretKey::generate().public().into();
     let owner1 = AccountSecretKey::generate().public().into();
     let storage = storage_builder.build().await?;
-    let (committee, worker) = init_worker_with_chains(
-        storage.clone(),
-        vec![
-            (ChainDescription::Root(0), owner0, Amount::ZERO),
-            (ChainDescription::Root(1), owner1, Amount::from_tokens(3)),
-        ],
-    )
-    .await;
+    let mut env = TestEnvironment::new(storage.clone(), false, false).await;
+    let chain_1_desc = env.add_root_chain(1, owner1, Amount::from_tokens(3)).await;
     let mut committees = BTreeMap::new();
+    let committee = env.committee().clone();
     committees.insert(Epoch::ZERO, committee.clone());
-    let admin_id = ChainId::root(0);
-    let user_id = ChainId::root(1);
+    let admin_id = env.admin_id();
+    let user_id = chain_1_desc.id();
 
     // Have the user chain start a transfer to the admin chain.
-    let certificate0 = make_certificate(
-        &committee,
-        &worker,
-        ConfirmedBlock::new(
-            BlockExecutionOutcome {
-                messages: vec![vec![direct_credit_message(admin_id, Amount::ONE)]],
-                previous_message_blocks: BTreeMap::new(),
-                events: vec![Vec::new()],
-                blobs: vec![Vec::new()],
-                state_hash: SystemExecutionState {
-                    committees: committees.clone(),
-                    ownership: ChainOwnership::single(owner1),
-                    balance: Amount::from_tokens(2),
-                    ..SystemExecutionState::new(Epoch::ZERO, ChainDescription::Root(1), admin_id)
-                }
-                .into_hash()
-                .await,
-                oracle_responses: vec![Vec::new()],
-                operation_results: vec![OperationResult::default()],
+    let certificate0 = env.make_certificate(ConfirmedBlock::new(
+        BlockExecutionOutcome {
+            messages: vec![vec![direct_credit_message(admin_id, Amount::ONE)]],
+            previous_message_blocks: BTreeMap::new(),
+            events: vec![Vec::new()],
+            blobs: vec![Vec::new()],
+            state_hash: SystemExecutionState {
+                committees: committees.clone(),
+                ownership: ChainOwnership::single(owner1),
+                balance: Amount::from_tokens(2),
+                ..SystemExecutionState::new(chain_1_desc.clone())
             }
-            .with(
-                make_first_block(user_id)
-                    .with_simple_transfer(admin_id, Amount::ONE)
-                    .with_authenticated_signer(Some(owner1)),
-            ),
+            .into_hash()
+            .await,
+            oracle_responses: vec![Vec::new()],
+            operation_results: vec![OperationResult::default()],
+        }
+        .with(
+            make_first_block(user_id)
+                .with_simple_transfer(admin_id, Amount::ONE)
+                .with_authenticated_signer(Some(owner1)),
         ),
-    );
+    ));
     // Have the admin chain create a new epoch without retiring the old one.
     let committees2 = BTreeMap::from_iter([
         (Epoch::ZERO, committee.clone()),
@@ -2666,51 +2522,48 @@ where
     let committee_blob = Blob::new(BlobContent::new_committee(bcs::to_bytes(&committee)?));
     let blob_hash = committee_blob.id().hash;
     storage.write_blob(&committee_blob).await?;
-    let certificate1 = make_certificate(
-        &committee,
-        &worker,
-        ConfirmedBlock::new(
-            BlockExecutionOutcome {
-                messages: vec![vec![]],
-                previous_message_blocks: BTreeMap::new(),
-                events: vec![vec![Event {
-                    stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
-                    index: 1,
-                    value: bcs::to_bytes(&committee_blob.id().hash).unwrap(),
-                }]],
-                blobs: vec![Vec::new()],
-                state_hash: SystemExecutionState {
-                    committees: committees2.clone(),
-                    ownership: ChainOwnership::single(owner0),
-                    used_blobs: BTreeSet::from([committee_blob.id()]),
-                    ..SystemExecutionState::new(Epoch::from(1), ChainDescription::Root(0), admin_id)
-                }
-                .into_hash()
-                .await,
-                oracle_responses: vec![vec![OracleResponse::Blob(committee_blob.id())]],
-                operation_results: vec![OperationResult::default()],
+    let certificate1 = env.make_certificate(ConfirmedBlock::new(
+        BlockExecutionOutcome {
+            messages: vec![vec![]],
+            previous_message_blocks: BTreeMap::new(),
+            events: vec![vec![Event {
+                stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
+                index: 1,
+                value: bcs::to_bytes(&committee_blob.id().hash).unwrap(),
+            }]],
+            blobs: vec![Vec::new()],
+            state_hash: SystemExecutionState {
+                committees: committees2.clone(),
+                used_blobs: BTreeSet::from([committee_blob.id()]),
+                admin_id: Some(admin_id),
+                epoch: Some(Epoch::from(1)),
+                ..SystemExecutionState::new(env.admin_description.clone())
             }
-            .with(
-                make_first_block(admin_id).with_operation(SystemOperation::Admin(
-                    AdminOperation::CreateCommittee {
-                        epoch: Epoch::from(1),
-                        blob_hash,
-                    },
-                )),
-            ),
+            .into_hash()
+            .await,
+            oracle_responses: vec![vec![OracleResponse::Blob(committee_blob.id())]],
+            operation_results: vec![OperationResult::default()],
+        }
+        .with(
+            make_first_block(admin_id).with_operation(SystemOperation::Admin(
+                AdminOperation::CreateCommittee {
+                    epoch: Epoch::from(1),
+                    blob_hash,
+                },
+            )),
         ),
-    );
-    worker
+    ));
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate1.clone(), &())
         .await?;
 
     // Try to execute the transfer.
-    worker
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate0.clone(), &())
         .await?;
 
     // The transfer was started..
-    let user_chain = worker.chain_state_view(user_id).await?;
+    let user_chain = env.worker().chain_state_view(user_id).await?;
     assert!(user_chain.is_active());
     assert_eq!(
         BlockHeight::from(1),
@@ -2726,7 +2579,7 @@ where
     );
 
     // .. and the message has gone through.
-    let admin_chain = worker.chain_state_view(admin_id).await?;
+    let admin_chain = env.worker().chain_state_view(admin_id).await?;
     assert!(admin_chain.is_active());
     assert_eq!(admin_chain.inboxes.indices().await?.len(), 1);
     matches!(
@@ -2755,110 +2608,98 @@ async fn test_transfers_and_committee_removal<B>(mut storage_builder: B) -> anyh
 where
     B: StorageBuilder,
 {
-    let owner0 = AccountSecretKey::generate().public().into();
-    let owner1 = AccountSecretKey::generate().public().into();
     let storage = storage_builder.build().await?;
-    let (committee, worker) = init_worker_with_chains(
-        storage.clone(),
-        vec![
-            (ChainDescription::Root(0), owner0, Amount::ZERO),
-            (ChainDescription::Root(1), owner1, Amount::from_tokens(3)),
-        ],
-    )
-    .await;
+    let mut env =
+        TestEnvironment::new_with_amount(storage.clone(), false, false, Amount::ZERO).await;
+    let owner1 = AccountSecretKey::generate().public().into();
+    let chain_1_desc = env.add_root_chain(1, owner1, Amount::from_tokens(3)).await;
     let mut committees = BTreeMap::new();
+    let committee = env.committee().clone();
     committees.insert(Epoch::ZERO, committee.clone());
-    let admin_id = ChainId::root(0);
-    let user_id = ChainId::root(1);
+    let admin_id = env.admin_id();
+    let user_id = chain_1_desc.id();
 
     // Have the user chain start a transfer to the admin chain.
-    let certificate0 = make_certificate(
-        &committee,
-        &worker,
-        ConfirmedBlock::new(
-            BlockExecutionOutcome {
-                messages: vec![vec![direct_credit_message(admin_id, Amount::ONE)]],
-                previous_message_blocks: BTreeMap::new(),
-                events: vec![Vec::new()],
-                blobs: vec![Vec::new()],
-                state_hash: SystemExecutionState {
-                    committees: committees.clone(),
-                    ownership: ChainOwnership::single(owner1),
-                    balance: Amount::from_tokens(2),
-                    ..SystemExecutionState::new(Epoch::ZERO, ChainDescription::Root(1), admin_id)
-                }
-                .into_hash()
-                .await,
-                oracle_responses: vec![Vec::new()],
-                operation_results: vec![OperationResult::default()],
+    let certificate0 = env.make_certificate(ConfirmedBlock::new(
+        BlockExecutionOutcome {
+            messages: vec![vec![direct_credit_message(admin_id, Amount::ONE)]],
+            previous_message_blocks: BTreeMap::new(),
+            events: vec![Vec::new()],
+            blobs: vec![Vec::new()],
+            state_hash: SystemExecutionState {
+                balance: Amount::from_tokens(2),
+                ..SystemExecutionState::new(chain_1_desc.clone())
             }
-            .with(
-                make_first_block(user_id)
-                    .with_simple_transfer(admin_id, Amount::ONE)
-                    .with_authenticated_signer(Some(owner1)),
-            ),
+            .into_hash()
+            .await,
+            oracle_responses: vec![Vec::new()],
+            operation_results: vec![OperationResult::default()],
+        }
+        .with(
+            make_first_block(user_id)
+                .with_simple_transfer(admin_id, Amount::ONE)
+                .with_authenticated_signer(Some(owner1)),
         ),
-    );
+    ));
     // Have the admin chain create a new epoch and retire the old one immediately.
     let committees3 = BTreeMap::from_iter([(Epoch::from(1), committee.clone())]);
     let committee_blob = Blob::new(BlobContent::new_committee(bcs::to_bytes(&committee)?));
     let blob_hash = committee_blob.id().hash;
     storage.write_blob(&committee_blob).await?;
-    let certificate1 = make_certificate(
-        &committee,
-        &worker,
-        ConfirmedBlock::new(
-            BlockExecutionOutcome {
-                messages: vec![vec![]; 2],
-                previous_message_blocks: BTreeMap::new(),
-                events: vec![
-                    vec![Event {
-                        stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
-                        index: 1,
-                        value: bcs::to_bytes(&committee_blob.id().hash).unwrap(),
-                    }],
-                    vec![Event {
-                        stream_id: StreamId::system(REMOVED_EPOCH_STREAM_NAME),
-                        index: 0,
-                        value: Vec::new(),
-                    }],
-                ],
-                blobs: vec![Vec::new(); 2],
-                state_hash: SystemExecutionState {
-                    committees: committees3.clone(),
-                    ownership: ChainOwnership::single(owner0),
-                    used_blobs: BTreeSet::from([committee_blob.id()]),
-                    ..SystemExecutionState::new(Epoch::from(1), ChainDescription::Root(0), admin_id)
-                }
-                .into_hash()
-                .await,
-                oracle_responses: vec![vec![OracleResponse::Blob(committee_blob.id())], vec![]],
-                operation_results: vec![OperationResult::default(); 2],
+
+    let certificate1 = env.make_certificate(ConfirmedBlock::new(
+        BlockExecutionOutcome {
+            messages: vec![vec![]; 2],
+            previous_message_blocks: BTreeMap::new(),
+            events: vec![
+                vec![Event {
+                    stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
+                    index: 1,
+                    value: bcs::to_bytes(&committee_blob.id().hash).unwrap(),
+                }],
+                vec![Event {
+                    stream_id: StreamId::system(REMOVED_EPOCH_STREAM_NAME),
+                    index: 0,
+                    value: Vec::new(),
+                }],
+            ],
+            blobs: vec![Vec::new(); 2],
+            state_hash: SystemExecutionState {
+                committees: committees3.clone(),
+                used_blobs: BTreeSet::from([committee_blob.id()]),
+                epoch: Some(Epoch::from(1)),
+                admin_id: Some(admin_id),
+                ..SystemExecutionState::new(env.admin_description.clone())
             }
-            .with(
-                make_first_block(admin_id)
-                    .with_operation(SystemOperation::Admin(AdminOperation::CreateCommittee {
-                        epoch: Epoch::from(1),
-                        blob_hash,
-                    }))
-                    .with_operation(SystemOperation::Admin(AdminOperation::RemoveCommittee {
-                        epoch: Epoch::ZERO,
-                    })),
-            ),
+            .into_hash()
+            .await,
+            oracle_responses: vec![vec![OracleResponse::Blob(committee_blob.id())], vec![]],
+            operation_results: vec![OperationResult::default(); 2],
+        }
+        .with(
+            make_first_block(admin_id)
+                .with_operation(SystemOperation::Admin(AdminOperation::CreateCommittee {
+                    epoch: Epoch::from(1),
+                    blob_hash,
+                }))
+                .with_operation(SystemOperation::Admin(AdminOperation::RemoveCommittee {
+                    epoch: Epoch::ZERO,
+                })),
         ),
-    );
-    worker
+    ));
+
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate1.clone(), &())
         .await?;
 
     // Try to execute the transfer from the user chain to the admin chain.
-    worker
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate0.clone(), &())
         .await?;
 
     {
         // The transfer was started..
-        let user_chain = worker.chain_state_view(user_id).await?;
+        let user_chain = env.worker().chain_state_view(user_id).await?;
         assert!(user_chain.is_active());
         assert_eq!(
             BlockHeight::from(1),
@@ -2874,58 +2715,56 @@ where
         );
 
         // .. but the message hasn't gone through.
-        let admin_chain = worker.chain_state_view(admin_id).await?;
+        let admin_chain = env.worker().chain_state_view(admin_id).await?;
         assert!(admin_chain.is_active());
         assert!(admin_chain.inboxes.indices().await?.is_empty());
     }
 
     // Force the admin chain to receive the money nonetheless by anticipation.
-    let certificate2 = make_certificate(
-        &committee,
-        &worker,
-        ConfirmedBlock::new(
-            BlockExecutionOutcome {
-                messages: vec![Vec::new()],
-                previous_message_blocks: BTreeMap::new(),
-                events: vec![Vec::new()],
-                blobs: vec![Vec::new()],
-                state_hash: SystemExecutionState {
-                    committees: committees3.clone(),
-                    ownership: ChainOwnership::single(owner0),
-                    balance: Amount::ONE,
-                    used_blobs: BTreeSet::from([committee_blob.id()]),
-                    ..SystemExecutionState::new(Epoch::from(1), ChainDescription::Root(0), admin_id)
-                }
-                .into_hash()
-                .await,
-                oracle_responses: vec![Vec::new()],
-                operation_results: vec![],
+    let certificate2 = env.make_certificate(ConfirmedBlock::new(
+        BlockExecutionOutcome {
+            messages: vec![Vec::new()],
+            previous_message_blocks: BTreeMap::new(),
+            events: vec![Vec::new()],
+            blobs: vec![Vec::new()],
+            state_hash: SystemExecutionState {
+                committees: committees3.clone(),
+                balance: Amount::ONE,
+                used_blobs: BTreeSet::from([committee_blob.id()]),
+                admin_id: Some(admin_id),
+                epoch: Some(Epoch::from(1)),
+                ..SystemExecutionState::new(env.admin_description.clone())
             }
-            .with(
-                make_child_block(&certificate1.into_value())
-                    .with_epoch(1)
-                    .with_incoming_bundle(IncomingBundle {
-                        origin: user_id,
-                        bundle: MessageBundle {
-                            certificate_hash: certificate0.hash(),
-                            height: BlockHeight::ZERO,
-                            timestamp: Timestamp::from(0),
-                            transaction_index: 0,
-                            messages: vec![system_credit_message(Amount::ONE)
-                                .to_posted(0, MessageKind::Tracked)],
-                        },
-                        action: MessageAction::Accept,
-                    }),
-            ),
+            .into_hash()
+            .await,
+            oracle_responses: vec![Vec::new()],
+            operation_results: vec![],
+        }
+        .with(
+            make_child_block(&certificate1.into_value())
+                .with_epoch(1)
+                .with_incoming_bundle(IncomingBundle {
+                    origin: user_id,
+                    bundle: MessageBundle {
+                        certificate_hash: certificate0.hash(),
+                        height: BlockHeight::ZERO,
+                        timestamp: Timestamp::from(0),
+                        transaction_index: 0,
+                        messages: vec![
+                            system_credit_message(Amount::ONE).to_posted(0, MessageKind::Tracked)
+                        ],
+                    },
+                    action: MessageAction::Accept,
+                }),
         ),
-    );
-    worker
+    ));
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate2.clone(), &())
         .await?;
 
     {
         // The admin chain has an anticipated message.
-        let admin_chain = worker.chain_state_view(admin_id).await?;
+        let admin_chain = env.worker().chain_state_view(admin_id).await?;
         assert!(admin_chain.is_active());
         assert_matches!(
             admin_chain.validate_incoming_bundles().await,
@@ -2935,13 +2774,13 @@ where
 
     // Try again to execute the transfer from the user chain to the admin chain.
     // This time, the epoch verification should be overruled.
-    worker
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate0.clone(), &())
         .await?;
 
     {
         // The admin chain has no more anticipated messages.
-        let admin_chain = worker.chain_state_view(admin_id).await?;
+        let admin_chain = env.worker().chain_state_view(admin_id).await?;
         assert!(admin_chain.is_active());
         admin_chain.validate_incoming_bundles().await?;
     }
@@ -2950,7 +2789,6 @@ where
 
 #[test(tokio::test)]
 async fn test_cross_chain_helper() -> anyhow::Result<()> {
-    // Make a committee and worker (only used for signing certificates)
     let store_config = MemoryStore::new_test_config().await?;
     let namespace = generate_test_namespace();
     let store = DbStorage::<MemoryStore, _>::new_for_testing(
@@ -2960,78 +2798,77 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
         TestClock::new(),
     )
     .await?;
-    let (committee, worker) = init_worker(store, true, false);
-    let committees = BTreeMap::from_iter([(Epoch::from(1), committee.clone())]);
+    let env = TestEnvironment::new(store, true, false).await;
+    let committees = BTreeMap::from([(Epoch::from(1), env.committee().clone())]);
+
+    let chain_0 = env.admin_description.clone();
+    let chain_1 = dummy_chain_description(1);
 
     let key_pair0 = AccountSecretKey::generate();
-    let id0 = ChainId::root(0);
-    let id1 = ChainId::root(1);
+    let id0 = chain_0.id();
+    let id1 = chain_1.id();
 
-    let certificate0 = make_transfer_certificate_for_epoch(
-        ChainDescription::Root(0),
-        &key_pair0,
-        Some(key_pair0.public().into()),
-        AccountOwner::CHAIN,
-        Recipient::chain(id1),
-        Amount::ONE,
-        Vec::new(),
-        Epoch::ZERO,
-        &committee,
-        Amount::ONE,
-        BTreeMap::new(),
-        &worker,
-        None,
-    )
-    .await;
-    let certificate1 = make_transfer_certificate_for_epoch(
-        ChainDescription::Root(0),
-        &key_pair0,
-        Some(key_pair0.public().into()),
-        AccountOwner::CHAIN,
-        Recipient::chain(id1),
-        Amount::ONE,
-        Vec::new(),
-        Epoch::ZERO,
-        &committee,
-        Amount::ONE,
-        BTreeMap::new(),
-        &worker,
-        Some(&certificate0),
-    )
-    .await;
-    let certificate2 = make_transfer_certificate_for_epoch(
-        ChainDescription::Root(0),
-        &key_pair0,
-        Some(key_pair0.public().into()),
-        AccountOwner::CHAIN,
-        Recipient::chain(id1),
-        Amount::ONE,
-        Vec::new(),
-        Epoch::from(1),
-        &committee,
-        Amount::ONE,
-        BTreeMap::new(),
-        &worker,
-        Some(&certificate1),
-    )
-    .await;
+    let certificate0 = env
+        .make_transfer_certificate_for_epoch(
+            chain_0.clone(),
+            &key_pair0,
+            Some(key_pair0.public().into()),
+            AccountOwner::CHAIN,
+            Recipient::chain(id1),
+            Amount::ONE,
+            Vec::new(),
+            Epoch::ZERO,
+            Amount::ONE,
+            BTreeMap::new(),
+            None,
+        )
+        .await;
+    let certificate1 = env
+        .make_transfer_certificate_for_epoch(
+            chain_0.clone(),
+            &key_pair0,
+            Some(key_pair0.public().into()),
+            AccountOwner::CHAIN,
+            Recipient::chain(id1),
+            Amount::ONE,
+            Vec::new(),
+            Epoch::ZERO,
+            Amount::ONE,
+            BTreeMap::new(),
+            Some(&certificate0),
+        )
+        .await;
+    let certificate2 = env
+        .make_transfer_certificate_for_epoch(
+            chain_0.clone(),
+            &key_pair0,
+            Some(key_pair0.public().into()),
+            AccountOwner::CHAIN,
+            Recipient::chain(id1),
+            Amount::ONE,
+            Vec::new(),
+            Epoch::from(1),
+            Amount::ONE,
+            BTreeMap::new(),
+            Some(&certificate1),
+        )
+        .await;
     // Weird case: epoch going backward.
-    let certificate3 = make_transfer_certificate_for_epoch(
-        ChainDescription::Root(0),
-        &key_pair0,
-        Some(key_pair0.public().into()),
-        AccountOwner::CHAIN,
-        Recipient::chain(id1),
-        Amount::ONE,
-        Vec::new(),
-        Epoch::ZERO,
-        &committee,
-        Amount::ONE,
-        BTreeMap::new(),
-        &worker,
-        Some(&certificate2),
-    )
-    .await;
+    let certificate3 = env
+        .make_transfer_certificate_for_epoch(
+            chain_0.clone(),
+            &key_pair0,
+            Some(key_pair0.public().into()),
+            AccountOwner::CHAIN,
+            Recipient::chain(id1),
+            Amount::ONE,
+            Vec::new(),
+            Epoch::ZERO,
+            Amount::ONE,
+            BTreeMap::new(),
+            Some(&certificate2),
+        )
+        .await;
     let bundles0 = certificate0.message_bundles_for(id1).collect::<Vec<_>>();
     let bundles1 = certificate1.message_bundles_for(id1).collect::<Vec<_>>();
     let bundles2 = certificate2.message_bundles_for(id1).collect::<Vec<_>>();
@@ -3135,15 +2972,15 @@ where
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
-    let chain_id = ChainId::root(0);
     let key_pairs = generate_key_pairs(2);
     let owner0 = AccountOwner::from(key_pairs[0].public());
     let owner1 = AccountOwner::from(key_pairs[1].public());
-    let balances = vec![(ChainDescription::Root(0), owner0, Amount::from_tokens(2))];
-    let (committee, worker) = init_worker_with_chains(storage, balances).await;
+    let mut env = TestEnvironment::new(storage, false, false).await;
+    let chain_1_desc = env.add_root_chain(1, owner0, Amount::from_tokens(2)).await;
+    let chain_1 = chain_1_desc.id();
 
     // Add another owner and use the leader-based protocol in all rounds.
-    let proposed_block0 = make_first_block(chain_id)
+    let proposed_block0 = make_first_block(chain_1)
         .with_operation(SystemOperation::ChangeOwnership {
             super_owners: Vec::new(),
             owners: vec![(owner0, 100), (owner1, 100)],
@@ -3152,12 +2989,14 @@ where
             timeout_config: TimeoutConfig::default(),
         })
         .with_authenticated_signer(Some(owner0));
-    let (block0, _) = worker
+    let (block0, _) = env
+        .worker()
         .stage_block_execution(proposed_block0, None, vec![])
         .await?;
     let value0 = ConfirmedBlock::new(block0);
-    let certificate0 = make_certificate(&committee, &worker, value0.clone());
-    let response = worker
+    let certificate0 = env.make_certificate(value0.clone());
+    let response = env
+        .worker()
         .fully_handle_certificate_with_notifications(certificate0, &())
         .await?;
 
@@ -3167,28 +3006,28 @@ where
     // So owner 0 cannot propose a block in this round. And the next round hasn't started yet.
     let proposal = make_child_block(&value0.clone())
         .into_proposal_with_round(&key_pairs[0], Round::SingleLeader(0));
-    let result = worker.handle_block_proposal(proposal).await;
+    let result = env.worker().handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::InvalidOwner));
     let proposal = make_child_block(&value0.clone())
         .into_proposal_with_round(&key_pairs[0], Round::SingleLeader(1));
-    let result = worker.handle_block_proposal(proposal).await;
+    let result = env.worker().handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::ChainError(ref error))
         if matches!(**error, ChainError::WrongRound(Round::SingleLeader(0)))
     );
 
     // The round hasn't timed out yet, so the validator won't sign a leader timeout vote yet.
-    let query = ChainInfoQuery::new(chain_id).with_timeout();
-    let (response, _) = worker.handle_chain_info_query(query).await?;
+    let query = ChainInfoQuery::new(chain_1).with_timeout();
+    let (response, _) = env.worker().handle_chain_info_query(query).await?;
     assert!(response.info.manager.timeout_vote.is_none());
 
     // Set the clock to the end of the round.
     clock.set(response.info.manager.round_timeout.unwrap());
 
     // Now the validator will sign a leader timeout vote.
-    let query = ChainInfoQuery::new(chain_id).with_timeout();
-    let (response, _) = worker.handle_chain_info_query(query).await?;
+    let query = ChainInfoQuery::new(chain_1).with_timeout();
+    let (response, _) = env.worker().handle_chain_info_query(query).await?;
     let vote = response.info.manager.timeout_vote.clone().unwrap();
-    let value_timeout = Timeout::new(chain_id, BlockHeight::from(1), Epoch::from(0));
+    let value_timeout = Timeout::new(chain_1, BlockHeight::from(1), Epoch::from(0));
 
     // Once we provide the validator with a timeout certificate, the next round starts, where owner
     // 0 happens to be the leader.
@@ -3196,32 +3035,38 @@ where
         .with_value(value_timeout.clone())
         .unwrap()
         .into_certificate();
-    let (response, _) = worker
+    let (response, _) = env
+        .worker()
         .handle_timeout_certificate(certificate_timeout)
         .await?;
     assert_eq!(response.info.manager.leader, Some(owner0));
 
     // Now owner 0 can propose a block, but owner 1 can't.
     let proposed_block1 = make_child_block(&value0.clone());
-    let (block1, _) = worker
+    let (block1, _) = env
+        .worker()
         .stage_block_execution(proposed_block1.clone(), None, vec![])
         .await?;
     let proposal1_wrong_owner = proposed_block1
         .clone()
         .with_authenticated_signer(Some(owner1))
         .into_proposal_with_round(&key_pairs[1], Round::SingleLeader(1));
-    let result = worker.handle_block_proposal(proposal1_wrong_owner).await;
+    let result = env
+        .worker()
+        .handle_block_proposal(proposal1_wrong_owner)
+        .await;
     assert_matches!(result, Err(WorkerError::InvalidOwner));
     let proposal1 = proposed_block1
         .clone()
         .into_proposal_with_round(&key_pairs[0], Round::SingleLeader(1));
-    let (response, _) = worker.handle_block_proposal(proposal1).await?;
+    let (response, _) = env.worker().handle_block_proposal(proposal1).await?;
     let value1 = ValidatedBlock::new(block1.clone());
 
     // If we send the validated block certificate to the worker, it votes to confirm.
     let vote = response.info.manager.pending.clone().unwrap();
     let certificate1 = vote.with_value(value1.clone()).unwrap().into_certificate();
-    let (response, _) = worker
+    let (response, _) = env
+        .worker()
         .handle_validated_certificate(certificate1.clone())
         .await?;
     let vote = response.info.manager.pending.as_ref().unwrap();
@@ -3229,13 +3074,10 @@ where
     assert_eq!(vote.value, LiteValue::new(&value));
 
     // Instead of submitting the confirmed block certificate, let rounds 2 to 4 time out, too.
-    let certificate_timeout = make_certificate_with_round(
-        &committee,
-        &worker,
-        value_timeout.clone(),
-        Round::SingleLeader(4),
-    );
-    let (response, _) = worker
+    let certificate_timeout =
+        env.make_certificate_with_round(value_timeout.clone(), Round::SingleLeader(4));
+    let (response, _) = env
+        .worker()
         .handle_timeout_certificate(certificate_timeout)
         .await?;
     assert_eq!(response.info.manager.leader, Some(owner1));
@@ -3243,19 +3085,23 @@ where
 
     // Create block2, also at height 1, but different from block 1.
     let amount = Amount::from_tokens(1);
-    let proposed_block2 =
-        make_child_block(&value0.clone()).with_simple_transfer(ChainId::root(1), amount);
-    let (block2, _) = worker
+    let proposed_block2 = make_child_block(&value0.clone()).with_simple_transfer(chain_1, amount);
+    let (block2, _) = env
+        .worker()
         .stage_block_execution(proposed_block2.clone(), None, vec![])
         .await?;
 
     // Since round 3 is already over, the validator won't vote for a validated block from round 3.
     let value2 = ValidatedBlock::new(block2.clone());
-    let certificate =
-        make_certificate_with_round(&committee, &worker, value2.clone(), Round::SingleLeader(2));
-    worker.handle_validated_certificate(certificate).await?;
-    let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
-    let (response, _) = worker.handle_chain_info_query(query_values.clone()).await?;
+    let certificate = env.make_certificate_with_round(value2.clone(), Round::SingleLeader(2));
+    env.worker()
+        .handle_validated_certificate(certificate)
+        .await?;
+    let query_values = ChainInfoQuery::new(chain_1).with_manager_values();
+    let (response, _) = env
+        .worker()
+        .handle_chain_info_query(query_values.clone())
+        .await?;
     let manager = response.info.manager;
     assert_eq!(
         manager.requested_confirmed.unwrap().block(),
@@ -3267,19 +3113,21 @@ where
         .clone()
         .with_authenticated_signer(Some(owner1))
         .into_proposal_with_round(&key_pairs[1], Round::SingleLeader(5));
-    let result = worker.handle_block_proposal(proposal.clone()).await;
+    let result = env.worker().handle_block_proposal(proposal.clone()).await;
     assert_matches!(result, Err(WorkerError::ChainError(error))
          if matches!(*error, ChainError::HasIncompatibleConfirmedVote(_, _))
     );
 
     // But with the validated block certificate for block2, it is allowed.
-    let certificate2 =
-        make_certificate_with_round(&committee, &worker, value2.clone(), Round::SingleLeader(4));
+    let certificate2 = env.make_certificate_with_round(value2.clone(), Round::SingleLeader(4));
     let proposal =
         BlockProposal::new_retry(Round::SingleLeader(5), certificate2.clone(), &key_pairs[1]);
     let lite_value2 = LiteValue::new(&value2);
-    let (_, _) = worker.handle_block_proposal(proposal).await?;
-    let (response, _) = worker.handle_chain_info_query(query_values.clone()).await?;
+    let (_, _) = env.worker().handle_block_proposal(proposal).await?;
+    let (response, _) = env
+        .worker()
+        .handle_chain_info_query(query_values.clone())
+        .await?;
     assert_eq!(
         response.info.manager.requested_locking,
         Some(Box::new(LockingBlock::Regular(certificate2)))
@@ -3289,13 +3137,10 @@ where
     assert_eq!(vote.round, Round::SingleLeader(5));
 
     // Let round 5 time out, too.
-    let certificate_timeout = make_certificate_with_round(
-        &committee,
-        &worker,
-        value_timeout.clone(),
-        Round::SingleLeader(5),
-    );
-    let (response, _) = worker
+    let certificate_timeout =
+        env.make_certificate_with_round(value_timeout.clone(), Round::SingleLeader(5));
+    let (response, _) = env
+        .worker()
         .handle_timeout_certificate(certificate_timeout)
         .await?;
     assert_eq!(response.info.manager.leader, Some(owner0));
@@ -3303,23 +3148,23 @@ where
 
     // Since the validator now voted for block2, it can't vote for block1 anymore.
     let proposal = proposed_block1.into_proposal_with_round(&key_pairs[0], Round::SingleLeader(6));
-    let result = worker.handle_block_proposal(proposal.clone()).await;
+    let result = env.worker().handle_block_proposal(proposal.clone()).await;
     assert_matches!(result, Err(WorkerError::ChainError(error))
          if matches!(*error, ChainError::HasIncompatibleConfirmedVote(_, _))
     );
 
     // Let rounds 6 and 7 time out.
     let certificate_timeout =
-        make_certificate_with_round(&committee, &worker, value_timeout, Round::SingleLeader(7));
-    let (response, _) = worker
+        env.make_certificate_with_round(value_timeout, Round::SingleLeader(7));
+    let (response, _) = env
+        .worker()
         .handle_timeout_certificate(certificate_timeout)
         .await?;
     assert_eq!(response.info.manager.current_round, Round::SingleLeader(8));
 
     // The worker updates its locking block even if it's from a past round.
-    let certificate =
-        make_certificate_with_round(&committee, &worker, value1, Round::SingleLeader(7));
-    let worker = worker.with_key_pair(None).await; // Forget validator keys.
+    let certificate = env.make_certificate_with_round(value1, Round::SingleLeader(7));
+    let worker = env.worker().clone().with_key_pair(None).await; // Forget validator keys.
     worker
         .handle_validated_certificate(certificate.clone())
         .await?;
@@ -3342,12 +3187,12 @@ where
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
-    let chain_id = ChainId::root(0);
     let key_pairs = generate_key_pairs(2);
     let owner0 = AccountOwner::from(key_pairs[0].public());
     let owner1 = AccountOwner::from(key_pairs[1].public());
-    let balances = vec![(ChainDescription::Root(0), owner0, Amount::from_tokens(2))];
-    let (committee, worker) = init_worker_with_chains(storage, balances).await;
+    let mut env = TestEnvironment::new(storage, false, false).await;
+    let chain_1_desc = env.add_root_chain(1, owner0, Amount::from_tokens(2)).await;
+    let chain_id = chain_1_desc.id();
 
     // Add another owner and configure two multi-leader rounds.
     let proposed_block0 =
@@ -3361,12 +3206,14 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (block0, _) = worker
+    let (block0, _) = env
+        .worker()
         .stage_block_execution(proposed_block0, None, vec![])
         .await?;
     let value0 = ConfirmedBlock::new(block0);
-    let certificate0 = make_certificate(&committee, &worker, value0.clone());
-    let response = worker
+    let certificate0 = env.make_certificate(value0.clone());
+    let response = env
+        .worker()
         .fully_handle_certificate_with_notifications(certificate0, &())
         .await?;
 
@@ -3376,18 +3223,18 @@ where
 
     // So owner 1 cannot propose a block in this round. And the next round hasn't started yet.
     let proposal = make_child_block(&value0).into_proposal_with_round(&key_pairs[1], Round::Fast);
-    let result = worker.handle_block_proposal(proposal).await;
+    let result = env.worker().handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::InvalidOwner));
     let proposal =
         make_child_block(&value0).into_proposal_with_round(&key_pairs[1], Round::MultiLeader(0));
-    let result = worker.handle_block_proposal(proposal).await;
+    let result = env.worker().handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::ChainError(ref error))
         if matches!(**error, ChainError::WrongRound(Round::Fast))
     );
 
     // The round hasn't timed out yet, so the validator won't sign a leader timeout vote yet.
     let query = ChainInfoQuery::new(chain_id).with_timeout();
-    let (response, _) = worker.handle_chain_info_query(query).await?;
+    let (response, _) = env.worker().handle_chain_info_query(query).await?;
     assert!(response.info.manager.timeout_vote.is_none());
 
     // Set the clock to the end of the round.
@@ -3395,7 +3242,7 @@ where
 
     // Now the validator will sign a leader timeout vote.
     let query = ChainInfoQuery::new(chain_id).with_timeout();
-    let (response, _) = worker.handle_chain_info_query(query).await?;
+    let (response, _) = env.worker().handle_chain_info_query(query).await?;
     let vote = response.info.manager.timeout_vote.clone().unwrap();
     let value_timeout = Timeout::new(chain_id, BlockHeight::from(1), Epoch::from(0));
 
@@ -3404,7 +3251,8 @@ where
         .with_value(value_timeout.clone())
         .unwrap()
         .into_certificate();
-    let (response, _) = worker
+    let (response, _) = env
+        .worker()
         .handle_timeout_certificate(certificate_timeout)
         .await?;
     assert_eq!(response.info.manager.current_round, Round::MultiLeader(0));
@@ -3416,9 +3264,9 @@ where
         .clone()
         .with_authenticated_signer(Some(owner1))
         .into_proposal_with_round(&key_pairs[1], Round::MultiLeader(1));
-    let _ = worker.handle_block_proposal(proposal1).await?;
+    let _ = env.worker().handle_block_proposal(proposal1).await?;
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
-    let (response, _) = worker.handle_chain_info_query(query_values).await?;
+    let (response, _) = env.worker().handle_chain_info_query(query_values).await?;
     assert_eq!(response.info.manager.current_round, Round::MultiLeader(1));
     Ok(())
 }
@@ -3433,12 +3281,11 @@ where
     B: StorageBuilder,
 {
     let storage = storage_builder.build().await?;
-    let chain_id = ChainId::root(0);
     let key_pair = AccountSecretKey::generate();
     let owner = key_pair.public().into();
-    let description = ChainDescription::Root(0);
-    let (committee, worker) =
-        init_worker_with_chain(storage, description, owner, Amount::from_tokens(2)).await;
+    let mut env = TestEnvironment::new(storage, false, false).await;
+    let chain_1_desc = env.add_root_chain(1, owner, Amount::from_tokens(2)).await;
+    let chain_id = chain_1_desc.id();
 
     // Configure open multi-leader rounds.
     let change_ownership_block =
@@ -3452,13 +3299,13 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (change_ownership_block, _) = worker
+    let (change_ownership_block, _) = env
+        .worker()
         .stage_block_execution(change_ownership_block, None, vec![])
         .await?;
     let change_ownership_value = ConfirmedBlock::new(change_ownership_block);
-    let change_ownership_certificate =
-        make_certificate(&committee, &worker, change_ownership_value.clone());
-    worker
+    let change_ownership_certificate = env.make_certificate(change_ownership_value.clone());
+    env.worker()
         .fully_handle_certificate_with_notifications(change_ownership_certificate, &())
         .await?;
 
@@ -3467,7 +3314,7 @@ where
     let proposal = make_child_block(&change_ownership_value)
         .with_transfer(AccountOwner::CHAIN, Recipient::Burn, Amount::from_tokens(1))
         .into_proposal_with_round(&AccountSecretKey::generate(), Round::MultiLeader(0));
-    let result = worker.handle_block_proposal(proposal).await;
+    let result = env.worker().handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::ChainError(error)) if matches!(&*error,
         ChainError::ExecutionError(error, _) if matches!(&**error,
         ExecutionError::UnauthenticatedTransferOwner
@@ -3476,11 +3323,12 @@ where
     // Without the transfer, a random key pair can propose a block.
     let proposal = make_child_block(&change_ownership_value)
         .into_proposal_with_round(&AccountSecretKey::generate(), Round::MultiLeader(0));
-    let (block, _) = worker
+    let (block, _) = env
+        .worker()
         .stage_block_execution(proposal.content.block.clone(), None, vec![])
         .await?;
     let value = ConfirmedBlock::new(block);
-    let (response, _) = worker.handle_block_proposal(proposal).await?;
+    let (response, _) = env.worker().handle_block_proposal(proposal).await?;
     let vote = response.info.manager.pending.unwrap();
     assert_eq!(vote.round, Round::MultiLeader(0));
     assert_eq!(vote.value.value_hash, value.hash());
@@ -3498,12 +3346,12 @@ where
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
-    let chain_id = ChainId::root(0);
     let key_pairs = generate_key_pairs(2);
     let owner0 = AccountOwner::from(key_pairs[0].public());
     let owner1 = AccountOwner::from(key_pairs[1].public());
-    let balances = vec![(ChainDescription::Root(0), owner0, Amount::from_tokens(2))];
-    let (committee, worker) = init_worker_with_chains(storage, balances).await;
+    let mut env = TestEnvironment::new(storage, false, false).await;
+    let chain_1_desc = env.add_root_chain(1, owner0, Amount::from_tokens(2)).await;
+    let chain_id = chain_1_desc.id();
 
     // Add another owner and configure two multi-leader rounds.
     let proposed_block0 =
@@ -3517,12 +3365,14 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (block0, _) = worker
+    let (block0, _) = env
+        .worker()
         .stage_block_execution(proposed_block0, None, vec![])
         .await?;
     let value0 = ConfirmedBlock::new(block0);
-    let certificate0 = make_certificate(&committee, &worker, value0.clone());
-    let response = worker
+    let certificate0 = env.make_certificate(value0.clone());
+    let response = env
+        .worker()
         .fully_handle_certificate_with_notifications(certificate0, &())
         .await?;
 
@@ -3535,11 +3385,12 @@ where
     let proposal1 = proposed_block1
         .clone()
         .into_proposal_with_round(&key_pairs[0], Round::Fast);
-    let (block1, _) = worker
+    let (block1, _) = env
+        .worker()
         .stage_block_execution(proposed_block1.clone(), None, vec![])
         .await?;
     let value1 = ConfirmedBlock::new(block1);
-    let (response, _) = worker.handle_block_proposal(proposal1).await?;
+    let (response, _) = env.worker().handle_block_proposal(proposal1).await?;
     let vote = response.info.manager.pending.as_ref().unwrap();
     assert_eq!(vote.round, Round::Fast);
     assert_eq!(vote.value.value_hash, value1.hash());
@@ -3549,9 +3400,9 @@ where
 
     // Once we provide the validator with a timeout certificate, the next round starts.
     let value_timeout = Timeout::new(chain_id, BlockHeight::from(1), Epoch::from(0));
-    let certificate_timeout =
-        make_certificate_with_round(&committee, &worker, value_timeout.clone(), Round::Fast);
-    let (response, _) = worker
+    let certificate_timeout = env.make_certificate_with_round(value_timeout.clone(), Round::Fast);
+    let (response, _) = env
+        .worker()
         .handle_timeout_certificate(certificate_timeout)
         .await?;
     assert_eq!(response.info.manager.current_round, Round::MultiLeader(0));
@@ -3561,40 +3412,40 @@ where
     let proposal1b = proposed_block1
         .clone()
         .into_proposal_with_round(&key_pairs[1], Round::MultiLeader(0));
-    let (response, _) = worker.handle_block_proposal(proposal1b).await?;
+    let (response, _) = env.worker().handle_block_proposal(proposal1b).await?;
     let vote = response.info.manager.pending.as_ref().unwrap();
     assert_eq!(vote.round, Round::MultiLeader(0));
     assert_eq!(vote.value.value_hash, value1.hash());
 
     // Proposing a different block is not.
     let proposed_block2 = make_child_block(&value0)
-        .with_simple_transfer(ChainId::root(1), Amount::ONE)
+        .with_simple_transfer(chain_id, Amount::ONE)
         .with_authenticated_signer(Some(owner1));
     let proposal2 = proposed_block2
         .clone()
         .into_proposal_with_round(&key_pairs[1], Round::MultiLeader(1));
-    let result = worker.handle_block_proposal(proposal2).await;
+    let result = env.worker().handle_block_proposal(proposal2).await;
     assert_matches!(result, Err(WorkerError::ChainError(err))
         if matches!(*err, ChainError::HasIncompatibleConfirmedVote(_, Round::Fast))
     );
     let proposal3 = proposed_block1
         .clone()
         .into_proposal_with_round(&key_pairs[1], Round::MultiLeader(2));
-    worker.handle_block_proposal(proposal3).await?;
+    env.worker().handle_block_proposal(proposal3).await?;
 
     // A validated block certificate from a later round can override the locked fast block.
-    let (block2, _) = worker
+    let (block2, _) = env
+        .worker()
         .stage_block_execution(proposed_block2.clone(), None, vec![])
         .await?;
     let value2 = ValidatedBlock::new(block2.clone());
-    let certificate2 =
-        make_certificate_with_round(&committee, &worker, value2.clone(), Round::MultiLeader(0));
+    let certificate2 = env.make_certificate_with_round(value2.clone(), Round::MultiLeader(0));
     let proposal =
         BlockProposal::new_retry(Round::MultiLeader(3), certificate2.clone(), &key_pairs[1]);
     let lite_value2 = LiteValue::new(&value2);
-    let (_, _) = worker.handle_block_proposal(proposal).await?;
+    let (_, _) = env.worker().handle_block_proposal(proposal).await?;
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
-    let (response, _) = worker.handle_chain_info_query(query_values).await?;
+    let (response, _) = env.worker().handle_chain_info_query(query_values).await?;
     assert_eq!(
         response.info.manager.requested_locking,
         Some(Box::new(LockingBlock::Regular(certificate2)))
@@ -3616,17 +3467,19 @@ where
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
-    let chain_id = ChainId::root(1);
     let key_pair = AccountSecretKey::generate();
+    let mut env = TestEnvironment::new(storage, false, false).await;
     let balance = Amount::from_tokens(5);
-    let balances = vec![(ChainDescription::Root(1), key_pair.public().into(), balance)];
-    let (committee, worker) = init_worker_with_chains(storage, balances).await;
+    let chain_1_desc = env
+        .add_root_chain(1, key_pair.public().into(), balance)
+        .await;
+    let chain_id = chain_1_desc.id();
 
     // At time 0 we don't vote for fallback mode.
     let query = ChainInfoQuery::new(chain_id)
         .with_fallback()
         .with_committees();
-    let (response, _) = worker.handle_chain_info_query(query.clone()).await?;
+    let (response, _) = env.worker().handle_chain_info_query(query.clone()).await?;
     let manager = response.info.manager;
     assert!(manager.fallback_vote.is_none());
     assert_eq!(manager.current_round, Round::MultiLeader(0));
@@ -3635,39 +3488,40 @@ where
 
     // Even if a long time passes: Without an incoming message there's no fallback mode.
     clock.add(fallback_duration);
-    let (response, _) = worker.handle_chain_info_query(query.clone()).await?;
+    let (response, _) = env.worker().handle_chain_info_query(query.clone()).await?;
     assert!(response.info.manager.fallback_vote.is_none());
 
     // Make a tracked message to ourselves. It's in the inbox now.
     let proposed_block = make_first_block(chain_id)
         .with_simple_transfer(chain_id, Amount::ONE)
         .with_authenticated_signer(Some(key_pair.public().into()));
-    let (block, _) = worker
+    let (block, _) = env
+        .worker()
         .stage_block_execution(proposed_block, None, vec![])
         .await?;
     let value = ConfirmedBlock::new(block);
-    let certificate = make_certificate(&committee, &worker, value);
-    worker
+    let certificate = env.make_certificate(value);
+    env.worker()
         .fully_handle_certificate_with_notifications(certificate, &())
         .await?;
 
     // The message only just arrived: No fallback mode.
-    let (response, _) = worker.handle_chain_info_query(query.clone()).await?;
+    let (response, _) = env.worker().handle_chain_info_query(query.clone()).await?;
     assert!(response.info.manager.fallback_vote.is_none());
 
     // If for a long time the message isn't handled, we vote for fallback mode.
     clock.add(fallback_duration);
-    let (response, _) = worker.handle_chain_info_query(query.clone()).await?;
+    let (response, _) = env.worker().handle_chain_info_query(query.clone()).await?;
     let vote = response.info.manager.fallback_vote.unwrap();
     let value = Timeout::new(chain_id, BlockHeight(1), Epoch::ZERO);
     let round = Round::SingleLeader(u32::MAX);
     assert_eq!(vote.value.value_hash, value.hash());
     assert_eq!(vote.round, round);
-    let certificate = make_certificate_with_round(&committee, &worker, value, round);
-    worker.handle_timeout_certificate(certificate).await?;
+    let certificate = env.make_certificate_with_round(value, round);
+    env.worker().handle_timeout_certificate(certificate).await?;
 
     // Now we are in fallback mode, and the validator is the leader.
-    let (response, _) = worker.handle_chain_info_query(query.clone()).await?;
+    let (response, _) = env.worker().handle_chain_info_query(query.clone()).await?;
     let manager = response.info.manager;
     let expected_key = response
         .info
@@ -3702,32 +3556,19 @@ where
 
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
-    let chain_description = ChainDescription::Root(1);
-    let chain_id = ChainId::from(chain_description);
-    let key_pair = AccountSecretKey::generate();
-    let balance = Amount::ZERO;
-
-    let (committee, worker) = init_worker(
-        storage.clone(),
-        /* is_client */ false,
-        /* has_long_lived_services */ true,
-    );
-    worker
-        .storage
-        .create_chain(
-            committee,
-            ChainId::root(0),
-            chain_description,
-            key_pair.public().into(),
-            balance,
-            Timestamp::from(0),
+    let mut env = TestEnvironment::new(storage, false, true).await;
+    let chain_description = env
+        .add_root_chain(
+            1,
+            AccountSecretKey::generate().public().into(),
+            Amount::from_tokens(2),
         )
-        .await
-        .unwrap();
+        .await;
+    let chain_id = chain_description.id();
 
     let (application_id, application);
     {
-        let mut chain = storage.load_chain(chain_id).await?;
+        let mut chain = env.worker().storage.load_chain(chain_id).await?;
         (application_id, application, _) =
             chain.execution_state.register_mock_application(0).await?;
         chain.save().await?;
@@ -3755,7 +3596,9 @@ where
         clock.set(query_time);
 
         assert_eq!(
-            worker.query_application(chain_id, query.clone()).await?,
+            env.worker()
+                .query_application(chain_id, query.clone())
+                .await?,
             QueryOutcome {
                 response: QueryResponse::User(vec![]),
                 operations: vec![],
@@ -3763,7 +3606,7 @@ where
         );
     }
 
-    drop(worker);
+    drop(env);
     linera_base::time::timer::sleep(Duration::from_millis(10)).await;
     application.assert_no_more_expected_calls();
     application.assert_no_active_instances();
@@ -3789,28 +3632,14 @@ where
 
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
-    let chain_description = ChainDescription::Root(1);
-    let chain_id = ChainId::from(chain_description);
     let key_pair = AccountSecretKey::generate();
     let balance = Amount::ZERO;
 
-    let (committee, worker) = init_worker(
-        storage.clone(),
-        /* is_client */ false,
-        /* has_long_lived_services */ true,
-    );
-    worker
-        .storage
-        .create_chain(
-            committee.clone(),
-            ChainId::root(0),
-            chain_description,
-            key_pair.public().into(),
-            balance,
-            Timestamp::from(0),
-        )
-        .await
-        .unwrap();
+    let mut env = TestEnvironment::new(storage.clone(), false, true).await;
+    let chain_description = env
+        .add_root_chain(1, key_pair.public().into(), balance)
+        .await;
+    let chain_id = chain_description.id();
 
     let (application_id, application);
     {
@@ -3863,7 +3692,9 @@ where
         clock.set(local_time);
 
         assert_eq!(
-            worker.query_application(chain_id, query.clone()).await?,
+            env.worker()
+                .query_application(chain_id, query.clone())
+                .await?,
             QueryOutcome {
                 response: QueryResponse::User(vec![]),
                 operations: vec![],
@@ -3875,13 +3706,15 @@ where
     let block = make_first_block(chain_id).with_timestamp(Timestamp::from(BLOCK_TIMESTAMP));
 
     let block_proposal = block.clone().into_first_proposal(&key_pair);
-    let _ = worker.handle_block_proposal(block_proposal).await?;
+    let _ = env.worker().handle_block_proposal(block_proposal).await?;
 
     for local_time in queries_before_confirmation {
         clock.set(local_time);
 
         assert_eq!(
-            worker.query_application(chain_id, query.clone()).await?,
+            env.worker()
+                .query_application(chain_id, query.clone())
+                .await?,
             QueryOutcome {
                 response: QueryResponse::User(vec![]),
                 operations: vec![],
@@ -3889,14 +3722,9 @@ where
         );
     }
 
-    let epoch = Epoch::ZERO;
-    let admin_id = ChainId::root(0);
     let mut state = SystemExecutionState {
-        committees: BTreeMap::from_iter([(epoch, committee.clone())]),
-        ownership: ChainOwnership::single(key_pair.public().into()),
-        balance,
         timestamp: Timestamp::from(BLOCK_TIMESTAMP),
-        ..SystemExecutionState::new(epoch, chain_description, admin_id)
+        ..SystemExecutionState::new(chain_description)
     }
     .into_view()
     .await;
@@ -3914,8 +3742,8 @@ where
         }
         .with(block),
     );
-    let certificate = make_certificate(&committee, &worker, value);
-    worker
+    let certificate = env.make_certificate(value);
+    env.worker()
         .handle_confirmed_certificate(certificate, None)
         .await?;
 
@@ -3930,7 +3758,9 @@ where
         clock.set(local_time);
 
         assert_eq!(
-            worker.query_application(chain_id, query.clone()).await?,
+            env.worker()
+                .query_application(chain_id, query.clone())
+                .await?,
             QueryOutcome {
                 response: QueryResponse::User(vec![]),
                 operations: vec![],
@@ -3938,7 +3768,7 @@ where
         );
     }
 
-    drop(worker);
+    drop(env);
     linera_base::time::timer::sleep(Duration::from_millis(10)).await;
     application.assert_no_more_expected_calls();
     application.assert_no_active_instances();

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -125,7 +125,7 @@ where
         )]);
 
         let origin = ChainOrigin::Root(0);
-        let config = OpenChainConfig {
+        let config = InitialChainConfig {
             admin_id: None,
             balance: amount,
             ownership: ChainOwnership::single(account_secret.public().into()),
@@ -181,7 +181,7 @@ where
         balance: Amount,
     ) -> ChainDescription {
         let origin = ChainOrigin::Root(index);
-        let config = OpenChainConfig {
+        let config = InitialChainConfig {
             admin_id: Some(self.admin_id()),
             epoch: self.admin_description.config().epoch,
             ownership: ChainOwnership::single(owner),
@@ -211,7 +211,7 @@ where
             block_height: BlockHeight(0),
             chain_index: 0,
         };
-        let config = OpenChainConfig {
+        let config = InitialChainConfig {
             admin_id: Some(self.admin_id()),
             epoch: self.admin_description.config().epoch,
             ownership: ChainOwnership::single(owner),
@@ -2286,7 +2286,7 @@ where
         }
         .with(
             make_first_block(admin_id)
-                .with_operation(SystemOperation::OpenChain(OpenChainConfig {
+                .with_operation(SystemOperation::OpenChain(InitialChainConfig {
                     ownership: ChainOwnership::single(env.admin_public_key().into()),
                     epoch: Epoch::ZERO,
                     committees: serialize_committees(committees.clone()),

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -42,7 +42,7 @@ use linera_chain::{
 use linera_execution::{
     committee::Committee,
     system::{
-        AdminOperation, Recipient, SystemMessage, SystemOperation,
+        AdminOperation, OpenChainConfig, Recipient, SystemMessage, SystemOperation,
         EPOCH_STREAM_NAME as NEW_EPOCH_STREAM_NAME, REMOVED_EPOCH_STREAM_NAME,
     },
     test_utils::{
@@ -2286,11 +2286,8 @@ where
         }
         .with(
             make_first_block(admin_id)
-                .with_operation(SystemOperation::OpenChain(InitialChainConfig {
+                .with_operation(SystemOperation::OpenChain(OpenChainConfig {
                     ownership: ChainOwnership::single(env.admin_public_key().into()),
-                    epoch: Epoch::ZERO,
-                    committees: serialize_committees(committees.clone()),
-                    admin_id: Some(admin_id),
                     balance: Amount::ZERO,
                     application_permissions: Default::default(),
                 }))

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -207,6 +207,12 @@ impl std::str::FromStr for ValidatorName {
     }
 }
 
+impl From<ValidatorPublicKey> for ValidatorName {
+    fn from(value: ValidatorPublicKey) -> Self {
+        Self(value)
+    }
+}
+
 impl Committee {
     pub fn new(
         validators: BTreeMap<ValidatorPublicKey, ValidatorState>,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -35,7 +35,7 @@ use crate::{
     ApplicationId, ContractSyncRuntime, ExecutionError, ExecutionRuntimeConfig,
     ExecutionRuntimeContext, Message, MessageContext, MessageKind, Operation, OperationContext,
     OutgoingMessage, ProcessStreamsContext, Query, QueryContext, QueryOutcome, ServiceSyncRuntime,
-    SystemMessage, TransactionTracker,
+    SystemMessage, Timestamp, TransactionTracker,
 };
 
 /// A view accessing the execution state of a chain.
@@ -80,11 +80,13 @@ where
             authenticated_caller_id: None,
             height: application_description.block_height,
             round: None,
+            timestamp: local_time,
         };
 
         let action = UserAction::Instantiate(context, instantiation_argument);
         let next_message_index = 0;
         let next_application_index = application_description.application_index + 1;
+        let next_chain_index = 0;
 
         let application_id = From::from(&application_description);
         let blob = Blob::new_application_description(&application_description);
@@ -119,6 +121,7 @@ where
             0,
             next_message_index,
             next_application_index,
+            next_chain_index,
             None,
         );
         txn_tracker.add_created_blob(blob);
@@ -168,6 +171,15 @@ impl UserAction {
             UserAction::Operation(context, _) => context.round,
             UserAction::ProcessStreams(context, _) => context.round,
             UserAction::Message(context, _) => context.round,
+        }
+    }
+
+    pub(crate) fn timestamp(&self) -> Timestamp {
+        match self {
+            UserAction::Instantiate(context, _) => context.timestamp,
+            UserAction::Operation(context, _) => context.timestamp,
+            UserAction::ProcessStreams(context, _) => context.timestamp,
+            UserAction::Message(context, _) => context.timestamp,
         }
     }
 }

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -16,8 +16,8 @@ use linera_base::prometheus_util::{
 };
 use linera_base::{
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, BlobContent, BlockHeight, OpenChainConfig,
-        Timestamp,
+        Amount, ApplicationPermissions, ArithmeticError, BlobContent, BlockHeight,
+        InitialChainConfig, Timestamp,
     },
     ensure, hex_debug, hex_vec_debug, http,
     identifiers::{Account, AccountOwner, BlobId, BlobType, ChainId, EventId, StreamId},
@@ -298,7 +298,7 @@ where
                 mut txn_tracker,
             } => {
                 let inactive_err = || ExecutionError::InactiveChain;
-                let config = OpenChainConfig {
+                let config = InitialChainConfig {
                     ownership,
                     admin_id: Some(self.system.admin_id.get().ok_or_else(inactive_err)?),
                     epoch: self.system.epoch.get().ok_or_else(inactive_err)?,

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -16,10 +16,11 @@ use linera_base::prometheus_util::{
 };
 use linera_base::{
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, BlobContent, BlockHeight, Timestamp,
+        Amount, ApplicationPermissions, ArithmeticError, BlobContent, BlockHeight, OpenChainConfig,
+        Timestamp,
     },
     ensure, hex_debug, hex_vec_debug, http,
-    identifiers::{Account, AccountOwner, BlobId, BlobType, ChainId, EventId, MessageId, StreamId},
+    identifiers::{Account, AccountOwner, BlobId, BlobType, ChainId, EventId, StreamId},
     ownership::ChainOwnership,
 };
 use linera_views::{batch::Batch, context::Context, views::View};
@@ -29,7 +30,7 @@ use prometheus::HistogramVec;
 use reqwest::{header::HeaderMap, Client, Url};
 
 use crate::{
-    system::{CreateApplicationResult, OpenChainConfig, Recipient},
+    system::{CreateApplicationResult, Recipient},
     util::RespondExt,
     ApplicationDescription, ApplicationId, ExecutionError, ExecutionRuntimeContext,
     ExecutionStateView, ModuleId, OutgoingMessage, ResourceController, TransactionTracker,
@@ -289,20 +290,27 @@ where
             OpenChain {
                 ownership,
                 balance,
-                next_message_id,
+                parent_id,
+                block_height,
                 application_permissions,
+                timestamp,
                 callback,
+                mut txn_tracker,
             } => {
                 let inactive_err = || ExecutionError::InactiveChain;
                 let config = OpenChainConfig {
                     ownership,
-                    admin_id: self.system.admin_id.get().ok_or_else(inactive_err)?,
+                    admin_id: Some(self.system.admin_id.get().ok_or_else(inactive_err)?),
                     epoch: self.system.epoch.get().ok_or_else(inactive_err)?,
-                    committees: self.system.committees.get().clone(),
+                    committees: self.system.get_committees(),
                     balance,
                     application_permissions,
                 };
-                callback.respond(self.system.open_chain(config, next_message_id).await?);
+                let chain_id = self
+                    .system
+                    .open_chain(config, parent_id, block_height, timestamp, &mut txn_tracker)
+                    .await?;
+                callback.respond((chain_id, txn_tracker));
             }
 
             CloseChain {
@@ -697,10 +705,14 @@ pub enum ExecutionRequest {
         ownership: ChainOwnership,
         #[debug(skip_if = Amount::is_zero)]
         balance: Amount,
-        next_message_id: MessageId,
+        parent_id: ChainId,
+        block_height: BlockHeight,
         application_permissions: ApplicationPermissions,
+        timestamp: Timestamp,
         #[debug(skip)]
-        callback: Sender<OutgoingMessage>,
+        txn_tracker: TransactionTracker,
+        #[debug(skip)]
+        callback: Sender<(ChainId, TransactionTracker)>,
     },
 
     CloseChain {

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -16,8 +16,7 @@ use linera_base::prometheus_util::{
 };
 use linera_base::{
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, BlobContent, BlockHeight,
-        InitialChainConfig, Timestamp,
+        Amount, ApplicationPermissions, ArithmeticError, BlobContent, BlockHeight, Timestamp,
     },
     ensure, hex_debug, hex_vec_debug, http,
     identifiers::{Account, AccountOwner, BlobId, BlobType, ChainId, EventId, StreamId},
@@ -30,7 +29,7 @@ use prometheus::HistogramVec;
 use reqwest::{header::HeaderMap, Client, Url};
 
 use crate::{
-    system::{CreateApplicationResult, Recipient},
+    system::{CreateApplicationResult, OpenChainConfig, Recipient},
     util::RespondExt,
     ApplicationDescription, ApplicationId, ExecutionError, ExecutionRuntimeContext,
     ExecutionStateView, ModuleId, OutgoingMessage, ResourceController, TransactionTracker,
@@ -297,12 +296,8 @@ where
                 callback,
                 mut txn_tracker,
             } => {
-                let inactive_err = || ExecutionError::InactiveChain;
-                let config = InitialChainConfig {
+                let config = OpenChainConfig {
                     ownership,
-                    admin_id: Some(self.system.admin_id.get().ok_or_else(inactive_err)?),
-                    epoch: self.system.epoch.get().ok_or_else(inactive_err)?,
-                    committees: self.system.get_committees(),
                     balance,
                     application_permissions,
                 };

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -5,9 +5,9 @@ use std::collections::BTreeMap;
 
 use linera_base::{
     crypto::ValidatorPublicKey,
-    data_types::{Amount, Epoch, Timestamp},
+    data_types::{Amount, ChainDescription, Epoch, Timestamp},
     doc_scalar,
-    identifiers::{AccountOwner, ChainDescription, ChainId},
+    identifiers::{AccountOwner, ChainId},
     ownership::ChainOwnership,
 };
 use linera_views::{context::Context, map_view::MapView};

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -397,7 +397,10 @@ impl ResourceControlPolicy {
                     ExecutionError::BytecodeTooLarge
                 );
             }
-            BlobType::Data | BlobType::ApplicationDescription | BlobType::Committee => {}
+            BlobType::Data
+            | BlobType::ApplicationDescription
+            | BlobType::Committee
+            | BlobType::ChainDescription => {}
         }
         Ok(())
     }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -43,8 +43,25 @@ use crate::{
 #[path = "unit_tests/runtime_tests.rs"]
 mod tests;
 
+pub trait WithContext {
+    type UserContext;
+}
+
+impl WithContext for UserContractInstance {
+    type UserContext = Timestamp;
+}
+
+impl WithContext for UserServiceInstance {
+    type UserContext = ();
+}
+
+#[cfg(test)]
+impl WithContext for Arc<dyn std::any::Any + Send + Sync> {
+    type UserContext = ();
+}
+
 #[derive(Debug)]
-pub struct SyncRuntime<UserInstance>(Option<SyncRuntimeHandle<UserInstance>>);
+pub struct SyncRuntime<UserInstance: WithContext>(Option<SyncRuntimeHandle<UserInstance>>);
 
 pub type ContractSyncRuntime = SyncRuntime<UserContractInstance>;
 
@@ -54,14 +71,16 @@ pub struct ServiceSyncRuntime {
 }
 
 #[derive(Debug)]
-pub struct SyncRuntimeHandle<UserInstance>(Arc<Mutex<SyncRuntimeInternal<UserInstance>>>);
+pub struct SyncRuntimeHandle<UserInstance: WithContext>(
+    Arc<Mutex<SyncRuntimeInternal<UserInstance>>>,
+);
 
 pub type ContractSyncRuntimeHandle = SyncRuntimeHandle<UserContractInstance>;
 pub type ServiceSyncRuntimeHandle = SyncRuntimeHandle<UserServiceInstance>;
 
 /// Runtime data tracked during the execution of a transaction on the synchronous thread.
 #[derive(Debug)]
-pub struct SyncRuntimeInternal<UserInstance> {
+pub struct SyncRuntimeInternal<UserInstance: WithContext> {
     /// The current chain ID.
     chain_id: ChainId,
     /// The height of the next block that will be added to this chain. During operations
@@ -110,6 +129,8 @@ pub struct SyncRuntimeInternal<UserInstance> {
     refund_grant_to: Option<Account>,
     /// Controller to track fuel and storage consumption.
     resource_controller: ResourceController,
+    /// Additional context for the runtime.
+    user_context: UserInstance::UserContext,
 }
 
 /// The runtime status of an application.
@@ -257,7 +278,7 @@ impl ViewUserState {
     }
 }
 
-impl<UserInstance> Deref for SyncRuntime<UserInstance> {
+impl<UserInstance: WithContext> Deref for SyncRuntime<UserInstance> {
     type Target = SyncRuntimeHandle<UserInstance>;
 
     fn deref(&self) -> &Self::Target {
@@ -267,7 +288,7 @@ impl<UserInstance> Deref for SyncRuntime<UserInstance> {
     }
 }
 
-impl<UserInstance> DerefMut for SyncRuntime<UserInstance> {
+impl<UserInstance: WithContext> DerefMut for SyncRuntime<UserInstance> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.as_mut().expect(
             "`SyncRuntime` should not be used after its `inner` contents have been moved out",
@@ -275,7 +296,7 @@ impl<UserInstance> DerefMut for SyncRuntime<UserInstance> {
     }
 }
 
-impl<UserInstance> Drop for SyncRuntime<UserInstance> {
+impl<UserInstance: WithContext> Drop for SyncRuntime<UserInstance> {
     fn drop(&mut self) {
         // Ensure the `loaded_applications` are cleared to prevent circular references in
         // the runtime
@@ -285,7 +306,7 @@ impl<UserInstance> Drop for SyncRuntime<UserInstance> {
     }
 }
 
-impl<UserInstance> SyncRuntimeInternal<UserInstance> {
+impl<UserInstance: WithContext> SyncRuntimeInternal<UserInstance> {
     #[expect(clippy::too_many_arguments)]
     fn new(
         chain_id: ChainId,
@@ -298,6 +319,7 @@ impl<UserInstance> SyncRuntimeInternal<UserInstance> {
         refund_grant_to: Option<Account>,
         resource_controller: ResourceController,
         transaction_tracker: TransactionTracker,
+        user_context: UserInstance::UserContext,
     ) -> Self {
         Self {
             chain_id,
@@ -317,6 +339,7 @@ impl<UserInstance> SyncRuntimeInternal<UserInstance> {
             resource_controller,
             transaction_tracker,
             scheduled_operations: Vec::new(),
+            user_context,
         }
     }
 
@@ -441,12 +464,14 @@ impl SyncRuntimeInternal<UserContractInstance> {
             _ => None,
         };
         let authenticated_caller_id = authenticated.then_some(caller_id);
+        let timestamp = self.user_context;
         let callee_context = OperationContext {
             chain_id: self.chain_id,
             authenticated_signer,
             authenticated_caller_id,
             height: self.height,
             round: self.round,
+            timestamp,
         };
         self.push_application(ApplicationStatus {
             caller_id: authenticated_caller_id,
@@ -548,7 +573,7 @@ impl SyncRuntimeInternal<UserServiceInstance> {
     }
 }
 
-impl<UserInstance> SyncRuntime<UserInstance> {
+impl<UserInstance: WithContext> SyncRuntime<UserInstance> {
     fn into_inner(mut self) -> Option<SyncRuntimeInternal<UserInstance>> {
         let handle = self.0.take().expect(
             "`SyncRuntime` should not be used after its `inner` contents have been moved out",
@@ -560,13 +585,15 @@ impl<UserInstance> SyncRuntime<UserInstance> {
     }
 }
 
-impl<UserInstance> From<SyncRuntimeInternal<UserInstance>> for SyncRuntimeHandle<UserInstance> {
+impl<UserInstance: WithContext> From<SyncRuntimeInternal<UserInstance>>
+    for SyncRuntimeHandle<UserInstance>
+{
     fn from(runtime: SyncRuntimeInternal<UserInstance>) -> Self {
         SyncRuntimeHandle(Arc::new(Mutex::new(runtime)))
     }
 }
 
-impl<UserInstance> SyncRuntimeHandle<UserInstance> {
+impl<UserInstance: WithContext> SyncRuntimeHandle<UserInstance> {
     fn inner(&self) -> std::sync::MutexGuard<'_, SyncRuntimeInternal<UserInstance>> {
         self.0
             .try_lock()
@@ -574,7 +601,7 @@ impl<UserInstance> SyncRuntimeHandle<UserInstance> {
     }
 }
 
-impl<UserInstance> BaseRuntime for SyncRuntimeHandle<UserInstance>
+impl<UserInstance: WithContext> BaseRuntime for SyncRuntimeHandle<UserInstance>
 where
     Self: ContractOrServiceRuntime,
 {
@@ -941,7 +968,7 @@ impl ContractOrServiceRuntime for ServiceSyncRuntimeHandle {
     const LIMIT_HTTP_RESPONSE_SIZE_TO_ORACLE_RESPONSE_SIZE: bool = false;
 }
 
-impl<UserInstance> Clone for SyncRuntimeHandle<UserInstance> {
+impl<UserInstance: WithContext> Clone for SyncRuntimeHandle<UserInstance> {
     fn clone(&self) -> Self {
         SyncRuntimeHandle(self.0.clone())
     }
@@ -972,6 +999,7 @@ impl ContractSyncRuntime {
                 refund_grant_to,
                 resource_controller,
                 txn_tracker,
+                action.timestamp(),
             ),
         )))
     }
@@ -1431,27 +1459,31 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
         balance: Amount,
-    ) -> Result<(MessageId, ChainId), ExecutionError> {
-        let mut this = self.inner();
-        let message_id = MessageId {
-            chain_id: this.chain_id,
-            height: this.height,
-            index: this.transaction_tracker.next_message_index(),
-        };
-        let chain_id = ChainId::child(message_id);
-        let open_chain_message = this
+    ) -> Result<ChainId, ExecutionError> {
+        let parent_id = self.inner().chain_id;
+        let block_height = self.block_height()?;
+
+        let txn_tracker_moved = mem::take(&mut self.inner().transaction_tracker);
+        let timestamp = self.inner().user_context;
+
+        let (chain_id, txn_tracker_moved) = self
+            .inner()
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::OpenChain {
                 ownership,
                 balance,
-                next_message_id: message_id,
+                parent_id,
+                block_height,
+                timestamp,
                 application_permissions,
                 callback,
+                txn_tracker: txn_tracker_moved,
             })?
             .recv_response()?;
-        this.transaction_tracker
-            .add_outgoing_message(open_chain_message)?;
-        Ok((message_id, chain_id))
+
+        self.inner().transaction_tracker = txn_tracker_moved;
+
+        Ok(chain_id)
     }
 
     fn close_chain(&mut self) -> Result<(), ExecutionError> {
@@ -1590,6 +1622,7 @@ impl ServiceSyncRuntime {
                 None,
                 ResourceController::default(),
                 txn_tracker,
+                (),
             )
             .into(),
         ));

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -18,7 +18,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight,
-        ChainDescription, ChainOrigin, Epoch, OpenChainConfig, OracleResponse, Timestamp,
+        ChainDescription, ChainOrigin, Epoch, InitialChainConfig, OracleResponse, Timestamp,
     },
     ensure, hex_debug,
     identifiers::{Account, AccountOwner, BlobId, BlobType, ChainId, EventId, ModuleId, StreamId},
@@ -121,7 +121,7 @@ pub enum SystemOperation {
     },
     /// Creates (or activates) a new chain.
     /// This will automatically subscribe to the future committees created by `admin_id`.
-    OpenChain(OpenChainConfig),
+    OpenChain(InitialChainConfig),
     /// Closes the chain.
     CloseChain,
     /// Changes the ownership of the chain.
@@ -723,7 +723,7 @@ where
             .read_blob_content(BlobId::new(chain_id.0, BlobType::ChainDescription))
             .await?;
         let description: ChainDescription = bcs::from_bytes(description_blob.bytes())?;
-        let OpenChainConfig {
+        let InitialChainConfig {
             ownership,
             admin_id,
             epoch,
@@ -770,7 +770,7 @@ where
     /// from this chain's.
     pub async fn open_chain(
         &mut self,
-        config: OpenChainConfig,
+        config: InitialChainConfig,
         parent: ChainId,
         block_height: BlockHeight,
         timestamp: Timestamp,

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -13,9 +13,13 @@ mod system_execution_state;
 use std::{collections::BTreeMap, sync::Arc, thread, vec};
 
 use linera_base::{
-    crypto::{BcsSignable, CryptoHash},
-    data_types::{Amount, Blob, BlockHeight, CompressedBytecode, OracleResponse, Timestamp},
+    crypto::{AccountPublicKey, BcsSignable, CryptoHash, ValidatorPublicKey},
+    data_types::{
+        Amount, Blob, BlockHeight, ChainDescription, ChainOrigin, CompressedBytecode, Epoch,
+        OpenChainConfig, OracleResponse, Timestamp,
+    },
     identifiers::{AccountOwner, ApplicationId, BlobId, BlobType, ChainId, MessageId, ModuleId},
+    ownership::ChainOwnership,
     vm::VmRuntime,
 };
 use linera_views::{
@@ -30,16 +34,63 @@ pub use self::{
     system_execution_state::SystemExecutionState,
 };
 use crate::{
-    ApplicationDescription, ExecutionRequest, ExecutionRuntimeContext, ExecutionStateView,
-    MessageContext, OperationContext, QueryContext, ServiceRuntimeEndpoint, ServiceRuntimeRequest,
-    ServiceSyncRuntime, SystemExecutionStateView, TestExecutionRuntimeContext,
+    committee::Committee, ApplicationDescription, ExecutionRequest, ExecutionRuntimeContext,
+    ExecutionStateView, MessageContext, OperationContext, QueryContext, ServiceRuntimeEndpoint,
+    ServiceRuntimeRequest, ServiceSyncRuntime, SystemExecutionStateView,
+    TestExecutionRuntimeContext,
 };
+
+pub fn dummy_chain_description_with_ownership_and_balance(
+    index: u32,
+    ownership: ChainOwnership,
+    balance: Amount,
+) -> ChainDescription {
+    let committee = Committee::make_simple(vec![(
+        ValidatorPublicKey::test_key(index as u8),
+        AccountPublicKey::test_key(2 * (index % 128) as u8),
+    )]);
+    let committees = BTreeMap::from([(
+        Epoch::ZERO,
+        bcs::to_bytes(&committee).expect("serializing a committee shouldn't fail"),
+    )]);
+    let origin = ChainOrigin::Root(index);
+    let config = OpenChainConfig {
+        admin_id: if index == 0 {
+            None
+        } else {
+            Some(
+                dummy_chain_description_with_ownership_and_balance(0, ownership.clone(), balance)
+                    .id(),
+            )
+        },
+        application_permissions: Default::default(),
+        balance,
+        committees,
+        epoch: Epoch::ZERO,
+        ownership,
+    };
+    ChainDescription::new(origin, config, Timestamp::default())
+}
+
+pub fn dummy_chain_description_with_owner(index: u32, owner: AccountOwner) -> ChainDescription {
+    dummy_chain_description_with_ownership_and_balance(
+        index,
+        ChainOwnership::single(owner),
+        Amount::MAX,
+    )
+}
+
+pub fn dummy_chain_description(index: u32) -> ChainDescription {
+    let chain_key = AccountPublicKey::test_key(2 * (index % 128) as u8 + 1);
+    let ownership = ChainOwnership::single(chain_key.into());
+    dummy_chain_description_with_ownership_and_balance(index, ownership, Amount::MAX)
+}
 
 /// Creates a dummy [`ApplicationDescription`] for use in tests.
 pub fn create_dummy_user_application_description(
     index: u32,
 ) -> (ApplicationDescription, Blob, Blob) {
-    let chain_id = ChainId::root(1);
+    let chain_id = dummy_chain_description(1).id();
     let mut contract_bytes = b"contract".to_vec();
     let mut service_bytes = b"service".to_vec();
     contract_bytes.push(index as u8);
@@ -67,37 +118,42 @@ pub fn create_dummy_user_application_description(
 }
 
 /// Creates a dummy [`OperationContext`] to use in tests.
-pub fn create_dummy_operation_context() -> OperationContext {
+pub fn create_dummy_operation_context(chain_id: ChainId) -> OperationContext {
     OperationContext {
-        chain_id: ChainId::root(0),
+        chain_id,
         height: BlockHeight(0),
         round: Some(0),
         authenticated_signer: None,
         authenticated_caller_id: None,
+        timestamp: Default::default(),
     }
 }
 
 /// Creates a dummy [`MessageContext`] to use in tests.
-pub fn create_dummy_message_context(authenticated_signer: Option<AccountOwner>) -> MessageContext {
+pub fn create_dummy_message_context(
+    chain_id: ChainId,
+    authenticated_signer: Option<AccountOwner>,
+) -> MessageContext {
     MessageContext {
-        chain_id: ChainId::root(0),
+        chain_id,
         is_bouncing: false,
         authenticated_signer,
         refund_grant_to: None,
         height: BlockHeight(0),
         round: Some(0),
         message_id: MessageId {
-            chain_id: ChainId::root(0),
+            chain_id,
             height: BlockHeight(0),
             index: 0,
         },
+        timestamp: Default::default(),
     }
 }
 
 /// Creates a dummy [`QueryContext`] to use in tests.
 pub fn create_dummy_query_context() -> QueryContext {
     QueryContext {
-        chain_id: ChainId::root(0),
+        chain_id: dummy_chain_description(0).id(),
         next_block_height: BlockHeight(0),
         local_time: Timestamp::from(0),
     }
@@ -169,7 +225,7 @@ where
     C::Extra: ExecutionRuntimeContext,
 {
     fn creator_chain_id(&self) -> ChainId {
-        self.description.get().expect(
+        self.description.get().as_ref().expect(
             "Can't register applications on a system state with no associated `ChainDescription`",
         ).into()
     }

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -16,7 +16,7 @@ use linera_base::{
     crypto::{AccountPublicKey, BcsSignable, CryptoHash, ValidatorPublicKey},
     data_types::{
         Amount, Blob, BlockHeight, ChainDescription, ChainOrigin, CompressedBytecode, Epoch,
-        OpenChainConfig, OracleResponse, Timestamp,
+        InitialChainConfig, OracleResponse, Timestamp,
     },
     identifiers::{AccountOwner, ApplicationId, BlobId, BlobType, ChainId, MessageId, ModuleId},
     ownership::ChainOwnership,
@@ -54,7 +54,7 @@ pub fn dummy_chain_description_with_ownership_and_balance(
         bcs::to_bytes(&committee).expect("serializing a committee shouldn't fail"),
     )]);
     let origin = ChainOrigin::Root(index);
-    let config = OpenChainConfig {
+    let config = InitialChainConfig {
         admin_id: if index == 0 {
             None
         } else {

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -10,8 +10,8 @@ use std::{
 use custom_debug_derive::Debug;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, ApplicationPermissions, Blob, Epoch, Timestamp},
-    identifiers::{AccountOwner, ApplicationId, BlobId, ChainDescription, ChainId},
+    data_types::{Amount, ApplicationPermissions, Blob, ChainDescription, Epoch, Timestamp},
+    identifiers::{AccountOwner, ApplicationId, BlobId, ChainId},
     ownership::ChainOwnership,
 };
 use linera_views::{
@@ -51,11 +51,30 @@ pub struct SystemExecutionState {
 }
 
 impl SystemExecutionState {
-    pub fn new(epoch: Epoch, description: ChainDescription, admin_id: impl Into<ChainId>) -> Self {
+    pub fn new(description: ChainDescription) -> Self {
+        let ownership = description.config().ownership.clone();
+        let balance = description.config().balance;
+        let epoch = description.config().epoch;
+        let admin_id = Some(description.config().admin_id.unwrap_or(description.id()));
+        let committees = description
+            .config()
+            .committees
+            .iter()
+            .map(|(epoch, serialized_committee)| {
+                (
+                    *epoch,
+                    bcs::from_bytes::<Committee>(serialized_committee)
+                        .expect("should correctly deserialize a committee"),
+                )
+            })
+            .collect();
         SystemExecutionState {
             epoch: Some(epoch),
             description: Some(description),
-            admin_id: Some(admin_id.into()),
+            admin_id,
+            ownership,
+            balance,
+            committees,
             ..SystemExecutionState::default()
         }
     }
@@ -70,6 +89,7 @@ impl SystemExecutionState {
     pub async fn into_view(self) -> ExecutionStateView<MemoryContext<TestExecutionRuntimeContext>> {
         let chain_id = self
             .description
+            .as_ref()
             .expect("Chain description should be set")
             .into();
         self.into_view_with(chain_id, ExecutionRuntimeConfig::default())
@@ -143,7 +163,7 @@ impl SystemExecutionState {
 
 impl RegisterMockApplication for SystemExecutionState {
     fn creator_chain_id(&self) -> ChainId {
-        self.description.expect(
+        self.description.as_ref().expect(
             "Can't register applications on a system state with no associated `ChainDescription`",
         ).into()
     }

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -20,7 +20,7 @@ use linera_views::{
     views::{CryptoHashView, View, ViewError},
 };
 
-use super::{MockApplication, RegisterMockApplication};
+use super::{dummy_chain_description, MockApplication, RegisterMockApplication};
 use crate::{
     committee::Committee, execution::UserAction, ApplicationDescription, ExecutionError,
     ExecutionRuntimeConfig, ExecutionRuntimeContext, ExecutionStateView, OperationContext,
@@ -77,6 +77,12 @@ impl SystemExecutionState {
             committees,
             ..SystemExecutionState::default()
         }
+    }
+
+    pub fn dummy_chain_state(index: u32) -> (Self, ChainId) {
+        let description = dummy_chain_description(index);
+        let chain_id = description.id();
+        (Self::new(description), chain_id)
     }
 
     pub async fn into_hash(self) -> CryptoHash {

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -30,6 +30,7 @@ pub struct TransactionTracker {
     transaction_index: u32,
     next_message_index: u32,
     next_application_index: u32,
+    next_chain_index: u32,
     /// Events recorded by contracts' `emit` calls.
     events: Vec<Event>,
     /// Blobs created by contracts.
@@ -49,6 +50,7 @@ pub struct TransactionOutcome {
     pub outgoing_messages: Vec<OutgoingMessage>,
     pub next_message_index: u32,
     pub next_application_index: u32,
+    pub next_chain_index: u32,
     /// Events recorded by contracts' `emit` calls.
     pub events: Vec<Event>,
     /// Blobs created by contracts.
@@ -63,6 +65,7 @@ impl TransactionTracker {
         transaction_index: u32,
         next_message_index: u32,
         next_application_index: u32,
+        next_chain_index: u32,
         oracle_responses: Option<Vec<OracleResponse>>,
     ) -> Self {
         TransactionTracker {
@@ -70,6 +73,7 @@ impl TransactionTracker {
             transaction_index,
             next_message_index,
             next_application_index,
+            next_chain_index,
             replaying_oracle_responses: oracle_responses.map(Vec::into_iter),
             ..Self::default()
         }
@@ -99,6 +103,12 @@ impl TransactionTracker {
     pub fn next_application_index(&mut self) -> u32 {
         let index = self.next_application_index;
         self.next_application_index += 1;
+        index
+    }
+
+    pub fn next_chain_index(&mut self) -> u32 {
+        let index = self.next_chain_index;
+        self.next_chain_index += 1;
         index
     }
 
@@ -251,6 +261,7 @@ impl TransactionTracker {
             transaction_index: _,
             next_message_index,
             next_application_index,
+            next_chain_index,
             events,
             blobs,
             operation_result,
@@ -271,6 +282,7 @@ impl TransactionTracker {
             oracle_responses,
             next_message_index,
             next_application_index,
+            next_chain_index,
             events,
             blobs: blobs.into_values().collect(),
             operation_result: operation_result.unwrap_or_default(),
@@ -283,7 +295,7 @@ impl TransactionTracker {
     /// Creates a new [`TransactionTracker`] for testing, with default values and the given
     /// oracle responses.
     pub fn new_replaying(oracle_responses: Vec<OracleResponse>) -> Self {
-        TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(oracle_responses))
+        TransactionTracker::new(Timestamp::from(0), 0, 0, 0, 0, Some(oracle_responses))
     }
 
     /// Creates a new [`TransactionTracker`] for testing, with default values and oracle responses

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -92,28 +92,10 @@ async fn application_message_index() -> anyhow::Result<()> {
 #[tokio::test]
 async fn open_chain_message_index() {
     let (mut view, context) = new_view_and_context().await;
-    let epoch = view.system.epoch.get().unwrap();
-    let admin_id = view.system.admin_id.get().unwrap();
-    let committees = view
-        .system
-        .committees
-        .get()
-        .clone()
-        .into_iter()
-        .map(|(epoch, committee)| {
-            (
-                epoch,
-                bcs::to_bytes(&committee).expect("serializing a committee shouldn't fail"),
-            )
-        })
-        .collect();
     let owner = linera_base::crypto::AccountPublicKey::test_key(0).into();
     let ownership = ChainOwnership::single(owner);
-    let config = InitialChainConfig {
+    let config = OpenChainConfig {
         ownership,
-        committees,
-        epoch,
-        admin_id: Some(admin_id),
         balance: Amount::ZERO,
         application_permissions: Default::default(),
     };

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -109,7 +109,7 @@ async fn open_chain_message_index() {
         .collect();
     let owner = linera_base::crypto::AccountPublicKey::test_key(0).into();
     let ownership = ChainOwnership::single(owner);
-    let config = OpenChainConfig {
+    let config = InitialChainConfig {
         ownership,
         committees,
         epoch,

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -7,7 +7,7 @@ use linera_base::vm::VmRuntime;
 use linera_views::context::MemoryContext;
 
 use super::*;
-use crate::{ExecutionStateView, Message, TestExecutionRuntimeContext};
+use crate::{test_utils::dummy_chain_description, ExecutionStateView, TestExecutionRuntimeContext};
 
 /// Returns an execution state view and a matching operation context, for epoch 1, with root
 /// chain 0 as the admin ID and one empty committee.
@@ -15,18 +15,19 @@ async fn new_view_and_context() -> (
     ExecutionStateView<MemoryContext<TestExecutionRuntimeContext>>,
     OperationContext,
 ) {
-    let description = ChainDescription::Root(5);
+    let description = dummy_chain_description(5);
     let context = OperationContext {
-        chain_id: ChainId::from(description),
+        chain_id: ChainId::from(&description),
         authenticated_signer: None,
         authenticated_caller_id: None,
         height: BlockHeight::from(7),
         round: Some(0),
+        timestamp: Default::default(),
     };
     let state = SystemExecutionState {
         description: Some(description),
         epoch: Some(Epoch(1)),
-        admin_id: Some(ChainId::root(0)),
+        admin_id: Some(dummy_chain_description(0).id()),
         committees: BTreeMap::new(),
         ..SystemExecutionState::default()
     };
@@ -93,14 +94,26 @@ async fn open_chain_message_index() {
     let (mut view, context) = new_view_and_context().await;
     let epoch = view.system.epoch.get().unwrap();
     let admin_id = view.system.admin_id.get().unwrap();
-    let committees = view.system.committees.get().clone();
+    let committees = view
+        .system
+        .committees
+        .get()
+        .clone()
+        .into_iter()
+        .map(|(epoch, committee)| {
+            (
+                epoch,
+                bcs::to_bytes(&committee).expect("serializing a committee shouldn't fail"),
+            )
+        })
+        .collect();
     let owner = linera_base::crypto::AccountPublicKey::test_key(0).into();
     let ownership = ChainOwnership::single(owner);
     let config = OpenChainConfig {
         ownership,
         committees,
         epoch,
-        admin_id,
+        admin_id: Some(admin_id),
         balance: Amount::ZERO,
         application_permissions: Default::default(),
     };
@@ -118,9 +131,8 @@ async fn open_chain_message_index() {
         .unwrap();
     assert_eq!(new_application, None);
     assert_eq!(
-        txn_tracker.into_outcome().unwrap().outgoing_messages[OPEN_CHAIN_MESSAGE_INDEX as usize]
-            .message,
-        Message::System(SystemMessage::OpenChain(Box::new(config)))
+        txn_tracker.into_outcome().unwrap().blobs[0].id().blob_type,
+        BlobType::ChainDescription,
     );
 }
 
@@ -131,7 +143,7 @@ async fn empty_accounts_are_removed() -> anyhow::Result<()> {
     let amount = Amount::from_tokens(99);
 
     let mut view = SystemExecutionState {
-        description: Some(ChainDescription::Root(0)),
+        description: Some(dummy_chain_description(0)),
         balances: BTreeMap::from([(owner, amount)]),
         ..SystemExecutionState::default()
     }

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -475,7 +475,7 @@ where
         chain_ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
         balance: Amount,
-    ) -> Result<(MessageId, ChainId), RuntimeError> {
+    ) -> Result<ChainId, RuntimeError> {
         caller
             .user_data_mut()
             .runtime

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -11,11 +11,12 @@ use linera_base::{
     crypto::AccountPublicKey,
     data_types::{Amount, BlockHeight, OracleResponse},
     http,
-    identifiers::{Account, AccountOwner, ChainDescription, ChainId, MessageId},
+    identifiers::{Account, AccountOwner, MessageId},
 };
 use linera_execution::{
     test_utils::{
-        blob_oracle_responses, ExpectedCall, RegisterMockApplication, SystemExecutionState,
+        blob_oracle_responses, dummy_chain_description, ExpectedCall, RegisterMockApplication,
+        SystemExecutionState,
     },
     ContractRuntime, ExecutionError, Message, MessageContext, ResourceControlPolicy,
     ResourceController, TransactionTracker,
@@ -186,8 +187,10 @@ async fn test_fee_consumption(
     owner_balance: Option<Amount>,
     initial_grant: Option<Amount>,
 ) -> anyhow::Result<()> {
+    let chain_description = dummy_chain_description(0);
+    let chain_id = chain_description.id();
     let mut state = SystemExecutionState {
-        description: Some(ChainDescription::Root(0)),
+        description: Some(chain_description.clone()),
         ..SystemExecutionState::default()
     };
     let (application_id, application, blobs) = state.register_mock_application(0).await?;
@@ -265,19 +268,17 @@ async fn test_fee_consumption(
     application.expect_call(ExpectedCall::default_finalize());
 
     let refund_grant_to = authenticated_signer
-        .map(|owner| Account {
-            chain_id: ChainId::root(0),
-            owner,
-        })
+        .map(|owner| Account { chain_id, owner })
         .or(None);
     let context = MessageContext {
-        chain_id: ChainId::root(0),
+        chain_id,
         is_bouncing: false,
         authenticated_signer,
         refund_grant_to,
         height: BlockHeight(0),
         round: Some(0),
         message_id: MessageId::default(),
+        timestamp: Default::default(),
     };
     let mut grant = initial_grant.unwrap_or_default();
     let mut txn_tracker = TransactionTracker::new_replaying(oracle_responses);

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -8,13 +8,12 @@ use std::sync::Arc;
 use alloy_sol_types::{sol, SolCall, SolValue};
 use linera_base::{
     data_types::{Amount, Blob, BlockHeight, Timestamp},
-    identifiers::ChainDescription,
     vm::EvmQuery,
 };
 use linera_execution::{
     evm::revm::{EvmContractModule, EvmServiceModule},
     test_utils::{
-        create_dummy_user_application_description,
+        create_dummy_user_application_description, dummy_chain_description,
         solidity::{load_solidity_example, read_evm_u64_entry},
         SystemExecutionState,
     },
@@ -44,7 +43,7 @@ async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
     let instantiation_argument = Vec::<u8>::new();
     let instantiation_argument = serde_json::to_string(&instantiation_argument)?.into_bytes();
     let state = SystemExecutionState {
-        description: Some(ChainDescription::Root(0)),
+        description: Some(dummy_chain_description(0)),
         ..Default::default()
     };
     let (mut app_desc, contract_blob, service_blob) = create_dummy_user_application_description(1);
@@ -88,6 +87,7 @@ async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
         round: Some(0),
         authenticated_signer: None,
         authenticated_caller_id: None,
+        timestamp: Default::default(),
     };
 
     let query_context = QueryContext {

--- a/linera-execution/tests/service_runtime_apis.rs
+++ b/linera-execution/tests/service_runtime_apis.rs
@@ -5,14 +5,11 @@
 
 use std::{collections::BTreeMap, vec};
 
-use linera_base::{
-    data_types::Amount,
-    identifiers::{AccountOwner, ChainDescription},
-};
+use linera_base::{data_types::Amount, identifiers::AccountOwner};
 use linera_execution::{
     test_utils::{
-        create_dummy_query_context, test_accounts_strategy, ExpectedCall, RegisterMockApplication,
-        SystemExecutionState,
+        create_dummy_query_context, dummy_chain_description, test_accounts_strategy, ExpectedCall,
+        RegisterMockApplication, SystemExecutionState,
     },
     BaseRuntime, Query,
 };
@@ -22,9 +19,8 @@ use test_strategy::proptest;
 #[proptest(async = "tokio")]
 async fn test_read_chain_balance_system_api(chain_balance: Amount) {
     let mut view = SystemExecutionState {
-        description: Some(ChainDescription::Root(0)),
         balance: chain_balance,
-        ..SystemExecutionState::default()
+        ..SystemExecutionState::new(dummy_chain_description(0))
     }
     .into_view()
     .await;
@@ -52,9 +48,8 @@ async fn test_read_owner_balance_system_api(
     #[strategy(test_accounts_strategy())] accounts: BTreeMap<AccountOwner, Amount>,
 ) {
     let mut view = SystemExecutionState {
-        description: Some(ChainDescription::Root(0)),
         balances: accounts.clone(),
-        ..SystemExecutionState::default()
+        ..SystemExecutionState::new(dummy_chain_description(0))
     }
     .into_view()
     .await;
@@ -81,12 +76,9 @@ async fn test_read_owner_balance_system_api(
 /// Tests if reading the balance of a missing account returns zero.
 #[proptest(async = "tokio")]
 async fn test_read_owner_balance_returns_zero_for_missing_accounts(missing_account: AccountOwner) {
-    let mut view = SystemExecutionState {
-        description: Some(ChainDescription::Root(0)),
-        ..SystemExecutionState::default()
-    }
-    .into_view()
-    .await;
+    let mut view = SystemExecutionState::new(dummy_chain_description(0))
+        .into_view()
+        .await;
 
     let (application_id, application, _) = view.register_mock_application(0).await.unwrap();
 
@@ -114,9 +106,8 @@ async fn test_read_owner_balances_system_api(
     #[strategy(test_accounts_strategy())] accounts: BTreeMap<AccountOwner, Amount>,
 ) {
     let mut view = SystemExecutionState {
-        description: Some(ChainDescription::Root(0)),
         balances: accounts.clone(),
-        ..SystemExecutionState::default()
+        ..SystemExecutionState::new(dummy_chain_description(0))
     }
     .into_view()
     .await;
@@ -147,9 +138,8 @@ async fn test_read_balance_owners_system_api(
     #[strategy(test_accounts_strategy())] accounts: BTreeMap<AccountOwner, Amount>,
 ) {
     let mut view = SystemExecutionState {
-        description: Some(ChainDescription::Root(0)),
         balances: accounts.clone(),
-        ..SystemExecutionState::default()
+        ..SystemExecutionState::new(dummy_chain_description(0))
     }
     .into_view()
     .await;

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -10,7 +10,7 @@ use linera_base::{
     crypto::{AccountPublicKey, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationPermissions, Blob, BlockHeight, ChainDescription, ChainOrigin, Epoch,
-        OpenChainConfig, Resources, SendMessageRequest, Timestamp,
+        InitialChainConfig, Resources, SendMessageRequest, Timestamp,
     },
     identifiers::{Account, AccountOwner, BlobType},
     ownership::ChainOwnership,
@@ -1235,7 +1235,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
         chain_index: 0,
     };
     let child_application_permissions = ApplicationPermissions::new_single(application_id);
-    let child_config = OpenChainConfig {
+    let child_config = InitialChainConfig {
         balance: Amount::ONE,
         ownership: child_ownership.clone(),
         application_permissions: child_application_permissions.clone(),

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -32,10 +32,7 @@ use test_case::test_case;
 
 #[tokio::test]
 async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
-    let mut state = SystemExecutionState::default();
-    let description = dummy_chain_description(0);
-    let chain_id = description.id();
-    state.description = Some(description);
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
     let mut view = state.into_view().await;
 
     let (app_id, app_desc, contract_blob, service_blob) =
@@ -77,10 +74,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
 #[tokio::test]
 // TODO(#1484): Split this test into multiple more specialized tests.
 async fn test_simple_user_operation() -> anyhow::Result<()> {
-    let mut state = SystemExecutionState::default();
-    let description = dummy_chain_description(0);
-    let chain_id = description.id();
-    state.description = Some(description);
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
     let mut view = state.into_view().await;
 
     let (caller_id, caller_application, caller_blobs) = view.register_mock_application(0).await?;
@@ -229,10 +223,7 @@ enum SessionCall {
 /// Tests a simulated session.
 #[tokio::test]
 async fn test_simulated_session() -> anyhow::Result<()> {
-    let mut state = SystemExecutionState::default();
-    let description = dummy_chain_description(0);
-    let chain_id = description.id();
-    state.description = Some(description);
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
     let mut view = state.into_view().await;
 
     let (caller_id, caller_application, caller_blobs) = view.register_mock_application(0).await?;
@@ -311,10 +302,7 @@ async fn test_simulated_session() -> anyhow::Result<()> {
 /// Tests if execution fails if a simulated session isn't properly closed.
 #[tokio::test]
 async fn test_simulated_session_leak() -> anyhow::Result<()> {
-    let mut state = SystemExecutionState::default();
-    let description = dummy_chain_description(0);
-    let chain_id = description.id();
-    state.description = Some(description);
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
     let mut view = state.into_view().await;
 
     let (caller_id, caller_application, caller_blobs) = view.register_mock_application(0).await?;
@@ -381,10 +369,7 @@ async fn test_simulated_session_leak() -> anyhow::Result<()> {
 /// Tests if `finalize` can cause execution to fail.
 #[tokio::test]
 async fn test_rejecting_block_from_finalize() -> anyhow::Result<()> {
-    let mut state = SystemExecutionState::default();
-    let description = dummy_chain_description(0);
-    let chain_id = description.id();
-    state.description = Some(description);
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
     let mut view = state.into_view().await;
 
     let (id, application, blobs) = view.register_mock_application(0).await?;
@@ -420,10 +405,7 @@ async fn test_rejecting_block_from_finalize() -> anyhow::Result<()> {
 /// Tests if `finalize` from a called application can cause execution to fail.
 #[tokio::test]
 async fn test_rejecting_block_from_called_applications_finalize() -> anyhow::Result<()> {
-    let mut state = SystemExecutionState::default();
-    let description = dummy_chain_description(0);
-    let chain_id = description.id();
-    state.description = Some(description);
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
     let mut view = state.into_view().await;
 
     let (first_id, first_application, first_app_blobs) = view.register_mock_application(0).await?;
@@ -491,10 +473,7 @@ async fn test_rejecting_block_from_called_applications_finalize() -> anyhow::Res
 /// Tests if `finalize` can send messages.
 #[tokio::test]
 async fn test_sending_message_from_finalize() -> anyhow::Result<()> {
-    let mut state = SystemExecutionState::default();
-    let description = dummy_chain_description(0);
-    let chain_id = description.id();
-    state.description = Some(description);
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
     let mut view = state.into_view().await;
 
     let (first_id, first_application, first_app_blobs) = view.register_mock_application(0).await?;
@@ -637,10 +616,7 @@ async fn test_sending_message_from_finalize() -> anyhow::Result<()> {
 /// Tests if an application can't perform cross-application calls during `finalize`.
 #[tokio::test]
 async fn test_cross_application_call_from_finalize() -> anyhow::Result<()> {
-    let mut state = SystemExecutionState::default();
-    let description = dummy_chain_description(0);
-    let chain_id = description.id();
-    state.description = Some(description);
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
     let mut view = state.into_view().await;
 
     let (caller_id, caller_application, caller_blobs) = view.register_mock_application(0).await?;
@@ -686,10 +662,7 @@ async fn test_cross_application_call_from_finalize() -> anyhow::Result<()> {
 /// have already called the same application.
 #[tokio::test]
 async fn test_cross_application_call_from_finalize_of_called_application() -> anyhow::Result<()> {
-    let mut state = SystemExecutionState::default();
-    let description = dummy_chain_description(0);
-    let chain_id = description.id();
-    state.description = Some(description);
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
     let mut view = state.into_view().await;
 
     let (caller_id, caller_application, caller_blobs) = view.register_mock_application(0).await?;
@@ -741,10 +714,7 @@ async fn test_cross_application_call_from_finalize_of_called_application() -> an
 /// Tests if a called application can't perform cross-application calls during `finalize`.
 #[tokio::test]
 async fn test_calling_application_again_from_finalize() -> anyhow::Result<()> {
-    let mut state = SystemExecutionState::default();
-    let description = dummy_chain_description(0);
-    let chain_id = description.id();
-    state.description = Some(description);
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
     let mut view = state.into_view().await;
 
     let (caller_id, caller_application, caller_blobs) = view.register_mock_application(0).await?;
@@ -799,10 +769,7 @@ async fn test_calling_application_again_from_finalize() -> anyhow::Result<()> {
 /// without panicking.
 #[tokio::test]
 async fn test_cross_application_error() -> anyhow::Result<()> {
-    let mut state = SystemExecutionState::default();
-    let description = dummy_chain_description(0);
-    let chain_id = description.id();
-    state.description = Some(description);
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
     let mut view = state.into_view().await;
 
     let (caller_id, caller_application, caller_blobs) = view.register_mock_application(0).await?;
@@ -846,10 +813,7 @@ async fn test_cross_application_error() -> anyhow::Result<()> {
 /// other chains.
 #[tokio::test]
 async fn test_simple_message() -> anyhow::Result<()> {
-    let mut state = SystemExecutionState::default();
-    let description = dummy_chain_description(0);
-    let chain_id = description.id();
-    state.description = Some(description);
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
     let mut view = state.into_view().await;
 
     let (application_id, application, blobs) = view.register_mock_application(0).await?;
@@ -908,10 +872,7 @@ async fn test_simple_message() -> anyhow::Result<()> {
 /// call.
 #[tokio::test]
 async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
-    let mut state = SystemExecutionState::default();
-    let description = dummy_chain_description(0);
-    let chain_id = description.id();
-    state.description = Some(description);
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
     let mut view = state.into_view().await;
 
     let (caller_id, caller_application, caller_blobs) = view.register_mock_application(0).await?;
@@ -978,10 +939,7 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
 /// Tests if a message is scheduled to be sent by a deeper cross-application call.
 #[tokio::test]
 async fn test_message_from_deeper_call() -> anyhow::Result<()> {
-    let mut state = SystemExecutionState::default();
-    let description = dummy_chain_description(0);
-    let chain_id = description.id();
-    state.description = Some(description);
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
     let mut view = state.into_view().await;
 
     let (caller_id, caller_application, caller_blobs) = view.register_mock_application(0).await?;
@@ -1067,10 +1025,7 @@ async fn test_message_from_deeper_call() -> anyhow::Result<()> {
 /// for the applications that will receive messages on them.
 #[tokio::test]
 async fn test_multiple_messages_from_different_applications() -> anyhow::Result<()> {
-    let mut state = SystemExecutionState::default();
-    let description = dummy_chain_description(0);
-    let chain_id = description.id();
-    state.description = Some(description);
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
     let mut view = state.into_view().await;
 
     // The entrypoint application, which sends a message and calls other applications
@@ -1204,10 +1159,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
         ValidatorPublicKey::test_key(0),
         AccountPublicKey::test_key(0),
     )]);
-    let committees = BTreeMap::from([(
-        Epoch::ZERO,
-        bcs::to_bytes(&committee).expect("serializing a committee should not fail"),
-    )]);
+    let committees = BTreeMap::from([(Epoch::ZERO, bcs::to_bytes(&committee)?)]);
     let chain_key = AccountPublicKey::test_key(1);
     let ownership = ChainOwnership::single(chain_key.into());
     let child_ownership = ChainOwnership::single(AccountPublicKey::test_key(2).into());
@@ -1287,7 +1239,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
     assert_eq!(created_description.config().ownership, child_ownership);
     assert_eq!(created_description.config().committees, committees);
 
-    // Initialize the child chain using the config from the message.
+    // Initialize the child chain using the new blob.
     let mut child_view = SystemExecutionState::default()
         .into_view_with(child_id, Default::default())
         .await;
@@ -1309,8 +1261,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
             .into_iter()
             .map(|(epoch, serialized_committee)| (
                 epoch,
-                bcs::from_bytes::<Committee>(&serialized_committee)
-                    .expect("deserializing a committee should not fail")
+                bcs::from_bytes::<Committee>(&serialized_committee).unwrap()
             ))
             .collect::<BTreeMap<_, _>>()
     );

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -5,12 +5,11 @@
 
 use std::sync::Arc;
 
-use linera_base::{
-    data_types::{Amount, Blob, BlockHeight, Timestamp},
-    identifiers::{ChainDescription, ChainId},
-};
+use linera_base::data_types::{Amount, Blob, BlockHeight, Timestamp};
 use linera_execution::{
-    test_utils::{create_dummy_user_application_description, SystemExecutionState},
+    test_utils::{
+        create_dummy_user_application_description, dummy_chain_description, SystemExecutionState,
+    },
     ExecutionRuntimeConfig, ExecutionRuntimeContext, Operation, OperationContext, Query,
     QueryContext, QueryOutcome, QueryResponse, ResourceControlPolicy, ResourceController,
     ResourceTracker, TransactionTracker, WasmContractModule, WasmRuntime, WasmServiceModule,
@@ -30,12 +29,14 @@ async fn test_fuel_for_counter_wasm_application(
     wasm_runtime: WasmRuntime,
     expected_fuel: u64,
 ) -> anyhow::Result<()> {
+    let chain_description = dummy_chain_description(0);
+    let chain_id = chain_description.id();
     let state = SystemExecutionState {
-        description: Some(ChainDescription::Root(0)),
+        description: Some(chain_description),
         ..Default::default()
     };
     let mut view = state
-        .into_view_with(ChainId::root(0), ExecutionRuntimeConfig::default())
+        .into_view_with(chain_id, ExecutionRuntimeConfig::default())
         .await;
     let (app_desc, contract_blob, service_blob) = create_dummy_user_application_description(1);
     let app_id = From::from(&app_desc);
@@ -67,11 +68,12 @@ async fn test_fuel_for_counter_wasm_application(
         .await?;
 
     let context = OperationContext {
-        chain_id: ChainId::root(0),
+        chain_id,
         height: BlockHeight(0),
         round: Some(0),
         authenticated_signer: None,
         authenticated_caller_id: None,
+        timestamp: Default::default(),
     };
     let increments = [2_u64, 9, 7, 1000];
     let policy = ResourceControlPolicy {
@@ -115,7 +117,7 @@ async fn test_fuel_for_counter_wasm_application(
     );
 
     let context = QueryContext {
-        chain_id: ChainId::root(0),
+        chain_id,
         next_block_height: BlockHeight(0),
         local_time: Timestamp::from(0),
     };

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -23,11 +23,7 @@ use gql_service::{
 };
 use graphql_client::Response;
 use js_utils::{getf, log_str, parse, setf, stringify, SER};
-use linera_base::{
-    crypto::CryptoHash,
-    data_types::BlockHeight,
-    identifiers::{ChainDescription, ChainId},
-};
+use linera_base::{crypto::CryptoHash, data_types::BlockHeight, identifiers::ChainId};
 use linera_indexer_graphql_client::{
     indexer::{plugins, Plugins},
     operations as gql_operations,
@@ -133,7 +129,10 @@ pub fn data() -> JsValue {
         config: Config::load(),
         page: Page::Unloaded,
         chains: Vec::new(),
-        chain: ChainId::from(ChainDescription::Root(0)),
+        chain: ChainId::from_str(
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        )
+        .unwrap(),
         plugins: Vec::new(),
     };
     data.serialize(&SER).unwrap()
@@ -284,10 +283,10 @@ async fn chains(app: &JsValue, node: &str) -> Result<ChainId> {
         .serialize(&SER)
         .expect("failed to serialize ChainIds");
     setf(app, "chains", &chains_js);
-    Ok(chains.default.unwrap_or_else(|| match chains.list.first() {
-        None => ChainId::from(ChainDescription::Root(0)),
-        Some(chain_id) => *chain_id,
-    }))
+    chains
+        .default
+        .or_else(|| chains.list.first().copied())
+        .ok_or_else(|| anyhow::Error::msg("no chains available"))
 }
 
 /// Queries indexer plugins.

--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -105,7 +105,7 @@ impl Faucet {
     ) -> Result<ClaimOutcome, Error> {
         let query = format!(
             "mutation {{ claim(owner: \"{owner}\") {{ \
-                messageId chainId certificateHash \
+                chainId certificateHash \
             }} }}"
         );
 

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -89,7 +89,7 @@ where
 
     /// Returns the current committee's validators.
     async fn current_validators(&self) -> Result<Vec<Validator>, Error> {
-        let chain_id = *self.chain_id.lock().await;        
+        let chain_id = *self.chain_id.lock().await;
         let client = self
             .context
             .lock()

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -12,7 +12,7 @@ use futures::{lock::Mutex, FutureExt as _};
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{Amount, ApplicationPermissions, BlockHeight, Timestamp},
-    identifiers::{AccountOwner, ChainId, MessageId},
+    identifiers::{AccountOwner, ChainId},
     ownership::ChainOwnership,
 };
 use linera_client::{
@@ -60,8 +60,6 @@ pub struct MutationRoot<C> {
 /// The result of a successful `claim` mutation.
 #[derive(SimpleObject)]
 pub struct ClaimOutcome {
-    /// The ID of the message that created the new chain.
-    pub message_id: MessageId,
     /// The ID of the new chain.
     pub chain_id: ChainId,
     /// The hash of the parent chain's certificate containing the `OpenChain` operation.
@@ -91,8 +89,13 @@ where
 
     /// Returns the current committee's validators.
     async fn current_validators(&self) -> Result<Vec<Validator>, Error> {
-        let chain_id = *self.chain_id.lock().await;
-        let client = self.context.lock().await.make_chain_client(chain_id)?;
+        let chain_id = *self.chain_id.lock().await;        
+        let client = self
+            .context
+            .lock()
+            .await
+            .make_chain_client(chain_id)
+            .await?;
         let committee = client.local_committee().await?;
         Ok(committee
             .validators()
@@ -122,7 +125,12 @@ where
 {
     async fn do_claim(&self, owner: AccountOwner) -> Result<ClaimOutcome, Error> {
         let chain_id = *self.chain_id.lock().await;
-        let client = self.context.lock().await.make_chain_client(chain_id)?;
+        let client = self
+            .context
+            .lock()
+            .await
+            .make_chain_client(chain_id)
+            .await?;
 
         if self.start_timestamp < self.end_timestamp {
             let local_time = client.storage_client().clock().current_time();
@@ -153,19 +161,27 @@ where
             .open_chain(ownership, ApplicationPermissions::default(), self.amount)
             .await;
         self.context.lock().await.update_wallet(&client).await?;
-        let (message_id, certificate) = result?.try_unwrap()?;
+        let (chain_id, certificate) = match result? {
+            ClientOutcome::Committed(result) => result,
+            ClientOutcome::WaitForTimeout(timeout) => {
+                return Err(Error::new(format!(
+                    "This faucet is using a multi-owner chain and is not the leader right now. \
+                    Try again at {}",
+                    timeout.timestamp,
+                )));
+            }
+        };
 
         if client.next_block_height() >= self.end_block_height {
             let key_pair = client.key_pair().await?;
             let balance = client.local_balance().await?.try_sub(Amount::ONE)?;
             let ownership = client.chain_state_view().await?.ownership().clone();
-            let (message_id, certificate) = client
+            let (chain_id, certificate) = client
                 .open_chain(ownership, ApplicationPermissions::default(), balance)
                 .await?
                 .try_unwrap()?;
             // TODO(#1795): Move the remaining tokens to the new chain.
             client.close_chain().await?.try_unwrap()?;
-            let chain_id = ChainId::child(message_id);
             info!("Switching to a new faucet chain {chain_id:8}; remaining balance: {balance}");
             self.context
                 .lock()
@@ -179,9 +195,7 @@ where
             *self.chain_id.lock().await = chain_id;
         }
 
-        let chain_id = ChainId::child(message_id);
         Ok(ClaimOutcome {
-            message_id,
             chain_id,
             certificate_hash: certificate.hash(),
         })
@@ -256,7 +270,7 @@ where
         config: ChainListenerConfig,
         storage: <C::Environment as linera_core::Environment>::Storage,
     ) -> anyhow::Result<Self> {
-        let client = context.make_chain_client(chain_id)?;
+        let client = context.make_chain_client(chain_id).await?;
         let context = Arc::new(Mutex::new(context));
         let start_timestamp = client.storage_client().clock().current_time();
         client.process_inbox().await?;

--- a/linera-faucet/server/src/tests.rs
+++ b/linera-faucet/server/src/tests.rs
@@ -38,7 +38,7 @@ impl chain_listener::ClientContext for ClientContext {
         self.client.storage_client()
     }
 
-    fn make_chain_client(
+    async fn make_chain_client(
         &self,
         chain_id: ChainId,
     ) -> Result<ChainClient<environment::Test>, linera_client::Error> {

--- a/linera-faucet/src/lib.rs
+++ b/linera-faucet/src/lib.rs
@@ -5,10 +5,7 @@
 Common definitions for the Linera faucet.
 */
 
-use linera_base::{
-    crypto::CryptoHash,
-    identifiers::{ChainId, MessageId},
-};
+use linera_base::{crypto::CryptoHash, identifiers::ChainId};
 
 /// The result of a successful `claim` mutation.
 #[cfg_attr(feature = "async-graphql", derive(async_graphql::SimpleObject))]
@@ -16,9 +13,6 @@ use linera_base::{
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClaimOutcome {
-    /// The ID of the message that created the new chain.
-    #[serde_as(as = "serde_with::DisplayFromStr")]
-    pub message_id: MessageId,
     /// The ID of the new chain.
     #[serde_as(as = "serde_with::DisplayFromStr")]
     pub chain_id: ChainId,

--- a/linera-indexer/example/tests/test.rs
+++ b/linera-indexer/example/tests/test.rs
@@ -120,8 +120,12 @@ async fn test_end_to_end_operations_indexer(config: impl LineraNetConfig) {
     );
 
     // making a few transfers
-    let chain0 = ChainId::root(0);
-    let chain1 = Account::chain(ChainId::root(1));
+    let node_chains = {
+        let wallet = client.load_wallet().unwrap();
+        wallet.chain_ids()
+    };
+    let chain0 = node_chains[0];
+    let chain1 = Account::chain(node_chains[1]);
     for _ in 0..10 {
         transfer(&req_client, chain0, chain1, "0.1").await;
         linera_base::time::timer::sleep(Duration::from_millis(TRANSFER_DELAY_MILLIS)).await;

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -984,8 +984,12 @@ pub mod tests {
 
     impl BcsSignable<'_> for Foo {}
 
+    fn dummy_chain_id(index: u32) -> ChainId {
+        ChainId(CryptoHash::test_hash(format!("chain{}", index)))
+    }
+
     fn get_block() -> ProposedBlock {
-        make_first_block(ChainId::root(0))
+        make_first_block(dummy_chain_id(0))
     }
 
     /// A convenience function for testing. It converts a type into its
@@ -1037,14 +1041,14 @@ pub mod tests {
 
     #[test]
     pub fn test_chain_id() {
-        let chain_id = ChainId::root(0);
+        let chain_id = dummy_chain_id(0);
         round_trip_check::<_, api::ChainId>(chain_id);
     }
 
     #[test]
     pub fn test_chain_info_response() {
         let chain_info = Box::new(ChainInfo {
-            chain_id: ChainId::root(0),
+            chain_id: dummy_chain_id(0),
             epoch: None,
             description: None,
             manager: Box::default(),
@@ -1081,11 +1085,11 @@ pub mod tests {
 
     #[test]
     pub fn test_chain_info_query() {
-        let chain_info_query_none = ChainInfoQuery::new(ChainId::root(0));
+        let chain_info_query_none = ChainInfoQuery::new(dummy_chain_id(0));
         round_trip_check::<_, api::ChainInfoQuery>(chain_info_query_none);
 
         let chain_info_query_some = ChainInfoQuery {
-            chain_id: ChainId::root(0),
+            chain_id: dummy_chain_id(0),
             test_next_block_height: Some(BlockHeight::from(10)),
             request_committees: false,
             request_owner_balance: AccountOwner::CHAIN,
@@ -1106,7 +1110,7 @@ pub mod tests {
 
     #[test]
     pub fn test_pending_blob_request() {
-        let chain_id = ChainId::root(2);
+        let chain_id = dummy_chain_id(2);
         let blob_id = Blob::new(BlobContent::new_data(*b"foo")).id();
         let pending_blob_request = (chain_id, blob_id);
         round_trip_check::<_, api::PendingBlobRequest>(pending_blob_request);
@@ -1120,7 +1124,7 @@ pub mod tests {
 
     #[test]
     pub fn test_handle_pending_blob_request() {
-        let chain_id = ChainId::root(2);
+        let chain_id = dummy_chain_id(2);
         let blob_content = BlobContent::new_data(*b"foo");
         let pending_blob_request = (chain_id, blob_content);
         round_trip_check::<_, api::HandlePendingBlobRequest>(pending_blob_request);
@@ -1132,7 +1136,7 @@ pub mod tests {
         let certificate = LiteCertificate {
             value: LiteValue {
                 value_hash: CryptoHash::new(&Foo("value".into())),
-                chain_id: ChainId::root(0),
+                chain_id: dummy_chain_id(0),
                 kind: CertificateKind::Validated,
             },
             round: Round::MultiLeader(2),
@@ -1174,16 +1178,16 @@ pub mod tests {
     #[test]
     pub fn test_cross_chain_request() {
         let cross_chain_request_update_recipient = CrossChainRequest::UpdateRecipient {
-            sender: ChainId::root(0),
-            recipient: ChainId::root(0),
+            sender: dummy_chain_id(0),
+            recipient: dummy_chain_id(0),
             bundles: vec![],
         };
         round_trip_check::<_, api::CrossChainRequest>(cross_chain_request_update_recipient);
 
         let cross_chain_request_confirm_updated_recipient =
             CrossChainRequest::ConfirmUpdatedRecipient {
-                sender: ChainId::root(0),
-                recipient: ChainId::root(0),
+                sender: dummy_chain_id(0),
+                recipient: dummy_chain_id(0),
                 latest_height: BlockHeight(1),
             };
         round_trip_check::<_, api::CrossChainRequest>(
@@ -1226,7 +1230,7 @@ pub mod tests {
     #[test]
     pub fn test_notification() {
         let notification = Notification {
-            chain_id: ChainId::root(0),
+            chain_id: dummy_chain_id(0),
             reason: linera_core::worker::Reason::NewBlock {
                 height: BlockHeight(0),
                 hash: CryptoHash::new(&Foo("".into())),

--- a/linera-rpc/tests/format.rs
+++ b/linera-rpc/tests/format.rs
@@ -4,8 +4,8 @@
 
 use linera_base::{
     crypto::{AccountPublicKey, AccountSignature, TestString},
-    data_types::{BlobContent, OracleResponse, Round},
-    identifiers::{AccountOwner, BlobType, ChainDescription, GenericApplicationId},
+    data_types::{BlobContent, ChainDescription, ChainOrigin, OracleResponse, Round},
+    identifiers::{AccountOwner, BlobType, GenericApplicationId},
     ownership::ChainOwnership,
     vm::VmRuntime,
 };
@@ -72,6 +72,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<ValidatedBlock>(&samples)?;
     tracer.trace_type::<Timeout>(&samples)?;
     tracer.trace_type::<ChainDescription>(&samples)?;
+    tracer.trace_type::<ChainOrigin>(&samples)?;
     tracer.trace_type::<ChainOwnership>(&samples)?;
     tracer.trace_type::<GenericApplicationId>(&samples)?;
     tracer.trace_type::<LockingBlock>(&samples)?;

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -731,6 +731,14 @@ NodeError:
       ResponseHandlingError:
         STRUCT:
           - error: STR
+OpenChainConfig:
+  STRUCT:
+    - ownership:
+        TYPENAME: ChainOwnership
+    - balance:
+        TYPENAME: Amount
+    - application_permissions:
+        TYPENAME: ApplicationPermissions
 Operation:
   ENUM:
     0:
@@ -1096,7 +1104,7 @@ SystemOperation:
     2:
       OpenChain:
         NEWTYPE:
-          TYPENAME: InitialChainConfig
+          TYPENAME: OpenChainConfig
     3:
       CloseChain: UNIT
     4:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -266,7 +266,7 @@ ChainDescription:
     - timestamp:
         TYPENAME: Timestamp
     - config:
-        TYPENAME: OpenChainConfig
+        TYPENAME: InitialChainConfig
 ChainId:
   NEWTYPESTRUCT:
     TYPENAME: CryptoHash
@@ -530,6 +530,25 @@ IncomingBundle:
         TYPENAME: MessageBundle
     - action:
         TYPENAME: MessageAction
+InitialChainConfig:
+  STRUCT:
+    - ownership:
+        TYPENAME: ChainOwnership
+    - admin_id:
+        OPTION:
+          TYPENAME: ChainId
+    - epoch:
+        TYPENAME: Epoch
+    - committees:
+        MAP:
+          KEY:
+            TYPENAME: Epoch
+          VALUE:
+            SEQ: U8
+    - balance:
+        TYPENAME: Amount
+    - application_permissions:
+        TYPENAME: ApplicationPermissions
 LiteCertificate:
   STRUCT:
     - value:
@@ -712,25 +731,6 @@ NodeError:
       ResponseHandlingError:
         STRUCT:
           - error: STR
-OpenChainConfig:
-  STRUCT:
-    - ownership:
-        TYPENAME: ChainOwnership
-    - admin_id:
-        OPTION:
-          TYPENAME: ChainId
-    - epoch:
-        TYPENAME: Epoch
-    - committees:
-        MAP:
-          KEY:
-            TYPENAME: Epoch
-          VALUE:
-            SEQ: U8
-    - balance:
-        TYPENAME: Amount
-    - application_permissions:
-        TYPENAME: ApplicationPermissions
 Operation:
   ENUM:
     0:
@@ -1096,7 +1096,7 @@ SystemOperation:
     2:
       OpenChain:
         NEWTYPE:
-          TYPENAME: OpenChainConfig
+          TYPENAME: InitialChainConfig
     3:
       CloseChain: UNIT
     4:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -124,6 +124,8 @@ BlobType:
       ApplicationDescription: UNIT
     5:
       Committee: UNIT
+    6:
+      ChainDescription: UNIT
 Block:
   STRUCT:
     - header:
@@ -258,14 +260,13 @@ ChainAndHeight:
     - height:
         TYPENAME: BlockHeight
 ChainDescription:
-  ENUM:
-    0:
-      Root:
-        NEWTYPE: U32
-    1:
-      Child:
-        NEWTYPE:
-          TYPENAME: MessageId
+  STRUCT:
+    - origin:
+        TYPENAME: ChainOrigin
+    - timestamp:
+        TYPENAME: Timestamp
+    - config:
+        TYPENAME: OpenChainConfig
 ChainId:
   NEWTYPESTRUCT:
     TYPENAME: CryptoHash
@@ -375,6 +376,19 @@ ChainManagerInfo:
     - round_timeout:
         OPTION:
           TYPENAME: Timestamp
+ChainOrigin:
+  ENUM:
+    0:
+      Root:
+        NEWTYPE: U32
+    1:
+      Child:
+        STRUCT:
+          - parent:
+              TYPENAME: ChainId
+          - block_height:
+              TYPENAME: BlockHeight
+          - chain_index: U32
 ChainOwnership:
   STRUCT:
     - super_owners:
@@ -585,13 +599,6 @@ MessageBundle:
     - messages:
         SEQ:
           TYPENAME: PostedMessage
-MessageId:
-  STRUCT:
-    - chain_id:
-        TYPENAME: ChainId
-    - height:
-        TYPENAME: BlockHeight
-    - index: U32
 MessageKind:
   ENUM:
     0:
@@ -710,7 +717,8 @@ OpenChainConfig:
     - ownership:
         TYPENAME: ChainOwnership
     - admin_id:
-        TYPENAME: ChainId
+        OPTION:
+          TYPENAME: ChainId
     - epoch:
         TYPENAME: Epoch
     - committees:
@@ -718,7 +726,7 @@ OpenChainConfig:
           KEY:
             TYPENAME: Epoch
           VALUE:
-            TYPENAME: Committee
+            SEQ: U8
     - balance:
         TYPENAME: Amount
     - application_permissions:
@@ -1062,10 +1070,6 @@ SystemMessage:
           - recipient:
               TYPENAME: Recipient
     2:
-      OpenChain:
-        NEWTYPE:
-          TYPENAME: OpenChainConfig
-    3:
       ApplicationCreated: UNIT
 SystemOperation:
   ENUM:

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -323,13 +323,13 @@ where
         chain_ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
         balance: Amount,
-    ) -> (MessageId, ChainId) {
-        let (message_id, chain_id) = contract_wit::open_chain(
+    ) -> ChainId {
+        let chain_id = contract_wit::open_chain(
             &chain_ownership.into(),
             &application_permissions.into(),
             balance.into(),
         );
-        (message_id.into(), chain_id.into())
+        chain_id.into()
     }
 
     /// Closes the current chain. Returns an error if the application doesn't have

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -62,8 +62,7 @@ where
     expected_http_requests: VecDeque<(http::Request, http::Response)>,
     expected_read_data_blob_requests: VecDeque<(DataBlobHash, Vec<u8>)>,
     expected_assert_data_blob_exists_requests: VecDeque<(DataBlobHash, Option<()>)>,
-    expected_open_chain_calls:
-        VecDeque<(ChainOwnership, ApplicationPermissions, Amount, MessageId)>,
+    expected_open_chain_calls: VecDeque<(ChainOwnership, ApplicationPermissions, Amount, ChainId)>,
     expected_create_application_calls: VecDeque<ExpectedCreateApplicationCall>,
     key_value_store: KeyValueStore,
 }
@@ -651,13 +650,13 @@ where
         ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
         balance: Amount,
-        message_id: MessageId,
+        chain_id: ChainId,
     ) {
         self.expected_open_chain_calls.push_back((
             ownership,
             application_permissions,
             balance,
-            message_id,
+            chain_id,
         ));
     }
 
@@ -668,16 +667,15 @@ where
         ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
         balance: Amount,
-    ) -> (MessageId, ChainId) {
-        let (expected_ownership, expected_permissions, expected_balance, message_id) = self
+    ) -> ChainId {
+        let (expected_ownership, expected_permissions, expected_balance, chain_id) = self
             .expected_open_chain_calls
             .pop_front()
             .expect("Unexpected open_chain call");
         assert_eq!(ownership, expected_ownership);
         assert_eq!(application_permissions, expected_permissions);
         assert_eq!(balance, expected_balance);
-        let chain_id = ChainId::child(message_id);
-        (message_id, chain_id)
+        chain_id
     }
 
     /// Adds a new expected call to `create_application`.

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -17,9 +17,10 @@ use futures::future;
 use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey},
     data_types::{
-        Amount, ApplicationDescription, Blob, BlockHeight, Bytecode, CompressedBytecode, Epoch,
+        Amount, ApplicationDescription, Blob, BlockHeight, Bytecode, ChainDescription,
+        CompressedBytecode, Epoch,
     },
-    identifiers::{AccountOwner, ApplicationId, ChainDescription, ChainId, ModuleId},
+    identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId},
     vm::VmRuntime,
 };
 use linera_chain::{types::ConfirmedBlockCertificate, ChainExecutionContext};
@@ -47,7 +48,7 @@ impl Clone for ActiveChain {
     fn clone(&self) -> Self {
         ActiveChain {
             key_pair: self.key_pair.copy(),
-            description: self.description,
+            description: self.description.clone(),
             tip: self.tip.clone(),
             validator: self.validator.clone(),
         }
@@ -75,7 +76,7 @@ impl ActiveChain {
 
     /// Returns the [`ChainId`] of this microchain.
     pub fn id(&self) -> ChainId {
-        self.description.into()
+        self.description.id()
     }
 
     /// Returns the [`AccountPublicKey`] of the active owner of this microchain.
@@ -256,7 +257,7 @@ impl ActiveChain {
     ) -> Result<ConfirmedBlockCertificate, WorkerError> {
         let mut tip = self.tip.lock().await;
         let mut block = BlockBuilder::new(
-            self.description.into(),
+            self.description.id(),
             self.key_pair.public().into(),
             self.epoch().await,
             tip.as_ref(),

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -17,7 +17,7 @@ use linera_base::{
     crypto::{AccountSecretKey, ValidatorKeypair, ValidatorSecretKey},
     data_types::{
         Amount, ApplicationPermissions, Blob, BlobContent, ChainDescription, ChainOrigin, Epoch,
-        OpenChainConfig, Timestamp,
+        InitialChainConfig, Timestamp,
     },
     identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId},
     ownership::ChainOwnership,
@@ -286,7 +286,7 @@ impl TestValidator {
 
         let (epoch, committee) = self.committee.lock().await.clone();
 
-        let new_chain_config = OpenChainConfig {
+        let new_chain_config = InitialChainConfig {
             ownership: ChainOwnership::single(owner),
             committees: [(
                 epoch,
@@ -326,7 +326,7 @@ impl TestValidator {
         let key_pair = AccountSecretKey::generate();
         let (epoch, committee) = self.committee.lock().await.clone();
 
-        let new_chain_config = OpenChainConfig {
+        let new_chain_config = InitialChainConfig {
             ownership: ChainOwnership::single(key_pair.public().into()),
             committees: [(
                 epoch,

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -15,14 +15,17 @@ use futures::{
 };
 use linera_base::{
     crypto::{AccountSecretKey, ValidatorKeypair, ValidatorSecretKey},
-    data_types::{Amount, ApplicationPermissions, Blob, BlobContent, Epoch, Timestamp},
-    identifiers::{AccountOwner, ApplicationId, ChainDescription, ChainId, MessageId, ModuleId},
+    data_types::{
+        Amount, ApplicationPermissions, Blob, BlobContent, ChainDescription, ChainOrigin, Epoch,
+        OpenChainConfig, Timestamp,
+    },
+    identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId},
     ownership::ChainOwnership,
 };
 use linera_core::worker::WorkerState;
 use linera_execution::{
     committee::Committee,
-    system::{AdminOperation, OpenChainConfig, SystemOperation, OPEN_CHAIN_MESSAGE_INDEX},
+    system::{AdminOperation, SystemOperation},
     ResourceControlPolicy, WasmRuntime,
 };
 use linera_storage::{DbStorage, Storage, TestClock};
@@ -52,12 +55,14 @@ pub struct TestValidator {
     storage: DbStorage<MemoryStore, TestClock>,
     worker: WorkerState<DbStorage<MemoryStore, TestClock>>,
     clock: TestClock,
+    admin_chain_id: Option<ChainId>,
     chains: Arc<DashMap<ChainId, ActiveChain>>,
 }
 
 impl Clone for TestValidator {
     fn clone(&self) -> Self {
         TestValidator {
+            admin_chain_id: self.admin_chain_id,
             validator_secret: self.validator_secret.copy(),
             account_secret: self.account_secret.copy(),
             committee: self.committee.clone(),
@@ -93,13 +98,14 @@ impl TestValidator {
             NonZeroUsize::new(40).expect("Chain worker limit should not be zero"),
         );
 
-        let validator = TestValidator {
+        let mut validator = TestValidator {
             validator_secret: validator_keypair.secret_key,
             account_secret,
             committee,
             storage,
             worker,
             clock,
+            admin_chain_id: None,
             chains: Arc::default(),
         };
 
@@ -172,6 +178,14 @@ impl TestValidator {
         &self.validator_secret
     }
 
+    /// Returns the ID of the admin chain.
+    pub fn admin_chain_id(&self) -> ChainId {
+        *self
+            .admin_chain_id
+            .as_ref()
+            .expect("should create admin chain first")
+    }
+
     /// Returns the latest committee that this test validator is part of.
     ///
     /// The committee contains only this validator.
@@ -182,7 +196,7 @@ impl TestValidator {
     /// Updates the admin chain, creating a new epoch with an updated
     /// [`ResourceControlPolicy`].
     pub async fn change_resource_control_policy(
-        &self,
+        &mut self,
         adjustment: impl FnOnce(&mut ResourceControlPolicy),
     ) {
         let (epoch, committee) = {
@@ -197,7 +211,10 @@ impl TestValidator {
             (*epoch, committee.clone())
         };
 
-        let admin_chain_id = ChainId::root(0);
+        if self.admin_chain_id.is_none() {
+            self.create_admin_chain().await;
+        }
+        let admin_chain_id = self.admin_chain_id.unwrap();
         let admin_chain = self.get_chain(&admin_chain_id);
 
         let committee_blob = Blob::new(BlobContent::new_committee(
@@ -236,11 +253,11 @@ impl TestValidator {
         let description = self
             .request_new_chain_from_admin_chain(key_pair.public().into())
             .await;
-        let chain = ActiveChain::new(key_pair, description, self.clone());
+        let chain = ActiveChain::new(key_pair, description.clone(), self.clone());
 
         chain.handle_received_messages().await;
 
-        self.chains.insert(description.into(), chain.clone());
+        self.chains.insert(description.id(), chain.clone());
 
         chain
     }
@@ -261,7 +278,7 @@ impl TestValidator {
     ///
     /// Returns the [`ChainDescription`] of the new chain.
     async fn request_new_chain_from_admin_chain(&self, owner: AccountOwner) -> ChainDescription {
-        let admin_id = ChainId::root(0);
+        let admin_id = self.admin_chain_id.expect("Should have an admin chain");
         let admin_chain = self
             .chains
             .get(&admin_id)
@@ -271,8 +288,13 @@ impl TestValidator {
 
         let new_chain_config = OpenChainConfig {
             ownership: ChainOwnership::single(owner),
-            committees: [(epoch, committee)].into_iter().collect(),
-            admin_id,
+            committees: [(
+                epoch,
+                bcs::to_bytes(&committee).expect("Serializing a committee should not fail!"),
+            )]
+            .into_iter()
+            .collect(),
+            admin_id: Some(admin_id),
             epoch,
             balance: Amount::ZERO,
             application_permissions: ApplicationPermissions::default(),
@@ -280,16 +302,18 @@ impl TestValidator {
 
         let certificate = admin_chain
             .add_block(|block| {
-                block.with_system_operation(SystemOperation::OpenChain(new_chain_config));
+                block.with_system_operation(SystemOperation::OpenChain(new_chain_config.clone()));
             })
             .await;
         let block = certificate.inner().block();
 
-        ChainDescription::Child(MessageId {
-            chain_id: block.header.chain_id,
-            height: block.header.height,
-            index: OPEN_CHAIN_MESSAGE_INDEX,
-        })
+        let origin = ChainOrigin::Child {
+            parent: block.header.chain_id,
+            block_height: block.header.height,
+            chain_index: 0,
+        };
+
+        ChainDescription::new(origin, new_chain_config, Timestamp::from(0))
     }
 
     /// Returns the [`ActiveChain`] reference to the microchain identified by `chain_id`.
@@ -298,26 +322,36 @@ impl TestValidator {
     }
 
     /// Creates the root admin microchain and returns the [`ActiveChain`] map with it.
-    async fn create_admin_chain(&self) {
+    async fn create_admin_chain(&mut self) {
         let key_pair = AccountSecretKey::generate();
-        let description = ChainDescription::Root(0);
-        let committee = self.committee.lock().await.1.clone();
+        let (epoch, committee) = self.committee.lock().await.clone();
+
+        let new_chain_config = OpenChainConfig {
+            ownership: ChainOwnership::single(key_pair.public().into()),
+            committees: [(
+                epoch,
+                bcs::to_bytes(&committee).expect("Serializing a committee should not fail!"),
+            )]
+            .into_iter()
+            .collect(),
+            admin_id: None,
+            epoch,
+            balance: Amount::MAX,
+            application_permissions: ApplicationPermissions::default(),
+        };
+
+        let origin = ChainOrigin::Root(0);
+        let description = ChainDescription::new(origin, new_chain_config, Timestamp::from(0));
+        self.admin_chain_id = Some(description.id());
 
         self.worker()
             .storage_client()
-            .create_chain(
-                committee,
-                ChainId::root(0),
-                description,
-                key_pair.public().into(),
-                Amount::MAX,
-                Timestamp::from(0),
-            )
+            .create_chain(description.clone())
             .await
             .expect("Failed to create root admin chain");
 
-        let chain = ActiveChain::new(key_pair, description, self.clone());
+        let chain = ActiveChain::new(key_pair, description.clone(), self.clone());
 
-        self.chains.insert(description.into(), chain);
+        self.chains.insert(description.id(), chain);
     }
 }

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -8,7 +8,7 @@ interface contract-runtime-api {
     send-message: func(message: send-message-request);
     transfer: func(source: account-owner, destination: account, amount: amount);
     claim: func(source: account, destination: account, amount: amount);
-    open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: amount) -> tuple<message-id, chain-id>;
+    open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: amount) -> chain-id;
     close-chain: func() -> result<tuple<>, close-chain-error>;
     change-application-permissions: func(application-permissions: application-permissions) -> result<tuple<>, change-application-permissions-error>;
     create-application: func(module-id: module-id, parameters: list<u8>, argument: list<u8>, required-application-ids: list<application-id>) -> application-id;

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -243,7 +243,7 @@ type ChainAndHeight {
 }
 
 """
-How to create a chain
+Initial chain configuration and chain origin.
 """
 scalar ChainDescription
 

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -4,10 +4,8 @@
 use graphql_client::GraphQLQuery;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, Blob, BlockHeight, OracleResponse, Round, Timestamp},
-    identifiers::{
-        Account, AccountOwner, BlobId, ChainDescription, ChainId, GenericApplicationId, StreamName,
-    },
+    data_types::{Amount, Blob, BlockHeight, ChainDescription, OracleResponse, Round, Timestamp},
+    identifiers::{Account, AccountOwner, BlobId, ChainId, GenericApplicationId, StreamName},
 };
 use thiserror::Error;
 

--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -61,7 +61,7 @@ async fn test_end_to_end_queries(config: impl LineraNetConfig) {
         let wallet = client.load_wallet().unwrap();
         (wallet.default_chain(), wallet.chain_ids())
     };
-    let chain_id = node_chains.0.unwrap();
+    let chain0 = node_chains.0.unwrap();
 
     // publishing an application
     let (contract, service) = client.build_example("fungible").await.unwrap();
@@ -91,8 +91,7 @@ async fn test_end_to_end_queries(config: impl LineraNetConfig) {
     let url = &format!("http://localhost:{}/", node_service.port());
 
     // sending a few transfers
-    let chain0 = ChainId::root(0);
-    let chain1 = Account::chain(ChainId::root(1));
+    let chain1 = Account::chain(node_chains.1[1]);
     for _ in 0..10 {
         transfer(req_client, url, chain0, chain1, "0.1").await;
     }
@@ -109,7 +108,7 @@ async fn test_end_to_end_queries(config: impl LineraNetConfig) {
         req_client,
         url,
         blocks::Variables {
-            chain_id,
+            chain_id: chain0,
             from: None,
             limit: None,
         },
@@ -124,7 +123,7 @@ async fn test_end_to_end_queries(config: impl LineraNetConfig) {
         &reqwest_client(),
         &format!("http://localhost:{}/", node_service.port()),
         block::Variables {
-            chain_id,
+            chain_id: chain0,
             hash: None,
         },
     )

--- a/linera-service/benches/transfers.rs
+++ b/linera-service/benches/transfers.rs
@@ -9,7 +9,7 @@ use futures::{
 use linera_base::{
     crypto::{AccountSecretKey, Ed25519SecretKey, EvmSecretKey, Secp256k1SecretKey},
     data_types::Amount,
-    identifiers::{Account, AccountOwner, ChainId},
+    identifiers::{Account, AccountOwner},
     time::{Duration, Instant},
 };
 use linera_execution::system::Recipient;
@@ -75,7 +75,7 @@ async fn setup_native_token_balances(
         .collect::<Vec<_>>()
         .await;
 
-    let admin_chain = validator.get_chain(&ChainId::root(0));
+    let admin_chain = validator.get_chain(&validator.admin_chain_id());
 
     for chain in &chains {
         let recipient = Recipient::Account(Account {

--- a/linera-service/src/linera-exporter/exporter_service.rs
+++ b/linera-service/src/linera-exporter/exporter_service.rs
@@ -295,6 +295,8 @@ mod test {
             destinations: vec![],
         };
 
+        let dummy_chain_id = ChainId(CryptoHash::test_hash("root1"));
+
         let block = BlockExecutionOutcome {
             messages: vec![Vec::new()],
             previous_message_blocks: BTreeMap::new(),
@@ -304,9 +306,7 @@ mod test {
             blobs: vec![Vec::new()],
             operation_results: vec![OperationResult::default()],
         }
-        .with(
-            make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(1), Amount::ONE),
-        );
+        .with(make_first_block(dummy_chain_id).with_simple_transfer(dummy_chain_id, Amount::ONE));
         let confirmed_block = ConfirmedBlock::new(block);
         let expected_byte_size = bcs::serialized_size(&confirmed_block).unwrap(); // here just to avoid cloning after the move below.
         let certificate = ConfirmedBlockCertificate::new(confirmed_block, Round::Fast, vec![]);

--- a/linera-service/src/linera/command.rs
+++ b/linera-service/src/linera/command.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 use linera_base::{
     crypto::{AccountPublicKey, CryptoHash, ValidatorPublicKey},
     data_types::Amount,
-    identifiers::{Account, AccountOwner, ApplicationId, ChainId, MessageId, ModuleId},
+    identifiers::{Account, AccountOwner, ApplicationId, ChainId, ModuleId},
     time::Duration,
     vm::VmRuntime,
 };
@@ -741,10 +741,9 @@ pub enum ClientCommand {
         #[arg(long)]
         owner: AccountOwner,
 
-        /// The ID of the message that created the chain. (This uniquely describes the
-        /// chain and where it was created.)
+        /// The ID of the chain.
         #[arg(long)]
-        message_id: MessageId,
+        chain_id: ChainId,
     },
 
     /// Retry a block we unsuccessfully tried to propose earlier.

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -24,7 +24,7 @@ use linera_base::{
     bcs,
     crypto::{AccountSecretKey, CryptoHash, CryptoRng, Ed25519SecretKey},
     data_types::{
-        ApplicationPermissions, BlockHeight, ChainDescription, ChainOrigin, Epoch, OpenChainConfig, Timestamp,
+        ApplicationPermissions, BlockHeight, ChainDescription, ChainOrigin, Epoch, InitialChainConfig, Timestamp,
     },
     identifiers::{AccountOwner, ChainId},
     listen_for_shutdown_signals,
@@ -1724,7 +1724,7 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
             )]
             .into_iter()
             .collect();
-            let admin_config = OpenChainConfig {
+            let admin_config = InitialChainConfig {
                 admin_id: None,
                 balance: *initial_funding,
                 committees,
@@ -1756,7 +1756,7 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                 let config = if i == 0 {
                     admin_config.clone()
                 } else {
-                    OpenChainConfig {
+                    InitialChainConfig {
                         admin_id: Some(admin_id),
                         ownership: ChainOwnership::single(key_pair.public().into()),
                         ..admin_config.clone()

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -21,9 +21,12 @@ use colored::Colorize;
 use command::{ClientCommand, DatabaseToolCommand, NetCommand, ProjectCommand, WalletCommand};
 use futures::{lock::Mutex, FutureExt as _, StreamExt};
 use linera_base::{
+    bcs,
     crypto::{AccountSecretKey, CryptoHash, CryptoRng, Ed25519SecretKey},
-    data_types::{ApplicationPermissions, BlockHeight, Timestamp},
-    identifiers::{AccountOwner, ChainDescription, ChainId},
+    data_types::{
+        ApplicationPermissions, BlockHeight, ChainDescription, ChainOrigin, Epoch, OpenChainConfig, Timestamp,
+    },
+    identifiers::{AccountOwner, ChainId},
     listen_for_shutdown_signals,
     ownership::ChainOwnership,
 };
@@ -100,7 +103,7 @@ impl Runnable for Job {
                 recipient,
                 amount,
             } => {
-                let chain_client = context.make_chain_client(sender.chain_id)?;
+                let chain_client = context.make_chain_client(sender.chain_id).await?;
                 info!(
                     "Starting transfer of {} native tokens from {} to {}",
                     amount, sender, recipient
@@ -128,7 +131,7 @@ impl Runnable for Job {
                 balance,
             } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id).await?;
                 let (new_owner, key_pair) = match owner {
                     Some(owner) => (owner, None),
                     None => {
@@ -138,7 +141,7 @@ impl Runnable for Job {
                 };
                 info!("Opening a new chain from existing chain {}", chain_id);
                 let time_start = Instant::now();
-                let (message_id, certificate) = context
+                let (id, certificate) = context
                     .apply_client_command(&chain_client, |chain_client| {
                         let ownership = ChainOwnership::single(new_owner);
                         let chain_client = chain_client.clone();
@@ -150,8 +153,16 @@ impl Runnable for Job {
                     })
                     .await
                     .context("Failed to open chain")?;
-                let id = ChainId::child(message_id);
                 let timestamp = certificate.block().header.timestamp;
+                storage
+                    .write_blobs(
+                        &certificate
+                            .block()
+                            .created_blobs()
+                            .into_values()
+                            .collect::<Vec<_>>(),
+                    )
+                    .await?;
                 context
                     .update_wallet_for_new_chain(id, key_pair, timestamp)
                     .await?;
@@ -161,9 +172,8 @@ impl Runnable for Job {
                     time_total.as_millis()
                 );
                 debug!("{:?}", certificate);
-                // Print the new chain ID, message ID, and owner on stdout for scripting purposes.
-                println!("{}", message_id);
-                println!("{}", ChainId::child(message_id));
+                // Print the new chain ID, and owner on stdout for scripting purposes.
+                println!("{}", id);
                 println!("{}", new_owner);
             }
 
@@ -174,7 +184,7 @@ impl Runnable for Job {
                 application_permissions_config,
             } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id).await?;
                 info!(
                     "Opening a new multi-owner chain from existing chain {}",
                     chain_id
@@ -183,7 +193,7 @@ impl Runnable for Job {
                 let ownership = ChainOwnership::try_from(ownership_config)?;
                 let application_permissions =
                     ApplicationPermissions::from(application_permissions_config);
-                let (message_id, certificate) = context
+                let (id, certificate) = context
                     .apply_client_command(&chain_client, |chain_client| {
                         let ownership = ownership.clone();
                         let application_permissions = application_permissions.clone();
@@ -198,7 +208,6 @@ impl Runnable for Job {
                     .context("Failed to open chain")?;
                 // No key pair. This chain can be assigned explicitly using the assign command.
                 let key_pair = None;
-                let id = ChainId::child(message_id);
                 let timestamp = certificate.block().header.timestamp;
                 context
                     .update_wallet_for_new_chain(id, key_pair, timestamp)
@@ -210,8 +219,7 @@ impl Runnable for Job {
                 );
                 debug!("{:?}", certificate);
                 // Print the new chain ID and message ID on stdout for scripting purposes.
-                println!("{}", message_id);
-                println!("{}", ChainId::child(message_id));
+                println!("{}", id);
             }
 
             ChangeOwnership {
@@ -224,7 +232,7 @@ impl Runnable for Job {
                 application_permissions_config,
             } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id).await?;
                 info!("Changing application permissions for chain {}", chain_id);
                 let time_start = Instant::now();
                 let application_permissions =
@@ -250,7 +258,7 @@ impl Runnable for Job {
             }
 
             CloseChain { chain_id } => {
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id).await?;
                 info!("Closing chain {}", chain_id);
                 let time_start = Instant::now();
                 let result = context
@@ -277,7 +285,7 @@ impl Runnable for Job {
 
             LocalBalance { account } => {
                 let account = account.unwrap_or_else(|| context.default_account());
-                let chain_client = context.make_chain_client(account.chain_id)?;
+                let chain_client = context.make_chain_client(account.chain_id).await?;
                 info!("Reading the balance of {} from the local state", account);
                 let time_start = Instant::now();
                 let balance = chain_client.local_owner_balance(account.owner).await?;
@@ -288,7 +296,7 @@ impl Runnable for Job {
 
             QueryBalance { account } => {
                 let account = account.unwrap_or_else(|| context.default_account());
-                let chain_client = context.make_chain_client(account.chain_id)?;
+                let chain_client = context.make_chain_client(account.chain_id).await?;
                 info!(
                     "Evaluating the local balance of {account} by staging execution of known \
                     incoming messages"
@@ -302,7 +310,7 @@ impl Runnable for Job {
 
             SyncBalance { account } => {
                 let account = account.unwrap_or_else(|| context.default_account());
-                let chain_client = context.make_chain_client(account.chain_id)?;
+                let chain_client = context.make_chain_client(account.chain_id).await?;
                 info!("Synchronizing chain information and querying the local balance");
                 warn!("This command is deprecated. Use `linera sync && linera query-balance` instead.");
                 let time_start = Instant::now();
@@ -320,7 +328,7 @@ impl Runnable for Job {
 
             Sync { chain_id } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id).await?;
                 info!("Synchronizing chain information");
                 let time_start = Instant::now();
                 chain_client.synchronize_from_validators().await?;
@@ -334,7 +342,7 @@ impl Runnable for Job {
 
             ProcessInbox { chain_id } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id).await?;
                 info!("Processing the inbox of chain {}", chain_id);
                 let time_start = Instant::now();
                 let certificates = context.process_inbox(&chain_client).await?;
@@ -418,7 +426,7 @@ impl Runnable for Job {
                 use linera_core::node::ValidatorNode as _;
 
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id).await?;
                 info!("Querying validators about chain {}", chain_id);
                 let result = chain_client.local_committee().await;
                 context.update_wallet_from_client(&chain_client).await?;
@@ -494,7 +502,7 @@ impl Runnable for Job {
                 let validator = context.make_node_provider().make_node(&address)?;
 
                 for chain_id in chains {
-                    let chain = context.make_chain_client(chain_id)?;
+                    let chain = context.make_chain_client(chain_id).await?;
 
                     Box::pin(chain.sync_validator(validator.clone())).await?;
                 }
@@ -544,8 +552,9 @@ impl Runnable for Job {
                         ),
                     }
                 }
-                let chain_client =
-                    context.make_chain_client(context.wallet.genesis_admin_chain())?;
+                let chain_client = context
+                    .make_chain_client(context.wallet.genesis_admin_chain())
+                    .await?;
                 let n = context
                     .process_inbox(&chain_client)
                     .await
@@ -713,8 +722,9 @@ impl Runnable for Job {
                 info!("Starting operations to remove old committees");
                 let time_start = Instant::now();
 
-                let chain_client =
-                    context.make_chain_client(context.wallet.genesis_admin_chain())?;
+                let chain_client = context
+                    .make_chain_client(context.wallet.genesis_admin_chain())
+                    .await?;
 
                 // Remove the old committee.
                 info!("Finalizing current committee");
@@ -805,7 +815,7 @@ impl Runnable for Job {
             Watch { chain_id, raw } => {
                 let mut join_set = JoinSet::new();
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id).await?;
                 info!("Watching for notifications for chain {:?}", chain_id);
                 let (listener, _listen_handle, mut notifications) = chain_client.listen().await?;
                 join_set.spawn_task(listener);
@@ -874,7 +884,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let publisher = publisher.unwrap_or_else(|| context.default_chain());
                 info!("Publishing module on chain {}", publisher);
-                let chain_client = context.make_chain_client(publisher)?;
+                let chain_client = context.make_chain_client(publisher).await?;
                 let module_id = context
                     .publish_module(&chain_client, contract, service, vm_runtime)
                     .await?;
@@ -892,7 +902,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let publisher = publisher.unwrap_or_else(|| context.default_chain());
                 info!("Publishing data blob on chain {}", publisher);
-                let chain_client = context.make_chain_client(publisher)?;
+                let chain_client = context.make_chain_client(publisher).await?;
                 let hash = context.publish_data_blob(&chain_client, blob_path).await?;
                 println!("{}", hash);
                 info!(
@@ -906,7 +916,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let reader = reader.unwrap_or_else(|| context.default_chain());
                 info!("Verifying data blob on chain {}", reader);
-                let chain_client = context.make_chain_client(reader)?;
+                let chain_client = context.make_chain_client(reader).await?;
                 context.read_data_blob(&chain_client, hash).await?;
                 info!("Data blob read in {} ms", start_time.elapsed().as_millis());
             }
@@ -923,7 +933,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let creator = creator.unwrap_or_else(|| context.default_chain());
                 info!("Creating application on chain {}", creator);
-                let chain_client = context.make_chain_client(creator)?;
+                let chain_client = context.make_chain_client(creator).await?;
                 let parameters = read_json(json_parameters, json_parameters_path)?;
                 let argument = read_json(json_argument, json_argument_path)?;
 
@@ -972,7 +982,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let publisher = publisher.unwrap_or_else(|| context.default_chain());
                 info!("Publishing and creating application on chain {}", publisher);
-                let chain_client = context.make_chain_client(publisher)?;
+                let chain_client = context.make_chain_client(publisher).await?;
                 let parameters = read_json(json_parameters, json_parameters_path)?;
                 let argument = read_json(json_argument, json_argument_path)?;
                 let module_id = context
@@ -1006,17 +1016,15 @@ impl Runnable for Job {
                 println!("{}", application_id);
             }
 
-            Assign { owner, message_id } => {
+            Assign { owner, chain_id } => {
                 let start_time = Instant::now();
-                let chain_id = ChainId::child(message_id);
                 info!(
                     "Linking chain {chain_id} to its corresponding key in the wallet, owned by \
                     {owner}",
                 );
                 context
-                    .assign_new_chain_to_key(chain_id, message_id, owner, None)
+                    .assign_new_chain_to_key(chain_id, owner, None)
                     .await?;
-                println!("{}", chain_id);
                 context.save_wallet().await?;
                 info!(
                     "Chain linked to owner in {} ms",
@@ -1039,7 +1047,7 @@ impl Runnable for Job {
                     let start_time = Instant::now();
                     let publisher = publisher.unwrap_or_else(|| context.default_chain());
                     info!("Creating application on chain {}", publisher);
-                    let chain_client = context.make_chain_client(publisher)?;
+                    let chain_client = context.make_chain_client(publisher).await?;
 
                     let parameters = read_json(json_parameters, json_parameters_path)?;
                     let argument = read_json(json_argument, json_argument_path)?;
@@ -1085,7 +1093,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
                 info!("Committing pending block for chain {}", chain_id);
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id).await?;
                 match chain_client.process_pending_block().await? {
                     ClientOutcome::Committed(Some(certificate)) => {
                         info!("Pending block committed successfully.");
@@ -1124,16 +1132,10 @@ impl Runnable for Job {
                 let outcome = faucet.claim(&owner).await?;
                 let validators = faucet.current_validators().await?;
                 println!("{}", outcome.chain_id);
-                println!("{}", outcome.message_id);
                 println!("{}", outcome.certificate_hash);
                 println!("{}", owner);
                 context
-                    .assign_new_chain_to_key(
-                        outcome.chain_id,
-                        outcome.message_id,
-                        owner,
-                        Some(validators),
-                    )
+                    .assign_new_chain_to_key(outcome.chain_id, owner, Some(validators))
                     .await?;
                 let admin_id = context.wallet().genesis_admin_chain();
                 let chains = with_other_chains
@@ -1169,16 +1171,10 @@ impl Runnable for Job {
                 let outcome = faucet.claim(&owner).await?;
                 let validators = faucet.current_validators().await?;
                 println!("{}", outcome.chain_id);
-                println!("{}", outcome.message_id);
                 println!("{}", outcome.certificate_hash);
                 println!("{}", owner);
                 context
-                    .assign_new_chain_to_key(
-                        outcome.chain_id,
-                        outcome.message_id,
-                        owner,
-                        Some(validators),
-                    )
+                    .assign_new_chain_to_key(outcome.chain_id, owner, Some(validators))
                     .await?;
                 if set_default {
                     context
@@ -1716,7 +1712,30 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                     Timestamp::from(micros)
                 })
                 .unwrap_or_else(Timestamp::now);
-            let admin_id = ChainId::root(*admin_root);
+
+            let mut rng = Box::<dyn CryptoRng>::from(*testing_prng_seed);
+            let origin = ChainOrigin::Root(*admin_root);
+            let admin_key_pair =
+                AccountSecretKey::Ed25519(Ed25519SecretKey::generate_from(&mut rng));
+            let committee = committee_config.clone().into_committee(policy.clone());
+            let committees = [(
+                Epoch::ZERO,
+                bcs::to_bytes(&committee).expect("serializing a committee should not fail"),
+            )]
+            .into_iter()
+            .collect();
+            let admin_config = OpenChainConfig {
+                admin_id: None,
+                balance: *initial_funding,
+                committees,
+                epoch: Epoch::ZERO,
+                application_permissions: Default::default(),
+                ownership: ChainOwnership::single(admin_key_pair.public().into()),
+            };
+            let admin_chain_description =
+                ChainDescription::new(origin, admin_config.clone(), timestamp);
+            let admin_id = admin_chain_description.id();
+
             let network_name = network_name.clone().unwrap_or_else(|| {
                 // Default: e.g. "linera-2023-11-14T23:13:20"
                 format!("linera-{}", Utc::now().naive_utc().format("%FT%T"))
@@ -1725,12 +1744,26 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                 genesis_config_path,
                 GenesisConfig::new(committee_config, admin_id, timestamp, policy, network_name),
             )?;
-            let mut rng = Box::<dyn CryptoRng>::from(*testing_prng_seed);
             let mut chains = vec![];
             for i in 0..=*num_other_initial_chains {
-                let description = ChainDescription::Root(i);
                 // Create keys.
-                let key_pair = AccountSecretKey::Ed25519(Ed25519SecretKey::generate_from(&mut rng));
+                let key_pair = if i == 0 {
+                    admin_key_pair.copy()
+                } else {
+                    AccountSecretKey::Ed25519(Ed25519SecretKey::generate_from(&mut rng))
+                };
+                let origin = ChainOrigin::Root(i);
+                let config = if i == 0 {
+                    admin_config.clone()
+                } else {
+                    OpenChainConfig {
+                        admin_id: Some(admin_id),
+                        ownership: ChainOwnership::single(key_pair.public().into()),
+                        ..admin_config.clone()
+                    }
+                };
+                let description = ChainDescription::new(origin, config, timestamp);
+                // TODO: store the description blob!
                 let chain = UserChain::make_initial(key_pair, description, timestamp);
                 // Public "genesis" state.
                 let key = chain.key_pair.as_ref().unwrap().public();

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -695,6 +695,7 @@ impl<T> GrpcMessageLimiter<T> {
 
 #[cfg(test)]
 mod proto_message_cap {
+    use linera_base::crypto::CryptoHash;
     use linera_chain::{
         data_types::BlockExecutionOutcome,
         types::{Block, Certificate, ConfirmedBlock, ConfirmedBlockCertificate},
@@ -710,7 +711,7 @@ mod proto_message_cap {
         let validator = keypair.public_key;
         let signature = ValidatorSignature::new(&TestString::new("Test"), &keypair.secret_key);
         let block = Block::new(
-            linera_chain::test::make_first_block(ChainId::root(0)),
+            linera_chain::test::make_first_block(ChainId(CryptoHash::test_hash("root_chain"))),
             BlockExecutionOutcome::default(),
         );
         let signatures = vec![(validator, signature)];

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -182,7 +182,7 @@ impl<P: ValidatorNodeProvider + Send, S: Storage + Clone + Send + Sync + 'static
         unimplemented!()
     }
 
-    fn make_chain_client(&self, _: ChainId) -> Result<ChainClient<Self::Environment>, Error> {
+    async fn make_chain_client(&self, _: ChainId) -> Result<ChainClient<Self::Environment>, Error> {
         unimplemented!()
     }
 
@@ -199,7 +199,7 @@ impl<P: ValidatorNodeProvider + Send, S: Storage + Clone + Send + Sync + 'static
         Ok(())
     }
 
-    fn clients(&self) -> Result<Vec<ChainClient<Self::Environment>>, Error> {
+    async fn clients(&self) -> Result<Vec<ChainClient<Self::Environment>>, Error> {
         Ok(vec![])
     }
 }

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -3108,6 +3108,10 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     net.ensure_is_running().await?;
     net.terminate().await?;
 
+    // Explicitly drop clients so that they aren't dropped earlier.
+    drop(client1);
+    drop(client2);
+
     Ok(())
 }
 

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -3108,10 +3108,6 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     net.ensure_is_running().await?;
     net.terminate().await?;
 
-    // Explicitly drop clients so that they aren't dropped earlier.
-    drop(client1);
-    drop(client2);
-
     Ok(())
 }
 

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -3279,7 +3279,7 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
 
     // Since the faucet chain exceeds the configured maximum length, the faucet should have
     // switched after the first new chain.
-    assert!(other_outcome.message_id.chain_id != outcome.message_id.chain_id);
+    assert!(other_outcome.chain_id != outcome.chain_id);
 
     let chain = outcome.chain_id;
     assert_eq!(chain, client.load_wallet()?.default_chain().unwrap());

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -20,7 +20,7 @@ use linera_base::vm::VmRuntime;
 use linera_base::{
     crypto::Secp256k1SecretKey,
     data_types::{Amount, BlockHeight, Epoch},
-    identifiers::{Account, AccountOwner, ChainId},
+    identifiers::{Account, AccountOwner},
 };
 use linera_core::{data_types::ChainInfoQuery, node::ValidatorNode};
 use linera_faucet::ClaimOutcome;
@@ -80,7 +80,10 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
 
     let client_2 = net.make_client().await;
     client_2.wallet_init(&[], FaucetOption::None).await?;
-    let chain_1 = ChainId::root(0);
+    let chain_1 = client
+        .load_wallet()?
+        .default_chain()
+        .expect("should have a default chain");
 
     let chain_2 = client
         .open_and_assign(&client_2, Amount::from_tokens(3))
@@ -293,12 +296,8 @@ async fn test_end_to_end_receipt_of_old_create_committee_messages(
 
     // Create a new chain starting on the new epoch
     let new_owner = client.keygen().await?;
-    let ClaimOutcome {
-        chain_id,
-        message_id,
-        ..
-    } = faucet.claim(&new_owner).await?;
-    client.assign(new_owner, message_id).await?;
+    let ClaimOutcome { chain_id, .. } = faucet.claim(&new_owner).await?;
+    client.assign(new_owner, chain_id).await?;
 
     // Attempt to receive the existing epoch change message
     client.process_inbox(chain_id).await?;
@@ -423,12 +422,8 @@ async fn test_end_to_end_receipt_of_old_remove_committee_messages(
 
     // Create a new chain starting on the new epoch
     let new_owner = client.keygen().await?;
-    let ClaimOutcome {
-        chain_id,
-        message_id,
-        ..
-    } = faucet.claim(&new_owner).await?;
-    client.assign(new_owner, message_id).await?;
+    let ClaimOutcome { chain_id, .. } = faucet.claim(&new_owner).await?;
+    client.assign(new_owner, chain_id).await?;
 
     // Attempt to receive the existing epoch change messages
     client.process_inbox(chain_id).await?;
@@ -449,8 +444,13 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetConfig) -> Re
 
     let (mut net, client1) = config.instantiate().await?;
 
+    let (chain, chain1) = {
+        let wallet = client1.load_wallet()?;
+        let chains = wallet.chain_ids();
+        (chains[0], chains[1])
+    };
+
     let client2 = net.make_client().await;
-    let chain = ChainId::root(0);
     let mut height = 0;
     client2.wallet_init(&[chain], FaucetOption::None).await?;
 
@@ -476,7 +476,7 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetConfig) -> Re
         for i in 0..10 {
             // Add a new block on the chain, triggering a notification.
             client1
-                .transfer(Amount::from_tokens(1), chain, ChainId::root(1))
+                .transfer(Amount::from_tokens(1), chain, chain1)
                 .await?;
             linera_base::time::timer::sleep(Duration::from_secs(i)).await;
             height += 1;
@@ -510,7 +510,11 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetConfig) -> Result<(
 
     // Create runner and client.
     let (mut net, client) = config.instantiate().await?;
-    let chain_id = client.load_wallet()?.default_chain().unwrap();
+    let (chain_id, chain1) = {
+        let wallet = client.load_wallet()?;
+        let chains = wallet.chain_ids();
+        (chains[0], chains[1])
+    };
     let account = Account::chain(chain_id);
     let balance = client.local_balance(account).await?;
     // Stop validators.
@@ -518,7 +522,7 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetConfig) -> Result<(
         net.remove_validator(i)?;
     }
     let result = client
-        .transfer_with_silent_logs(Amount::from_tokens(2), chain_id, ChainId::root(1))
+        .transfer_with_silent_logs(Amount::from_tokens(2), chain_id, chain1)
         .await;
     assert!(result.is_err());
     // The transfer didn't get confirmed.
@@ -789,7 +793,7 @@ async fn test_sync_validator(config: LocalNetConfig) -> Result<()> {
 
     // Create some blocks
     let sender_chain = client.default_chain().expect("Client has no default chain");
-    let (_, receiver_chain, _) = client
+    let (receiver_chain, _) = client
         .open_chain(sender_chain, None, Amount::from_tokens(1_000))
         .await?;
 


### PR DESCRIPTION
## Motivation

This will allow for easier initialization of the network at genesis, among other things.

## Proposal

`ChainDescription` will become a blob, and `OpenChain` messages will be removed. Calling `open_chain` will create the blob, and the chain will actually get initialized when a block is proposed for it.

## Test Plan

Should be covered by CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- #2390 