### PR TITLE
build: update checkout action to v4

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 40
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-node@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Check toolchain symlinks

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 40
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Clear up some space
       run: |

--- a/.github/workflows/performance_summary.yml
+++ b/.github/workflows/performance_summary.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Post Performance Summary comment on PR
         if: ${{ github.event.workflow_run.event == 'pull_request' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 40
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
@@ -74,7 +74,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Run some extra execution tests with wasmtime
       run: |
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Run metrics tests
       run: |
@@ -96,7 +96,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
@@ -112,7 +112,7 @@ jobs:
     timeout-minutes: 40
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
@@ -134,7 +134,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
@@ -154,7 +154,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
@@ -173,7 +173,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - uses: foundry-rs/foundry-toolchain@v1.2.0
     - name: Ensure Solc Directory Exists
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
@@ -237,7 +237,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
@@ -261,7 +261,7 @@ jobs:
     - uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Switch to nightly Rust toolchain
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
@@ -287,7 +287,7 @@ jobs:
   check-wit-files:
     runs-on: ubuntu-latest-16-cores
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Check WIT files
       run: |
@@ -298,7 +298,7 @@ jobs:
     timeout-minutes: 2
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check for unexpected chain load operations
       run: |
         ./scripts/check_chain_loads.sh
@@ -308,7 +308,7 @@ jobs:
     timeout-minutes: 2
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build check_copyright_header script
       run: |
         cd ./scripts/check_copyright_header
@@ -323,7 +323,7 @@ jobs:
     timeout-minutes: 2
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Put lint toolchain file in place
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
@@ -340,7 +340,7 @@ jobs:
     timeout-minutes: 2
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Put lint toolchain file in place
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
@@ -354,7 +354,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install `taplo-cli`
       run: RUSTFLAGS='' cargo install taplo-cli@0.9.3 --locked
@@ -366,7 +366,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Put lint toolchain file in place
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
@@ -383,7 +383,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Put lint toolchain file in place
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
@@ -406,7 +406,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Put lint toolchain file in place
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
@@ -430,7 +430,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Put lint toolchain file in place
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
@@ -448,7 +448,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
@@ -463,7 +463,7 @@ jobs:
     timeout-minutes: 40
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Put lint toolchain file in place
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 40
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
       uses: arduino/setup-protoc@v1


### PR DESCRIPTION
Node 20 compatibility: switch all jobs to actions/checkout@v4. Pure maintenance, behavior unchanged.