### PR TITLE
Remove redundant default help text.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -950,10 +950,10 @@ Start a Local Linera Network
 * `--initial-amount <INITIAL_AMOUNT>` — The initial amount of native tokens credited in the initial "root" chains, including the default "admin" chain
 
   Default value: `1000000`
-* `--validators <VALIDATORS>` — The number of validators in the local test network. Default is 1
+* `--validators <VALIDATORS>` — The number of validators in the local test network
 
   Default value: `1`
-* `--shards <SHARDS>` — The number of shards per validator in the local test network. Default is 1
+* `--shards <SHARDS>` — The number of shards per validator in the local test network
 
   Default value: `1`
 * `--policy-config <POLICY_CONFIG>` — Configure the resource control policy (notably fees) according to pre-defined settings

--- a/linera-service/src/linera/command.rs
+++ b/linera-service/src/linera/command.rs
@@ -880,11 +880,11 @@ pub enum NetCommand {
         #[arg(long, default_value = "1000000")]
         initial_amount: u128,
 
-        /// The number of validators in the local test network. Default is 1.
+        /// The number of validators in the local test network.
         #[arg(long, default_value = "1")]
         validators: usize,
 
-        /// The number of shards per validator in the local test network. Default is 1.
+        /// The number of shards per validator in the local test network.
         #[arg(long, default_value = "1")]
         shards: usize,
 


### PR DESCRIPTION
## Motivation

If there is a default value, `clap` automatically adds that to the help text. (See `CLI.md`.)

## Proposal

Remove the redundant comment about the default value.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
