### PR TITLE
`metrics` submodules; other cleanups.

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -511,6 +511,15 @@ impl Block {
         &self.body.messages
     }
 
+    /// Returns all recipients of messages in this block.
+    pub fn recipients(&self) -> BTreeSet<ChainId> {
+        self.body
+            .messages
+            .iter()
+            .flat_map(|messages| messages.iter().map(|message| message.destination))
+            .collect()
+    }
+
     /// Returns whether there are any oracle responses in this block.
     pub fn has_oracle_responses(&self) -> bool {
         self.body

--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(with_metrics)]
-use std::sync::LazyLock;
-
 use async_graphql::SimpleObject;
 use linera_base::{
     data_types::{ArithmeticError, BlockHeight},
@@ -28,30 +25,30 @@ use crate::{data_types::MessageBundle, ChainError};
 mod inbox_tests;
 
 #[cfg(with_metrics)]
-use {
-    linera_base::prometheus_util::{exponential_bucket_interval, register_histogram_vec},
-    prometheus::HistogramVec,
-};
+mod metrics {
+    use std::sync::LazyLock;
 
-#[cfg(with_metrics)]
-static INBOX_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
-    register_histogram_vec(
-        "inbox_size",
-        "Inbox size",
-        &[],
-        exponential_bucket_interval(1.0, 2_000_000.0),
-    )
-});
+    use linera_base::prometheus_util::{exponential_bucket_interval, register_histogram_vec};
+    use prometheus::HistogramVec;
 
-#[cfg(with_metrics)]
-static REMOVED_BUNDLES: LazyLock<HistogramVec> = LazyLock::new(|| {
-    register_histogram_vec(
-        "removed_bundles",
-        "Number of bundles removed by anticipation",
-        &[],
-        exponential_bucket_interval(1.0, 10_000.0),
-    )
-});
+    pub static INBOX_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "inbox_size",
+            "Inbox size",
+            &[],
+            exponential_bucket_interval(1.0, 2_000_000.0),
+        )
+    });
+
+    pub static REMOVED_BUNDLES: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "removed_bundles",
+            "Number of bundles removed by anticipation",
+            &[],
+            exponential_bucket_interval(1.0, 10_000.0),
+        )
+    });
+}
 
 /// The state of an inbox.
 /// * An inbox is used to track bundles received and executed locally.
@@ -222,7 +219,7 @@ where
             );
             self.added_bundles.delete_front();
             #[cfg(with_metrics)]
-            INBOX_SIZE
+            metrics::INBOX_SIZE
                 .with_label_values(&[])
                 .observe(self.added_bundles.count() as f64);
             tracing::trace!("Skipping previously received bundle {:?}", previous_bundle);
@@ -244,7 +241,7 @@ where
                 );
                 self.added_bundles.delete_front();
                 #[cfg(with_metrics)]
-                INBOX_SIZE
+                metrics::INBOX_SIZE
                     .with_label_values(&[])
                     .observe(self.added_bundles.count() as f64);
                 tracing::trace!("Consuming bundle {:?}", bundle);
@@ -254,7 +251,7 @@ where
                 tracing::trace!("Marking bundle as expected: {:?}", bundle);
                 self.removed_bundles.push_back(bundle.clone());
                 #[cfg(with_metrics)]
-                REMOVED_BUNDLES
+                metrics::REMOVED_BUNDLES
                     .with_label_values(&[])
                     .observe(self.removed_bundles.count() as f64);
                 false
@@ -293,7 +290,7 @@ where
                     );
                     self.removed_bundles.delete_front();
                     #[cfg(with_metrics)]
-                    REMOVED_BUNDLES
+                    metrics::REMOVED_BUNDLES
                         .with_label_values(&[])
                         .observe(self.removed_bundles.count() as f64);
                 } else {
@@ -313,7 +310,7 @@ where
                 // Otherwise, schedule the messages for execution.
                 self.added_bundles.push_back(bundle);
                 #[cfg(with_metrics)]
-                INBOX_SIZE
+                metrics::INBOX_SIZE
                     .with_label_values(&[])
                     .observe(self.added_bundles.count() as f64);
                 true

--- a/linera-chain/src/outbox.rs
+++ b/linera-chain/src/outbox.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(with_metrics)]
-use std::sync::LazyLock;
-
 use linera_base::data_types::{ArithmeticError, BlockHeight};
 #[cfg(with_testing)]
 use linera_views::context::MemoryContext;
