### PR TITLE
Several corrections to the error handling.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -14,7 +14,7 @@ use linera_base::{
         Epoch, OracleResponse, Timestamp,
     },
     ensure,
-    identifiers::{AccountOwner, ApplicationId, ChainId, MessageId},
+    identifiers::{AccountOwner, ApplicationId, BlobType, ChainId, MessageId},
     ownership::ChainOwnership,
 };
 use linera_execution::{
@@ -553,8 +553,10 @@ where
             // if the only issue was that we couldn't initialize the chain because of a
             // missing chain description blob, we might still want to update the inbox
             Err(ChainError::ExecutionError(exec_err, _))
-                if matches!(*exec_err, ExecutionError::InactiveChain(inactive_chain_id)
-                            if chain_id == inactive_chain_id) => {}
+                if matches!(*exec_err, ExecutionError::BlobsNotFound(ref blobs)
+                if blobs.iter().all(|blob_id| {
+                    blob_id.blob_type == BlobType::ChainDescription && blob_id.hash == chain_id.0
+                })) => {}
             err => {
                 return err;
             }

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -118,7 +118,7 @@ impl ProposedBlock {
         let size = bcs::serialized_size(self)?;
         ensure!(
             size <= usize::try_from(maximum_block_proposal_size).unwrap_or(usize::MAX),
-            ChainError::BlockProposalTooLarge
+            ChainError::BlockProposalTooLarge(size)
         );
         Ok(())
     }

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -46,7 +46,7 @@ pub enum ChainError {
     #[error("Execution error: {0} during {1:?}")]
     ExecutionError(Box<ExecutionError>, ChainExecutionContext),
 
-    #[error("The chain being queried is not active {0:?}")]
+    #[error("The chain being queried is not active {0}")]
     InactiveChain(ChainId),
     #[error(
         "Cannot vote for block proposal of chain {chain_id:?} because a message \

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -119,8 +119,10 @@ pub enum ChainError {
     UnexpectedPreviousBlockHash,
     #[error("Sequence numbers above the maximal value are not usable for blocks")]
     InvalidBlockHeight,
-    #[error("Block timestamp must not be earlier than the parent block's.")]
-    InvalidBlockTimestamp,
+    #[error(
+        "Block timestamp {new} must not be earlier than the parent block's timestamp {parent}"
+    )]
+    InvalidBlockTimestamp { parent: Timestamp, new: Timestamp },
     #[error("Cannot initiate a new block while the previous one is still pending confirmation")]
     PreviousBlockMustBeConfirmedFirst,
     #[error("Round number should be at least {0:?}")]
@@ -143,8 +145,8 @@ pub enum ChainError {
     CertificateSignatureVerificationFailed { error: String },
     #[error("Internal error {0}")]
     InternalError(String),
-    #[error("Block proposal is too large")]
-    BlockProposalTooLarge,
+    #[error("Block proposal has size {0} which is too large")]
+    BlockProposalTooLarge(usize),
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
     #[error("Insufficient balance to pay the fees")]

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -298,7 +298,7 @@ impl<Env: Environment> Client<Env> {
                 let blobs =
                     RemoteNode::download_blobs(&blob_ids, validators, self.blob_download_timeout)
                         .await
-                        .ok_or(LocalNodeError::InactiveChain(chain_id))?;
+                        .ok_or(LocalNodeError::BlobsNotFound(blob_ids))?;
                 self.local_node.storage_client().write_blobs(&blobs).await?;
                 self.local_node.chain_info(chain_id).await
             }
@@ -489,7 +489,7 @@ impl<Env: Environment> Client<Env> {
         let nodes = self.validator_nodes().await?;
         let blob = RemoteNode::download_blob(&nodes, chain_desc_id, self.blob_download_timeout)
             .await
-            .ok_or(LocalNodeError::InactiveChain(chain_id))?;
+            .ok_or(LocalNodeError::BlobsNotFound(vec![chain_desc_id]))?;
         self.local_node.storage_client().write_blob(&blob).await?;
         Ok(blob)
     }

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -63,7 +63,7 @@ pub enum LocalNodeError {
     #[error("Failed to read blob {blob_id:?} of chain {chain_id:?}")]
     CannotReadLocalBlob { chain_id: ChainId, blob_id: BlobId },
 
-    #[error("The local node doesn't have an active chain {0:?}")]
+    #[error("The local node doesn't have an active chain {0}")]
     InactiveChain(ChainId),
 
     #[error("The chain info response received from the local node is invalid")]

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -195,7 +195,7 @@ pub enum NodeError {
     WorkerError { error: String },
 
     // This error must be normalized during conversions.
-    #[error("The chain {0:?} is not active in validator")]
+    #[error("The chain {0} is not active in validator")]
     InactiveChain(ChainId),
 
     // This error must be normalized during conversions.

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -20,7 +20,7 @@ use linera_chain::{
     },
     ChainError,
 };
-use linera_execution::committee::Committee;
+use linera_execution::{committee::Committee, ExecutionError};
 use linera_version::VersionInfo;
 use linera_views::views::ViewError;
 use serde::{Deserialize, Serialize};
@@ -319,7 +319,7 @@ impl From<ChainError> for NodeError {
             },
             ChainError::InactiveChain(chain_id) => Self::InactiveChain(chain_id),
             ChainError::ExecutionError(execution_error, context) => {
-                if let Some(blob_ids) = execution_error.blobs_not_found() {
+                if let ExecutionError::BlobsNotFound(blob_ids) = *execution_error {
                     Self::BlobsNotFound(blob_ids)
                 } else {
                     Self::ChainError {

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -20,7 +20,7 @@ use linera_chain::{
     },
     ChainError,
 };
-use linera_execution::{committee::Committee, ExecutionError};
+use linera_execution::committee::Committee;
 use linera_version::VersionInfo;
 use linera_views::views::ViewError;
 use serde::{Deserialize, Serialize};
@@ -222,11 +222,6 @@ pub enum NodeError {
     #[error("Validator's response to block proposal failed to include a vote")]
     MissingVoteInValidatorResponse,
 
-    #[error(
-        "Failed to update validator because our local node doesn't have an active chain {0:?}"
-    )]
-    InactiveLocalChain(ChainId),
-
     #[error("The received chain info response is invalid")]
     InvalidChainInfoResponse,
     #[error("Unexpected certificate value")]
@@ -324,7 +319,7 @@ impl From<ChainError> for NodeError {
             },
             ChainError::InactiveChain(chain_id) => Self::InactiveChain(chain_id),
             ChainError::ExecutionError(execution_error, context) => {
-                if let ExecutionError::BlobsNotFound(blob_ids) = *execution_error {
+                if let Some(blob_ids) = execution_error.blobs_not_found() {
                     Self::BlobsNotFound(blob_ids)
                 } else {
                     Self::ChainError {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2502,7 +2502,7 @@ where
         result,
         Err(ChainClientError::LocalNodeError(
             LocalNodeError::WorkerError(WorkerError::ChainError(chain_error))
-        )) if matches!(*chain_error, ChainError::BlockProposalTooLarge)
+        )) if matches!(*chain_error, ChainError::BlockProposalTooLarge(_))
     );
 
     assert_matches!(

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -689,7 +689,7 @@ where
         assert_matches!(
             env.worker().handle_block_proposal(block_proposal).await,
             Err(WorkerError::ChainError(error))
-                if matches!(*error, ChainError::InvalidBlockTimestamp)
+                if matches!(*error, ChainError::InvalidBlockTimestamp { .. })
         );
     }
     Ok(())

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -31,7 +31,7 @@ use linera_chain::{
     },
     ChainError, ChainStateView,
 };
-use linera_execution::{ExecutionStateView, Query, QueryOutcome};
+use linera_execution::{ExecutionError, ExecutionStateView, Query, QueryOutcome};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
 use lru::LruCache;
@@ -222,7 +222,7 @@ impl From<ChainError> for WorkerError {
     fn from(chain_error: ChainError) -> Self {
         match chain_error {
             ChainError::ExecutionError(execution_error, context) => {
-                if let Some(blob_ids) = execution_error.blobs_not_found() {
+                if let ExecutionError::BlobsNotFound(blob_ids) = *execution_error {
                     Self::BlobsNotFound(blob_ids)
                 } else {
                     Self::ChainError(Box::new(ChainError::ExecutionError(
@@ -238,15 +238,15 @@ impl From<ChainError> for WorkerError {
 
 #[cfg(with_testing)]
 impl WorkerError {
-    /// Returns the inner [`linera_execution::ExecutionError`] in this error.
+    /// Returns the inner [`ExecutionError`] in this error.
     ///
     /// # Panics
     ///
-    /// If this is not caused by an [`linera_execution::ExecutionError`].
+    /// If this is not caused by an [`ExecutionError`].
     pub fn expect_execution_error(
         self,
         expected_context: ChainExecutionContext,
-    ) -> linera_execution::ExecutionError {
+    ) -> ExecutionError {
         let WorkerError::ChainError(chain_error) = self else {
             panic!("Expected an `ExecutionError`. Got: {self:#?}");
         };

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -243,10 +243,7 @@ impl WorkerError {
     /// # Panics
     ///
     /// If this is not caused by an [`ExecutionError`].
-    pub fn expect_execution_error(
-        self,
-        expected_context: ChainExecutionContext,
-    ) -> ExecutionError {
+    pub fn expect_execution_error(self, expected_context: ChainExecutionContext) -> ExecutionError {
         let WorkerError::ChainError(chain_error) = self else {
             panic!("Expected an `ExecutionError`. Got: {self:#?}");
         };

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -344,19 +344,6 @@ pub enum ExecutionError {
     OutdatedUpdateStreams,
 }
 
-impl ExecutionError {
-    /// Returns the missing blobs from this error if any.
-    pub fn blobs_not_found(&self) -> Option<Vec<BlobId>> {
-        match self {
-            Self::InactiveChain(chain_id) => {
-                Some(vec![BlobId::new(chain_id.0, BlobType::ChainDescription)])
-            }
-            Self::BlobsNotFound(blob_ids) => Some(blob_ids.to_vec()),
-            _ => None,
-        }
-    }
-}
-
 /// The public entry points provided by the contract part of an application.
 pub trait UserContract {
     /// Instantiate the application state on the chain that owns the application.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -281,7 +281,7 @@ pub enum ExecutionError {
     ContractModuleSend(#[from] linera_base::task::SendError<UserContractCode>),
     #[error("Failed to send service code to worker thread: {0:?}")]
     ServiceModuleSend(#[from] linera_base::task::SendError<UserServiceCode>),
-    #[error("The chain being queried is not active {0:?}")]
+    #[error("The chain being queried is not active {0}")]
     InactiveChain(ChainId),
     #[error("Blobs not found: {0:?}")]
     BlobsNotFound(Vec<BlobId>),

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -281,6 +281,8 @@ pub enum ExecutionError {
     ContractModuleSend(#[from] linera_base::task::SendError<UserContractCode>),
     #[error("Failed to send service code to worker thread: {0:?}")]
     ServiceModuleSend(#[from] linera_base::task::SendError<UserServiceCode>),
+    #[error("The chain being queried is not active {0:?}")]
+    InactiveChain(ChainId),
     #[error("Blobs not found: {0:?}")]
     BlobsNotFound(Vec<BlobId>),
     #[error("Events not found: {0:?}")]
@@ -330,8 +332,6 @@ pub enum ExecutionError {
     TicksOutOfOrder,
     #[error("Application {0:?} is not registered by the chain")]
     UnknownApplicationId(Box<ApplicationId>),
-    #[error("Chain is not active yet.")]
-    InactiveChain,
     #[error("No recorded response for oracle query")]
     MissingOracleResponse,
     #[error("process_streams was not called for all stream updates")]
@@ -342,6 +342,19 @@ pub enum ExecutionError {
     EventNotFound(EventId),
     #[error("UpdateStreams is outdated")]
     OutdatedUpdateStreams,
+}
+
+impl ExecutionError {
+    /// Returns the missing blobs from this error if any.
+    pub fn blobs_not_found(&self) -> Option<Vec<BlobId>> {
+        match self {
+            Self::InactiveChain(chain_id) => {
+                Some(vec![BlobId::new(chain_id.0, BlobType::ChainDescription)])
+            }
+            Self::BlobsNotFound(blob_ids) => Some(blob_ids.to_vec()),
+            _ => None,
+        }
+    }
 }
 
 /// The public entry points provided by the contract part of an application.

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -515,7 +515,7 @@ where
                 let admin_id = self
                     .admin_id
                     .get()
-                    .ok_or_else(|| ExecutionError::InactiveChain)?;
+                    .ok_or_else(|| ExecutionError::InactiveChain(context.chain_id))?;
                 let event_id = EventId {
                     chain_id: admin_id,
                     stream_id: StreamId::system(EPOCH_STREAM_NAME),
@@ -545,7 +545,7 @@ where
                 let admin_id = self
                     .admin_id
                     .get()
-                    .ok_or_else(|| ExecutionError::InactiveChain)?;
+                    .ok_or_else(|| ExecutionError::InactiveChain(context.chain_id))?;
                 let event_id = EventId {
                     chain_id: admin_id,
                     stream_id: StreamId::system(REMOVED_EPOCH_STREAM_NAME),

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -691,48 +691,44 @@ NodeError:
     10:
       MissingVoteInValidatorResponse: UNIT
     11:
-      InactiveLocalChain:
-        NEWTYPE:
-          TYPENAME: ChainId
-    12:
       InvalidChainInfoResponse: UNIT
-    13:
+    12:
       UnexpectedCertificateValue: UNIT
-    14:
+    13:
       InvalidDecoding: UNIT
-    15:
+    14:
       UnexpectedMessage: UNIT
-    16:
+    15:
       GrpcError:
         STRUCT:
           - error: STR
-    17:
+    16:
       ClientIoError:
         STRUCT:
           - error: STR
-    18:
+    17:
       CannotResolveValidatorAddress:
         STRUCT:
           - address: STR
-    19:
+    18:
       SubscriptionError:
         STRUCT:
           - transport: STR
-    20:
+    19:
       SubscriptionFailed:
         STRUCT:
           - status: STR
-    21:
+    20:
       InvalidCertificateForBlob:
         NEWTYPE:
           TYPENAME: BlobId
-    22:
+    21:
       DuplicatesInBlobsNotFound: UNIT
-    23:
+    22:
       UnexpectedEntriesInBlobsNotFound: UNIT
-    24:
+    23:
       EmptyBlobsNotFound: UNIT
-    25:
+    24:
       ResponseHandlingError:
         STRUCT:
           - error: STR


### PR DESCRIPTION
## Motivation

Several corrections are done to the error handling.

## Proposal

The following unrelated simple changes are made:
* Removal of `InactiveLocalChain` which is never used.
* Addition of the size to `BlockTooLarge`.
* Addition of the timestamp to the timestamp errors.
* The `InactiveChain` of the `ExecutionError` now contains a specific `ChainId`.
* The ChainId of the `InactiveChain` is now printed as `{0}`, no longer as `{0:?}`.

## Test Plan

The CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.