### PR TITLE
`linera-sdk`: build docs without tests

### DIFF
--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 development = ["linera-sdk"]
 
 [package.metadata.docs.rs]
-features = ["test", "wasmer"]
+features = ["wasmer"]
 targets = ["wasm32-unknown-unknown", "x86_64-unknown-linux-gnu"]
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
## Motivation

Docs are broken because they're trying to build testing code.

## Proposal

Don't document testing code.

## Test Plan

`docs.rs` is the only way of testing this consistently that I know of.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
