### PR TITLE
Rotate the faucet chain automatically.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -603,6 +603,11 @@ Run a GraphQL service that exposes a faucet where users can claim tokens. This g
   Default value: `8080`
 * `--amount <AMOUNT>` — The number of tokens to send to each new chain
 * `--limit-rate-until <LIMIT_RATE_UNTIL>` — The end timestamp: The faucet will rate-limit the token supply so it runs out of money no earlier than this
+* `--max-claims-per-chain <MAX_CLAIMS_PER_CHAIN>` — The maximum number of claims per faucet chain, after which a new one is created.
+
+   A lower number improves performance for clients but creates overhead in the faucet.
+
+  Default value: `100`
 * `--listener-skip-process-inbox` — Do not create blocks automatically to receive incoming messages. Instead, wait for an explicit mutation `processInbox`
 * `--listener-delay-before-ms <DELAY_BEFORE_MS>` — Wait before processing any notification (useful for testing)
 

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -371,7 +371,7 @@ macro_rules! impl_wrapped_number {
             }
 
             /// Saturating addition.
-            pub fn saturating_add(self, other: Self) -> Self {
+            pub const fn saturating_add(self, other: Self) -> Self {
                 let val = self.0.saturating_add(other.0);
                 Self(val)
             }
@@ -392,7 +392,7 @@ macro_rules! impl_wrapped_number {
             }
 
             /// Saturating subtraction.
-            pub fn saturating_sub(self, other: Self) -> Self {
+            pub const fn saturating_sub(self, other: Self) -> Self {
                 let val = self.0.saturating_sub(other.0);
                 Self(val)
             }
@@ -413,7 +413,7 @@ macro_rules! impl_wrapped_number {
             }
 
             /// Saturating in-place addition.
-            pub fn saturating_add_assign(&mut self, other: Self) {
+            pub const fn saturating_add_assign(&mut self, other: Self) {
                 self.0 = self.0.saturating_add(other.0);
             }
 
@@ -427,7 +427,7 @@ macro_rules! impl_wrapped_number {
             }
 
             /// Saturating multiplication.
-            pub fn saturating_mul(&self, other: $wrapped) -> Self {
+            pub const fn saturating_mul(&self, other: $wrapped) -> Self {
                 Self(self.0.saturating_mul(other))
             }
 
@@ -662,37 +662,37 @@ impl Amount {
     pub const ONE: Amount = Amount(10u128.pow(Amount::DECIMAL_PLACES as u32));
 
     /// Returns an `Amount` corresponding to that many tokens, or `Amount::MAX` if saturated.
-    pub fn from_tokens(tokens: u128) -> Amount {
+    pub const fn from_tokens(tokens: u128) -> Amount {
         Self::ONE.saturating_mul(tokens)
     }
 
     /// Returns an `Amount` corresponding to that many millitokens, or `Amount::MAX` if saturated.
-    pub fn from_millis(millitokens: u128) -> Amount {
+    pub const fn from_millis(millitokens: u128) -> Amount {
         Amount(10u128.pow(Amount::DECIMAL_PLACES as u32 - 3)).saturating_mul(millitokens)
     }
 
     /// Returns an `Amount` corresponding to that many microtokens, or `Amount::MAX` if saturated.
-    pub fn from_micros(microtokens: u128) -> Amount {
+    pub const fn from_micros(microtokens: u128) -> Amount {
         Amount(10u128.pow(Amount::DECIMAL_PLACES as u32 - 6)).saturating_mul(microtokens)
     }
 
     /// Returns an `Amount` corresponding to that many nanotokens, or `Amount::MAX` if saturated.
-    pub fn from_nanos(nanotokens: u128) -> Amount {
+    pub const fn from_nanos(nanotokens: u128) -> Amount {
         Amount(10u128.pow(Amount::DECIMAL_PLACES as u32 - 9)).saturating_mul(nanotokens)
     }
 
     /// Returns an `Amount` corresponding to that many attotokens.
-    pub fn from_attos(attotokens: u128) -> Amount {
+    pub const fn from_attos(attotokens: u128) -> Amount {
         Amount(attotokens)
     }
 
     /// Helper function to obtain the 64 most significant bits of the balance.
-    pub fn upper_half(self) -> u64 {
+    pub const fn upper_half(self) -> u64 {
         (self.0 >> 64) as u64
     }
 
     /// Helper function to obtain the 64 least significant bits of the balance.
-    pub fn lower_half(self) -> u64 {
+    pub const fn lower_half(self) -> u64 {
         self.0 as u64
     }
 

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -81,6 +81,8 @@ pub trait ClientContext: 'static {
         }
         Ok(clients)
     }
+
+    async fn forget_chain(&mut self, chain_id: &ChainId) -> Result<(), Error>;
 }
 
 /// A `ChainListener` is a process that listens to notifications from validators and reacts

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -111,6 +111,14 @@ where
     async fn update_wallet(&mut self, client: &ChainClient<NodeProvider, S>) -> Result<(), Error> {
         self.update_wallet_from_client(client).await
     }
+
+    async fn forget_chain(&mut self, chain_id: &ChainId) -> Result<(), Error> {
+        self.wallet
+            .mutate(|w| w.forget_chain(chain_id))
+            .await
+            .map_err(|e| error::Inner::Persistence(Box::new(e)))??;
+        Ok(())
+    }
 }
 
 impl<S, W> ClientContext<S, W>

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -101,6 +101,11 @@ impl chain_listener::ClientContext for ClientContext {
         self.wallet.update_from_state(client).await;
         Ok(())
     }
+
+    async fn forget_chain(&mut self, chain_id: &ChainId) -> Result<(), Error> {
+        self.wallet.forget_chain(chain_id)?;
+        Ok(())
+    }
 }
 
 /// Tests that the chain listener, if there is a message in the inbox, will continue requesting

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -25,6 +25,9 @@ use serde::Deserialize;
 use tower_http::cors::CorsLayer;
 use tracing::info;
 
+/// A rough estimate of the maximum fee for a block.
+const MAX_FEE: Amount = Amount::from_millis(100);
+
 /// Returns an HTML response constructing the GraphiQL web page for the given URI.
 pub(crate) async fn graphiql(uri: axum::http::Uri) -> impl axum::response::IntoResponse {
     axum::response::Html(
@@ -47,9 +50,11 @@ pub struct QueryRoot<C> {
 
 /// The root GraphQL mutation type.
 pub struct MutationRoot<C> {
-    chain_id: ChainId,
+    main_chain_id: ChainId,
+    tmp_chain_id: Arc<Mutex<Option<ChainId>>>,
     context: Arc<Mutex<C>>,
     amount: Amount,
+    max_claims_per_chain: u32,
     end_timestamp: Timestamp,
     start_timestamp: Timestamp,
     start_balance: Amount,
@@ -118,17 +123,55 @@ where
     C: ClientContext,
 {
     async fn do_claim(&self, owner: AccountOwner) -> Result<ClaimOutcome, Error> {
-        let client = self.context.lock().await.make_chain_client(self.chain_id)?;
+        let main_client = self
+            .context
+            .lock()
+            .await
+            .make_chain_client(self.main_chain_id)?;
+        let maybe_tmp_chain_id = *self.tmp_chain_id.lock().await;
+        let tmp_chain_id = match maybe_tmp_chain_id {
+            Some(tmp_chain_id) => tmp_chain_id,
+            None => {
+                let key_pair = main_client.key_pair().await?;
+                let balance = self
+                    .amount
+                    .try_add(MAX_FEE)?
+                    .try_mul(u128::from(self.max_claims_per_chain))?
+                    .try_add(MAX_FEE)?; // One more block fee for closing the chain.
+                let ownership = main_client.chain_state_view().await?.ownership().clone();
+                let (message_id, certificate) = main_client
+                    .open_chain(ownership, ApplicationPermissions::default(), balance)
+                    .await?
+                    .try_unwrap()?;
+                let chain_id = ChainId::child(message_id);
+                info!("Switching to a new faucet chain {chain_id:8}");
+                self.context
+                    .lock()
+                    .await
+                    .update_wallet_for_new_chain(
+                        chain_id,
+                        Some(key_pair),
+                        certificate.block().header.timestamp,
+                    )
+                    .await?;
+                *self.tmp_chain_id.lock().await = Some(chain_id);
+                chain_id
+            }
+        };
+        let tmp_client = self.context.lock().await.make_chain_client(tmp_chain_id)?;
 
         if self.start_timestamp < self.end_timestamp {
-            let local_time = client.storage_client().clock().current_time();
+            let local_time = tmp_client.storage_client().clock().current_time();
             if local_time < self.end_timestamp {
                 let full_duration = self
                     .end_timestamp
                     .delta_since(self.start_timestamp)
                     .as_micros();
                 let remaining_duration = self.end_timestamp.delta_since(local_time).as_micros();
-                let balance = client.local_balance().await?;
+                let balance = tmp_client
+                    .local_balance()
+                    .await?
+                    .try_add(main_client.local_balance().await?)?;
                 let Ok(remaining_balance) = balance.try_sub(self.amount) else {
                     return Err(Error::new("The faucet is empty."));
                 };
@@ -145,20 +188,29 @@ where
         }
 
         let ownership = ChainOwnership::single(owner);
-        let result = client
+        let result = tmp_client
             .open_chain(ownership, ApplicationPermissions::default(), self.amount)
             .await;
-        self.context.lock().await.update_wallet(&client).await?;
-        let (message_id, certificate) = match result? {
-            ClientOutcome::Committed(result) => result,
-            ClientOutcome::WaitForTimeout(timeout) => {
-                return Err(Error::new(format!(
-                    "This faucet is using a multi-owner chain and is not the leader right now. \
-                    Try again at {}",
-                    timeout.timestamp,
-                )));
+        self.context.lock().await.update_wallet(&tmp_client).await?;
+        let (message_id, certificate) = result?.try_unwrap()?;
+
+        // Only keep using this chain if there will still be enough balance to close it.
+        if tmp_client.local_balance().await? < self.amount.try_add(MAX_FEE.try_mul(2)?)? {
+            // TODO(#1795): Move the remaining tokens back to the main chain.
+            match tmp_client.close_chain().await {
+                Ok(outcome) => {
+                    outcome.try_unwrap()?;
+                }
+                Err(err) => tracing::warn!("Failed to close the chain: {err:?}"),
             }
-        };
+            self.context
+                .lock()
+                .await
+                .forget_chain(&tmp_chain_id)
+                .await?;
+            self.tmp_chain_id.lock().await.take();
+        }
+
         let chain_id = ChainId::child(message_id);
         Ok(ClaimOutcome {
             message_id,
@@ -185,7 +237,8 @@ pub struct FaucetService<C>
 where
     C: ClientContext,
 {
-    chain_id: ChainId,
+    main_chain_id: ChainId,
+    tmp_chain_id: Arc<Mutex<Option<ChainId>>>,
     context: Arc<Mutex<C>>,
     genesis_config: Arc<GenesisConfig>,
     config: ChainListenerConfig,
@@ -193,6 +246,7 @@ where
     port: NonZeroU16,
     amount: Amount,
     end_timestamp: Timestamp,
+    max_claims_per_chain: u32,
     start_timestamp: Timestamp,
     start_balance: Amount,
 }
@@ -203,13 +257,15 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            chain_id: self.chain_id,
+            main_chain_id: self.main_chain_id,
+            tmp_chain_id: Arc::clone(&self.tmp_chain_id),
             context: Arc::clone(&self.context),
             genesis_config: Arc::clone(&self.genesis_config),
             config: self.config.clone(),
             storage: self.storage.clone(),
             port: self.port,
             amount: self.amount,
+            max_claims_per_chain: self.max_claims_per_chain,
             end_timestamp: self.end_timestamp,
             start_timestamp: self.start_timestamp,
             start_balance: self.start_balance,
@@ -228,6 +284,7 @@ where
         chain_id: ChainId,
         context: C,
         amount: Amount,
+        max_claims_per_chain: u32,
         end_timestamp: Timestamp,
         genesis_config: Arc<GenesisConfig>,
         config: ChainListenerConfig,
@@ -239,13 +296,15 @@ where
         client.process_inbox().await?;
         let start_balance = client.local_balance().await?;
         Ok(Self {
-            chain_id,
+            main_chain_id: chain_id,
+            tmp_chain_id: Arc::new(Mutex::new(None)),
             context,
             genesis_config,
             config,
             storage,
             port,
             amount,
+            max_claims_per_chain,
             end_timestamp,
             start_timestamp,
             start_balance,
@@ -254,9 +313,11 @@ where
 
     pub fn schema(&self) -> Schema<QueryRoot<C>, MutationRoot<C>, EmptySubscription> {
         let mutation_root = MutationRoot {
-            chain_id: self.chain_id,
+            main_chain_id: self.main_chain_id,
+            tmp_chain_id: Arc::clone(&self.tmp_chain_id),
             context: Arc::clone(&self.context),
             amount: self.amount,
+            max_claims_per_chain: self.max_claims_per_chain,
             end_timestamp: self.end_timestamp,
             start_timestamp: self.start_timestamp,
             start_balance: self.start_balance,
@@ -264,13 +325,16 @@ where
         let query_root = QueryRoot {
             genesis_config: Arc::clone(&self.genesis_config),
             context: Arc::clone(&self.context),
-            chain_id: self.chain_id,
+            chain_id: self.main_chain_id,
         };
         Schema::build(query_root, mutation_root, EmptySubscription).finish()
     }
 
     /// Runs the faucet.
-    #[tracing::instrument(name = "FaucetService::run", skip_all, fields(port = self.port, chain_id = ?self.chain_id))]
+    #[tracing::instrument(
+        name = "FaucetService::run",
+        skip_all, fields(port = self.port, chain_id = ?self.main_chain_id))
+    ]
     pub async fn run(self) -> anyhow::Result<()> {
         let port = self.port.get();
         let index_handler = axum::routing::get(graphiql).post(Self::index_handler);
@@ -301,5 +365,29 @@ where
     async fn index_handler(service: Extension<Self>, request: GraphQLRequest) -> GraphQLResponse {
         let schema = service.0.schema();
         schema.execute(request.into_inner()).await.into()
+    }
+}
+
+trait ClientOutcomeExt {
+    type Output;
+
+    /// Returns the committed result or an error if we are not the leader.
+    ///
+    /// It is recommended to use single-owner chains for the faucet to avoid this error.
+    fn try_unwrap(self) -> Result<Self::Output, Error>;
+}
+
+impl<T> ClientOutcomeExt for ClientOutcome<T> {
+    type Output = T;
+
+    fn try_unwrap(self) -> Result<Self::Output, Error> {
+        match self {
+            ClientOutcome::Committed(result) => Ok(result),
+            ClientOutcome::WaitForTimeout(timeout) => Err(Error::new(format!(
+                "This faucet is using a multi-owner chain and is not the leader right now. \
+                Try again at {}",
+                timeout.timestamp,
+            ))),
+        }
     }
 }

--- a/linera-faucet/server/src/tests.rs
+++ b/linera-faucet/server/src/tests.rs
@@ -90,10 +90,10 @@ async fn test_faucet_rate_limiting() {
     let context = Arc::new(Mutex::new(context));
     let root = MutationRoot {
         main_chain_id,
-        tmp_chain_id: Arc::new(Mutex::new(Some(chain_id))),
+        faucet_chain_id: Arc::new(Mutex::new(Some(chain_id))),
         context: context.clone(),
         amount: Amount::from_tokens(1),
-        max_claims_per_chain: 10,
+        faucet_init_balance: Amount::from_tokens(10),
         end_timestamp: Timestamp::from(6000),
         start_timestamp: Timestamp::from(0),
         start_balance: Amount::from_tokens(6),

--- a/linera-faucet/server/src/tests.rs
+++ b/linera-faucet/server/src/tests.rs
@@ -134,7 +134,7 @@ async fn test_faucet_rate_limiting() {
         .do_claim(AccountPublicKey::test_key(6).into())
         .await
         .is_err());
-    assert_eq!(context.lock().await.update_calls, 4); // Also called in the last error case.
+    assert_eq!(context.lock().await.update_calls, 3);
 }
 
 #[test]

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -517,15 +517,22 @@ impl ClientWrapper {
         port: impl Into<Option<u16>>,
         chain_id: ChainId,
         amount: Amount,
+        max_claims_per_chain: Option<u64>,
     ) -> Result<FaucetService> {
         let port = port.into().unwrap_or(8080);
         let mut command = self.command().await?;
-        let child = command
+        command
             .arg("faucet")
             .arg(chain_id.to_string())
             .args(["--port".to_string(), port.to_string()])
-            .args(["--amount".to_string(), amount.to_string()])
-            .spawn_into()?;
+            .args(["--amount".to_string(), amount.to_string()]);
+        if let Some(max_claims_per_chain) = max_claims_per_chain {
+            command.args([
+                "--max-claims-per-chain".to_string(),
+                max_claims_per_chain.to_string(),
+            ]);
+        }
+        let child = command.spawn_into()?;
         let client = reqwest_client();
         for i in 0..10 {
             linera_base::time::timer::sleep(Duration::from_secs(i)).await;

--- a/linera-service/src/linera/command.rs
+++ b/linera-service/src/linera/command.rs
@@ -614,6 +614,12 @@ pub enum ClientCommand {
         #[arg(long)]
         limit_rate_until: Option<DateTime<Utc>>,
 
+        /// The maximum number of claims per faucet chain, after which a new one is created.
+        ///
+        /// A lower number improves performance for clients but creates overhead in the faucet.
+        #[arg(long, default_value = "100")]
+        max_claims_per_chain: u32,
+
         /// Configuration for the faucet chain listener.
         #[command(flatten)]
         config: ChainListenerConfig,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -849,6 +849,7 @@ impl Runnable for Job {
                 port,
                 amount,
                 limit_rate_until,
+                max_claims_per_chain,
                 config,
             } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
@@ -866,6 +867,7 @@ impl Runnable for Job {
                     chain_id,
                     context,
                     amount,
+                    max_claims_per_chain,
                     end_timestamp,
                     genesis_config,
                     config,

--- a/linera-service/src/linera/net_up_utils.rs
+++ b/linera-service/src/linera/net_up_utils.rs
@@ -290,7 +290,7 @@ async fn print_messages_and_create_faucet(
             ChainId::root(1)
         };
         let service = client
-            .run_faucet(Some(faucet_port.into()), faucet_chain, faucet_amount)
+            .run_faucet(Some(faucet_port.into()), faucet_chain, faucet_amount, None)
             .await?;
         Some(service)
     } else {

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -201,6 +201,10 @@ impl<P: ValidatorNodeProvider + Send, S: Storage + Clone + Send + Sync + 'static
     ) -> Result<Vec<ChainClient<Self::ValidatorNodeProvider, Self::Storage>>, Error> {
         Ok(vec![])
     }
+
+    async fn forget_chain(&mut self, _: &ChainId) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 #[tokio::main]

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2862,7 +2862,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
     let owner2 = client2.keygen().await?;
 
     let mut faucet_service = client1
-        .run_faucet(None, chain1, Amount::from_tokens(2))
+        .run_faucet(None, chain1, Amount::from_tokens(2), None)
         .await?;
     let faucet = faucet_service.instance();
     let outcome = faucet.claim(&owner2).await?;
@@ -2928,7 +2928,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
     Ok(())
 }
 
-/// Tests creating a new wallet using a Faucet that has already created a lot of microchains.
+/// Tests creating a new wallet using a faucet that has already created a lot of microchains.
 #[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
@@ -2955,7 +2955,9 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
     }
 
     let amount = Amount::ONE;
-    let mut faucet_service = faucet_client.run_faucet(None, faucet_chain, amount).await?;
+    let mut faucet_service = faucet_client
+        .run_faucet(None, faucet_chain, amount, None)
+        .await?;
     let faucet = faucet_service.instance();
 
     // Create a new wallet using the faucet
@@ -2988,6 +2990,88 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
     Ok(())
 }
 
+/// Tests that the faucet can switch the chain it uses to serve users.
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
+#[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_end_to_end_faucet_chain_limit(config: impl LineraNetConfig) -> Result<()> {
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let chain_count = 3;
+
+    let (mut net, faucet_client) = config.instantiate().await?;
+
+    let faucet_chain = faucet_client.load_wallet()?.default_chain().unwrap();
+
+    let amount = Amount::ONE;
+    let mut faucet_service = faucet_client
+        .run_faucet(None, faucet_chain, amount, Some(chain_count as u64))
+        .await?;
+    let faucet = faucet_service.instance();
+
+    // Create one less chain than the configured limit.
+    for _ in 1..chain_count {
+        let client = net.make_client().await;
+        let _ = client
+            .wallet_init(&[], FaucetOption::NewChain(&faucet))
+            .await?
+            .unwrap();
+    }
+
+    // The next one should use the first faucet chain.
+    let client1 = net.make_client().await;
+    let (outcome1, _) = client1
+        .wallet_init(&[], FaucetOption::NewChain(&faucet))
+        .await?
+        .unwrap();
+
+    // But then the faucet should switch to a new chain.
+    let client2 = net.make_client().await;
+    let (outcome2, _) = client2
+        .wallet_init(&[], FaucetOption::NewChain(&faucet))
+        .await?
+        .unwrap();
+
+    // So the two new chain should have different parents.
+    assert_ne!(outcome1.message_id.chain_id, outcome2.message_id.chain_id);
+
+    // Create another chain:
+    let client3 = net.make_client().await;
+    let (outcome3, _) = client3
+        .wallet_init(&[], FaucetOption::NewChain(&faucet))
+        .await?
+        .unwrap();
+
+    // The second faucet chain should be good for a few more requests.
+    assert_eq!(outcome2.message_id.chain_id, outcome3.message_id.chain_id);
+
+    let chain = outcome3.chain_id;
+    assert_eq!(chain, client3.load_wallet()?.default_chain().unwrap());
+
+    let initial_balance = client3.query_balance(Account::chain(chain)).await?;
+    let fees_paid = amount - initial_balance;
+    assert!(initial_balance > Amount::ZERO);
+
+    client3
+        .transfer(initial_balance - fees_paid, chain, faucet_chain)
+        .await?;
+
+    let final_balance = client3.query_balance(Account::chain(chain)).await?;
+    assert_eq!(final_balance, Amount::ZERO);
+
+    faucet_service.ensure_is_running()?;
+    faucet_service.terminate().await?;
+
+    net.ensure_is_running().await?;
+    net.terminate().await?;
+
+    Ok(())
+}
+
 #[cfg(feature = "benchmark")]
 #[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
@@ -3007,7 +3091,7 @@ async fn test_end_to_end_fungible_client_benchmark(config: impl LineraNetConfig)
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
 
-    let mut faucet_service = client1.run_faucet(None, chain1, Amount::ONE).await?;
+    let mut faucet_service = client1.run_faucet(None, chain1, Amount::ONE, None).await?;
     let faucet = faucet_service.instance();
 
     let path =

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -3002,7 +3002,7 @@ async fn test_end_to_end_faucet_chain_limit(config: impl LineraNetConfig) -> Res
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
-    let chain_count = 3;
+    let max_claims_per_chain = 3;
 
     let (mut net, faucet_client) = config.instantiate().await?;
 
@@ -3010,12 +3010,17 @@ async fn test_end_to_end_faucet_chain_limit(config: impl LineraNetConfig) -> Res
 
     let amount = Amount::ONE;
     let mut faucet_service = faucet_client
-        .run_faucet(None, faucet_chain, amount, Some(chain_count as u64))
+        .run_faucet(
+            None,
+            faucet_chain,
+            amount,
+            Some(max_claims_per_chain as u64),
+        )
         .await?;
     let faucet = faucet_service.instance();
 
     // Create one less chain than the configured limit.
-    for _ in 1..chain_count {
+    for _ in 1..max_claims_per_chain {
         let client = net.make_client().await;
         let _ = client
             .wallet_init(&[], FaucetOption::NewChain(&faucet))

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2861,8 +2861,9 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
     // Generate keys for client 2.
     let owner2 = client2.keygen().await?;
 
+    // We set the temporary chain limit to 1, so unused tokens remain on the main chain.
     let mut faucet_service = client1
-        .run_faucet(None, chain1, Amount::from_tokens(2), None)
+        .run_faucet(None, chain1, Amount::from_tokens(2), Some(1))
         .await?;
     let faucet = faucet_service.instance();
     let outcome = faucet.claim(&owner2).await?;

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -70,7 +70,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
         .await?;
 
     let mut faucet_service = faucet_client
-        .run_faucet(None, faucet_chain, Amount::from_tokens(2))
+        .run_faucet(None, faucet_chain, Amount::from_tokens(2), None)
         .await?;
 
     faucet_service.ensure_is_running()?;
@@ -247,7 +247,7 @@ async fn test_end_to_end_receipt_of_old_create_committee_messages(
 
     if matches!(network, Network::Grpc) {
         let mut faucet_service = faucet_client
-            .run_faucet(None, faucet_chain, Amount::from_tokens(2))
+            .run_faucet(None, faucet_chain, Amount::from_tokens(2), None)
             .await?;
 
         faucet_service.ensure_is_running()?;
@@ -281,7 +281,7 @@ async fn test_end_to_end_receipt_of_old_create_committee_messages(
     faucet_client.process_inbox(faucet_chain).await?;
 
     let mut faucet_service = faucet_client
-        .run_faucet(None, faucet_chain, Amount::from_tokens(2))
+        .run_faucet(None, faucet_chain, Amount::from_tokens(2), None)
         .await?;
 
     faucet_service.ensure_is_running()?;
@@ -339,7 +339,7 @@ async fn test_end_to_end_receipt_of_old_remove_committee_messages(
 
     if matches!(network, Network::Grpc) {
         let mut faucet_service = faucet_client
-            .run_faucet(None, faucet_chain, Amount::from_tokens(2))
+            .run_faucet(None, faucet_chain, Amount::from_tokens(2), None)
             .await?;
 
         faucet_service.ensure_is_running()?;
@@ -375,7 +375,7 @@ async fn test_end_to_end_receipt_of_old_remove_committee_messages(
 
     if matches!(network, Network::Grpc) {
         let mut faucet_service = faucet_client
-            .run_faucet(None, faucet_chain, Amount::from_tokens(2))
+            .run_faucet(None, faucet_chain, Amount::from_tokens(2), None)
             .await?;
 
         faucet_service.ensure_is_running()?;
@@ -411,7 +411,7 @@ async fn test_end_to_end_receipt_of_old_remove_committee_messages(
     faucet_client.process_inbox(faucet_chain).await?;
 
     let mut faucet_service = faucet_client
-        .run_faucet(None, faucet_chain, Amount::from_tokens(2))
+        .run_faucet(None, faucet_chain, Amount::from_tokens(2), None)
         .await?;
 
     faucet_service.ensure_is_running()?;


### PR DESCRIPTION
## Motivation

If the faucet chain gets very long, requesting a new chain becomes very slow for new wallets.

## Proposal

Make the faucet switch chains every 100 blocks.

The previous attempt was reverted: https://github.com/linera-io/linera-protocol/pull/3852
This new approach makes it less problematic to restart the faucet:

The faucet now only uses the main chain (which in practice will usually be one of our root chains in the testnet) to create temporary child chains. It only provides each child with enough funds to serve 100 user requests. (That number is a config option.) Once the child's funds are exhausted, it is closed and removed from the wallet, and a new child is created from the main chain.

In particular, the main chain is never drained of all funds at once, it never gets closed, and it is never used to directly serve user requests. All chains requested by users are _grandchildren_ of the main chain, because they are created by one of the temporary chains. Since these are never longer than 100 blocks, synchronization for new users should be much faster.

## Test Plan

`test_end_to_end_faucet_chain_limit`

## Release Plan

- These changes should be deployed on Testnet Babbage.
- They _could_ be ported to `main`.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/3846.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
