### PR TITLE
Make some operations exempt from app permissions. (#3851)

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -1137,6 +1137,10 @@ where
             app_permissions.mandatory_applications.iter().cloned(),
         );
         for operation in &block.operations {
+            if operation.is_exempt_from_permissions() {
+                mandatory.clear();
+                continue;
+            }
             ensure!(
                 app_permissions.can_execute_operations(&operation.application_id()),
                 ChainError::AuthorizedApplications(

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1193,6 +1193,17 @@ impl Operation {
             _ => vec![],
         }
     }
+
+    /// Returns whether this operation is allowed regardless of application permissions.
+    pub fn is_exempt_from_permissions(&self) -> bool {
+        let Operation::System(system_op) = self else {
+            return false;
+        };
+        matches!(
+            **system_op,
+            SystemOperation::ProcessNewEpoch(_) | SystemOperation::ProcessRemovedEpoch(_)
+        )
+    }
 }
 
 impl From<SystemMessage> for Message {


### PR DESCRIPTION
## Motivation

Chains with restricted block operations can't process e.g. new events because system operations are not allowed.

## Proposal

Allow `Process*Epoch` regardless of permissions.

## Test Plan

A test was extended.

## Release Plan

- These changes should
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- Backport of part of https://github.com/linera-io/linera-protocol/pull/3851.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
