### PR TITLE
Optimize ScyllaDB usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5696,6 +5696,7 @@ dependencies = [
  "cfg_aliases",
  "convert_case",
  "criterion",
+ "dashmap 5.5.3",
  "derive_more 1.0.0",
  "futures",
  "generic-array",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3938,6 +3938,7 @@ dependencies = [
  "bcs",
  "cfg_aliases",
  "convert_case",
+ "dashmap 5.5.3",
  "derive_more 1.0.0",
  "futures",
  "generic-array",

--- a/kubernetes/linera-validator/templates/scylla-config.yaml
+++ b/kubernetes/linera-validator/templates/scylla-config.yaml
@@ -6,3 +6,4 @@ metadata:
 data:
   scylla.yaml: |
     query_tombstone_page_limit: 200000
+    commitlog_segment_size_in_mb: 256

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -37,6 +37,7 @@ aws-sdk-dynamodb = { workspace = true, optional = true }
 aws-smithy-types = { workspace = true, optional = true }
 bcs.workspace = true
 convert_case.workspace = true
+dashmap.workspace = true
 derive_more = { workspace = true, features = ["from"] }
 futures.workspace = true
 generic-array.workspace = true


### PR DESCRIPTION
## Motivation

There are some optimization that we can do in how we're using ScyllaDB

## Proposal

This PR removes the use of:
* Non token aware queries
* Unpaged queries
* Most usages of `ALLOW FILTERING` (the ones remaining should be fine)
* Non prepared statements

Also:
* Tuned page creation and other settings a bit
* Some refactoring/code cleanup

## Test Plan

CI + deployed a network, benchmarked it, and saw an over 10x decrease in ScyllaDB`s write latency

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
