### PR TITLE
Fix authenticated signer when re-proposing a fast block.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -204,6 +204,21 @@ pub struct MessageBundle {
     pub messages: Vec<PostedMessage>,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(with_testing, derive(Eq, PartialEq))]
+/// An earlier proposal that is being retried.
+pub enum OriginalProposal {
+    /// A proposal in the fast round.
+    Fast {
+        public_key: AccountPublicKey,
+        signature: AccountSignature,
+    },
+    /// A validated block certificate from an earlier round.
+    Regular {
+        certificate: LiteCertificate<'static>,
+    },
+}
+
 /// An authenticated proposal for a new block.
 // TODO(#456): the signature of the block owner is currently lost but it would be useful
 // to have it for auditing purposes.
@@ -214,7 +229,7 @@ pub struct BlockProposal {
     pub public_key: AccountPublicKey,
     pub signature: AccountSignature,
     #[debug(skip_if = Option::is_none)]
-    pub validated_block_certificate: Option<LiteCertificate<'static>>,
+    pub original_proposal: Option<OriginalProposal>,
 }
 
 /// A message together with kind, authentication and grant information.
@@ -502,17 +517,42 @@ impl BlockProposal {
             content,
             public_key,
             signature,
-            validated_block_certificate: None,
+            original_proposal: None,
         })
     }
 
