### PR TITLE
Move `Epoch` to linera_base

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -11,13 +11,11 @@ use std::{
 use async_graphql::SimpleObject;
 use linera_base::{
     crypto::{BcsHashable, CryptoHash},
-    data_types::{Blob, BlockHeight, Event, OracleResponse, Timestamp},
+    data_types::{Blob, BlockHeight, Epoch, Event, OracleResponse, Timestamp},
     hashed::Hashed,
     identifiers::{AccountOwner, BlobId, ChainId, MessageId},
 };
-use linera_execution::{
-    committee::Epoch, system::OpenChainConfig, BlobState, Operation, OutgoingMessage,
-};
+use linera_execution::{system::OpenChainConfig, BlobState, Operation, OutgoingMessage};
 use serde::{ser::SerializeStruct, Deserialize, Serialize};
 use thiserror::Error;
 

--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -4,10 +4,9 @@
 
 use linera_base::{
     crypto::{ValidatorPublicKey, ValidatorSignature},
-    data_types::Round,
+    data_types::{Epoch, Round},
     identifiers::{BlobId, ChainId, MessageId},
 };
-use linera_execution::committee::Epoch;
 use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize};
 
 use super::{generic::GenericCertificate, Certificate};

--- a/linera-chain/src/certificate/mod.rs
+++ b/linera-chain/src/certificate/mod.rs
@@ -13,10 +13,9 @@ use std::collections::BTreeSet;
 pub use generic::GenericCertificate;
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey, ValidatorSignature},
-    data_types::{BlockHeight, Round},
+    data_types::{BlockHeight, Epoch, Round},
     identifiers::{BlobId, ChainId},
 };
