### PR TITLE
Make `epoch` not optional in `ChainInfo` and state.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -776,13 +776,7 @@ where
             .default_chain()
             .expect("should have default chain");
         let default_chain_client = self.make_chain_client(default_chain_id).await?;
-        let (epoch, mut committees) = default_chain_client
-            .epoch_and_committees(default_chain_id)
-            .await?;
-        let epoch = epoch.expect("default chain should have an epoch");
-        let committee = committees
-            .remove(&epoch)
-            .expect("current epoch should have a committee");
+        let (epoch, committee) = default_chain_client.latest_committee().await?;
         let blocks_infos = Benchmark::<Env>::make_benchmark_block_info(
             key_pairs,
             transactions_per_block,

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -160,8 +160,7 @@ pub struct ChainInfo {
     /// The chain ID.
     pub chain_id: ChainId,
     /// The number identifying the current configuration.
-    #[debug(skip_if = Option::is_none)]
-    pub epoch: Option<Epoch>,
+    pub epoch: Epoch,
     /// The chain description.
     #[debug(skip_if = Option::is_none)]
     pub description: Option<ChainDescription>,
@@ -311,7 +310,7 @@ impl ChainInfoResponse {
     /// Returns the committee in the latest epoch.
     pub fn latest_committee(&self) -> Option<&Committee> {
         let committees = self.info.requested_committees.as_ref()?;
-        committees.get(&self.info.epoch?)
+        committees.get(&self.info.epoch)
     }
 }
 

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -208,6 +208,12 @@ impl ChainInfo {
             next_block_height: self.next_block_height,
         })
     }
+
+    /// Returns the committee in the latest epoch.
+    pub fn latest_committee(&self) -> Option<&Committee> {
+        let committees = self.requested_committees.as_ref()?;
+        committees.get(&self.epoch)
+    }
 }
 
 /// The response to an `ChainInfoQuery`
@@ -305,12 +311,6 @@ impl ChainInfoResponse {
             Some(sig) => sig.check(&*self.info, public_key),
             None => Err(CryptoError::MissingValidatorSignature),
         }
-    }
-
-    /// Returns the committee in the latest epoch.
-    pub fn latest_committee(&self) -> Option<&Committee> {
-        let committees = self.info.requested_committees.as_ref()?;
-        committees.get(&self.info.epoch)
     }
 }
 

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -208,12 +208,6 @@ impl ChainInfo {
             next_block_height: self.next_block_height,
         })
     }
-
-    /// Returns the committee in the latest epoch.
-    pub fn latest_committee(&self) -> Option<&Committee> {
-        let committees = self.requested_committees.as_ref()?;
-        committees.get(&self.epoch)
-    }
 }
 
 /// The response to an `ChainInfoQuery`

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2423,7 +2423,7 @@ where
                 // The root chain knows both committees at the end.
                 committees: committees2.clone(),
                 used_blobs: BTreeSet::from([committee_blob.id()]),
-                epoch: Some(Epoch::from(1)),
+                epoch: Epoch::from(1),
                 admin_id: Some(admin_id),
                 balance: Amount::ZERO,
                 ..SystemExecutionState::new(env.admin_description.clone())
@@ -2486,7 +2486,7 @@ where
                 committees: committees2.clone(),
                 balance: Amount::from_tokens(2),
                 used_blobs: BTreeSet::from([committee_blob.id()]),
-                epoch: Some(Epoch::from(1)),
+                epoch: Epoch::from(1),
                 ..SystemExecutionState::new(user_description)
             }
             .into_hash()
@@ -2609,7 +2609,7 @@ where
                 committees: committees2.clone(),
                 used_blobs: BTreeSet::from([committee_blob.id()]),
                 admin_id: Some(admin_id),
-                epoch: Some(Epoch::from(1)),
+                epoch: Epoch::from(1),
                 ..SystemExecutionState::new(env.admin_description.clone())
             }
             .into_hash()
@@ -2646,10 +2646,7 @@ where
         *user_chain.execution_state.system.balance.get(),
         Amount::from_tokens(2)
     );
-    assert_eq!(
-        *user_chain.execution_state.system.epoch.get(),
-        Some(Epoch::ZERO)
-    );
+    assert_eq!(*user_chain.execution_state.system.epoch.get(), Epoch::ZERO);
 
     // .. and the message has gone through.
     let admin_chain = env.worker().chain_state_view(admin_id).await?;
