### PR TITLE
Make sure we're building release images

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -49,7 +49,7 @@ jobs:
   
       - name: Build Docker image
         run: |
-          docker build --build-arg git_commit=${{ env.GIT_COMMIT_LONG }} \
+          docker build --build-arg git_commit=${{ env.GIT_COMMIT_LONG }} --build-arg build_flag="--release" --build-arg build_folder="release" \
             -f docker/Dockerfile . \
             -t ${{ env.DOCKER_IMAGE }}:${{ env.BRANCH_NAME }} \
             -t ${{ env.DOCKER_IMAGE }}:${{ env.GIT_COMMIT_SHORT }} \

--- a/scripts/deploy-validator.sh
+++ b/scripts/deploy-validator.sh
@@ -54,7 +54,7 @@ GENESIS_CONFIG="docker/genesis.json"
 
 if [ -z "$REMOTE_IMAGE" ]; then
   echo "Building local image from commit $GIT_COMMIT..."
-  docker build --build-arg git_commit="$GIT_COMMIT" -f  docker/Dockerfile . -t linera
+  docker build --build-arg git_commit="$GIT_COMMIT" --build-arg build_flag="--release" --build-arg build_folder="release" -f  docker/Dockerfile . -t linera
   export LINERA_IMAGE=linera
 else
   export LINERA_IMAGE="us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:${BRANCH_NAME}_release"


### PR DESCRIPTION
## Motivation

These places were missed, and are the most important ones 🤦🏻‍♂️

## Proposal

Make sure we're building with release mode in the places we should be

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

This doesn't seem to have affected our `testnet_babbage` image though, so this might be optional
