### PR TITLE
Don't strip binaries (Port of #3866)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,8 +71,6 @@ RUN mv \
     target/"$target"/release/linera-server \
     ./
 
-RUN strip linera linera-proxy linera-server
-
 # Optionally copy binaries instead of using the build images above
 FROM scratch AS builder_copy
 ARG binaries


### PR DESCRIPTION
## Motivation

We need the debug symbols in general, but we'll also require this once I add Pyroscope back

## Proposal

Stop stripping binaries, so that we have debug symbols in production

## Test Plan

CI
