### PR TITLE
Simplification storage initialization of the dual-store database backend

### DIFF
--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -4,7 +4,7 @@
 #[cfg(with_testing)]
 use std::sync::LazyLock;
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::BTreeMap,
     env,
     path::{Path, PathBuf},
     sync::Arc,
@@ -195,8 +195,8 @@ pub struct LocalNet {
     num_shards: usize,
     validator_keys: BTreeMap<usize, (String, String)>,
     running_validators: BTreeMap<usize, Validator>,
+    initialized_validator_storages: BTreeMap<usize, StorageConfigNamespace>,
     namespace: String,
-    validators_with_initialized_storage: HashSet<usize>,
     storage_config: StorageConfig,
     cross_chain_config: CrossChainConfig,
     path_provider: PathProvider,
@@ -395,8 +395,8 @@ impl LocalNet {
             num_shards,
             validator_keys: BTreeMap::new(),
             running_validators: BTreeMap::new(),
+            initialized_validator_storages: BTreeMap::new(),
             namespace,
-            validators_with_initialized_storage: HashSet::new(),
             storage_config,
             cross_chain_config,
             path_provider,
@@ -559,12 +559,15 @@ impl LocalNet {
     }
 
     async fn run_proxy(&mut self, validator: usize) -> Result<Child> {
-        let storage = self.initialize_shared_storage(validator).await?;
+        let storage = self
+            .initialized_validator_storages
+            .get(&validator)
+            .expect("initialized storage");
         let child = self
             .command_for_binary("linera-proxy")
             .await?
             .arg(format!("server_{}.json", validator))
-            .args(["--storage", &storage])
+            .args(["--storage", &storage.to_string()])
             .args(["--genesis", "genesis.json"])
             .spawn_into()?;
 
@@ -588,14 +591,17 @@ impl LocalNet {
     }
 
     async fn run_exporter(&mut self, validator: usize, exporter_id: u32) -> Result<Child> {
-        let storage = self.initialize_shared_storage(validator).await?;
         let config_path = format!("exporter_config_{validator}:{exporter_id}.toml");
+        let storage = self
+            .initialized_validator_storages
+            .get(&validator)
+            .expect("initialized storage");
 
         let child = self
             .command_for_binary("linera-exporter")
             .await?
             .arg(config_path)
-            .args(["--storage", &storage])
+            .args(["--storage", &storage.to_string()])
             .args(["--genesis", "genesis.json"])
             .spawn_into()?;
 
@@ -652,84 +658,43 @@ impl LocalNet {
         bail!("Failed to start {nickname}");
     }
 
-    async fn initialize_storage_internal(&mut self, storage: &str, genesis: &str) -> Result<()> {
-        let max_try = 4;
-        let mut i_try = 0;
-        loop {
-            let mut command = self.command_for_binary("linera-server").await?;
-            if let Ok(var) = env::var(SERVER_ENV) {
-                command.args(var.split_whitespace());
-            }
-            command.arg("initialize");
-            let result = command
-                .args(["--storage", storage])
-                .args(["--genesis", genesis])
-                .spawn_and_wait_for_stdout()
-                .await;
-            if result.is_ok() {
-                return Ok(());
-            }
-            warn!(
-                "Failed to initialize storage={} using linera-server, i_try={}, error={:?}",
-                storage, i_try, result
-            );
-            i_try += 1;
-            if i_try == max_try {
-                bail!("Failed to initialize after {} attempts", max_try);
-            }
-            let one_second = linera_base::time::Duration::from_secs(1);
-            std::thread::sleep(one_second);
-        }
-    }
-
-    async fn initialize_shared_storage(&mut self, validator: usize) -> Result<String> {
+    async fn initialize_storage(&mut self, validator: usize) -> Result<()> {
         let namespace = format!("{}_server_{}_db", self.namespace, validator);
-        let storage_config = self.storage_config.get_shared_storage();
+        let storage_config = self.storage_config.clone();
         let storage = StorageConfigNamespace {
             storage_config,
             namespace,
-        }
-        .to_string();
-        if !self
-            .validators_with_initialized_storage
-            .contains(&validator)
-        {
-            self.initialize_storage_internal(&storage, "genesis.json")
-                .await?;
-            self.validators_with_initialized_storage.insert(validator);
-        }
-        Ok(storage)
-    }
+        };
 
-    async fn initialize_storage(&mut self, validator: usize, shard: usize) -> Result<String> {
-        if self.storage_config.are_chains_shared() {
-            self.initialize_shared_storage(validator).await
-        } else {
-            let namespace = format!("{}_server_{}_db", self.namespace, validator);
-            let mut storage_config = self.storage_config.clone();
-            let shard_str = format!("shard_{}", shard);
-            storage_config.append_shard_str(&shard_str);
-            let storage = StorageConfigNamespace {
-                storage_config,
-                namespace,
-            }
-            .to_string();
-
-            self.initialize_storage_internal(&storage, "genesis.json")
-                .await?;
-            Ok(storage)
+        let mut command = self.command_for_binary("linera-server").await?;
+        if let Ok(var) = env::var(SERVER_ENV) {
+            command.args(var.split_whitespace());
         }
+        command.arg("initialize");
+        command
+            .args(["--storage", &storage.to_string()])
+            .args(["--genesis", "genesis.json"])
+            .spawn_and_wait_for_stdout()
+            .await?;
+
+        self.initialized_validator_storages
+            .insert(validator, storage);
+        Ok(())
     }
 
     async fn run_server(&mut self, validator: usize, shard: usize) -> Result<Child> {
-        let storage = self.initialize_storage(validator, shard).await?;
+        let storage = self
+            .initialized_validator_storages
+            .get(&validator)
+            .expect("initialized storage");
+
         let mut command = self.command_for_binary("linera-server").await?;
         if let Ok(var) = env::var(SERVER_ENV) {
             command.args(var.split_whitespace());
         }
         command
             .arg("run")
-            .args(["--storage", &storage])
+            .args(["--storage", &storage.to_string()])
             .args(["--server", &format!("server_{}.json", validator)])
             .args(["--shard", &shard.to_string()])
             .args(["--genesis", "genesis.json"])
@@ -762,28 +727,34 @@ impl LocalNet {
         Ok(())
     }
 
-    pub async fn start_validator(&mut self, validator: usize) -> Result<()> {
-        let proxy = self.run_proxy(validator).await?;
-        let mut validator_proxy = Validator::new(proxy);
+    /// Start a validator.
+    pub async fn start_validator(&mut self, index: usize) -> Result<()> {
+        self.initialize_storage(index).await?;
+        self.restart_validator(index).await
+    }
+
+    /// Restart a validator. This is similar to `start_validator` except that the
+    /// database was already initialized once.
+    pub async fn restart_validator(&mut self, index: usize) -> Result<()> {
+        let proxy = self.run_proxy(index).await?;
+        let mut validator = Validator::new(proxy);
         for shard in 0..self.num_shards {
-            let server = self.run_server(validator, shard).await?;
-            validator_proxy.add_server(server);
+            let server = self.run_server(index, shard).await?;
+            validator.add_server(server);
         }
-
         for block_exporter in 0..self.num_block_exporters {
-            let exporter = self.run_exporter(validator, block_exporter).await?;
-            validator_proxy.add_block_exporter(exporter);
+            let exporter = self.run_exporter(index, block_exporter).await?;
+            validator.add_block_exporter(exporter);
         }
-
-        self.running_validators.insert(validator, validator_proxy);
+        self.running_validators.insert(index, validator);
         Ok(())
     }
 
     /// Terminates all the processes of a given validator.
-    pub async fn stop_validator(&mut self, validator_index: usize) -> Result<()> {
-        if let Some(mut validator) = self.running_validators.remove(&validator_index) {
+    pub async fn stop_validator(&mut self, index: usize) -> Result<()> {
+        if let Some(mut validator) = self.running_validators.remove(&index) {
             if let Err(error) = validator.terminate().await {
-                error!("Failed to stop validator {validator_index}: {error}");
+                error!("Failed to stop validator {index}: {error}");
                 return Err(error);
             }
         }
@@ -857,7 +828,7 @@ impl LocalNet {
         let server = self.run_server(validator, shard).await?;
         self.running_validators
             .get_mut(&validator)
-            .context("could not find server")?
+            .context("could not find validator")?
             .add_server(server);
         Ok(())
     }

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -196,8 +196,8 @@ pub struct LocalNet {
     validator_keys: BTreeMap<usize, (String, String)>,
     running_validators: BTreeMap<usize, Validator>,
     initialized_validator_storages: BTreeMap<usize, StorageConfigNamespace>,
-    namespace: String,
-    storage_config: StorageConfig,
+    common_namespace: String,
+    common_storage_config: StorageConfig,
     cross_chain_config: CrossChainConfig,
     path_provider: PathProvider,
     num_block_exporters: u32,
@@ -379,10 +379,10 @@ impl LocalNet {
     fn new(
         network: NetworkConfig,
         testing_prng_seed: Option<u64>,
-        namespace: String,
+        common_namespace: String,
         num_initial_validators: usize,
         num_shards: usize,
-        storage_config: StorageConfig,
+        common_storage_config: StorageConfig,
         cross_chain_config: CrossChainConfig,
         path_provider: PathProvider,
         num_block_exporters: u32,
@@ -396,8 +396,8 @@ impl LocalNet {
             validator_keys: BTreeMap::new(),
             running_validators: BTreeMap::new(),
             initialized_validator_storages: BTreeMap::new(),
-            namespace,
-            storage_config,
+            common_namespace,
+            common_storage_config,
             cross_chain_config,
             path_provider,
             num_block_exporters,
@@ -659,8 +659,8 @@ impl LocalNet {
     }
 
     async fn initialize_storage(&mut self, validator: usize) -> Result<()> {
-        let namespace = format!("{}_server_{}_db", self.namespace, validator);
-        let storage_config = self.storage_config.clone();
+        let namespace = format!("{}_server_{}_db", self.common_namespace, validator);
+        let storage_config = self.common_storage_config.clone();
         let storage = StorageConfigNamespace {
             storage_config,
             namespace,

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -46,64 +46,79 @@ use {
 pub enum StoreConfig {
     /// The storage service key-value store
     #[cfg(feature = "storage-service")]
-    Service(ServiceStoreConfig, String),
+    Service {
+        config: ServiceStoreConfig,
+        namespace: String,
+    },
     /// The memory key value store
-    Memory(MemoryStoreConfig, String),
+    Memory {
+        config: MemoryStoreConfig,
+        namespace: String,
+    },
     /// The RocksDB key value store
     #[cfg(feature = "rocksdb")]
-    RocksDb(RocksDbStoreConfig, String),
+    RocksDb {
+        config: RocksDbStoreConfig,
+        namespace: String,
+    },
     /// The DynamoDB key value store
     #[cfg(feature = "dynamodb")]
-    DynamoDb(DynamoDbStoreConfig, String),
+    DynamoDb {
+        config: DynamoDbStoreConfig,
+        namespace: String,
+    },
     /// The ScyllaDB key value store
     #[cfg(feature = "scylladb")]
-    ScyllaDb(ScyllaDbStoreConfig, String),
+    ScyllaDb {
+        config: ScyllaDbStoreConfig,
+        namespace: String,
+    },
     #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
-    DualRocksDbScyllaDb(
-        DualStoreConfig<RocksDbStoreConfig, ScyllaDbStoreConfig>,
-        String,
-    ),
+    DualRocksDbScyllaDb {
+        config: DualStoreConfig<RocksDbStoreConfig, ScyllaDbStoreConfig>,
+        namespace: String,
+    },
 }
 
 /// The description of a storage implementation.
 #[derive(Clone, Debug)]
 #[cfg_attr(any(test), derive(Eq, PartialEq))]
 pub enum StorageConfig {
-    /// The storage service description
+    /// The storage service description.
     #[cfg(feature = "storage-service")]
     Service {
-        /// The endpoint used
+        /// The endpoint used.
         endpoint: String,
     },
-    /// The memory description
+    /// The memory description.
     Memory,
-    /// The RocksDB description
+    /// The RocksDB description.
     #[cfg(feature = "rocksdb")]
     RocksDb {
-        /// The path used
+        /// The path used.
         path: PathBuf,
         /// Whether to use `block_in_place` or `spawn_blocking`.
         spawn_mode: RocksDbSpawnMode,
     },
-    /// The DynamoDB description
+    /// The DynamoDB description.
     #[cfg(feature = "dynamodb")]
     DynamoDb {
         /// Whether to use the DynamoDB Local system
         use_dynamodb_local: bool,
     },
-    /// The ScyllaDB description
+    /// The ScyllaDB description.
     #[cfg(feature = "scylladb")]
     ScyllaDb {
-        /// The URI for accessing the database
+        /// The URI for accessing the database.
         uri: String,
     },
     #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
     DualRocksDbScyllaDb {
-        /// The path used
+        /// The path used.
         path_with_guard: PathWithGuard,
         /// Whether to use `block_in_place` or `spawn_blocking`.
         spawn_mode: RocksDbSpawnMode,
-        /// The URI for accessing the database
+        /// The URI for accessing the database.
         uri: String,
     },
 }
@@ -402,30 +417,30 @@ impl StorageConfigNamespace {
                     inner_config,
                     storage_cache_config: common_config.storage_cache_config,
                 };
-                Ok(StoreConfig::Service(config, namespace))
+                Ok(StoreConfig::Service { config, namespace })
             }
             StorageConfig::Memory => {
                 let config = MemoryStoreConfig {
                     common_config: common_config.reduced(),
                 };
-                Ok(StoreConfig::Memory(config, namespace))
+                Ok(StoreConfig::Memory { config, namespace })
             }
             #[cfg(feature = "rocksdb")]
             StorageConfig::RocksDb { path, spawn_mode } => {
                 let path_buf = path.to_path_buf();
                 let path_with_guard = PathWithGuard::new(path_buf);
                 let config = RocksDbStoreConfig::new(*spawn_mode, path_with_guard, common_config);
-                Ok(StoreConfig::RocksDb(config, namespace))
+                Ok(StoreConfig::RocksDb { config, namespace })
             }
             #[cfg(feature = "dynamodb")]
             StorageConfig::DynamoDb { use_dynamodb_local } => {
                 let config = DynamoDbStoreConfig::new(*use_dynamodb_local, common_config);
-                Ok(StoreConfig::DynamoDb(config, namespace))
+                Ok(StoreConfig::DynamoDb { config, namespace })
             }
             #[cfg(feature = "scylladb")]
             StorageConfig::ScyllaDb { uri } => {
                 let config = ScyllaDbStoreConfig::new(uri.to_string(), common_config);
-                Ok(StoreConfig::ScyllaDb(config, namespace))
+                Ok(StoreConfig::ScyllaDb { config, namespace })
             }
             #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
             StorageConfig::DualRocksDbScyllaDb {
@@ -443,7 +458,7 @@ impl StorageConfigNamespace {
                     first_config,
                     second_config,
                 };
-                Ok(StoreConfig::DualRocksDbScyllaDb(config, namespace))
+                Ok(StoreConfig::DualRocksDbScyllaDb { config, namespace })
             }
         }
     }
@@ -528,7 +543,7 @@ impl StoreConfig {
         Job: Runnable,
     {
         match self {
-            StoreConfig::Memory(config, namespace) => {
+            StoreConfig::Memory { config, namespace } => {
                 let store_config = MemoryStoreConfig::new(config.common_config.max_stream_queries);
                 let mut storage = DbStorage::<MemoryStore, _>::maybe_create_and_connect(
                     &store_config,
@@ -541,35 +556,35 @@ impl StoreConfig {
                 Ok(job.run(storage).await)
             }
             #[cfg(feature = "storage-service")]
-            StoreConfig::Service(config, namespace) => {
+            StoreConfig::Service { config, namespace } => {
                 let storage =
                     DbStorage::<ServiceStoreClient, _>::connect(&config, &namespace, wasm_runtime)
                         .await?;
                 Ok(job.run(storage).await)
             }
             #[cfg(feature = "rocksdb")]
-            StoreConfig::RocksDb(config, namespace) => {
+            StoreConfig::RocksDb { config, namespace } => {
                 let storage =
                     DbStorage::<RocksDbStore, _>::connect(&config, &namespace, wasm_runtime)
                         .await?;
                 Ok(job.run(storage).await)
             }
             #[cfg(feature = "dynamodb")]
-            StoreConfig::DynamoDb(config, namespace) => {
+            StoreConfig::DynamoDb { config, namespace } => {
                 let storage =
                     DbStorage::<DynamoDbStore, _>::connect(&config, &namespace, wasm_runtime)
                         .await?;
                 Ok(job.run(storage).await)
             }
             #[cfg(feature = "scylladb")]
-            StoreConfig::ScyllaDb(config, namespace) => {
+            StoreConfig::ScyllaDb { config, namespace } => {
                 let storage =
                     DbStorage::<ScyllaDbStore, _>::connect(&config, &namespace, wasm_runtime)
                         .await?;
                 Ok(job.run(storage).await)
             }
             #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
-            StoreConfig::DualRocksDbScyllaDb(config, namespace) => {
+            StoreConfig::DualRocksDbScyllaDb { config, namespace } => {
                 let storage = DbStorage::<
                     DualStore<RocksDbStore, ScyllaDbStore, ChainStatesFirstAssignment>,
                     _,
@@ -586,27 +601,27 @@ impl StoreConfig {
         Job: RunnableWithStore,
     {
         match self {
-            StoreConfig::Memory(_, _) => {
+            StoreConfig::Memory { .. } => {
                 Err(anyhow!("Cannot run admin operations on the memory store"))
             }
             #[cfg(feature = "storage-service")]
-            StoreConfig::Service(config, namespace) => {
+            StoreConfig::Service { config, namespace } => {
                 Ok(job.run::<ServiceStoreClient>(config, namespace).await?)
             }
             #[cfg(feature = "rocksdb")]
-            StoreConfig::RocksDb(config, namespace) => {
+            StoreConfig::RocksDb { config, namespace } => {
                 Ok(job.run::<RocksDbStore>(config, namespace).await?)
             }
             #[cfg(feature = "dynamodb")]
-            StoreConfig::DynamoDb(config, namespace) => {
+            StoreConfig::DynamoDb { config, namespace } => {
                 Ok(job.run::<DynamoDbStore>(config, namespace).await?)
             }
             #[cfg(feature = "scylladb")]
-            StoreConfig::ScyllaDb(config, namespace) => {
+            StoreConfig::ScyllaDb { config, namespace } => {
                 Ok(job.run::<ScyllaDbStore>(config, namespace).await?)
             }
             #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
-            StoreConfig::DualRocksDbScyllaDb(config, namespace) => Ok(job
+            StoreConfig::DualRocksDbScyllaDb { config, namespace } => Ok(job
                 .run::<DualStore<RocksDbStore, ScyllaDbStore, ChainStatesFirstAssignment>>(
                     config, namespace,
                 )

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -123,45 +123,6 @@ pub enum StorageConfig {
     },
 }
 
-impl StorageConfig {
-    pub fn get_shared_storage(&self) -> Self {
-        match self {
-            #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
-            StorageConfig::DualRocksDbScyllaDb {
-                path_with_guard: _,
-                spawn_mode: _,
-                uri,
-            } => {
-                let uri = uri.clone();
-                StorageConfig::ScyllaDb { uri }
-            }
-            x => x.clone(),
-        }
-    }
-
-    pub fn are_chains_shared(&self) -> bool {
-        match self {
-            #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
-            StorageConfig::DualRocksDbScyllaDb { .. } => false,
-            _ => true,
-        }
-    }
-
-    pub fn append_shard_str(&mut self, _shard_str: &str) {
-        match self {
-            #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
-            StorageConfig::DualRocksDbScyllaDb {
-                path_with_guard,
-                spawn_mode: _,
-                uri: _,
-            } => {
-                path_with_guard.path_buf.push(_shard_str);
-            }
-            _ => panic!("append_shard_str is not available for this storage"),
-        }
-    }
-}
-
 /// The description of a storage implementation.
 #[derive(Clone, Debug)]
 #[cfg_attr(any(test), derive(Eq, PartialEq))]

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -469,7 +469,7 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetConfig) -> Re
 
     // Oh no! The first validator has an outage and gets restarted!
     net.remove_validator(0)?;
-    net.start_validator(0).await?;
+    net.restart_validator(0).await?;
 
     // The node service should try to reconnect.
     'success: {
@@ -529,7 +529,7 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetConfig) -> Result<(
     assert_eq!(client.local_balance(account).await?, balance);
     // Restart validators.
     for i in 0..4 {
-        net.start_validator(i).await?;
+        net.restart_validator(i).await?;
     }
     let result = client.retry_pending_block(Some(chain_id)).await;
     assert!(result?.is_some());
@@ -808,7 +808,7 @@ async fn test_sync_validator(config: LocalNetConfig) -> Result<()> {
     }
 
     // Restart the stopped validator
-    net.start_validator(LAGGING_VALIDATOR_INDEX).await?;
+    net.restart_validator(LAGGING_VALIDATOR_INDEX).await?;
 
     let lagging_validator = net.validator_client(LAGGING_VALIDATOR_INDEX).await?;
 


### PR DESCRIPTION
## Motivation

After #3787, it is no longer needed to initialize the shard of the dual-store databases separately.

## Proposal

Remove special code added in #2734

## Test Plan

CI
