### PR TITLE
Add dual store support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,7 @@
 #   `aarch64-unknown-linux-gnu`.
 # - `build_flag` is either "--release" or an empty string.
 # - `build_folder` is either "release" or "debug".
+# - `build_features` is a comma-separated list of features to build the binaries with.
 
 # Stage 1 - Generate recipe file for dependencies
 
@@ -24,12 +25,14 @@ ARG binaries=
 ARG copy=${binaries:+_copy}
 ARG build_flag=--release
 ARG build_folder=release
+ARG build_features=scylladb,metrics
 
 FROM rust:1.74-slim-bookworm AS builder
 ARG git_commit
 ARG target
 ARG build_flag
 ARG build_folder
+ARG build_features
 
 RUN apt-get update && apt-get install -y \
     pkg-config \
@@ -69,7 +72,7 @@ RUN cargo build ${build_flag:+"$build_flag"} \
     --bin linera \
     --bin linera-proxy \
     --bin linera-server \
-    --features scylladb,metrics
+    --features $build_features
 
 RUN mv \
     target/"$target"/"$build_folder"/linera \

--- a/docker/compose-server-entrypoint.sh
+++ b/docker/compose-server-entrypoint.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
+storage=$1
+
 exec ./linera-server run \
-  --storage scylladb:tcp:scylla:9042 \
+  --storage $storage \
   --server /config/server.json \
   --shard 0 \
   --genesis /config/genesis.json

--- a/docker/compose-server-init.sh
+++ b/docker/compose-server-init.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
+storage=$1
+
 while true; do
-  ./linera storage check-existence --storage "scylladb:tcp:scylla:9042"
+  ./linera storage check-existence --storage $storage
   status=$?
 
   if [ $status -eq 0 ]; then
@@ -10,7 +12,7 @@ while true; do
   elif [ $status -eq 1 ]; then
     echo "Database does not exist, attempting to initialize..."
     if ./linera-server initialize \
-      --storage scylladb:tcp:scylla:9042 \
+      --storage $storage \
       --genesis /config/genesis.json; then
       echo "Initialization successful."
       exit 0

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     image: "${LINERA_IMAGE:-linera}"
     deploy:
       replicas: 4
-    command: [ "./compose-server-entrypoint.sh" ]
+    command: [ "./compose-server-entrypoint.sh", "scylladb:tcp:scylla:9042" ]
     volumes:
       - .:/config
     labels:
@@ -42,7 +42,7 @@ services:
   shard-init:
     image: "${LINERA_IMAGE:-linera}"
     container_name: shard-init
-    command: [ "./compose-server-init.sh" ]
+    command: [ "./compose-server-init.sh", "scylladb:tcp:scylla:9042" ]
     volumes:
       - .:/config
     depends_on:

--- a/docker/server-entrypoint.sh
+++ b/docker/server-entrypoint.sh
@@ -2,9 +2,10 @@
 
 # Extract the ordinal number from the pod hostname
 ORDINAL="${HOSTNAME##*-}"
+storage=$1
 
 exec ./linera-server run \
-  --storage scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042 \
+  --storage $storage \
   --server /config/server.json \
   --shard $ORDINAL \
   --genesis /config/genesis.json

--- a/docker/server-init.sh
+++ b/docker/server-init.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
+storage=$1
+
 while true; do
-  ./linera storage check-existence --storage "scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042"
+  ./linera storage check-existence --storage $storage
   status=$?
 
   if [ $status -eq 0 ]; then
@@ -10,7 +12,7 @@ while true; do
   elif [ $status -eq 1 ]; then
     echo "Database does not exist, attempting to initialize..."
     if ./linera-server initialize \
-      --storage scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042 \
+      --storage $storage \
       --genesis /config/genesis.json; then
       echo "Initialization successful."
       exit 0

--- a/kubernetes/linera-validator/scylla-manager.values.yaml
+++ b/kubernetes/linera-validator/scylla-manager.values.yaml
@@ -14,7 +14,7 @@ scylla:
     tag: 5.4.3
   agentImage:
     tag: 3.2.8
-  datacenter: manager-dc
+  datacenter: validator
   racks:
   - name: manager-rack
     members: 1

--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -35,7 +35,7 @@ spec:
         - name: linera-server-initializer
           image: {{ .Values.lineraImage }}
           imagePullPolicy: {{ .Values.lineraImagePullPolicy }}
-          command: ["./server-init.sh"]
+          command: ["./server-init.sh", {{ .Values.storage | quote }}]
           env:
             - name: RUST_LOG
               value: {{ .Values.logLevel }}
@@ -45,11 +45,15 @@ spec:
             - name: config
               mountPath: "/config"
               readOnly: true
+            {{- if .Values.dualStore }}
+            - name: linera-db
+              mountPath: "/linera.db"
+            {{- end }}
       containers:
         - name: linera-server
           image: {{ .Values.lineraImage }}
           imagePullPolicy: {{ .Values.lineraImagePullPolicy }}
-          command: ["./server-entrypoint.sh"]
+          command: ["./server-entrypoint.sh", {{ .Values.storage | quote }}]
           env:
             - name: RUST_LOG
               value: {{ .Values.logLevel }}
@@ -57,6 +61,10 @@ spec:
             - name: config
               mountPath: "/config"
               readOnly: true
+            {{- if .Values.dualStore }}
+            - name: linera-db
+              mountPath: "/linera.db"
+            {{- end }}
       volumes:
         - name: config
           configMap:
@@ -66,3 +74,13 @@ spec:
                 path: server.json
               - key: genesisConfig
                 path: genesis.json
