### PR TITLE
Add new applications to `used_blobs`; change `applications` query.

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -502,7 +502,7 @@ impl Block {
     }
 
     /// Returns whether this block requires the blob with the specified ID.
-    pub fn requires_blob(&self, blob_id: &BlobId) -> bool {
+    pub fn requires_or_creates_blob(&self, blob_id: &BlobId) -> bool {
         self.oracle_blob_ids().contains(blob_id)
             || self.published_blob_ids().contains(blob_id)
             || self.created_blob_ids().contains(blob_id)

--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -5,7 +5,7 @@
 use linera_base::{
     crypto::{ValidatorPublicKey, ValidatorSignature},
     data_types::{Epoch, Round},
-    identifiers::{BlobId, ChainId, MessageId},
+    identifiers::{ChainId, MessageId},
 };
 use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize};
 
@@ -38,10 +38,6 @@ impl GenericCertificate<ConfirmedBlock> {
         let certificate_hash = self.hash();
         self.block()
             .message_bundles_for(medium, recipient, certificate_hash)
-    }
-
-    pub fn requires_blob(&self, blob_id: &BlobId) -> bool {
-        self.block().requires_blob(blob_id)
     }
 
     #[cfg(with_testing)]

--- a/linera-chain/src/certificate/validated.rs
+++ b/linera-chain/src/certificate/validated.rs
@@ -5,7 +5,6 @@
 use linera_base::{
     crypto::{ValidatorPublicKey, ValidatorSignature},
     data_types::Round,
-    identifiers::BlobId,
 };
 use serde::{
     ser::{Serialize, SerializeStruct, Serializer},
@@ -16,10 +15,6 @@ use super::{generic::GenericCertificate, Certificate};
 use crate::block::{Block, ConversionError, ValidatedBlock};
 
 impl GenericCertificate<ValidatedBlock> {
-    pub fn requires_blob(&self, blob_id: &BlobId) -> bool {
-        self.block().requires_blob(blob_id)
-    }
-
     #[cfg(with_testing)]
     pub fn outgoing_message_count(&self) -> usize {
         self.block().messages().iter().map(Vec::len).sum()

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -202,7 +202,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
     ) -> Result<ConfirmedBlockCertificate, NodeError> {
         let last_used_hash = self.node.blob_last_used_by(blob_id).await?;
         let certificate = self.node.download_certificate(last_used_hash).await?;
-        if !certificate.requires_blob(&blob_id) {
+        if !certificate.block().requires_or_creates_blob(&blob_id) {
             warn!(
                 "Got invalid last used by certificate for blob {} from validator {}",
                 blob_id, self.public_key

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1336,7 +1336,9 @@ where
         .await
         .unwrap()
         .unwrap();
-    assert!(publish_certificate.block().requires_blob(&blob0_id));
+    assert!(publish_certificate
+        .block()
+        .requires_or_creates_blob(&blob0_id));
 
     // Validators goes back up
     builder.set_fault_type([2], FaultType::Honest).await;
@@ -1353,7 +1355,7 @@ where
         .unwrap();
     assert_eq!(certificate.round, Round::MultiLeader(0));
     // The blob is not new on this chain, so it is not required.
-    assert!(!certificate.block().requires_blob(&blob0_id));
+    assert!(!certificate.block().requires_or_creates_blob(&blob0_id));
 
     // Validators 0, 1, 2 now don't process validated block certificates. Client 2A tries to
     // commit a block that reads blob 0 and publishes blob 1. Client 2A will have that block
@@ -1503,7 +1505,9 @@ where
         .await
         .unwrap()
         .unwrap();
-    assert!(publish_certificate.block().requires_blob(&blob0_id));
+    assert!(publish_certificate
+        .block()
+        .requires_or_creates_blob(&blob0_id));
 
     builder
         .set_fault_type([0, 1, 2], FaultType::DontProcessValidated)
@@ -1641,7 +1645,9 @@ where
         .await
         .unwrap()
         .unwrap();
-    assert!(publish_certificate0.block().requires_blob(&blob0_id));
+    assert!(publish_certificate0
+        .block()
+        .requires_or_creates_blob(&blob0_id));
 
     let blob2_bytes = b"blob2".to_vec();
     let blob2_id = Blob::new(BlobContent::new_data(blob2_bytes.clone())).id();
@@ -1653,7 +1659,9 @@ where
         .await
         .unwrap()
         .unwrap();
-    assert!(publish_certificate2.block().requires_blob(&blob2_id));
+    assert!(publish_certificate2
+        .block()
+        .requires_or_creates_blob(&blob2_id));
 
     builder
         .set_fault_type([0, 1], FaultType::DontProcessValidated)

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -296,6 +296,10 @@ where
         )
         .await?;
     creator_state.system.timestamp.set(Timestamp::from(3));
+    creator_state
+        .system
+        .used_blobs
+        .insert(&application_description_blob_id)?;
     let run_block_proposal = ConfirmedBlock::new(
         BlockExecutionOutcome {
             messages: vec![Vec::new()],
@@ -303,7 +307,7 @@ where
             events: vec![Vec::new()],
             blobs: vec![Vec::new()],
             state_hash: creator_state.crypto_hash().await?,
-            oracle_responses: vec![vec![OracleResponse::Blob(application_description_blob_id)]],
+            oracle_responses: vec![vec![]],
             operation_results: vec![OperationResult(bcs::to_bytes(&15u64)?)],
         }
         .with(run_block),

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -6,7 +6,7 @@ use std::{mem, vec};
 use futures::{FutureExt, StreamExt};
 use linera_base::{
     data_types::{Amount, BlockHeight},
-    identifiers::{Account, AccountOwner, BlobType, Destination, StreamId},
+    identifiers::{Account, AccountOwner, Destination, StreamId},
 };
 use linera_views::{
     context::Context,
@@ -484,14 +484,11 @@ where
         &self,
     ) -> Result<Vec<(ApplicationId, ApplicationDescription)>, ExecutionError> {
         let mut applications = vec![];
-        for blob_id in self.system.used_blobs.indices().await? {
-            if blob_id.blob_type == BlobType::ApplicationDescription {
-                let blob_content = self.system.read_blob_content(blob_id).await?;
-                let application_description: ApplicationDescription =
-                    bcs::from_bytes(blob_content.bytes())?;
-                let app_id = ApplicationId::from(&application_description);
-                applications.push((app_id, application_description));
-            }
+        for app_id in self.users.indices().await? {
+            let blob_id = app_id.description_blob_id();
+            let blob_content = self.system.read_blob_content(blob_id).await?;
+            let application_description = bcs::from_bytes(blob_content.bytes())?;
+            applications.push((app_id, application_description));
         }
         Ok(applications)
     }

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -85,7 +85,9 @@ where
         let next_application_index = application_description.application_index + 1;
 
         let application_id = From::from(&application_description);
+        let blob = Blob::new_application_description(&application_description);
 
+        self.system.used_blobs.insert(&blob.id())?;
         self.system.used_blobs.insert(&contract_blob.id())?;
         self.system.used_blobs.insert(&service_blob.id())?;
 
@@ -117,7 +119,7 @@ where
             next_application_index,
             None,
         );
-        txn_tracker.add_created_blob(Blob::new_application_description(&application_description));
+        txn_tracker.add_created_blob(blob);
         self.run_user_action(
             application_id,
             action,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -799,7 +799,9 @@ where
         self.check_required_applications(&application_description, Some(&mut txn_tracker))
             .await?;
 
-        txn_tracker.add_created_blob(Blob::new_application_description(&application_description));
+        let blob = Blob::new_application_description(&application_description);
+        self.used_blobs.insert(&blob.id())?;
+        txn_tracker.add_created_blob(blob);
 
         Ok(CreateApplicationResult {
             app_id: ApplicationId::from(&application_description),

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -851,6 +851,12 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
         .await?;
     let port = get_node_port().await;
     let mut node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
+    let query = format!("query {{ applications(chainId:\"{chain}\") {{ id }} }}");
+    let response = node_service.query_node(query).await?;
+    assert_eq!(
+        response["applications"][0]["id"].as_str().unwrap(),
+        &application_id.forget_abi().to_string()
+    );
 
     let application = node_service
         .make_application(&chain, &application_id)


### PR DESCRIPTION
## Motivation

The `applications` query uses `used_blobs`, but newly created applications are not actually added to `used_blobs`.

## Proposal

Add new applications to `used_blobs`.

Make the `applications` query return the applications with an execution state.

## Test Plan

I added a regression test.

I also tested it locally:

```
cargo run --bin linera -- net up --with-faucet --faucet-port 8080
```

```
cargo run --bin linera -- wallet init --with-new-chain --faucet http://localhost:8080
cargo run --bin linera -- project publish-and-create examples/counter --json-argument "42"
cargo run --bin linera -- service --port 8081
```

Then `list_applications` doesn't show the new app. With this fix, it does.

## Release Plan

Since this changes the execution semantics, we could consider a different workaround for the testnet: Instead of using `used_blobs`, show the keys of `ExecutionStateView::users`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
