### PR TITLE
Add a test that en EVM failing function results in an error

### DIFF
--- a/linera-service/tests/fixtures/evm_example_counter.sol
+++ b/linera-service/tests/fixtures/evm_example_counter.sol
@@ -17,4 +17,10 @@ contract ExampleCounter {
     function get_value() external view returns (uint64) {
         return value;
     }
+
+
+  function failing_function() external view returns (uint64) {
+    require(false);
+    return 0;
+  }
 }

--- a/linera-service/tests/fixtures/evm_example_counter.sol
+++ b/linera-service/tests/fixtures/evm_example_counter.sol
@@ -18,9 +18,8 @@ contract ExampleCounter {
         return value;
     }
 
-
-  function failing_function() external view returns (uint64) {
-    require(false);
-    return 0;
-  }
+    function failing_function() external view returns (uint64) {
+        require(false);
+        return 0;
+    }
 }

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -352,6 +352,7 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
         }
         function increment(uint64 input);
         function get_value();
+        function failing_function();
     }
 
     let original_counter_value = 35;
@@ -385,6 +386,12 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
     let application = node_service
         .make_application(&chain, &application_id)
         .await?;
+
+    let failing_function = failing_functionCall {};
+    let failing_function = failing_function.abi_encode();
+    let failing_function = EvmQuery::Query(failing_function);
+    let result = application.run_json_query(failing_function).await;
+    assert!(result.is_err());
 
     let query = get_valueCall {};
     let query = query.abi_encode();


### PR DESCRIPTION
## Motivation

It was a little unclear whether an EVM smart contract failing would result in an error.

## Proposal

It turns out that yes the error are being passed down and a test is added for this feature.

## Test Plan

SI is the point.

## Release Plan

Normal realease.

## Links

None.