### PR TITLE
Make sure `process_inbox` never creates empty blocks.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2103,9 +2103,6 @@ where
         blobs: Vec<Blob>,
         guard: Option<OwnedMutexGuard<()>>,
     ) -> Result<ExecuteBlockOutcome, ChainClientError> {
-        #[cfg(with_metrics)]
-        let _latency = metrics::EXECUTE_BLOCK_LATENCY.measure_latency();
-
         let _guard = if let Some(guard) = guard {
             guard
         } else {
@@ -2114,6 +2111,10 @@ where
             let mutex = self.state().client_mutex();
             mutex.lock_owned().await
         };
+
+        #[cfg(with_metrics)]
+        let _latency = metrics::EXECUTE_BLOCK_LATENCY.measure_latency();
+
         match self.process_pending_block_without_prepare().await? {
             ClientOutcome::Committed(Some(certificate)) => {
                 return Ok(ExecuteBlockOutcome::Conflict(certificate))


### PR DESCRIPTION
## Motivation

`process_inbox_without_prepare` collects the pending incoming messages and then calls `execute_block`. The latter first finalizes any pending blocks before actually creating the new block, so it collects the pending messages _again_, in case they have changed (a new block could have received some of them).

Since the mutex lock is only obtained inside `execute_block`, it can happen even just inside the local client that `process_inbox_without_prepare` sees pending messages, but those all disappeared once `execute_block` actually puts together the block, resulting in an empty block.

## Proposal

Acquire the lock earlier.

## Test Plan

```
export LINERA_FAUCET_URL="https://faucet.testnet-babbage.linera.net"
cargo test -p linera-service test_end_to_end_repeated_transfers::remote_net_grpc --features remote-net
```

failed for me, but passes with this fix.

## Release Plan

- Possibly release a new SDK patch version.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
