### PR TITLE
Find current chain on faucet restart.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -605,7 +605,7 @@ Run a GraphQL service that exposes a faucet where users can claim tokens. This g
 * `--limit-rate-until <LIMIT_RATE_UNTIL>` — The end timestamp: The faucet will rate-limit the token supply so it runs out of money no earlier than this
 * `--max-chain-length <MAX_CHAIN_LENGTH>` — The maximum number of blocks in the faucet chain, before a new one is created
 
-  Default value: `100`
+  Default value: `500`
 * `--listener-skip-process-inbox` — Do not create blocks automatically to receive incoming messages. Instead, wait for an explicit mutation `processInbox`
 * `--listener-delay-before-ms <DELAY_BEFORE_MS>` — Wait before processing any notification (useful for testing)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4759,6 +4759,7 @@ dependencies = [
  "linera-base",
  "linera-client",
  "linera-core",
+ "linera-execution",
  "linera-storage",
  "linera-version",
  "linera-views",

--- a/linera-faucet/server/Cargo.toml
+++ b/linera-faucet/server/Cargo.toml
@@ -20,6 +20,7 @@ futures.workspace = true
 linera-base.workspace = true
 linera-client.workspace = true
 linera-core.workspace = true
+linera-execution.workspace = true
 linera-storage.workspace = true
 linera-version.workspace = true
 serde.workspace = true

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -11,7 +11,7 @@ use axum::{Extension, Router};
 use futures::lock::Mutex;
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
-    data_types::{Amount, ApplicationPermissions, BlockHeight, Timestamp},
+    data_types::{Amount, ApplicationPermissions, ArithmeticError, BlockHeight, Timestamp},
     identifiers::{AccountOwner, ChainId, MessageId},
     ownership::ChainOwnership,
 };
@@ -20,6 +20,7 @@ use linera_client::{
     config::GenesisConfig,
 };
 use linera_core::data_types::ClientOutcome;
+use linera_execution::SystemMessage;
 use linera_storage::{Clock as _, Storage};
 use serde::Deserialize;
 use tower_http::cors::CorsLayer;
@@ -296,6 +297,8 @@ where
     /// Runs the faucet.
     #[tracing::instrument(name = "FaucetService::run", skip_all, fields(port = self.port, chain_id = ?self.chain_id))]
     pub async fn run(self) -> anyhow::Result<()> {
+        self.find_current_chain().await?;
+
         let port = self.port.get();
         let index_handler = axum::routing::get(graphiql).post(Self::index_handler);
 
@@ -325,6 +328,52 @@ where
     async fn index_handler(service: Extension<Self>, request: GraphQLRequest) -> GraphQLResponse {
         let schema = service.0.schema();
         schema.execute(request.into_inner()).await.into()
+    }
+
+    /// Finds the current chain ID, even if the configured chain has been closed and the tokens
+    /// moved to a new one.
+    async fn find_current_chain(&self) -> anyhow::Result<()> {
+        let mut chain_id = *self.chain_id.lock().await;
+        let mut client = self.context.lock().await.make_chain_client(chain_id)?;
+        client.synchronize_from_validators().await?;
+        loop {
+            let chain = client.chain_state_view().await?;
+            if !chain.execution_state.system.closed.get() {
+                break; // This is the current chain; it has not been closed yet.
+            }
+            // The faucet closes each chain in the last block; the next-to-last block opens the
+            // new chain.
+            let index = chain
+                .confirmed_log
+                .count()
+                .checked_sub(2)
+                .ok_or(ArithmeticError::Underflow)?;
+            let hash = chain
+                .confirmed_log
+                .get(index)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("Missing confirmed_log entry"))?;
+            let certificate = client.storage_client().read_certificate(hash).await?;
+            chain_id = certificate
+                .block()
+                .messages()
+                .iter()
+                .flatten()
+                .find_map(|message| {
+                    if let linera_execution::Message::System(SystemMessage::OpenChain(_)) =
+                        &message.message
+                    {
+                        Some(message.destination.recipient()?)
+                    } else {
+                        None
+                    }
+                })
+                .ok_or_else(|| anyhow::anyhow!("No OpenChain message found"))?;
+            client = self.context.lock().await.make_chain_client(chain_id)?;
+            client.synchronize_from_validators().await?;
+        }
+        *self.chain_id.lock().await = chain_id;
+        Ok(())
     }
 }
 

--- a/linera-service/src/linera/command.rs
+++ b/linera-service/src/linera/command.rs
@@ -615,7 +615,7 @@ pub enum ClientCommand {
         limit_rate_until: Option<DateTime<Utc>>,
 
         /// The maximum number of blocks in the faucet chain, before a new one is created.
-        #[arg(long, default_value = "100")]
+        #[arg(long, default_value = "500")]
         max_chain_length: u64,
 
         /// Configuration for the faucet chain listener.


### PR DESCRIPTION
## Motivation

As of https://github.com/linera-io/linera-protocol/pull/3852, the faucet switches chains every 100 blocks. That means it cannot be restarted with the same command line, because the original chain may be closed (and broke).

## Proposal

On restart, while the current chain is closed, keep switching to the last chain that it opened until we find the most recent one.

Also, change the default maximum length to 500 blocks to reduce the overhead and the number of chains that end up in the faucet wallet.

## Test Plan

`test_end_to_end_faucet_with_long_chains` restarts the faucet now.

## Release Plan

- These changes should be ported to the `main` branch.
- The faucet should be restarted with this.

## Links

- See https://github.com/linera-io/linera-protocol/pull/3852.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
