### PR TITLE
Fix typos in TODO comments and notifications reference

### DIFF
--- a/linera-execution/src/evm/database.rs
+++ b/linera-execution/src/evm/database.rs
@@ -176,7 +176,7 @@ where
                 if !account.storage.is_empty() {
                     panic!("For user account, storage must be empty");
                 }
-                // TODO(#3756): Implement EVM transferts within Linera.
+                // TODO(#3756): Implement EVM transfers within Linera.
                 // The only allowed operations are the ones for the
                 // account balances.
                 if account.info.balance != U256::ZERO {

--- a/linera-service/src/linera-exporter/state.rs
+++ b/linera-service/src/linera-exporter/state.rs
@@ -35,7 +35,7 @@ where
     C: Context + Clone + Send + Sync + 'static,
 {
     // Update with the latest [`BlockHeight`] rather than incrementing by one.
-    // As in cases notfications are lost, exporter is lagging behind, crashes etc.
+    // As in cases notifications are lost, exporter is lagging behind, crashes etc.
     pub fn update_block_height(&mut self, height: BlockHeight, hash: CryptoHash) {
         self.known_height.set(Some((height, hash)));
     }


### PR DESCRIPTION


**Description:**
This PR fixes minor typos in the codebase:
- Corrects "transferts" to "transfers" in the EVM TODO comment in database.rs
- Fixes "notfications" to "notifications" in the state exporter comment in linera-exporter/state.rs

These changes are purely cosmetic and don't affect functionality.

