### PR TITLE
Revert back to 7.0.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,11 +1019,12 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-graphql"
 version = "7.0.2"
-source = "git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18#02e3f66810ac10b9454a23a154a4be5f56a2fac8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba89a35adbed833e0d21db467093a087c3a07b497626009eae02cb36f060567"
 dependencies = [
- "async-graphql-derive 7.0.2 (git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18)",
- "async-graphql-parser 7.0.2",
- "async-graphql-value 7.0.2",
+ "async-graphql-derive",
+ "async-graphql-parser",
+ "async-graphql-value",
  "async-stream",
  "async-trait",
  "base64 0.21.7",
@@ -1051,7 +1052,8 @@ dependencies = [
 [[package]]
 name = "async-graphql-axum"
 version = "7.0.2"
-source = "git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18#02e3f66810ac10b9454a23a154a4be5f56a2fac8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74cb0d91622015797c94dbb862580ba5e89bfd4b9066ad7d8d9ac8e1ca5ab6f8"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -1072,7 +1074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9547f7f22688f022ea8001bdd57a1fce8996045dcb959b1730a79bafd366a9d9"
 dependencies = [
  "Inflector",
- "async-graphql-parser 7.0.13",
+ "async-graphql-parser",
  "darling",
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -1080,33 +1082,6 @@ dependencies = [
  "strum 0.25.0",
  "syn 2.0.100",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "async-graphql-derive"
-version = "7.0.2"
-source = "git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18#02e3f66810ac10b9454a23a154a4be5f56a2fac8"
-dependencies = [
- "Inflector",
- "async-graphql-parser 7.0.2",
- "darling",
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "strum 0.25.0",
- "syn 2.0.100",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "async-graphql-parser"
-version = "7.0.2"
-source = "git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18#02e3f66810ac10b9454a23a154a4be5f56a2fac8"
-dependencies = [
- "async-graphql-value 7.0.2",
- "pest",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1115,19 +1090,8 @@ version = "7.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d271ddda2f55b13970928abbcbc3423cfc18187c60e8769b48f21a93b7adaa"
 dependencies = [
- "async-graphql-value 7.0.13",
+ "async-graphql-value",
  "pest",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-graphql-value"
-version = "7.0.2"
-source = "git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18#02e3f66810ac10b9454a23a154a4be5f56a2fac8"
-dependencies = [
- "bytes",
- "indexmap 2.7.0",
  "serde",
  "serde_json",
 ]
@@ -4657,7 +4621,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-graphql",
- "async-graphql-derive 7.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-graphql-derive",
  "async-trait",
  "bcs",
  "cfg-if",
@@ -5350,7 +5314,7 @@ version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-graphql",
- "async-graphql-derive 7.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-graphql-derive",
  "base64 0.22.1",
  "cargo_metadata",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -283,10 +283,5 @@ branch = "no-uuid-wasm-bindgen"
 git = "https://github.com/Twey/wasm_thread"
 branch = "post-message"
 
-[patch.crates-io]
-async-graphql = { git = "https://github.com/deuszx/async-graphql", branch = "v7.0.2-react18" }
-async-graphql-axum = { git = "https://github.com/deuszx/async-graphql", branch = "v7.0.2-react18" }
-async-graphql-value = { git = "https://github.com/deuszx/async-graphql", branch = "v7.0.2-react18" }
-
 [workspace.metadata.spellcheck]
 config = "spellcheck-cfg.toml"


### PR DESCRIPTION
## Motivation

We cannot publish from github forks.

## Proposal

Revert back to official GraphQL release which should be now fixed.

## Test Plan

CI

## Release Plan


- Nothing to do / These changes follow the usual release cycle.
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
