### PR TITLE
Revert automatic faucet chain rotation.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -619,9 +619,6 @@ Run a GraphQL service that exposes a faucet where users can claim tokens. This g
   Default value: `8080`
 * `--amount <AMOUNT>` — The number of tokens to send to each new chain
 * `--limit-rate-until <LIMIT_RATE_UNTIL>` — The end timestamp: The faucet will rate-limit the token supply so it runs out of money no earlier than this
-* `--max-chain-length <MAX_CHAIN_LENGTH>` — The maximum number of blocks in the faucet chain, before a new one is created
-
-  Default value: `100`
 * `--listener-skip-process-inbox` — Do not create blocks automatically to receive incoming messages. Instead, wait for an explicit mutation `processInbox`
 * `--listener-delay-before-ms <DELAY_BEFORE_MS>` — Wait before processing any notification (useful for testing)
 

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -11,7 +11,7 @@ use axum::{Extension, Router};
 use futures::{lock::Mutex, FutureExt as _};
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
-    data_types::{Amount, ApplicationPermissions, BlockHeight, Timestamp},
+    data_types::{Amount, ApplicationPermissions, Timestamp},
     identifiers::{AccountOwner, ChainId},
     ownership::ChainOwnership,
 };
@@ -43,15 +43,14 @@ mod tests;
 pub struct QueryRoot<C> {
     context: Arc<Mutex<C>>,
     genesis_config: Arc<GenesisConfig>,
-    chain_id: Arc<Mutex<ChainId>>,
+    chain_id: ChainId,
 }
 
 /// The root GraphQL mutation type.
 pub struct MutationRoot<C> {
-    chain_id: Arc<Mutex<ChainId>>,
+    chain_id: ChainId,
     context: Arc<Mutex<C>>,
     amount: Amount,
-    end_block_height: BlockHeight,
     end_timestamp: Timestamp,
     start_timestamp: Timestamp,
     start_balance: Amount,
@@ -89,12 +88,11 @@ where
 
     /// Returns the current committee's validators.
     async fn current_validators(&self) -> Result<Vec<Validator>, Error> {
-        let chain_id = *self.chain_id.lock().await;
         let client = self
             .context
             .lock()
             .await
-            .make_chain_client(chain_id)
+            .make_chain_client(self.chain_id)
             .await?;
         let committee = client.local_committee().await?;
         Ok(committee
@@ -124,12 +122,11 @@ where
     C: ClientContext,
 {
     async fn do_claim(&self, owner: AccountOwner) -> Result<ClaimOutcome, Error> {
-        let chain_id = *self.chain_id.lock().await;
         let client = self
             .context
             .lock()
             .await
-            .make_chain_client(chain_id)
+            .make_chain_client(self.chain_id)
             .await?;
 
         if self.start_timestamp < self.end_timestamp {
@@ -171,30 +168,6 @@ where
                 )));
             }
         };
-
-        if client.next_block_height() >= self.end_block_height {
-            let preferred_owner = client.preferred_owner();
-            let balance = client.local_balance().await?.try_sub(Amount::ONE)?;
-            let ownership = client.chain_state_view().await?.ownership().clone();
-            let (chain_id, certificate) = client
-                .open_chain(ownership, ApplicationPermissions::default(), balance)
-                .await?
-                .try_unwrap()?;
-            // TODO(#1795): Move the remaining tokens to the new chain.
-            client.close_chain().await?.try_unwrap()?;
-            info!("Switching to a new faucet chain {chain_id:8}; remaining balance: {balance}");
-            self.context
-                .lock()
-                .await
-                .update_wallet_for_new_chain(
-                    chain_id,
-                    preferred_owner,
-                    certificate.block().header.timestamp,
-                )
-                .await?;
-            *self.chain_id.lock().await = chain_id;
-        }
-
         Ok(ClaimOutcome {
             chain_id,
             certificate_hash: certificate.hash(),
@@ -219,7 +192,7 @@ pub struct FaucetService<C>
 where
     C: ClientContext,
 {
-    chain_id: Arc<Mutex<ChainId>>,
+    chain_id: ChainId,
     context: Arc<Mutex<C>>,
     genesis_config: Arc<GenesisConfig>,
     config: ChainListenerConfig,
@@ -227,7 +200,6 @@ where
     port: NonZeroU16,
     amount: Amount,
     end_timestamp: Timestamp,
-    end_block_height: BlockHeight,
     start_timestamp: Timestamp,
     start_balance: Amount,
 }
@@ -238,14 +210,13 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            chain_id: self.chain_id.clone(),
+            chain_id: self.chain_id,
             context: Arc::clone(&self.context),
             genesis_config: Arc::clone(&self.genesis_config),
             config: self.config.clone(),
             storage: self.storage.clone(),
             port: self.port,
             amount: self.amount,
-            end_block_height: self.end_block_height,
             end_timestamp: self.end_timestamp,
             start_timestamp: self.start_timestamp,
             start_balance: self.start_balance,
@@ -264,7 +235,6 @@ where
         chain_id: ChainId,
         context: C,
         amount: Amount,
-        end_block_height: BlockHeight,
         end_timestamp: Timestamp,
         genesis_config: Arc<GenesisConfig>,
         config: ChainListenerConfig,
@@ -276,14 +246,13 @@ where
         client.process_inbox().await?;
         let start_balance = client.local_balance().await?;
         Ok(Self {
-            chain_id: Arc::new(Mutex::new(chain_id)),
+            chain_id,
             context,
             genesis_config,
             config,
             storage,
             port,
             amount,
-            end_block_height,
             end_timestamp,
             start_timestamp,
             start_balance,
@@ -292,10 +261,9 @@ where
 
     pub fn schema(&self) -> Schema<QueryRoot<C>, MutationRoot<C>, EmptySubscription> {
         let mutation_root = MutationRoot {
-            chain_id: self.chain_id.clone(),
+            chain_id: self.chain_id,
             context: Arc::clone(&self.context),
             amount: self.amount,
-            end_block_height: self.end_block_height,
             end_timestamp: self.end_timestamp,
             start_timestamp: self.start_timestamp,
             start_balance: self.start_balance,
@@ -303,7 +271,7 @@ where
         let query_root = QueryRoot {
             genesis_config: Arc::clone(&self.genesis_config),
             context: Arc::clone(&self.context),
-            chain_id: self.chain_id.clone(),
+            chain_id: self.chain_id,
         };
         Schema::build(query_root, mutation_root, EmptySubscription).finish()
     }
@@ -340,29 +308,5 @@ where
     async fn index_handler(service: Extension<Self>, request: GraphQLRequest) -> GraphQLResponse {
         let schema = service.0.schema();
         schema.execute(request.into_inner()).await.into()
-    }
-}
-
-trait ClientOutcomeExt {
-    type Output;
-
-    /// Returns the committed result or an error if we are not the leader.
-    ///
-    /// It is recommended to use single-owner chains for the faucet to avoid this error.
-    fn try_unwrap(self) -> Result<Self::Output, Error>;
-}
-
-impl<T> ClientOutcomeExt for ClientOutcome<T> {
-    type Output = T;
-
-    fn try_unwrap(self) -> Result<Self::Output, Error> {
-        match self {
-            ClientOutcome::Committed(result) => Ok(result),
-            ClientOutcome::WaitForTimeout(timeout) => Err(Error::new(format!(
-                "This faucet is using a multi-owner chain and is not the leader right now. \
-                Try again at {}",
-                timeout.timestamp,
-            ))),
-        }
     }
 }

--- a/linera-faucet/server/src/tests.rs
+++ b/linera-faucet/server/src/tests.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use futures::lock::Mutex;
 use linera_base::{
     crypto::{AccountPublicKey, InMemorySigner},
-    data_types::{Amount, BlockHeight, Timestamp},
+    data_types::{Amount, Timestamp},
     identifiers::{AccountOwner, ChainId},
 };
 use linera_client::{chain_listener, wallet::Wallet};
@@ -89,10 +89,9 @@ async fn test_faucet_rate_limiting() {
     };
     let context = Arc::new(Mutex::new(context));
     let root = MutationRoot {
-        chain_id: Arc::new(Mutex::new(chain_id)),
+        chain_id,
         context: context.clone(),
         amount: Amount::from_tokens(1),
-        end_block_height: BlockHeight::from(10),
         end_timestamp: Timestamp::from(6000),
         start_timestamp: Timestamp::from(0),
         start_balance: Amount::from_tokens(6),

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -520,22 +520,15 @@ impl ClientWrapper {
         port: impl Into<Option<u16>>,
         chain_id: ChainId,
         amount: Amount,
-        max_chain_length: Option<u64>,
     ) -> Result<FaucetService> {
         let port = port.into().unwrap_or(8080);
         let mut command = self.command().await?;
-        command
+        let child = command
             .arg("faucet")
             .arg(chain_id.to_string())
             .args(["--port".to_string(), port.to_string()])
-            .args(["--amount".to_string(), amount.to_string()]);
-        if let Some(max_chain_length) = max_chain_length {
-            command.args([
-                "--max-chain-length".to_string(),
-                max_chain_length.to_string(),
-            ]);
-        }
-        let child = command.spawn_into()?;
+            .args(["--amount".to_string(), amount.to_string()])
+            .spawn_into()?;
         let client = reqwest_client();
         for i in 0..10 {
             linera_base::time::timer::sleep(Duration::from_secs(i)).await;

--- a/linera-service/src/linera/command.rs
+++ b/linera-service/src/linera/command.rs
@@ -631,10 +631,6 @@ pub enum ClientCommand {
         #[arg(long)]
         limit_rate_until: Option<DateTime<Utc>>,
 
-        /// The maximum number of blocks in the faucet chain, before a new one is created.
-        #[arg(long, default_value = "100")]
-        max_chain_length: u64,
-
         /// Configuration for the faucet chain listener.
         #[command(flatten)]
         config: ChainListenerConfig,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -25,8 +25,7 @@ use linera_base::{
     bcs,
     crypto::{CryptoHash, InMemorySigner, Signer},
     data_types::{
-        ApplicationPermissions, BlockHeight, ChainDescription, ChainOrigin, Epoch,
-        InitialChainConfig, Timestamp,
+        ApplicationPermissions, ChainDescription, ChainOrigin, Epoch, InitialChainConfig, Timestamp,
     },
     identifiers::{AccountOwner, ChainId},
     listen_for_shutdown_signals,
@@ -974,7 +973,6 @@ impl Runnable for Job {
                 port,
                 amount,
                 limit_rate_until,
-                max_chain_length,
                 config,
             } => {
                 let context = ClientContext::new(
@@ -999,7 +997,6 @@ impl Runnable for Job {
                     chain_id,
                     context,
                     amount,
-                    BlockHeight(max_chain_length),
                     end_timestamp,
                     genesis_config,
                     config,

--- a/linera-service/src/linera/net_up_utils.rs
+++ b/linera-service/src/linera/net_up_utils.rs
@@ -306,7 +306,7 @@ async fn print_messages_and_create_faucet(
             .nth(faucet_chain_idx as usize)
             .unwrap(); // we checked that there are enough chains above, so this should be safe
         let service = client
-            .run_faucet(Some(faucet_port.into()), faucet_chain, faucet_amount, None)
+            .run_faucet(Some(faucet_port.into()), faucet_chain, faucet_amount)
             .await?;
         Some(service)
     } else {

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -3166,7 +3166,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
     let owner2 = client2.keygen().await?;
 
     let mut faucet_service = client1
-        .run_faucet(None, chain1, Amount::from_tokens(2), None)
+        .run_faucet(None, chain1, Amount::from_tokens(2))
         .await?;
     let faucet = faucet_service.instance();
     let outcome = faucet.claim(&owner2).await?;
@@ -3258,17 +3258,8 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
     }
 
     let amount = Amount::ONE;
-    let mut faucet_service = faucet_client
-        .run_faucet(None, faucet_chain, amount, Some(chain_count as u64))
-        .await?;
+    let mut faucet_service = faucet_client.run_faucet(None, faucet_chain, amount).await?;
     let faucet = faucet_service.instance();
-
-    // Create a new wallet using the faucet
-    let other_client = net.make_client().await;
-    let (other_outcome, _) = other_client
-        .wallet_init(&[], FaucetOption::NewChain(&faucet))
-        .await?
-        .unwrap();
 
     // Create a new wallet using the faucet
     let client = net.make_client().await;
@@ -3276,10 +3267,6 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
         .wallet_init(&[], FaucetOption::NewChain(&faucet))
         .await?
         .unwrap();
-
-    // Since the faucet chain exceeds the configured maximum length, the faucet should have
-    // switched after the first new chain.
-    assert!(other_outcome.chain_id != outcome.chain_id);
 
     let chain = outcome.chain_id;
     assert_eq!(chain, client.load_wallet()?.default_chain().unwrap());
@@ -3323,7 +3310,7 @@ async fn test_end_to_end_fungible_client_benchmark(config: impl LineraNetConfig)
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
 
-    let mut faucet_service = client1.run_faucet(None, chain1, Amount::ONE, None).await?;
+    let mut faucet_service = client1.run_faucet(None, chain1, Amount::ONE).await?;
     let faucet = faucet_service.instance();
 
     let path =

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -69,7 +69,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
         .await?;
 
     let mut faucet_service = faucet_client
-        .run_faucet(None, faucet_chain, Amount::from_tokens(2), None)
+        .run_faucet(None, faucet_chain, Amount::from_tokens(2))
         .await?;
 
     faucet_service.ensure_is_running()?;
@@ -249,7 +249,7 @@ async fn test_end_to_end_receipt_of_old_create_committee_messages(
 
     if matches!(network, Network::Grpc) {
         let mut faucet_service = faucet_client
-            .run_faucet(None, faucet_chain, Amount::from_tokens(2), None)
+            .run_faucet(None, faucet_chain, Amount::from_tokens(2))
             .await?;
 
         faucet_service.ensure_is_running()?;
@@ -283,7 +283,7 @@ async fn test_end_to_end_receipt_of_old_create_committee_messages(
     faucet_client.process_inbox(faucet_chain).await?;
 
     let mut faucet_service = faucet_client
-        .run_faucet(None, faucet_chain, Amount::from_tokens(2), None)
+        .run_faucet(None, faucet_chain, Amount::from_tokens(2))
         .await?;
 
     faucet_service.ensure_is_running()?;
@@ -337,7 +337,7 @@ async fn test_end_to_end_receipt_of_old_remove_committee_messages(
 
     if matches!(network, Network::Grpc) {
         let mut faucet_service = faucet_client
-            .run_faucet(None, faucet_chain, Amount::from_tokens(2), None)
+            .run_faucet(None, faucet_chain, Amount::from_tokens(2))
             .await?;
 
         faucet_service.ensure_is_running()?;
@@ -373,7 +373,7 @@ async fn test_end_to_end_receipt_of_old_remove_committee_messages(
 
     if matches!(network, Network::Grpc) {
         let mut faucet_service = faucet_client
-            .run_faucet(None, faucet_chain, Amount::from_tokens(2), None)
+            .run_faucet(None, faucet_chain, Amount::from_tokens(2))
             .await?;
 
         faucet_service.ensure_is_running()?;
@@ -409,7 +409,7 @@ async fn test_end_to_end_receipt_of_old_remove_committee_messages(
     faucet_client.process_inbox(faucet_chain).await?;
 
     let mut faucet_service = faucet_client
-        .run_faucet(None, faucet_chain, Amount::from_tokens(2), None)
+        .run_faucet(None, faucet_chain, Amount::from_tokens(2))
         .await?;
 
     faucet_service.ensure_is_running()?;


### PR DESCRIPTION
## Motivation

The current approach to automatic faucet chain rotation doesn't work well. In particular, it closes the original chain, so restarts don't work with the same command line arguments.

## Proposal

Revert https://github.com/linera-io/linera-protocol/pull/3848.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Reverted PR: https://github.com/linera-io/linera-protocol/pull/3848
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
