### PR TITLE
Build `linera-web` in CI instead of `linera-client`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -267,13 +267,10 @@ jobs:
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - name: Compile `linera-client` for the browser
-      run: |
-        cargo build -p linera-client \
-          --locked \
-          --target wasm32-unknown-unknown \
-          --no-default-features \
-          --features web-default
+    - name: Compile `linera-web` for the browser
+      run:  |
+        cd linera-web
+        cargo build
     - name: Install chromedriver
       uses: nanasess/setup-chromedriver@v2
     - name: Install wasm-pack


### PR DESCRIPTION
## Motivation

Now that `linera-web` is in this repository, we should at least build it as part of our CI.  It has to be excluded from `default-members` due to requiring a nightly compiler, so let's add a separate job to build it.

## Proposal

Build it as part of CI.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
