### PR TITLE
Remove metrics feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,7 +91,7 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Run metrics tests
       run: |
-        cargo test --locked -p linera-base --features metrics
+        cargo test --locked -p linera-base
 
   wasm-application-test:
     runs-on: ubuntu-latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ ARG binaries=
 ARG copy=${binaries:+_copy}
 ARG build_flag=--release
 ARG build_folder=release
-ARG build_features=scylladb,metrics
+ARG build_features=scylladb
 
 FROM rust:1.74-slim-bookworm AS builder
 ARG git_commit

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-metrics = ["prometheus"]
 reqwest = ["dep:reqwest"]
 revm = []
 test = ["test-strategy", "proptest"]
@@ -48,7 +47,7 @@ hex.workspace = true
 is-terminal.workspace = true
 k256.workspace = true
 linera-witty = { workspace = true, features = ["macros"] }
-prometheus = { workspace = true, optional = true }
+prometheus = { workspace = true }
 proptest = { workspace = true, optional = true, features = ["alloc"] }
 rand.workspace = true
 reqwest = { workspace = true, optional = true }

--- a/linera-base/build.rs
+++ b/linera-base/build.rs
@@ -5,7 +5,6 @@ fn main() {
     cfg_aliases::cfg_aliases! {
         web: { all(target_arch = "wasm32", feature = "web") },
         chain: { all(target_arch = "wasm32", not(web)) },
-        with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
         with_reqwest: { feature = "reqwest" },
         with_testing: { any(test, feature = "test") },
         with_revm: { any(test, feature = "revm") },

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -23,7 +23,7 @@ use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use crate::prometheus_util::MeasureLatency as _;
 use crate::{
     crypto::{BcsHashable, CryptoError, CryptoHash},
@@ -1079,7 +1079,6 @@ impl Bytecode {
     /// Compresses the [`Bytecode`] into a [`CompressedBytecode`].
     #[cfg(not(target_arch = "wasm32"))]
     pub fn compress(&self) -> CompressedBytecode {
-        #[cfg(with_metrics)]
         let _compression_latency = metrics::BYTECODE_COMPRESSION_LATENCY.measure_latency();
         let compressed_bytes = zstd::stream::encode_all(&*self.bytes, 19)
             .expect("Compressing bytes in memory should not fail");
@@ -1133,7 +1132,6 @@ impl CompressedBytecode {
 
     /// Decompresses a [`CompressedBytecode`] into a [`Bytecode`].
     pub fn decompress(&self) -> Result<Bytecode, DecompressionError> {
-        #[cfg(with_metrics)]
         let _decompression_latency = metrics::BYTECODE_DECOMPRESSION_LATENCY.measure_latency();
         let bytes = zstd::stream::decode_all(&*self.compressed_bytes)?;
 
@@ -1166,9 +1164,6 @@ impl CompressedBytecode {
     /// Decompresses a [`CompressedBytecode`] into a [`Bytecode`].
     pub fn decompress(&self) -> Result<Bytecode, DecompressionError> {
         use ruzstd::{io::Read, streaming_decoder::StreamingDecoder};
-
-        #[cfg(with_metrics)]
-        let _decompression_latency = BYTECODE_DECOMPRESSION_LATENCY.measure_latency();
 
         let compressed_bytes = &*self.compressed_bytes;
         let mut bytes = Vec::new();
@@ -1485,7 +1480,7 @@ doc_scalar!(
 );
 doc_scalar!(ApplicationDescription, "Description of a user application");
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -30,7 +30,7 @@ mod limited_writer;
 pub mod ownership;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod port;
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod prometheus_util;
 #[cfg(not(chain))]
 pub mod task;

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -13,7 +13,6 @@ version.workspace = true
 
 [features]
 benchmark = ["linera-base/test"]
-metrics = ["prometheus", "linera-views/metrics", "linera-execution/metrics"]
 test = [
     "dep:anyhow",
     "dep:axum",
@@ -32,7 +31,7 @@ futures.workspace = true
 linera-base.workspace = true
 linera-execution.workspace = true
 linera-views.workspace = true
-prometheus = { workspace = true, optional = true }
+prometheus = { workspace = true }
 rand_chacha.workspace = true
 rand_distr = { workspace = true, features = ["alloc", "serde1"] }
 serde.workspace = true

--- a/linera-chain/build.rs
+++ b/linera-chain/build.rs
@@ -5,7 +5,6 @@ fn main() {
     cfg_aliases::cfg_aliases! {
         web: { all(target_arch = "wasm32", feature = "web") },
         with_testing: { any(test, feature = "test") },
-        with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
         with_graphql: { not(web) },
     };
 }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -52,10 +52,10 @@ use crate::{
 #[path = "unit_tests/chain_tests.rs"]
 mod chain_tests;
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_base::prometheus_util::MeasureLatency;
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -78,7 +78,6 @@ mod metrics {
         )
     });
 
-    #[cfg(with_metrics)]
     pub static MESSAGE_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         register_histogram_vec(
             "message_execution_latency",
@@ -400,7 +399,7 @@ where
         if outbox.queue.count() == 0 {
             self.outboxes.remove_entry(target)?;
         }
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         metrics::NUM_OUTBOXES
             .with_label_values(&[])
             .observe(self.outboxes.count().await? as f64);
@@ -542,7 +541,7 @@ where
 
         // Process the inbox bundle and update the inbox state.
         let mut inbox = self.inboxes.try_load_entry_mut(origin).await?;
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         metrics::NUM_INBOXES
             .with_label_values(&[])
             .observe(self.inboxes.count().await? as f64);
@@ -666,7 +665,7 @@ where
                 self.removed_unskippable_bundles.insert(&entry)?;
             }
         }
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         metrics::NUM_INBOXES
             .with_label_values(&[])
             .observe(self.inboxes.count().await? as f64);
@@ -686,7 +685,7 @@ where
         published_blobs: &[Blob],
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
     ) -> Result<BlockExecutionOutcome, ChainError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _execution_latency = metrics::BLOCK_EXECUTION_LATENCY.measure_latency();
 
         ensure!(
@@ -795,7 +794,7 @@ where
                     resource_controller
                         .track_block_size_of(&operation)
                         .with_execution_context(chain_execution_context)?;
-                    #[cfg(with_metrics)]
+                    #[cfg(not(target_arch = "wasm32"))]
                     let _operation_latency = metrics::OPERATION_EXECUTION_LATENCY.measure_latency();
                     let context = OperationContext {
                         chain_id: block.chain_id,
@@ -909,11 +908,11 @@ where
         assert_eq!(events.len(), txn_count);
         assert_eq!(blobs.len(), txn_count);
 
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         Self::track_block_metrics(&resource_controller.tracker);
 
         let state_hash = {
-            #[cfg(with_metrics)]
+            #[cfg(not(target_arch = "wasm32"))]
             let _hash_latency = metrics::STATE_HASH_COMPUTATION_LATENCY.measure_latency();
             chain.crypto_hash().await?
         };
@@ -1003,7 +1002,7 @@ where
         txn_tracker: &mut TransactionTracker,
         resource_controller: &mut ResourceController<Option<AccountOwner>>,
     ) -> Result<(), ChainError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _message_latency = metrics::MESSAGE_EXECUTION_LATENCY.measure_latency();
         let context = MessageContext {
             chain_id: block.chain_id,
@@ -1130,7 +1129,7 @@ where
     }
 
     /// Tracks block execution metrics in Prometheus.
-    #[cfg(with_metrics)]
+    #[cfg(not(target_arch = "wasm32"))]
     fn track_block_metrics(tracker: &ResourceTracker) {
         metrics::NUM_BLOCKS_EXECUTED.with_label_values(&[]).inc();
         metrics::WASM_FUEL_USED_PER_BLOCK
@@ -1172,7 +1171,7 @@ where
             }
         }
 
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         metrics::NUM_OUTBOXES
             .with_label_values(&[])
             .observe(self.outboxes.count().await? as f64);

--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -24,7 +24,7 @@ use crate::{data_types::MessageBundle, ChainError};
 #[path = "unit_tests/inbox_tests.rs"]
 mod inbox_tests;
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -218,7 +218,7 @@ where
                 }
             );
             self.added_bundles.delete_front();
-            #[cfg(with_metrics)]
+            #[cfg(not(target_arch = "wasm32"))]
             metrics::INBOX_SIZE
                 .with_label_values(&[])
                 .observe(self.added_bundles.count() as f64);
@@ -240,7 +240,7 @@ where
                     }
                 );
                 self.added_bundles.delete_front();
-                #[cfg(with_metrics)]
+                #[cfg(not(target_arch = "wasm32"))]
                 metrics::INBOX_SIZE
                     .with_label_values(&[])
                     .observe(self.added_bundles.count() as f64);
@@ -250,7 +250,7 @@ where
             None => {
                 tracing::trace!("Marking bundle as expected: {:?}", bundle);
                 self.removed_bundles.push_back(bundle.clone());
-                #[cfg(with_metrics)]
+                #[cfg(not(target_arch = "wasm32"))]
                 metrics::REMOVED_BUNDLES
                     .with_label_values(&[])
                     .observe(self.removed_bundles.count() as f64);
@@ -289,7 +289,7 @@ where
                         }
                     );
                     self.removed_bundles.delete_front();
-                    #[cfg(with_metrics)]
+                    #[cfg(not(target_arch = "wasm32"))]
                     metrics::REMOVED_BUNDLES
                         .with_label_values(&[])
                         .observe(self.removed_bundles.count() as f64);
@@ -309,7 +309,7 @@ where
             None => {
                 // Otherwise, schedule the messages for execution.
                 self.added_bundles.push_back(bundle);
-                #[cfg(with_metrics)]
+                #[cfg(not(target_arch = "wasm32"))]
                 metrics::INBOX_SIZE
                     .with_label_values(&[])
                     .observe(self.added_bundles.count() as f64);

--- a/linera-chain/src/outbox.rs
+++ b/linera-chain/src/outbox.rs
@@ -15,7 +15,7 @@ use linera_views::{
 #[path = "unit_tests/outbox_tests.rs"]
 mod outbox_tests;
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -73,7 +73,7 @@ where
         }
         self.next_height_to_schedule.set(height.try_add_one()?);
         self.queue.push_back(height);
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         metrics::OUTBOX_SIZE
             .with_label_values(&[])
             .observe(self.queue.count() as f64);
@@ -94,7 +94,7 @@ where
             self.queue.delete_front().await?;
             updates.push(h);
         }
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         metrics::OUTBOX_SIZE
             .with_label_values(&[])
             .observe(self.queue.count() as f64);

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -29,14 +29,6 @@ wasmer = [
 ]
 wasmtime = ["linera-execution/wasmtime", "linera-storage/wasmtime"]
 fs = ["fs-err", "fs4", "linera-execution/fs"]
-metrics = [
-    "linera-base/metrics",
-    "linera-chain/metrics",
-    "linera-core/metrics",
-    "linera-execution/metrics",
-    "linera-rpc/metrics",
-    "linera-views/metrics",
-]
 web = [
     "dep:web-sys",
     "dep:wasm-bindgen-futures",

--- a/linera-client/build.rs
+++ b/linera-client/build.rs
@@ -7,6 +7,5 @@ fn main() {
         with_persist: { any(feature = "fs", with_indexed_db) },
         with_indexed_db: { all(web, feature = "indexed-db") },
         with_testing: { any(test, feature = "test") },
-        with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
     };
 }

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -31,14 +31,6 @@ rocksdb = ["linera-views/rocksdb"]
 dynamodb = ["linera-views/dynamodb"]
 scylladb = ["linera-views/scylladb"]
 storage-service = ["linera-storage-service"]
-metrics = [
-    "prometheus",
-    "linera-base/metrics",
-    "linera-chain/metrics",
-    "linera-execution/metrics",
-    "linera-storage/metrics",
-    "linera-views/metrics",
-]
 web = [
     "linera-base/web",
     "linera-chain/web",
@@ -65,7 +57,7 @@ linera-storage.workspace = true
 linera-version.workspace = true
 linera-views.workspace = true
 lru.workspace = true
-prometheus = { workspace = true, optional = true }
+prometheus = { workspace = true }
 proptest = { workspace = true, optional = true }
 rand = { workspace = true, features = ["std_rng"] }
 serde.workspace = true

--- a/linera-core/build.rs
+++ b/linera-core/build.rs
@@ -5,7 +5,6 @@ fn main() {
     cfg_aliases::cfg_aliases! {
         web: { all(target_arch = "wasm32", feature = "web") },
         with_testing: { any(test, feature = "test") },
-        with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
 
         // the old version of `getrandom` we pin here is available on all targets, but
         // using it will panic if no suitable source of entropy is found

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -22,7 +22,7 @@ use futures::{
     future::{self, Either, FusedFuture, Future},
     stream::{self, AbortHandle, FusedStream, FuturesUnordered, StreamExt},
 };
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     abi::Abi,
@@ -89,7 +89,7 @@ mod chain_client_state;
 #[path = "../unit_tests/client_tests.rs"]
 mod client_tests;
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -899,7 +899,7 @@ impl<Env: Environment> Client<Env> {
         &self,
         chain_id: ChainId,
     ) -> Result<Box<ChainInfo>, ChainClientError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = metrics::SYNCHRONIZE_CHAIN_STATE_LATENCY.measure_latency();
 
         let committee = self
@@ -1815,7 +1815,7 @@ impl<Env: Environment> ChainClient<Env> {
     /// its current height and are not missing any received messages from the inbox.
     #[instrument(level = "trace")]
     pub async fn prepare_chain(&self) -> Result<Box<ChainInfo>, ChainClientError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = metrics::PREPARE_CHAIN_LATENCY.measure_latency();
 
         let mut info = self.synchronize_to_known_height().await?;
@@ -2055,7 +2055,7 @@ impl<Env: Environment> ChainClient<Env> {
     /// is regularly upgraded to new committees.
     #[instrument(level = "trace")]
     async fn find_received_certificates(&self) -> Result<(), ChainClientError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = metrics::FIND_RECEIVED_CERTIFICATES_LATENCY.measure_latency();
 
         // Use network information from the local chain.
@@ -2237,7 +2237,7 @@ impl<Env: Environment> ChainClient<Env> {
         operations: Vec<Operation>,
         blobs: Vec<Blob>,
     ) -> Result<ExecuteBlockOutcome, ChainClientError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = metrics::EXECUTE_BLOCK_LATENCY.measure_latency();
 
         let mutex = self.state().client_mutex();
@@ -3242,7 +3242,7 @@ impl<Env: Environment> ChainClient<Env> {
     pub async fn process_inbox_without_prepare(
         &self,
     ) -> Result<(Vec<ConfirmedBlockCertificate>, Option<RoundTimeout>), ChainClientError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = metrics::PROCESS_INBOX_WITHOUT_PREPARE_LATENCY.measure_latency();
 
         let mut epoch_change_ops = self.collect_epoch_changes().await?.into_iter();

--- a/linera-core/src/value_cache.rs
+++ b/linera-core/src/value_cache.rs
@@ -7,7 +7,7 @@
 #[path = "unit_tests/value_cache_tests.rs"]
 mod unit_tests;
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use std::any::type_name;
 use std::{borrow::Cow, hash::Hash, num::NonZeroUsize, sync::Mutex};
 
@@ -18,7 +18,7 @@ use lru::LruCache;
 pub const DEFAULT_VALUE_CACHE_SIZE: usize = 10_000;
 
 /// A counter metric for the number of cache hits in the [`ValueCache`].
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -139,7 +139,7 @@ where
     }
 
     fn track_cache_usage(maybe_value: Option<V>) -> Option<V> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         {
             let metric = if maybe_value.is_some() {
                 &metrics::CACHE_HIT_COUNT

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -52,7 +52,7 @@ use crate::{
 #[path = "unit_tests/worker_tests.rs"]
 mod worker_tests;
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -589,7 +589,7 @@ where
             })
             .await?;
 
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         metrics::NUM_BLOCKS.with_label_values(&[]).inc();
 
         Ok((response, actions))
@@ -810,14 +810,14 @@ where
         proposal: BlockProposal,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname, proposal);
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let round = proposal.content.round;
         let response = self
             .query_chain_worker(proposal.content.block.chain_id, move |callback| {
                 ChainWorkerRequest::HandleBlockProposal { proposal, callback }
             })
             .await?;
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         metrics::NUM_ROUNDS_IN_BLOCK_PROPOSAL
             .with_label_values(&[round.type_name()])
             .observe(round.number() as f64);
@@ -861,7 +861,7 @@ where
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname, certificate);
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         {
             let confirmed_transactions = (certificate.block().body.incoming_bundles.len()
                 + certificate.block().body.operations.len())
@@ -902,13 +902,13 @@ where
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname, certificate);
 
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let round = certificate.round;
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let cert_str = certificate.inner().to_log_str();
 
         let (info, actions, _duplicated) = self.process_validated_block(certificate).await?;
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         {
             if !_duplicated {
                 metrics::NUM_ROUNDS_IN_CERTIFICATE

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -24,7 +24,6 @@ revm = [
     "dep:tempfile",
 ]
 fs = ["tokio/fs"]
-metrics = ["prometheus", "linera-views/metrics"]
 wasmer = ["dep:wasmer", "wasmer/enable-serde", "linera-witty/wasmer"]
 wasmtime = ["dep:wasmtime", "linera-witty/wasmtime"]
 web = ["linera-base/web", "linera-views/web", "js-sys"]
@@ -51,7 +50,7 @@ linera-views-derive.workspace = true
 linera-witty = { workspace = true, features = ["log", "macros"] }
 lru.workspace = true
 oneshot.workspace = true
-prometheus = { workspace = true, optional = true }
+prometheus = { workspace = true }
 proptest = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["blocking", "json", "stream"] }
 revm = { workspace = true, optional = true, features = ["serde"] }

--- a/linera-execution/build.rs
+++ b/linera-execution/build.rs
@@ -6,7 +6,6 @@ fn main() {
         web: { all(target_arch = "wasm32", feature = "web") },
 
         with_fs: { all(not(target_arch = "wasm32"), feature = "fs") },
-        with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
         with_graphql: { not(web) },
         with_testing: { any(test, feature = "test") },
         with_tokio_multi_thread: { not(target_arch = "wasm32") },

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -6,7 +6,7 @@
 use core::ops::Range;
 use std::sync::Arc;
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     crypto::CryptoHash,
@@ -87,7 +87,7 @@ mod tests {
     }
 }
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -181,7 +181,7 @@ impl UserContractModule for EvmContractModule {
         &self,
         runtime: ContractSyncRuntimeHandle,
     ) -> Result<UserContractInstance, ExecutionError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _instantiation_latency = metrics::CONTRACT_INSTANTIATION_LATENCY.measure_latency();
 
         let instance: UserContractInstance = match self {
@@ -242,7 +242,7 @@ impl UserServiceModule for EvmServiceModule {
         &self,
         runtime: ServiceSyncRuntimeHandle,
     ) -> Result<UserServiceInstance, ExecutionError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _instantiation_latency = metrics::SERVICE_INSTANTIATION_LATENCY.measure_latency();
 
         let instance: UserServiceInstance = match self {

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use custom_debug_derive::Debug;
 use futures::{channel::mpsc, StreamExt as _};
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     data_types::{
@@ -30,7 +30,7 @@ use crate::{
     UserContractCode, UserServiceCode,
 };
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -70,7 +70,7 @@ where
         id: ApplicationId,
         txn_tracker: &mut TransactionTracker,
     ) -> Result<(UserContractCode, ApplicationDescription), ExecutionError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = metrics::LOAD_CONTRACT_LATENCY.measure_latency();
         let blob_id = id.description_blob_id();
         let description = match txn_tracker.created_blobs().get(&blob_id) {
@@ -97,7 +97,7 @@ where
         id: ApplicationId,
         txn_tracker: Option<&mut TransactionTracker>,
     ) -> Result<(UserServiceCode, ApplicationDescription), ExecutionError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = metrics::LOAD_SERVICE_LATENCY.measure_latency();
         let blob_id = id.description_blob_id();
         let description = match txn_tracker

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -45,7 +45,7 @@ pub static EPOCH_STREAM_NAME: &[u8] = &[0];
 pub static REMOVED_EPOCH_STREAM_NAME: &[u8] = &[1];
 
 /// The number of times the [`SystemOperation::OpenChain`] was executed.
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -373,7 +373,7 @@ where
                         txn_tracker,
                     )
                     .await?;
-                #[cfg(with_metrics)]
+                #[cfg(not(target_arch = "wasm32"))]
                 metrics::OPEN_CHAIN_COUNT.with_label_values(&[]).inc();
             }
             ChangeOwnership {

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -20,7 +20,7 @@ mod wasmer;
 mod wasmtime;
 
 use linera_base::data_types::Bytecode;
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_base::prometheus_util::MeasureLatency as _;
 use thiserror::Error;
 use wasm_instrument::{gas_metering, parity_wasm};
@@ -38,7 +38,7 @@ use crate::{
     UserContractModule, UserServiceInstance, UserServiceModule, WasmRuntime,
 };
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -113,7 +113,7 @@ impl UserContractModule for WasmContractModule {
         &self,
         runtime: ContractSyncRuntimeHandle,
     ) -> Result<UserContractInstance, ExecutionError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _instantiation_latency = metrics::CONTRACT_INSTANTIATION_LATENCY.measure_latency();
 
         let instance: UserContractInstance = match self {
@@ -176,7 +176,7 @@ impl UserServiceModule for WasmServiceModule {
         &self,
         runtime: ServiceSyncRuntimeHandle,
     ) -> Result<UserServiceInstance, ExecutionError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _instantiation_latency = metrics::SERVICE_INSTANTIATION_LATENCY.measure_latency();
 
         let instance: UserServiceInstance = match self {

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -20,15 +20,6 @@ test = [
     "linera-storage/test",
 ]
 
-metrics = [
-    "prometheus",
-    "linera-base/metrics",
-    "linera-chain/metrics",
-    "linera-core/metrics",
-    "linera-execution/metrics",
-    "linera-storage/metrics",
-]
-
 server = ["tokio-util", "tonic-health", "tonic-reflection"]
 simple-network = ["tokio-util/net"]
 
@@ -57,7 +48,7 @@ linera-core.workspace = true
 linera-execution.workspace = true
 linera-storage.workspace = true
 linera-version.workspace = true
-prometheus = { workspace = true, optional = true }
+prometheus = { workspace = true }
 prost.workspace = true
 rand.workspace = true
 serde.workspace = true

--- a/linera-rpc/build.rs
+++ b/linera-rpc/build.rs
@@ -31,7 +31,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     cfg_aliases::cfg_aliases! {
         with_testing: { any(test, feature = "test") },
         web: { all(target_arch = "wasm32", target_os = "unknown") },
-        with_metrics: { all(not(web), feature = "metrics") },
         with_server: { all(not(web), feature = "server") },
         with_simple_network: { all(not(web), feature = "simple-network") },
     };

--- a/linera-rpc/src/cross_chain_message_queue.rs
+++ b/linera-rpc/src/cross_chain_message_queue.rs
@@ -19,7 +19,7 @@ use tracing::{trace, warn};
 
 use crate::config::ShardId;
 
-#[cfg(with_metrics)]
+#[cfg(not(web))]
 static CROSS_CHAIN_MESSAGE_TASKS: std::sync::LazyLock<prometheus::IntGauge> =
     std::sync::LazyLock::new(|| {
         prometheus::register_int_gauge!(
@@ -86,7 +86,7 @@ pub(crate) async fn forward_cross_chain_queries<F, G>(
     };
 
     loop {
-        #[cfg(with_metrics)]
+        #[cfg(not(web))]
         CROSS_CHAIN_MESSAGE_TASKS.set(job_states.len() as i64);
         tokio::select! {
             Some((queue, action)) = steps.next() => {

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -64,11 +64,11 @@ wit-bindgen.workspace = true
 anyhow.workspace = true
 cargo_toml.workspace = true
 dashmap.workspace = true
-linera-base = { workspace = true, features = ["metrics"] }
-linera-chain = { workspace = true, features = ["metrics"] }
-linera-core = { workspace = true, features = ["metrics", "wasmer"] }
-linera-execution = { workspace = true, features = ["fs", "metrics", "wasmer"] }
-linera-storage = { workspace = true, features = ["metrics", "wasmer"] }
+linera-base = { workspace = true }
+linera-chain = { workspace = true }
+linera-core = { workspace = true, features = ["wasmer"] }
+linera-execution = { workspace = true, features = ["fs", "wasmer"] }
+linera-storage = { workspace = true, features = ["wasmer"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -47,7 +47,6 @@ dynamodb = ["linera-views/dynamodb", "linera-core/dynamodb"]
 scylladb = ["linera-views/scylladb", "linera-core/scylladb"]
 kubernetes = ["dep:k8s-openapi", "dep:kube", "dep:pathdiff", "dep:fs_extra"]
 remote-net = []
-metrics = ["prometheus", "linera-base/metrics", "linera-client/metrics"]
 storage-service = ["linera-storage-service"]
 
 [dependencies]
@@ -95,7 +94,7 @@ linera-version.workspace = true
 linera-views.workspace = true
 pathdiff = { workspace = true, optional = true }
 port-selector.workspace = true
-prometheus = { workspace = true, optional = true }
+prometheus = { workspace = true }
 prost = { workspace = true }
 rand.workspace = true
 reqwest = { workspace = true, features = ["json"] }

--- a/linera-service/build.rs
+++ b/linera-service/build.rs
@@ -5,6 +5,5 @@ fn main() {
     cfg_aliases::cfg_aliases! {
         with_revm: { feature = "revm" },
         with_testing: { any(test, feature = "test") },
-        with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
     };
 }

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -10,7 +10,7 @@ pub mod cli;
 pub mod cli_wrappers;
 pub mod node_service;
 pub mod project;
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod prometheus_server;
 pub mod storage;
 pub mod util;

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -20,7 +20,7 @@ use linera_rpc::{
     RpcMessage,
 };
 use linera_sdk::linera_base_types::Blob;
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_service::prometheus_server;
 use linera_service::{
     storage::{Runnable, StorageConfigNamespace},
@@ -263,7 +263,7 @@ where
         let mut join_set = JoinSet::new();
         let address = self.get_listen_address(self.public_config.port);
 
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         Self::start_metrics(
             self.get_listen_address(self.internal_config.metrics_port),
             shutdown_signal.clone(),
@@ -280,7 +280,7 @@ where
         Ok(())
     }
 
-    #[cfg(with_metrics)]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn start_metrics(address: SocketAddr, shutdown_signal: CancellationToken) {
         prometheus_server::start_metrics(address, shutdown_signal)
     }

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -32,7 +32,7 @@ use linera_rpc::{
     grpc, simple,
 };
 use linera_sdk::linera_base_types::{AccountSecretKey, ValidatorKeypair};
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_service::prometheus_server;
 use linera_service::{
     storage::{Runnable, StorageConfigNamespace},
@@ -105,7 +105,7 @@ impl ServerContext {
             let cross_chain_config = self.cross_chain_config.clone();
             let listen_address = listen_address.to_owned();
 
-            #[cfg(with_metrics)]
+            #[cfg(not(target_arch = "wasm32"))]
             if let Some(port) = shard.metrics_port {
                 Self::start_metrics(&listen_address, port, shutdown_signal.clone());
             }
@@ -148,7 +148,7 @@ impl ServerContext {
         let handles = FuturesUnordered::new();
 
         for (state, shard_id, shard) in states {
-            #[cfg(with_metrics)]
+            #[cfg(not(target_arch = "wasm32"))]
             if let Some(port) = shard.metrics_port {
                 Self::start_metrics(listen_address, port, shutdown_signal.clone());
             }
@@ -180,7 +180,7 @@ impl ServerContext {
         join_set
     }
 
-    #[cfg(with_metrics)]
+    #[cfg(not(target_arch = "wasm32"))]
     fn start_metrics(host: &str, port: u16, shutdown_signal: CancellationToken) {
         prometheus_server::start_metrics((host.to_owned(), port), shutdown_signal);
     }

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-metrics = ["linera-views/metrics"]
 rocksdb = ["linera-views/rocksdb"]
 storage-service = []
 test = ["linera-views/test"]

--- a/linera-storage-service/build.rs
+++ b/linera-storage-service/build.rs
@@ -5,7 +5,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     cfg_aliases::cfg_aliases! {
         with_rocksdb: { all(feature = "rocksdb") },
         with_testing: { any(test, feature = "test") },
-        with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
     };
     let no_includes: &[&str] = &[];
     tonic_build::configure()

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -12,7 +12,7 @@ use std::{
 use async_lock::{Semaphore, SemaphoreGuard};
 use futures::future::join_all;
 use linera_base::ensure;
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_views::metering::MeteredStore;
 #[cfg(with_testing)]
 use linera_views::store::TestKeyValueStore;
@@ -573,10 +573,10 @@ pub async fn storage_service_check_validity(endpoint: &str) -> Result<(), Servic
 }
 
 /// The service store client with metrics
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 pub type ServiceStoreClient =
     MeteredStore<LruCachingStore<MeteredStore<ServiceStoreClientInternal>>>;
 
 /// The service store client without metrics
-#[cfg(not(with_metrics))]
+#[cfg(target_arch = "wasm32")]
 pub type ServiceStoreClient = LruCachingStore<ServiceStoreClientInternal>;

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -16,12 +16,6 @@ revm = ["linera-execution/revm"]
 test = ["linera-execution/test", "linera-views/test"]
 wasmer = ["linera-execution/wasmer"]
 wasmtime = ["linera-execution/wasmtime"]
-metrics = [
-    "linera-base/metrics",
-    "linera-chain/metrics",
-    "linera-execution/metrics",
-    "linera-views/metrics",
-]
 web = [
     "linera-base/web",
     "linera-chain/web",

--- a/linera-storage/build.rs
+++ b/linera-storage/build.rs
@@ -4,7 +4,6 @@
 fn main() {
     cfg_aliases::cfg_aliases! {
         with_testing: { any(test, feature = "test") },
-        with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
         with_wasmer: { all(any(feature = "web", not(target_arch = "wasm32")), feature = "wasmer") },
         with_wasmtime: { all(not(target_arch = "wasm32"), feature = "wasmtime") },
         with_wasm_runtime: { any(with_wasmer, with_wasmtime) },

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -40,7 +40,7 @@ use linera_views::{
     views::{RootView, ViewError},
 };
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 pub use crate::db_storage::metrics;
 #[cfg(with_testing)]
 pub use crate::db_storage::TestClock;

--- a/linera-views-derive/Cargo.toml
+++ b/linera-views-derive/Cargo.toml
@@ -9,9 +9,6 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
-[features]
-metrics = []
-
 [lib]
 proc-macro = true
 

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
@@ -78,6 +78,7 @@ where
         );
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
@@ -79,6 +79,7 @@ where
         );
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
@@ -96,6 +96,7 @@ where
         );
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
@@ -97,6 +97,7 @@ where
         );
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
@@ -103,6 +103,7 @@ where
         );
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
@@ -104,6 +104,7 @@ where
         );
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
@@ -103,6 +103,7 @@ where
         );
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
@@ -105,6 +105,7 @@ where
         );
         #[cfg(not(target_arch = "wasm32"))]
         use linera_views::metrics::prometheus_util::MeasureLatency as _;
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -19,7 +19,6 @@ features = ["scylladb", "rocksdb", "dynamodb", "test"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [features]
-metrics = ["dep:hex", "linera-base/metrics", "linera-views-derive/metrics"]
 test = ["tokio/macros"]
 web = ["linera-base/web"]
 indexeddb = ["indexed_db_futures", "wasm-bindgen"]
@@ -40,7 +39,7 @@ convert_case.workspace = true
 derive_more = { workspace = true, features = ["from"] }
 futures.workspace = true
 generic-array.workspace = true
-hex = { workspace = true, optional = true }
+hex = { workspace = true }
 linera-base.workspace = true
 linera-views-derive.workspace = true
 linera-witty.workspace = true

--- a/linera-views/build.rs
+++ b/linera-views/build.rs
@@ -5,7 +5,6 @@ fn main() {
     cfg_aliases::cfg_aliases! {
         web: { all(target_arch = "wasm32", feature = "web") },
         with_testing: { any(test, feature = "test") },
-        with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
         with_dynamodb: { all(not(target_arch = "wasm32"), feature = "dynamodb") },
         with_indexeddb: { all(web, feature = "indexeddb") },
         with_rocksdb: { all(not(target_arch = "wasm32"), feature = "rocksdb") },

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -38,7 +38,7 @@ use linera_base::ensure;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use crate::metering::MeteredStore;
 #[cfg(with_testing)]
 use crate::store::TestKeyValueStore;
@@ -1167,7 +1167,7 @@ impl TestKeyValueStore for JournalingKeyValueStore<DynamoDbStoreInternal> {
 }
 
 /// A shared DB client for DynamoDB implementing LRU caching and metrics
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 pub type DynamoDbStore = MeteredStore<
     LruCachingStore<
         MeteredStore<
@@ -1177,7 +1177,7 @@ pub type DynamoDbStore = MeteredStore<
 >;
 
 /// A shared DB client for DynamoDB implementing LRU caching
-#[cfg(not(with_metrics))]
+#[cfg(target_arch = "wasm32")]
 pub type DynamoDbStore =
     LruCachingStore<ValueSplittingStore<JournalingKeyValueStore<DynamoDbStoreInternal>>>;
 

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -19,7 +19,7 @@ use crate::{
 #[cfg(with_testing)]
 use crate::{memory::MemoryStore, store::TestKeyValueStore};
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -283,14 +283,14 @@ where
         {
             let mut cache = cache.lock().unwrap();
             if let Some(value) = cache.query_read_value(key) {
-                #[cfg(with_metrics)]
+                #[cfg(not(target_arch = "wasm32"))]
                 metrics::READ_VALUE_CACHE_HIT_COUNT
                     .with_label_values(&[])
                     .inc();
                 return Ok(value);
             }
         }
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         metrics::READ_VALUE_CACHE_MISS_COUNT
             .with_label_values(&[])
             .inc();
@@ -307,14 +307,14 @@ where
         {
             let mut cache = cache.lock().unwrap();
             if let Some(value) = cache.query_contains_key(key) {
-                #[cfg(with_metrics)]
+                #[cfg(not(target_arch = "wasm32"))]
                 metrics::CONTAINS_KEY_CACHE_HIT_COUNT
                     .with_label_values(&[])
                     .inc();
                 return Ok(value);
             }
         }
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         metrics::CONTAINS_KEY_CACHE_MISS_COUNT
             .with_label_values(&[])
             .inc();
@@ -336,13 +336,13 @@ where
             let mut cache = cache.lock().unwrap();
             for i in 0..size {
                 if let Some(value) = cache.query_contains_key(&keys[i]) {
-                    #[cfg(with_metrics)]
+                    #[cfg(not(target_arch = "wasm32"))]
                     metrics::CONTAINS_KEY_CACHE_HIT_COUNT
                         .with_label_values(&[])
                         .inc();
                     results[i] = value;
                 } else {
-                    #[cfg(with_metrics)]
+                    #[cfg(not(target_arch = "wasm32"))]
                     metrics::CONTAINS_KEY_CACHE_MISS_COUNT
                         .with_label_values(&[])
                         .inc();
@@ -377,13 +377,13 @@ where
             let mut cache = cache.lock().unwrap();
             for (i, key) in keys.into_iter().enumerate() {
                 if let Some(value) = cache.query_read_value(&key) {
-                    #[cfg(with_metrics)]
+                    #[cfg(not(target_arch = "wasm32"))]
                     metrics::READ_VALUE_CACHE_HIT_COUNT
                         .with_label_values(&[])
                         .inc();
                     result.push(value);
                 } else {
-                    #[cfg(with_metrics)]
+                    #[cfg(not(target_arch = "wasm32"))]
                     metrics::READ_VALUE_CACHE_MISS_COUNT
                         .with_label_values(&[])
                         .inc();

--- a/linera-views/src/backends/mod.rs
+++ b/linera-views/src/backends/mod.rs
@@ -3,7 +3,7 @@
 
 pub mod journaling;
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod metering;
 
 pub mod value_splitting;

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -20,7 +20,7 @@ use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 use tempfile::TempDir;
 use thiserror::Error;
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use crate::metering::MeteredStore;
 #[cfg(with_testing)]
 use crate::store::TestKeyValueStore;
@@ -671,13 +671,13 @@ impl KeyValueStoreError for RocksDbStoreInternalError {
 }
 
 /// The `RocksDbStore` composed type with metrics
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 pub type RocksDbStore = MeteredStore<
     LruCachingStore<MeteredStore<ValueSplittingStore<MeteredStore<RocksDbStoreInternal>>>>,
 >;
 
 /// The `RocksDbStore` composed type
-#[cfg(not(with_metrics))]
+#[cfg(target_arch = "wasm32")]
 pub type RocksDbStore = LruCachingStore<ValueSplittingStore<RocksDbStoreInternal>>;
 
 /// The composed error type for the `RocksDbStore`

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -31,7 +31,7 @@ use scylla::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use crate::metering::MeteredStore;
 #[cfg(with_testing)]
 use crate::store::TestKeyValueStore;
@@ -916,7 +916,7 @@ impl TestKeyValueStore for JournalingKeyValueStore<ScyllaDbStoreInternal> {
 }
 
 /// The `ScyllaDbStore` composed type with metrics
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 pub type ScyllaDbStore = MeteredStore<
     LruCachingStore<
         MeteredStore<
@@ -926,7 +926,7 @@ pub type ScyllaDbStore = MeteredStore<
 >;
 
 /// The `ScyllaDbStore` composed type
-#[cfg(not(with_metrics))]
+#[cfg(target_arch = "wasm32")]
 pub type ScyllaDbStore =
     LruCachingStore<ValueSplittingStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>>;
 

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -80,7 +80,7 @@ pub mod views;
 pub mod backends;
 
 /// Support for metrics.
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod metrics;
 
 /// GraphQL implementations.
@@ -99,7 +99,7 @@ pub mod test_utils;
 pub use backends::dynamo_db;
 #[cfg(with_indexeddb)]
 pub use backends::indexed_db;
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 pub use backends::metering;
 #[cfg(with_rocksdb)]
 pub use backends::rocks_db;

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{vec_deque::IterMut, VecDeque};
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_base::prometheus_util::MeasureLatency as _;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -16,7 +16,7 @@ use crate::{
     views::{ClonableView, HashableView, Hasher, View, ViewError, MIN_VIEW_TAG},
 };
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -712,7 +712,7 @@ where
     }
 
     async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _hash_latency = metrics::BUCKET_QUEUE_VIEW_HASH_RUNTIME.measure_latency();
         let elements = self.elements().await?;
         let mut hasher = sha3::Sha3_256::default();

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use async_lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_base::prometheus_util::MeasureLatency as _;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -23,7 +23,7 @@ use crate::{
     views::{ClonableView, HashableView, Hasher, View, ViewError, MIN_VIEW_TAG},
 };
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -643,7 +643,7 @@ where
     type Hasher = sha3::Sha3_256;
 
     async fn hash_mut(&mut self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _hash_latency = metrics::COLLECTION_VIEW_HASH_RUNTIME.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
         let keys = self.keys().await?;
@@ -675,7 +675,7 @@ where
     }
 
     async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _hash_latency = metrics::COLLECTION_VIEW_HASH_RUNTIME.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
         let keys = self.keys().await?;

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -15,7 +15,7 @@
 
 use std::{collections::BTreeMap, fmt::Debug, mem, ops::Bound::Included, sync::Mutex};
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{data_types::ArithmeticError, ensure};
 use serde::{Deserialize, Serialize};
@@ -32,7 +32,7 @@ use crate::{
     views::{ClonableView, HashableView, Hasher, View, ViewError, MIN_VIEW_TAG},
 };
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -689,7 +689,7 @@ where
     /// # })
     /// ```
     pub async fn get(&self, index: &[u8]) -> Result<Option<Vec<u8>>, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = metrics::KEY_VALUE_STORE_VIEW_GET_LATENCY.measure_latency();
         ensure!(index.len() <= self.max_key_size(), ViewError::KeyTooLong);
         if let Some(update) = self.updates.get(index) {
@@ -723,7 +723,7 @@ where
     /// # })
     /// ```
     pub async fn contains_key(&self, index: &[u8]) -> Result<bool, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = metrics::KEY_VALUE_STORE_VIEW_CONTAINS_KEY_LATENCY.measure_latency();
         ensure!(index.len() <= self.max_key_size(), ViewError::KeyTooLong);
         if let Some(update) = self.updates.get(index) {
@@ -758,7 +758,7 @@ where
     /// # })
     /// ```
     pub async fn contains_keys(&self, indices: Vec<Vec<u8>>) -> Result<Vec<bool>, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = metrics::KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_LATENCY.measure_latency();
         let mut results = Vec::with_capacity(indices.len());
         let mut missed_indices = Vec::new();
@@ -809,7 +809,7 @@ where
         &self,
         indices: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = metrics::KEY_VALUE_STORE_VIEW_MULTI_GET_LATENCY.measure_latency();
         let mut result = Vec::with_capacity(indices.len());
         let mut missed_indices = Vec::new();
@@ -864,7 +864,7 @@ where
     /// # })
     /// ```
     pub async fn write_batch(&mut self, batch: Batch) -> Result<(), ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = metrics::KEY_VALUE_STORE_VIEW_WRITE_BATCH_LATENCY.measure_latency();
         *self.hash.get_mut().unwrap() = None;
         let max_key_size = self.max_key_size();
@@ -1002,7 +1002,7 @@ where
     /// # })
     /// ```
     pub async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency = metrics::KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_LATENCY.measure_latency();
         ensure!(
             key_prefix.len() <= self.max_key_size(),
@@ -1082,7 +1082,7 @@ where
         &self,
         key_prefix: &[u8],
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _latency =
             metrics::KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_LATENCY.measure_latency();
         ensure!(
@@ -1146,7 +1146,7 @@ where
     }
 
     async fn compute_hash(&self) -> Result<<sha3::Sha3_256 as Hasher>::Output, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _hash_latency = metrics::KEY_VALUE_STORE_VIEW_HASH_LATENCY.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
         let mut count = 0u32;

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -3,7 +3,7 @@
 
 use std::ops::{Bound, Range, RangeBounds};
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_base::prometheus_util::MeasureLatency as _;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -16,7 +16,7 @@ use crate::{
     views::{ClonableView, HashableView, Hasher, View, ViewError, MIN_VIEW_TAG},
 };
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -362,7 +362,7 @@ where
     }
 
     async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _hash_latency = metrics::LOG_VIEW_HASH_RUNTIME.measure_latency();
         let elements = self.read(..).await?;
         let mut hasher = sha3::Sha3_256::default();

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -16,10 +16,10 @@
 //! [class2]: map_view::MapView
 //! [class3]: map_view::CustomMapView
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_base::prometheus_util::MeasureLatency as _;
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -933,7 +933,7 @@ where
     }
 
     async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _hash_latency = metrics::MAP_VIEW_HASH_RUNTIME.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
         let mut count = 0u32;

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -6,7 +6,7 @@ use std::{
     ops::Range,
 };
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_base::prometheus_util::MeasureLatency as _;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -19,7 +19,7 @@ use crate::{
     views::{ClonableView, HashableView, Hasher, View, ViewError, MIN_VIEW_TAG},
 };
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -467,7 +467,7 @@ where
     }
 
     async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _hash_latency = metrics::QUEUE_VIEW_HASH_RUNTIME.measure_latency();
         let elements = self.elements().await?;
         let mut hasher = sha3::Sha3_256::default();

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use async_lock::{RwLock, RwLockReadGuardArc, RwLockWriteGuardArc};
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_base::prometheus_util::MeasureLatency as _;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -24,7 +24,7 @@ use crate::{
     views::{ClonableView, HashableView, Hasher, View, ViewError, MIN_VIEW_TAG},
 };
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -1012,7 +1012,7 @@ where
     type Hasher = sha3::Sha3_256;
 
     async fn hash_mut(&mut self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _hash_latency = metrics::REENTRANT_COLLECTION_VIEW_HASH_RUNTIME.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
         let keys = self.keys().await?;
@@ -1049,7 +1049,7 @@ where
     }
 
     async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _hash_latency = metrics::REENTRANT_COLLECTION_VIEW_HASH_RUNTIME.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
         let keys = self.keys().await?;

--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_base::prometheus_util::MeasureLatency as _;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -14,7 +14,7 @@ use crate::{
     views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -201,7 +201,7 @@ where
     }
 
     fn compute_hash(&self) -> Result<<sha3::Sha3_256 as Hasher>::Output, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _hash_latency = metrics::REGISTER_VIEW_HASH_RUNTIME.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
         hasher.update_with_bcs_bytes(self.get())?;

--- a/linera-views/src/views/set_view.rs
+++ b/linera-views/src/views/set_view.rs
@@ -3,7 +3,7 @@
 
 use std::{borrow::Borrow, collections::BTreeMap, marker::PhantomData, mem};
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 use linera_base::prometheus_util::MeasureLatency as _;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -16,7 +16,7 @@ use crate::{
     views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
 
-#[cfg(with_metrics)]
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics {
     use std::sync::LazyLock;
 
@@ -371,7 +371,7 @@ where
     }
 
     async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
-        #[cfg(with_metrics)]
+        #[cfg(not(target_arch = "wasm32"))]
         let _hash_latency = metrics::SET_VIEW_HASH_RUNTIME.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
         let mut count = 0u32;


### PR DESCRIPTION
## Motivation

Having metrics should be always useful. Even when there's no prometheus server scraping them and sending to Grafana or something for visualization, it will still expose a metrics endpoint that can be queried to get the metrics.
So it's useful in general to have. So it makes sense to not have this behind a feature.

## Proposal

Remove the `metrics` feature. The `prometheus` crate can't be compiled on `wasm32`, so we still need to check for that.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.