@@ -2740,7 +2737,7 @@ where
             state_hash: SystemExecutionState {
                 committees: committees3.clone(),
                 used_blobs: BTreeSet::from([committee_blob.id()]),
-                epoch: Some(Epoch::from(1)),
+                epoch: Epoch::from(1),
                 admin_id: Some(admin_id),
                 ..SystemExecutionState::new(env.admin_description.clone())
             }
@@ -2782,10 +2779,7 @@ where
             *user_chain.execution_state.system.balance.get(),
             Amount::from_tokens(2)
         );
-        assert_eq!(
-            *user_chain.execution_state.system.epoch.get(),
-            Some(Epoch::ZERO)
-        );
+        assert_eq!(*user_chain.execution_state.system.epoch.get(), Epoch::ZERO);
 
         // .. but the message hasn't gone through.
         let admin_chain = env.worker().chain_state_view(admin_id).await?;
@@ -2805,7 +2799,7 @@ where
                 balance: Amount::ONE,
                 used_blobs: BTreeSet::from([committee_blob.id()]),
                 admin_id: Some(admin_id),
-                epoch: Some(Epoch::from(1)),
+                epoch: Epoch::from(1),
                 ..SystemExecutionState::new(env.admin_description.clone())
             }
             .into_hash()
@@ -2961,7 +2955,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
 
     let helper = CrossChainUpdateHelper {
         allow_messages_from_deprecated_epochs: true,
-        current_epoch: Some(Epoch::from(1)),
+        current_epoch: Epoch::from(1),
         committees: &committees,
     };
     // Epoch is not tested when `allow_messages_from_deprecated_epochs` is true.
@@ -2992,7 +2986,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
 
     let helper = CrossChainUpdateHelper {
         allow_messages_from_deprecated_epochs: false,
-        current_epoch: Some(Epoch::from(1)),
+        current_epoch: Epoch::from(1),
         committees: &committees,
     };
     // Epoch is tested when `allow_messages_from_deprecated_epochs` is false.
@@ -3677,7 +3671,7 @@ where
         .info
         .requested_committees
         .unwrap()
-        .get(&response.info.epoch.unwrap())
+        .get(&response.info.epoch)
         .unwrap()
         .validators
         .get(&vote.public_key)

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -60,7 +60,7 @@ impl<C: Send + Sync + Context> SystemExecutionStateView<C> {
     }
 
     #[graphql(derived(name = "epoch"))]
