### PR TITLE
Remove 2 deprecated CLI options of `linera wallet init`.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -817,8 +817,6 @@ Initialize a wallet from the genesis configuration
 
 * `--genesis <GENESIS_CONFIG_PATH>` — The path to the genesis configuration for a Linera deployment. Either this or `--faucet` must be specified
 * `--faucet <FAUCET>` — The address of a faucet
-* `--with-new-chain` — Request a new chain from the faucet, credited with tokens. This requires `--faucet`
-* `--with-other-chains <WITH_OTHER_CHAINS>` — Other chains to follow
 * `--testing-prng-seed <TESTING_PRNG_SEED>` — Force this wallet to generate keys using a PRNG and a given seed. USE FOR TESTING ONLY
 
 

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -87,7 +87,7 @@ async fn benchmark_with_fungible(
         num_wallets,
         OnClientDrop::CloseChains,
     );
-    publisher.wallet_init(&[], Some(&faucet)).await?;
+    publisher.wallet_init(Some(&faucet)).await?;
     publisher.request_chain(&faucet, true).await?;
     let clients = (0..num_wallets)
         .map(|n| {
@@ -102,7 +102,7 @@ async fn benchmark_with_fungible(
         })
         .collect::<Result<Vec<_>, anyhow::Error>>()?;
     try_join_all(clients.iter().map(|client| async {
-        client.wallet_init(&[], Some(&faucet)).await?;
+        client.wallet_init(Some(&faucet)).await?;
         client.request_chain(&faucet, true).await
     }))
     .await?;

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -196,7 +196,7 @@ impl LineraNetConfig for SharedLocalKubernetesNetTestingConfig {
         let client = net.make_client().await;
         // The tests assume we've created a genesis config with 2
         // chains with 10 tokens each.
-        client.wallet_init(&[], None).await.unwrap();
+        client.wallet_init(None).await.unwrap();
         for _ in 0..2 {
             initial_client
                 .open_and_assign(&client, Amount::from_tokens(10))

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -16,10 +16,7 @@ use linera_client::client_options::ResourceControlPolicyConfig;
 use tempfile::{tempdir, TempDir};
 use tokio::process::Command;
 #[cfg(with_testing)]
-use {
-    crate::cli_wrappers::wallet::FaucetOption, linera_base::command::current_binary_parent,
-    tokio::sync::OnceCell,
-};
+use {linera_base::command::current_binary_parent, tokio::sync::OnceCell};
 
 use crate::cli_wrappers::{
     docker::{BuildArg, DockerImage},
@@ -199,7 +196,7 @@ impl LineraNetConfig for SharedLocalKubernetesNetTestingConfig {
         let client = net.make_client().await;
         // The tests assume we've created a genesis config with 2
         // chains with 10 tokens each.
-        client.wallet_init(&[], FaucetOption::None).await.unwrap();
+        client.wallet_init(&[], None).await.unwrap();
         for _ in 0..2 {
             initial_client
                 .open_and_assign(&client, Amount::from_tokens(10))

--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -34,9 +34,7 @@ mod wallet;
 use anyhow::Result;
 use async_trait::async_trait;
 pub use linera_faucet_client::Faucet;
-pub use wallet::{
-    ApplicationWrapper, ClientWrapper, FaucetOption, FaucetService, NodeService, OnClientDrop,
-};
+pub use wallet::{ApplicationWrapper, ClientWrapper, FaucetService, NodeService, OnClientDrop};
 
 /// The information needed to start a Linera net of a particular kind.
 #[async_trait]

--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -50,7 +50,7 @@ impl LineraNetConfig for RemoteNetTestingConfig {
         let client = net.make_client().await;
         // The tests assume we've created a genesis config with 2
         // chains with 10 tokens each. We create the first chain here
-        client.wallet_init(&[], Some(&self.faucet)).await?;
+        client.wallet_init(Some(&self.faucet)).await?;
         client.request_chain(&self.faucet, true).await?;
 
         // And the remaining 2 here

--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -10,8 +10,8 @@ use linera_client::persistent::{self, Persist};
 use tempfile::{tempdir, TempDir};
 
 use super::{
-    local_net::PathProvider, ClientWrapper, Faucet, FaucetOption, LineraNet, LineraNetConfig,
-    Network, OnClientDrop,
+    local_net::PathProvider, ClientWrapper, Faucet, LineraNet, LineraNetConfig, Network,
+    OnClientDrop,
 };
 
 pub struct RemoteNetTestingConfig {
@@ -50,10 +50,8 @@ impl LineraNetConfig for RemoteNetTestingConfig {
         let client = net.make_client().await;
         // The tests assume we've created a genesis config with 2
         // chains with 10 tokens each. We create the first chain here
-        client
-            .wallet_init(&[], FaucetOption::NewChain(&self.faucet))
-            .await
-            .unwrap();
+        client.wallet_init(&[], Some(&self.faucet)).await?;
+        client.request_chain(&self.faucet, true).await?;
 
         // And the remaining 2 here
         for _ in 0..2 {

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -269,11 +269,7 @@ impl ClientWrapper {
 
     /// Runs `linera wallet init`. The genesis config is read from `genesis.json`, or from the
     /// faucet if provided.
-    pub async fn wallet_init(
-        &self,
-        chain_ids: &[ChainId],
-        faucet: Option<&'_ Faucet>,
-    ) -> Result<()> {
+    pub async fn wallet_init(&self, faucet: Option<&'_ Faucet>) -> Result<()> {
         let mut command = self.command().await?;
         command.args(["wallet", "init"]);
         match faucet {
@@ -282,10 +278,6 @@ impl ClientWrapper {
         };
         if let Some(seed) = self.testing_prng_seed {
             command.arg("--testing-prng-seed").arg(seed.to_string());
-        }
-        if !chain_ids.is_empty() {
-            let ids = chain_ids.iter().map(ChainId::to_string);
-            command.arg("--with-other-chains").args(ids);
         }
         command.spawn_and_wait_for_stdout().await?;
         Ok(())

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -267,25 +267,19 @@ impl ClientWrapper {
         Ok(())
     }
 
-    /// Runs `linera wallet init`.
+    /// Runs `linera wallet init`. The genesis config is read from `genesis.json`, or from the
+    /// faucet if provided.
     pub async fn wallet_init(
         &self,
         chain_ids: &[ChainId],
-        faucet: FaucetOption<'_>,
-    ) -> Result<Option<(ClaimOutcome, AccountOwner)>> {
+        faucet: Option<&'_ Faucet>,
+    ) -> Result<()> {
         let mut command = self.command().await?;
         command.args(["wallet", "init"]);
         match faucet {
-            FaucetOption::None => {
-                command.args(["--genesis", "genesis.json"]);
-            }
-            FaucetOption::GenesisOnly(faucet) => {
-                command.args(["--faucet", faucet.url()]);
-            }
-            FaucetOption::NewChain(faucet) => {
-                command.args(["--with-new-chain", "--faucet", faucet.url()]);
-            }
-        }
+            None => command.args(["--genesis", "genesis.json"]),
+            Some(faucet) => command.args(["--faucet", faucet.url()]),
+        };
         if let Some(seed) = self.testing_prng_seed {
             command.arg("--testing-prng-seed").arg(seed.to_string());
         }
@@ -293,26 +287,8 @@ impl ClientWrapper {
             let ids = chain_ids.iter().map(ChainId::to_string);
             command.arg("--with-other-chains").args(ids);
         }
-        let stdout = command.spawn_and_wait_for_stdout().await?;
-        if matches!(faucet, FaucetOption::NewChain(_)) {
-            let mut lines = stdout.split_whitespace();
-            let chain_id_str = lines.next().context("missing chain ID")?;
-            let certificate_hash_str = lines.next().context("missing certificate hash")?;
-            let outcome = ClaimOutcome {
-                chain_id: chain_id_str.parse().context("invalid chain ID")?,
-                certificate_hash: certificate_hash_str
-                    .parse()
-                    .context("invalid certificate hash")?,
-            };
-            let owner = lines
-                .next()
-                .context("missing chain owner")?
-                .parse()
-                .context("invalid chain owner")?;
-            Ok(Some((outcome, owner)))
-        } else {
-            Ok(None)
-        }
+        command.spawn_and_wait_for_stdout().await?;
+        Ok(())
     }
 
     /// Runs `linera wallet request-chain`.
@@ -1064,14 +1040,6 @@ impl Drop for ClientWrapper {
             }
         }
     }
-}
-
-/// Whether `wallet_init` should use a faucet.
-#[derive(Clone, Copy, Debug)]
-pub enum FaucetOption<'a> {
-    None,
-    GenesisOnly(&'a Faucet),
-    NewChain(&'a Faucet),
 }
 
 #[cfg(with_testing)]

--- a/linera-service/src/linera/command.rs
+++ b/linera-service/src/linera/command.rs
@@ -1026,14 +1026,6 @@ pub enum WalletCommand {
         #[arg(long = "faucet")]
         faucet: Option<String>,
 
-        /// Request a new chain from the faucet, credited with tokens. This requires `--faucet`.
-        #[arg(long)]
-        with_new_chain: bool,
-
-        /// Other chains to follow.
-        #[arg(long, num_args(0..))]
-        with_other_chains: Vec<ChainId>,
-
         /// Force this wallet to generate keys using a PRNG and a given seed. USE FOR
         /// TESTING ONLY.
         #[arg(long)]

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -6,7 +6,7 @@
 #![deny(clippy::large_futures)]
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet},
     env,
     ops::Deref,
     path::PathBuf,
@@ -23,11 +23,11 @@ use command::{ClientCommand, DatabaseToolCommand, NetCommand, ProjectCommand, Wa
 use futures::{lock::Mutex, FutureExt as _, StreamExt};
 use linera_base::{
     bcs,
-    crypto::{CryptoHash, InMemorySigner, Signer},
+    crypto::{InMemorySigner, Signer},
     data_types::{
         ApplicationPermissions, ChainDescription, ChainOrigin, Epoch, InitialChainConfig, Timestamp,
     },
-    identifiers::{AccountOwner, ChainId},
+    identifiers::AccountOwner,
     listen_for_shutdown_signals,
     ownership::ChainOwnership,
 };
@@ -1235,48 +1235,6 @@ impl Runnable for Job {
                 );
             }
 
-            Wallet(WalletCommand::Init {
-                faucet: Some(faucet_url),
-                with_new_chain: true,
-                with_other_chains,
-                ..
-            }) => {
-                let start_time = Instant::now();
-                let public_key = signer.mutate(|s| s.generate_new()).await?;
-                let mut context = ClientContext::new(
-                    storage.clone(),
-                    options.inner.clone(),
-                    wallet,
-                    Box::new(signer.into_value()),
-                );
-                let owner: AccountOwner = public_key.into();
-                info!(
-                    "Requesting a new chain for owner {owner} using the faucet at address \
-                    {faucet_url}",
-                );
-                let faucet = cli_wrappers::Faucet::new(faucet_url);
-                let outcome = faucet.claim(&owner).await?;
-                println!("{}", outcome.chain_id);
-                println!("{}", outcome.certificate_hash);
-                println!("{}", owner);
-                context
-                    .assign_new_chain_to_key(outcome.chain_id, owner)
-                    .await?;
-                let admin_id = context.wallet().genesis_admin_chain();
-                let chains = with_other_chains
-                    .into_iter()
-                    .chain([admin_id, outcome.chain_id]);
-                Self::print_peg_certificate_hash(storage, chains, &context).await?;
-                context
-                    .wallet_mut()
-                    .mutate(|w| w.set_default_chain(outcome.chain_id))
-                    .await??;
-                info!(
-                    "Wallet initialized in {} ms",
-                    start_time.elapsed().as_millis()
-                );
-            }
-
             Wallet(WalletCommand::RequestChain {
                 faucet: faucet_url,
                 set_default,
@@ -1324,67 +1282,6 @@ impl Runnable for Job {
                 unreachable!()
             }
         }
-        Ok(())
-    }
-}
-
-impl Job {
-    /// Prints a warning message to explain that the wallet has been initialized using data from
-    /// untrusted nodes, and gives instructions to verify that we are connected to the right
-    /// network.
-    async fn print_peg_certificate_hash<S>(
-        storage: S,
-        chain_ids: impl IntoIterator<Item = ChainId>,
-        context: &ClientContext<impl linera_core::Environment, impl Persist<Target = Wallet>>,
-    ) -> anyhow::Result<()>
-    where
-        S: Storage + Clone + Send + Sync + 'static,
-    {
-        let mut chains = HashMap::new();
-        for chain_id in chain_ids {
-            if chains.contains_key(&chain_id) {
-                continue;
-            }
-            chains.insert(chain_id, storage.load_chain(chain_id).await?);
-        }
-        // Find a chain with the latest known epoch, preferably the admin chain.
-        let (peg_chain_id, _) = chains
-            .iter()
-            .filter_map(|(chain_id, chain)| {
-                let epoch = (*chain.execution_state.system.epoch.get())?;
-                let is_admin = Some(*chain_id) == *chain.execution_state.system.admin_id.get();
-                Some((*chain_id, (epoch, is_admin)))
-            })
-            .max_by_key(|(_, epoch)| *epoch)
-            .context("no active chain found")?;
-        let peg_chain = chains.remove(&peg_chain_id).unwrap();
-        // These are the still-trusted committees. Every chain tip should be signed by one of them.
-        let committees = peg_chain.execution_state.system.committees.get();
-        for (chain_id, chain) in &chains {
-            let Some(hash) = chain.tip_state.get().block_hash else {
-                continue; // This chain was created based on the genesis config.
-            };
-            let certificate = storage.read_certificate(hash).await?;
-            let committee = committees
-                .get(&certificate.block().header.epoch)
-                .ok_or_else(|| anyhow!("tip of chain {chain_id} is outdated."))?;
-            certificate.check(committee)?;
-        }
-        // This proves that once we have verified that the peg chain's tip is a block in the real
-        // network, we can be confident that all downloaded chains are.
-        let config_hash = CryptoHash::new(context.wallet.genesis_config());
-        let maybe_epoch = peg_chain.execution_state.system.epoch.get();
-        let epoch = maybe_epoch.context("missing epoch in peg chain")?.0;
-        info!(
-            "Initialized wallet based on data provided by the faucet.\n\
-            The current epoch is {epoch}.\n\
-            The genesis config hash is {config_hash}{}",
-            if let Some(peg_hash) = peg_chain.tip_state.get().block_hash {
-                format!("\nThe latest certificate on chain {peg_chain_id} is {peg_hash}.")
-            } else {
-                "".to_string()
-            }
-        );
         Ok(())
     }
 }
@@ -2181,8 +2078,6 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
             WalletCommand::Init {
                 genesis_config_path,
                 faucet,
-                with_new_chain,
-                with_other_chains,
                 testing_prng_seed,
             } => {
                 let start_time = Instant::now();
@@ -2215,27 +2110,10 @@ Make sure to use a Linera client compatible with this network.
                     }
                     (_, _) => bail!("Either --faucet or --genesis must be specified, but not both"),
                 };
-                let timestamp = genesis_config.timestamp;
                 let mut keystore = options.create_keystore(*testing_prng_seed)?;
                 keystore.persist().await?;
-                options
-                    .create_wallet(genesis_config)?
-                    .mutate(|wallet| {
-                        wallet.extend(
-                            with_other_chains
-                                .iter()
-                                .map(|chain_id| UserChain::make_other(*chain_id, timestamp)),
-                        )
-                    })
-                    .await?;
+                options.create_wallet(genesis_config)?.persist().await?;
                 options.initialize_storage().boxed().await?;
-                if *with_new_chain {
-                    ensure!(
-                        faucet.is_some(),
-                        "Using --with-new-chain requires --faucet to be set"
-                    );
-                    options.run_with_storage(Job(options.clone())).await??;
-                }
                 info!(
                     "Wallet initialized in {} ms",
                     start_time.elapsed().as_millis()

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -733,7 +733,7 @@ async fn test_evm_execute_message_end_to_end_counter(config: impl LineraNetConfi
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await?;
+    client2.wallet_init(None).await?;
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
@@ -1013,7 +1013,7 @@ async fn test_wasm_end_to_end_social_event_streams(config: impl LineraNetConfig)
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await?;
+    client2.wallet_init(None).await?;
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
@@ -1107,7 +1107,7 @@ async fn test_wasm_end_to_end_fungible(
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await?;
+    client2.wallet_init(None).await?;
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
@@ -1396,7 +1396,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await?;
+    client2.wallet_init(None).await?;
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
@@ -1687,7 +1687,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await?;
+    client2.wallet_init(None).await?;
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
@@ -1817,8 +1817,8 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     let client_a = net.make_client().await;
     let client_b = net.make_client().await;
 
-    client_a.wallet_init(&[], None).await?;
-    client_b.wallet_init(&[], None).await?;
+    client_a.wallet_init(None).await?;
+    client_b.wallet_init(None).await?;
 
     // Create initial server and client config.
     let (contract_fungible_a, service_fungible_a) = client_a.build_example("fungible").await?;
@@ -2075,8 +2075,8 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
 
     let client0 = net.make_client().await;
     let client1 = net.make_client().await;
-    client0.wallet_init(&[], None).await?;
-    client1.wallet_init(&[], None).await?;
+    client0.wallet_init(None).await?;
+    client1.wallet_init(None).await?;
 
     let (contract_fungible, service_fungible) = client_amm.build_example("fungible").await?;
     let (contract_amm, service_amm) = client_amm.build_example("amm").await?;
@@ -2915,7 +2915,7 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) -> Resul
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await?;
+    client2.wallet_init(None).await?;
 
     // Get some chain owned by Client 1.
     let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
@@ -2961,7 +2961,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) ->
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await?;
+    client2.wallet_init(None).await?;
 
     let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
 
@@ -3071,10 +3071,10 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await?;
+    client2.wallet_init(None).await?;
 
     let client3 = net.make_client().await;
-    client3.wallet_init(&[], None).await?;
+    client3.wallet_init(None).await?;
 
     let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
 
@@ -3125,7 +3125,7 @@ async fn test_end_to_end_publish_data_blob_in_cli(config: impl LineraNetConfig) 
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await?;
+    client2.wallet_init(None).await?;
     client1.open_and_assign(&client2, Amount::ONE).await?;
 
     let tmp_dir = tempfile::tempdir()?;
@@ -3157,7 +3157,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await?;
+    client2.wallet_init(None).await?;
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let balance1 = client1.local_balance(Account::chain(chain1)).await?;
@@ -3178,7 +3178,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
 
     // Use the faucet directly to initialize client 3.
     let client3 = net.make_client().await;
-    client3.wallet_init(&[], None).await?;
+    client3.wallet_init(None).await?;
     let (outcome, _) = client3.request_chain(&faucet, false).await?;
     assert_eq!(
         outcome.chain_id,
@@ -3263,7 +3263,7 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
 
     // Create a new wallet using the faucet
     let client = net.make_client().await;
-    client.wallet_init(&[], Some(&faucet)).await?;
+    client.wallet_init(Some(&faucet)).await?;
     let (outcome, _) = client.request_chain(&faucet, true).await?;
 
     let chain = outcome.chain_id;
@@ -3356,7 +3356,7 @@ async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> 
     // Create runner and two clients.
     let (mut net, client1) = config.instantiate().await?;
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await?;
+    client2.wallet_init(None).await?;
     let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
 
     // Open a chain owned by both clients, with only single-leader rounds.
@@ -3468,7 +3468,7 @@ async fn test_end_to_end_repeated_transfers(config: impl LineraNetConfig) -> Res
     let (mut net, client1) = config.instantiate().await?;
     let chain_id1 = client1.load_wallet()?.default_chain().unwrap();
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await?;
+    client2.wallet_init(None).await?;
     let chain_id2 = client1.open_and_assign(&client2, Amount::ONE).await?;
     let port1 = get_node_port().await;
     let port2 = get_node_port().await;

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -58,7 +58,7 @@ use linera_service::cli_wrappers::{
 use linera_service::{
     cli_wrappers::{
         local_net::{get_node_port, ProcessInbox},
-        ApplicationWrapper, ClientWrapper, FaucetOption, LineraNet, LineraNetConfig,
+        ApplicationWrapper, ClientWrapper, LineraNet, LineraNetConfig,
     },
     test_name,
 };
@@ -733,7 +733,7 @@ async fn test_evm_execute_message_end_to_end_counter(config: impl LineraNetConfi
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], FaucetOption::None).await?;
+    client2.wallet_init(&[], None).await?;
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
@@ -1013,7 +1013,7 @@ async fn test_wasm_end_to_end_social_event_streams(config: impl LineraNetConfig)
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], FaucetOption::None).await?;
+    client2.wallet_init(&[], None).await?;
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
@@ -1107,7 +1107,7 @@ async fn test_wasm_end_to_end_fungible(
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], FaucetOption::None).await?;
+    client2.wallet_init(&[], None).await?;
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
@@ -1396,7 +1396,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], FaucetOption::None).await?;
+    client2.wallet_init(&[], None).await?;
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
@@ -1687,7 +1687,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], FaucetOption::None).await?;
+    client2.wallet_init(&[], None).await?;
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
@@ -1817,8 +1817,8 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     let client_a = net.make_client().await;
     let client_b = net.make_client().await;
 
-    client_a.wallet_init(&[], FaucetOption::None).await?;
-    client_b.wallet_init(&[], FaucetOption::None).await?;
+    client_a.wallet_init(&[], None).await?;
+    client_b.wallet_init(&[], None).await?;
 
     // Create initial server and client config.
     let (contract_fungible_a, service_fungible_a) = client_a.build_example("fungible").await?;
@@ -2075,8 +2075,8 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
 
     let client0 = net.make_client().await;
     let client1 = net.make_client().await;
-    client0.wallet_init(&[], FaucetOption::None).await?;
-    client1.wallet_init(&[], FaucetOption::None).await?;
+    client0.wallet_init(&[], None).await?;
+    client1.wallet_init(&[], None).await?;
 
     let (contract_fungible, service_fungible) = client_amm.build_example("fungible").await?;
     let (contract_amm, service_amm) = client_amm.build_example("amm").await?;
@@ -2915,7 +2915,7 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) -> Resul
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], FaucetOption::None).await?;
+    client2.wallet_init(&[], None).await?;
 
     // Get some chain owned by Client 1.
     let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
@@ -2961,7 +2961,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) ->
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], FaucetOption::None).await?;
+    client2.wallet_init(&[], None).await?;
 
     let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
 
