### PR TITLE
`linera-service-graphql-client`: use `similar-asserts` for schema snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5151,6 +5151,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
+ "similar-asserts",
  "tempfile",
  "test-case",
  "test-log",

--- a/linera-service-graphql-client/Cargo.toml
+++ b/linera-service-graphql-client/Cargo.toml
@@ -35,6 +35,7 @@ linera-execution.workspace = true
 fungible.workspace = true
 linera-base = { workspace = true, features = ["test"] }
 linera-service = { workspace = true, features = ["test"] }
+similar-asserts.workspace = true
 tempfile.workspace = true
 test-case.workspace = true
 test-log = { workspace = true, features = ["trace"] }

--- a/linera-service-graphql-client/tests/test_check_service_schema.rs
+++ b/linera-service-graphql-client/tests/test_check_service_schema.rs
@@ -19,8 +19,9 @@ async fn test_check_service_schema() {
     let mut file_base = std::fs::File::open("gql/service_schema.graphql").unwrap();
     let mut graphql_schema = String::new();
     file_base.read_to_string(&mut graphql_schema).unwrap();
-    assert_eq!(
-        graphql_schema, service_schema,
+    similar_asserts::assert_eq!(
+        graphql_schema,
+        service_schema,
         "\nGraphQL service schema has changed -> \
          regenerate schema following steps in linera-service-graphql-client/README.md\n"
     )


### PR DESCRIPTION
## Motivation

When the schema snapshot test fails, it's hard to read the output.

## Proposal

Use [`similar_asserts::assert_eq`](https://github.com/mitsuhiko/similar-asserts) instead of `std::assert_eq`, which gives a nice diff on failure.

## Test Plan

Caused test to fail and checked output locally.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
