### PR TITLE
Add a script to manage the ownership of the Linera crates

### DIFF
--- a/scripts/owner.sh
+++ b/scripts/owner.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Run cargo owner on the current workspace.
+#
+# Usage: scripts/owner.sh packages.txt ARGS..
+
+set -e
+
+PACKAGES="$1"
+shift
+
+echo "Type 'yes' to run the following command on every crate: cargo owner $@"
+read INPUT
+if [ "$INPUT" != "yes" ]; then exit 0; fi
+
+grep -v '^#' "$PACKAGES" | while read LINE; do
+    LINE=($LINE)
+    NAME="${LINE[0]}"
+    (
+        set -x;
+        cargo owner "$@" "$NAME"
+    )
+done


### PR DESCRIPTION
## Motivation

Verify and modify the ownership of our crates in bulk

## Proposal

We create `scripts/owner.sh`
* This script works like the other package-related scripts but runs `cargo owner`
* Because this command is potentially risky, we ask for the user to type "yes"

## Test Plan

```
scripts/owner.sh packages.txt --list
```