@@ -3071,10 +3071,10 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], FaucetOption::None).await?;
+    client2.wallet_init(&[], None).await?;
 
     let client3 = net.make_client().await;
-    client3.wallet_init(&[], FaucetOption::None).await?;
+    client3.wallet_init(&[], None).await?;
 
     let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
 
@@ -3125,7 +3125,7 @@ async fn test_end_to_end_publish_data_blob_in_cli(config: impl LineraNetConfig) 
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], FaucetOption::None).await?;
+    client2.wallet_init(&[], None).await?;
     client1.open_and_assign(&client2, Amount::ONE).await?;
 
     let tmp_dir = tempfile::tempdir()?;
@@ -3157,7 +3157,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
     let (mut net, client1) = config.instantiate().await?;
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], FaucetOption::None).await?;
+    client2.wallet_init(&[], None).await?;
 
     let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let balance1 = client1.local_balance(Account::chain(chain1)).await?;
@@ -3178,7 +3178,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
 
     // Use the faucet directly to initialize client 3.
     let client3 = net.make_client().await;
-    client3.wallet_init(&[], FaucetOption::None).await?;
+    client3.wallet_init(&[], None).await?;
     let (outcome, _) = client3.request_chain(&faucet, false).await?;
     assert_eq!(
         outcome.chain_id,
@@ -3263,10 +3263,8 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
 
     // Create a new wallet using the faucet
     let client = net.make_client().await;
-    let (outcome, _) = client
-        .wallet_init(&[], FaucetOption::NewChain(&faucet))
-        .await?
-        .unwrap();
+    client.wallet_init(&[], Some(&faucet)).await?;
+    let (outcome, _) = client.request_chain(&faucet, true).await?;
 
     let chain = outcome.chain_id;
     assert_eq!(chain, client.load_wallet()?.default_chain().unwrap());
@@ -3358,7 +3356,7 @@ async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> 
     // Create runner and two clients.
     let (mut net, client1) = config.instantiate().await?;
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], FaucetOption::None).await?;
+    client2.wallet_init(&[], None).await?;
     let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
 
     // Open a chain owned by both clients, with only single-leader rounds.
