### PR TITLE
`linera-sdk`: build docs without tests

### DIFF
--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 development = ["linera-sdk"]
 
 [package.metadata.docs.rs]
-features = ["test", "wasmer"]
+features = ["wasmer"]
 targets = ["wasm32-unknown-unknown", "x86_64-unknown-linux-gnu"]
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
Babbage backport of https://github.com/linera-io/linera-protocol/pull/3964.