### PR TITLE
Don't fail if faucet chain was opened but old one not closed.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -342,6 +342,11 @@ where
                 })
             })
             .await?;
+        } else {
+            self.mutate_wallet(|w| {
+                w.get_mut(chain_id).unwrap().key_pair = key_pair;
+            })
+            .await?;
         }
 
         Ok(())

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -344,7 +344,9 @@ where
             .await?;
         } else {
             self.mutate_wallet(|w| {
-                w.get_mut(chain_id).unwrap().key_pair = key_pair;
+                let user_chain = w.get_mut(chain_id).unwrap();
+                user_chain.timestamp = timestamp.max(user_chain.timestamp);
+                user_chain.key_pair = key_pair;
             })
             .await?;
         }

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -60,6 +60,10 @@ impl Wallet {
         self.chains.get(&chain_id)
     }
 
+    pub fn get_mut(&mut self, chain_id: ChainId) -> Option<&mut UserChain> {
+        self.chains.get_mut(&chain_id)
+    }
+
     pub fn insert(&mut self, chain: UserChain) {
         if self.default.is_none() {
             self.default = Some(chain.chain_id);

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -378,8 +378,9 @@ where
                     })
                     .ok_or_else(|| anyhow::anyhow!("No OpenChain message found"))?;
                 info!("Found new faucet chain {chain_id:8}");
+                let timestamp = certificate.block().header.timestamp;
                 guard
-                    .update_wallet_for_new_chain(chain_id, Some(key_pair), Timestamp::now())
+                    .update_wallet_for_new_chain(chain_id, Some(key_pair), timestamp)
                     .await?;
                 (chain_id, guard.make_chain_client(chain_id)?)
             };

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2961,6 +2961,64 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
     let faucet = faucet_service.instance();
 
     // Create a new wallet using the faucet
+    let client = net.make_client().await;
+    let (outcome, _) = client
+        .wallet_init(&[], FaucetOption::NewChain(&faucet))
+        .await?
+        .unwrap();
+
+    let chain = outcome.chain_id;
+    let initial_balance = client.query_balance(Account::chain(chain)).await?;
+    let fees_paid = amount - initial_balance;
+    assert!(initial_balance > Amount::ZERO);
+
+    client
+        .transfer(initial_balance - fees_paid, chain, faucet_chain)
+        .await?;
+
+    let final_balance = client.query_balance(Account::chain(chain)).await?;
+    assert_eq!(final_balance, Amount::ZERO);
+
+    faucet_service.ensure_is_running()?;
+    faucet_service.terminate().await?;
+
+    net.ensure_is_running().await?;
+    net.terminate().await?;
+
+    Ok(())
+}
+
+/// Tests rotating faucet chains.
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
+#[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_end_to_end_faucet_chain_rotation(config: impl LineraNetConfig) -> Result<()> {
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let chain_count = 4;
+
+    let (mut net, faucet_client) = config.instantiate().await?;
+
+    let faucet_chain = faucet_client.load_wallet()?.default_chain().unwrap();
+
+    // Use the faucet directly to initialize chains
+    for _ in 0..chain_count {
+        faucet_client
+            .open_chain(faucet_chain, None, Amount::ONE)
+            .await?;
+    }
+
+    let amount = Amount::ONE;
+    let mut faucet_service = faucet_client
+        .run_faucet(None, faucet_chain, amount, Some(chain_count as u64))
+        .await?;
+    let faucet = faucet_service.instance();
+
+    // Create a new wallet using the faucet
     let client1 = net.make_client().await;
     let (outcome1, _) = client1
         .wallet_init(&[], FaucetOption::NewChain(&faucet))
@@ -2996,18 +3054,56 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
     // with it.
     assert_eq!(outcome2.message_id.chain_id, outcome3.message_id.chain_id);
 
-    let chain = outcome3.chain_id;
-    assert_eq!(chain, client3.load_wallet()?.default_chain().unwrap());
+    faucet_service.ensure_is_running()?;
+    faucet_service.terminate().await?;
 
-    let initial_balance = client3.query_balance(Account::chain(chain)).await?;
+    faucet_client.sync(outcome3.message_id.chain_id).await?;
+    let owner = faucet_client
+        .load_wallet()?
+        .chains
+        .values()
+        .next()
+        .unwrap()
+        .key_pair
+        .as_ref()
+        .unwrap()
+        .public()
+        .into();
+    let balance = faucet_client
+        .query_balance(Account::chain(outcome3.message_id.chain_id))
+        .await?
+        - Amount::ONE;
+    faucet_client
+        .open_chain(outcome3.message_id.chain_id, Some(owner), balance)
+        .await?;
+
+    let mut faucet_service = faucet_client
+        .run_faucet(None, faucet_chain, amount, Some(chain_count as u64))
+        .await?;
+
+    // Create a new wallet using the faucet
+    let client4 = net.make_client().await;
+    let (outcome4, _) = client4
+        .wallet_init(&[], FaucetOption::NewChain(&faucet))
+        .await?
+        .unwrap();
+
+    // After restarting, the faucet found its second chain, even though it was not initialized
+    // with it.
+    assert_ne!(outcome3.message_id.chain_id, outcome4.message_id.chain_id);
+
+    let chain = outcome4.chain_id;
+    assert_eq!(chain, client4.load_wallet()?.default_chain().unwrap());
+
+    let initial_balance = client4.query_balance(Account::chain(chain)).await?;
     let fees_paid = amount - initial_balance;
     assert!(initial_balance > Amount::ZERO);
 
-    client3
+    client4
         .transfer(initial_balance - fees_paid, chain, faucet_chain)
         .await?;
 
-    let final_balance = client3.query_balance(Account::chain(chain)).await?;
+    let final_balance = client4.query_balance(Account::chain(chain)).await?;
     assert_eq!(final_balance, Amount::ZERO);
 
     faucet_service.ensure_is_running()?;


### PR DESCRIPTION
## Motivation

On the testnet, for some reason the faucet failed to close the old chain after migrating to a new one.

## Proposal

Make the faucet handle that case on startup: Also migrate if the old chain has no tokens, even if it is not closed.

## Test Plan

A new test for all these cases was added.

## Release Plan

- These changes should be ported to the main branch.
- We should try this on the faucet with the `a3edc33d8e951a1139333be8a4b56646b5598a8f51216e86592d881808972b07` chain.

## Links

- Extending the functionality from #3863.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
