### PR TITLE
Improve download certificate performance.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -410,41 +410,34 @@ where
         S: Storage + Clone + Send + Sync + 'static,
     {
         let node_provider = self.make_node_provider();
-        let client = self.client.clone_with(
-            node_provider.clone(),
-            "Temporary client for fetching the parent chain",
-            vec![message_id.chain_id, chain_id],
-            false,
-        );
+        self.client.track_chain(chain_id);
 
         // Take the latest committee we know of.
         let admin_chain_id = self.wallet.genesis_admin_chain();
         let query = ChainInfoQuery::new(admin_chain_id).with_committees();
-        let nodes: Vec<_> = if let Some(validators) = validators {
-            node_provider
-                .make_nodes_from_list(validators)?
-                .map(|(public_key, node)| RemoteNode { public_key, node })
-                .collect()
-        } else {
-            let info = client.local_node().handle_chain_info_query(query).await?;
-            let committee = info
-                .latest_committee()
-                .ok_or(error::Inner::ChainInfoResponseMissingCommittee)?;
-            node_provider
-                .make_nodes(committee)?
-                .map(|(public_key, node)| RemoteNode { public_key, node })
-                .collect()
-        };
+        let info = self
+            .client
+            .local_node()
+            .handle_chain_info_query(query)
+            .await?;
+        let committee = info
+            .latest_committee()
+            .ok_or(error::Inner::ChainInfoResponseMissingCommittee)?;
+        let nodes: Vec<_> = node_provider
+            .make_nodes(committee)?
+            .map(|(public_key, node)| RemoteNode { public_key, node })
+            .collect();
 
         // Download the parent chain.
         let target_height = message_id.height.try_add_one()?;
-        client
-            .download_certificates(&nodes, message_id.chain_id, target_height)
+        self.client
+            .download_certificates(&nodes, message_id.chain_id, target_height, committee.clone())
             .await
             .context("downloading parent chain")?;
 
         // The initial timestamp for the new chain is taken from the block with the message.
-        let certificate = client
+        let certificate = self
+            .client
             .local_node()
             .certificate_for(&message_id)
             .await

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -317,6 +317,7 @@ impl<P, S: Storage + Clone> Client<P, S> {
     }
 }
 
+
 impl<P, S> Client<P, S>
 where
     P: ValidatorNodeProvider + Sync + 'static,
@@ -329,32 +330,51 @@ where
         validators: &[RemoteNode<impl ValidatorNode>],
         chain_id: ChainId,
         target_next_block_height: BlockHeight,
+        committee: Committee
     ) -> Result<Box<ChainInfo>, ChainClientError> {
-        // Sequentially try each validator in random order.
-        let mut validators = validators.iter().collect::<Vec<_>>();
-        validators.shuffle(&mut rand::thread_rng());
-        for remote_node in validators {
-            let info = self.local_node.chain_info(chain_id).await?;
-            if target_next_block_height <= info.next_block_height {
-                return Ok(info);
-            }
-            self.try_download_certificates_from(
-                remote_node,
-                chain_id,
-                info.next_block_height,
-                target_next_block_height,
-            )
-            .await?;
-        }
+        // Request certificates in parallel from 1/3 + 1 of total validators in terms of votes.
+        let mut validators_and_votes = validators.iter()
+            .map(|validator| (validator, committee.validators.get(&validator.public_key).expect("validator should always be in committee").votes))
+            .collect::<Vec<_>>();
+        validators_and_votes.shuffle(&mut rand::thread_rng());
+        let sufficient_threshold = (committee.total_votes() / 3) + 1;
+        let sufficient_validator_subset: Vec<_> = validators_and_votes
+            .into_iter()
+            .scan(0u64, move |sum, (validator, votes)| {
+                let prev = *sum;
+                *sum += votes;
+                (prev < sufficient_threshold).then(|| validator)
+            })
+            .collect();
         let info = self.local_node.chain_info(chain_id).await?;
         if target_next_block_height <= info.next_block_height {
-            Ok(info)
-        } else {
-            Err(ChainClientError::CannotDownloadCertificates {
-                chain_id,
-                target_next_block_height,
-            })
+            return Ok(info);
         }
+        let mut stream = sufficient_validator_subset
+            .iter()
+            .map(|remote_node| {
+                let info = info.clone();
+                async move {
+                    self.try_download_certificates_from(
+                        remote_node,
+                        chain_id,
+                        info.next_block_height,
+                        target_next_block_height,
+                    ).await
+                }}).collect::<FuturesUnordered<_>>();
+        while let Some(downloaded) = stream.next().await {
+            if downloaded.is_ok() {
+                let info = self.local_node.chain_info(chain_id).await?;
+                if target_next_block_height <= info.next_block_height {
+                    return Ok(info);
+                }
+            }
+        }
+        Err(ChainClientError::CannotDownloadCertificates {
+            chain_id,
+            target_next_block_height,
+        })
+
     }
 
     /// Downloads and processes all certificates up to (excluding) the specified height from the
