### PR TITLE
Address two issues with EVM

### DIFF
--- a/examples/counter-no-graphql/README.md
+++ b/examples/counter-no-graphql/README.md
@@ -2,11 +2,11 @@
 
 This example application implements a simple counter contract, it is initialized with an
 unsigned integer that can be increased by the `increment` operation. In contrast with the
-counter application, it works without GraphQL 
+counter application, it works without GraphQL.
 
 ## How It Works
 
-It is a very basic Linera application, which is initialized by a `u64` which can be incremented
+It is a simple Linera application, which is initialized by a `u64` which can be incremented
 by a `u64`.
 
 For example, if the contract was initialized with 1, querying the contract would give us 1. Now if we want to

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -5,7 +5,7 @@ unsigned integer that can be increased by the `increment` operation.
 
 ## How It Works
 
-It is a very basic Linera application, which is initialized by a `u64` which can be incremented
+It is a simple Linera application, which is initialized by a `u64` which can be incremented
 by a `u64`.
 
 For example, if the contract was initialized with 1, querying the contract would give us 1. Now if we want to

--- a/linera-execution/src/evm/database.rs
+++ b/linera-execution/src/evm/database.rs
@@ -9,6 +9,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use linera_base::vm::VmRuntime;
 use linera_views::common::from_bytes_option;
 use revm::{
     db::AccountState,
@@ -17,7 +18,13 @@ use revm::{
 };
 use revm_primitives::{address, Address, BlobExcessGasAndPrice, BlockEnv, EvmState, B256, U256};
 
-use crate::{BaseRuntime, Batch, ContractRuntime, ExecutionError, ViewError};
+use crate::{BaseRuntime, Batch, ContractRuntime, ExecutionError, ServiceRuntime, ViewError};
+
+// The runtime costs are not available in service operations.
+// We need to set a limit to gas usage in order to avoid blocking
+// the validator.
+// We set up the limit similarly to Infura to 20 million.
+pub const EVM_SERVICE_GAS_LIMIT: u64 = 20_000_000;
 
 /// The cost of loading from storage.
 const SLOAD_COST: u64 = 2100;
@@ -329,12 +336,7 @@ where
         let result = runtime.contains_keys_wait(&promise)?;
         Ok(result[0] && result[1])
     }
-}
 
-impl<Runtime> DatabaseRuntime<Runtime>
-where
-    Runtime: BaseRuntime,
-{
     pub fn get_block_env(&self) -> Result<BlockEnv, ExecutionError> {
         let mut runtime = self.runtime.lock().expect("The lock should be possible");
         // The block height being used
@@ -344,8 +346,7 @@ where
         let beneficiary = address!("00000000000000000000000000000000000000bb");
         // The difficulty which is no longer relevant after The Merge.
         let difficulty = U256::ZERO;
-        // We do not have access to the Resources so we keep it to the maximum
-        // and the control is done elsewhere.
+        // Set up in the next section.
         let gas_limit = U256::MAX;
         // The timestamp. Both the EVM and Linera use the same UNIX epoch.
         // But the Linera epoch is in microseconds since the start and the
@@ -376,5 +377,36 @@ where
             prevrandao: Some(prevrandao),
             blob_excess_gas_and_price,
         })