@@ -19,20 +16,21 @@ use linera_views::{
 mod outbox_tests;
 
 #[cfg(with_metrics)]
-use {
-    linera_base::prometheus_util::{exponential_bucket_interval, register_histogram_vec},
-    prometheus::HistogramVec,
-};
+mod metrics {
+    use std::sync::LazyLock;
 
-#[cfg(with_metrics)]
-static OUTBOX_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
-    register_histogram_vec(
-        "outbox_size",
-        "Outbox size",
-        &[],
-        exponential_bucket_interval(1.0, 10_000.0),
-    )
-});
+    use linera_base::prometheus_util::{exponential_bucket_interval, register_histogram_vec};
+    use prometheus::HistogramVec;
+
+    pub static OUTBOX_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "outbox_size",
+            "Outbox size",
+            &[],
+            exponential_bucket_interval(1.0, 10_000.0),
+        )
+    });
+}
 
 // The number of block heights in a bucket
 // The `BlockHeight` has just 8 bytes so the size is constant.
@@ -76,7 +74,7 @@ where
         self.next_height_to_schedule.set(height.try_add_one()?);
         self.queue.push_back(height);
         #[cfg(with_metrics)]
-        OUTBOX_SIZE
+        metrics::OUTBOX_SIZE
             .with_label_values(&[])
             .observe(self.queue.count() as f64);
         Ok(true)
@@ -97,7 +95,7 @@ where
             updates.push(h);
         }
         #[cfg(with_metrics)]
-        OUTBOX_SIZE
+        metrics::OUTBOX_SIZE
             .with_label_values(&[])
             .observe(self.queue.count() as f64);
         Ok(updates)

--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -10,7 +10,7 @@ use linera_base::{
 };
 use linera_core::test_utils::{ChainClient, MemoryStorageBuilder, StorageBuilder, TestBuilder};
 use linera_execution::system::Recipient;
-use linera_storage::{
+use linera_storage::metrics::{
     READ_CERTIFICATE_COUNTER, READ_CONFIRMED_BLOCK_COUNTER, WRITE_CERTIFICATE_COUNTER,
 };
 use linera_views::metrics::{LOAD_VIEW_COUNTER, SAVE_VIEW_COUNTER};

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -143,34 +143,19 @@ where
         let (response, _actions) = self.node.state.handle_chain_info_query(query).await?;
         Ok(response)
     }
-}
 
-impl<S> LocalNodeClient<S>
-where
-    S: Storage,
-{
     #[instrument(level = "trace", skip_all)]
     pub fn new(state: WorkerState<S>) -> Self {
         Self {
             node: Arc::new(LocalNode { state }),
         }
     }
-}
 
-impl<S> LocalNodeClient<S>
-where
-    S: Storage + Clone,
-{
     #[instrument(level = "trace", skip_all)]
     pub(crate) fn storage_client(&self) -> S {
         self.node.state.storage_client().clone()
     }
-}
 