-use linera_execution::committee::Epoch;
 pub use lite::LiteCertificate;
 use serde::{Deserialize, Serialize};
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -14,7 +14,7 @@ use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlockHeight,
-        OracleResponse, Timestamp,
+        Epoch, OracleResponse, Timestamp,
     },
     ensure,
     identifiers::{
@@ -24,11 +24,9 @@ use linera_base::{
     ownership::ChainOwnership,
 };
 use linera_execution::{
-    committee::{Committee, Epoch},
-    system::OpenChainConfig,
-    ExecutionRuntimeContext, ExecutionStateView, Message, MessageContext, Operation,
-    OperationContext, OutgoingMessage, Query, QueryContext, QueryOutcome, ResourceController,
-    ResourceTracker, ServiceRuntimeEndpoint, TransactionTracker,
+    committee::Committee, system::OpenChainConfig, ExecutionRuntimeContext, ExecutionStateView,
+    Message, MessageContext, Operation, OperationContext, OutgoingMessage, Query, QueryContext,
+    QueryOutcome, ResourceController, ResourceTracker, ServiceRuntimeEndpoint, TransactionTracker,
 };
 use linera_views::{
     bucket_queue_view::BucketQueueView,

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -15,7 +15,7 @@ use linera_base::{
         AccountPublicKey, AccountSecretKey, AccountSignature, BcsHashable, BcsSignable,
         CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSecretKey, ValidatorSignature,
     },
-    data_types::{Amount, Blob, BlockHeight, Event, OracleResponse, Round, Timestamp},
+    data_types::{Amount, Blob, BlockHeight, Epoch, Event, OracleResponse, Round, Timestamp},
     doc_scalar, ensure, hex_debug,
     identifiers::{
         Account, AccountOwner, BlobId, ChainId, ChannelFullName, Destination, GenericApplicationId,
@@ -23,8 +23,7 @@ use linera_base::{
     },
 };
 use linera_execution::{
-    committee::{Committee, Epoch},
-    Message, MessageKind, Operation, OutgoingMessage, SystemMessage,
+    committee::Committee, Message, MessageKind, Operation, OutgoingMessage, SystemMessage,
 };
 use serde::{Deserialize, Serialize};
 
@@ -832,10 +831,9 @@ doc_scalar!(
 mod signing {
     use linera_base::{
         crypto::{AccountSecretKey, AccountSignature, CryptoHash, EvmSignature, TestString},
-        data_types::{BlockHeight, Round},
+        data_types::{BlockHeight, Epoch, Round},
         identifiers::ChainId,
     };
-    use linera_execution::committee::Epoch;
 
     use crate::data_types::{ProposalContent, ProposedBlock};
 

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -75,12 +75,12 @@ use custom_debug_derive::Debug;
 use futures::future::Either;
 use linera_base::{
     crypto::{AccountPublicKey, ValidatorSecretKey},
-    data_types::{Blob, BlockHeight, Round, Timestamp},
+    data_types::{Blob, BlockHeight, Epoch, Round, Timestamp},
     ensure,
     identifiers::{AccountOwner, BlobId, ChainId},
     ownership::ChainOwnership,
 };
-use linera_execution::{committee::Epoch, ExecutionRuntimeContext};
+use linera_execution::ExecutionRuntimeContext;
 use linera_views::{
     context::Context,
     map_view::MapView,

--- a/linera-chain/src/test/mod.rs
+++ b/linera-chain/src/test/mod.rs
@@ -7,11 +7,11 @@ mod http_server;
 
 use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey},
-    data_types::{Amount, BlockHeight, Round, Timestamp},
+    data_types::{Amount, BlockHeight, Epoch, Round, Timestamp},
     identifiers::{AccountOwner, ChainId},
 };
 use linera_execution::{
-    committee::{Committee, Epoch, ValidatorState},
+    committee::{Committee, ValidatorState},
     system::Recipient,
     Message, MessageKind, Operation, ResourceControlPolicy, SystemOperation,
 };

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -14,7 +14,7 @@ use axum::{routing::get, Router};
 use linera_base::{
     crypto::{AccountPublicKey, CryptoHash, ValidatorPublicKey},
     data_types::{
-        Amount, ApplicationDescription, ApplicationPermissions, Blob, BlockHeight, Bytecode,
+        Amount, ApplicationDescription, ApplicationPermissions, Blob, BlockHeight, Bytecode, Epoch,
         Timestamp,
     },
     http,
@@ -23,7 +23,7 @@ use linera_base::{
     vm::VmRuntime,
 };
 use linera_execution::{
-    committee::{Committee, Epoch, ValidatorState},
+    committee::{Committee, ValidatorState},
     system::{OpenChainConfig, Recipient},
     test_utils::{ExpectedCall, MockApplication},
     BaseRuntime, ContractRuntime, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext,

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, iter, sync::Arc};
 
 use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey},
-    data_types::{Amount, Timestamp},
+    data_types::{Amount, Epoch, Timestamp},
     identifiers::{AccountOwner, ApplicationId, ChainId},
     listen_for_shutdown_signals,
     time::Instant,
@@ -16,7 +16,7 @@ use linera_chain::{
 };
 use linera_core::{client::ChainClient, local_node::LocalNodeClient};
 use linera_execution::{
-    committee::{Committee, Epoch},
+    committee::Committee,
     system::{Recipient, SystemOperation},
     Operation,
 };

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -32,10 +32,13 @@ use tracing::{debug, info};
 use {
     crate::benchmark::{Benchmark, BenchmarkError},
     futures::{stream, StreamExt, TryStreamExt},
-    linera_base::{data_types::Amount, identifiers::ApplicationId},
+    linera_base::{
+        data_types::{Amount, Epoch},
+        identifiers::ApplicationId,
+    },
     linera_core::client::ChainClientError,
     linera_execution::{
-        committee::{Committee, Epoch},
+        committee::Committee,
         system::{OpenChainConfig, SystemOperation, OPEN_CHAIN_MESSAGE_INDEX},
         Operation,
     },

--- a/linera-client/src/unit_tests/wallet.rs
+++ b/linera-client/src/unit_tests/wallet.rs
@@ -4,7 +4,7 @@
 use anyhow::anyhow;
 use linera_base::{
     crypto::{AccountSecretKey, Ed25519SecretKey},
-    data_types::{Amount, Blob, BlockHeight},
+    data_types::{Amount, Blob, BlockHeight, Epoch},
     identifiers::{ChainDescription, ChainId},
 };
 use linera_chain::data_types::ProposedBlock;
@@ -12,7 +12,6 @@ use linera_core::{
     client::PendingProposal,
     test_utils::{MemoryStorageBuilder, StorageBuilder, TestBuilder},
 };
-use linera_execution::committee::Epoch;
 use rand::{rngs::StdRng, SeedableRng as _};
 
 use super::util::make_genesis_config;

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -12,7 +12,7 @@ use std::{
 use custom_debug_derive::Debug;
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
-    data_types::{ApplicationDescription, Blob, BlockHeight, Timestamp},
+    data_types::{ApplicationDescription, Blob, BlockHeight, Epoch, Timestamp},
     hashed::Hashed,
     identifiers::{ApplicationId, BlobId, ChainId},
 };
@@ -22,8 +22,8 @@ use linera_chain::{
     ChainStateView,
 };
 use linera_execution::{
-    committee::Epoch, ExecutionStateView, Query, QueryContext, QueryOutcome,
-    ServiceRuntimeEndpoint, ServiceSyncRuntime,
+    ExecutionStateView, Query, QueryContext, QueryOutcome, ServiceRuntimeEndpoint,
+    ServiceSyncRuntime,
 };
 use linera_storage::Storage;
 use tokio::sync::{mpsc, oneshot, OwnedRwLockReadGuard};

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -8,7 +8,7 @@ use std::{borrow::Cow, collections::BTreeMap};
 use futures::future::Either;
 use linera_base::{
     crypto::ValidatorPublicKey,
-    data_types::{Blob, BlockHeight, Timestamp},
+    data_types::{Blob, BlockHeight, Epoch, Timestamp},
     ensure,
     identifiers::{AccountOwner, ChainId},
 };
@@ -20,7 +20,7 @@ use linera_chain::{
     types::{ConfirmedBlockCertificate, TimeoutCertificate, ValidatedBlockCertificate},
     ChainExecutionContext, ChainStateView, ExecutionResultExt as _,
 };
-use linera_execution::committee::{Committee, Epoch};
+use linera_execution::committee::Committee;
 use linera_storage::{Clock as _, Storage};
 use linera_views::{
     context::Context,

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -14,7 +14,7 @@ use std::{
 
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
-    data_types::{ApplicationDescription, Blob, BlockHeight},
+    data_types::{ApplicationDescription, Blob, BlockHeight, Epoch},
     ensure,
     hashed::Hashed,
     identifiers::{ApplicationId, BlobId, ChainId},
@@ -28,8 +28,8 @@ use linera_chain::{
     ChainError, ChainStateView,
 };
 use linera_execution::{
-    committee::Epoch, ExecutionStateView, Message, Query, QueryContext, QueryOutcome,
-    ServiceRuntimeEndpoint, SystemMessage,
+    ExecutionStateView, Message, Query, QueryContext, QueryOutcome, ServiceRuntimeEndpoint,
+    SystemMessage,
 };
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::{ClonableView, ViewError};

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -28,8 +28,8 @@ use linera_base::{
     abi::Abi,
     crypto::{AccountPublicKey, AccountSecretKey, CryptoHash, ValidatorPublicKey},
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight, Round,
-        Timestamp,
+        Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight, Epoch,
+        Round, Timestamp,
     },
     ensure,
     identifiers::{
@@ -52,7 +52,7 @@ use linera_chain::{
     ChainError, ChainExecutionContext, ChainStateView,
 };
 use linera_execution::{
-    committee::{Committee, Epoch},
+    committee::Committee,
     system::{
         AdminOperation, OpenChainConfig, Recipient, SystemOperation, EPOCH_STREAM_NAME,
         OPEN_CHAIN_MESSAGE_INDEX, REMOVED_EPOCH_STREAM_NAME,

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -10,7 +10,7 @@ use linera_base::{
         BcsSignable, CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSecretKey,
         ValidatorSignature,
     },
-    data_types::{Amount, BlockHeight, Round, Timestamp},
+    data_types::{Amount, BlockHeight, Epoch, Round, Timestamp},
     identifiers::{AccountOwner, ChainDescription, ChainId},
 };
 use linera_chain::{
@@ -18,10 +18,7 @@ use linera_chain::{
     manager::ChainManagerInfo,
     ChainStateView,
 };
-use linera_execution::{
-    committee::{Committee, Epoch},
-    ExecutionRuntimeContext,
-};
+use linera_execution::{committee::Committee, ExecutionRuntimeContext};
 use linera_storage::ChainRuntimeContext;
 use linera_views::context::Context;
 use serde::{Deserialize, Serialize};

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -21,7 +21,7 @@ use linera_chain::{
     ChainError, ChainExecutionContext,
 };
 use linera_execution::{
-    committee::{Committee, Epoch},
+    committee::Committee,
     system::{Recipient, SystemOperation},
     ExecutionError, Message, MessageKind, Operation, QueryOutcome, ResourceControlPolicy,
     SystemMessage, SystemQuery, SystemResponse,

--- a/linera-core/src/unit_tests/value_cache_tests.rs
+++ b/linera-core/src/unit_tests/value_cache_tests.rs
@@ -5,12 +5,11 @@ use std::{borrow::Cow, collections::BTreeSet};
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, BlockHeight},
+    data_types::{Blob, BlockHeight, Epoch},
     hashed::Hashed,
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::types::Timeout;
-use linera_execution::committee::Epoch;
 
 use super::{ValueCache, DEFAULT_VALUE_CACHE_SIZE};
 

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -16,7 +16,8 @@ use assert_matches::assert_matches;
 use linera_base::{
     crypto::AccountSecretKey,
     data_types::{
-        Amount, ApplicationDescription, Blob, BlockHeight, Bytecode, OracleResponse, Timestamp,
+        Amount, ApplicationDescription, Blob, BlockHeight, Bytecode, Epoch, OracleResponse,
+        Timestamp,
     },
     identifiers::{ChainDescription, ChainId, ModuleId},
     ownership::ChainOwnership,
@@ -28,9 +29,8 @@ use linera_chain::{
     types::ConfirmedBlock,
 };
 use linera_execution::{
-    committee::Epoch, system::SystemOperation, test_utils::SystemExecutionState,
-    ExecutionRuntimeContext, Operation, OperationContext, ResourceController, TransactionTracker,
-    WasmContractModule, WasmRuntime,
+    system::SystemOperation, test_utils::SystemExecutionState, ExecutionRuntimeContext, Operation,
+    OperationContext, ResourceController, TransactionTracker, WasmContractModule, WasmRuntime,
 };
 use linera_storage::{DbStorage, Storage};
 #[cfg(feature = "dynamodb")]

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -42,7 +42,7 @@ use linera_chain::{
     ChainError, ChainExecutionContext,
 };
 use linera_execution::{
-    committee::{Committee, Epoch},
+    committee::Committee,
     system::{
         AdminOperation, OpenChainConfig, Recipient, SystemMessage, SystemOperation,
         EPOCH_STREAM_NAME as NEW_EPOCH_STREAM_NAME, REMOVED_EPOCH_STREAM_NAME,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -13,7 +13,8 @@ use futures::future::Either;
 use linera_base::{
     crypto::{CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSecretKey},
     data_types::{
-        ApplicationDescription, ArithmeticError, Blob, BlockHeight, DecompressionError, Round,
+        ApplicationDescription, ArithmeticError, Blob, BlockHeight, DecompressionError, Epoch,
+        Round,
     },
     doc_scalar,
     hashed::Hashed,
@@ -32,7 +33,7 @@ use linera_chain::{
     },
     ChainError, ChainStateView,
 };
-use linera_execution::{committee::Epoch, ExecutionError, ExecutionStateView, Query, QueryOutcome};
+use linera_execution::{ExecutionError, ExecutionStateView, Query, QueryOutcome};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
 use lru::LruCache;

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 
 use linera_base::{
     crypto::ValidatorPublicKey,
-    data_types::{Amount, Timestamp},
+    data_types::{Amount, Epoch, Timestamp},
     doc_scalar,
     identifiers::{AccountOwner, ChainDescription, ChainId},
     ownership::ChainOwnership,
@@ -13,15 +13,11 @@ use linera_base::{
 use linera_views::{context::Context, map_view::MapView};
 
 use crate::{
-    committee::{Committee, Epoch, ValidatorState},
+    committee::{Committee, ValidatorState},
     system::{Recipient, UserData},
     ExecutionStateView, SystemExecutionStateView,
 };
 
-doc_scalar!(
-    Epoch,
-    "A number identifying the configuration of the chain (aka the committee)"
-);
 doc_scalar!(Recipient, "The recipient of a transfer");
 doc_scalar!(UserData, "Optional user message attached to a transfer");
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -25,7 +25,6 @@ use std::{any::Any, fmt, str::FromStr, sync::Arc};
 
 use async_graphql::SimpleObject;
 use async_trait::async_trait;
-use committee::Epoch;
 use custom_debug_derive::Debug;
 use dashmap::DashMap;
 use derive_more::Display;
@@ -36,7 +35,7 @@ use linera_base::{
     crypto::{BcsHashable, CryptoHash},
     data_types::{
         Amount, ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlockHeight,
-        DecompressionError, Resources, SendMessageRequest, Timestamp,
+        DecompressionError, Epoch, Resources, SendMessageRequest, Timestamp,
     },
     doc_scalar, hex_debug, http,
     identifiers::{

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -17,7 +17,8 @@ use custom_debug_derive::Debug;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
-        Amount, ApplicationPermissions, Blob, BlobContent, BlockHeight, OracleResponse, Timestamp,
+        Amount, ApplicationPermissions, Blob, BlobContent, BlockHeight, Epoch, OracleResponse,
+        Timestamp,
     },
     ensure, hex_debug,
     identifiers::{
@@ -40,10 +41,9 @@ use {linera_base::prometheus_util::register_int_counter_vec, prometheus::IntCoun
 #[cfg(test)]
 use crate::test_utils::SystemExecutionState;
 use crate::{
-    committee::{Committee, Epoch},
-    ApplicationDescription, ApplicationId, ExecutionError, ExecutionRuntimeContext, MessageContext,
-    MessageKind, OperationContext, OutgoingMessage, QueryContext, QueryOutcome, ResourceController,
-    TransactionTracker,
+    committee::Committee, ApplicationDescription, ApplicationId, ExecutionError,
+    ExecutionRuntimeContext, MessageContext, MessageKind, OperationContext, OutgoingMessage,
+    QueryContext, QueryOutcome, ResourceController, TransactionTracker,
 };
 
 /// The relative index of the `OpenChain` message created by the `OpenChain` operation.

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -10,7 +10,7 @@ use std::{
 use custom_debug_derive::Debug;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, ApplicationPermissions, Blob, Timestamp},
+    data_types::{Amount, ApplicationPermissions, Blob, Epoch, Timestamp},
     identifiers::{AccountOwner, ApplicationId, BlobId, ChainDescription, ChainId},
     ownership::ChainOwnership,
 };
@@ -22,11 +22,10 @@ use linera_views::{
 
 use super::{MockApplication, RegisterMockApplication};
 use crate::{
-    committee::{Committee, Epoch},
-    execution::UserAction,
-    ApplicationDescription, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext,
-    ExecutionStateView, OperationContext, ResourceControlPolicy, ResourceController,
-    ResourceTracker, TestExecutionRuntimeContext, UserContractCode,
+    committee::Committee, execution::UserAction, ApplicationDescription, ExecutionError,
+    ExecutionRuntimeConfig, ExecutionRuntimeContext, ExecutionStateView, OperationContext,
+    ResourceControlPolicy, ResourceController, ResourceTracker, TestExecutionRuntimeContext,
+    UserContractCode,
 };
 
 /// A system execution state, not represented as a view but as a simple struct.

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -9,13 +9,14 @@ use assert_matches::assert_matches;
 use linera_base::{
     crypto::{AccountPublicKey, ValidatorPublicKey},
     data_types::{
-        Amount, ApplicationPermissions, Blob, BlockHeight, Resources, SendMessageRequest, Timestamp,
+        Amount, ApplicationPermissions, Blob, BlockHeight, Epoch, Resources, SendMessageRequest,
+        Timestamp,
     },
     identifiers::{Account, AccountOwner, ChainDescription, ChainId, Destination, MessageId},
     ownership::ChainOwnership,
 };
 use linera_execution::{
-    committee::{Committee, Epoch},
+    committee::Committee,
     system::SystemMessage,
     test_utils::{
         blob_oracle_responses, create_dummy_message_context, create_dummy_operation_context,

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -7,7 +7,7 @@
 
 use linera_base::{
     abi::ContractAbi,
-    data_types::{Amount, ApplicationPermissions, Blob, Round, Timestamp},
+    data_types::{Amount, ApplicationPermissions, Blob, Epoch, Round, Timestamp},
     identifiers::{AccountOwner, ApplicationId, ChainId},
     ownership::TimeoutConfig,
 };
@@ -20,7 +20,6 @@ use linera_chain::{
 };
 use linera_core::worker::WorkerError;
 use linera_execution::{
-    committee::Epoch,
     system::{Recipient, SystemOperation},
     Operation,
 };

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -15,14 +15,15 @@ use std::{
 use cargo_toml::Manifest;
 use linera_base::{
     crypto::{AccountPublicKey, AccountSecretKey},
-    data_types::{Amount, ApplicationDescription, Blob, BlockHeight, Bytecode, CompressedBytecode},
+    data_types::{
+        Amount, ApplicationDescription, Blob, BlockHeight, Bytecode, CompressedBytecode, Epoch,
+    },
     identifiers::{AccountOwner, ApplicationId, ChainDescription, ChainId, ModuleId},
     vm::VmRuntime,
 };
 use linera_chain::{types::ConfirmedBlockCertificate, ChainExecutionContext};
 use linera_core::{data_types::ChainInfoQuery, worker::WorkerError};
 use linera_execution::{
-    committee::Epoch,
     system::{SystemOperation, SystemQuery, SystemResponse},
     ExecutionError, Operation, Query, QueryOutcome, QueryResponse,
 };

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -15,13 +15,13 @@ use futures::{
 };
 use linera_base::{
     crypto::{AccountSecretKey, ValidatorKeypair, ValidatorSecretKey},
-    data_types::{Amount, ApplicationPermissions, Blob, BlobContent, Timestamp},
+    data_types::{Amount, ApplicationPermissions, Blob, BlobContent, Epoch, Timestamp},
     identifiers::{AccountOwner, ApplicationId, ChainDescription, ChainId, MessageId, ModuleId},
     ownership::ChainOwnership,
 };
 use linera_core::worker::WorkerState;
 use linera_execution::{
-    committee::{Committee, Epoch},
+    committee::Committee,
     system::{AdminOperation, OpenChainConfig, SystemOperation, OPEN_CHAIN_MESSAGE_INDEX},
     ResourceControlPolicy, WasmRuntime,
 };

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -63,14 +63,16 @@ mod types {
 #[cfg(not(target_arch = "wasm32"))]
 mod types {
     pub use linera_base::{
-        data_types::ApplicationDescription, identifiers::ChannelFullName, ownership::ChainOwnership,
+        data_types::{ApplicationDescription, Epoch},
+        identifiers::ChannelFullName,
+        ownership::ChainOwnership,
     };
     pub use linera_chain::{
         data_types::{MessageAction, MessageBundle, OperationResult, Origin, Target},
         manager::ChainManager,
     };
     pub use linera_core::worker::{Notification, Reason};
-    pub use linera_execution::{committee::Epoch, Message, MessageKind, Operation};
+    pub use linera_execution::{Message, MessageKind, Operation};
 }
 
 pub use types::*;

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -22,13 +22,13 @@ use linera_base::{
     abi::ContractAbi,
     command::{resolve_binary, CommandExt},
     crypto::CryptoHash,
-    data_types::{Amount, Bytecode},
+    data_types::{Amount, Bytecode, Epoch},
     identifiers::{Account, AccountOwner, ApplicationId, ChainId, MessageId, ModuleId},
     vm::VmRuntime,
 };
 use linera_client::{client_options::ResourceControlPolicyConfig, wallet::Wallet};
 use linera_core::worker::Notification;
-use linera_execution::committee::{Committee, Epoch};
+use linera_execution::committee::Committee;
 use linera_faucet::ClaimOutcome;
 use linera_faucet_client::Faucet;
 use serde::{de::DeserializeOwned, ser::Serialize};

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -12,7 +12,9 @@ use axum::{extract::Path, http::StatusCode, response, response::IntoResponse, Ex
 use futures::{lock::Mutex, Future, FutureExt as _};
 use linera_base::{
     crypto::{CryptoError, CryptoHash},
-    data_types::{Amount, ApplicationDescription, ApplicationPermissions, Bytecode, TimeDelta},
+    data_types::{
+        Amount, ApplicationDescription, ApplicationPermissions, Bytecode, Epoch, TimeDelta,
+    },
     identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId},
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
@@ -29,7 +31,7 @@ use linera_core::{
     worker::Notification,
 };
 use linera_execution::{
-    committee::{Committee, Epoch},
+    committee::Committee,
     system::{AdminOperation, Recipient},
     Operation, Query, QueryOutcome, QueryResponse, SystemOperation,
 };

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -19,11 +19,10 @@ use guard::INTEGRATION_TEST_GUARD;
 use linera_base::vm::VmRuntime;
 use linera_base::{
     crypto::Secp256k1SecretKey,
-    data_types::{Amount, BlockHeight},
+    data_types::{Amount, BlockHeight, Epoch},
     identifiers::{Account, AccountOwner, ChainId},
 };
 use linera_core::{data_types::ChainInfoQuery, node::ValidatorNode};
-use linera_execution::committee::Epoch;
 use linera_faucet::ClaimOutcome;
 use linera_sdk::linera_base_types::AccountSecretKey;
 use linera_service::{

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, TimeDelta, Timestamp},
+    data_types::{Blob, Epoch, TimeDelta, Timestamp},
     identifiers::{ApplicationId, BlobId, ChainId, EventId},
 };
 use linera_chain::{
@@ -17,8 +17,7 @@ use linera_chain::{
     ChainStateView,
 };
 use linera_execution::{
-    committee::Epoch, BlobState, ExecutionRuntimeConfig, UserContractCode, UserServiceCode,
-    WasmRuntime,
+    BlobState, ExecutionRuntimeConfig, UserContractCode, UserServiceCode, WasmRuntime,
 };
 use linera_views::{
     backends::dual::{DualStoreRootKeyAssignment, StoreInUse},

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -14,7 +14,8 @@ use dashmap::{mapref::entry::Entry, DashMap};
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
-        Amount, ApplicationDescription, Blob, BlockHeight, CompressedBytecode, TimeDelta, Timestamp,
+        Amount, ApplicationDescription, Blob, BlockHeight, CompressedBytecode, Epoch, TimeDelta,
+        Timestamp,
     },
     identifiers::{AccountOwner, ApplicationId, BlobId, ChainDescription, ChainId, EventId},
     ownership::ChainOwnership,
@@ -25,9 +26,8 @@ use linera_chain::{
     ChainError, ChainStateView,
 };
 use linera_execution::{
-    committee::{Committee, Epoch},
-    BlobState, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, UserContractCode,
-    UserServiceCode, WasmRuntime,
+    committee::Committee, BlobState, ExecutionError, ExecutionRuntimeConfig,
+    ExecutionRuntimeContext, UserContractCode, UserServiceCode, WasmRuntime,
 };
 #[cfg(with_revm)]
 use linera_execution::{


### PR DESCRIPTION
## Motivation

This will slightly reduce the size of the `ChainDescription` as blob PR.

## Proposal

Move the `Epoch` type from `linera_execution::committee` to `linera_base::data_types`.

## Test Plan

This is just a type relocation, so if it compiles, it works. But CI will also make sure nothing is broken.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
