### PR TITLE
Enable three EVM tests that were forgotten.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -211,8 +211,7 @@ jobs:
         cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum,storage-service
     - name: Run REVM test
       run: |
-        cargo test -p linera-execution test_fuel_for_counter_revm_application --features revm
-        cargo test test_evm_end_to_end_counter --features revm,storage-service
+        cargo test evm --features revm,storage-service
 
   storage-service-tests:
     runs-on: ubuntu-latest-16-cores


### PR DESCRIPTION
## Motivation

The tests for EVM were not enabled for the CI.

## Proposal

The cargo command is changed to `cargo test evm` which makes some small repetition with other tests. But that is fine.

## Test Plan

The CI.

## Release Plan

Normal release plan.

## Links

None.