### PR TITLE
Patch GraphQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,12 +1019,11 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-graphql"
 version = "7.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba89a35adbed833e0d21db467093a087c3a07b497626009eae02cb36f060567"
+source = "git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18#02e3f66810ac10b9454a23a154a4be5f56a2fac8"
 dependencies = [
- "async-graphql-derive",
- "async-graphql-parser",
- "async-graphql-value",
+ "async-graphql-derive 7.0.2 (git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18)",
+ "async-graphql-parser 7.0.2",
+ "async-graphql-value 7.0.2",
  "async-stream",
  "async-trait",
  "base64 0.21.7",
@@ -1052,8 +1051,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-axum"
 version = "7.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74cb0d91622015797c94dbb862580ba5e89bfd4b9066ad7d8d9ac8e1ca5ab6f8"
+source = "git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18#02e3f66810ac10b9454a23a154a4be5f56a2fac8"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -1074,7 +1072,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9547f7f22688f022ea8001bdd57a1fce8996045dcb959b1730a79bafd366a9d9"
 dependencies = [
  "Inflector",
- "async-graphql-parser",
+ "async-graphql-parser 7.0.13",
+ "darling",
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "strum 0.25.0",
+ "syn 2.0.100",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "async-graphql-derive"
+version = "7.0.2"
+source = "git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18#02e3f66810ac10b9454a23a154a4be5f56a2fac8"
+dependencies = [
+ "Inflector",
+ "async-graphql-parser 7.0.2",
  "darling",
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -1086,12 +1100,34 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
+version = "7.0.2"
+source = "git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18#02e3f66810ac10b9454a23a154a4be5f56a2fac8"
+dependencies = [
+ "async-graphql-value 7.0.2",
+ "pest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-graphql-parser"
 version = "7.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d271ddda2f55b13970928abbcbc3423cfc18187c60e8769b48f21a93b7adaa"
 dependencies = [
- "async-graphql-value",
+ "async-graphql-value 7.0.13",
  "pest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-graphql-value"
+version = "7.0.2"
+source = "git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18#02e3f66810ac10b9454a23a154a4be5f56a2fac8"
+dependencies = [
+ "bytes",
+ "indexmap 2.7.0",
  "serde",
  "serde_json",
 ]
@@ -4621,7 +4657,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-graphql",
- "async-graphql-derive",
+ "async-graphql-derive 7.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "bcs",
  "cfg-if",
@@ -5314,7 +5350,7 @@ version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-graphql",
- "async-graphql-derive",
+ "async-graphql-derive 7.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.22.1",
  "cargo_metadata",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -283,5 +283,10 @@ branch = "no-uuid-wasm-bindgen"
 git = "https://github.com/Twey/wasm_thread"
 branch = "post-message"
 
+[patch.crates-io]
+async-graphql = { git = "https://github.com/deuszx/async-graphql", branch = "v7.0.2-react18" }
+async-graphql-axum = { git = "https://github.com/deuszx/async-graphql", branch = "v7.0.2-react18" }
+async-graphql-value = { git = "https://github.com/deuszx/async-graphql", branch = "v7.0.2-react18" }
+
 [workspace.metadata.spellcheck]
 config = "spellcheck-cfg.toml"


### PR DESCRIPTION
## Motivation

GraphQL playground is not working (see https://github.com/async-graphql/async-graphql/issues/1703)

## Proposal

Patch it to a fork of async-graphql where `v7.0.2` is patched to use React18.

## Test Plan
Tested locally and it works
<img width="1443" alt="Screenshot 2025-05-08 at 13 16 42" src="https://github.com/user-attachments/assets/affb9123-2f4f-4aef-a7f8-d249b6f0c5fb" />

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.
- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- Backporting is not possible but we may want to deploy a new `devnet` and release a new
      SDK soon.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
