### PR TITLE
Include 'set -e' to script

### DIFF
--- a/docker/server-entrypoint.sh
+++ b/docker/server-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # Extract the ordinal number from the pod hostname
 ORDINAL="${HOSTNAME##*-}"


### PR DESCRIPTION
### Description

In case the script fails, it shouldn't fail silently. To avoid silent errors I added `set -e`.