### PR TITLE
Update github actions versions due to deprecation

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 40
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Clear up some space
       run: |

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 40
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -39,7 +39,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 90
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
       uses: arduino/setup-protoc@v1

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 40
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
       uses: arduino/setup-protoc@v1


### PR DESCRIPTION
Artifact Actions v3 will be deprecated by January 30, 2025. GitHub has started temporarily failing workflows that haven't been updated ahead of this deadline. This PR updates the action versions accordingly, following the [official migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md).
