### PR TITLE
Test that follow-chain also works with child chains.

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -3073,6 +3073,9 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
+    let client3 = net.make_client().await;
+    client3.wallet_init(&[], FaucetOption::None).await?;
+
     let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
 
     // Generate keys for client 2.
@@ -3096,6 +3099,11 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     client2.sync(chain2).await?;
     client2.process_inbox(chain2).await?;
     assert!(client2.local_balance(account2).await? > Amount::ZERO);
+
+    // Verify that a third party can also follow the chain.
+    client3.follow_chain(chain2).await?;
+    client3.sync(chain2).await?;
+    assert!(client3.local_balance(account2).await? > Amount::ZERO);
 
     net.ensure_is_running().await?;
     net.terminate().await?;


### PR DESCRIPTION
## Motivation

There were some reports of `sync` after `follow-chain` not working. `follow-chain` is only used directly after `forget-chain` (for the same chain) in the tests currently, so that the chain is still in the database.

## Proposal

Also test `follow_chain` in `test_end_to_end_assign_greatgrandchild_chain`.

## Test Plan

This seems fine on `main`. I will backport this to `testnet_babbage`.

## Release Plan

- Backport to `testnet_babbage` and fix, if necessary.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
