### PR TITLE
Add the computation of the BlockEnv for EVM.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -175,7 +175,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - uses: foundry-rs/foundry-toolchain@v1.2.0
+    - uses: foundry-rs/foundry-toolchain@v1.4.0
     - name: Ensure Solc Directory Exists
       run: mkdir -p /home/runner/.solc
     - name: Cache Solc

--- a/linera-execution/src/evm/database.rs
+++ b/linera-execution/src/evm/database.rs
@@ -274,7 +274,10 @@ where
         let prevrandao = keccak256(entry.as_bytes());
         // The blob excess gas and price is not relevant to the execution
         // on Linera. We set up a default value as in REVM.
-        let entry = BlobExcessGasAndPrice { excess_blob_gas: 0, blob_gasprice: 1 };
+        let entry = BlobExcessGasAndPrice {
+            excess_blob_gas: 0,
+            blob_gasprice: 1,
+        };
         let blob_excess_gas_and_price = Some(entry);
         Ok(BlockEnv {
             number: block_height_evm,

--- a/linera-execution/src/evm/database.rs
+++ b/linera-execution/src/evm/database.rs
@@ -252,9 +252,8 @@ where
         // The block height being used
         let block_height_linera = runtime.block_height()?;
         let block_height_evm = U256::from(block_height_linera.0);
-        // The coinbase receiving the minted ethereum in Proof Of Work.
-        // Not relevant anymore
-        let coinbase = address!("00000000000000000000000000000000000000bb");
+        // This is the receiver address of all the gas spent in the block.
+        let beneficiary = address!("00000000000000000000000000000000000000bb");
         // The difficulty which is no longer relevant after The Merge.
         let difficulty = U256::ZERO;
         // We do not have access to the Resources so we keep it to the maximum
@@ -281,7 +280,7 @@ where
         let blob_excess_gas_and_price = Some(entry);
         Ok(BlockEnv {
             number: block_height_evm,
-            coinbase,
+            coinbase: beneficiary,
             difficulty,
             gas_limit,
             timestamp: timestamp_evm,

--- a/linera-execution/src/evm/database.rs
+++ b/linera-execution/src/evm/database.rs
@@ -19,7 +19,7 @@ use revm::{
     },
     Database, DatabaseCommit, DatabaseRef,
 };
-use revm_primitives::{address, BlockEnv};
+use revm_primitives::{address, BlobExcessGasAndPrice, BlockEnv};
 
 use crate::{BaseRuntime, Batch, ContractRuntime, EvmExecutionError, ExecutionError, ViewError};
 
@@ -268,13 +268,14 @@ where
         // The basefee is the minimum feee for executing. We have no such
         // concept in Linera
         let basefee = U256::ZERO;
-        // The randomness beacon being used.
         let chain_id = runtime.chain_id()?;
         let entry = format!("{}{}", chain_id, block_height_linera);
+        // The randomness beacon being used.
         let prevrandao = keccak256(entry.as_bytes());
         // The blob excess gas and price is not relevant to the execution
-        // on Linera.
-        let blob_excess_gas_and_price = None;
+        // on Linera. We set up a default value as in REVM.
+        let entry = BlobExcessGasAndPrice { excess_blob_gas: 0, blob_gasprice: 1 };
+        let blob_excess_gas_and_price = Some(entry);
         Ok(BlockEnv {
             number: block_height_evm,
             coinbase,

--- a/linera-execution/src/evm/mod.rs
+++ b/linera-execution/src/evm/mod.rs
@@ -19,13 +19,13 @@ pub enum EvmExecutionError {
     LoadContractModule(#[source] anyhow::Error),
     #[error("Failed to load service EVM module: {_0}")]
     LoadServiceModule(#[source] anyhow::Error),
-    #[error("Commit error")]
+    #[error("Commit error {0}")]
     CommitError(String),
     #[error("It is illegal to call execute_message from an operation")]
     OperationCallExecuteMessage,
     #[error("The operation should contain the evm selector and so have length 4 or more")]
     OperationIsTooShort,
-    #[error("Transact commit error")]
+    #[error("Transact commit error {0}")]
     TransactCommitError(String),
     #[error("The operation was reverted")]
     Revert {

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -603,6 +603,7 @@ where
         let mut inspector = CallInterceptorContract {
             db: self.db.clone(),
         };
+        let block_env = self.db.get_block_env()?;
         let mut evm: Evm<'_, _, _> = Evm::builder()
             .with_ref_db(&mut self.db)
             .with_external_context(&mut inspector)
@@ -610,6 +611,9 @@ where
                 tx.clear();
                 tx.transact_to = kind;
                 tx.data = tx_data;
+            })
+            .modify_block_env(|block| {
+                *block = block_env;
             })
             .append_handler_register(|handler| {
                 inspector_handle_register(handler);
@@ -705,6 +709,7 @@ where
             db: self.db.clone(),
         };
 
+        let block_env = self.db.get_block_env()?;
         let mut evm: Evm<'_, _, _> = Evm::builder()
             .with_ref_db(&mut self.db)
             .with_external_context(&mut inspector)
@@ -712,6 +717,9 @@ where
                 tx.clear();
                 tx.transact_to = TxKind::Call(contract_address);
                 tx.data = tx_data;
+            })
+            .modify_block_env(|block| {
+                *block = block_env;
             })
             .append_handler_register(|handler| {
                 inspector_handle_register(handler);


### PR DESCRIPTION
## Motivation

Several variables such as block height are available in the `block` variable in the EVM. Support was missing.

## Proposal

The `BlockEnv` is computed from the `runtime`. The `gas_limit` could not be put since the limit in `Resources`
does not appear to be available from the `runtime`.

## Test Plan

The CI.

## Release Plan

Normal release plan.

## Links

Documentation on the `BlockEnv` is available in https://docs.rs/revm-primitives/15.2.0/revm_primitives/env/struct.BlockEnv.html