### PR TITLE
Move cross-chain error log to after the loop.

### DIFF
--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -455,16 +455,16 @@ where
                                     to_shard = shard_id,
                                     "Sent cross-chain query",
                                 );
-                                break;
+                                return;
                             }
                         }
-                        error!(
-                            nickname,
-                            from_shard = this_shard,
-                            to_shard = shard_id,
-                            "Dropping cross-chain query",
-                        );
                     }
+                    error!(
+                        nickname,
+                        from_shard = this_shard,
+                        to_shard = shard_id,
+                        "Dropping cross-chain query",
+                    );
                 }
             })
             .await;

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -91,7 +91,7 @@ where
             .await
             .expect("Initialization should not fail");
 
-        while let Some((message, shard_id)) = receiver.next().await {
+        'receive_loop: while let Some((message, shard_id)) = receiver.next().await {
             if cross_chain_sender_failure_rate > 0.0
                 && rand::thread_rng().gen::<f32>() < cross_chain_sender_failure_rate
             {
@@ -128,16 +128,16 @@ where
                             to_shard = shard_id,
                             "Sent cross-chain query",
                         );
-                        break;
+                        continue 'receive_loop;
                     }
                 }
-                error!(
-                    nickname,
-                    from_shard = this_shard,
-                    to_shard = shard_id,
-                    "Dropping cross-chain query",
-                );
             }
+            error!(
+                nickname,
+                from_shard = this_shard,
+                to_shard = shard_id,
+                "Dropping cross-chain query",
+            );
         }
     }
 


### PR DESCRIPTION
## Motivation

The error log `Dropping cross-chain query` is printed on every retry attempt.

## Proposal

Print it only after the last attempt.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