-impl<S> LocalNodeClient<S>
-where
-    S: Storage + Clone + Send + Sync + 'static,
-{
     #[instrument(level = "trace", skip_all)]
     pub async fn stage_block_execution(
         &self,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -39,14 +39,6 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot, OwnedRwLockReadGuard};
 use tracing::{error, instrument, trace, warn};
-#[cfg(with_metrics)]
-use {
-    linera_base::prometheus_util::{
-        exponential_bucket_interval, register_histogram_vec, register_int_counter_vec,
-    },
-    prometheus::{HistogramVec, IntCounterVec},
-    std::sync::LazyLock,
-};
 
 use crate::{
     chain_worker::{ChainWorkerActor, ChainWorkerConfig, ChainWorkerRequest, DeliveryNotifier},
@@ -61,42 +53,47 @@ use crate::{
 mod worker_tests;
 
 #[cfg(with_metrics)]
-static NUM_ROUNDS_IN_CERTIFICATE: LazyLock<HistogramVec> = LazyLock::new(|| {
-    register_histogram_vec(
-        "num_rounds_in_certificate",
-        "Number of rounds in certificate",
-        &["certificate_value", "round_type"],
-        exponential_bucket_interval(0.1, 50.0),
-    )
-});
+mod metrics {
+    use std::sync::LazyLock;
 
-#[cfg(with_metrics)]
-static NUM_ROUNDS_IN_BLOCK_PROPOSAL: LazyLock<HistogramVec> = LazyLock::new(|| {
-    register_histogram_vec(
-        "num_rounds_in_block_proposal",
-        "Number of rounds in block proposal",
-        &["round_type"],
-        exponential_bucket_interval(0.1, 50.0),
-    )
-});
+    use linera_base::prometheus_util::{
+        exponential_bucket_interval, register_histogram_vec, register_int_counter_vec,
+    };
+    use prometheus::{HistogramVec, IntCounterVec};
 
-#[cfg(with_metrics)]
-static TRANSACTION_COUNT: LazyLock<IntCounterVec> =
-    LazyLock::new(|| register_int_counter_vec("transaction_count", "Transaction count", &[]));
+    pub static NUM_ROUNDS_IN_CERTIFICATE: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "num_rounds_in_certificate",
+            "Number of rounds in certificate",
+            &["certificate_value", "round_type"],
+            exponential_bucket_interval(0.1, 50.0),
+        )
+    });
 
-#[cfg(with_metrics)]
-static NUM_BLOCKS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    register_int_counter_vec("num_blocks", "Number of blocks added to chains", &[])
-});
+    pub static NUM_ROUNDS_IN_BLOCK_PROPOSAL: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "num_rounds_in_block_proposal",
+            "Number of rounds in block proposal",
+            &["round_type"],
+            exponential_bucket_interval(0.1, 50.0),
+        )
+    });
 
-#[cfg(with_metrics)]
-static CERTIFICATES_SIGNED: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    register_int_counter_vec(
-        "certificates_signed",
-        "Number of confirmed block certificates signed by each validator",
-        &["validator_name"],
-    )
-});
+    pub static TRANSACTION_COUNT: LazyLock<IntCounterVec> =
+        LazyLock::new(|| register_int_counter_vec("transaction_count", "Transaction count", &[]));
+
+    pub static NUM_BLOCKS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec("num_blocks", "Number of blocks added to chains", &[])
+    });
+
+    pub static CERTIFICATES_SIGNED: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "certificates_signed",
+            "Number of confirmed block certificates signed by each validator",
+            &["validator_name"],
+        )
+    });
+}
 
 /// Instruct the networking layer to send cross-chain requests and/or push notifications.
 #[derive(Default, Debug)]
@@ -593,7 +590,7 @@ where
             .await?;
 
         #[cfg(with_metrics)]
-        NUM_BLOCKS.with_label_values(&[]).inc();
+        metrics::NUM_BLOCKS.with_label_values(&[]).inc();
 
         Ok((response, actions))
     }
@@ -821,7 +818,7 @@ where
             })
             .await?;
         #[cfg(with_metrics)]
-        NUM_ROUNDS_IN_BLOCK_PROPOSAL
+        metrics::NUM_ROUNDS_IN_BLOCK_PROPOSAL
             .with_label_values(&[round.type_name()])
             .observe(round.number() as f64);
         Ok(response)
@@ -870,20 +867,20 @@ where
                 + certificate.block().body.operations.len())
                 as u64;
 
-            NUM_ROUNDS_IN_CERTIFICATE
+            metrics::NUM_ROUNDS_IN_CERTIFICATE
                 .with_label_values(&[
                     certificate.inner().to_log_str(),
                     certificate.round.type_name(),
                 ])
                 .observe(certificate.round.number() as f64);
             if confirmed_transactions > 0 {
-                TRANSACTION_COUNT
+                metrics::TRANSACTION_COUNT
                     .with_label_values(&[])
                     .inc_by(confirmed_transactions);
             }
 
             for (validator_name, _) in certificate.signatures() {
-                CERTIFICATES_SIGNED
+                metrics::CERTIFICATES_SIGNED
                     .with_label_values(&[&validator_name.to_string()])
                     .inc();
             }
