### PR TITLE
Remove unused message ID functions.

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -13,7 +13,7 @@ use linera_base::{
     crypto::{BcsHashable, CryptoHash},
     data_types::{Blob, BlockHeight, Epoch, Event, OracleResponse, Timestamp},
     hashed::Hashed,
-    identifiers::{AccountOwner, BlobId, BlobType, ChainId, MessageId},
+    identifiers::{AccountOwner, BlobId, BlobType, ChainId},
 };
 use linera_execution::{BlobState, Operation, OutgoingMessage};
 use serde::{ser::SerializeStruct, Deserialize, Serialize};
@@ -435,60 +435,6 @@ impl Block {
                     (block_epoch, bundle)
                 })
             })
-    }
-
-    /// Returns the `message_index`th outgoing message created by the `operation_index`th operation,
-    /// or `None` if there is no such operation or message.
-    pub fn message_id_for_operation(
-        &self,
-        operation_index: usize,
-        message_index: u32,
-    ) -> Option<MessageId> {
-        let block = &self.body;
-        let transaction_index = block.incoming_bundles.len().checked_add(operation_index)?;
-        if message_index >= u32::try_from(self.body.messages.get(transaction_index)?.len()).ok()? {
-            return None;
-        }
-        let first_message_index = u32::try_from(
-            self.body
-                .messages
-                .iter()
-                .take(transaction_index)
-                .map(Vec::len)
-                .sum::<usize>(),
-        )
-        .ok()?;
-        let index = first_message_index.checked_add(message_index)?;
-        Some(self.message_id(index))
-    }
-
-    /// Returns the message ID belonging to the `index`th outgoing message in this block.
-    pub fn message_id(&self, index: u32) -> MessageId {
-        MessageId {
-            chain_id: self.header.chain_id,
-            height: self.header.height,
-            index,
-        }
-    }
-
-    /// Returns the outgoing message with the specified id, or `None` if there is no such message.
-    pub fn message_by_id(&self, message_id: &MessageId) -> Option<&OutgoingMessage> {
-        let MessageId {
-            chain_id,
-            height,
-            index,
-        } = message_id;
-        if self.header.chain_id != *chain_id || self.header.height != *height {
-            return None;
-        }
-        let mut index = usize::try_from(*index).ok()?;
-        for messages in self.messages() {
-            if let Some(message) = messages.get(index) {
-                return Some(message);
-            }
-            index -= messages.len();
-        }
-        None
     }
 
     /// Returns all the blob IDs required by this block.

--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -5,7 +5,7 @@
 use linera_base::{
     crypto::{ValidatorPublicKey, ValidatorSignature},
     data_types::{Epoch, Round},
-    identifiers::{ChainId, MessageId},
+    identifiers::ChainId,
 };
 use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize};
 
@@ -19,11 +19,6 @@ impl GenericCertificate<ConfirmedBlock> {
     /// Returns reference to the `Block` contained in this certificate.
     pub fn block(&self) -> &Block {
         self.inner().block()
-    }
-
-    /// Returns whether this value contains the message with the specified ID.
-    pub fn has_message(&self, message_id: &MessageId) -> bool {
-        self.block().message_by_id(message_id).is_some()
     }
 
     /// Returns the bundles of messages sent to the specified recipient.

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -123,15 +123,6 @@ impl ProposedBlock {
         );
         Ok(())
     }
-
-    /// Returns the message ID belonging to the `index`th outgoing message in this block.
-    pub fn message_id(&self, index: u32) -> MessageId {
-        MessageId {
-            chain_id: self.chain_id,
-            height: self.height,
-            index,
-        }
-    }
 }
 
 /// A transaction in a block: incoming messages or an operation.


### PR DESCRIPTION
## Motivation

`MessageId` is now used only in the SDK, not in the protocol itself.

## Proposal

Remove unused functions.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
