### PR TITLE
Fix error msg enrichement for Bytecode::load_from_file

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -640,12 +640,24 @@ where
         vm_runtime: VmRuntime,
     ) -> Result<ModuleId, Error> {
         info!("Loading bytecode files");
-        let contract_bytecode = Bytecode::load_from_file(&contract)
-            .await
-            .with_context(|| format!("failed to load contract bytecode from {:?}", &contract))?;
-        let service_bytecode = Bytecode::load_from_file(&service)
-            .await
-            .with_context(|| format!("failed to load service bytecode from {:?}", &service))?;
+        let contract_bytecode = Bytecode::load_from_file(&contract).await.map_err(|e| {
+            error::Inner::Persistence(
+                format!(
+                    "failed to load contract bytecode from {:?}. error: {}",
+                    &contract, e
+                )
+                .into(),
+            )
+        })?;
+        let service_bytecode = Bytecode::load_from_file(&service).await.map_err(|e| {
+            error::Inner::Persistence(
+                format!(
+                    "failed to load service bytecode from {:?}. error: {}",
+                    &service, e
+                )
+                .into(),
+            )
+        })?;
 
         info!("Publishing module");
         let (blobs, module_id) =


### PR DESCRIPTION
## Motivation

When we fail to load the `Bytecode` the errors message doesn't contain the path:
```
2025-05-08T11:07:28.399520Z ERROR linera: Error is persistence error: I/O error: No such file or directory (os error 2)
```

even though the code tries to add it. The issue seems to be due to a mismatch between the error type returned `load_from_file` function and the expectations of `.with_context` from the `anyhow` crate.

`load_from_file` returns `std::io::Result<Self>`, which means the error type is `std::io::Error`. However, `with_context` is only available on `Result<T, anyhow::Error>`, and it only adds context to errors that are already converted to `anyhow::Error`.

## Proposal

Enrich the log manually on the callsite.

## Test Plan

Tested locally and the result is now
```
2025-05-08T11:20:04.498782Z ERROR linera: Error is persistence error: failed to load contract bytecode from "./target/wasm32-unknown-unknown/release/my-counter_contract.wasm". error: No such file or directory (os error 2)
```

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
