### PR TITLE
Add BlockExecutionTracker 

### DIFF
--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 /// Tracks execution of transactions within a block.
-/// Captures the resource policy, produced messages, oracle events.
+/// Captures the resource policy, produced messages, oracle responses and events.
 #[derive(Debug)]
 pub struct BlockExecutionTracker<'resources> {
     resource_controller: &'resources mut ResourceController<Option<AccountOwner>, ResourceTracker>,
@@ -106,7 +106,7 @@ impl<'resources> BlockExecutionTracker<'resources> {
 
     /// Processes the transaction outcome.
     ///
-    /// Updates block tracker with indexes for the next messages, applicatios, etc.
+    /// Updates block tracker with indexes for the next messages, applications, etc.
     /// so that the execution of the next transaction doesn't overwrite the previous ones.
     ///
     /// Tracks the resources used by the transaction - size of the incoming and outgoing messages, blobs, etc.
@@ -191,7 +191,7 @@ impl<'resources> BlockExecutionTracker<'resources> {
         self.resource_controller
     }
 
-    /// Finalized the execution and returns the collected results.
+    /// Finalizes the execution and returns the collected results.
     ///
     /// This method should be called after all transactions have been processed.
     /// Panics if the number of outcomes does match the expected count.

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -1,0 +1,131 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeSet;
+
+use custom_debug_derive::Debug;
+use linera_base::{
+    data_types::{Blob, Event, OracleResponse, Timestamp},
+    identifiers::ChainId,
+};
+use linera_execution::{OutgoingMessage, TransactionOutcome, TransactionTracker};
+
+use crate::{
+    data_types::{OperationResult, Transaction},
+    ChainError, ChainExecutionContext,
+};
+
+/// Tracks execution of transactions within a block.
+/// Captures the resource policy, produced messages, oracle events.
+#[derive(Debug, Default)]
+pub struct BlockExecutionTracker {
+    local_time: Timestamp,
+    #[debug(skip_if = Option::is_none)]
+    pub replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
+    pub next_message_index: u32,
+    pub next_application_index: u32,
+    pub next_chain_index: u32,
+    #[debug(skip_if = Vec::is_empty)]
+    pub oracle_responses: Vec<Vec<OracleResponse>>,
+    #[debug(skip_if = Vec::is_empty)]
+    pub events: Vec<Vec<Event>>,
+    #[debug(skip_if = Vec::is_empty)]
+    pub blobs: Vec<Vec<Blob>>,
+    #[debug(skip_if = Vec::is_empty)]
+    pub messages: Vec<Vec<OutgoingMessage>>,
+    #[debug(skip_if = Vec::is_empty)]
+    pub operation_results: Vec<OperationResult>,
+    // Index of the currently executed transaction in a block.
+    transaction_index: u32,
+}
+
+impl BlockExecutionTracker {
+    /// Creates a new BlockExecutionTracker.
+    pub fn new(
+        local_time: Timestamp,
+        replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
+    ) -> Self {
+        Self {
+            local_time,
+            replaying_oracle_responses,
+            next_message_index: 0,
+            next_application_index: 0,
+            next_chain_index: 0,
+            oracle_responses: Vec::new(),
+            events: Vec::new(),
+            blobs: Vec::new(),
+            messages: Vec::new(),
+            operation_results: Vec::new(),
+            transaction_index: 0,
+        }
+    }
+
+    /// Returns a new TransactionTracker for the current transaction.
+    pub fn new_transaction_tracker(&mut self) -> Result<TransactionTracker, ChainError> {
+        Ok(TransactionTracker::new(
+            self.local_time,
+            self.transaction_index,
+            self.next_message_index,
+            self.next_application_index,
+            self.next_chain_index,
+            self.oracle_responses()?,
+        ))
+    }
+
+    /// Returns oracle responses for the current transaction.
+    fn oracle_responses(&self) -> Result<Option<Vec<OracleResponse>>, ChainError> {
+        if let Some(responses) = self.replaying_oracle_responses.as_ref() {
+            match responses.get(self.transaction_index as usize) {
+                Some(responses) => Ok(Some(responses.clone())),
+                None => Err(ChainError::MissingOracleResponseList),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Processes the transaction outcome and updates the tracker.
+    pub fn add_txn_outcome(&mut self, txn_outcome: &TransactionOutcome) {
+        self.next_message_index = txn_outcome.next_message_index;
+        self.next_application_index = txn_outcome.next_application_index;
+        self.next_chain_index = txn_outcome.next_chain_index;
+        self.oracle_responses
+            .push(txn_outcome.oracle_responses.clone());
+        self.events.push(txn_outcome.events.clone());
+        self.blobs.push(txn_outcome.blobs.clone());
+        self.messages.push(txn_outcome.outgoing_messages.clone());
+        self.operation_results
+            .push(OperationResult(txn_outcome.operation_result.clone()));
+
+        self.transaction_index += 1;
+    }
+
+    /// Returns recipient chain ids for outgoing messages in the block.
+    pub fn recipients(&self) -> BTreeSet<ChainId> {
+        self.messages
+            .iter()
+            .flatten()
+            .map(|msg| msg.destination)
+            .collect()
+    }
+
+    /// Asserts that the number of outcomes matches the expected count.
+    pub fn assert_outcomes_count(&self, txn_count: usize) {
+        assert_eq!(self.oracle_responses.len(), txn_count);
+        assert_eq!(self.messages.len(), txn_count);
+        assert_eq!(self.events.len(), txn_count);
+        assert_eq!(self.blobs.len(), txn_count);
+    }
+
+    /// Returns the execution context for the current transaction.
+    pub fn chain_execution_context(&self, transaction: &Transaction<'_>) -> ChainExecutionContext {
+        match transaction {
+            Transaction::ReceiveMessages(_) => {
+                ChainExecutionContext::IncomingBundle(self.transaction_index)
+            }
+            Transaction::ExecuteOperation(_) => {
+                ChainExecutionContext::Operation(self.transaction_index)
+            }
+        }
+    }
+}

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -154,14 +154,6 @@ impl BlockExecutionTracker {
             .collect()
     }
 
-    /// Asserts that the number of outcomes matches the expected count.
-    pub fn assert_outcomes_count(&self, txn_count: usize) {
-        assert_eq!(self.oracle_responses.len(), txn_count);
-        assert_eq!(self.messages.len(), txn_count);
-        assert_eq!(self.events.len(), txn_count);
-        assert_eq!(self.blobs.len(), txn_count);
-    }
-
     /// Returns the execution context for the current transaction.
     pub fn chain_execution_context(&self, transaction: &Transaction<'_>) -> ChainExecutionContext {
         match transaction {
@@ -173,4 +165,31 @@ impl BlockExecutionTracker {
             }
         }
     }
+
+    /// Finalized the execution and returns the collected results.
+    ///
+    /// This method should be called after all transactions have been processed.
+    /// Panics if the number of outcomes does match the expected count.
+    pub fn finalize(self) -> FinalizeExecutionResult {
+        // Asserts that the number of outcomes matches the expected count.
+        assert_eq!(self.oracle_responses.len(), self.expected_outcomes_count);
+        assert_eq!(self.messages.len(), self.expected_outcomes_count);
+        assert_eq!(self.events.len(), self.expected_outcomes_count);
+        assert_eq!(self.blobs.len(), self.expected_outcomes_count);
+        (
+            self.messages,
+            self.oracle_responses,
+            self.events,
+            self.blobs,
+            self.operation_results,
+        )
+    }
 }
+
+pub(crate) type FinalizeExecutionResult = (
+    Vec<Vec<OutgoingMessage>>,
+    Vec<Vec<OracleResponse>>,
+    Vec<Vec<Event>>,
+    Vec<Vec<Blob>>,
+    Vec<OperationResult>,
+);

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -127,8 +127,10 @@ impl<'resources> BlockExecutionTracker<'resources> {
         self.events.push(txn_outcome.events.clone());
         self.blobs.push(txn_outcome.blobs.clone());
         self.messages.push(txn_outcome.outgoing_messages.clone());
-        self.operation_results
-            .push(OperationResult(txn_outcome.operation_result.clone()));
+        if matches!(context, ChainExecutionContext::Operation(_)) {
+            self.operation_results
+                .push(OperationResult(txn_outcome.operation_result.clone()));
+        }
 
         let mut resource_controller = self.resource_controller.with_state(view).await?;
 

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -201,6 +201,10 @@ impl<'resources> BlockExecutionTracker<'resources> {
         assert_eq!(self.messages.len(), self.expected_outcomes_count);
         assert_eq!(self.events.len(), self.expected_outcomes_count);
         assert_eq!(self.blobs.len(), self.expected_outcomes_count);
+
+        #[cfg(with_metrics)]
+        crate::chain::metrics::track_block_metrics(&self.resource_controller.tracker);
+
         (
             self.messages,
             self.oracle_responses,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -697,11 +697,11 @@ where
             .1
             .policy()
             .clone();
-        let mut resource_controller = ResourceController {
-            policy: Arc::new(policy),
-            tracker: ResourceTracker::default(),
-            account: block.authenticated_signer,
-        };
+        let mut resource_controller = ResourceController::new(
+            Arc::new(policy),
+            ResourceTracker::default(),
+            block.authenticated_signer,
+        );
         resource_controller
             .track_block_size(EMPTY_BLOCK_SIZE)
             .with_execution_context(ChainExecutionContext::Block)?;

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -801,6 +801,7 @@ where
                     &txn_outcome.blobs,
                 ))
                 .with_execution_context(chain_execution_context)?;
+
             for blob in &txn_outcome.blobs {
                 if blob.content().blob_type() == BlobType::Data {
                     resource_controller
@@ -811,11 +812,9 @@ where
                 }
             }
 
-            if let Transaction::ExecuteOperation(_) = transaction {
-                resource_controller
-                    .track_block_size_of(&(&txn_outcome.operation_result))
-                    .with_execution_context(chain_execution_context)?;
-            }
+            resource_controller
+                .track_block_size_of(&(&txn_outcome.operation_result))
+                .with_execution_context(chain_execution_context)?;
         }
 
         let recipients = block_execution_tracker.recipients();

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -785,21 +785,12 @@ where
 
             block_execution_tracker.add_txn_outcome(&txn_outcome);
 
-            if matches!(
-                transaction,
-                Transaction::ExecuteOperation(_)
-                    | Transaction::ReceiveMessages(IncomingBundle {
-                        action: MessageAction::Accept,
-                        ..
-                    })
-            ) {
-                for message_out in &txn_outcome.outgoing_messages {
-                    resource_controller
-                        .with_state(&mut chain.system)
-                        .await?
-                        .track_message(&message_out.message)
-                        .with_execution_context(chain_execution_context)?;
-                }
+            for message_out in &txn_outcome.outgoing_messages {
+                resource_controller
+                    .with_state(&mut chain.system)
+                    .await?
+                    .track_message(&message_out.message)
+                    .with_execution_context(chain_execution_context)?;
             }
 
             resource_controller

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -804,9 +804,6 @@ where
             }
         }
 
-        block_execution_tracker
-            .assert_outcomes_count(block.incoming_bundles.len() + block.operations.len());
-
         #[cfg(with_metrics)]
         Self::track_block_metrics(&resource_controller.tracker);
 
@@ -816,14 +813,17 @@ where
             chain.crypto_hash().await?
         };
 
+        let (messages, oracle_responses, events, blobs, operation_results) =
+            block_execution_tracker.finalize();
+
         Ok(BlockExecutionOutcome {
-            messages: block_execution_tracker.messages,
+            messages,
             previous_message_blocks,
             state_hash,
-            oracle_responses: block_execution_tracker.oracle_responses,
-            events: block_execution_tracker.events,
-            blobs: block_execution_tracker.blobs,
-            operation_results: block_execution_tracker.operation_results,
+            oracle_responses,
+            events,
+            blobs,
+            operation_results,
         })
     }
 

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -105,14 +105,16 @@ impl ProposedBlock {
             .sum()
     }
 
