### PR TITLE
Adjust state hash computation bucket

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -154,7 +154,7 @@ static STATE_HASH_COMPUTATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(||
         "state_hash_computation_latency",
         "Time to recompute the state hash",
         &[],
-        exponential_bucket_latencies(10.0),
+        exponential_bucket_latencies(500.0),
     )
 });
 


### PR DESCRIPTION
## Motivation

This state hash computation can apparently take much longer than 10ms

## Proposal

Adjust the bucket sizes to be more generous and catch larger values

## Test Plan

CI + have deployed networks with this already

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