@@ -3470,7 +3468,7 @@ async fn test_end_to_end_repeated_transfers(config: impl LineraNetConfig) -> Res
     let (mut net, client1) = config.instantiate().await?;
     let chain_id1 = client1.load_wallet()?.default_chain().unwrap();
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], FaucetOption::None).await?;
+    client2.wallet_init(&[], None).await?;
     let chain_id2 = client1.open_and_assign(&client2, Amount::ONE).await?;
     let port1 = get_node_port().await;
     let port2 = get_node_port().await;

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -62,7 +62,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
     let (mut net, client) = config.instantiate().await?;
 
     let faucet_client = net.make_client().await;
-    faucet_client.wallet_init(&[], None).await?;
+    faucet_client.wallet_init(None).await?;
 
     let faucet_chain = client
         .open_and_assign(&faucet_client, Amount::from_tokens(1_000u128))
@@ -79,7 +79,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
     assert_eq!(faucet.current_validators().await?.len(), 4);
 
     let client_2 = net.make_client().await;
-    client_2.wallet_init(&[], None).await?;
+    client_2.wallet_init(None).await?;
     let chain_1 = client
         .load_wallet()?
         .default_chain()
@@ -247,7 +247,7 @@ async fn test_end_to_end_receipt_of_old_create_committee_messages(
     let (mut net, client) = config.instantiate().await?;
 
     let faucet_client = net.make_client().await;
-    faucet_client.wallet_init(&[], None).await?;
+    faucet_client.wallet_init(None).await?;
 
     let faucet_chain = client
         .open_and_assign(&faucet_client, Amount::from_tokens(1_000u128))
@@ -335,7 +335,7 @@ async fn test_end_to_end_receipt_of_old_remove_committee_messages(
     let (mut net, client) = config.instantiate().await?;
 
     let faucet_client = net.make_client().await;
-    faucet_client.wallet_init(&[], None).await?;
+    faucet_client.wallet_init(None).await?;
 
     let faucet_chain = client
         .open_and_assign(&faucet_client, Amount::from_tokens(1_000u128))
@@ -458,7 +458,8 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetConfig) -> Re
 
     let client2 = net.make_client().await;
     let mut height = 0;
-    client2.wallet_init(&[chain], None).await?;
+    client2.wallet_init(None).await?;
+    client2.follow_chain(chain).await?;
 
     // Listen for updates on root chain 0. There are no blocks on that chain yet.
     let port = get_node_port().await;

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -28,7 +28,7 @@ use linera_sdk::linera_base_types::AccountSecretKey;
 use linera_service::{
     cli_wrappers::{
         local_net::{get_node_port, Database, LocalNet, LocalNetConfig, ProcessInbox},
-        ClientWrapper, FaucetOption, LineraNet, LineraNetConfig, Network,
+        ClientWrapper, LineraNet, LineraNetConfig, Network,
     },
     test_name,
 };
@@ -62,7 +62,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
     let (mut net, client) = config.instantiate().await?;
 
     let faucet_client = net.make_client().await;
-    faucet_client.wallet_init(&[], FaucetOption::None).await?;
+    faucet_client.wallet_init(&[], None).await?;
 
     let faucet_chain = client
         .open_and_assign(&faucet_client, Amount::from_tokens(1_000u128))
@@ -79,7 +79,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
     assert_eq!(faucet.current_validators().await?.len(), 4);
 
     let client_2 = net.make_client().await;
-    client_2.wallet_init(&[], FaucetOption::None).await?;
+    client_2.wallet_init(&[], None).await?;
     let chain_1 = client
         .load_wallet()?
         .default_chain()
@@ -247,7 +247,7 @@ async fn test_end_to_end_receipt_of_old_create_committee_messages(
     let (mut net, client) = config.instantiate().await?;
 
     let faucet_client = net.make_client().await;
-    faucet_client.wallet_init(&[], FaucetOption::None).await?;
+    faucet_client.wallet_init(&[], None).await?;
 
     let faucet_chain = client
         .open_and_assign(&faucet_client, Amount::from_tokens(1_000u128))
@@ -335,7 +335,7 @@ async fn test_end_to_end_receipt_of_old_remove_committee_messages(
     let (mut net, client) = config.instantiate().await?;
 
     let faucet_client = net.make_client().await;
-    faucet_client.wallet_init(&[], FaucetOption::None).await?;
+    faucet_client.wallet_init(&[], None).await?;
 
     let faucet_chain = client
         .open_and_assign(&faucet_client, Amount::from_tokens(1_000u128))
@@ -458,7 +458,7 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetConfig) -> Re
 
     let client2 = net.make_client().await;
     let mut height = 0;
-    client2.wallet_init(&[chain], FaucetOption::None).await?;
+    client2.wallet_init(&[chain], None).await?;
 
     // Listen for updates on root chain 0. There are no blocks on that chain yet.
     let port = get_node_port().await;


### PR DESCRIPTION
## Motivation

`--with-new-chain` and `--with-other-chains` are not necessary anymore; `request-chain` and `follow-chain` should be used instead.

## Proposal

Remove them, and the `FaucetOption` enum.

Also don't print the latest hash anymore: This was meant to avoid trusting the faucet or expired committees, but we already don't sync on `wallet init` anymore, so it's in the wrong place. I created #3909 to revisit this once we address the rest of the long-range attack issue.

## Test Plan

The tests were updated to use `request-chain` instead.

## Release Plan

- Before the next testnet, the Linera Manual needs to be updated.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/3399.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
