### PR TITLE
Fix typos: correct spelling

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -754,7 +754,7 @@ where
         self.client.local_node.chain_state_view(self.chain_id).await
     }
 
-    /// Returns chain IDs that this chain subcribes to.
+    /// Returns chain IDs that this chain subscribes to.
     #[instrument(level = "trace", skip(self))]
     pub async fn event_stream_publishers(&self) -> Result<BTreeSet<ChainId>, LocalNodeError> {
         let mut publishers = self

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -822,7 +822,7 @@ pub async fn root_key_admin_test<S: TestKeyValueStore>() {
 /// or in shared access where only values are stored and (key, value) once
 /// written are never modified nor erased.
 ///
-/// In case of no exclusive access the following scenarion is checked
+/// In case of no exclusive access the following scenario is checked
 /// * Store 1 deletes a key and does not mark it as missing in its cache.
 /// * Store 2 writes the key
 /// * Store 1 reads the key, but since it is not in the cache it can read


### PR DESCRIPTION
This PR fixes two minor typos in comments:
- Corrects "subcribes" to "subscribes" in client/mod.rs
- Corrects "scenarion" to "scenario" in test_utils/mod.rs

These changes only affect comments and do not modify any functional code.