@@ -1077,7 +1097,7 @@ where
         let nodes = self.validator_nodes().await?;
         let info = self
             .client
-            .download_certificates(&nodes, self.chain_id, next_block_height)
+            .download_certificates(&nodes, self.chain_id, next_block_height, self.local_committee().await?)
             .await?;
         if info.next_block_height == next_block_height {
             // Check that our local node has the expected block hash.
@@ -1316,7 +1336,7 @@ where
             self.make_nodes(remote_committee)?
         };
         self.client
-            .download_certificates(&nodes, block.header.chain_id, block.header.height)
+            .download_certificates(&nodes, block.header.chain_id, block.header.height, self.local_committee().await?)
             .await?;
         // Process the received operations. Download required hashed certificate values if
         // necessary.

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1026,7 +1026,7 @@ impl Runnable for Job {
                     {owner}",
                 );
                 context
-                    .assign_new_chain_to_key(chain_id, message_id, owner, None)
+                    .assign_new_chain_to_key(chain_id, message_id, owner)
                     .await?;
                 println!("{}", chain_id);
                 context.save_wallet().await?;
@@ -1134,18 +1134,12 @@ impl Runnable for Job {
                     .await?;
                 let faucet = cli_wrappers::Faucet::new(faucet_url);
                 let outcome = faucet.claim(&owner).await?;
-                let validators = faucet.current_validators().await?;
                 println!("{}", outcome.chain_id);
                 println!("{}", outcome.message_id);
                 println!("{}", outcome.certificate_hash);
                 println!("{}", owner);
                 context
-                    .assign_new_chain_to_key(
-                        outcome.chain_id,
-                        outcome.message_id,
-                        owner,
-                        Some(validators),
-                    )
+                    .assign_new_chain_to_key(outcome.chain_id, outcome.message_id, owner)
                     .await?;
                 let admin_id = context.wallet().genesis_admin_chain();
                 let chains = with_other_chains
@@ -1179,18 +1173,12 @@ impl Runnable for Job {
                     .await?;
                 let faucet = cli_wrappers::Faucet::new(faucet_url);
                 let outcome = faucet.claim(&owner).await?;
-                let validators = faucet.current_validators().await?;
                 println!("{}", outcome.chain_id);
                 println!("{}", outcome.message_id);
                 println!("{}", outcome.certificate_hash);
                 println!("{}", owner);
                 context
-                    .assign_new_chain_to_key(
-                        outcome.chain_id,
-                        outcome.message_id,
-                        owner,
-                        Some(validators),
-                    )
+                    .assign_new_chain_to_key(outcome.chain_id, outcome.message_id, owner)
                     .await?;
                 if set_default {
                     context


### PR DESCRIPTION
Continuation of #3862 

## Motivation

Currently, slow or inactive validators can slow down the process of downloading certificates. We can prevent this by downloading them from multiple validators in parallel.

## Proposal

Download certificates from 1/3 of the validators in parallel instead of trying the validators one by one.

## Test Plan

CI will make sure that no functionality is broken.
Manual benchmarks against the testnet will be used to determine if the performance improvement is noticeable.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,

## Links

- [Previous PR](https://github.com/linera-io/linera-protocol/pull/3862)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