-    async fn _epoch(&self) -> &Option<Epoch> {
+    async fn _epoch(&self) -> &Epoch {
         self.epoch.get()
     }
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -64,7 +64,7 @@ pub struct SystemExecutionStateView<C> {
     /// How the chain was created. May be unknown for inactive chains.
     pub description: HashedRegisterView<C, Option<ChainDescription>>,
     /// The number identifying the current configuration.
-    pub epoch: HashedRegisterView<C, Option<Epoch>>,
+    pub epoch: HashedRegisterView<C, Epoch>,
     /// The admin of the chain.
     pub admin_id: HashedRegisterView<C, Option<ChainId>>,
     /// The committees that we trust, indexed by epoch number.
@@ -332,7 +332,7 @@ where
 
     /// Returns the current committee, if any.
     pub fn current_committee(&self) -> Option<(Epoch, &Committee)> {
-        let epoch = self.epoch.get().as_ref()?;
+        let epoch = self.epoch.get();
         let committee = self.committees.get().get(epoch)?;
         Some((*epoch, committee))
     }
@@ -438,7 +438,7 @@ where
                             bcs::from_bytes(self.read_blob_content(blob_id).await?.bytes())?;
                         self.blob_used(Some(txn_tracker), blob_id).await?;
                         self.committees.get_mut().insert(epoch, committee);
-                        self.epoch.set(Some(epoch));
+                        self.epoch.set(epoch);
                         txn_tracker.add_event(
                             StreamId::system(EPOCH_STREAM_NAME),
                             epoch.0,
@@ -524,7 +524,7 @@ where
                 let committee = bcs::from_bytes(self.read_blob_content(blob_id).await?.bytes())?;
                 self.blob_used(Some(txn_tracker), blob_id).await?;
                 self.committees.get_mut().insert(epoch, committee);
-                self.epoch.set(Some(epoch));
+                self.epoch.set(epoch);
             }
             ProcessRemovedEpoch(epoch) => {
                 ensure!(
@@ -596,7 +596,7 @@ where
     /// Returns an error if the `provided` epoch is not exactly one higher than the chain's current
     /// epoch.
     fn check_next_epoch(&self, provided: Epoch) -> Result<(), ExecutionError> {
-        let expected = self.epoch.get().expect("chain is active").try_add_one()?;
+        let expected = self.epoch.get().try_add_one()?;
         ensure!(
             provided == expected,
             ExecutionError::InvalidCommitteeEpoch { provided, expected }
@@ -777,7 +777,7 @@ where
         } = description.config().clone();
         self.timestamp.set(description.timestamp());
         self.description.set(Some(description));
-        self.epoch.set(Some(epoch));
+        self.epoch.set(epoch);
         let committees = committees
             .into_iter()
             .map(|(epoch, serialized_committee)| {
@@ -827,11 +827,8 @@ where
             chain_index,
         };
         let committees = self.get_committees();
-        let init_chain_config = config.init_chain_config(
-            (*self.epoch.get()).ok_or(ExecutionError::InactiveChain)?,
-            *self.admin_id.get(),
-            committees,
-        );
+        let init_chain_config =
+            config.init_chain_config(*self.epoch.get(), *self.admin_id.get(), committees);
         let chain_description = ChainDescription::new(chain_origin, init_chain_config, timestamp);
         let child_id = chain_description.id();
         self.debit(&AccountOwner::CHAIN, config.balance).await?;

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -32,7 +32,7 @@ use crate::{
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub struct SystemExecutionState {
     pub description: Option<ChainDescription>,
-    pub epoch: Option<Epoch>,
+    pub epoch: Epoch,
     pub admin_id: Option<ChainId>,
     pub committees: BTreeMap<Epoch, Committee>,
     pub ownership: ChainOwnership,
@@ -69,7 +69,7 @@ impl SystemExecutionState {
             })
             .collect();
         SystemExecutionState {
-            epoch: Some(epoch),
+            epoch,
             description: Some(description),
             admin_id,
             ownership,

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -26,7 +26,7 @@ async fn new_view_and_context() -> (
     };
     let state = SystemExecutionState {
         description: Some(description),
-        epoch: Some(Epoch(1)),
+        epoch: Epoch(1),
         admin_id: Some(dummy_chain_description(0).id()),
         committees: BTreeMap::new(),
         ..SystemExecutionState::default()

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -1001,7 +1001,7 @@ pub mod tests {
 
     use linera_base::{
         crypto::{AccountSecretKey, BcsSignable, CryptoHash, Secp256k1SecretKey, ValidatorKeypair},
-        data_types::{Amount, Blob, Round, Timestamp},
+        data_types::{Amount, Blob, Epoch, Round, Timestamp},
     };
     use linera_chain::{
         data_types::{BlockExecutionOutcome, OriginalProposal, ProposedBlock},
@@ -1083,7 +1083,7 @@ pub mod tests {
     pub fn test_chain_info_response() {
         let chain_info = Box::new(ChainInfo {
             chain_id: dummy_chain_id(0),
-            epoch: None,
+            epoch: Epoch::ZERO,
             description: None,
             manager: Box::default(),
             chain_balance: Amount::ZERO,

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -275,8 +275,7 @@ ChainInfo:
     - chain_id:
         TYPENAME: ChainId
     - epoch:
-        OPTION:
-          TYPENAME: Epoch
+        TYPENAME: Epoch
     - description:
         OPTION:
           TYPENAME: ChainDescription

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -96,7 +96,8 @@ impl ActiveChain {
 
     /// Returns the current [`Epoch`] the chain is in.
     pub async fn epoch(&self) -> Epoch {
-        self.validator
+        *self
+            .validator
             .worker()
             .chain_state_view(self.id())
             .await
@@ -105,7 +106,6 @@ impl ActiveChain {
             .system
             .epoch
             .get()
-            .expect("Active chains should be in an epoch")
     }
 
     /// Reads the current shared balance available to all of the owners of this microchain.

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -1123,7 +1123,7 @@ type SubscriptionRoot {
 
 type SystemExecutionStateView {
 	description: ChainDescription
-	epoch: Epoch
+	epoch: Epoch!
 	adminId: ChainId
 	committees: JSONObject!
 	ownership: ChainOwnership!


### PR DESCRIPTION
## Motivation

Every initialized chain has a current epoch, and we are not using the `epoch` field to check whether a chain is initialized.

## Proposal

Make `epoch` not optional.
Also deduplicate some related chain client code.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
