### PR TITLE
When syncing, also process timeout certificates. (main port)

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1871,6 +1871,9 @@ where
         {
             return Ok(());
         };
+        if let Some(timeout) = info.manager.timeout {
+            self.client.handle_certificate(*timeout).await?;
+        }
         let mut proposals = Vec::new();
         if let Some(proposal) = info.manager.requested_proposed {
             proposals.push(*proposal);

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -583,6 +583,14 @@ pub enum ChainClientError {
 
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
+
+    #[error("Unexpected quorum: got {hash}, {round}, expected {expected_hash}, {expected_round}")]
+    UnexpectedQuorum {
+        hash: CryptoHash,
+        round: Round,
+        expected_hash: CryptoHash,
+        expected_round: Round,
+    },
 }
 
 impl From<Infallible> for ChainClientError {
@@ -1262,7 +1270,12 @@ where
         .await?;
         ensure!(
             (votes_hash, votes_round) == (value.hash(), action.round()),
-            ChainClientError::ProtocolError("Unexpected response from validators")
+            ChainClientError::UnexpectedQuorum {
+                hash: votes_hash,
+                round: votes_round,
+                expected_hash: value.hash(),
+                expected_round: action.round(),
+            }
         );
         // Certificate is valid because
         // * `communicate_with_quorum` ensured a sufficient "weight" of

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1846,13 +1846,17 @@ where
     let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     let client = builder.add_root_chain(1, Amount::from_tokens(3)).await?;
+    let observer = builder.add_root_chain(2, Amount::ZERO).await?;
     let chain_id = client.chain_id();
     let owner0 = client.public_key().await.unwrap().into();
     let owner1 = AccountSecretKey::generate().public().into();
 
     let owners = [(owner0, 100), (owner1, 100)];
     let ownership = ChainOwnership::multiple(owners, 0, TimeoutConfig::default());
-    client.change_ownership(ownership).await.unwrap();
+    client.change_ownership(ownership.clone()).await.unwrap();
+
+    let info = observer.synchronize_chain_state(chain_id).await?;
+    assert_eq!(info.manager.ownership, ownership);
 
     let manager = client.chain_info().await.unwrap().manager;
 
@@ -1887,6 +1891,10 @@ where
     builder
         .check_that_validators_are_in_round(chain_id, BlockHeight::from(1), expected_round, 3)
         .await;
+
+    // Another client can process the timeout certificate, to arrive at the same round.
+    let info = observer.synchronize_chain_state(chain_id).await?;
+    assert_eq!(info.manager.current_round, expected_round);
 
     let round = loop {
         let manager = client.chain_info().await.unwrap().manager;


### PR DESCRIPTION
## Motivation


When syncing a chain, a client needs to also process the latest timeout certificate from the validators, so that it knows what the current round is, and it can propose blocks. This is currently missing in `try_synchronize_chain_state_from`.

## Proposal

Port the fix from https://github.com/linera-io/linera-protocol/pull/3840 to `main`.

## Test Plan

A client test was extended to verify that client will process the timeout certificate requested by another client.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #3839.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
