### PR TITLE
Add `input_name` entry to some RFQ types.

### DIFF
--- a/examples/rfq/src/state.rs
+++ b/examples/rfq/src/state.rs
@@ -10,12 +10,14 @@ use rfq::{RequestId, TokenPair, Tokens};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize, SimpleObject, InputObject)]
+#[graphql(input_name = "QuoteRequestedInput")]
 pub struct QuoteRequested {
     token_pair: TokenPair,
     amount: Amount,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, SimpleObject, InputObject)]
+#[graphql(input_name = "QuoteProvidedInput")]
 pub struct QuoteProvided {
     token_pair: TokenPair,
     amount: Amount,
@@ -34,11 +36,13 @@ impl QuoteProvided {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, SimpleObject, InputObject)]
+#[graphql(input_name = "ExchangeInProgressInput")]
 pub struct ExchangeInProgress {
     temp_chain_id: ChainId,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, SimpleObject, InputObject)]
+#[graphql(input_name = "AwaitingTokensInput")]
 pub struct AwaitingTokens {
     pub token_pair: TokenPair,
     pub amount_offered: Amount,


### PR DESCRIPTION
## Motivation

For a given type T, we can apply the derive statement for `SimpleObject` and `InputObject`. Those will implement the `Object` and `InputObject` GraphQL trait. For a given type, we should implement at most one of those. 

If both are introduced, then we should have an `input_name` statement associated to it so that the Input type has a different name to the output type.

This is generally satisfied in the code, with the exception of 4 types in RFQ.

## Proposal

The solution is to add the `input_name` statement.
It might be a better idea to remove some traits definition altogether. 


## Test Plan

The CI. Currently, the RFQ passes only via the README.md test

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None