@@ -914,7 +911,7 @@ where
         #[cfg(with_metrics)]
         {
             if !_duplicated {
-                NUM_ROUNDS_IN_CERTIFICATE
+                metrics::NUM_ROUNDS_IN_CERTIFICATE
                     .with_label_values(&[cert_str, round.type_name()])
                     .observe(round.number() as f64);
             }

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -20,20 +20,14 @@ mod wasmer;
 mod wasmtime;
 
 use linera_base::data_types::Bytecode;
+#[cfg(with_metrics)]
+use linera_base::prometheus_util::MeasureLatency as _;
 use thiserror::Error;
 use wasm_instrument::{gas_metering, parity_wasm};
 #[cfg(with_wasmer)]
 use wasmer::{WasmerContractInstance, WasmerServiceInstance};
 #[cfg(with_wasmtime)]
 use wasmtime::{WasmtimeContractInstance, WasmtimeServiceInstance};
-#[cfg(with_metrics)]
-use {
-    linera_base::prometheus_util::{
-        exponential_bucket_latencies, register_histogram_vec, MeasureLatency as _,
-    },
-    prometheus::HistogramVec,
-    std::sync::LazyLock,
-};
 
 pub use self::{
     entrypoints::{ContractEntrypoints, ServiceEntrypoints},
@@ -45,24 +39,30 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-static CONTRACT_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    register_histogram_vec(
-        "wasm_contract_instantiation_latency",
-        "Wasm contract instantiation latency",
-        &[],
-        exponential_bucket_latencies(1.0),
-    )
-});
+mod metrics {
+    use std::sync::LazyLock;
 
-#[cfg(with_metrics)]
-static SERVICE_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    register_histogram_vec(
-        "wasm_service_instantiation_latency",
-        "Wasm service instantiation latency",
-        &[],
-        exponential_bucket_latencies(1.0),
-    )
-});
+    use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
+    use prometheus::HistogramVec;
+
+    pub static CONTRACT_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "wasm_contract_instantiation_latency",
+            "Wasm contract instantiation latency",
+            &[],
+            exponential_bucket_latencies(1.0),
+        )
+    });
+
+    pub static SERVICE_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "wasm_service_instantiation_latency",
+            "Wasm service instantiation latency",
+            &[],
+            exponential_bucket_latencies(1.0),
+        )
+    });
+}
 
 /// A user contract in a compiled WebAssembly module.
 #[derive(Clone)]
@@ -114,7 +114,7 @@ impl UserContractModule for WasmContractModule {
         runtime: ContractSyncRuntimeHandle,
     ) -> Result<UserContractInstance, ExecutionError> {
         #[cfg(with_metrics)]
-        let _instantiation_latency = CONTRACT_INSTANTIATION_LATENCY.measure_latency();
+        let _instantiation_latency = metrics::CONTRACT_INSTANTIATION_LATENCY.measure_latency();
 
         let instance: UserContractInstance = match self {
             #[cfg(with_wasmtime)]
@@ -177,7 +177,7 @@ impl UserServiceModule for WasmServiceModule {
         runtime: ServiceSyncRuntimeHandle,
     ) -> Result<UserServiceInstance, ExecutionError> {
         #[cfg(with_metrics)]
-        let _instantiation_latency = SERVICE_INSTANTIATION_LATENCY.measure_latency();
+        let _instantiation_latency = metrics::SERVICE_INSTANTIATION_LATENCY.measure_latency();
 
         let instance: UserServiceInstance = match self {
             #[cfg(with_wasmtime)]

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -40,13 +40,11 @@ use linera_views::{
     views::{RootView, ViewError},
 };
 
+#[cfg(with_metrics)]
+pub use crate::db_storage::metrics;
 #[cfg(with_testing)]
 pub use crate::db_storage::TestClock;
 pub use crate::db_storage::{ChainStatesFirstAssignment, DbStorage, WallClock};
-#[cfg(with_metrics)]
-pub use crate::db_storage::{
-    READ_CERTIFICATE_COUNTER, READ_CONFIRMED_BLOCK_COUNTER, WRITE_CERTIFICATE_COUNTER,
-};
 
 /// The default namespace to be used when none is specified
 pub const DEFAULT_NAMESPACE: &str = "table_linera";

--- a/linera-views/src/backends/metering.rs
+++ b/linera-views/src/backends/metering.rs
@@ -10,7 +10,7 @@ use std::{
 
 use convert_case::{Case, Casing};
 use linera_base::prometheus_util::{
-    register_histogram_vec, register_int_counter_vec, MeasureLatency,
+    register_histogram_vec, register_int_counter_vec, MeasureLatency as _,
 };
 use prometheus::{HistogramVec, IntCounterVec};
 

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -2,17 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{vec_deque::IterMut, VecDeque};
-#[cfg(with_metrics)]
-use std::sync::LazyLock;
 
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
 #[cfg(with_metrics)]
-use {
-    linera_base::prometheus_util::{
-        exponential_bucket_latencies, register_histogram_vec, MeasureLatency,
-    },
-    prometheus::HistogramVec,
-};
+use linera_base::prometheus_util::MeasureLatency as _;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
     batch::Batch,
@@ -24,15 +17,22 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-/// The runtime of hash computation
-static BUCKET_QUEUE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-    register_histogram_vec(
-        "bucket_queue_view_hash_runtime",
-        "BucketQueueView hash runtime",
-        &[],
-        exponential_bucket_latencies(5.0),
-    )
-});
+mod metrics {
+    use std::sync::LazyLock;
+
+    use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
+    use prometheus::HistogramVec;
+
+    /// The runtime of hash computation
+    pub static BUCKET_QUEUE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "bucket_queue_view_hash_runtime",
+            "BucketQueueView hash runtime",
+            &[],
+            exponential_bucket_latencies(5.0),
+        )
+    });
+}
 
 /// Key tags to create the sub-keys of a [`BucketQueueView`] on top of the base key.
 /// * The Front is special and downloaded at the view loading.
