### PR TITLE
Change the behavior of LogView read function

### DIFF
--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -333,7 +333,7 @@ where
     /// Returns the appropriate gRPC status for the given [`ViewError`].
     fn error_to_status(err: ViewError) -> Status {
         let mut status = match &err {
-            ViewError::TooLargeValue | ViewError::BcsError(_) => {
+            ViewError::TooLargeValue | ViewError::BcsError(_) | ViewError::IncorrectRange => {
                 Status::invalid_argument(err.to_string())
             }
             ViewError::StoreError { .. }

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -318,14 +318,22 @@ where
             Bound::Included(end) => *end + 1,
             Bound::Excluded(end) => *end,
             Bound::Unbounded => self.count(),
+        };
+        if end > self.count() {
+            return Err(ViewError::IncorrectRange);
         }
-        .min(self.count());
         let start = match range.start_bound() {
             Bound::Included(start) => *start,
             Bound::Excluded(start) => *start + 1,
             Bound::Unbounded => 0,
         };
-        if start >= end {
+        if start > self.count() {
+            return Err(ViewError::IncorrectRange);
+        }
+        if start > end {
+            return Err(ViewError::IncorrectRange);
+        }
+        if start == end {
             return Ok(Vec::new());
         }
         if start < effective_stored_count {

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -134,6 +134,10 @@ pub enum ViewError {
         error: String,
     },
 
+    /// Incorrect range
+    #[error("Incorrect range")]
+    IncorrectRange,
+
     /// The key must not be too long
     #[error("The key must not be too long")]
     KeyTooLong,

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -374,7 +374,11 @@ where
             assert_eq!(view.x2.get(), &2);
         }
         if config.with_log {
-            assert_eq!(view.log.read(0..10).await?, vec![4]);
+            assert!(view.log.read(0..10).await.is_err());
+            assert!(view.log.read(0..2).await.is_err());
+            assert!(view.log.read(2..).await.is_err());
+            assert_eq!(view.log.read(1..).await?, Vec::<u32>::new());
+            assert_eq!(view.log.read(0..1).await?, vec![4]);
         }
         if config.with_queue {
             assert_eq!(view.queue.read_front(10).await?, vec![7]);
@@ -401,7 +405,7 @@ where
                 assert_eq!(count, 1);
             }
             let subview = view.collection.try_load_entry("hola").await?.unwrap();
-            assert_eq!(subview.read(0..10).await?, vec![17, 18]);
+            assert_eq!(subview.read(0..).await?, vec![17, 18]);
         }
     };
     let staged_hash = {
@@ -414,7 +418,7 @@ where
             assert_eq!(view.x2.get(), &0);
         }
         if config.with_log {
-            assert_eq!(view.log.read(0..10).await?, Vec::<u32>::new());
+            assert_eq!(view.log.read(..).await?, Vec::<u32>::new());
         }
         if config.with_queue {
             assert_eq!(view.queue.read_front(10).await?, Vec::<u64>::new());
@@ -427,7 +431,7 @@ where
         }
         if config.with_collection {
             let subview = view.collection.load_entry_or_insert("hola").await?;
-            assert_eq!(subview.read(0..10).await?, Vec::<u32>::new());
+            assert_eq!(subview.read(0..).await?, Vec::<u32>::new());
             let subview = view.collection2.load_entry_mut("ciao").await?;
             let subsubview = subview.load_entry_mut("!").await?;
             subsubview.set(3);
@@ -479,7 +483,7 @@ where
             assert_eq!(view.x2.get(), &0);
         }
         if config.with_log {
-            assert_eq!(view.log.read(0..10).await?, vec![4]);
+            assert_eq!(view.log.read(..).await?, vec![4]);
         }
         if config.with_queue {
             view.queue.push_back(8);
@@ -507,7 +511,8 @@ where
         }
         if config.with_collection {
             let subview = view.collection.try_load_entry("hola").await?.unwrap();
-            assert_eq!(subview.read(0..10).await?, vec![17, 18]);
+            assert!(subview.read(0..10).await.is_err());
+            assert_eq!(subview.read(0..).await?, vec![17, 18]);
             assert_eq!(subview.read(..).await?, vec![17, 18]);
             assert_eq!(subview.read(1..).await?, vec![18]);
             assert_eq!(subview.read(..=0).await?, vec![17]);
@@ -598,7 +603,7 @@ where
         let mut view = store.load(1).await?;
         if config.with_collection {
             let subview = view.collection.load_entry_or_insert("hola").await?;
-            assert_eq!(subview.read(0..10).await?, Vec::<u32>::new());
+            assert_eq!(subview.read(..).await?, Vec::<u32>::new());
         }
         if config.with_queue {
             assert_eq!(view.queue.front().await?, Some(13));


### PR DESCRIPTION
## Motivation

The function `read` of the `LogView` is restricting the range on input. That behavior is at odds with the one of other containers where we return an error on incorrect input. Moreover, there is no use case for handling incorrect range on input.

## Proposal

An incorrect range error is returned when the input range is incorrect.

## Test Plan

The CI. The tests have to be addressed for the change of API.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

Help.