### PR TITLE
Set default fallback duration to `MAX`.

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -1018,7 +1018,7 @@ mod tests {
         );
         assert_eq!(
             description.id().to_string(),
-            "f8c2f02adc0ac763ffd74a32d02aa37490d869605c356a2da55e1d09e7d253bf"
+            "0e94923a8f72ef1d0e69e6958e655002f2b1883bac9a67a4704d2f4125825217"
         );
     }
 

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -41,7 +41,9 @@ impl Default for TimeoutConfig {
             fast_round_duration: None,
             base_timeout: TimeDelta::from_secs(10),
             timeout_increment: TimeDelta::from_secs(1),
-            fallback_duration: TimeDelta::from_secs(60 * 60 * 24),
+            // This is `MAX` because the validators are not currently expected to start clients for
+            // every chain with an old tracked message in the inbox.
+            fallback_duration: TimeDelta::MAX,
         }
     }
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3571,6 +3571,7 @@ where
     let mut env = TestEnvironment::new(storage, false, false).await;
     let balance = Amount::from_tokens(5);
     let mut ownership = ChainOwnership::single(public_key.into());
+    // Configure a fallback duration. (The default is `MAX`, i.e. never.)
     ownership.timeout_config.fallback_duration = TimeDelta::from_secs(5);
     let chain_1_desc = env
         .add_root_chain_with_ownership(1, balance, ownership)


### PR DESCRIPTION
## Motivation

The validators are not currently expected to start client processes automatically. So chains that enter fallback mode are effectively bricked.

## Proposal

Set the default fallback timeout to `MAX`, so validators will never sign a fallback timeout certificate.

## Test Plan

(Only a default chain config change.)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
