### PR TITLE
Use execution state for `applications` query.

### DIFF
--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -6,7 +6,7 @@ use std::{mem, vec};
 use futures::{FutureExt, StreamExt};
 use linera_base::{
     data_types::{Amount, BlockHeight},
-    identifiers::{Account, AccountOwner, BlobType, Destination, StreamId},
+    identifiers::{Account, AccountOwner, Destination, StreamId},
 };
 use linera_views::{
     context::Context,
@@ -484,14 +484,11 @@ where
         &self,
     ) -> Result<Vec<(ApplicationId, ApplicationDescription)>, ExecutionError> {
         let mut applications = vec![];
-        for blob_id in self.system.used_blobs.indices().await? {
-            if blob_id.blob_type == BlobType::ApplicationDescription {
-                let blob_content = self.system.read_blob_content(blob_id).await?;
-                let application_description: ApplicationDescription =
-                    bcs::from_bytes(blob_content.bytes())?;
-                let app_id = ApplicationId::from(&application_description);
-                applications.push((app_id, application_description));
-            }
+        for app_id in self.users.indices().await? {
+            let blob_id = app_id.description_blob_id();
+            let blob_content = self.system.read_blob_content(blob_id).await?;
+            let application_description = bcs::from_bytes(blob_content.bytes())?;
+            applications.push((app_id, application_description));
         }
         Ok(applications)
     }

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -649,6 +649,12 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
         .await?;
     let port = get_node_port().await;
     let mut node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
+    let query = format!("query {{ applications(chainId:\"{chain}\") {{ id }} }}");
+    let response = node_service.query_node(query).await?;
+    assert_eq!(
+        response["applications"][0]["id"].as_str().unwrap(),
+        &application_id.forget_abi().to_string()
+    );
 
     let application = node_service
         .make_application(&chain, &application_id)


### PR DESCRIPTION
## Motivation

The applications query uses `used_blobs`, but newly created applications are not actually added to `used_blobs`.

## Proposal

Return the keys of the user execution states map instead.

## Test Plan

A regression test was added.

## Release Plan

- These changes should be released in a new SDK.

## Links

- Changes on main: https://github.com/linera-io/linera-protocol/pull/3818
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