@@ -713,7 +713,7 @@ where
 
     async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
         #[cfg(with_metrics)]
-        let _hash_latency = BUCKET_QUEUE_VIEW_HASH_RUNTIME.measure_latency();
+        let _hash_latency = metrics::BUCKET_QUEUE_VIEW_HASH_RUNTIME.measure_latency();
         let elements = self.elements().await?;
         let mut hasher = sha3::Sha3_256::default();
         hasher.update_with_bcs_bytes(&elements)?;

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -13,19 +13,12 @@
 //!
 //! Key tags to create the sub-keys of a `KeyValueStoreView` on top of the base key.
 
-#[cfg(with_metrics)]
-use std::sync::LazyLock;
 use std::{collections::BTreeMap, fmt::Debug, mem, ops::Bound::Included, sync::Mutex};
 
+#[cfg(with_metrics)]
+use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{data_types::ArithmeticError, ensure};
 use serde::{Deserialize, Serialize};
-#[cfg(with_metrics)]
-use {
-    linera_base::prometheus_util::{
-        exponential_bucket_latencies, register_histogram_vec, MeasureLatency,
-    },
-    prometheus::HistogramVec,
-};
 
 use crate::{
     batch::{Batch, WriteOperation},
@@ -40,94 +33,98 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-/// The latency of hash computation
-static KEY_VALUE_STORE_VIEW_HASH_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    register_histogram_vec(
-        "key_value_store_view_hash_latency",
-        "KeyValueStoreView hash latency",
-        &[],
-        exponential_bucket_latencies(5.0),
-    )
-});
+mod metrics {
+    use std::sync::LazyLock;
 
-#[cfg(with_metrics)]
-/// The latency of get operation
-static KEY_VALUE_STORE_VIEW_GET_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    register_histogram_vec(
-        "key_value_store_view_get_latency",
-        "KeyValueStoreView get latency",
-        &[],
-        exponential_bucket_latencies(5.0),
-    )
-});
+    use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
+    use prometheus::HistogramVec;
 
-#[cfg(with_metrics)]
-/// The latency of multi get
-static KEY_VALUE_STORE_VIEW_MULTI_GET_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    register_histogram_vec(
-        "key_value_store_view_multi_get_latency",
-        "KeyValueStoreView multi get latency",
-        &[],
-        exponential_bucket_latencies(5.0),
-    )
-});
-
-#[cfg(with_metrics)]
-/// The latency of contains key
-static KEY_VALUE_STORE_VIEW_CONTAINS_KEY_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    register_histogram_vec(
-        "key_value_store_view_contains_key_latency",
-        "KeyValueStoreView contains key latency",
-        &[],
-        exponential_bucket_latencies(5.0),
-    )
-});
-
-#[cfg(with_metrics)]
-/// The latency of contains keys
-static KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    register_histogram_vec(
-        "key_value_store_view_contains_keys_latency",
-        "KeyValueStoreView contains keys latency",
-        &[],
-        exponential_bucket_latencies(5.0),
-    )
-});
-
-#[cfg(with_metrics)]
-/// The latency of find keys by prefix operation
-static KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_LATENCY: LazyLock<HistogramVec> =
-    LazyLock::new(|| {
+    /// The latency of hash computation
+    pub static KEY_VALUE_STORE_VIEW_HASH_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         register_histogram_vec(
-            "key_value_store_view_find_keys_by_prefix_latency",
-            "KeyValueStoreView find keys by prefix latency",
+            "key_value_store_view_hash_latency",
+            "KeyValueStoreView hash latency",
             &[],
             exponential_bucket_latencies(5.0),
         )
     });
 
