### PR TITLE
Use non admin chain for faucet if chain not specified

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -262,6 +262,12 @@ where
             .expect("No chain specified in wallet with no default chain")
     }
 
+    pub fn first_non_admin_chain(&self) -> ChainId {
+        self.wallet
+            .first_non_admin_chain()
+            .expect("No non-admin chain specified in wallet with no non-admin chain")
+    }
+
     pub async fn make_chain_client(&self, chain_id: ChainId) -> Result<ChainClient<Env>, Error> {
         // We only create clients for chains we have in the wallet, or for the admin chain.
         let chain: UserChain = match self.wallet.get(chain_id) {

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -79,6 +79,12 @@ impl Wallet {
         self.default
     }
 
+    pub fn first_non_admin_chain(&self) -> Option<ChainId> {
+        self.chain_ids()
+            .into_iter()
+            .find(|chain_id| *chain_id != self.genesis_config.admin_id)
+    }
+
     pub fn chain_ids(&self) -> Vec<ChainId> {
         self.chains.keys().copied().collect()
     }

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -919,7 +919,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
 
-                let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
+                let chain_id = chain_id.unwrap_or_else(|| context.first_non_admin_chain());
                 info!("Starting faucet service using chain {}", chain_id);
                 let end_timestamp = limit_rate_until
                     .map(|et| {


### PR DESCRIPTION
## Motivation

Right now if you don't specify a chain, the faucet will just use the default chain of the wallet. However, for the faucet, this will often be using the admin wallet, which means the default chain will be the admin chain.

## Proposal

Instead of using the default chain, use a non admin chain instead in this case.

## Test Plan

Deployed a network with a faucet using this updated code, and it works as expected.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
