### PR TITLE
Chain description duplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4708,7 +4708,6 @@ version = "0.15.0"
 dependencies = [
  "amm",
  "anyhow",
- "async-trait",
  "base64 0.22.1",
  "bcs",
  "cfg-if",

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -54,7 +54,6 @@ web-default = ["web", "wasmer", "indexed-db"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-async-trait.workspace = true
 bcs.workspace = true
 cfg-if.workspace = true
 clap.workspace = true

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -69,8 +69,7 @@ pub trait ClientContext {
 
     fn storage(&self) -> &<Self::Environment as linera_core::Environment>::Storage;
 
-    fn make_chain_client(&self, chain_id: ChainId)
-        -> Result<ContextChainClient<Self>, Error>;
+    fn make_chain_client(&self, chain_id: ChainId) -> Result<ContextChainClient<Self>, Error>;
 
     fn client(&self) -> &linera_core::client::Client<Self::Environment>;
 
@@ -311,11 +310,7 @@ impl<C: ClientContext> ChainListener<C> {
         if self.listening.contains_key(&chain_id) {
             return Ok(BTreeSet::new());
         }
-        let client = self
-            .context
-            .lock()
-            .await
-            .make_chain_client(chain_id)?;
+        let client = self.context.lock().await.make_chain_client(chain_id)?;
         let (listener, abort_handle, notification_stream) = client.listen().await?;
         if client.is_tracked() {
             client.synchronize_from_validators().await?;

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -793,11 +793,7 @@ where
     async fn process_inboxes_and_force_validator_updates(&mut self) {
         let mut chain_clients = vec![];
         for chain_id in &self.wallet.owned_chain_ids() {
-            chain_clients.push(
-                self.make_chain_client(*chain_id)
-                    .await
-                    .expect("chains in the wallet must exist"),
-            );
+            chain_clients.push(self.make_chain_client(*chain_id));
         }
 
         let mut join_set = task::JoinSet::new();

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -263,7 +263,10 @@ impl<Env: Environment, W: Persist<Target = Wallet>> ClientContext<Env, W> {
 
     pub fn make_chain_client(&self, chain_id: ChainId) -> Result<ChainClient<Env>, Error> {
         // We only create clients for chains we have in the wallet, or for the admin chain.
-        let chain = self.wallet.get(chain_id).cloned()
+        let chain = self
+            .wallet
+            .get(chain_id)
+            .cloned()
             .unwrap_or_else(|| UserChain::make_other(chain_id, Timestamp::from(0)));
 
         self.make_chain_client_internal(
@@ -285,16 +288,14 @@ impl<Env: Environment, W: Persist<Target = Wallet>> ClientContext<Env, W> {
         pending_proposal: Option<PendingProposal>,
         preferred_owner: Option<AccountOwner>,
     ) -> Result<ChainClient<Env>, Error> {
-        let mut chain_client = self
-            .client
-            .create_chain_client(
-                chain_id,
-                block_hash,
-                timestamp,
-                next_block_height,
-                pending_proposal,
-                preferred_owner,
-            )?;
+        let mut chain_client = self.client.create_chain_client(
+            chain_id,
+            block_hash,
+            timestamp,
+            next_block_height,
+            pending_proposal,
+            preferred_owner,
+        )?;
         chain_client.options_mut().message_policy = MessagePolicy::new(
             self.blanket_message_policy,
             self.restrict_chain_ids_to.clone(),

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -54,14 +54,12 @@ use {
     std::{fs, path::PathBuf},
 };
 
-#[cfg(web)]
-use crate::persistent::{LocalPersist as Persist, LocalPersistExt as _};
-#[cfg(not(web))]
-use crate::persistent::{Persist, PersistExt as _};
 use crate::{
     chain_listener::{self, ClientContext as _, ClientContextExt as _},
     client_options::{ChainOwnershipConfig, ClientContextOptions},
-    error, util,
+    error,
+    persistent::{Persist, PersistExt as _},
+    util,
     wallet::{UserChain, Wallet},
     Error,
 };
@@ -846,6 +844,7 @@ where
         ),
         Error,
     > {
+        use linera_base::identifiers::BlobType;
         let mut benchmark_chains = HashMap::new();
         let mut chain_clients = HashMap::new();
         let start = Instant::now();

--- a/linera-client/src/lib.rs
+++ b/linera-client/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![recursion_limit = "256"]
 #![deny(clippy::large_futures)]
+#![allow(async_fn_in_trait)]
 
 pub mod chain_listener;
 pub mod client_context;

--- a/linera-client/src/persistent/indexed_db.rs
+++ b/linera-client/src/persistent/indexed_db.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::wasm_bindgen;
 use web_sys::DomException;
 
-use super::{dirty::Dirty, LocalPersist};
+use super::{dirty::Dirty, Persist};
 
 /// An implementation of [`Persist`] based on an IndexedDB record with a given key.
 #[derive(derive_more::Deref)]
@@ -109,7 +109,7 @@ impl<T: serde::de::DeserializeOwned> IndexedDb<T> {
     }
 }
 
-impl<T: serde::Serialize> LocalPersist for IndexedDb<T> {
+impl<T: serde::Serialize> Persist for IndexedDb<T> {
     type Error = Error;
 
     #[instrument(level = "trace")]

--- a/linera-client/src/persistent/mod.rs
+++ b/linera-client/src/persistent/mod.rs
@@ -27,8 +27,6 @@ pub use memory::Memory;
 /// persistent way. A minimal implementation provides an `Error` type, a `persist`
 /// function to persist the value, and an `as_mut` function to get a mutable reference to
 /// the value in memory.
-///
-/// `LocalPersist` is a non-`Send` version.
 #[cfg_attr(not(web), trait_variant::make(Send))]
 pub trait Persist: Deref {
     type Error: std::error::Error + Send + Sync + 'static;

--- a/linera-client/src/persistent/mod.rs
+++ b/linera-client/src/persistent/mod.rs
@@ -29,8 +29,8 @@ pub use memory::Memory;
 /// the value in memory.
 ///
 /// `LocalPersist` is a non-`Send` version.
-#[trait_variant::make(Persist: Send)]
-pub trait LocalPersist: Deref {
+#[cfg_attr(not(web), trait_variant::make(Send))]
+pub trait Persist: Deref {
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// Gets a mutable reference to the value. This is not expressed as a
@@ -47,34 +47,13 @@ pub trait LocalPersist: Deref {
         Self::Target: Sized;
 }
 
-#[allow(async_fn_in_trait)]
-pub trait LocalPersistExt: LocalPersist {
-    /// Applies a mutation to the value, persisting when done.
-    async fn mutate<R>(
-        &mut self,
-        mutation: impl FnOnce(&mut Self::Target) -> R,
-    ) -> Result<R, Self::Error>;
-}
-
-#[trait_variant::make(Send)]
+#[cfg_attr(not(web), trait_variant::make(Send))]
 pub trait PersistExt: Persist {
     /// Applies a mutation to the value, persisting when done.
     async fn mutate<R: Send>(
         &mut self,
         mutation: impl FnOnce(&mut Self::Target) -> R + Send,
     ) -> Result<R, Self::Error>;
-}
-
-#[allow(async_fn_in_trait)]
-impl<T: LocalPersist> LocalPersistExt for T {
-    async fn mutate<R>(
-        &mut self,
-        mutation: impl FnOnce(&mut Self::Target) -> R,
-    ) -> Result<R, Self::Error> {
-        let output = mutation(self.as_mut());
-        self.persist().await?;
-        Ok(output)
-    }
 }
 
 impl<T: Persist> PersistExt for T {

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -5,7 +5,6 @@
 
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
-use async_trait::async_trait;
 use futures::{lock::Mutex, FutureExt as _};
 use linera_base::{
     crypto::{AccountPublicKey, InMemorySigner},
@@ -35,8 +34,6 @@ struct ClientContext {
     client: Arc<Client<environment::Test>>,
 }
 
-#[cfg_attr(not(web), async_trait)]
-#[cfg_attr(web, async_trait(?Send))]
 impl chain_listener::ClientContext for ClientContext {
     type Environment = environment::Test;
 
@@ -52,7 +49,7 @@ impl chain_listener::ClientContext for ClientContext {
         &self.client
     }
 
-    async fn make_chain_client(
+    fn make_chain_client(
         &self,
         chain_id: ChainId,
     ) -> Result<ChainClient<environment::Test>, Error> {
@@ -69,8 +66,7 @@ impl chain_listener::ClientContext for ClientContext {
                 chain.next_block_height,
                 chain.pending_proposal.clone(),
                 chain.owner,
-            )
-            .await?)
+            )?)
     }
 
     async fn update_wallet_for_new_chain(

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -57,16 +57,14 @@ impl chain_listener::ClientContext for ClientContext {
             .wallet
             .get(chain_id)
             .unwrap_or_else(|| panic!("Unknown chain: {}", chain_id));
-        Ok(self
-            .client
-            .create_chain_client(
-                chain_id,
-                chain.block_hash,
-                chain.timestamp,
-                chain.next_block_height,
-                chain.pending_proposal.clone(),
-                chain.owner,
-            )?)
+        Ok(self.client.create_chain_client(
+            chain_id,
+            chain.block_hash,
+            chain.timestamp,
+            chain.next_block_height,
+            chain.pending_proposal.clone(),
+            chain.owner,
+        )?)
     }
 
     async fn update_wallet_for_new_chain(

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -49,22 +49,19 @@ impl chain_listener::ClientContext for ClientContext {
         &self.client
     }
 
-    fn make_chain_client(
-        &self,
-        chain_id: ChainId,
-    ) -> Result<ChainClient<environment::Test>, Error> {
+    fn make_chain_client(&self, chain_id: ChainId) -> ChainClient<environment::Test> {
         let chain = self
             .wallet
             .get(chain_id)
             .unwrap_or_else(|| panic!("Unknown chain: {}", chain_id));
-        Ok(self.client.create_chain_client(
+        self.client.create_chain_client(
             chain_id,
             chain.block_hash,
             chain.timestamp,
             chain.next_block_height,
             chain.pending_proposal.clone(),
             chain.owner,
-        )?)
+        )
     }
 
     async fn update_wallet_for_new_chain(

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -253,7 +253,7 @@ impl<Env: Environment> Client<Env> {
 
     /// Creates a new `ChainClient`.
     #[instrument(level = "trace", skip_all, fields(chain_id, next_block_height))]
-    pub async fn create_chain_client(
+    pub fn create_chain_client(
         self: &Arc<Self>,
         chain_id: ChainId,
         block_hash: Option<CryptoHash>,
@@ -272,8 +272,6 @@ impl<Env: Environment> Client<Env> {
                 pending_proposal,
             ));
         }
-
-        let _ = self.ensure_has_chain_description(chain_id).await?;
 
         Ok(ChainClient {
             client: self.clone(),

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -261,7 +261,7 @@ impl<Env: Environment> Client<Env> {
         next_block_height: BlockHeight,
         pending_proposal: Option<PendingProposal>,
         preferred_owner: Option<AccountOwner>,
-    ) -> Result<ChainClient<Env>, ChainClientError> {
+    ) -> ChainClient<Env> {
         // If the entry already exists we assume that the entry is more up to date than
         // the arguments: If they were read from the wallet file, they might be stale.
         if let dashmap::mapref::entry::Entry::Vacant(e) = self.chains.entry(chain_id) {
@@ -273,7 +273,7 @@ impl<Env: Environment> Client<Env> {
             ));
         }
 
-        Ok(ChainClient {
+        ChainClient {
             client: self.clone(),
             chain_id,
             options: ChainClientOptions {
@@ -284,7 +284,7 @@ impl<Env: Environment> Client<Env> {
                 blob_download_timeout: self.blob_download_timeout,
             },
             preferred_owner,
-        })
+        }
     }
 
     /// Fetches the chain description blob if needed, and returns the chain info.

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -957,8 +957,7 @@ where
                 block_height,
                 None,
                 self.chain_owners.get(&chain_id).copied(),
-            )
-            .await?)
+            )?)
     }
 
     /// Tries to find a (confirmation) certificate for the given chain_id and block height.

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -949,15 +949,14 @@ where
             DEFAULT_GRACE_PERIOD,
             Duration::from_secs(1),
         ));
-        Ok(builder
-            .create_chain_client(
-                chain_id,
-                block_hash,
-                Timestamp::from(0),
-                block_height,
-                None,
-                self.chain_owners.get(&chain_id).copied(),
-            )?)
+        Ok(builder.create_chain_client(
+            chain_id,
+            block_hash,
+            Timestamp::from(0),
+            block_height,
+            None,
+            self.chain_owners.get(&chain_id).copied(),
+        )?)
     }
 
     /// Tries to find a (confirmation) certificate for the given chain_id and block height.

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -933,7 +933,7 @@ where
         // the rest by asking validators.
         let storage = self.make_storage().await?;
         self.chain_client_storages.push(storage.clone());
-        let builder = Arc::new(Client::new(
+        let client = Arc::new(Client::new(
             crate::environment::Impl {
                 network: self.make_node_provider(),
                 storage,
@@ -949,14 +949,14 @@ where
             DEFAULT_GRACE_PERIOD,
             Duration::from_secs(1),
         ));
-        Ok(builder.create_chain_client(
+        Ok(client.create_chain_client(
             chain_id,
             block_hash,
             Timestamp::from(0),
             block_height,
             None,
             self.chain_owners.get(&chain_id).copied(),
-        )?)
+        ))
     }
 
     /// Tries to find a (confirmation) certificate for the given chain_id and block height.

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -93,7 +93,7 @@ where
 
     /// Returns the current committee's validators.
     async fn current_validators(&self) -> Result<Vec<Validator>, Error> {
-        let client = self.context.lock().await.make_chain_client(self.chain_id)?;
+        let client = self.context.lock().await.make_chain_client(self.chain_id);
         let committee = client.local_committee().await?;
         Ok(committee
             .validators()
@@ -122,7 +122,7 @@ where
     C: ClientContext,
 {
     async fn do_claim(&self, owner: AccountOwner) -> Result<ChainDescription, Error> {
-        let client = self.context.lock().await.make_chain_client(self.chain_id)?;
+        let client = self.context.lock().await.make_chain_client(self.chain_id);
 
         if self.start_timestamp < self.end_timestamp {
             let local_time = client.storage_client().clock().current_time();
@@ -237,7 +237,7 @@ where
         config: ChainListenerConfig,
         storage: <C::Environment as linera_core::Environment>::Storage,
     ) -> anyhow::Result<Self> {
-        let client = context.make_chain_client(chain_id)?;
+        let client = context.make_chain_client(chain_id);
         let context = Arc::new(Mutex::new(context));
         let start_timestamp = client.storage_client().clock().current_time();
         client.process_inbox().await?;

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -93,11 +93,7 @@ where
 
     /// Returns the current committee's validators.
     async fn current_validators(&self) -> Result<Vec<Validator>, Error> {
-        let client = self
-            .context
-            .lock()
-            .await
-            .make_chain_client(self.chain_id)?;
+        let client = self.context.lock().await.make_chain_client(self.chain_id)?;
         let committee = client.local_committee().await?;
         Ok(committee
             .validators()
@@ -126,11 +122,7 @@ where
     C: ClientContext,
 {
     async fn do_claim(&self, owner: AccountOwner) -> Result<ChainDescription, Error> {
-        let client = self
-            .context
-            .lock()
-            .await
-            .make_chain_client(self.chain_id)?;
+        let client = self.context.lock().await.make_chain_client(self.chain_id)?;
 
         if self.start_timestamp < self.end_timestamp {
             let local_time = client.storage_client().clock().current_time();

--- a/linera-faucet/server/src/tests.rs
+++ b/linera-faucet/server/src/tests.rs
@@ -40,12 +40,9 @@ impl chain_listener::ClientContext for ClientContext {
         unimplemented!()
     }
 
-    fn make_chain_client(
-        &self,
-        chain_id: ChainId,
-    ) -> Result<ChainClient<environment::Test>, linera_client::Error> {
+    fn make_chain_client(&self, chain_id: ChainId) -> ChainClient<environment::Test> {
         assert_eq!(chain_id, self.client.chain_id());
-        Ok(self.client.clone())
+        self.client.clone()
     }
 
     async fn update_wallet_for_new_chain(

--- a/linera-faucet/server/src/tests.rs
+++ b/linera-faucet/server/src/tests.rs
@@ -5,7 +5,6 @@
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use futures::lock::Mutex;
 use linera_base::{
     crypto::{AccountPublicKey, InMemorySigner},
@@ -26,7 +25,6 @@ struct ClientContext {
     update_calls: usize,
 }
 
-#[async_trait]
 impl chain_listener::ClientContext for ClientContext {
     type Environment = environment::Test;
 
@@ -42,7 +40,7 @@ impl chain_listener::ClientContext for ClientContext {
         unimplemented!()
     }
 
-    async fn make_chain_client(
+    fn make_chain_client(
         &self,
         chain_id: ChainId,
     ) -> Result<ChainClient<environment::Test>, linera_client::Error> {

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -587,8 +587,8 @@ impl Runnable for Job {
                         .check_matching_network_description(address, &node)
                         .await?;
                 }
-                let chain_client = context
-                    .make_chain_client(context.wallet.genesis_admin_chain())?;
+                let chain_client =
+                    context.make_chain_client(context.wallet.genesis_admin_chain())?;
                 let n = context
                     .process_inbox(&chain_client)
                     .await
@@ -767,8 +767,8 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
 
-                let chain_client = context
-                    .make_chain_client(context.wallet.genesis_admin_chain())?;
+                let chain_client =
+                    context.make_chain_client(context.wallet.genesis_admin_chain())?;
 
                 // Remove the old committee.
                 info!("Finalizing current committee");

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -28,6 +28,7 @@ use linera_base::{
     ownership::ChainOwnership,
 };
 use linera_client::{
+    chain_listener::ClientContext as _,
     client_context::ClientContext,
     client_options::ClientContextOptions,
     config::{CommitteeConfig, GenesisConfig},
@@ -116,7 +117,7 @@ impl Runnable for Job {
                     wallet,
                     Box::new(signer.into_value()),
                 );
-                let chain_client = context.make_chain_client(sender.chain_id)?;
+                let chain_client = context.make_chain_client(sender.chain_id);
                 info!(
                     "Starting transfer of {} native tokens from {} to {}",
                     amount, sender, recipient
@@ -152,7 +153,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id);
                 info!("Opening a new chain from existing chain {}", chain_id);
                 let time_start = Instant::now();
                 let (id, certificate) = context
@@ -195,7 +196,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id);
                 info!(
                     "Opening a new multi-owner chain from existing chain {}",
                     chain_id
@@ -267,7 +268,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id);
                 info!("Changing application permissions for chain {}", chain_id);
                 let time_start = Instant::now();
                 let application_permissions =
@@ -299,7 +300,7 @@ impl Runnable for Job {
                     wallet,
                     Box::new(signer.into_value()),
                 );
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id);
                 info!("Closing chain {}", chain_id);
                 let time_start = Instant::now();
                 let result = context
@@ -332,7 +333,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let account = account.unwrap_or_else(|| context.default_account());
-                let chain_client = context.make_chain_client(account.chain_id)?;
+                let chain_client = context.make_chain_client(account.chain_id);
                 info!("Reading the balance of {} from the local state", account);
                 let time_start = Instant::now();
                 let balance = chain_client.local_owner_balance(account.owner).await?;
@@ -349,7 +350,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let account = account.unwrap_or_else(|| context.default_account());
-                let chain_client = context.make_chain_client(account.chain_id)?;
+                let chain_client = context.make_chain_client(account.chain_id);
                 info!(
                     "Evaluating the local balance of {account} by staging execution of known \
                     incoming messages"
@@ -369,7 +370,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let account = account.unwrap_or_else(|| context.default_account());
-                let chain_client = context.make_chain_client(account.chain_id)?;
+                let chain_client = context.make_chain_client(account.chain_id);
                 info!("Synchronizing chain information and querying the local balance");
                 warn!("This command is deprecated. Use `linera sync && linera query-balance` instead.");
                 let time_start = Instant::now();
@@ -393,7 +394,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id);
                 info!("Synchronizing chain information");
                 let time_start = Instant::now();
                 chain_client.synchronize_from_validators().await?;
@@ -413,7 +414,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id);
                 info!("Processing the inbox of chain {}", chain_id);
                 let time_start = Instant::now();
                 let certificates = context.process_inbox(&chain_client).await?;
@@ -480,7 +481,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id);
                 info!("Querying validators about chain {}", chain_id);
                 let result = chain_client.local_committee().await;
                 context.update_wallet_from_client(&chain_client).await?;
@@ -551,7 +552,7 @@ impl Runnable for Job {
                 let validator = context.make_node_provider().make_node(&address)?;
 
                 for chain_id in chains {
-                    let chain = context.make_chain_client(chain_id)?;
+                    let chain = context.make_chain_client(chain_id);
 
                     Box::pin(chain.sync_validator(validator.clone())).await?;
                 }
@@ -587,8 +588,7 @@ impl Runnable for Job {
                         .check_matching_network_description(address, &node)
                         .await?;
                 }
-                let chain_client =
-                    context.make_chain_client(context.wallet.genesis_admin_chain())?;
+                let chain_client = context.make_chain_client(context.wallet.genesis_admin_chain());
                 let n = context
                     .process_inbox(&chain_client)
                     .await
@@ -767,8 +767,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
 
-                let chain_client =
-                    context.make_chain_client(context.wallet.genesis_admin_chain())?;
+                let chain_client = context.make_chain_client(context.wallet.genesis_admin_chain());
 
                 // Remove the old committee.
                 info!("Finalizing current committee");
@@ -878,7 +877,7 @@ impl Runnable for Job {
 
                 let mut join_set = JoinSet::new();
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id);
                 info!("Watching for notifications for chain {:?}", chain_id);
                 let (listener, _listen_handle, mut notifications) = chain_client.listen().await?;
                 join_set.spawn_task(listener);
@@ -966,7 +965,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let publisher = publisher.unwrap_or_else(|| context.default_chain());
                 info!("Publishing module on chain {}", publisher);
-                let chain_client = context.make_chain_client(publisher)?;
+                let chain_client = context.make_chain_client(publisher);
                 let module_id = context
                     .publish_module(&chain_client, contract, service, vm_runtime)
                     .await?;
@@ -1011,7 +1010,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let publisher = publisher.unwrap_or_else(|| context.default_chain());
                 info!("Publishing data blob on chain {}", publisher);
-                let chain_client = context.make_chain_client(publisher)?;
+                let chain_client = context.make_chain_client(publisher);
                 let hash = context.publish_data_blob(&chain_client, blob_path).await?;
                 println!("{}", hash);
                 info!(
@@ -1032,7 +1031,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let reader = reader.unwrap_or_else(|| context.default_chain());
                 info!("Verifying data blob on chain {}", reader);
-                let chain_client = context.make_chain_client(reader)?;
+                let chain_client = context.make_chain_client(reader);
                 context.read_data_blob(&chain_client, hash).await?;
                 info!("Data blob read in {} ms", start_time.elapsed().as_millis());
             }
@@ -1056,7 +1055,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let creator = creator.unwrap_or_else(|| context.default_chain());
                 info!("Creating application on chain {}", creator);
-                let chain_client = context.make_chain_client(creator)?;
+                let chain_client = context.make_chain_client(creator);
                 let parameters = read_json(json_parameters, json_parameters_path)?;
                 let argument = read_json(json_argument, json_argument_path)?;
 
@@ -1112,7 +1111,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let publisher = publisher.unwrap_or_else(|| context.default_chain());
                 info!("Publishing and creating application on chain {}", publisher);
-                let chain_client = context.make_chain_client(publisher)?;
+                let chain_client = context.make_chain_client(publisher);
                 let parameters = read_json(json_parameters, json_parameters_path)?;
                 let argument = read_json(json_argument, json_argument_path)?;
                 let module_id = context
@@ -1187,7 +1186,7 @@ impl Runnable for Job {
                     let start_time = Instant::now();
                     let publisher = publisher.unwrap_or_else(|| context.default_chain());
                     info!("Creating application on chain {}", publisher);
-                    let chain_client = context.make_chain_client(publisher)?;
+                    let chain_client = context.make_chain_client(publisher);
 
                     let parameters = read_json(json_parameters, json_parameters_path)?;
                     let argument = read_json(json_argument, json_argument_path)?;
@@ -1239,7 +1238,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
                 info!("Committing pending block for chain {}", chain_id);
-                let chain_client = context.make_chain_client(chain_id)?;
+                let chain_client = context.make_chain_client(chain_id);
                 match chain_client.process_pending_block().await? {
                     ClientOutcome::Committed(Some(certificate)) => {
                         info!("Pending block committed successfully.");

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -116,7 +116,7 @@ impl Runnable for Job {
                     wallet,
                     Box::new(signer.into_value()),
                 );
-                let chain_client = context.make_chain_client(sender.chain_id).await?;
+                let chain_client = context.make_chain_client(sender.chain_id)?;
                 info!(
                     "Starting transfer of {} native tokens from {} to {}",
                     amount, sender, recipient
@@ -152,7 +152,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id).await?;
+                let chain_client = context.make_chain_client(chain_id)?;
                 info!("Opening a new chain from existing chain {}", chain_id);
                 let time_start = Instant::now();
                 let (id, certificate) = context
@@ -195,7 +195,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id).await?;
+                let chain_client = context.make_chain_client(chain_id)?;
                 info!(
                     "Opening a new multi-owner chain from existing chain {}",
                     chain_id
@@ -267,7 +267,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id).await?;
+                let chain_client = context.make_chain_client(chain_id)?;
                 info!("Changing application permissions for chain {}", chain_id);
                 let time_start = Instant::now();
                 let application_permissions =
@@ -299,7 +299,7 @@ impl Runnable for Job {
                     wallet,
                     Box::new(signer.into_value()),
                 );
-                let chain_client = context.make_chain_client(chain_id).await?;
+                let chain_client = context.make_chain_client(chain_id)?;
                 info!("Closing chain {}", chain_id);
                 let time_start = Instant::now();
                 let result = context
@@ -332,7 +332,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let account = account.unwrap_or_else(|| context.default_account());
-                let chain_client = context.make_chain_client(account.chain_id).await?;
+                let chain_client = context.make_chain_client(account.chain_id)?;
                 info!("Reading the balance of {} from the local state", account);
                 let time_start = Instant::now();
                 let balance = chain_client.local_owner_balance(account.owner).await?;
@@ -349,7 +349,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let account = account.unwrap_or_else(|| context.default_account());
-                let chain_client = context.make_chain_client(account.chain_id).await?;
+                let chain_client = context.make_chain_client(account.chain_id)?;
                 info!(
                     "Evaluating the local balance of {account} by staging execution of known \
                     incoming messages"
@@ -369,7 +369,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let account = account.unwrap_or_else(|| context.default_account());
-                let chain_client = context.make_chain_client(account.chain_id).await?;
+                let chain_client = context.make_chain_client(account.chain_id)?;
                 info!("Synchronizing chain information and querying the local balance");
                 warn!("This command is deprecated. Use `linera sync && linera query-balance` instead.");
                 let time_start = Instant::now();
@@ -393,7 +393,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id).await?;
+                let chain_client = context.make_chain_client(chain_id)?;
                 info!("Synchronizing chain information");
                 let time_start = Instant::now();
                 chain_client.synchronize_from_validators().await?;
@@ -413,7 +413,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id).await?;
+                let chain_client = context.make_chain_client(chain_id)?;
                 info!("Processing the inbox of chain {}", chain_id);
                 let time_start = Instant::now();
                 let certificates = context.process_inbox(&chain_client).await?;
@@ -480,7 +480,7 @@ impl Runnable for Job {
                     Box::new(signer.into_value()),
                 );
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id).await?;
+                let chain_client = context.make_chain_client(chain_id)?;
                 info!("Querying validators about chain {}", chain_id);
                 let result = chain_client.local_committee().await;
                 context.update_wallet_from_client(&chain_client).await?;
@@ -551,7 +551,7 @@ impl Runnable for Job {
                 let validator = context.make_node_provider().make_node(&address)?;
 
                 for chain_id in chains {
-                    let chain = context.make_chain_client(chain_id).await?;
+                    let chain = context.make_chain_client(chain_id)?;
 
                     Box::pin(chain.sync_validator(validator.clone())).await?;
                 }
@@ -588,8 +588,7 @@ impl Runnable for Job {
                         .await?;
                 }
                 let chain_client = context
-                    .make_chain_client(context.wallet.genesis_admin_chain())
-                    .await?;
+                    .make_chain_client(context.wallet.genesis_admin_chain())?;
                 let n = context
                     .process_inbox(&chain_client)
                     .await
@@ -769,8 +768,7 @@ impl Runnable for Job {
                 );
 
                 let chain_client = context
-                    .make_chain_client(context.wallet.genesis_admin_chain())
-                    .await?;
+                    .make_chain_client(context.wallet.genesis_admin_chain())?;
 
                 // Remove the old committee.
                 info!("Finalizing current committee");
@@ -880,7 +878,7 @@ impl Runnable for Job {
 
                 let mut join_set = JoinSet::new();
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(chain_id).await?;
+                let chain_client = context.make_chain_client(chain_id)?;
                 info!("Watching for notifications for chain {:?}", chain_id);
                 let (listener, _listen_handle, mut notifications) = chain_client.listen().await?;
                 join_set.spawn_task(listener);
@@ -968,7 +966,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let publisher = publisher.unwrap_or_else(|| context.default_chain());
                 info!("Publishing module on chain {}", publisher);
-                let chain_client = context.make_chain_client(publisher).await?;
+                let chain_client = context.make_chain_client(publisher)?;
                 let module_id = context
                     .publish_module(&chain_client, contract, service, vm_runtime)
                     .await?;
@@ -1013,7 +1011,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let publisher = publisher.unwrap_or_else(|| context.default_chain());
                 info!("Publishing data blob on chain {}", publisher);
-                let chain_client = context.make_chain_client(publisher).await?;
+                let chain_client = context.make_chain_client(publisher)?;
                 let hash = context.publish_data_blob(&chain_client, blob_path).await?;
                 println!("{}", hash);
                 info!(
@@ -1034,7 +1032,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let reader = reader.unwrap_or_else(|| context.default_chain());
                 info!("Verifying data blob on chain {}", reader);
-                let chain_client = context.make_chain_client(reader).await?;
+                let chain_client = context.make_chain_client(reader)?;
                 context.read_data_blob(&chain_client, hash).await?;
                 info!("Data blob read in {} ms", start_time.elapsed().as_millis());
             }
@@ -1058,7 +1056,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let creator = creator.unwrap_or_else(|| context.default_chain());
                 info!("Creating application on chain {}", creator);
-                let chain_client = context.make_chain_client(creator).await?;
+                let chain_client = context.make_chain_client(creator)?;
                 let parameters = read_json(json_parameters, json_parameters_path)?;
                 let argument = read_json(json_argument, json_argument_path)?;
 
@@ -1114,7 +1112,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let publisher = publisher.unwrap_or_else(|| context.default_chain());
                 info!("Publishing and creating application on chain {}", publisher);
-                let chain_client = context.make_chain_client(publisher).await?;
+                let chain_client = context.make_chain_client(publisher)?;
                 let parameters = read_json(json_parameters, json_parameters_path)?;
                 let argument = read_json(json_argument, json_argument_path)?;
                 let module_id = context
@@ -1189,7 +1187,7 @@ impl Runnable for Job {
                     let start_time = Instant::now();
                     let publisher = publisher.unwrap_or_else(|| context.default_chain());
                     info!("Creating application on chain {}", publisher);
-                    let chain_client = context.make_chain_client(publisher).await?;
+                    let chain_client = context.make_chain_client(publisher)?;
 
                     let parameters = read_json(json_parameters, json_parameters_path)?;
                     let argument = read_json(json_argument, json_argument_path)?;
@@ -1241,7 +1239,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
                 info!("Committing pending block for chain {}", chain_id);
-                let chain_client = context.make_chain_client(chain_id).await?;
+                let chain_client = context.make_chain_client(chain_id)?;
                 match chain_client.process_pending_block().await? {
                     ClientOutcome::Committed(Some(certificate)) => {
                         info!("Pending block committed successfully.");

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -117,11 +117,7 @@ where
         &self,
         chain_id: ChainId,
     ) -> Result<impl Stream<Item = Notification>, Error> {
-        let client = self
-            .context
-            .lock()
-            .await
-            .make_chain_client(chain_id)?;
+        let client = self.context.lock().await.make_chain_client(chain_id)?;
         Ok(client.subscribe().await?)
     }
 }
@@ -163,11 +159,7 @@ where
         Fut: Future<Output = (Result<ClientOutcome<T>, Error>, ChainClient<C::Environment>)>,
     {
         loop {
-            let client = self
-                .context
-                .lock()
-                .await
-                .make_chain_client(*chain_id)?;
+            let client = self.context.lock().await.make_chain_client(*chain_id)?;
             let mut stream = client.subscribe().await?;
             let (result, client) = f(client).await;
             self.context.lock().await.update_wallet(&client).await?;
@@ -190,11 +182,7 @@ where
     async fn process_inbox(&self, chain_id: ChainId) -> Result<Vec<CryptoHash>, Error> {
         let mut hashes = Vec::new();
         loop {
-            let client = self
-                .context
-                .lock()
-                .await
-                .make_chain_client(chain_id)?;
+            let client = self.context.lock().await.make_chain_client(chain_id)?;
             client.synchronize_from_validators().await?;
             let result = client.process_inbox_without_prepare().await;
             self.context.lock().await.update_wallet(&client).await?;
@@ -213,11 +201,7 @@ where
 
     /// Retries the pending block that was unsuccessfully proposed earlier.
     async fn retry_pending_block(&self, chain_id: ChainId) -> Result<Option<CryptoHash>, Error> {
-        let client = self
-            .context
-            .lock()
-            .await
-            .make_chain_client(chain_id)?;
+        let client = self.context.lock().await.make_chain_client(chain_id)?;
         let outcome = client.process_pending_block().await?;
         self.context.lock().await.update_wallet(&client).await?;
         match outcome {
@@ -596,21 +580,13 @@ where
         ChainStateExtendedView<<C::Environment as linera_core::Environment>::StorageContext>,
         Error,
     > {
-        let client = self
-            .context
-            .lock()
-            .await
-            .make_chain_client(chain_id)?;
+        let client = self.context.lock().await.make_chain_client(chain_id)?;
         let view = client.chain_state_view().await?;
         Ok(ChainStateExtendedView::new(view))
     }
 
     async fn applications(&self, chain_id: ChainId) -> Result<Vec<ApplicationOverview>, Error> {
-        let client = self
-            .context
-            .lock()
-            .await
-            .make_chain_client(chain_id)?;
+        let client = self.context.lock().await.make_chain_client(chain_id)?;
         let applications = client
             .chain_state_view()
             .await?
@@ -638,11 +614,7 @@ where
         hash: Option<CryptoHash>,
         chain_id: ChainId,
     ) -> Result<Option<ConfirmedBlock>, Error> {
-        let client = self
-            .context
-            .lock()
-            .await
-            .make_chain_client(chain_id)?;
+        let client = self.context.lock().await.make_chain_client(chain_id)?;
         let hash = match hash {
             Some(hash) => Some(hash),
             None => {
@@ -679,11 +651,7 @@ where
         chain_id: ChainId,
         limit: Option<u32>,
     ) -> Result<Vec<ConfirmedBlock>, Error> {
-        let client = self
-            .context
-            .lock()
-            .await
-            .make_chain_client(chain_id)?;
+        let client = self.context.lock().await.make_chain_client(chain_id)?;
         let limit = limit.unwrap_or(10);
         let from = match from {
             Some(from) => Some(from),

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -630,13 +630,13 @@ where
         stream_id: StreamId,
         start_index: u32,
     ) -> Result<Vec<IndexAndEvent>, Error> {
-        let client = self
+        Ok(self
             .context
             .lock()
             .await
             .make_chain_client(chain_id)
-            .await?;
-        Ok(client.events_from_index(stream_id, start_index).await?)
+            .events_from_index(stream_id, start_index)
+            .await?)
     }
 
     async fn blocks(

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_trait::async_trait;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{BlobContent, NetworkDescription, Timestamp},
@@ -168,7 +167,6 @@ struct DummyContext<P, S> {
     _phantom: std::marker::PhantomData<(P, S)>,
 }
 
-#[async_trait]
 impl<P: ValidatorNodeProvider + Send, S: Storage + Clone + Send + Sync + 'static> ClientContext
     for DummyContext<P, S>
 {
@@ -186,7 +184,7 @@ impl<P: ValidatorNodeProvider + Send, S: Storage + Clone + Send + Sync + 'static
         unimplemented!()
     }
 
-    async fn make_chain_client(&self, _: ChainId) -> Result<ChainClient<Self::Environment>, Error> {
+    fn make_chain_client(&self, _: ChainId) -> Result<ChainClient<Self::Environment>, Error> {
         unimplemented!()
     }
 
@@ -201,10 +199,6 @@ impl<P: ValidatorNodeProvider + Send, S: Storage + Clone + Send + Sync + 'static
 
     async fn update_wallet(&mut self, _: &ChainClient<Self::Environment>) -> Result<(), Error> {
         Ok(())
-    }
-
-    async fn clients(&self) -> Result<Vec<ChainClient<Self::Environment>>, Error> {
-        Ok(vec![])
     }
 }
 

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -184,7 +184,7 @@ impl<P: ValidatorNodeProvider + Send, S: Storage + Clone + Send + Sync + 'static
         unimplemented!()
     }
 
-    fn make_chain_client(&self, _: ChainId) -> Result<ChainClient<Self::Environment>, Error> {
+    fn make_chain_client(&self, _: ChainId) -> ChainClient<Self::Environment> {
         unimplemented!()
     }
 

--- a/linera-web/src/lib.rs
+++ b/linera-web/src/lib.rs
@@ -19,7 +19,7 @@ use linera_base::{
 use linera_client::{
     chain_listener::{ChainListener, ChainListenerConfig, ClientContext as _},
     client_options::ClientContextOptions,
-    persistent::LocalPersist as _,
+    persistent::Persist as _,
     wallet::Wallet,
 };
 use linera_core::{
@@ -122,7 +122,7 @@ impl JsFaucet {
     /// If an error occurs in the chain listener task.
     #[wasm_bindgen(js_name = claimChain)]
     pub async fn claim_chain(&self, wallet: &mut JsWallet) -> JsResult<String> {
-        use linera_client::persistent::LocalPersistExt as _;
+        use linera_client::persistent::PersistExt as _;
         let owner = AccountOwner::from(wallet.signer.mutate(InMemorySigner::generate_new).await?);
         tracing::info!(
             "Requesting a new chain for owner {} using the faucet at address {}",
@@ -250,7 +250,7 @@ impl Client {
             .wallet()
             .default_chain()
             .expect("A default chain should be configured");
-        Ok(client_context.make_chain_client(chain_id).await?)
+        Ok(client_context.make_chain_client(chain_id))
     }
 
     async fn apply_client_command<Fut, T, E>(
@@ -354,7 +354,7 @@ impl Frontend {
             .wallet()
             .default_chain()
             .expect("No default chain");
-        let chain_client = client_context.make_chain_client(chain_id).await?;
+        let chain_client = client_context.make_chain_client(chain_id);
         chain_client.synchronize_from_validators().await?;
         let result = chain_client.local_committee().await;
         client_context.update_wallet(&chain_client).await?;


### PR DESCRIPTION
## Motivation

The `chain_description` function is duplicated between the `ClientContext` struct and the `ClientContext` trait due to `Sync`ness issues with `Persist`.  As requested by @deuszx in https://github.com/linera-io/linera-protocol/pull/3956, deduplicate it, which entails several proximal cleanups.

## Proposal

- Further our goal of making `ChainClient` a syntactic convenience for calling `Client` with a chain ID by removing the `ensure_has_chain_description` call from `make_chain_client` and correspondingly making `make_chain_client` sync.  This removes the need for the wallet to be `Sync`, even when we `tokio::spawn`.
- Merge `LocalPersist` and `Persist` using conditional compilation, as we do elsewhere.
- Split the provided functions in `ClientContext` into `ClientContextExt` to allow dropping `async_trait`.
- Use the `ClientContextExt` version of `chain_description()` in `client_context.rs`.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
