### PR TITLE
Use admin chain instead of `known_committees`.

### DIFF
--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1095,12 +1095,13 @@ where
 
     let committee = Committee::new(validators.clone(), ResourceControlPolicy::only_fuel());
     admin.stage_new_committee(committee).await.unwrap();
-    admin.finalize_committee().await.unwrap();
 
     // Root chain 1 receives the notification about the new epoch.
+    // This must happen before the old committee is removed.
     user.synchronize_from_validators().await.unwrap();
     user.process_inbox().await.unwrap();
     assert_eq!(user.epoch().await.unwrap(), Epoch::from(1));
+    admin.finalize_committee().await.unwrap();
 
     // Create a new committee.
     let committee = Committee::new(validators.clone(), ResourceControlPolicy::only_fuel());

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -166,6 +166,21 @@ pub fn parse_millis_delta(s: &str) -> Result<TimeDelta, ParseIntError> {
     Ok(TimeDelta::from_millis(s.parse()?))
 }
 
+/// Checks the condition five times with increasing delays. Returns true if it is met.
+#[cfg(with_testing)]
+pub async fn eventually<F>(condition: impl Fn() -> F) -> bool
+where
+    F: std::future::Future<Output = bool>,
+{
+    for i in 0..5 {
+        linera_base::time::timer::sleep(std::time::Duration::from_secs(i)).await;
+        if condition().await {
+            return true;
+        }
+    }
+    false
+}
+
 #[test]
 fn test_parse_version_message() {
     let s = "something\n . . . version12\nother things";

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -128,7 +128,6 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
     client
         .set_validator(net.validator_keys(4).unwrap(), LocalNet::proxy_port(4), 100)
         .await?;
-    client.finalize_committee().await?;
 
     client.query_validators(None).await?;
     client.query_validators(Some(chain_1)).await?;
@@ -141,28 +140,46 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
     client
         .set_validator(net.validator_keys(5).unwrap(), LocalNet::proxy_port(5), 100)
         .await?;
-    client.finalize_committee().await?;
     if matches!(network, Network::Grpc) {
-        assert_eq!(faucet.current_validators().await?.len(), 6);
+        for i in 0.. {
+            linera_base::time::timer::sleep(Duration::from_secs(i)).await;
+            if faucet.current_validators().await?.len() == 6 {
+                break;
+            }
+            if i >= 5 {
+                panic!("Faucet failed to migrate to new epoch");
+            }
+        }
     }
 
     // Remove 5th validator
     client
         .remove_validator(&net.validator_keys(4).unwrap().0)
         .await?;
-    client.finalize_committee().await?;
     net.remove_validator(4)?;
     if matches!(network, Network::Grpc) {
-        assert_eq!(faucet.current_validators().await?.len(), 5);
+        for i in 0.. {
+            linera_base::time::timer::sleep(Duration::from_secs(i)).await;
+            if faucet.current_validators().await?.len() == 5 {
+                break;
+            }
+            if i >= 5 {
+                panic!("Faucet failed to migrate to new epoch");
+            }
+        }
     }
     client.query_validators(None).await?;
     client.query_validators(Some(chain_1)).await?;
     if let Some(service) = &node_service_2 {
         service.process_inbox(&chain_2).await?;
+        client.finalize_committee().await?;
+        service.process_inbox(&chain_2).await?;
         let committees = service.query_committees(&chain_2).await?;
         let epochs = committees.into_keys().collect::<Vec<_>>();
         assert_eq!(&epochs, &[Epoch(3)]);
     } else {
+        client_2.process_inbox(chain_2).await?;
+        client.finalize_committee().await?;
         client_2.process_inbox(chain_2).await?;
     }
 
@@ -170,13 +187,16 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
     for i in 0..4 {
         let validator_key = net.validator_keys(i).unwrap();
         client.remove_validator(&validator_key.0).await?;
-        client.finalize_committee().await?;
         if let Some(service) = &node_service_2 {
+            service.process_inbox(&chain_2).await?;
+            client.finalize_committee().await?;
             service.process_inbox(&chain_2).await?;
             let committees = service.query_committees(&chain_2).await?;
             let epochs = committees.into_keys().collect::<Vec<_>>();
             assert_eq!(&epochs, &[Epoch(4 + i as u32)]);
         } else {
+            client_2.process_inbox(chain_2).await?;
+            client.finalize_committee().await?;
             client_2.process_inbox(chain_2).await?;
         }
         net.remove_validator(i)?;
@@ -369,11 +389,12 @@ async fn test_end_to_end_receipt_of_old_remove_committee_messages(
     client
         .set_validator(net.validator_keys(4).unwrap(), LocalNet::proxy_port(4), 100)
         .await?;
-    client.finalize_committee().await?;
 
     client.query_validators(None).await?;
 
-    // Ensure the faucet is on the new epoch
+    // Ensure the faucet is on the new epoch before removing the old ones.
+    faucet_client.process_inbox(faucet_chain).await?;
+    client.finalize_committee().await?;
     faucet_client.process_inbox(faucet_chain).await?;
 
     if matches!(network, Network::Grpc) {


### PR DESCRIPTION
## Motivation

We want to move more functionality into `Client` (https://github.com/linera-io/linera-protocol/issues/3942) and in general simplify the logic.

`known_committees` currently returns the union of all committees known to the `ChainClient`'s local chain and the admin chain. This prevents moving its call sites to `Client`, and also doesn't make sense when we move towards addressing https://github.com/linera-io/linera-protocol/issues/285: The currently trusted committees cannot depend on which `ChainClient` instance caused the synchronization.

## Proposal

In `prepare_chain` make sure that the admin chain is always at least as up-to-date as the local chain.

Replace `known_committees` with `admin_committees`.

Update `test_change_voting_rights`: It makes sense that the test would fail now if we revoked the old committee _before_ migrating the other chain!

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Part of https://github.com/linera-io/linera-protocol/issues/3942.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
