### PR TITLE
windows build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,6 @@ linker = "aarch64-linux-gnu-gcc"
 [build]
 # We allow redundant explicit links because `cargo rdme` doesn't know how to resolve implicit intra-crate links.
 rustdocflags = ["-Arustdoc::redundant_explicit_links"]
+
+[target.'cfg(windows)']
+rustflags = ["-C", "link-args=/STACK:8388608"]

--- a/linera-base/src/command.rs
+++ b/linera-base/src/command.rs
@@ -67,7 +67,11 @@ pub async fn resolve_binary_in_same_directory_as<P: AsRef<Path>>(
     let current_binary_parent =
         binary_parent(current_binary).expect("Fetching binary directory should not fail");
 
-    let binary = current_binary_parent.join(name);
+    let mut binary = current_binary_parent.join(name);
+    if cfg!(windows) {
+        binary.set_extension("exe");
+    }
+
     let version = format!("v{}", env!("CARGO_PKG_VERSION"));
     if !binary.exists() {
         error!(

--- a/linera-service/src/project.rs
+++ b/linera-service/src/project.rs
@@ -244,13 +244,16 @@ impl Project {
         // We're putting the Cargo.toml file one level above the current directory.
         let linera_root = PathBuf::from("..").join(linera_root);
         let linera_sdk_path = linera_root.join("linera-sdk");
-        let linera_sdk_dep = format!(
-            "linera-sdk = {{ path = \"{}\" }}",
-            linera_sdk_path.display()
-        );
+
+        let path_str = linera_sdk_path
+            .to_str()
+            .expect("Invalid UTF-8 path")
+            .replace('\\', "/");
+
+        let linera_sdk_dep = format!("linera-sdk = {{ path = \"{}\" }}", path_str);
         let linera_sdk_dev_dep = format!(
             "linera-sdk = {{ path = \"{}\", features = [\"test\", \"wasmer\"] }}",
-            linera_sdk_path.display()
+            path_str
         );
         (linera_sdk_dep, linera_sdk_dev_dep)
     }


### PR DESCRIPTION
## Motivation
Some minor issues that fails the build for windows.
Also fails the integration tests for the linera-service crate.

## Proposal
- Change the default stack size for windows from 1 megabytes to 8 megabytes which is the default for linux.
- Windows binary paths don't recognize a binary without the ".exe" extension.
- Some other minor workarounds around the paths and directories and toml naming.
## Test Plan
Nothing to test other than the CI, these are just simple workarounds.
Nevertheless, had included some tests later.
## Release Plan

- Nothing to do / These changes follow the usual release cycle.
