### PR TITLE
Fix syncing after `follow-chain` for child chains.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1046,9 +1046,7 @@ where
 
         let mut info = self.synchronize_until(self.next_block_height()).await?;
 
-        if self.state().has_other_owners(&info.manager.ownership)
-            || info.next_block_height == BlockHeight::ZERO
-        {
+        if self.state().has_other_owners(&info.manager.ownership) {
             // For chains with any owner other than ourselves, we could be missing recent
             // certificates created by other owners. Further synchronize blocks from the network.
             // This is a best-effort that depends on network conditions.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -922,9 +922,7 @@ where
             .await?
             .info;
         let epoch = info.epoch;
-        let committees = info
-            .requested_committees
-            .ok_or(LocalNodeError::InvalidChainInfoResponse)?;
+        let committees = info.requested_committees.unwrap_or_else(BTreeMap::new);
         Ok((epoch, committees))
     }
 
@@ -951,7 +949,7 @@ where
     /// Obtains the committee for the latest epoch.
     #[instrument(level = "trace")]
     pub async fn latest_committee(&self) -> Result<Committee, LocalNodeError> {
-        let (mut committees, epoch) = self.known_committees().await?;
+        let (epoch, mut committees) = self.known_committees().await?;
         committees
             .remove(&epoch)
             .ok_or(LocalNodeError::InactiveChain(self.chain_id))
@@ -962,12 +960,12 @@ where
     #[instrument(level = "trace")]
     async fn known_committees(
         &self,
-    ) -> Result<(BTreeMap<Epoch, Committee>, Epoch), LocalNodeError> {
+    ) -> Result<(Epoch, BTreeMap<Epoch, Committee>), LocalNodeError> {
         let (epoch, mut committees) = self.epoch_and_committees(self.chain_id).await?;
         let (admin_epoch, admin_committees) = self.epoch_and_committees(self.admin_id).await?;
         committees.extend(admin_committees);
         let epoch = std::cmp::max(epoch.unwrap_or_default(), admin_epoch.unwrap_or_default());
-        Ok((committees, epoch))
+        Ok((epoch, committees))
     }
 
     #[instrument(level = "trace")]
@@ -1048,7 +1046,9 @@ where
 
         let mut info = self.synchronize_until(self.next_block_height()).await?;
 
-        if self.state().has_other_owners(&info.manager.ownership) {
+        if self.state().has_other_owners(&info.manager.ownership)
+            || info.next_block_height == BlockHeight::ZERO
+        {
             // For chains with any owner other than ourselves, we could be missing recent
             // certificates created by other owners. Further synchronize blocks from the network.
             // This is a best-effort that depends on network conditions.
@@ -1297,7 +1297,7 @@ where
         let block = certificate.block();
 
         // Verify the certificate before doing any expensive networking.
-        let (committees, max_epoch) = self.known_committees().await?;
+        let (max_epoch, committees) = self.known_committees().await?;
         ensure!(
             block.header.epoch <= max_epoch,
             ChainClientError::CommitteeSynchronizationError
@@ -1361,7 +1361,7 @@ where
             .get(&remote_node.public_key)
             .copied()
             .unwrap_or(0);
-        let (committees, max_epoch) = self.known_committees().await?;
+        let (max_epoch, committees) = self.known_committees().await?;
 
         // Retrieve the list of newly received certificates from this validator.
         let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_n(tracker);
@@ -1750,9 +1750,12 @@ where
         #[cfg(with_metrics)]
         let _latency = metrics::SYNCHRONIZE_CHAIN_STATE_LATENCY.measure_latency();
 
-        let (epoch, mut committees) = self.epoch_and_committees(chain_id).await?;
+        let (epoch, mut committees) = match self.epoch_and_committees(chain_id).await? {
+            (Some(epoch), committees) => (epoch, committees),
+            (None, _) => self.known_committees().await?, // Chain is not active yet.
+        };
         let committee = committees
-            .remove(&epoch.ok_or(LocalNodeError::InvalidChainInfoResponse)?)
+            .remove(&epoch)
             .ok_or(LocalNodeError::InvalidChainInfoResponse)?;
         let validators = self.make_nodes(&committee)?;
         communicate_with_quorum(

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1046,7 +1046,9 @@ where
 
         let mut info = self.synchronize_until(self.next_block_height()).await?;
 
-        if self.state().has_other_owners(&info.manager.ownership) {
+        if self.state().has_other_owners(&info.manager.ownership)
+            || !info.manager.ownership.is_active()
+        {
             // For chains with any owner other than ourselves, we could be missing recent
             // certificates created by other owners. Further synchronize blocks from the network.
             // This is a best-effort that depends on network conditions.

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2777,6 +2777,9 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
+    let client3 = net.make_client().await;
+    client3.wallet_init(&[], FaucetOption::None).await?;
+
     let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
 
     // Generate keys for client 2.
@@ -2800,6 +2803,11 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     client2.sync(chain2).await?;
     client2.process_inbox(chain2).await?;
     assert!(client2.local_balance(account2).await? > Amount::ZERO);
+
+    // Verify that a third party can also follow the chain.
+    client3.follow_chain(chain2).await?;
+    client3.sync(chain2).await?;
+    assert!(client3.local_balance(account2).await? > Amount::ZERO);
 
     net.ensure_is_running().await?;
     net.terminate().await?;


### PR DESCRIPTION
## Motivation

`sync` after `follow-chain` doesn't work.

## Proposal

Add a test (backport of https://github.com/linera-io/linera-protocol/pull/3887). Handle the case where a chain is uninitialized.

## Test Plan

The test was backported.

## Release Plan

- These changes should be released in a new SDK.

## Links

- Closes #3891.
- Test for `main` (doesn't have the bug): https://github.com/linera-io/linera-protocol/pull/3887
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
