### PR TITLE
Remove block field from ResourceTracker

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -875,16 +875,6 @@ where
             }
         }
 
-        // Finally, charge for the block fee, except if the chain is closed. Closed chains should
-        // always be able to reject incoming messages.
-        if !chain.system.closed.get() {
-            resource_controller
-                .with_state(&mut chain.system)
-                .await?
-                .track_block()
-                .with_execution_context(ChainExecutionContext::Block)?;
-        }
-
         let recipients = messages
             .iter()
             .flatten()

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -30,8 +30,6 @@ pub struct ResourceController<Account = Amount, Tracker = ResourceTracker> {
 /// The resources used so far by an execution process.
 #[derive(Copy, Debug, Clone, Default)]
 pub struct ResourceTracker {
-    /// The number of blocks created.
-    pub blocks: u32,
     /// The total size of the block so far.
     pub block_size: u64,
     /// The EVM fuel used so far.
@@ -147,17 +145,6 @@ where
     pub fn track_grant(&mut self, grant: Amount) -> Result<(), ExecutionError> {
         self.tracker.as_mut().grants.try_add_assign(grant)?;
         self.update_balance(grant)
-    }
-
-    /// Tracks the creation of a block.
-    pub fn track_block(&mut self) -> Result<(), ExecutionError> {
-        self.tracker.as_mut().blocks = self
-            .tracker
-            .as_mut()
-            .blocks
-            .checked_add(1)
-            .ok_or(ArithmeticError::Overflow)?;
-        Ok(())
     }
 
     /// Tracks the execution of an operation in block.


### PR DESCRIPTION
## Motivation

`ResourceTracker.blocks` field was meant to track blocks created so far to charge a constant cost for it but that was removed in a recent PR.

## Proposal

Remove the field. It was unused anyway.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
