### PR TITLE
Remove unused context args and fields.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -842,7 +842,6 @@ where
                     let context = OperationContext {
                         chain_id: block.chain_id,
                         height: block.height,
-                        index: Some(txn_index),
                         round,
                         authenticated_signer: block.authenticated_signer,
                         authenticated_caller_id: None,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -1066,7 +1066,6 @@ where
             is_bouncing: posted_message.is_bouncing(),
             height: block.height,
             round,
-            certificate_hash: incoming_bundle.bundle.certificate_hash,
             message_id,
             authenticated_signer: posted_message.authenticated_signer,
             refund_grant_to: posted_message.refund_grant_to,

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -253,7 +253,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     );
 
     // After registering, an app operation can already be used in the first block.
-    application.expect_call(ExpectedCall::execute_operation(|_, _, _| Ok(vec![])));
+    application.expect_call(ExpectedCall::execute_operation(|_, _| Ok(vec![])));
     application.expect_call(ExpectedCall::default_finalize());
     let app_operation = Operation::User {
         application_id,
@@ -289,7 +289,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     );
 
     // But app operations continue to work.
-    application.expect_call(ExpectedCall::execute_operation(|_, _, _| Ok(vec![])));
+    application.expect_call(ExpectedCall::execute_operation(|_, _| Ok(vec![])));
     application.expect_call(ExpectedCall::default_finalize());
     let valid_block = make_child_block(&value).with_operation(app_operation);
     let (outcome, _, _) = chain
@@ -322,7 +322,7 @@ async fn test_service_as_oracles(service_oracle_execution_times_ms: &[u64]) -> a
         })
         .await?;
 
