### PR TITLE
Use newer ScyllaDB Chart versions

### DIFF
--- a/kubernetes/linera-validator/helmfile.yaml
+++ b/kubernetes/linera-validator/helmfile.yaml
@@ -58,7 +58,7 @@ releases:
       - name: crds.enabled
         value: "true"
   - name: scylla
-    version: v1.13.0
+    version: v1.16.0
     namespace: scylla
     chart: scylla/scylla
     timeout: 900
@@ -68,7 +68,7 @@ releases:
     values:
       - {{ env "LINERA_HELMFILE_VALUES_SCYLLA" | default "scylla.values.yaml.gotmpl" }}
   - name: scylla-manager
-    version: v1.13.0
+    version: v1.16.0
     namespace: scylla-manager
     chart: scylla/scylla-manager
     timeout: 900
@@ -77,7 +77,7 @@ releases:
     values:
       - {{ env "LINERA_HELMFILE_VALUES_SCYLLA_MANAGER" | default "scylla-manager.values.yaml" }}
   - name: scylla-operator
-    version: v1.13.0
+    version: v1.16.0
     namespace: scylla-operator
     chart: scylla/scylla-operator
     timeout: 900
@@ -86,7 +86,7 @@ releases:
     values:
       - {{ env "LINERA_HELMFILE_VALUES_SCYLLA_OPERATOR" | default "scylla-operator.values.yaml" }}
   - name: cert-manager
-    version: v1.15.3
+    version: v1.17.0
     namespace: cert-manager
     chart: jetstack/cert-manager
     timeout: 900


### PR DESCRIPTION
## Motivation

When talking to the ScyllaDB contact, he said that using up to date charts is probably a good idea, to make sure we don't have any bugs that were fixed

## Proposal

Update ScyllaDB chart versions

## Test Plan

Deployed network locally

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
