### PR TITLE
Update explorer.yml – bump setup-node to v4

### DIFF
--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Check toolchain symlinks
       run: |


### PR DESCRIPTION
v3 is outdated. v4 is the latest stable version and works better with Node.js 20.
Official info: [setup-node v4 release](https://github.com/actions/setup-node/releases/tag/v4.0.0)