-    pub async fn new_retry(
+    pub async fn new_retry_fast(
+        owner: AccountOwner,
+        round: Round,
+        old_proposal: BlockProposal,
+        signer: &(impl Signer + ?Sized),
+    ) -> Result<Self, Box<dyn Error>> {
+        let content = ProposalContent {
+            round,
+            block: old_proposal.content.block,
+            outcome: None,
+        };
+        let signature = signer.sign(&owner, &CryptoHash::new(&content)).await?;
+        let public_key = signer.get_public_key(&owner).await?;
+
+        Ok(Self {
+            content,
+            public_key,
+            signature,
+            original_proposal: Some(OriginalProposal::Fast {
+                public_key: old_proposal.public_key,
+                signature: old_proposal.signature,
+            }),
+        })
+    }
+
+    pub async fn new_retry_regular(
         owner: AccountOwner,
         round: Round,
         validated_block_certificate: ValidatedBlockCertificate,
         signer: &(impl Signer + ?Sized),
     ) -> Result<Self, Box<dyn Error>> {
-        let lite_cert = validated_block_certificate.lite_certificate().cloned();
+        let certificate = validated_block_certificate.lite_certificate().cloned();
         let block = validated_block_certificate.into_inner().into_inner();
         let (block, outcome) = block.into_proposal();
         let content = ProposalContent {
@@ -527,7 +567,7 @@ impl BlockProposal {
             content,
             public_key,
             signature,
-            validated_block_certificate: Some(lite_cert),
+            original_proposal: Some(OriginalProposal::Regular { certificate }),
         })
     }
 
@@ -558,17 +598,19 @@ impl BlockProposal {
     /// Checks that the public key matches the owner and that the optional certificate matches
     /// the outcome.
     pub fn check_invariants(&self) -> Result<(), &'static str> {
-        match (&self.validated_block_certificate, &self.content.outcome) {
-            (None, None) => {}
-            (None, Some(_)) | (Some(_), None) => {
+        match (&self.original_proposal, &self.content.outcome) {
+            (None, None) | (Some(OriginalProposal::Fast { .. }), None) => {}
+            (None, Some(_))
+            | (Some(OriginalProposal::Fast { .. }), Some(_))
+            | (Some(OriginalProposal::Regular { .. }), None) => {
                 return Err("Must contain a validation certificate if and only if \
                      it contains the execution outcome from a previous round");
             }
-            (Some(lite_certificate), Some(outcome)) => {
+            (Some(OriginalProposal::Regular { certificate }), Some(outcome)) => {
                 let block = outcome.clone().with(self.content.block.clone());
                 let value = ValidatedBlock::new(block);
                 ensure!(
-                    lite_certificate.check_value(&value),
+                    certificate.check_value(&value),
                     "Lite certificate must match the given block and execution outcome"
                 );
             }

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -454,8 +454,8 @@ where
     ) -> Result<Option<ValidatedOrConfirmedVote>, ChainError> {
         let round = proposal.content.round;
 
-        // If the validated block certificate is more recent, update our locking block.
         match &proposal.original_proposal {
+            // If the validated block certificate is more recent, update our locking block.
             Some(OriginalProposal::Regular { certificate }) => {
                 if self
                     .locking_block
@@ -469,6 +469,8 @@ where
                     }
                 }
             }
+            // If this contains a proposal from the fast round, we consider that a locking block.
+            // It is useful for clients synchronizing with us, so they can re-propose it.
             Some(OriginalProposal::Fast {
                 public_key,
                 signature,
@@ -482,6 +484,8 @@ where
                     self.update_locking(LockingBlock::Fast(original_proposal), blobs.clone())?;
                 }
             }
+            // If this proposal itself is from the fast round, it is also a locking block: We
+            // will vote to confirm it, so it is locked.
             None => {
                 if round.is_fast() && self.locking_block.get().is_none() {
                     // The fast block also counts as locking.

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -92,7 +92,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     block::{Block, ConfirmedBlock, Timeout, ValidatedBlock},
-    data_types::{BlockProposal, LiteVote, ProposedBlock, Vote},
+    data_types::{BlockProposal, LiteVote, OriginalProposal, ProposedBlock, Vote},
     types::{TimeoutCertificate, ValidatedBlockCertificate},
     ChainError,
 };
@@ -343,10 +343,13 @@ where
         // if there is a validated block certificate from a later round.
         if let Some(vote) = self.confirmed_vote() {
             ensure!(
-                if let Some(validated_cert) = proposal.validated_block_certificate.as_ref() {
-                    vote.round <= validated_cert.round
-                } else {
-                    vote.round.is_fast() && vote.value().matches_proposed_block(new_block)
+                match proposal.original_proposal.as_ref() {
+                    None => false,
+                    Some(OriginalProposal::Regular { certificate }) =>
+                        vote.round <= certificate.round,
+                    Some(OriginalProposal::Fast { .. }) => {
+                        vote.round.is_fast() && vote.value().matches_proposed_block(new_block)
+                    }
                 },
                 ChainError::HasIncompatibleConfirmedVote(new_block.height, vote.round)
             );
@@ -452,21 +455,39 @@ where
         let round = proposal.content.round;
 
         // If the validated block certificate is more recent, update our locking block.
-        if let Some(lite_cert) = &proposal.validated_block_certificate {
-            if self
-                .locking_block
-                .get()
-                .as_ref()
-                .is_none_or(|locking| locking.round() < lite_cert.round)
-            {
-                let value = ValidatedBlock::new(block.clone());
-                if let Some(certificate) = lite_cert.clone().with_value(value) {
-                    self.update_locking(LockingBlock::Regular(certificate), blobs.clone())?;
+        match &proposal.original_proposal {
+            Some(OriginalProposal::Regular { certificate }) => {
+                if self
+                    .locking_block
+                    .get()
+                    .as_ref()
+                    .is_none_or(|locking| locking.round() < certificate.round)
+                {
+                    let value = ValidatedBlock::new(block.clone());
+                    if let Some(certificate) = certificate.clone().with_value(value) {
+                        self.update_locking(LockingBlock::Regular(certificate), blobs.clone())?;
+                    }
                 }
             }
-        } else if round.is_fast() && self.locking_block.get().is_none() {
-            // The fast block also counts as locking.
-            self.update_locking(LockingBlock::Fast(proposal.clone()), blobs.clone())?;
+            Some(OriginalProposal::Fast {
+                public_key,
+                signature,
+            }) => {
+                if self.locking_block.get().is_none() {
+                    let original_proposal = BlockProposal {
+                        public_key: *public_key,
+                        signature: *signature,
+                        ..proposal.clone()
+                    };
+                    self.update_locking(LockingBlock::Fast(original_proposal), blobs.clone())?;
+                }
+            }
+            None => {
+                if round.is_fast() && self.locking_block.get().is_none() {
+                    // The fast block also counts as locking.
+                    self.update_locking(LockingBlock::Fast(proposal.clone()), blobs.clone())?;
+                }
+            }
         }
 
         // We record the proposed block, in case it affects the current round number.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2744,12 +2744,12 @@ impl<Env: Environment> ChainClient<Env> {
         let proposal = if let Some(locking) = info.manager.requested_locking {
             Box::new(match *locking {
                 LockingBlock::Regular(cert) => {
-                    BlockProposal::new_retry(owner, round, cert, self.signer())
+                    BlockProposal::new_retry_regular(owner, round, cert, self.signer())
                         .await
                         .map_err(ChainClientError::signer_failure)?
                 }
                 LockingBlock::Fast(proposal) => {
-                    BlockProposal::new_initial(owner, round, proposal.content.block, self.signer())
+                    BlockProposal::new_retry_fast(owner, round, proposal, self.signer())
                         .await
                         .map_err(ChainClientError::signer_failure)?
                 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -6,6 +6,8 @@ mod test_helpers;
 #[path = "./wasm_client_tests.rs"]
 mod wasm;
 
+use std::collections::{BTreeMap, BTreeSet};
+
 use assert_matches::assert_matches;
 use futures::StreamExt;
 use linera_base::{
@@ -2246,6 +2248,117 @@ where
     assert_eq!(
         client0.local_balance().await.unwrap(),
         Amount::from_tokens(3)
+    );
+    Ok(())
+}
+
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_re_propose_fast_block<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    // Configure a chain with one regular and one super owner.
+    let mut signer = InMemorySigner::new(None);
+    let clock = storage_builder.clock().clone();
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, &mut signer).await?;
+    let client0 = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
+    let chain_id = client0.chain_id();
+    let owner0 = client0.public_key().await.unwrap().into();
+    let owner1 = builder.signer.generate_new().into();
+
+    let timeout_config = TimeoutConfig {
+        fast_round_duration: Some(TimeDelta::from_secs(5)),
+        ..TimeoutConfig::default()
+    };
+    let ownership = ChainOwnership {
+        super_owners: BTreeSet::from_iter([owner0]),
+        owners: BTreeMap::from_iter([(owner1, 100)]),
+        multi_leader_rounds: 10,
+        open_multi_leader_rounds: false,
+        timeout_config,
+    };
+    client0.change_ownership(ownership).await.unwrap();
+    let mut client1 = builder
+        .make_client(chain_id, client0.block_hash(), BlockHeight::from(1))
+        .await?;
+    client1.set_preferred_owner(owner1);
+
+    // Client 0 transfers 5 tokens from the chain account to themselves.
+    client0
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(5),
+            Account::new(chain_id, owner0),
+        )
+        .await?;
+
+    // Client 0 tries to burn 3 of their own tokens, but three validators are faulty.
+    builder
+        .set_fault_type([1, 2, 3], FaultType::OfflineWithInfo)
+        .await;
+
+    let result = client0.burn(owner0, Amount::from_tokens(3)).await;
+    assert!(result.is_err());
+    let manager = client0
+        .chain_info_with_manager_values()
+        .await
+        .unwrap()
+        .manager;
+    // Validator 0 may or may not have processed the proposal before the update was
+    // canceled due to the errors from the faulty validators. Submit it again to make sure
+    // it's there, so that client 1 can download and re-propose it later.
+    let locking = *manager.requested_locking.unwrap();
+    let LockingBlock::Fast(proposal) = locking else {
+        panic!("Unexpected locking regular block.");
+    };
+    builder
+        .node(0)
+        .handle_block_proposal(proposal)
+        .await
+        .unwrap();
+
+    // Round 0 times out.
+    clock.add(TimeDelta::from_secs(5));
+    builder.set_fault_type([0], FaultType::Offline).await;
+    builder.set_fault_type([1, 2, 3], FaultType::Honest).await;
+    client1.synchronize_from_validators().await.unwrap();
+    client1.request_leader_timeout().await.unwrap();
+
+    // Client 1 wants to burn 2 tokens. But now validators 0 and 3 is offline, so they don't learn
+    // about the proposed fast block and make their own instead.
+    builder.set_fault_type([3], FaultType::Offline).await;
+    let result = client1
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(2))
+        .await;
+    assert!(result.is_err());
+
+    // Finally, three validators are online and honest again. Client 1 realizes there has been a
+    // validated block in round 0, and re-proposes it when it tries to burn 4 tokens.
+    builder.set_fault_type([0, 1, 2], FaultType::Honest).await;
+    client1.synchronize_from_validators().await.unwrap();
+    assert!(client1.pending_proposal().is_some());
+    client1
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(4))
+        .await
+        .unwrap();
+    // Round 0 needs to time out again, so client 1 is actually allowed to propose.
+    clock.add(TimeDelta::from_secs(5));
+    client1.process_pending_block().await.unwrap();
+
+    // Burning 3 and 4 tokens got finalized; the pending 2 tokens got skipped.
+    client0.synchronize_from_validators().await.unwrap();
+    assert_eq!(
+        client0.local_balance().await.unwrap(),
+        Amount::from_tokens(1)
+    );
+    assert_eq!(
+        client0.local_owner_balance(owner0).await.unwrap(),
+        Amount::from_tokens(2)
     );
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3186,7 +3186,7 @@ where
     // But with the validated block certificate for block2, it is allowed.
     let certificate2 = env.make_certificate_with_round(value2.clone(), Round::SingleLeader(4));
 
-    let proposal = BlockProposal::new_retry(
+    let proposal = BlockProposal::new_retry_regular(
         owner1,
         Round::SingleLeader(5),
         certificate2.clone(),
@@ -3537,10 +3537,14 @@ where
         .await?;
     let value2 = ValidatedBlock::new(block2.clone());
     let certificate2 = env.make_certificate_with_round(value2.clone(), Round::MultiLeader(0));
-    let proposal =
-        BlockProposal::new_retry(owner1, Round::MultiLeader(3), certificate2.clone(), &signer)
-            .await
-            .unwrap();
+    let proposal = BlockProposal::new_retry_regular(
+        owner1,
+        Round::MultiLeader(3),
+        certificate2.clone(),
+        &signer,
+    )
+    .await
+    .unwrap();
     let lite_value2 = LiteValue::new(&value2);
     let (_, _) = env.worker().handle_block_proposal(proposal).await?;
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -219,8 +219,9 @@ message BlockProposal {
   // Signature by chain owner
   AccountSignature signature = 5;
 
-  // A lite certificate for a validated block that justifies the proposal in this round.
-  optional bytes validated_block_certificate = 6;
+  // A lite certificate for a validated block, or a fast block proposal, that
+  // justifies the proposal in this round.
+  optional bytes original_proposal = 6;
 }
 
 // A certified statement from the committee, without the value.

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -234,8 +234,8 @@ impl TryFrom<BlockProposal> for api::BlockProposal {
             public_key: Some(block_proposal.public_key.into()),
             owner: Some(AccountOwner::from(block_proposal.public_key).try_into()?),
             signature: Some(block_proposal.signature.into()),
-            validated_block_certificate: block_proposal
-                .validated_block_certificate
+            original_proposal: block_proposal
+                .original_proposal
                 .map(|cert| bincode::serialize(&cert))
                 .transpose()?,
         })
@@ -255,8 +255,8 @@ impl TryFrom<api::BlockProposal> for BlockProposal {
             content,
             public_key: try_proto_convert(block_proposal.public_key)?,
             signature: try_proto_convert(block_proposal.signature)?,
-            validated_block_certificate: block_proposal
-                .validated_block_certificate
+            original_proposal: block_proposal
+                .original_proposal
                 .map(|bytes| bincode::deserialize(&bytes))
                 .transpose()?,
         })
@@ -1004,7 +1004,7 @@ pub mod tests {
         data_types::{Amount, Blob, Round, Timestamp},
     };
     use linera_chain::{
-        data_types::{BlockExecutionOutcome, ProposedBlock},
+        data_types::{BlockExecutionOutcome, OriginalProposal, ProposedBlock},
         test::make_first_block,
         types::CertificateKind,
     };
@@ -1236,7 +1236,7 @@ pub mod tests {
             state_hash: CryptoHash::new(&Foo("validated".into())),
             ..BlockExecutionOutcome::default()
         };
-        let cert = ValidatedBlockCertificate::new(
+        let certificate = ValidatedBlockCertificate::new(
             ValidatedBlock::new(outcome.clone().with(get_block())),
             Round::SingleLeader(2),
             vec![(
@@ -1255,7 +1255,7 @@ pub mod tests {
             },
             public_key: key_pair.public(),
             signature: key_pair.sign(&Foo("test".into())),
-            validated_block_certificate: Some(cert),
+            original_proposal: Some(OriginalProposal::Regular { certificate }),
         };
 
         round_trip_check::<_, api::BlockProposal>(block_proposal);

--- a/linera-rpc/tests/format.rs
+++ b/linera-rpc/tests/format.rs
@@ -10,7 +10,7 @@ use linera_base::{
     vm::VmRuntime,
 };
 use linera_chain::{
-    data_types::MessageAction,
+    data_types::{MessageAction, OriginalProposal},
     manager::{ChainManagerInfo, LockingBlock},
     types::{Certificate, CertificateKind, ConfirmedBlock, Timeout, ValidatedBlock},
 };
@@ -63,6 +63,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<SystemMessage>(&samples)?;
     tracer.trace_type::<Operation>(&samples)?;
     tracer.trace_type::<Message>(&samples)?;
+    tracer.trace_type::<OriginalProposal>(&samples)?;
     tracer.trace_type::<VmRuntime>(&samples)?;
     tracer.trace_type::<MessageAction>(&samples)?;
     tracer.trace_type::<MessageKind>(&samples)?;

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -228,9 +228,9 @@ BlockProposal:
         TYPENAME: AccountPublicKey
     - signature:
         TYPENAME: AccountSignature
-    - validated_block_certificate:
+    - original_proposal:
         OPTION:
-          TYPENAME: LiteCertificate
+          TYPENAME: OriginalProposal
 Certificate:
   ENUM:
     0:
@@ -784,6 +784,20 @@ OracleResponse:
         TUPLE:
           - TYPENAME: EventId
           - SEQ: U8
+OriginalProposal:
+  ENUM:
+    0:
+      Fast:
+        STRUCT:
+          - public_key:
+              TYPENAME: AccountPublicKey
+          - signature:
+              TYPENAME: AccountSignature
+    1:
+      Regular:
+        STRUCT:
+          - certificate:
+              TYPENAME: LiteCertificate
 OutgoingMessage:
   STRUCT:
     - destination:


### PR DESCRIPTION
## Motivation

When re-proposing a validated block from an earlier round there is a validated block certificate, signed by a quorum of validators, attesting the correctness of the outcome and the validity of the oracle responses—_and_ that the `authenticated_signer` is actually the one who originally submitted the block proposal to the validators!

This last part I missed in the special case where we re-propose an earlier proposal by a super owner from the fast round! In that case, there is no validated block certificate, which is why we disallow oracles. But we erroneously compare the `authenticated_signer` to the owner _re-proposing_ the block, rather than the original super owner.

Of course comparing it to the super owner is not enough: The regular owner must not be able to do something in the super owner's name without permission. So we need to also verify the super owner's signature (and super ownership!) again.

Super owners by design take greater responsibility for a chain's liveness than regular owners, and in the case of re-proposing a _fast_ block, the super owner's signature needs to play a similar role to the validators' signatures when re-proposing a _regular_ block.

## Proposal

Properly distinguish the _three_ cases of a block proposal:
* The current proposer is the one who originally created this block. They are the authenticated signer.
* This is a retry of an earlier proposal by a super owner in the _fast_ round: The super owner is the authenticated signer, but their signature must be included in the proposal and verified again.
* This is a retry of an earlier proposal in regular round: The original proposer is the authenticated signer, but we don't need to verify their signature again; the validators' signatures of the earlier round's certificate already proves that the proposal is valid (in addition to proving that the included oracle responses are, too).

## Test Plan

`test_re_propose_fast_block` was added.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