+  {{- if .Values.dualStore }}
+  volumeClaimTemplates:
+    - metadata:
+        name: linera-db
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: {{ .Values.rocksdbStorageSize }}
+  {{- end }}

--- a/kubernetes/linera-validator/values-local.yaml.gotmpl
+++ b/kubernetes/linera-validator/values-local.yaml.gotmpl
@@ -7,6 +7,10 @@ logLevel: "debug"
 proxyPort: 19100
 metricsPort: 21100
 numShards: {{ env "LINERA_HELMFILE_SET_NUM_SHARDS" | default 10 }}
+# Size of the RocksDB storage per shard, IF using `DualStore`. Otherwise will be ignored.
+rocksdbStorageSize: {{ env "LINERA_HELMFILE_SET_ROCKSDB_STORAGE_SIZE" | default "2Gi" }}
+storage: {{ env "LINERA_HELMFILE_SET_STORAGE" | default "scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042" }}
+dualStore: {{ env "LINERA_HELMFILE_SET_DUAL_STORE" | default "false" }}
 
 # Loki
 loki-stack:

--- a/linera-service/src/cli_wrappers/docker.rs
+++ b/linera-service/src/cli_wrappers/docker.rs
@@ -24,6 +24,7 @@ impl DockerImage {
         binaries: &BuildArg,
         github_root: &PathBuf,
         build_mode: &BuildMode,
+        dual_store: bool,
     ) -> Result<Self> {
         let build_arg = match binaries {
             BuildArg::Directory(bin_path) => {
@@ -71,6 +72,10 @@ impl DockerImage {
                 command.args(["--build-arg", "build_folder=debug"]);
                 command.args(["--build-arg", "build_flag="]);
             }
+        }
+
+        if dual_store {
+            command.args(["--build-arg", "build_features=rocksdb,scylladb,metrics"]);
         }
 
         #[cfg(not(with_testing))]

--- a/linera-service/src/cli_wrappers/helmfile.rs
+++ b/linera-service/src/cli_wrappers/helmfile.rs
@@ -17,14 +17,25 @@ impl HelmFile {
         num_shards: usize,
         cluster_id: u32,
         docker_image_name: String,
+        dual_store: bool,
     ) -> Result<()> {
         let chart_dir = format!("{}/kubernetes/linera-validator", github_root.display());
 
         let temp_dir = tempfile::tempdir()?;
         fs_extra::copy_items(&[&chart_dir], temp_dir.path(), &CopyOptions::new())?;
 
-        Command::new("helmfile")
-            .current_dir(temp_dir.path().join("linera-validator"))
+        let mut command = Command::new("helmfile");
+        command.current_dir(temp_dir.path().join("linera-validator"));
+
+        if dual_store {
+            command.env(
+                "LINERA_HELMFILE_SET_STORAGE",
+                "dualrocksdbscylladb:/linera.db:spawn_blocking:tcp:scylla-client.scylla.svc.cluster.local:9042",
+            );
+            command.env("LINERA_HELMFILE_SET_DUAL_STORE", "true");
+        }
+
+        command
             .env(
                 "LINERA_HELMFILE_SET_SERVER_CONFIG",
                 format!("working/server_{server_config_id}.json"),

--- a/linera-service/src/linera/command.rs
+++ b/linera-service/src/linera/command.rs
@@ -991,6 +991,12 @@ pub enum NetCommand {
         /// The number of block exporters per validator in the local test network. Default is 0.
         #[arg(long, default_value = "0")]
         block_exporters: u32,
+
+        /// Use dual store (rocksdb and scylladb) instead of just scylladb. This is exclusive for
+        /// kubernetes deployments.
+        #[cfg(feature = "kubernetes")]
+        #[arg(long, default_value = "false")]
+        dual_store: bool,
     },
 
     /// Print a bash helper script to make `linera net up` easier to use. The script is

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -2000,6 +2000,7 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                 faucet_chain,
                 faucet_port,
                 faucet_amount,
+                dual_store,
                 ..
             } => {
                 net_up_utils::handle_net_up_kubernetes(
@@ -2017,6 +2018,7 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                     *faucet_chain,
                     *faucet_port,
                     *faucet_amount,
+                    *dual_store,
                 )
                 .boxed()
                 .await?;

--- a/linera-service/src/linera/net_up_utils.rs
+++ b/linera-service/src/linera/net_up_utils.rs
@@ -119,6 +119,7 @@ pub async fn handle_net_up_kubernetes(
     faucet_chain: Option<u32>,
     faucet_port: NonZeroU16,
     faucet_amount: Amount,
+    dual_store: bool,
 ) -> anyhow::Result<()> {
     if num_initial_validators < 1 {
         panic!("The local test network must have at least one validator.");
@@ -148,6 +149,7 @@ pub async fn handle_net_up_kubernetes(
         docker_image_name,
         build_mode,
         policy_config,
+        dual_store,
     };
     let (mut net, client) = config.instantiate().await?;
     let faucet_service = print_messages_and_create_faucet(


### PR DESCRIPTION
## Motivation

Our benchmarks are currently using `DualStore`, so it makes sense for us to add support to use it if we need it. We won't ideally need this, as the plan is to get `ScyllaDB` to a state that we reach the big numbers with it.

## Proposal

This PR adds the `linera-protocol` side support for `DualStore` networks, as well as support for doing local `linera net up --kubernetes` runs with `DualStore`

## Test Plan

Ran a local network with default params (scylladb) and `DualStore`, both work

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