+    }
+
+    pub fn constructor_argument(&self) -> Result<Vec<u8>, ExecutionError> {
+        let mut runtime = self.runtime.lock().expect("The lock should be possible");
+        let constructor_argument = runtime.application_parameters()?;
+        Ok(serde_json::from_slice::<Vec<u8>>(&constructor_argument)?)
+    }
+}
+
+impl<Runtime> DatabaseRuntime<Runtime>
+where
+    Runtime: ContractRuntime,
+{
+    pub fn get_contract_block_env(&self) -> Result<BlockEnv, ExecutionError> {
+        let mut block_env = self.get_block_env()?;
+        let mut runtime = self.runtime.lock().expect("The lock should be possible");
+        // We use the gas_limit from the runtime
+        let gas_limit = runtime.maximum_fuel_per_block(VmRuntime::Evm)?;
+        block_env.gas_limit = U256::from(gas_limit);
+        Ok(block_env)
+    }
+}
+
+impl<Runtime> DatabaseRuntime<Runtime>
+where
+    Runtime: ServiceRuntime,
+{
+    pub fn get_service_block_env(&self) -> Result<BlockEnv, ExecutionError> {
+        let mut block_env = self.get_block_env()?;
+        block_env.gas_limit = U256::from(EVM_SERVICE_GAS_LIMIT);
+        Ok(block_env)
     }
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -720,6 +720,9 @@ pub trait ContractRuntime: BaseRuntime {
     /// based on the execution context.
     fn authenticated_caller_id(&mut self) -> Result<Option<ApplicationId>, ExecutionError>;
 
+    /// Returns the maximum gas fuel per block.
+    fn maximum_fuel_per_block(&mut self, vm_runtime: VmRuntime) -> Result<u64, ExecutionError>;
+
     /// Returns the amount of execution fuel remaining before execution is aborted.
     fn remaining_fuel(&mut self, vm_runtime: VmRuntime) -> Result<u64, ExecutionError>;
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1174,6 +1174,14 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         Ok(this.current_application().caller_id)
     }
 
+    fn maximum_fuel_per_block(&mut self, vm_runtime: VmRuntime) -> Result<u64, ExecutionError> {
+        let policy = &self.inner().resource_controller.policy;
+        Ok(match vm_runtime {
+            VmRuntime::Wasm => policy.maximum_wasm_fuel_per_block,
+            VmRuntime::Evm => policy.maximum_evm_fuel_per_block,
+        })
+    }
+
     fn remaining_fuel(&mut self, vm_runtime: VmRuntime) -> Result<u64, ExecutionError> {
         Ok(self.inner().resource_controller.remaining_fuel(vm_runtime))
     }

--- a/linera-service/tests/fixtures/evm_example_execute_message.sol
+++ b/linera-service/tests/fixtures/evm_example_execute_message.sol
@@ -8,6 +8,10 @@ contract ExampleExecuteMessage {
     uint64 value;
     Linera.MessageId last_message_id;
 
+    constructor(uint64 test_value) {
+       require(test_value == 42);
+    }
+
     function instantiate(bytes memory input) external {
         uint64 read_value = abi.decode(input, (uint64));
         value = read_value;

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -744,11 +744,18 @@ async fn test_evm_execute_message_end_to_end_counter(config: impl LineraNetConfi
     // Creating the API of the contracts
 
     sol! {
+        struct ConstructorArgs {
+            uint64 test_value;
+        }
         function move_value_to_chain(bytes32 chain_id, uint64 moved_value);
         function get_value();
     }
+    let query = get_valueCall {};
+    let query = query.abi_encode();
+    let query = EvmQuery::Query(query);
 
-    let constructor_argument = Vec::new();
+    let constructor_argument = ConstructorArgs { test_value: 42 };
+    let constructor_argument = constructor_argument.abi_encode();
 
     let instantiation_argument: Vec<u8> = u64::abi_encode(&original_value);
 
@@ -785,9 +792,6 @@ async fn test_evm_execute_message_end_to_end_counter(config: impl LineraNetConfi
     // Now checking the APIs.
     // First: checking the initial value of the contracts.
 
-    let query = get_valueCall {};
-    let query = query.abi_encode();
-    let query = EvmQuery::Query(query);
     let result = application1.run_json_query(query.clone()).await?;
     let counter_value = read_evm_u64_entry(result);
     assert_eq!(counter_value, original_value);


### PR DESCRIPTION
## Motivation

We identified two problems with the EVM, which we correct now. Also, some typos from the closed PR #3883 are put there.

## Proposal

The `gas_limit` is added to the BlobkEnv variable.

A more serious problem is the constructor argument for the contract being run in `execute_message`. It was incorrect when running a non-trivial constructor on another chain. The serialization was missing.

## Test Plan

A non-trivial constructor that does not do anything, just making a check, was introduced to `evm_example_execute_message.sol`. It triggers the previous problem.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
