### PR TITLE
Move admin_id from ChainDescription into NetworkDescription

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -811,8 +811,6 @@ impl Epoch {
 pub struct InitialChainConfig {
     /// The ownership configuration of the new chain.
     pub ownership: ChainOwnership,
-    /// The ID of the admin chain.
-    pub admin_id: Option<ChainId>,
     /// The epoch in which the chain is created.
     pub epoch: Epoch,
     /// Serialized committees corresponding to epochs.
@@ -868,6 +866,19 @@ impl ChainDescription {
 }
 
 impl BcsHashable<'_> for ChainDescription {}
+
+/// A description of the current Linera network to be stored in every node's database.
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct NetworkDescription {
+    /// The name of the network.
+    pub name: String,
+    /// Hash of the network's genesis config.
+    pub genesis_config_hash: CryptoHash,
+    /// Genesis timestamp.
+    pub genesis_timestamp: Timestamp,
+    /// The chain ID of the admin chain.
+    pub admin_chain_id: ChainId,
+}
 
 /// Permissions for applications on a chain.
 #[derive(

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -1007,7 +1007,7 @@ mod tests {
         );
         assert_eq!(
             description.id().to_string(),
-            "0e94923a8f72ef1d0e69e6958e655002f2b1883bac9a67a4704d2f4125825217"
+            "4423610c1010c31be88bc6cc041a9c1063d58062e9d748c1552a1e75e7ea13a9"
         );
     }
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -994,7 +994,6 @@ mod tests {
     fn chain_id_computing() {
         let example_chain_origin = ChainOrigin::Root(0);
         let example_chain_config = InitialChainConfig {
-            admin_id: None,
             epoch: Epoch::ZERO,
             ownership: ChainOwnership::single(AccountOwner::Reserved(0)),
             balance: Amount::ZERO,

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -73,7 +73,6 @@ impl TestEnvironment {
         )]);
         let config = InitialChainConfig {
             ownership: ChainOwnership::single(AccountPublicKey::test_key(0).into()),
-            admin_id: None,
             epoch: Epoch::ZERO,
             committees: iter::once((
                 Epoch::ZERO,
@@ -145,10 +144,6 @@ impl TestEnvironment {
             parent: self.admin_id(),
             block_height: BlockHeight(height),
             chain_index: 0,
-        };
-        let config = InitialChainConfig {
-            admin_id: Some(self.admin_id()),
-            ..config
         };
         let description = ChainDescription::new(origin, config, Timestamp::from(0));
         self.created_descriptions

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -6,7 +6,10 @@ use std::{collections::BTreeMap, iter::IntoIterator};
 
 use linera_base::{
     crypto::{AccountPublicKey, BcsSignable, CryptoHash, ValidatorPublicKey, ValidatorSecretKey},
-    data_types::{Amount, ChainDescription, ChainOrigin, Epoch, InitialChainConfig, Timestamp},
+    data_types::{
+        Amount, ChainDescription, ChainOrigin, Epoch, InitialChainConfig, NetworkDescription,
+        Timestamp,
+    },
     identifiers::ChainId,
     ownership::ChainOwnership,
 };
@@ -17,7 +20,7 @@ use linera_execution::{
 use linera_rpc::config::{
     ExporterServiceConfig, ValidatorInternalNetworkConfig, ValidatorPublicNetworkConfig,
 };
-use linera_storage::{NetworkDescription, Storage};
+use linera_storage::Storage;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, thiserror::Error)]
@@ -30,6 +33,8 @@ pub enum Error {
     Persistence(Box<dyn std::error::Error + Send + Sync>),
     #[error("storage is already initialized: {0:?}")]
     StorageIsAlreadyInitialized(NetworkDescription),
+    #[error("no admin chain configured")]
+    NoAdminChain,
 }
 
 use crate::{persistent, util};
@@ -98,7 +103,6 @@ impl BcsSignable<'_> for GenesisConfig {}
 fn make_chain(
     committee: &Committee,
     index: u32,
-    admin_id: Option<ChainId>,
     public_key: AccountPublicKey,
     balance: Amount,
     timestamp: Timestamp,
@@ -111,7 +115,6 @@ fn make_chain(
     .collect();
     let origin = ChainOrigin::Root(index);
     let config = InitialChainConfig {
-        admin_id,
         application_permissions: Default::default(),
         balance,
         committees: committees.clone(),
@@ -132,14 +135,7 @@ impl GenesisConfig {
         admin_balance: Amount,
     ) -> Self {
         let committee = committee.into_committee(policy);
-        let admin_chain = make_chain(
-            &committee,
-            0,
-            None,
-            admin_public_key,
-            admin_balance,
-            timestamp,
-        );
+        let admin_chain = make_chain(&committee, 0, admin_public_key, admin_balance, timestamp);
         Self {
             committee,
             timestamp,
@@ -156,7 +152,6 @@ impl GenesisConfig {
         let description = make_chain(
             &self.committee,
             self.chains.len() as u32,
-            Some(self.admin_id()),
             public_key,
             balance,
             self.timestamp,
@@ -187,11 +182,7 @@ impl GenesisConfig {
         for description in &self.chains {
             storage.create_chain(description.clone()).await?;
         }
-        let network_description = NetworkDescription {
-            name: self.network_name.clone(),
-            genesis_config_hash: CryptoHash::new(self),
-            genesis_timestamp: self.timestamp,
-        };
+        let network_description = self.network_description();
         storage
             .write_network_description(&network_description)
             .await
@@ -208,6 +199,7 @@ impl GenesisConfig {
             name: self.network_name.clone(),
             genesis_config_hash: CryptoHash::new(self),
             genesis_timestamp: self.timestamp,
+            admin_chain_id: self.admin_id(),
         }
     }
 }

--- a/linera-client/src/error.rs
+++ b/linera-client/src/error.rs
@@ -1,9 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_base::{crypto::ValidatorPublicKey, identifiers::ChainId};
+use linera_base::{
+    crypto::ValidatorPublicKey, data_types::NetworkDescription, identifiers::ChainId,
+};
 use linera_core::node::NodeError;
-use linera_storage::NetworkDescription;
 use linera_version::VersionInfo;
 use thiserror_context::Context;
 

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -9,7 +9,7 @@ use futures::stream::LocalBoxStream as BoxStream;
 use futures::stream::Stream;
 use linera_base::{
     crypto::{CryptoError, CryptoHash, ValidatorPublicKey},
-    data_types::{ArithmeticError, BlobContent, BlockHeight},
+    data_types::{ArithmeticError, BlobContent, BlockHeight, NetworkDescription},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::{
@@ -21,7 +21,6 @@ use linera_chain::{
     ChainError,
 };
 use linera_execution::{committee::Committee, ExecutionError};
-use linera_storage::NetworkDescription;
 use linera_version::VersionInfo;
 use linera_views::views::ViewError;
 use serde::{Deserialize, Serialize};

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -526,7 +526,6 @@ where
 
     let new_chain_config = InitialChainConfig {
         ownership: ChainOwnership::single(new_public_key.into()),
-        admin_id: Some(builder.admin_id()),
         epoch: Epoch::ZERO,
         committees: builder
             .admin_description()

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -29,7 +29,7 @@ use linera_chain::{
     },
 };
 use linera_execution::{committee::Committee, ResourceControlPolicy, WasmRuntime};
-use linera_storage::{DbStorage, NetworkDescription, Storage, TestClock};
+use linera_storage::{DbStorage, Storage, TestClock};
 #[cfg(all(not(target_arch = "wasm32"), feature = "storage-service"))]
 use linera_storage_service::client::ServiceStoreClient;
 use linera_version::VersionInfo;
@@ -178,6 +178,17 @@ where
             name: "test network".to_string(),
             genesis_config_hash: CryptoHash::test_hash("genesis config"),
             genesis_timestamp: Timestamp::default(),
+            admin_chain_id: self
+                .client
+                .lock()
+                .await
+                .state
+                .storage_client()
+                .read_network_description()
+                .await
+                .unwrap()
+                .unwrap()
+                .admin_chain_id,
         })
     }
 
@@ -817,11 +828,6 @@ where
         let public_key = self.signer.generate_new();
         let open_chain_config = InitialChainConfig {
             ownership: ChainOwnership::single(public_key.into()),
-            admin_id: if index == 0 {
-                None
-            } else {
-                Some(self.admin_id())
-            },
             epoch: Epoch(0),
             committees,
             balance,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -142,6 +142,15 @@ where
             .write_blob(&Blob::new_chain_description(&admin_description))
             .await
             .expect("writing a blob should not fail");
+        storage
+            .write_network_description(&NetworkDescription {
+                admin_chain_id: admin_description.id(),
+                genesis_config_hash: CryptoHash::test_hash("genesis config"),
+                genesis_timestamp: Timestamp::from(0),
+                name: "test network".to_string(),
+            })
+            .await
+            .expect("writing a network description should not fail");
 
         let worker = WorkerState::new(
             "Single validator node".to_string(),

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -131,7 +131,6 @@ where
 
         let origin = ChainOrigin::Root(0);
         let config = InitialChainConfig {
-            admin_id: None,
             balance: amount,
             ownership: ChainOwnership::single(account_secret.public().into()),
             epoch: Epoch::ZERO,
@@ -197,7 +196,6 @@ where
     ) -> ChainDescription {
         let origin = ChainOrigin::Root(index);
         let config = InitialChainConfig {
-            admin_id: Some(self.admin_id()),
             epoch: self.admin_description.config().epoch,
             ownership,
             committees: self.admin_description.config().committees.clone(),
@@ -227,7 +225,6 @@ where
             chain_index: 0,
         };
         let config = InitialChainConfig {
-            admin_id: Some(self.admin_id()),
             epoch: self.admin_description.config().epoch,
             ownership: ChainOwnership::single(owner),
             committees: self.admin_description.config().committees.clone(),

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -55,6 +55,8 @@ use thiserror::Error;
 #[cfg(with_revm)]
 use crate::evm::EvmExecutionError;
 use crate::runtime::ContractSyncRuntime;
+#[cfg(with_testing)]
+use crate::test_utils::dummy_chain_description;
 #[cfg(all(with_testing, with_wasm_runtime))]
 pub use crate::wasm::test as wasm_test;
 #[cfg(with_wasm_runtime)]
@@ -1085,7 +1087,12 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
     }
 
     async fn get_network_description(&self) -> Result<Option<NetworkDescription>, ViewError> {
-        Ok(None)
+        Ok(Some(NetworkDescription {
+            admin_chain_id: dummy_chain_description(0).id(),
+            genesis_config_hash: CryptoHash::test_hash("genesis config"),
+            genesis_timestamp: Timestamp::from(0),
+            name: "dummy network description".to_string(),
+        }))
     }
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -36,7 +36,7 @@ use linera_base::{
     crypto::{BcsHashable, CryptoHash},
     data_types::{
         Amount, ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlockHeight,
-        DecompressionError, Epoch, SendMessageRequest, StreamUpdate, Timestamp,
+        DecompressionError, Epoch, NetworkDescription, SendMessageRequest, StreamUpdate, Timestamp,
     },
     doc_scalar, hex_debug, http,
     identifiers::{
@@ -287,8 +287,8 @@ pub enum ExecutionError {
     #[error("Invalid HTTP header value used for HTTP request")]
     InvalidHeaderValue(#[from] reqwest::header::InvalidHeaderValue),
 
-    #[error("Invalid admin ID in new chain: {0}")]
-    InvalidNewChainAdminId(ChainId),
+    #[error("No NetworkDescription found in storage")]
+    NoNetworkDescriptionFound,
     #[error("Invalid committees")]
     InvalidCommittees,
     #[error("{epoch:?} is not recognized by chain {chain_id:}")]
@@ -403,6 +403,8 @@ pub trait ExecutionRuntimeContext {
     async fn get_blob(&self, blob_id: BlobId) -> Result<Blob, ViewError>;
 
     async fn get_event(&self, event_id: EventId) -> Result<Vec<u8>, ViewError>;
+
+    async fn get_network_description(&self) -> Result<Option<NetworkDescription>, ViewError>;
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError>;
 
@@ -1080,6 +1082,10 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
             .get(&event_id)
             .ok_or_else(|| ViewError::EventsNotFound(vec![event_id]))?
             .clone())
+    }
+
+    async fn get_network_description(&self) -> Result<Option<NetworkDescription>, ViewError> {
+        Ok(None)
     }
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -831,8 +831,7 @@ where
             chain_index,
         };
         let committees = self.get_committees();
-        let init_chain_config =
-            config.init_chain_config(*self.epoch.get(), committees);
+        let init_chain_config = config.init_chain_config(*self.epoch.get(), committees);
         let chain_description = ChainDescription::new(chain_origin, init_chain_config, timestamp);
         let child_id = chain_description.id();
         self.debit(&AccountOwner::CHAIN, config.balance).await?;

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -55,14 +55,6 @@ pub fn dummy_chain_description_with_ownership_and_balance(
     )]);
     let origin = ChainOrigin::Root(index);
     let config = InitialChainConfig {
-        admin_id: if index == 0 {
-            None
-        } else {
-            Some(
-                dummy_chain_description_with_ownership_and_balance(0, ownership.clone(), balance)
-                    .id(),
-            )
-        },
         application_permissions: Default::default(),
         balance,
         committees,

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -55,7 +55,7 @@ impl SystemExecutionState {
         let ownership = description.config().ownership.clone();
         let balance = description.config().balance;
         let epoch = description.config().epoch;
-        let admin_id = Some(description.config().admin_id.unwrap_or(description.id()));
+        let admin_id = Some(dummy_chain_description(0).id());
         let committees = description
             .config()
             .committees

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1191,7 +1191,6 @@ async fn test_open_chain() -> anyhow::Result<()> {
         balance: Amount::ONE,
         ownership: child_ownership.clone(),
         application_permissions: child_application_permissions.clone(),
-        admin_id: Some(root_description.id()),
         ..root_description.config().clone()
     };
     let child_description = ChainDescription::new(child_origin, child_config, Timestamp::default());

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -124,6 +124,7 @@ message NetworkDescription {
     string name = 1;
     CryptoHash genesis_config_hash = 2;
     uint64 genesis_timestamp = 3;
+    ChainId admin_chain_id = 4;
 }
 
 // A request for client to subscribe to notifications for a given `ChainId`

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -3,7 +3,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::BlobContent,
+    data_types::{BlobContent, NetworkDescription},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::{
@@ -160,9 +160,7 @@ impl ValidatorNode for Client {
         })
     }
 
-    async fn get_network_description(
-        &self,
-    ) -> Result<linera_storage::NetworkDescription, NodeError> {
+    async fn get_network_description(&self) -> Result<NetworkDescription, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => grpc_client.get_network_description().await?,
 

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -6,7 +6,7 @@ use std::{fmt, future::Future, iter};
 use futures::{future, stream, StreamExt};
 use linera_base::{
     crypto::CryptoHash,
-    data_types::BlobContent,
+    data_types::{BlobContent, NetworkDescription},
     ensure,
     identifiers::{BlobId, ChainId},
     time::Duration,
@@ -23,7 +23,6 @@ use linera_core::{
     node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
     worker::Notification,
 };
-use linera_storage::NetworkDescription;
 use linera_version::VersionInfo;
 use tonic::{Code, IntoRequest, Request, Status};
 use tracing::{debug, error, info, instrument, warn};

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -6,7 +6,7 @@ use linera_base::{
         AccountPublicKey, AccountSignature, CryptoError, CryptoHash, ValidatorPublicKey,
         ValidatorSignature,
     },
-    data_types::{BlobContent, BlockHeight},
+    data_types::{BlobContent, BlockHeight, NetworkDescription},
     ensure,
     identifiers::{AccountOwner, BlobId, ChainId},
 };
@@ -142,23 +142,25 @@ impl From<api::VersionInfo> for linera_version::VersionInfo {
     }
 }
 
-impl From<linera_storage::NetworkDescription> for api::NetworkDescription {
+impl From<NetworkDescription> for api::NetworkDescription {
     fn from(
-        linera_storage::NetworkDescription {
+        NetworkDescription {
             name,
             genesis_config_hash,
             genesis_timestamp,
-        }: linera_storage::NetworkDescription,
+            admin_chain_id,
+        }: NetworkDescription,
     ) -> Self {
         Self {
             name,
             genesis_config_hash: Some(genesis_config_hash.into()),
             genesis_timestamp: genesis_timestamp.micros(),
+            admin_chain_id: Some(admin_chain_id.into()),
         }
     }
 }
 
-impl TryFrom<api::NetworkDescription> for linera_storage::NetworkDescription {
+impl TryFrom<api::NetworkDescription> for NetworkDescription {
     type Error = GrpcProtoConversionError;
 
     fn try_from(
@@ -166,12 +168,14 @@ impl TryFrom<api::NetworkDescription> for linera_storage::NetworkDescription {
             name,
             genesis_config_hash,
             genesis_timestamp,
+            admin_chain_id,
         }: api::NetworkDescription,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
             name,
             genesis_config_hash: try_proto_convert(genesis_config_hash)?,
             genesis_timestamp: genesis_timestamp.into(),
+            admin_chain_id: try_proto_convert(admin_chain_id)?,
         })
     }
 }

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -4,7 +4,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::BlobContent,
+    data_types::{BlobContent, NetworkDescription},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::{
@@ -15,7 +15,6 @@ use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     node::NodeError,
 };
-use linera_storage::NetworkDescription;
 use linera_version::VersionInfo;
 use serde::{Deserialize, Serialize};
 

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -7,7 +7,7 @@ use std::future::Future;
 use futures::{sink::SinkExt, stream::StreamExt};
 use linera_base::{
     crypto::CryptoHash,
-    data_types::BlobContent,
+    data_types::{BlobContent, NetworkDescription},
     identifiers::{BlobId, ChainId},
     time::{timer, Duration},
 };
@@ -21,7 +21,6 @@ use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
     node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
 };
-use linera_storage::NetworkDescription;
 use linera_version::VersionInfo;
 
 use super::{codec, transport::TransportProtocol};

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -107,7 +107,6 @@ impl TestValidator {
             )]
             .into_iter()
             .collect(),
-            admin_id: None,
             epoch,
             balance: Amount::from_tokens(1_000_000),
             application_permissions: ApplicationPermissions::default(),
@@ -314,7 +313,6 @@ impl TestValidator {
         };
         let new_chain_config = open_chain_config.init_chain_config(
             epoch,
-            Some(admin_id),
             [(
                 epoch,
                 bcs::to_bytes(&committee).expect("Serializing a committee should not fail!"),

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -4,7 +4,7 @@
 use async_trait::async_trait;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{BlobContent, Timestamp},
+    data_types::{BlobContent, NetworkDescription, Timestamp},
     identifiers::{AccountOwner, BlobId, ChainId},
 };
 use linera_chain::{
@@ -30,7 +30,7 @@ use linera_core::{
 use linera_execution::committee::Committee;
 use linera_sdk::linera_base_types::ValidatorPublicKey;
 use linera_service::node_service::NodeService;
-use linera_storage::{DbStorage, NetworkDescription, Storage};
+use linera_storage::{DbStorage, Storage};
 use linera_version::VersionInfo;
 use linera_views::memory::MemoryStore;
 

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, Epoch, TimeDelta, Timestamp},
+    data_types::{Blob, Epoch, NetworkDescription, TimeDelta, Timestamp},
     identifiers::{ApplicationId, BlobId, ChainId, EventId},
 };
 use linera_chain::{
@@ -42,7 +42,7 @@ use {
     prometheus::{HistogramVec, IntCounterVec},
 };
 
-use crate::{ChainRuntimeContext, Clock, NetworkDescription, Storage};
+use crate::{ChainRuntimeContext, Clock, Storage};
 
 /// The metric counting how often a blob is tested for existence from storage
 #[cfg(with_metrics)]

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -14,8 +14,8 @@ use dashmap::{mapref::entry::Entry, DashMap};
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
-        ApplicationDescription, Blob, ChainDescription, CompressedBytecode, Epoch, TimeDelta,
-        Timestamp,
+        ApplicationDescription, Blob, ChainDescription, CompressedBytecode, Epoch,
+        NetworkDescription, TimeDelta, Timestamp,
     },
     identifiers::{ApplicationId, BlobId, ChainId, EventId},
     vm::VmRuntime,
@@ -39,7 +39,6 @@ use linera_views::{
     context::Context,
     views::{RootView, ViewError},
 };
-use serde::{Deserialize, Serialize};
 
 #[cfg(with_testing)]
 pub use crate::db_storage::TestClock;
@@ -328,14 +327,6 @@ pub trait Storage: Sized {
     ) -> Result<Self::BlockExporterContext, ViewError>;
 }
 
-/// A description of the current Linera network to be stored in every node's database.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct NetworkDescription {
-    pub name: String,
-    pub genesis_config_hash: CryptoHash,
-    pub genesis_timestamp: Timestamp,
-}
-
 /// An implementation of `ExecutionRuntimeContext` suitable for the core protocol.
 #[derive(Clone)]
 pub struct ChainRuntimeContext<S> {
@@ -402,6 +393,10 @@ where
 
     async fn get_event(&self, event_id: EventId) -> Result<Vec<u8>, ViewError> {
         self.storage.read_event(event_id).await
+    }
+
+    async fn get_network_description(&self) -> Result<Option<NetworkDescription>, ViewError> {
+        self.storage.read_network_description().await
     }
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {


### PR DESCRIPTION
## Motivation

There is no use case for different chains having different admin chain IDs, so admin ID should be a network-wide value, not a per-chain value.

## Proposal

Move the admin chain ID from `ChainDescription` into `NetworkDescription`.

## Test Plan

Regressions should be caught by CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
