### PR TITLE
When syncing, also process timeout certificates.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -619,6 +619,14 @@ pub enum ChainClientError {
 
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
+
+    #[error("Unexpected quorum: got {hash}, {round}, expected {expected_hash}, {expected_round}")]
+    UnexpectedQuorum {
+        hash: CryptoHash,
+        round: Round,
+        expected_hash: CryptoHash,
+        expected_round: Round,
+    },
 }
 
 impl From<Infallible> for ChainClientError {
@@ -1228,7 +1236,12 @@ where
         .await?;
         ensure!(
             (votes_hash, votes_round) == (value.hash(), action.round()),
-            ChainClientError::ProtocolError("Unexpected response from validators")
+            ChainClientError::UnexpectedQuorum {
+                hash: votes_hash,
+                round: votes_round,
+                expected_hash: value.hash(),
+                expected_round: action.round(),
+            }
         );
         // Certificate is valid because
         // * `communicate_with_quorum` ensured a sufficient "weight" of

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1812,6 +1812,9 @@ where
         {
             return Ok(());
         };
+        if let Some(timeout) = info.manager.timeout {
+            self.client.handle_certificate(*timeout).await?;
+        }
         let mut proposals = Vec::new();
         if let Some(proposal) = info.manager.requested_proposed {
             proposals.push(*proposal);


### PR DESCRIPTION
## Motivation

When syncing a chain, a client needs to also process the latest timeout certificate from the validators, so that it knows what the current round is, and it can propose blocks. This is currently missing in `try_synchronize_chain_state_from`.

## Proposal

Process the timeout certificate.

## Test Plan

A client test was extended to verify that client will process the timeout certificate requested by another client.

## Release Plan

- These changes should be released in a new SDK, and
- ported to `main`.

## Links

- #3839
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