-    application.expect_call(ExpectedCall::execute_operation(move |runtime, _, _| {
+    application.expect_call(ExpectedCall::execute_operation(move |runtime, _| {
         for _ in 0..service_oracle_call_count {
             runtime.query_service(application_id, vec![])?;
         }
@@ -330,7 +330,7 @@ async fn test_service_as_oracles(service_oracle_execution_times_ms: &[u64]) -> a
     }));
 
     for service_oracle_execution_time in service_oracle_execution_times {
-        application.expect_call(ExpectedCall::handle_query(move |_, _, _| {
+        application.expect_call(ExpectedCall::handle_query(move |_, _| {
             thread::sleep(service_oracle_execution_time);
             Ok(vec![])
         }));
@@ -367,7 +367,7 @@ async fn test_service_as_oracle_exceeding_time_limit(
         })
         .await?;
 
-    application.expect_call(ExpectedCall::execute_operation(move |runtime, _, _| {
+    application.expect_call(ExpectedCall::execute_operation(move |runtime, _| {
         for _ in 0..service_oracle_call_count {
             runtime.query_service(application_id, vec![])?;
         }
@@ -375,7 +375,7 @@ async fn test_service_as_oracle_exceeding_time_limit(
     }));
 
     for service_oracle_execution_time in service_oracle_execution_times {
-        application.expect_call(ExpectedCall::handle_query(move |_, _, _| {
+        application.expect_call(ExpectedCall::handle_query(move |_, _| {
             thread::sleep(service_oracle_execution_time);
             Ok(vec![])
         }));
@@ -427,7 +427,7 @@ async fn test_service_as_oracle_timeout_early_stop(
         })
         .await?;
 
-    application.expect_call(ExpectedCall::execute_operation(move |runtime, _, _| {
+    application.expect_call(ExpectedCall::execute_operation(move |runtime, _| {
         for _ in 0..service_oracle_call_count {
             runtime.query_service(application_id, vec![])?;
         }
@@ -435,7 +435,7 @@ async fn test_service_as_oracle_timeout_early_stop(
     }));
 
     for service_oracle_execution_time in service_oracle_execution_times {
-        application.expect_call(ExpectedCall::handle_query(move |runtime, _, _| {
+        application.expect_call(ExpectedCall::handle_query(move |runtime, _| {
             let execution_time = Instant::now();
             while execution_time.elapsed() < service_oracle_execution_time {
                 runtime.check_execution_time()?;
@@ -488,12 +488,12 @@ async fn test_service_as_oracle_response_size_limit(
         .await
         .expect("Failed to set up test with mock application");
 
-    application.expect_call(ExpectedCall::execute_operation(move |runtime, _, _| {
+    application.expect_call(ExpectedCall::execute_operation(move |runtime, _| {
         runtime.query_service(application_id, vec![])?;
         Ok(vec![])
     }));
 
-    application.expect_call(ExpectedCall::handle_query(move |_runtime, _, _| {
+    application.expect_call(ExpectedCall::handle_query(move |_runtime, _| {
         Ok(vec![0; response_size])
     }));
 
@@ -551,7 +551,7 @@ async fn test_contract_http_response_size_limit(
         .await
         .expect("Failed to set up test with mock application");
 
-    application.expect_call(ExpectedCall::execute_operation(move |runtime, _, _| {
+    application.expect_call(ExpectedCall::execute_operation(move |runtime, _| {
         runtime.perform_http_request(http::Request::get(http_server.url()))?;
         Ok(vec![])
     }));
@@ -605,12 +605,12 @@ async fn test_service_http_response_size_limit(
         .await
         .expect("Failed to set up test with mock application");
 
-    application.expect_call(ExpectedCall::execute_operation(move |runtime, _, _| {
+    application.expect_call(ExpectedCall::execute_operation(move |runtime, _| {
         runtime.query_service(application_id, vec![])?;
         Ok(vec![])
     }));
 
-    application.expect_call(ExpectedCall::handle_query(move |runtime, _, _| {
+    application.expect_call(ExpectedCall::handle_query(move |runtime, _| {
         runtime.perform_http_request(http::Request::get(http_server.url()))?;
         Ok(vec![])
     }));

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -275,7 +275,6 @@ where
         authenticated_caller_id: None,
         height: run_block.height,
         round: Some(0),
-        index: Some(0),
     };
     let mut controller = ResourceController::default();
     creator_state

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3786,14 +3786,11 @@ where
         local_time,
     });
 
-    for query_context in query_contexts {
-        application.expect_call(ExpectedCall::handle_query(
-            move |_runtime, context, query| {
-                assert_eq!(context, query_context);
-                assert!(query.is_empty());
-                Ok(vec![])
-            },
-        ));
+    for _ in query_contexts {
+        application.expect_call(ExpectedCall::handle_query(move |_runtime, query| {
+            assert!(query.is_empty());
+            Ok(vec![])
+        }));
     }
 
     let query = Query::User {
@@ -3901,14 +3898,11 @@ where
                 local_time,
             });
 
-    for query_context in query_contexts_before_new_block {
-        application.expect_call(ExpectedCall::handle_query(
-            move |_runtime, context, query| {
-                assert_eq!(context, query_context);
-                assert!(query.is_empty());
-                Ok(vec![])
-            },
-        ));
+    for _ in query_contexts_before_new_block.clone() {
+        application.expect_call(ExpectedCall::handle_query(move |_runtime, query| {
+            assert!(query.is_empty());
+            Ok(vec![])
+        }));
     }
 
     for local_time in queries_before_proposal {
@@ -3971,14 +3965,11 @@ where
         .handle_confirmed_certificate(certificate, None)
         .await?;
 
-    for query_context in query_contexts_after_new_block.clone() {
-        application.expect_call(ExpectedCall::handle_query(
-            move |_runtime, context, query| {
-                assert_eq!(context, query_context);
-                assert!(query.is_empty());
-                Ok(vec![])
-            },
-        ));
+    for _ in query_contexts_after_new_block.clone() {
+        application.expect_call(ExpectedCall::handle_query(move |_runtime, query| {
+            assert!(query.is_empty());
+            Ok(vec![])
+        }));
     }
 
     for local_time in queries_after_new_block {

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -35,9 +35,8 @@ use {
 
 use crate::{
     evm::database::DatabaseRuntime, ContractRuntime, ContractSyncRuntimeHandle, EvmExecutionError,
-    EvmRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext, QueryContext,
-    ServiceRuntime, ServiceSyncRuntimeHandle, UserContract, UserContractInstance,
-    UserContractModule, UserService, UserServiceInstance, UserServiceModule,
+    EvmRuntime, ExecutionError, ServiceRuntime, ServiceSyncRuntimeHandle, UserContract,
+    UserContractInstance, UserContractModule, UserService, UserServiceInstance, UserServiceModule,
 };
 
 /// This is the selector of the `execute_message` that should be called
@@ -512,11 +511,7 @@ impl<Runtime> UserContract for RevmContractInstance<Runtime>
 where
     Runtime: ContractRuntime,
 {
-    fn instantiate(
-        &mut self,
-        _context: OperationContext,
-        argument: Vec<u8>,
-    ) -> Result<(), ExecutionError> {
+    fn instantiate(&mut self, argument: Vec<u8>) -> Result<(), ExecutionError> {
         let argument = serde_json::from_slice::<Vec<u8>>(&argument)?;
         let mut vec = self.module.clone();
         vec.extend_from_slice(&argument);
@@ -528,11 +523,7 @@ where
         Ok(())
     }
 
-    fn execute_operation(
-        &mut self,
-        _context: OperationContext,
-        operation: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError> {
+    fn execute_operation(&mut self, operation: Vec<u8>) -> Result<Vec<u8>, ExecutionError> {
         ensure_message_length(operation.len(), 4)?;
         let (output, logs) = if &operation[..4] == INTERPRETER_RESULT_SELECTOR {
             let result = self.transact_commit_tx_data(Choice::Call, &operation[4..])?;
@@ -545,16 +536,12 @@ where
         Ok(output)
     }
 
-    fn execute_message(
-        &mut self,
-        _context: MessageContext,
-        _message: Vec<u8>,
-    ) -> Result<(), ExecutionError> {
+    fn execute_message(&mut self, _message: Vec<u8>) -> Result<(), ExecutionError> {
         // TODO(#3760): Implement execute_message for EVM
         todo!("The execute_message part of the Ethereum smart contract has not yet been coded");
     }
 
-    fn finalize(&mut self, _context: FinalizeContext) -> Result<(), ExecutionError> {
+    fn finalize(&mut self) -> Result<(), ExecutionError> {
         Ok(())
     }
 }
@@ -674,11 +661,7 @@ impl<Runtime> UserService for RevmServiceInstance<Runtime>
 where
     Runtime: ServiceRuntime,
 {
-    fn handle_query(
-        &mut self,
-        _context: QueryContext,
-        argument: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError> {
+    fn handle_query(&mut self, argument: Vec<u8>) -> Result<Vec<u8>, ExecutionError> {
         let evm_query = serde_json::from_slice(&argument)?;
         let query = match evm_query {
             EvmQuery::Query(vec) => vec,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -142,11 +142,10 @@ pub enum UserAction {
 
 impl UserAction {
     pub(crate) fn signer(&self) -> Option<AccountOwner> {
-        use UserAction::*;
         match self {
-            Instantiate(context, _) => context.authenticated_signer,
-            Operation(context, _) => context.authenticated_signer,
-            Message(context, _) => context.authenticated_signer,
+            UserAction::Instantiate(context, _) => context.authenticated_signer,
+            UserAction::Operation(context, _) => context.authenticated_signer,
+            UserAction::Message(context, _) => context.authenticated_signer,
         }
     }
 

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -77,7 +77,6 @@ where
             authenticated_caller_id: None,
             height: application_description.block_height,
             round: None,
-            index: Some(0),
         };
 
         let action = UserAction::Instantiate(context, instantiation_argument);

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -343,38 +343,22 @@ impl From<ViewError> for ExecutionError {
 /// The public entry points provided by the contract part of an application.
 pub trait UserContract {
     /// Instantiate the application state on the chain that owns the application.
-    fn instantiate(
-        &mut self,
-        context: OperationContext,
-        argument: Vec<u8>,
-    ) -> Result<(), ExecutionError>;
+    fn instantiate(&mut self, argument: Vec<u8>) -> Result<(), ExecutionError>;
 
     /// Applies an operation from the current block.
-    fn execute_operation(
-        &mut self,
-        context: OperationContext,
-        operation: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError>;
+    fn execute_operation(&mut self, operation: Vec<u8>) -> Result<Vec<u8>, ExecutionError>;
 
     /// Applies a message originating from a cross-chain message.
-    fn execute_message(
-        &mut self,
-        context: MessageContext,
-        message: Vec<u8>,
-    ) -> Result<(), ExecutionError>;
+    fn execute_message(&mut self, message: Vec<u8>) -> Result<(), ExecutionError>;
 
     /// Finishes execution of the current transaction.
-    fn finalize(&mut self, context: FinalizeContext) -> Result<(), ExecutionError>;
+    fn finalize(&mut self) -> Result<(), ExecutionError>;
 }
 
 /// The public entry points provided by the service part of an application.
 pub trait UserService {
     /// Executes unmetered read-only queries on the state of this application.
-    fn handle_query(
-        &mut self,
-        context: QueryContext,
-        argument: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError>;
+    fn handle_query(&mut self, argument: Vec<u8>) -> Result<Vec<u8>, ExecutionError>;
 }
 
 /// Configuration options for the execution runtime available to applications.
@@ -459,8 +443,6 @@ pub struct MessageContext {
     pub height: BlockHeight,
     /// The consensus round number, if this is a block that gets validated in a multi-leader round.
     pub round: Option<u32>,
-    /// The hash of the remote certificate that created the message.
-    pub certificate_hash: CryptoHash,
     /// The ID of the message (based on the operation height and index in the remote
     /// certificate).
     pub message_id: MessageId,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -422,9 +422,6 @@ pub struct OperationContext {
     pub height: BlockHeight,
     /// The consensus round number, if this is a block that gets validated in a multi-leader round.
     pub round: Option<u32>,
-    /// The current index of the operation.
-    #[debug(skip_if = Option::is_none)]
-    pub index: Option<u32>,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -447,7 +447,6 @@ impl SyncRuntimeInternal<UserContractInstance> {
             authenticated_caller_id,
             height: self.height,
             round: self.round,
-            index: None,
         };
         self.push_application(ApplicationStatus {
             caller_id: authenticated_caller_id,

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -87,7 +87,6 @@ pub fn create_dummy_message_context(authenticated_signer: Option<AccountOwner>) 
         refund_grant_to: None,
         height: BlockHeight(0),
         round: Some(0),
-        certificate_hash: CryptoHash::test_hash("block receiving a message"),
         message_id: MessageId {
             chain_id: ChainId::root(0),
             height: BlockHeight(0),

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -72,7 +72,6 @@ pub fn create_dummy_operation_context() -> OperationContext {
         chain_id: ChainId::root(0),
         height: BlockHeight(0),
         round: Some(0),
-        index: Some(0),
         authenticated_signer: None,
         authenticated_caller_id: None,
     }

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -22,7 +22,6 @@ async fn new_view_and_context() -> (
         authenticated_caller_id: None,
         height: BlockHeight::from(7),
         round: Some(0),
-        index: Some(2),
     };
     let state = SystemExecutionState {
         description: Some(description),

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -19,8 +19,7 @@ use super::{
 };
 use crate::{
     wasm::{WasmContractModule, WasmServiceModule},
-    ContractRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext,
-    QueryContext, ServiceRuntime,
+    ContractRuntime, ExecutionError, ServiceRuntime,
 };
 
 /// An [`Engine`] instance configured to run application services.
@@ -128,39 +127,27 @@ impl<Runtime> crate::UserContract for WasmerContractInstance<Runtime>
 where
     Runtime: ContractRuntime + Unpin + 'static,
 {
-    fn instantiate(
-        &mut self,
-        _context: OperationContext,
-        argument: Vec<u8>,
-    ) -> Result<(), ExecutionError> {
+    fn instantiate(&mut self, argument: Vec<u8>) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)
             .instantiate(argument)
             .map_err(WasmExecutionError::from)?;
         Ok(())
     }
 
-    fn execute_operation(
-        &mut self,
-        _context: OperationContext,
-        operation: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError> {
+    fn execute_operation(&mut self, operation: Vec<u8>) -> Result<Vec<u8>, ExecutionError> {
         Ok(ContractEntrypoints::new(&mut self.instance)
             .execute_operation(operation)
             .map_err(WasmExecutionError::from)?)
     }
 
-    fn execute_message(
-        &mut self,
-        _context: MessageContext,
-        message: Vec<u8>,
-    ) -> Result<(), ExecutionError> {
+    fn execute_message(&mut self, message: Vec<u8>) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)
             .execute_message(message)
             .map_err(WasmExecutionError::from)?;
         Ok(())
     }
 
-    fn finalize(&mut self, _context: FinalizeContext) -> Result<(), ExecutionError> {
+    fn finalize(&mut self) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)
             .finalize()
             .map_err(WasmExecutionError::from)?;
@@ -169,11 +156,7 @@ where
 }
 
 impl<Runtime: 'static> crate::UserService for WasmerServiceInstance<Runtime> {
-    fn handle_query(
-        &mut self,
-        _context: QueryContext,
-        argument: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError> {
+    fn handle_query(&mut self, argument: Vec<u8>) -> Result<Vec<u8>, ExecutionError> {
         Ok(ServiceEntrypoints::new(&mut self.instance)
             .handle_query(argument)
             .map_err(WasmExecutionError::from)?)

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -17,8 +17,7 @@ use super::{
 };
 use crate::{
     wasm::{WasmContractModule, WasmServiceModule},
-    ContractRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext,
-    QueryContext, ServiceRuntime,
+    ContractRuntime, ExecutionError, ServiceRuntime,
 };
 
 /// An [`Engine`] instance configured to run application contracts.
@@ -132,40 +131,28 @@ impl<Runtime> crate::UserContract for WasmtimeContractInstance<Runtime>
 where
     Runtime: ContractRuntime + 'static,
 {
-    fn instantiate(
-        &mut self,
-        _context: OperationContext,
-        argument: Vec<u8>,
-    ) -> Result<(), ExecutionError> {
+    fn instantiate(&mut self, argument: Vec<u8>) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)
             .instantiate(argument)
             .map_err(WasmExecutionError::from)?;
         Ok(())
     }
 
-    fn execute_operation(
-        &mut self,
-        _context: OperationContext,
-        operation: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError> {
+    fn execute_operation(&mut self, operation: Vec<u8>) -> Result<Vec<u8>, ExecutionError> {
         let result = ContractEntrypoints::new(&mut self.instance)
             .execute_operation(operation)
             .map_err(WasmExecutionError::from)?;
         Ok(result)
     }
 
-    fn execute_message(
-        &mut self,
-        _context: MessageContext,
-        message: Vec<u8>,
-    ) -> Result<(), ExecutionError> {
+    fn execute_message(&mut self, message: Vec<u8>) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)
             .execute_message(message)
             .map_err(WasmExecutionError::from)?;
         Ok(())
     }
 
-    fn finalize(&mut self, _context: FinalizeContext) -> Result<(), ExecutionError> {
+    fn finalize(&mut self) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)
             .finalize()
             .map_err(WasmExecutionError::from)?;
@@ -177,11 +164,7 @@ impl<Runtime> crate::UserService for WasmtimeServiceInstance<Runtime>
 where
     Runtime: ServiceRuntime + 'static,
 {
-    fn handle_query(
-        &mut self,
-        _context: QueryContext,
-        argument: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError> {
+    fn handle_query(&mut self, argument: Vec<u8>) -> Result<Vec<u8>, ExecutionError> {
         Ok(ServiceEntrypoints::new(&mut self.instance)
             .handle_query(argument)
             .map_err(WasmExecutionError::from)?)

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -8,7 +8,7 @@
 use std::{collections::BTreeSet, sync::Arc, vec};
 
 use linera_base::{
-    crypto::{AccountPublicKey, CryptoHash},
+    crypto::AccountPublicKey,
     data_types::{Amount, BlockHeight, OracleResponse},
     http,
     identifiers::{Account, AccountOwner, ChainDescription, ChainId, MessageId},
@@ -256,14 +256,12 @@ async fn test_fee_consumption(
         oracle_responses.extend(spend.expected_oracle_responses());
     }
 
-    application.expect_call(ExpectedCall::execute_message(
-        move |runtime, _context, _operation| {
-            for spend in spends {
-                spend.execute(runtime)?;
-            }
-            Ok(())
-        },
-    ));
+    application.expect_call(ExpectedCall::execute_message(move |runtime, _operation| {
+        for spend in spends {
+            spend.execute(runtime)?;
+        }
+        Ok(())
+    }));
     application.expect_call(ExpectedCall::default_finalize());
 
     let refund_grant_to = authenticated_signer
@@ -279,7 +277,6 @@ async fn test_fee_consumption(
         refund_grant_to,
         height: BlockHeight(0),
         round: Some(0),
-        certificate_hash: CryptoHash::default(),
         message_id: MessageId::default(),
     };
     let mut grant = initial_grant.unwrap_or_default();

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -84,7 +84,6 @@ async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
         chain_id,
         height: BlockHeight(0),
         round: Some(0),
-        index: Some(0),
         authenticated_signer: None,
         authenticated_caller_id: None,
     };

--- a/linera-execution/tests/service_runtime_apis.rs
+++ b/linera-execution/tests/service_runtime_apis.rs
@@ -31,12 +31,10 @@ async fn test_read_chain_balance_system_api(chain_balance: Amount) {
 
     let (application_id, application, _) = view.register_mock_application(0).await.unwrap();
 
-    application.expect_call(ExpectedCall::handle_query(
-        move |runtime, _context, _query| {
-            assert_eq!(runtime.read_chain_balance().unwrap(), chain_balance);
-            Ok(vec![])
-        },
-    ));
+    application.expect_call(ExpectedCall::handle_query(move |runtime, _query| {
+        assert_eq!(runtime.read_chain_balance().unwrap(), chain_balance);
+        Ok(vec![])
+    }));
     application.expect_call(ExpectedCall::default_finalize());
 
     let context = create_dummy_query_context();
@@ -63,14 +61,12 @@ async fn test_read_owner_balance_system_api(
 
     let (application_id, application, _) = view.register_mock_application(0).await.unwrap();
 
-    application.expect_call(ExpectedCall::handle_query(
-        move |runtime, _context, _query| {
-            for (owner, balance) in accounts {
-                assert_eq!(runtime.read_owner_balance(owner).unwrap(), balance);
-            }
-            Ok(vec![])
-        },
-    ));
+    application.expect_call(ExpectedCall::handle_query(move |runtime, _query| {
+        for (owner, balance) in accounts {
+            assert_eq!(runtime.read_owner_balance(owner).unwrap(), balance);
+        }
+        Ok(vec![])
+    }));
     application.expect_call(ExpectedCall::default_finalize());
 
     let context = create_dummy_query_context();
@@ -94,15 +90,13 @@ async fn test_read_owner_balance_returns_zero_for_missing_accounts(missing_accou
 
     let (application_id, application, _) = view.register_mock_application(0).await.unwrap();
 
-    application.expect_call(ExpectedCall::handle_query(
-        move |runtime, _context, _query| {
-            assert_eq!(
-                runtime.read_owner_balance(missing_account).unwrap(),
-                Amount::ZERO
-            );
-            Ok(vec![])
-        },
-    ));
+    application.expect_call(ExpectedCall::handle_query(move |runtime, _query| {
+        assert_eq!(
+            runtime.read_owner_balance(missing_account).unwrap(),
+            Amount::ZERO
+        );
+        Ok(vec![])
+    }));
     application.expect_call(ExpectedCall::default_finalize());
 
     let context = create_dummy_query_context();
@@ -129,15 +123,13 @@ async fn test_read_owner_balances_system_api(
 
     let (application_id, application, _) = view.register_mock_application(0).await.unwrap();
 
-    application.expect_call(ExpectedCall::handle_query(
-        move |runtime, _context, _query| {
-            assert_eq!(
-                runtime.read_owner_balances().unwrap(),
-                accounts.into_iter().collect::<Vec<_>>(),
-            );
-            Ok(vec![])
-        },
-    ));
+    application.expect_call(ExpectedCall::handle_query(move |runtime, _query| {
+        assert_eq!(
+            runtime.read_owner_balances().unwrap(),
+            accounts.into_iter().collect::<Vec<_>>(),
+        );
+        Ok(vec![])
+    }));
     application.expect_call(ExpectedCall::default_finalize());
 
     let context = create_dummy_query_context();
@@ -164,15 +156,13 @@ async fn test_read_balance_owners_system_api(
 
     let (application_id, application, _) = view.register_mock_application(0).await.unwrap();
 
-    application.expect_call(ExpectedCall::handle_query(
-        move |runtime, _context, _query| {
-            assert_eq!(
-                runtime.read_balance_owners().unwrap(),
-                accounts.keys().copied().collect::<Vec<_>>()
-            );
-            Ok(vec![])
-        },
-    ));
+    application.expect_call(ExpectedCall::handle_query(move |runtime, _query| {
+        assert_eq!(
+            runtime.read_balance_owners().unwrap(),
+            accounts.keys().copied().collect::<Vec<_>>()
+        );
+        Ok(vec![])
+    }));
     application.expect_call(ExpectedCall::default_finalize());
 
     let context = create_dummy_query_context();

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::field_reassign_with_default)]
 
 use linera_base::{
-    crypto::{AccountSecretKey, CryptoHash},
+    crypto::AccountSecretKey,
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{AccountOwner, ChainDescription, ChainId, MessageId},
     ownership::ChainOwnership,
@@ -73,7 +73,6 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         is_bouncing: false,
         height: BlockHeight(0),
         round: Some(0),
-        certificate_hash: CryptoHash::test_hash("certificate"),
         message_id: MessageId {
             chain_id: ChainId::root(1),
             height: BlockHeight(0),

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -38,7 +38,6 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         chain_id: ChainId::root(0),
         height: BlockHeight(0),
         round: Some(0),
-        index: Some(0),
         authenticated_signer: Some(owner),
         authenticated_caller_id: None,
     };

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -70,7 +70,6 @@ async fn test_fuel_for_counter_wasm_application(
         chain_id: ChainId::root(0),
         height: BlockHeight(0),
         round: Some(0),
-        index: Some(0),
         authenticated_signer: None,
         authenticated_caller_id: None,
     };


### PR DESCRIPTION
## Motivation

Some arguments and fields of `*Context` types are unused. The linter doesn't catch that because they are trait methods or public fields.

## Proposal

Remove the unused code.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
