### PR TITLE
Update gh-pages GitHub Action to v4

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         cargo doc --all-features
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         publish_branch: gh-pages


### PR DESCRIPTION

This PR updates the peaceiris/actions-gh-pages action from v3 to v4 in .github/workflows/documentation.yml to use the latest version with improved security and maintenance support.

https://github.com/peaceiris/actions-gh-pages/releases