### PR TITLE
Replace React version and revert back to official graphql release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,8 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-graphql"
 version = "7.0.2"
-source = "git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18#02e3f66810ac10b9454a23a154a4be5f56a2fac8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba89a35adbed833e0d21db467093a087c3a07b497626009eae02cb36f060567"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -1051,7 +1052,8 @@ dependencies = [
 [[package]]
 name = "async-graphql-axum"
 version = "7.0.2"
-source = "git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18#02e3f66810ac10b9454a23a154a4be5f56a2fac8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74cb0d91622015797c94dbb862580ba5e89bfd4b9066ad7d8d9ac8e1ca5ab6f8"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -1068,7 +1070,8 @@ dependencies = [
 [[package]]
 name = "async-graphql-derive"
 version = "7.0.2"
-source = "git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18#02e3f66810ac10b9454a23a154a4be5f56a2fac8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9547f7f22688f022ea8001bdd57a1fce8996045dcb959b1730a79bafd366a9d9"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -1083,8 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "7.0.2"
-source = "git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18#02e3f66810ac10b9454a23a154a4be5f56a2fac8"
+version = "7.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4904895044116aab098ca82c6cec831ec43ed99efd04db9b70a390419bc88c5b"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -1094,8 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "7.0.2"
-source = "git+https://github.com/deuszx/async-graphql?branch=v7.0.2-react18#02e3f66810ac10b9454a23a154a4be5f56a2fac8"
+version = "7.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0cde74de18e3a00c5dd5cfa002ab6f532e1a06c2a79ee6671e2fc353b400b92"
 dependencies = [
  "bytes",
  "indexmap 2.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -285,11 +285,5 @@ branch = "no-uuid-wasm-bindgen"
 git = "https://github.com/Twey/wasm_thread"
 branch = "post-message"
 
-[patch.crates-io]
-async-graphql = { git = "https://github.com/deuszx/async-graphql", branch = "v7.0.2-react18" }
-async-graphql-axum = { git = "https://github.com/deuszx/async-graphql", branch = "v7.0.2-react18" }
-async-graphql-value = { git = "https://github.com/deuszx/async-graphql", branch = "v7.0.2-react18" }
-async-graphql-derive = { git = "https://github.com/deuszx/async-graphql", branch = "v7.0.2-react18" }
-
 [workspace.metadata.spellcheck]
 config = "spellcheck-cfg.toml"

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -32,7 +32,12 @@ pub(crate) async fn graphiql(uri: axum::http::Uri) -> impl axum::response::IntoR
         async_graphql::http::GraphiQLSource::build()
             .endpoint(uri.path())
             .subscription_endpoint("/ws")
-            .finish(),
+            .finish()
+            .replace("@17", "@18")
+            .replace(
+                "ReactDOM.render(",
+                "ReactDOM.createRoot(document.getElementById(\"graphiql\")).render(",
+            ),
     )
 }
 

--- a/linera-indexer/lib/src/common.rs
+++ b/linera-indexer/lib/src/common.rs
@@ -71,5 +71,14 @@ impl From<linera_views::scylla_db::ScyllaDbStoreError> for IndexerError {
 }
 
 pub async fn graphiql(uri: Uri) -> impl IntoResponse {
-    response::Html(GraphiQLSource::build().endpoint(uri.path()).finish())
+    response::Html(
+        GraphiQLSource::build()
+            .endpoint(uri.path())
+            .finish()
+            .replace("@17", "@18")
+            .replace(
+                "ReactDOM.render(",
+                "ReactDOM.createRoot(document.getElementById(\"graphiql\")).render(",
+            ),
+    )
 }

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -149,7 +149,12 @@ pub(crate) async fn graphiql(uri: Uri) -> impl IntoResponse {
     let source = GraphiQLSource::build()
         .endpoint(uri.path())
         .subscription_endpoint("/ws")
-        .finish();
+        .finish()
+        .replace("@17", "@18")
+        .replace(
+            "ReactDOM.render(",
+            "ReactDOM.createRoot(document.getElementById(\"graphiql\")).render(",
+        );
     response::Html(source)
 }
 


### PR DESCRIPTION
## Motivation

We cannot publish to crates with some dependencies are patched w/ github references.

## Proposal

Replace strings to use React @ 18.

## Test Plan

CI and manually that GraphiQL playground works.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
## Links
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
