### PR TITLE
Implement `BucketLogView` as a view and in the protocol.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -29,8 +29,8 @@ use linera_execution::{
     QueryOutcome, ResourceController, ResourceTracker, ServiceRuntimeEndpoint, TransactionTracker,
 };
 use linera_views::{
-    bucket_queue_view::BucketQueueView,
     bucket_log_view::BucketLogView,
+    bucket_queue_view::BucketQueueView,
     context::Context,
     map_view::MapView,
     reentrant_collection_view::ReentrantCollectionView,

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -207,6 +207,18 @@ A block height to identify blocks in a chain
 scalar BlockHeight
 
 
+type BucketLogView_BlockHeight_e824a938 {
+	entries(start: Int, end: Int): [BlockHeight!]!
+}
+
+type BucketLogView_ChainAndHeight_7af83576 {
+	entries(start: Int, end: Int): [ChainAndHeight!]!
+}
+
+type BucketLogView_CryptoHash_87fbb60c {
+	entries(start: Int, end: Int): [CryptoHash!]!
+}
+
 type BucketQueueView_BlockHeight_e824a938 {
 	entries(count: Int): [BlockHeight!]!
 }
@@ -327,11 +339,11 @@ type ChainStateExtendedView {
 	Hashes of all certified blocks for this sender.
 	This ends with `block_hash` and has length `usize::from(next_block_height)`.
 	"""
-	confirmedLog: LogView_CryptoHash_87fbb60c!
+	confirmedLog: BucketLogView_CryptoHash_87fbb60c!
 	"""
 	Sender chain and height of all certified blocks known as a receiver (local ordering).
 	"""
-	receivedLog: LogView_ChainAndHeight_7af83576!
+	receivedLog: BucketLogView_ChainAndHeight_7af83576!
 	"""
 	The number of `received_log` entries we have synchronized, for each validator.
 	"""
@@ -414,7 +426,7 @@ type ChannelStateView {
 	"""
 	The block heights so far, to be sent to future subscribers.
 	"""
-	blockHeights: LogView_BlockHeight_e824a938!
+	blockHeights: BucketLogView_BlockHeight_e824a938!
 }
 
 """
@@ -619,18 +631,6 @@ type IncomingBundle {
 A scalar that can represent any JSON Object value.
 """
 scalar JSONObject
-
-type LogView_BlockHeight_e824a938 {
-	entries(start: Int, end: Int): [BlockHeight!]!
-}
-
-type LogView_ChainAndHeight_7af83576 {
-	entries(start: Int, end: Int): [ChainAndHeight!]!
-}
-
-type LogView_CryptoHash_87fbb60c {
-	entries(start: Int, end: Int): [CryptoHash!]!
-}
 
 input MapFilters_AccountOwner_d6668c53 {
 	keys: [AccountOwner!]

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -88,3 +88,7 @@ harness = false
 [[bench]]
 name = "queue_view"
 harness = false
+
+[[bench]]
+name = "log_view"
+harness = false

--- a/linera-views/benches/log_view.rs
+++ b/linera-views/benches/log_view.rs
@@ -13,8 +13,8 @@ use linera_views::scylla_db::ScyllaDbStore;
 use linera_views::{
     bucket_log_view::BucketLogView,
     context::ViewContext,
-    memory::MemoryStore,
     log_view::LogView,
+    memory::MemoryStore,
     random::{make_deterministic_rng, DeterministicRng},
     store::TestKeyValueStore,
     views::{CryptoHashRootView, RootView, View},

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -104,8 +104,8 @@ pub use backends::rocks_db;
 pub use backends::scylla_db;
 pub use backends::{journaling, lru_caching, memory, value_splitting};
 pub use views::{
-    bucket_log_view, bucket_queue_view, collection_view, hashable_wrapper, key_value_store_view, log_view, map_view,
-    queue_view, reentrant_collection_view, register_view, set_view,
+    bucket_log_view, bucket_queue_view, collection_view, hashable_wrapper, key_value_store_view,
+    log_view, map_view, queue_view, reentrant_collection_view, register_view, set_view,
 };
 /// Re-exports used by the derive macros of this library.
 #[doc(hidden)]

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -104,7 +104,7 @@ pub use backends::rocks_db;
 pub use backends::scylla_db;
 pub use backends::{journaling, lru_caching, memory, value_splitting};
 pub use views::{
-    bucket_queue_view, collection_view, hashable_wrapper, key_value_store_view, log_view, map_view,
+    bucket_log_view, bucket_queue_view, collection_view, hashable_wrapper, key_value_store_view, log_view, map_view,
     queue_view, reentrant_collection_view, register_view, set_view,
 };
 /// Re-exports used by the derive macros of this library.

--- a/linera-views/src/views/bucket_log_view.rs
+++ b/linera-views/src/views/bucket_log_view.rs
@@ -135,6 +135,7 @@ where
         let mut delete_view = false;
         if self.delete_storage_first {
             batch.delete_key_prefix(self.context.base_key());
+            self.stored_data.clear();
             self.stored_count = 0;
             delete_view = true;
         }

--- a/linera-views/src/views/bucket_log_view.rs
+++ b/linera-views/src/views/bucket_log_view.rs
@@ -69,7 +69,6 @@ impl<T> Bucket<T> {
     }
 }
 
-
 /// A view that supports logging values of type `T`.
 #[derive(Debug)]
 pub struct BucketLogView<C, T, const N: usize> {
@@ -402,6 +401,26 @@ where
             )
         }
     }
+
+    /// Read all the elements of the bucket log view
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::log_view::LogView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut log = LogView::load(context).await.unwrap();
+    /// log.push(34);
+    /// log.push(42);
+    /// log.push(56);
+    /// assert_eq!(log.elements().await.unwrap(), vec![34, 42, 56]);
+    /// # })
+    /// ```
+    pub async fn elements(&self) -> Result<Vec<T>, ViewError> {
+        self.read(..).await
+    }
+
+
 }
 
 #[async_trait]

--- a/linera-views/src/views/bucket_log_view.rs
+++ b/linera-views/src/views/bucket_log_view.rs
@@ -1,0 +1,469 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::{BTreeSet, HashMap}, ops::{Bound, Range, RangeBounds}};
+#[cfg(with_metrics)]
+use std::sync::LazyLock;
+
+use async_trait::async_trait;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+#[cfg(with_metrics)]
+use {
+    linera_base::prometheus_util::{
+        exponential_bucket_latencies, register_histogram_vec, MeasureLatency,
+    },
+    prometheus::HistogramVec,
+};
+
+use crate::{
+    batch::Batch,
+    common::{from_bytes_option_or_default, HasherOutput},
+    context::Context,
+    hashable_wrapper::WrappedHashableContainerView,
+    views::{ClonableView, HashableView, Hasher, View, ViewError, MIN_VIEW_TAG},
+};
+
+#[cfg(with_metrics)]
+/// The runtime of hash computation
+static BUCKET_LOG_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+    register_histogram_vec(
+        "bucket_log_view_hash_runtime",
+        "BucketLogView hash runtime",
+        &[],
+        exponential_bucket_latencies(5.0),
+    )
+});
+
+/// Key tags to create the sub-keys of a `LogView` on top of the base key.
+#[repr(u8)]
+enum KeyTag {
+    /// Prefix for the storing of the variable `stored_count`.
+    StoredSizes = MIN_VIEW_TAG,
+    /// Prefix for the indices of the log.
+    Index,
+}
+
+
+/// The `StoredIndices` contains the description of the stored buckets.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct StoredSizes {
+    /// The stored buckets with the first index being the size (at most N) and the
+    /// second one is the index in the storage. If the index is 0 then it corresponds
+    /// with the first value (entry `KeyTag::Front`), otherwise to the keys with
+    /// prefix `KeyTag::Index`.
+    sizes: Vec<usize>,
+}
+
+#[derive(Clone, Debug)]
+enum Bucket<T> {
+    Loaded { data: Vec<T> },
+    NotLoaded { length: usize },
+}
+
+impl<T> Bucket<T> {
+    fn len(&self) -> usize {
+        match self {
+            Bucket::Loaded { data } => data.len(),
+            Bucket::NotLoaded { length } => *length,
+        }
+    }
+}
+
+
+/// A view that supports logging values of type `T`.
+#[derive(Debug)]
+pub struct BucketLogView<C, T, const N: usize> {
+    context: C,
+    delete_storage_first: bool,
+    stored_data: Vec<Bucket<T>>,
+    stored_count: usize,
+    new_values: Vec<T>,
+}
+
+#[async_trait]
+impl<C, T, const N: usize> View<C> for BucketLogView<C, T, N>
+where
+    C: Context + Send + Sync,
+    ViewError: From<C::Error>,
+    T: Clone + Send + Sync + Serialize,
+{
+    const NUM_INIT_KEYS: usize = 1;
+
+    fn context(&self) -> &C {
+        &self.context
+    }
+
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        Ok(vec![context.base_tag(KeyTag::StoredSizes as u8)])
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let value = values.first().ok_or(ViewError::PostLoadValuesError)?;
+        let stored_sizes = from_bytes_option_or_default::<StoredSizes, _>(value)?;
+        let stored_count = stored_sizes.sizes.iter().sum();
+        let stored_data = stored_sizes.sizes
+            .into_iter()
+            .map(|length| Bucket::NotLoaded { length })
+            .collect::<Vec<_>>();
+        Ok(Self {
+            context,
+            delete_storage_first: false,
+            stored_data,
+            stored_count,
+            new_values: Vec::new(),
+        })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
+    }
+
+    fn rollback(&mut self) {
+        self.delete_storage_first = false;
+        self.new_values.clear();
+    }
+
+    async fn has_pending_changes(&self) -> bool {
+        if self.delete_storage_first {
+            return true;
+        }
+        !self.new_values.is_empty()
+    }
+
+    fn flush(&mut self, batch: &mut Batch) -> Result<bool, ViewError> {
+        let mut delete_view = false;
+        if self.delete_storage_first {
+            batch.delete_key_prefix(self.context.base_key());
+            self.stored_count = 0;
+            delete_view = true;
+        }
+        if !self.new_values.is_empty() {
+            let mut i_block = self.stored_data.len();
+            self.stored_count += self.new_values.len();
+            let new_values = std::mem::take(&mut self.new_values);
+            for value_chunk in new_values.chunks(N) {
+                let key = self
+                    .context
+                    .derive_tag_key(KeyTag::Index as u8, &i_block)?;
+                batch.put_key_value(key, &value_chunk.to_vec())?;
+                self.stored_data.push(
+                    Bucket::Loaded {
+                        data: value_chunk.to_vec(),
+                    },
+                );
+                i_block += 1;
+            }
+            delete_view = false;
+            self.new_values.clear();
+        }
+        if !self.delete_storage_first || !self.stored_data.is_empty() {
+            let stored_sizes = self.stored_data
+                .iter()
+                .map(|bucket| bucket.len())
+                .collect::<Vec<_>>();
+            let key = self.context.base_tag(KeyTag::StoredSizes as u8);
+            batch.put_key_value(key, &stored_sizes)?;
+        }
+        self.delete_storage_first = false;
+        Ok(delete_view)
+    }
+
+    fn clear(&mut self) {
+        self.delete_storage_first = true;
+        self.new_values.clear();
+    }
+}
+
+impl<C, T, const N: usize> ClonableView<C> for BucketLogView<C, T, N>
+where
+    C: Context + Send + Sync,
+    ViewError: From<C::Error>,
+    T: Clone + Send + Sync + Serialize,
+{
+    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(BucketLogView {
+            context: self.context.clone(),
+            delete_storage_first: self.delete_storage_first,
+            stored_data: self.stored_data.clone(),
+            stored_count: self.stored_count.clone(),
+            new_values: self.new_values.clone(),
+        })
+    }
+}
+
+impl<C, T, const N: usize> BucketLogView<C, T, N>
+where
+    C: Context,
+{
+    /// Pushes a value to the end of the log.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::log_view::LogView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut log = LogView::load(context).await.unwrap();
+    /// log.push(34);
+    /// # })
+    /// ```
+    pub fn push(&mut self, value: T) {
+        self.new_values.push(value);
+    }
+
+    /// Reads the size of the log.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::log_view::LogView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut log = LogView::load(context).await.unwrap();
+    /// log.push(34);
+    /// log.push(42);
+    /// assert_eq!(log.count(), 2);
+    /// # })
+    /// ```
+    pub fn count(&self) -> usize {
+        if self.delete_storage_first {
+            self.new_values.len()
+        } else {
+            self.stored_count + self.new_values.len()
+        }
+    }
+
+    /// Obtains the extra data.
+    pub fn extra(&self) -> &C::Extra {
+        self.context.extra()
+    }
+}
+
+impl<C, T, const N: usize> BucketLogView<C, T, N>
+where
+    C: Context + Send + Sync,
+    ViewError: From<C::Error>,
+    T: Clone + DeserializeOwned + Serialize + Send,
+{
+    /// Returns the corresponding bucket and the corresponding position
+    fn get_position(&self, mut index: usize) -> Option<(usize, usize)> {
+        for i_bucket in 0..self.stored_data.len() {
+            let size = self.stored_data[i_bucket].len();
+            if index < size {
+                return Some((i_bucket, index));
+            }
+            index -= size;
+        }
+        None
+    }
+
+    /// Reads the logged value with the given index (including staged ones).
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::log_view::LogView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut log = LogView::load(context).await.unwrap();
+    /// log.push(34);
+    /// assert_eq!(log.get(0).await.unwrap(), Some(34));
+    /// # })
+    /// ```
+    pub async fn get(&self, index: usize) -> Result<Option<T>, ViewError> {
+        let value = if self.delete_storage_first {
+            self.new_values.get(index).cloned()
+        } else if index < self.stored_count {
+            let (i_bucket, position) = self.get_position(index).unwrap();
+            let key = self.context.derive_tag_key(KeyTag::Index as u8, &i_bucket)?;
+            let bucket = self.context.read_value::<Vec<T>>(&key).await?.unwrap();
+            Some(bucket[position].clone())
+        } else {
+            self.new_values.get(index - self.stored_count).cloned()
+        };
+        Ok(value)
+    }
+
+    /// Reads several logged keys (including staged ones)
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::log_view::LogView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut log = LogView::load(context).await.unwrap();
+    /// log.push(34);
+    /// log.push(42);
+    /// assert_eq!(
+    ///     log.multi_get(vec![0, 1]).await.unwrap(),
+    ///     vec![Some(34), Some(42)]
+    /// );
+    /// # })
+    /// ```
+    pub async fn multi_get(&self, indices: Vec<usize>) -> Result<Vec<Option<T>>, ViewError> {
+        let mut result = Vec::new();
+        if self.delete_storage_first {
+            for index in indices {
+                result.push(self.new_values.get(index).cloned());
+            }
+        } else {
+            let mut infos = Vec::new();
+            let mut set_bucket = BTreeSet::new();
+            for (pos, index) in indices.into_iter().enumerate() {
+                if index < self.stored_count {
+                    let (i_bucket, position) = self.get_position(index).unwrap();
+                    set_bucket.insert(i_bucket);
+                    infos.push((pos, i_bucket, position));
+                    result.push(None);
+                } else {
+                    result.push(self.new_values.get(index - self.stored_count).cloned());
+                }
+            }
+            let mut keys = Vec::new();
+            let mut map_bucket = HashMap::new();
+            for (pos_bucket, i_bucket) in set_bucket.into_iter().enumerate() {
+                keys.push(self.context.derive_tag_key(KeyTag::Index as u8, &i_bucket)?);
+                map_bucket.insert(i_bucket, pos_bucket);
+            }
+            let values = self.context.read_multi_values::<Vec<T>>(keys).await?;
+            for (pos, i_bucket, position) in infos {
+                let pos_bucket = map_bucket.get(&i_bucket).unwrap();
+                let bucket = values[*pos_bucket].as_ref().unwrap();
+                *result.get_mut(pos).unwrap() = Some(bucket[position].clone());
+            }
+        }
+        Ok(result)
+    }
+
+    async fn read_context(&self, range: Range<usize>) -> Result<Vec<T>, ViewError> {
+        let mut indices = Vec::new();
+        for index in range {
+            indices.push(index);
+        }
+        let values = self.multi_get(indices).await?;
+        Ok(values
+            .into_iter()
+            .map(|x| x.unwrap())
+            .collect::<Vec<_>>())
+    }
+
+    /// Reads the logged values in the given range (including staged ones).
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::log_view::LogView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut log = LogView::load(context).await.unwrap();
+    /// log.push(34);
+    /// log.push(42);
+    /// log.push(56);
+    /// assert_eq!(log.read(0..2).await.unwrap(), vec![34, 42]);
+    /// # })
+    /// ```
+    pub async fn read<R>(&self, range: R) -> Result<Vec<T>, ViewError>
+    where
+        R: RangeBounds<usize>,
+    {
+        let effective_stored_count = if self.delete_storage_first {
+            0
+        } else {
+            self.stored_count
+        };
+        let end = match range.end_bound() {
+            Bound::Included(end) => *end + 1,
+            Bound::Excluded(end) => *end,
+            Bound::Unbounded => self.count(),
+        }
+        .min(self.count());
+        let start = match range.start_bound() {
+            Bound::Included(start) => *start,
+            Bound::Excluded(start) => *start + 1,
+            Bound::Unbounded => 0,
+        };
+        if start >= end {
+            return Ok(Vec::new());
+        }
+        if start < effective_stored_count {
+            if end <= effective_stored_count {
+                self.read_context(start..end).await
+            } else {
+                let mut values = self.read_context(start..effective_stored_count).await?;
+                values.extend(
+                    self.new_values[0..(end - effective_stored_count)]
+                        .iter()
+                        .cloned(),
+                );
+                Ok(values)
+            }
+        } else {
+            Ok(
+                self.new_values[(start - effective_stored_count)..(end - effective_stored_count)]
+                    .to_vec(),
+            )
+        }
+    }
+}
+
+#[async_trait]
+impl<C, T, const N: usize> HashableView<C> for BucketLogView<C, T, N>
+where
+    C: Context + Send + Sync,
+    ViewError: From<C::Error>,
+    T: Send + Sync + Clone + Serialize + DeserializeOwned,
+{
+    type Hasher = sha3::Sha3_256;
+
+    async fn hash_mut(&mut self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
+        self.hash().await
+    }
+
+    async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
+        #[cfg(with_metrics)]
+        let _hash_latency = BUCKET_LOG_VIEW_HASH_RUNTIME.measure_latency();
+        let elements = self.read(..).await?;
+        let mut hasher = sha3::Sha3_256::default();
+        hasher.update_with_bcs_bytes(&elements)?;
+        Ok(hasher.finalize())
+    }
+}
+
+/// Type wrapping `LogView` while memoizing the hash.
+pub type HashedBucketLogView<C, T, const N: usize> = WrappedHashableContainerView<C, BucketLogView<C, T, N>, HasherOutput>;
+
+mod graphql {
+    use std::borrow::Cow;
+
+    use super::BucketLogView;
+    use crate::{
+        context::Context,
+        graphql::{hash_name, mangle},
+    };
+
+    impl<C: Send + Sync, T: async_graphql::OutputType, const N: usize> async_graphql::TypeName for BucketLogView<C, T, N> {
+        fn type_name() -> Cow<'static, str> {
+            format!(
+                "BucketLogView_{}_{:08x}",
+                mangle(T::type_name()),
+                hash_name::<T>()
+            )
+            .into()
+        }
+    }
+
+    #[async_graphql::Object(cache_control(no_cache), name_type)]
+    impl<C: Context, T: async_graphql::OutputType, const N: usize> BucketLogView<C, T, N>
+    where
+        C: Send + Sync,
+        T: serde::ser::Serialize + serde::de::DeserializeOwned + Clone + Send + Sync,
+    {
+        async fn entries(
+            &self,
+            start: Option<usize>,
+            end: Option<usize>,
+        ) -> async_graphql::Result<Vec<T>> {
+            Ok(self
+                .read(start.unwrap_or_default()..end.unwrap_or_else(|| self.count()))
+                .await?)
+        }
+    }
+}

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -24,6 +24,9 @@ mod tests;
 /// The `RegisterView` implements a register for a single value.
 pub mod register_view;
 
+/// The `BucketLogView` implements a log list that can be pushed and group data in buckets.
+pub mod bucket_log_view;
+
 /// The `LogView` implements a log list that can be pushed.
 pub mod log_view;
 

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -404,8 +404,6 @@ async fn map_view_mutability() -> Result<()> {
     Ok(())
 }
 
-
-
 #[derive(CryptoHashRootView)]
 pub struct BucketLogStateView<C> {
     pub log: HashedBucketLogView<C, u8, 5>,
@@ -484,12 +482,6 @@ async fn bucket_log_view_mutability_check() -> Result<()> {
     }
     Ok(())
 }
-
-
-
-
-
-
 
 #[derive(CryptoHashRootView)]
 pub struct BucketQueueStateView<C> {

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    ops::Range,
+    collections::{BTreeMap, BTreeSet},
+};
 
 use anyhow::Result;
 use linera_views::{
@@ -465,6 +468,14 @@ async fn bucket_log_view_mutability_check() -> Result<()> {
                         vec2.push(Some(new_vector[pos]));
                     }
                     let vec1 = view.log.multi_get(indices).await?;
+                    assert_eq!(vec1, vec2);
+                }
+                for _ in 0..3 {
+                    let start = rng.gen_range(0..count);
+                    let end = rng.gen_range(start..count);
+                    let range = Range { start, end };
+                    let vec1: Vec<u8> = view.log.read(range.clone()).await?;
+                    let vec2: Vec<u8> = new_vector[range].to_vec();
                     assert_eq!(vec1, vec2);
                 }
             }

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -426,7 +426,7 @@ async fn bucket_log_view_mutability_check() -> Result<()> {
         let count_oper = rng.gen_range(0..25);
         let mut new_vector = vector.clone();
         for _ in 0..count_oper {
-            let choice = rng.gen_range(0..6);
+            let choice = rng.gen_range(0..3);
             if choice == 0 {
                 // inserting random stuff
                 let n_ins = rng.gen_range(0..100);


### PR DESCRIPTION
## Motivation

The `LogView` that are used in the protocol have a type T that is constant in size. So, this can be grouped into a single bucket so as to avoid having too many keys.

## Proposal

The following is done:
* The `BucketQueueView` is introduced.
* A random test is introduced.
* The test is implemented in the protocol.

This is simpler than the `BucketQueueView`.

## Test Plan

A benchmark has been added that demonstrates that the Bucket version is 80% faster than the native version: 43.9ms for `memory_log_view` vs 24.2ms for `memory_bucket_log_view`.

The CI.

## Release Plan

Normal release.

## Links

None.