-    /// Returns an iterator over all transactions, by index.
-    pub fn transactions(&self) -> impl Iterator<Item = (u32, Transaction<'_>)> {
+    /// Returns an iterator over all transactions.
+    ///
+    /// First incoming bundles, then operations.
+    pub fn transactions(&self) -> impl Iterator<Item = Transaction<'_>> {
         let bundles = self
             .incoming_bundles
             .iter()
             .map(Transaction::ReceiveMessages);
         let operations = self.operations.iter().map(Transaction::ExecuteOperation);
-        (0u32..).zip(bundles.chain(operations))
+        bundles.chain(operations)
     }
 
     pub fn check_proposal_size(&self, maximum_block_proposal_size: u64) -> Result<(), ChainError> {

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -12,6 +12,7 @@ pub mod types {
     pub use super::{block::*, certificate::*};
 }
 
+mod block_tracker;
 mod chain;
 pub mod data_types;
 mod inbox;

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -181,7 +181,7 @@ where
     /// Runs the [`ChainWorkerActor`], first by loading the chain state from `storage` then
     /// handling all `incoming_requests` as they arrive.
     ///
-    /// If loading the chain state fails the next request will receive the error reported by the
+    /// If loading the chain state fails, the next request will receive the error reported by the
     /// `storage`, and the actor will then try again to load the state.
     #[expect(clippy::too_many_arguments)]
     pub async fn run(

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -111,11 +111,7 @@ where
 
         let tracker = ResourceTracker::default();
         let policy = ResourceControlPolicy::no_fees();
-        let mut resource_controller = ResourceController {
-            policy: Arc::new(policy),
-            tracker,
-            account: None,
-        };
+        let mut resource_controller = ResourceController::new(Arc::new(policy), tracker, None);
         let mut txn_tracker = TransactionTracker::new(
             local_time,
             0,
@@ -225,11 +221,11 @@ where
             .with_state_and_grant(&mut self.system, cloned_grant.as_mut())
             .await?
             .balance()?;
-        let controller = ResourceController {
-            policy: resource_controller.policy.clone(),
-            tracker: resource_controller.tracker,
-            account: initial_balance,
-        };
+        let controller = ResourceController::new(
+            resource_controller.policy().clone(),
+            resource_controller.tracker,
+            initial_balance,
+        );
         let (execution_state_sender, mut execution_state_receiver) =
             futures::channel::mpsc::unbounded();
         let (code, description) = self.load_contract(application_id, txn_tracker).await?;

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -68,7 +68,7 @@ pub use crate::{
     execution::{ExecutionStateView, ServiceRuntimeEndpoint},
     execution_state_actor::ExecutionRequest,
     policy::ResourceControlPolicy,
-    resources::{ResourceController, ResourceTracker},
+    resources::{BalanceHolder, ResourceController, ResourceTracker},
     runtime::{
         ContractSyncRuntimeHandle, ServiceRuntimeRequest, ServiceSyncRuntime,
         ServiceSyncRuntimeHandle,

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -2,6 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module contains types related to fees and pricing.
+//! Defines the economic parameters and hard limits for resource consumption
+//! within the Linera network. It specifies prices for fundamental units like fuel,
+//! individual read/write operations, costs per byte read/written,
+//! base costs for messages and operations, and costs associated with publishing blobs.
+//! It also sets overarching limits such as the maximum fuel allowed per block,
+//! the maximum block size, and limits on concurrent operations.
 
 use std::{collections::BTreeSet, fmt};
 

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -20,14 +20,34 @@ use crate::{ExecutionError, Message, Operation, ResourceControlPolicy, SystemExe
 #[derive(Clone, Debug, Default)]
 pub struct ResourceController<Account = Amount, Tracker = ResourceTracker> {
     /// The (fixed) policy used to charge fees and control resource usage.
-    pub policy: Arc<ResourceControlPolicy>,
+    policy: Arc<ResourceControlPolicy>,
     /// How the resources were used so far.
     pub tracker: Tracker,
     /// The account paying for the resource usage.
     pub account: Account,
 }
 
+impl<Account, Tracker> ResourceController<Account, Tracker> {
+    /// Creates a new resource controller with the given policy and account.
+    pub fn new(policy: Arc<ResourceControlPolicy>, tracker: Tracker, account: Account) -> Self {
+        Self {
+            policy,
+            tracker,
+            account,
+        }
+    }
+
+    /// Returns a reference to the policy.
+    pub fn policy(&self) -> &Arc<ResourceControlPolicy> {
+        &self.policy
+    }
+}
+
 /// The resources used so far by an execution process.
+/// Acts as an accumulator for all resources consumed during
+/// a specific execution flow. This could be the execution of a block,
+/// the processing of a single message, or a specific phase within these
+/// broader operations.
 #[derive(Copy, Debug, Clone, Default)]
 pub struct ResourceTracker {
     /// The total size of the block so far.

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -41,6 +41,11 @@ impl<Account, Tracker> ResourceController<Account, Tracker> {
     pub fn policy(&self) -> &Arc<ResourceControlPolicy> {
         &self.policy
     }
+
+    /// Returns a reference to the tracker.
+    pub fn tracker(&self) -> &Tracker {
+        &self.tracker
+    }
 }
 
 /// The resources used so far by an execution process.
@@ -264,14 +269,14 @@ where
     }
 
     /// Tracks a read operation.
-    pub(crate) fn track_read_operations(&mut self, count: u32) -> Result<(), ExecutionError> {
+    pub(crate) fn track_read_operation(&mut self) -> Result<(), ExecutionError> {
         self.tracker.as_mut().read_operations = self
             .tracker
             .as_mut()
             .read_operations
-            .checked_add(count)
+            .checked_add(1)
             .ok_or(ArithmeticError::Overflow)?;
-        self.update_balance(self.policy.read_operations_price(count)?)
+        self.update_balance(self.policy.read_operations_price(1)?)
     }
 
     /// Tracks a write operation.

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -450,6 +450,54 @@ where
     }
 }
 
+impl ResourceController<Option<AccountOwner>, ResourceTracker> {
+    /// Provides a reference to the current execution state and obtains a temporary object
+    /// where the accounting functions of [`ResourceController`] are available.
+    pub async fn with_state<'a, C>(
+        &mut self,
+        view: &'a mut SystemExecutionStateView<C>,
+    ) -> Result<ResourceController<Sources<'a>, &mut ResourceTracker>, ViewError>
+    where
+        C: Context + Clone + Send + Sync + 'static,
+    {
+        self.with_state_and_grant(view, None).await
+    }
+
+    /// Provides a reference to the current execution state as well as an optional grant,
+    /// and obtains a temporary object where the accounting functions of
+    /// [`ResourceController`] are available.
+    pub async fn with_state_and_grant<'a, C>(
+        &mut self,
+        view: &'a mut SystemExecutionStateView<C>,
+        grant: Option<&'a mut Amount>,
+    ) -> Result<ResourceController<Sources<'a>, &mut ResourceTracker>, ViewError>
+    where
+        C: Context + Clone + Send + Sync + 'static,
+    {
+        let mut sources = Vec::new();
+        // First, use the grant (e.g. for messages) and otherwise use the chain account
+        // (e.g. for blocks and operations).
+        if let Some(grant) = grant {
+            sources.push(grant);
+        } else {
+            sources.push(view.balance.get_mut());
+        }
+        // Then the local account, if any. Currently, any negative fee (e.g. storage
+        // refund) goes preferably to this account.
+        if let Some(owner) = &self.account {
+            if let Some(balance) = view.balances.get_mut(owner).await? {
+                sources.push(balance);
+            }
+        }
+
+        Ok(ResourceController {
+            policy: self.policy.clone(),
+            tracker: &mut self.tracker,
+            account: Sources { sources },
+        })
+    }
+}
+
 // The simplest `BalanceHolder` is an `Amount`.
 impl BalanceHolder for Amount {
     fn balance(&self) -> Result<Amount, ArithmeticError> {
@@ -513,53 +561,5 @@ impl BalanceHolder for Sources<'_> {
         } else {
             Ok(())
         }
-    }
-}
-
-impl ResourceController<Option<AccountOwner>, ResourceTracker> {
-    /// Provides a reference to the current execution state and obtains a temporary object
-    /// where the accounting functions of [`ResourceController`] are available.
-    pub async fn with_state<'a, C>(
-        &mut self,
-        view: &'a mut SystemExecutionStateView<C>,
-    ) -> Result<ResourceController<Sources<'a>, &mut ResourceTracker>, ViewError>
-    where
-        C: Context + Clone + Send + Sync + 'static,
-    {
-        self.with_state_and_grant(view, None).await
-    }
-
-    /// Provides a reference to the current execution state as well as an optional grant,
-    /// and obtains a temporary object where the accounting functions of
-    /// [`ResourceController`] are available.
-    pub async fn with_state_and_grant<'a, C>(
-        &mut self,
-        view: &'a mut SystemExecutionStateView<C>,
-        grant: Option<&'a mut Amount>,
-    ) -> Result<ResourceController<Sources<'a>, &mut ResourceTracker>, ViewError>
-    where
-        C: Context + Clone + Send + Sync + 'static,
-    {
-        let mut sources = Vec::new();
-        // First, use the grant (e.g. for messages) and otherwise use the chain account
-        // (e.g. for blocks and operations).
-        if let Some(grant) = grant {
-            sources.push(grant);
-        } else {
-            sources.push(view.balance.get_mut());
-        }
-        // Then the local account, if any. Currently, any negative fee (e.g. storage
-        // refund) goes preferably to this account.
-        if let Some(owner) = &self.account {
-            if let Some(balance) = view.balances.get_mut(owner).await? {
-                sources.push(balance);
-            }
-        }
-
-        Ok(ResourceController {
-            policy: self.policy.clone(),
-            tracker: &mut self.tracker,
-            account: Sources { sources },
-        })
     }
 }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -688,7 +688,7 @@ where
     fn contains_key_new(&mut self, key: Vec<u8>) -> Result<Self::ContainsKey, ExecutionError> {
         let mut this = self.inner();
         let id = this.current_application().id;
-        this.resource_controller.track_read_operations(1)?;
+        this.resource_controller.track_read_operation()?;
         let receiver = this
             .execution_state_sender
             .send_request(move |callback| ExecutionRequest::ContainsKey { id, key, callback })?;
@@ -710,7 +710,7 @@ where
     ) -> Result<Self::ContainsKeys, ExecutionError> {
         let mut this = self.inner();
         let id = this.current_application().id;
-        this.resource_controller.track_read_operations(1)?;
+        this.resource_controller.track_read_operation()?;
         let receiver = this
             .execution_state_sender
             .send_request(move |callback| ExecutionRequest::ContainsKeys { id, keys, callback })?;
@@ -735,7 +735,7 @@ where
     ) -> Result<Self::ReadMultiValuesBytes, ExecutionError> {
         let mut this = self.inner();
         let id = this.current_application().id;
-        this.resource_controller.track_read_operations(1)?;
+        this.resource_controller.track_read_operation()?;
         let receiver = this.execution_state_sender.send_request(move |callback| {
             ExecutionRequest::ReadMultiValuesBytes { id, keys, callback }
         })?;
@@ -766,7 +766,7 @@ where
     ) -> Result<Self::ReadValueBytes, ExecutionError> {
         let mut this = self.inner();
         let id = this.current_application().id;
-        this.resource_controller.track_read_operations(1)?;
+        this.resource_controller.track_read_operation()?;
         let receiver = this
             .execution_state_sender
             .send_request(move |callback| ExecutionRequest::ReadValueBytes { id, key, callback })?;
@@ -797,7 +797,7 @@ where
     ) -> Result<Self::FindKeysByPrefix, ExecutionError> {
         let mut this = self.inner();
         let id = this.current_application().id;
-        this.resource_controller.track_read_operations(1)?;
+        this.resource_controller.track_read_operation()?;
         let receiver = this.execution_state_sender.send_request(move |callback| {
             ExecutionRequest::FindKeysByPrefix {
                 id,
@@ -834,7 +834,7 @@ where
     ) -> Result<Self::FindKeyValuesByPrefix, ExecutionError> {
         let mut this = self.inner();
         let id = this.current_application().id;
-        this.resource_controller.track_read_operations(1)?;
+        this.resource_controller.track_read_operation()?;
         let receiver = this.execution_state_sender.send_request(move |callback| {
             ExecutionRequest::FindKeyValuesByPrefix {
                 id,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1175,10 +1175,19 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
     }
 
     fn maximum_fuel_per_block(&mut self, vm_runtime: VmRuntime) -> Result<u64, ExecutionError> {
-        let policy = &self.inner().resource_controller.policy;
         Ok(match vm_runtime {
-            VmRuntime::Wasm => policy.maximum_wasm_fuel_per_block,
-            VmRuntime::Evm => policy.maximum_evm_fuel_per_block,
+            VmRuntime::Wasm => {
+                self.inner()
+                    .resource_controller
+                    .policy()
+                    .maximum_wasm_fuel_per_block
+            }
+            VmRuntime::Evm => {
+                self.inner()
+                    .resource_controller
+                    .policy()
+                    .maximum_evm_fuel_per_block
+            }
         })
     }
 
@@ -1200,7 +1209,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
 
         let grant = this
             .resource_controller
-            .policy
+            .policy()
             .total_price(&message.grant)?;
         if grant.is_zero() {
             refund_grant_to = None;

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -20,7 +20,7 @@ use linera_execution::{
         SystemExecutionState,
     },
     ContractRuntime, ExecutionError, Message, MessageContext, ResourceControlPolicy,
-    ResourceController, TransactionTracker,
+    ResourceController, ResourceTracker, TransactionTracker,
 };
 use test_case::test_case;
 
@@ -251,11 +251,11 @@ async fn test_fee_consumption(
     } else {
         None
     };
-    let mut controller = ResourceController {
-        policy: Arc::new(prices),
-        account: authenticated_signer,
-        ..ResourceController::default()
-    };
+    let mut controller = ResourceController::new(
+        Arc::new(prices),
+        ResourceTracker::default(),
+        authenticated_signer,
+    );
 
     for spend in &spends {
         oracle_responses.extend(spend.expected_oracle_responses());

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -103,11 +103,8 @@ async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
     };
     let amount = Amount::from_tokens(1);
     *view.system.balance.get_mut() = amount;
-    let mut controller = ResourceController {
-        policy: Arc::new(policy),
-        tracker: ResourceTracker::default(),
-        account: None,
-    };
+    let mut controller =
+        ResourceController::new(Arc::new(policy), ResourceTracker::default(), None);
     for increment in &increments {
         let mut txn_tracker = TransactionTracker::new_replaying_blobs([
             app_desc_blob_id,
@@ -224,11 +221,8 @@ async fn test_terminate_execute_operation_by_lack_of_fuel() -> anyhow::Result<()
     };
     let amount = Amount::from_tokens(1);
     *view.system.balance.get_mut() = amount;
-    let mut controller = ResourceController {
-        policy: Arc::new(policy),
-        tracker: ResourceTracker::default(),
-        account: None,
-    };
+    let mut controller =
+        ResourceController::new(Arc::new(policy), ResourceTracker::default(), None);
 
     // Trying the increment, should fail
     let mut txn_tracker = TransactionTracker::new_replaying_blobs([

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -82,11 +82,8 @@ async fn test_fuel_for_counter_wasm_application(
     };
     let amount = Amount::from_tokens(1);
     *view.system.balance.get_mut() = amount;
-    let mut controller = ResourceController {
-        policy: Arc::new(policy),
-        tracker: ResourceTracker::default(),
-        account: None,
-    };
+    let mut controller =
+        ResourceController::new(Arc::new(policy), ResourceTracker::default(), None);
 
     for (index, increment) in increments.iter().enumerate() {
         let mut txn_tracker = TransactionTracker::new_replaying_blobs(if index == 0 {


### PR DESCRIPTION
## Motivation

Logic that tracks the resource consumption during block execution is scattered. The execution of block's transactions was imperative - we tracked every index (application, message, blob) in the main function logic which made reading and understanding harder. This meant an error of incompleteness was easy to miss.

## Proposal

Add a new struct `BlockExecutionTracker` (similar to `TransactionTracker`) that wraps the block-wide context of the underlying transaction execution. It's responsible for updating indices, updating resources used after transaction execution.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