-#[cfg(with_metrics)]
-/// The latency of find key values by prefix operation
-static KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_LATENCY: LazyLock<HistogramVec> =
-    LazyLock::new(|| {
+    /// The latency of get operation
+    pub static KEY_VALUE_STORE_VIEW_GET_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         register_histogram_vec(
-            "key_value_store_view_find_key_values_by_prefix_latency",
-            "KeyValueStoreView find key values by prefix latency",
+            "key_value_store_view_get_latency",
+            "KeyValueStoreView get latency",
             &[],
             exponential_bucket_latencies(5.0),
         )
     });
 
-#[cfg(with_metrics)]
-/// The latency of write batch operation
-static KEY_VALUE_STORE_VIEW_WRITE_BATCH_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    register_histogram_vec(
-        "key_value_store_view_write_batch_latency",
-        "KeyValueStoreView write batch latency",
-        &[],
-        exponential_bucket_latencies(5.0),
-    )
-});
+    /// The latency of multi get
+    pub static KEY_VALUE_STORE_VIEW_MULTI_GET_LATENCY: LazyLock<HistogramVec> =
+        LazyLock::new(|| {
+            register_histogram_vec(
+                "key_value_store_view_multi_get_latency",
+                "KeyValueStoreView multi get latency",
+                &[],
+                exponential_bucket_latencies(5.0),
+            )
+        });
+
+    /// The latency of contains key
+    pub static KEY_VALUE_STORE_VIEW_CONTAINS_KEY_LATENCY: LazyLock<HistogramVec> =
+        LazyLock::new(|| {
+            register_histogram_vec(
+                "key_value_store_view_contains_key_latency",
+                "KeyValueStoreView contains key latency",
+                &[],
+                exponential_bucket_latencies(5.0),
+            )
+        });
+
+    /// The latency of contains keys
+    pub static KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_LATENCY: LazyLock<HistogramVec> =
+        LazyLock::new(|| {
+            register_histogram_vec(
+                "key_value_store_view_contains_keys_latency",
+                "KeyValueStoreView contains keys latency",
+                &[],
+                exponential_bucket_latencies(5.0),
+            )
+        });
+
+    /// The latency of find keys by prefix operation
+    pub static KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_LATENCY: LazyLock<HistogramVec> =
+        LazyLock::new(|| {
+            register_histogram_vec(
+                "key_value_store_view_find_keys_by_prefix_latency",
+                "KeyValueStoreView find keys by prefix latency",
+                &[],
+                exponential_bucket_latencies(5.0),
+            )
+        });
+
+    /// The latency of find key values by prefix operation
+    pub static KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_LATENCY: LazyLock<HistogramVec> =
+        LazyLock::new(|| {
+            register_histogram_vec(
+                "key_value_store_view_find_key_values_by_prefix_latency",
+                "KeyValueStoreView find key values by prefix latency",
+                &[],
+                exponential_bucket_latencies(5.0),
+            )
+        });
+
+    /// The latency of write batch operation
+    pub static KEY_VALUE_STORE_VIEW_WRITE_BATCH_LATENCY: LazyLock<HistogramVec> =
+        LazyLock::new(|| {
+            register_histogram_vec(
+                "key_value_store_view_write_batch_latency",
+                "KeyValueStoreView write batch latency",
+                &[],
+                exponential_bucket_latencies(5.0),
+            )
+        });
+}
 
 #[cfg(with_testing)]
 use {
@@ -693,7 +690,7 @@ where
     /// ```
     pub async fn get(&self, index: &[u8]) -> Result<Option<Vec<u8>>, ViewError> {
         #[cfg(with_metrics)]
-        let _latency = KEY_VALUE_STORE_VIEW_GET_LATENCY.measure_latency();
+        let _latency = metrics::KEY_VALUE_STORE_VIEW_GET_LATENCY.measure_latency();
         ensure!(index.len() <= self.max_key_size(), ViewError::KeyTooLong);
         if let Some(update) = self.updates.get(index) {
             let value = match update {
@@ -727,7 +724,7 @@ where
     /// ```
     pub async fn contains_key(&self, index: &[u8]) -> Result<bool, ViewError> {
         #[cfg(with_metrics)]
-        let _latency = KEY_VALUE_STORE_VIEW_CONTAINS_KEY_LATENCY.measure_latency();
+        let _latency = metrics::KEY_VALUE_STORE_VIEW_CONTAINS_KEY_LATENCY.measure_latency();
         ensure!(index.len() <= self.max_key_size(), ViewError::KeyTooLong);
         if let Some(update) = self.updates.get(index) {
             let test = match update {
@@ -762,7 +759,7 @@ where
     /// ```
     pub async fn contains_keys(&self, indices: Vec<Vec<u8>>) -> Result<Vec<bool>, ViewError> {
         #[cfg(with_metrics)]
-        let _latency = KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_LATENCY.measure_latency();
+        let _latency = metrics::KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_LATENCY.measure_latency();
         let mut results = Vec::with_capacity(indices.len());
         let mut missed_indices = Vec::new();
         let mut vector_query = Vec::new();
@@ -813,7 +810,7 @@ where
         indices: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, ViewError> {
         #[cfg(with_metrics)]
-        let _latency = KEY_VALUE_STORE_VIEW_MULTI_GET_LATENCY.measure_latency();
+        let _latency = metrics::KEY_VALUE_STORE_VIEW_MULTI_GET_LATENCY.measure_latency();
         let mut result = Vec::with_capacity(indices.len());
         let mut missed_indices = Vec::new();
         let mut vector_query = Vec::new();
@@ -868,7 +865,7 @@ where
     /// ```
     pub async fn write_batch(&mut self, batch: Batch) -> Result<(), ViewError> {
         #[cfg(with_metrics)]
-        let _latency = KEY_VALUE_STORE_VIEW_WRITE_BATCH_LATENCY.measure_latency();
+        let _latency = metrics::KEY_VALUE_STORE_VIEW_WRITE_BATCH_LATENCY.measure_latency();
         *self.hash.get_mut().unwrap() = None;
         let max_key_size = self.max_key_size();
         for operation in batch.operations {
@@ -1006,7 +1003,7 @@ where
     /// ```
     pub async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, ViewError> {
         #[cfg(with_metrics)]
-        let _latency = KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_LATENCY.measure_latency();
+        let _latency = metrics::KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_LATENCY.measure_latency();
         ensure!(
             key_prefix.len() <= self.max_key_size(),
             ViewError::KeyTooLong
@@ -1086,7 +1083,8 @@ where
         key_prefix: &[u8],
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ViewError> {
         #[cfg(with_metrics)]
-        let _latency = KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_LATENCY.measure_latency();
+        let _latency =
+            metrics::KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_LATENCY.measure_latency();
         ensure!(
             key_prefix.len() <= self.max_key_size(),
             ViewError::KeyTooLong
@@ -1149,7 +1147,7 @@ where
 
     async fn compute_hash(&self) -> Result<<sha3::Sha3_256 as Hasher>::Output, ViewError> {
         #[cfg(with_metrics)]
-        let _hash_latency = KEY_VALUE_STORE_VIEW_HASH_LATENCY.measure_latency();
+        let _hash_latency = metrics::KEY_VALUE_STORE_VIEW_HASH_LATENCY.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
         let mut count = 0u32;
         self.for_each_index_value(|index, value| -> Result<(), ViewError> {


### PR DESCRIPTION
## Motivation

The Prometheus metrics are behind a feature flag. In some files there are dozens of conditionally compiled items, and the metrics-only imports are often far away from the places where they are used. This makes it hard to add imports in the right places and keep track of interactions between different feature flags.

We also call `process_outgoing_messages` separately for each transaction which could cause some redundant loading of outboxes. Probably not a big issue since views stay in memory, but still unnecessary, and I will need to change this anyway soon for https://github.com/linera-io/linera-protocol/issues/3969.

Finally, there are a few redundantly separated `impl` blocks, and we're inconsistent whether we fully qualify or import `try_join_all`.

## Proposal

* Create `metrics` submodules in several places, so only a single `#[cfg(with_metrics)]` attribute is needed to cover their items and imports. This reduces the total number of that attribute from 250 to 165.
* Pass the whole block into `process_outgoing_messages`: That function only needs all the recipients of messages sent by that block; it's irrelevant what transaction they originate from.
* Merge `impl` blocks.
* Fully qualify `try_join_all`.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
