### PR TITLE
Make numeric constructors and arithmetic const.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -142,17 +142,17 @@ pub struct TimeDelta(u64);
 
 impl TimeDelta {
     /// Returns the given number of microseconds as a [`TimeDelta`].
-    pub fn from_micros(micros: u64) -> Self {
+    pub const fn from_micros(micros: u64) -> Self {
         TimeDelta(micros)
     }
 
     /// Returns the given number of milliseconds as a [`TimeDelta`].
-    pub fn from_millis(millis: u64) -> Self {
+    pub const fn from_millis(millis: u64) -> Self {
         TimeDelta(millis.saturating_mul(1_000))
     }
 
     /// Returns the given number of seconds as a [`TimeDelta`].
-    pub fn from_secs(secs: u64) -> Self {
+    pub const fn from_secs(secs: u64) -> Self {
         TimeDelta(secs.saturating_mul(1_000_000))
     }
 
@@ -163,12 +163,12 @@ impl TimeDelta {
     }
 
     /// Returns this [`TimeDelta`] as a number of microseconds.
-    pub fn as_micros(&self) -> u64 {
+    pub const fn as_micros(&self) -> u64 {
         self.0
     }
 
     /// Returns this [`TimeDelta`] as a [`Duration`].
-    pub fn as_duration(&self) -> Duration {
+    pub const fn as_duration(&self) -> Duration {
         Duration::from_micros(self.as_micros())
     }
 }
@@ -206,41 +206,41 @@ impl Timestamp {
     }
 
     /// Returns the number of microseconds since the Unix epoch.
-    pub fn micros(&self) -> u64 {
+    pub const fn micros(&self) -> u64 {
         self.0
     }
 
     /// Returns the [`TimeDelta`] between `other` and `self`, or zero if `other` is not earlier
     /// than `self`.
-    pub fn delta_since(&self, other: Timestamp) -> TimeDelta {
+    pub const fn delta_since(&self, other: Timestamp) -> TimeDelta {
         TimeDelta::from_micros(self.0.saturating_sub(other.0))
     }
 
     /// Returns the [`Duration`] between `other` and `self`, or zero if `other` is not
     /// earlier than `self`.
-    pub fn duration_since(&self, other: Timestamp) -> Duration {
+    pub const fn duration_since(&self, other: Timestamp) -> Duration {
         Duration::from_micros(self.0.saturating_sub(other.0))
     }
 
     /// Returns the timestamp that is `duration` later than `self`.
-    pub fn saturating_add(&self, duration: TimeDelta) -> Timestamp {
+    pub const fn saturating_add(&self, duration: TimeDelta) -> Timestamp {
         Timestamp(self.0.saturating_add(duration.0))
     }
 
     /// Returns the timestamp that is `duration` earlier than `self`.
-    pub fn saturating_sub(&self, duration: TimeDelta) -> Timestamp {
+    pub const fn saturating_sub(&self, duration: TimeDelta) -> Timestamp {
         Timestamp(self.0.saturating_sub(duration.0))
     }
 
     /// Returns a timestamp `micros` microseconds later than `self`, or the highest possible value
     /// if it would overflow.
-    pub fn saturating_add_micros(&self, micros: u64) -> Timestamp {
+    pub const fn saturating_add_micros(&self, micros: u64) -> Timestamp {
         Timestamp(self.0.saturating_add(micros))
     }
 
     /// Returns a timestamp `micros` microseconds earlier than `self`, or the lowest possible value
     /// if it would underflow.
-    pub fn saturating_sub_micros(&self, micros: u64) -> Timestamp {
+    pub const fn saturating_sub_micros(&self, micros: u64) -> Timestamp {
         Timestamp(self.0.saturating_sub(micros))
     }
 }
@@ -374,7 +374,7 @@ macro_rules! impl_wrapped_number {
             }
 
             /// Saturating addition.
-            pub fn saturating_add(self, other: Self) -> Self {
+            pub const fn saturating_add(self, other: Self) -> Self {
                 let val = self.0.saturating_add(other.0);
                 Self(val)
             }
@@ -395,7 +395,7 @@ macro_rules! impl_wrapped_number {
             }
 
             /// Saturating subtraction.
-            pub fn saturating_sub(self, other: Self) -> Self {
+            pub const fn saturating_sub(self, other: Self) -> Self {
                 let val = self.0.saturating_sub(other.0);
                 Self(val)
             }
@@ -416,7 +416,7 @@ macro_rules! impl_wrapped_number {
             }
 
             /// Saturating in-place addition.
-            pub fn saturating_add_assign(&mut self, other: Self) {
+            pub const fn saturating_add_assign(&mut self, other: Self) {
                 self.0 = self.0.saturating_add(other.0);
             }
 
@@ -430,7 +430,7 @@ macro_rules! impl_wrapped_number {
             }
 
             /// Saturating multiplication.
-            pub fn saturating_mul(&self, other: $wrapped) -> Self {
+            pub const fn saturating_mul(&self, other: $wrapped) -> Self {
                 Self(self.0.saturating_mul(other))
             }
 
@@ -665,37 +665,37 @@ impl Amount {
     pub const ONE: Amount = Amount(10u128.pow(Amount::DECIMAL_PLACES as u32));
 
     /// Returns an `Amount` corresponding to that many tokens, or `Amount::MAX` if saturated.
-    pub fn from_tokens(tokens: u128) -> Amount {
+    pub const fn from_tokens(tokens: u128) -> Amount {
         Self::ONE.saturating_mul(tokens)
     }
 
     /// Returns an `Amount` corresponding to that many millitokens, or `Amount::MAX` if saturated.
-    pub fn from_millis(millitokens: u128) -> Amount {
+    pub const fn from_millis(millitokens: u128) -> Amount {
         Amount(10u128.pow(Amount::DECIMAL_PLACES as u32 - 3)).saturating_mul(millitokens)
     }
 
     /// Returns an `Amount` corresponding to that many microtokens, or `Amount::MAX` if saturated.
-    pub fn from_micros(microtokens: u128) -> Amount {
+    pub const fn from_micros(microtokens: u128) -> Amount {
         Amount(10u128.pow(Amount::DECIMAL_PLACES as u32 - 6)).saturating_mul(microtokens)
     }
 
     /// Returns an `Amount` corresponding to that many nanotokens, or `Amount::MAX` if saturated.
-    pub fn from_nanos(nanotokens: u128) -> Amount {
+    pub const fn from_nanos(nanotokens: u128) -> Amount {
         Amount(10u128.pow(Amount::DECIMAL_PLACES as u32 - 9)).saturating_mul(nanotokens)
     }
 
     /// Returns an `Amount` corresponding to that many attotokens.
-    pub fn from_attos(attotokens: u128) -> Amount {
+    pub const fn from_attos(attotokens: u128) -> Amount {
         Amount(attotokens)
     }
 
     /// Helper function to obtain the 64 most significant bits of the balance.
-    pub fn upper_half(self) -> u64 {
+    pub const fn upper_half(self) -> u64 {
         (self.0 >> 64) as u64
     }
 
     /// Helper function to obtain the 64 least significant bits of the balance.
-    pub fn lower_half(self) -> u64 {
+    pub const fn lower_half(self) -> u64 {
         self.0 as u64
     }
 

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -3231,7 +3231,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
     Ok(())
 }
 
-/// Tests creating a new wallet using a Faucet that has already created a lot of microchains.
+/// Tests creating a new wallet using a faucet that has already created a lot of microchains.
 #[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]


### PR DESCRIPTION
## Motivation

It should be possible to e.g. define a `const x: Amount` using some addition and multiplication. (I ran into this in https://github.com/linera-io/linera-protocol/pull/3893.)

## Proposal

Make more functions `const`. (Also fix a typo.)

## Test Plan

N/A

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
