### PR TITLE
Support for running ScyllaDB in its own NodePool

### DIFF
--- a/kubernetes/linera-validator/helmfile.yaml
+++ b/kubernetes/linera-validator/helmfile.yaml
@@ -4,6 +4,7 @@ environments:
       - writeToGrafanaCloud: {{ env "LINERA_WRITE_TO_GRAFANA_CLOUD" | default "false" }}
         validatorLabel: {{ env "LINERA_VALIDATOR_LABEL" | default (printf "local-%s" (env "USER")) }}
         usingLocalSsd: {{ env "LINERA_HELMFILE_SET_USING_LOCAL_SSD" | default "false" }}
+        usingRecommendedScyllaDbSettings: {{ env "LINERA_HELMFILE_SET_USING_RECOMMENDED_SCYLLA_DB_SETTINGS" | default "false" }}
         kubeContext: {{ env "LINERA_HELMFILE_SET_KUBE_CONTEXT" | default "" }}
         kubeConfigPath: {{ env "KUBECONFIG" | default "" }}
 
@@ -12,7 +13,7 @@ helmDefaults:
   recreatePods: false
   kubeContext: {{ .Values.kubeContext | quote }}
 
-{{- if .Values.usingLocalSsd }}
+{{- if or .Values.usingLocalSsd .Values.usingRecommendedScyllaDbSettings }}
 hooks:
   - events: ["prepare"]
     showlogs: true

--- a/kubernetes/linera-validator/scylla-setup/gke-daemonset-raid-disks.yaml
+++ b/kubernetes/linera-validator/scylla-setup/gke-daemonset-raid-disks.yaml
@@ -16,6 +16,11 @@ spec:
     spec:
       nodeSelector:
         cloud.google.com/gke-local-nvme-ssd: "true"
+      tolerations:
+        - key: "scylla-db"
+          operator: "Equal"
+          value: "true"
+          effect: "NoSchedule"
       hostPID: true
       containers:
       - name: startup-script

--- a/kubernetes/linera-validator/scylla-setup/local-csi-driver/50_daemonset.yaml
+++ b/kubernetes/linera-validator/scylla-setup/local-csi-driver/50_daemonset.yaml
@@ -16,6 +16,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+        cloud.google.com/gke-local-nvme-ssd: "true"
       serviceAccountName: local-csi-driver
       tolerations:
       - operator: Exists

--- a/kubernetes/linera-validator/values-local.yaml.gotmpl
+++ b/kubernetes/linera-validator/values-local.yaml.gotmpl
@@ -12,6 +12,7 @@ rocksdbStorageSize: {{ env "LINERA_HELMFILE_SET_ROCKSDB_STORAGE_SIZE" | default 
 storage: {{ env "LINERA_HELMFILE_SET_STORAGE" | default "scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042" }}
 dualStore: {{ env "LINERA_HELMFILE_SET_DUAL_STORE" | default "false" }}
 usingLocalSsd: {{ env "LINERA_HELMFILE_SET_USING_LOCAL_SSD" | default "false" }}
+usingRecommendedScyllaDbSettings: {{ env "LINERA_HELMFILE_SET_USING_RECOMMENDED_SCYLLA_DB_SETTINGS" | default "false" }}
 storageReplicationFactor: {{ env "LINERA_HELMFILE_SET_STORAGE_REPLICATION_FACTOR" | default 1 }}
 
 # Loki


### PR DESCRIPTION
## Motivation

We're adding support for deploying ScyllaDB in the recommended way.

## Proposal

This is the `linera-protocol` side support for the `linera-infra` PR https://github.com/linera-io/linera-infra/pull/250.

## Test Plan

Ran benchmarks with this. ScyllaDB's performance drastically increases when deploying it in the recommended way.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
