### PR TITLE
Recursively create parent directories when creating config dir

### DIFF
--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1521,7 +1521,7 @@ impl ClientOptions {
         config_dir.push("linera");
         if !config_dir.exists() {
             debug!("Creating default wallet directory {}", config_dir.display());
-            fs_err::create_dir(&config_dir)?;
+            fs_err::create_dir_all(&config_dir)?;
         }
         info!("Using default wallet directory {}", config_dir.display());
         Ok(config_dir)


### PR DESCRIPTION
## Motivation

When this path is executed from inside a docker container, which we usually run as root, `$HOME` will point to `/root`, but `dirs::config_dir()` will actually return `$HOME/.config`, but the `.config` directory won't be created yet.
Then when we call `fs_err::create_dir("/root/.config/linera")`, it can fail because `.config` won't exist yet.

## Proposal

Recursively create directories so that `.config` is also created, and the command succeeds from within Docker containers as well.

## Test Plan

Deploys were failing with this, now they succeed.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
