### PR TITLE
Remove chain ID from mutex before closing it.

### DIFF
--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -178,6 +178,7 @@ where
 
         // Only keep using this chain if there will still be enough balance to close it.
         if faucet_client.local_balance().await? < self.amount.try_add(MAX_FEE.try_mul(2)?)? {
+            self.faucet_chain_id.lock().await.take();
             // TODO(#1795): Move the remaining tokens back to the main chain.
             match faucet_client.close_chain().await {
                 Ok(outcome) => {
@@ -190,7 +191,6 @@ where
                 .await
                 .forget_chain(&faucet_chain_id)
                 .await?;
-            self.faucet_chain_id.lock().await.take();
         }
 
         let chain_id = ChainId::child(message_id);

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -186,11 +186,17 @@ where
                 }
                 Err(err) => tracing::warn!("Failed to close the temporary faucet chain: {err:?}"),
             }
-            self.context
+            if let Err(err) = self
+                .context
                 .lock()
                 .await
                 .forget_chain(&faucet_chain_id)
-                .await?;
+                .await
+            {
+                tracing::error!(
+                    "Failed to remove the temporary faucet chain from the wallet: {err:?}"
+                );
+            }
         }
 
         let chain_id = ChainId::child(message_id);


### PR DESCRIPTION
## Motivation

It looks like the faucet on the testnet closed a chain but then failed to switch to a new one.

## Proposal

Remove the temporary chain ID from the mutex _before_ attempting to close it and remove it from the wallet, so that in case any of those steps fail, we will create a new temporary chain next time anyway.

Also, don't fail the request if we can't remove the chain from the wallet.

## Test Plan

It's not clear yet what actually failed, but this change should be safe: we could deploy it so that next time something goes wrong, the faucet does not break entirely.

## Release Plan

- Deploy a new faucet on the testnet.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
