### PR TITLE
Don't execute sender chains

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -488,13 +488,13 @@ impl TryFrom<BlockHeight> for usize {
 }
 
 /// Allows converting [`BlockHeight`] ranges to inclusive tuples of bounds.
-pub trait RangeExt {
+pub trait BlockHeightRangeBounds {
     /// Returns the range as a tuple of inclusive bounds.
     /// If the range is empty, returns `None`.
     fn to_inclusive(&self) -> Option<(BlockHeight, BlockHeight)>;
 }
 
-impl<T: RangeBounds<BlockHeight>> RangeExt for T {
+impl<T: RangeBounds<BlockHeight>> BlockHeightRangeBounds for T {
     fn to_inclusive(&self) -> Option<(BlockHeight, BlockHeight)> {
         let start = match self.start_bound() {
             Bound::Included(height) => *height,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -946,6 +946,15 @@ where
         Ok(())
     }
 
+    /// Applies a loose block without executing it. This only updates the outboxes.
+    pub async fn apply_loose_block(&mut self, block: &ConfirmedBlock) -> Result<(), ChainError> {
+        let hash = block.inner().hash();
+        let block = block.inner().inner();
+        self.process_outgoing_messages(block).await?;
+        self.loose_blocks.insert(&block.header.height, hash)?;
+        Ok(())
+    }
+
     /// Executes a message as part of an incoming bundle in a block.
     #[expect(clippy::too_many_arguments)]
     async fn execute_message_in_block(

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -12,7 +12,7 @@ use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlockHeight,
-        Epoch, OracleResponse, RangeExt as _, Timestamp,
+        BlockHeightRangeBounds as _, Epoch, OracleResponse, Timestamp,
     },
     ensure,
     identifiers::{AccountOwner, ApplicationId, BlobType, ChainId, MessageId},

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -1181,7 +1181,7 @@ where
 
 trait RangeExt {
     /// Returns the range as a tuple of inclusive bounds.
-    /// If the range is empty, returns None.
+    /// If the range is empty, returns `None`.
     fn to_inclusive(&self) -> Option<(BlockHeight, BlockHeight)>;
 }
 
@@ -1197,6 +1197,9 @@ impl<T: RangeBounds<BlockHeight>> RangeExt for T {
             Bound::Excluded(height) => height.try_sub_one().ok()?,
             Bound::Unbounded => BlockHeight::MAX,
         };
+        if start > end {
+            return None;
+        }
         Some((start, end))
     }
 }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -947,7 +947,7 @@ where
         Ok(())
     }
 
-    /// Applies an unexecuted block without executing it. This only updates the outboxes.
+    /// Applies a block without executing it. This only updates the outboxes.
     pub async fn apply_unexecuted_block(
         &mut self,
         block: &ConfirmedBlock,
@@ -1084,6 +1084,8 @@ where
         Ok(())
     }
 
+    /// Returns the hashes of all blocks in the given range. Returns an error if we are missing
+    /// any of those blocks.
     pub async fn block_hashes(
         &self,
         range: impl RangeBounds<BlockHeight>,

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -121,8 +121,8 @@ where
         callback: oneshot::Sender<Result<(ChainInfoResponse, NetworkActions), WorkerError>>,
     },
 
-    /// Apply a block without executing it.
-    ProcessCertificateWithoutExecuting {
+    /// Preprocess a block without executing it.
+    PreprocessCertificate {
         certificate: ConfirmedBlockCertificate,
         #[debug(skip)]
         callback: oneshot::Sender<Result<NetworkActions, WorkerError>>,
@@ -399,15 +399,11 @@ where
                         .await,
                 )
                 .is_ok(),
-            ChainWorkerRequest::ProcessCertificateWithoutExecuting {
+            ChainWorkerRequest::PreprocessCertificate {
                 certificate,
                 callback,
             } => callback
-                .send(
-                    self.worker
-                        .process_certificate_without_executing(certificate)
-                        .await,
-                )
+                .send(self.worker.preprocess_certificate(certificate).await)
                 .is_ok(),
             ChainWorkerRequest::ProcessCrossChainUpdate {
                 origin,
@@ -497,7 +493,7 @@ where
             ChainWorkerRequest::ProcessConfirmedBlock { callback, .. } => {
                 callback.send(Err(error)).is_ok()
             }
-            ChainWorkerRequest::ProcessCertificateWithoutExecuting { callback, .. } => {
+            ChainWorkerRequest::PreprocessCertificate { callback, .. } => {
                 callback.send(Err(error)).is_ok()
             }
             ChainWorkerRequest::ProcessCrossChainUpdate { callback, .. } => {

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -121,8 +121,8 @@ where
         callback: oneshot::Sender<Result<(ChainInfoResponse, NetworkActions), WorkerError>>,
     },
 
-    /// Apply an unexecuted block without executing it.
-    ProcessUnexecutedCertificate {
+    /// Apply a block without executing it.
+    ProcessCertificateWithoutExecuting {
         certificate: ConfirmedBlockCertificate,
         #[debug(skip)]
         callback: oneshot::Sender<Result<NetworkActions, WorkerError>>,
@@ -399,13 +399,13 @@ where
                         .await,
                 )
                 .is_ok(),
-            ChainWorkerRequest::ProcessUnexecutedCertificate {
+            ChainWorkerRequest::ProcessCertificateWithoutExecuting {
                 certificate,
                 callback,
             } => callback
                 .send(
                     self.worker
-                        .process_unexecuted_certificate(certificate)
+                        .process_certificate_without_executing(certificate)
                         .await,
                 )
                 .is_ok(),
@@ -497,7 +497,7 @@ where
             ChainWorkerRequest::ProcessConfirmedBlock { callback, .. } => {
                 callback.send(Err(error)).is_ok()
             }
-            ChainWorkerRequest::ProcessUnexecutedCertificate { callback, .. } => {
+            ChainWorkerRequest::ProcessCertificateWithoutExecuting { callback, .. } => {
                 callback.send(Err(error)).is_ok()
             }
             ChainWorkerRequest::ProcessCrossChainUpdate { callback, .. } => {

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -122,7 +122,7 @@ where
     },
 
     /// Apply a loose block without executing it.
-    ProcessLooseCertificate {
+    ProcessUnexecutedCertificate {
         certificate: ConfirmedBlockCertificate,
         #[debug(skip)]
         callback: oneshot::Sender<Result<NetworkActions, WorkerError>>,
@@ -399,11 +399,15 @@ where
                         .await,
                 )
                 .is_ok(),
-            ChainWorkerRequest::ProcessLooseCertificate {
+            ChainWorkerRequest::ProcessUnexecutedCertificate {
                 certificate,
                 callback,
             } => callback
-                .send(self.worker.process_loose_certificate(certificate).await)
+                .send(
+                    self.worker
+                        .process_unexecuted_certificate(certificate)
+                        .await,
+                )
                 .is_ok(),
             ChainWorkerRequest::ProcessCrossChainUpdate {
                 origin,
@@ -493,7 +497,7 @@ where
             ChainWorkerRequest::ProcessConfirmedBlock { callback, .. } => {
                 callback.send(Err(error)).is_ok()
             }
-            ChainWorkerRequest::ProcessLooseCertificate { callback, .. } => {
+            ChainWorkerRequest::ProcessUnexecutedCertificate { callback, .. } => {
                 callback.send(Err(error)).is_ok()
             }
             ChainWorkerRequest::ProcessCrossChainUpdate { callback, .. } => {

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -121,7 +121,7 @@ where
         callback: oneshot::Sender<Result<(ChainInfoResponse, NetworkActions), WorkerError>>,
     },
 
-    /// Apply a loose block without executing it.
+    /// Apply an unexecuted block without executing it.
     ProcessUnexecutedCertificate {
         certificate: ConfirmedBlockCertificate,
         #[debug(skip)]

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -414,8 +414,9 @@ where
         Ok((info, actions))
     }
 
-    /// Processes an unexecuted block without executing it.
-    pub(super) async fn process_unexecuted_certificate(
+    /// Stores a block's blobs, and adds its messages to the outbox where possible.
+    /// Does not execute the block.
+    pub(super) async fn process_certificate_without_executing(
         &mut self,
         certificate: ConfirmedBlockCertificate,
     ) -> Result<NetworkActions, WorkerError> {
@@ -453,7 +454,7 @@ where
         // Update the outboxes.
         self.state
             .chain
-            .apply_unexecuted_block(certificate.value())
+            .process_block_without_executing(certificate.value())
             .await?;
         // Persist chain.
         self.save().await?;

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -415,6 +415,53 @@ where
         Ok((info, actions))
     }
 
+    /// Processes a loose block without executing it.
+    pub(super) async fn process_loose_certificate(
+        &mut self,
+        certificate: ConfirmedBlockCertificate,
+    ) -> Result<NetworkActions, WorkerError> {
+        let block = certificate.block();
+        // Check that the chain is active and ready for this confirmation.
+        let tip = self.state.chain.tip_state.get().clone();
+        if tip.next_block_height > block.header.height {
+            // We already processed this block.
+            return self.state.create_network_actions().await;
+        }
+
+        let required_blob_ids = block.required_blob_ids();
+        let created_blobs: BTreeMap<_, _> = block.iter_created_blobs().collect();
+        let blobs_result = self
+            .state
+            .get_required_blobs(block.required_blob_ids(), &created_blobs)
+            .await
+            .map(|blobs| blobs.into_values().collect::<Vec<_>>());
+
+        if let Ok(blobs) = &blobs_result {
+            self.state
+                .storage
+                .write_blobs_and_certificate(blobs, &certificate)
+                .await?;
+        }
+
+        // Update the blob state with last used certificate hash.
+        let blob_state = certificate.value().to_blob_state();
+        let overwrite = blobs_result.is_ok(); // Overwrite only if we wrote the certificate.
+        let blob_ids = required_blob_ids.into_iter().collect::<Vec<_>>();
+        self.state
+            .storage
+            .maybe_write_blob_states(&blob_ids, blob_state, overwrite)
+            .await?;
+        blobs_result?;
+        // Update the outboxes.
+        self.state
+            .chain
+            .apply_loose_block(certificate.value())
+            .await?;
+        // Persist chain.
+        self.save().await?;
+        self.state.create_network_actions().await
+    }
+
     /// Schedules a notification for when cross-chain messages are delivered up to the given
     /// `height`.
     #[instrument(level = "trace", skip(self, notify_when_messages_are_delivered))]

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -443,12 +443,11 @@ where
         }
 
         // Update the blob state with last used certificate hash.
-        let blob_state = certificate.value().to_blob_state();
-        let overwrite = blobs_result.is_ok(); // Overwrite only if we wrote the certificate.
+        let blob_state = certificate.value().to_blob_state(blobs_result.is_ok());
         let blob_ids = required_blob_ids.into_iter().collect::<Vec<_>>();
         self.state
             .storage
-            .maybe_write_blob_states(&blob_ids, blob_state, overwrite)
+            .maybe_write_blob_states(&blob_ids, blob_state)
             .await?;
         blobs_result?;
         // Update the outboxes.

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -416,7 +416,7 @@ where
 
     /// Stores a block's blobs, and adds its messages to the outbox where possible.
     /// Does not execute the block.
-    pub(super) async fn process_certificate_without_executing(
+    pub(super) async fn preprocess_certificate(
         &mut self,
         certificate: ConfirmedBlockCertificate,
     ) -> Result<NetworkActions, WorkerError> {
@@ -454,7 +454,7 @@ where
         // Update the outboxes.
         self.state
             .chain
-            .process_block_without_executing(certificate.value())
+            .preprocess_block(certificate.value())
             .await?;
         // Persist chain.
         self.save().await?;

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -415,7 +415,7 @@ where
         Ok((info, actions))
     }
 
-    /// Processes a loose block without executing it.
+    /// Processes an unexecuted block without executing it.
     pub(super) async fn process_unexecuted_certificate(
         &mut self,
         certificate: ConfirmedBlockCertificate,

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -416,7 +416,7 @@ where
     }
 
     /// Processes a loose block without executing it.
-    pub(super) async fn process_loose_certificate(
+    pub(super) async fn process_unexecuted_certificate(
         &mut self,
         certificate: ConfirmedBlockCertificate,
     ) -> Result<NetworkActions, WorkerError> {
@@ -455,7 +455,7 @@ where
         // Update the outboxes.
         self.state
             .chain
-            .apply_loose_block(certificate.value())
+            .apply_unexecuted_block(certificate.value())
             .await?;
         // Persist chain.
         self.save().await?;

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -261,7 +261,7 @@ where
             .await
     }
 
-    /// Processes a loose block without executing it.
+    /// Processes an unexecuted block without executing it.
     #[tracing::instrument(level = "debug", skip(self))]
     pub(super) async fn process_unexecuted_certificate(
         &mut self,

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -261,6 +261,18 @@ where
             .await
     }
 
+    /// Processes a loose block without executing it.
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(super) async fn process_loose_certificate(
+        &mut self,
+        certificate: ConfirmedBlockCertificate,
+    ) -> Result<NetworkActions, WorkerError> {
+        ChainWorkerStateWithAttemptedChanges::new(self)
+            .await
+            .process_loose_certificate(certificate)
+            .await
+    }
+
     /// Updates the chain's inboxes, receiving messages from a cross-chain update.
     #[tracing::instrument(level = "debug", skip(self))]
     pub(super) async fn process_cross_chain_update(

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -778,8 +778,6 @@ impl<Env: Environment> Client<Env> {
         } else {
             self.validator_nodes().await?
         };
-        self.download_certificates(&nodes, block.header.chain_id, block.header.height)
-            .await?;
         // Process the received operations. Download required hashed certificate values if
         // necessary.
         if let Err(err) = self.process_loose_certificate(certificate.clone()).await {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -758,10 +758,13 @@ impl<Env: Environment> Client<Env> {
         {
             match &err {
                 LocalNodeError::BlobsNotFound(blob_ids) => {
-                    let blobs =
-                        RemoteNode::download_blobs(blob_ids, &nodes, self.blob_download_timeout)
-                            .await
-                            .ok_or(err)?;
+                    let blobs = RemoteNode::download_blobs(
+                        blob_ids,
+                        &nodes,
+                        self.options.blob_download_timeout,
+                    )
+                    .await
+                    .ok_or(err)?;
                     self.local_node.store_blobs(&blobs).await?;
                     self.process_unexecuted_certificate(certificate.clone())
                         .await?;
@@ -804,10 +807,13 @@ impl<Env: Environment> Client<Env> {
         {
             match &err {
                 LocalNodeError::BlobsNotFound(blob_ids) => {
-                    let blobs =
-                        RemoteNode::download_blobs(blob_ids, &nodes, self.blob_download_timeout)
-                            .await
-                            .ok_or(err)?;
+                    let blobs = RemoteNode::download_blobs(
+                        blob_ids,
+                        &nodes,
+                        self.options.blob_download_timeout,
+                    )
+                    .await
+                    .ok_or(err)?;
                     self.local_node.store_blobs(&blobs).await?;
                     self.process_unexecuted_certificate(certificate).await?;
                 }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -332,7 +332,7 @@ impl<Env: Environment> Client<Env> {
         {
             let chain = self.local_node.chain_state_view(chain_id).await?;
             while start < stop {
-                let Some(hash) = chain.unexecuted_blocks.get(&start).await? else {
+                let Some(hash) = chain.other_blocks.get(&start).await? else {
                     break;
                 };
                 hashes.push(hash);
@@ -507,12 +507,12 @@ impl<Env: Environment> Client<Env> {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub async fn process_unexecuted_certificate(
+    pub async fn process_certificate_without_executing(
         &self,
         certificate: Box<ConfirmedBlockCertificate>,
     ) -> Result<(), LocalNodeError> {
         self.local_node
-            .process_unexecuted_certificate(*certificate, &self.notifier)
+            .process_certificate_without_executing(*certificate, &self.notifier)
             .await?;
         Ok(())
     }
@@ -753,7 +753,7 @@ impl<Env: Environment> Client<Env> {
             self.validator_nodes().await?
         };
         if let Err(err) = self
-            .process_unexecuted_certificate(certificate.clone())
+            .process_certificate_without_executing(certificate.clone())
             .await
         {
             match &err {
@@ -766,7 +766,7 @@ impl<Env: Environment> Client<Env> {
                     .await
                     .ok_or(err)?;
                     self.local_node.store_blobs(&blobs).await?;
-                    self.process_unexecuted_certificate(certificate.clone())
+                    self.process_certificate_without_executing(certificate.clone())
                         .await?;
                 }
                 _ => {
@@ -781,7 +781,7 @@ impl<Env: Environment> Client<Env> {
     }
 
     #[instrument(level = "trace", skip_all)]
-    async fn receive_checked_unexecuted_certificate(
+    async fn receive_checked_certificate_without_executing(
         &self,
         certificate: ConfirmedBlockCertificate,
     ) -> Result<(), ChainClientError> {
@@ -802,7 +802,7 @@ impl<Env: Environment> Client<Env> {
         // Process the received operations. Download required hashed certificate values if
         // necessary.
         if let Err(err) = self
-            .process_unexecuted_certificate(certificate.clone())
+            .process_certificate_without_executing(certificate.clone())
             .await
         {
             match &err {
@@ -815,7 +815,8 @@ impl<Env: Environment> Client<Env> {
                     .await
                     .ok_or(err)?;
                     self.local_node.store_blobs(&blobs).await?;
-                    self.process_unexecuted_certificate(certificate).await?;
+                    self.process_certificate_without_executing(certificate)
+                        .await?;
                 }
                 _ => {
                     // The certificate is not as expected. Give up.
@@ -3005,7 +3006,7 @@ impl<Env: Environment> ChainClient<Env> {
         skip(certificate),
         fields(certificate_hash = ?certificate.hash()),
     )]
-    async fn receive_unexecuted_certificate(
+    async fn receive_certificate_without_executing(
         &self,
         certificate: ConfirmedBlockCertificate,
     ) -> Result<(), ChainClientError> {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -826,7 +826,7 @@ impl<Env: Environment> Client<Env> {
                 }
                 _ => {
                     // The certificate is not as expected. Give up.
-                    warn!("Failed to process loosed certificate value");
+                    warn!("Failed to process loose certificate value");
                     return Err(err.into());
                 }
             }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2073,11 +2073,11 @@ impl<Env: Environment> ChainClient<Env> {
                 for certificate in certificates.into_values() {
                     let hash = certificate.hash();
                     let mode = ReceiveCertificateMode::AlreadyChecked;
-                    if let Err(e) = client
+                    if let Err(err) = client
                         .receive_loose_certificate(certificate, mode, None)
                         .await
                     {
-                        warn!("Received invalid certificate {hash}: {e}");
+                        error!("Received invalid certificate {hash}: {err}");
                     }
                 }
             }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -594,6 +594,7 @@ impl<Env: Environment> Client<Env> {
                     chain_worker_count,
                     remote_node,
                     local_node: local_node.clone(),
+                    client: self,
                 };
                 Box::pin(async move {
                     updater
@@ -632,6 +633,7 @@ impl<Env: Environment> Client<Env> {
                     chain_worker_count,
                     remote_node,
                     local_node: local_node.clone(),
+                    client: self,
                 };
                 let action = action.clone();
                 Box::pin(async move { updater.send_chain_update(action).await })

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -594,7 +594,6 @@ impl<Env: Environment> Client<Env> {
                     chain_worker_count,
                     remote_node,
                     local_node: local_node.clone(),
-                    client: self,
                 };
                 Box::pin(async move {
                     updater
@@ -633,7 +632,6 @@ impl<Env: Environment> Client<Env> {
                     chain_worker_count,
                     remote_node,
                     local_node: local_node.clone(),
-                    client: self,
                 };
                 let action = action.clone();
                 Box::pin(async move { updater.send_chain_update(action).await })
@@ -3917,9 +3915,9 @@ enum CheckCertificateResult {
 impl CheckCertificateResult {
     fn into_result(self) -> Result<(), ChainClientError> {
         match self {
-            Self::OldEpoch => Err(ChainClientError::CommitteeSynchronizationError),
+            Self::OldEpoch => Err(ChainClientError::CommitteeDeprecationError),
             Self::New => Ok(()),
-            Self::FutureEpoch => Err(ChainClientError::CommitteeDeprecationError),
+            Self::FutureEpoch => Err(ChainClientError::CommitteeSynchronizationError),
         }
     }
 }

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -126,14 +126,14 @@ where
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub async fn process_loose_certificate(
+    pub async fn process_unexecuted_certificate(
         &self,
         certificate: ConfirmedBlockCertificate,
         notifier: &impl Notifier,
     ) -> Result<(), LocalNodeError> {
         self.node
             .state
-            .fully_process_loose_certificate_with_notifications(certificate, notifier)
+            .fully_process_unexecuted_certificate_with_notifications(certificate, notifier)
             .await?;
         Ok(())
     }
@@ -298,7 +298,7 @@ where
             .map(|chain_id| async move {
                 let chain = self.chain_state_view(*chain_id).await?;
                 let mut next_height = chain.tip_state.get().next_block_height;
-                while chain.loose_blocks.contains_key(&next_height).await? {
+                while chain.unexecuted_blocks.contains_key(&next_height).await? {
                     next_height.try_add_assign_one()?;
                 }
                 Ok::<_, LocalNodeError>((*chain_id, next_height))

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -125,15 +125,16 @@ where
         .await?)
     }
 
+    /// Preprocesses a block without executing it.
     #[instrument(level = "trace", skip_all)]
-    pub async fn process_certificate_without_executing(
+    pub async fn preprocess_certificate(
         &self,
         certificate: ConfirmedBlockCertificate,
         notifier: &impl Notifier,
     ) -> Result<(), LocalNodeError> {
         self.node
             .state
-            .fully_process_certificate_with_notifications_without_executing(certificate, notifier)
+            .fully_preprocess_certificate_with_notifications(certificate, notifier)
             .await?;
         Ok(())
     }
@@ -325,7 +326,7 @@ where
                 let mut next_height = chain.tip_state.get().next_block_height;
                 // TODO(#3969): This is not great for performance, but the whole function will
                 // probably go away with #3969 anyway.
-                while chain.other_blocks.contains_key(&next_height).await? {
+                while chain.preprocessed_blocks.contains_key(&next_height).await? {
                     next_height.try_add_assign_one()?;
                 }
                 Ok::<_, LocalNodeError>((*chain_id, next_height))

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -597,7 +597,7 @@ where
             .await?;
         assert_eq!(chain.tip_state.get().next_block_height.0, 0);
         assert_eq!(
-            chain.loose_blocks.get(&cert.inner().height()).await?,
+            chain.unexecuted_blocks.get(&cert.inner().height()).await?,
             Some(cert.hash())
         );
     }

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -589,10 +589,18 @@ where
         .unwrap();
 
     receiver.synchronize_from_validators().await.unwrap();
-    receiver
-        .receive_certificate_and_update_validators(cert.clone())
-        .await
-        .unwrap();
+    {
+        // The receiver did not execute the sender chain.
+        let chain = receiver
+            .storage_client()
+            .load_chain(sender.chain_id())
+            .await?;
+        assert_eq!(chain.tip_state.get().next_block_height.0, 0);
+        assert_eq!(
+            chain.loose_blocks.get(&cert.inner().height()).await?,
+            Some(cert.hash())
+        );
+    }
     let certs = receiver.process_inbox().await.unwrap().0;
     assert_eq!(certs.len(), 1);
     let messages = &certs[0].block().body.incoming_bundles;

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -597,7 +597,7 @@ where
             .await?;
         assert_eq!(chain.tip_state.get().next_block_height.0, 0);
         assert_eq!(
-            chain.unexecuted_blocks.get(&cert.inner().height()).await?,
+            chain.other_blocks.get(&cert.inner().height()).await?,
             Some(cert.hash())
         );
     }

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -597,7 +597,10 @@ where
             .await?;
         assert_eq!(chain.tip_state.get().next_block_height.0, 0);
         assert_eq!(
-            chain.other_blocks.get(&cert.inner().height()).await?,
+            chain
+                .preprocessed_blocks
+                .get(&cert.inner().height())
+                .await?,
             Some(cert.hash())
         );
     }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -7,7 +7,6 @@ use std::{
     fmt,
     hash::Hash,
     mem,
-    ops::Range,
 };
 
 use futures::{stream, stream::TryStreamExt, Future, StreamExt};
@@ -368,12 +367,11 @@ where
         let remote_info = self.remote_node.handle_chain_info_query(query).await?;
         let initial_block_height = remote_info.next_block_height;
         // Obtain the missing blocks and the manager state from the local node.
-        let range: Range<usize> =
-            initial_block_height.try_into()?..target_block_height.try_into()?;
+        let range = initial_block_height..target_block_height;
         let (keys, timeout) = {
             let chain = self.local_node.chain_state_view(chain_id).await?;
             (
-                chain.confirmed_log.read(range).await?,
+                chain.block_hashes(range).await?,
                 chain.manager.timeout.get().clone(),
             )
         };

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -208,8 +208,8 @@ pub enum WorkerError {
         height: BlockHeight,
         chain_id: ChainId,
     },
-    #[error("loose_blocks entry at height {height} for chain {chain_id:8} not found")]
-    LooseBlocksEntryNotFound {
+    #[error("unexecuted_blocks entry at height {height} for chain {chain_id:8} not found")]
+    UnexecutedBlocksEntryNotFound {
         height: BlockHeight,
         chain_id: ChainId,
     },
@@ -898,7 +898,7 @@ where
         chain_id = format!("{:.8}", certificate.block().header.chain_id),
         height = %certificate.block().header.height,
     ))]
-    pub async fn fully_process_loose_certificate_with_notifications(
+    pub async fn fully_process_unexecuted_certificate_with_notifications(
         &self,
         certificate: ConfirmedBlockCertificate,
         notifier: &impl Notifier,
@@ -910,7 +910,7 @@ where
         linera_base::task::spawn(async move {
             let actions = this
                 .query_chain_worker(certificate.block().header.chain_id, move |callback| {
-                    ChainWorkerRequest::ProcessLooseCertificate {
+                    ChainWorkerRequest::ProcessUnexecutedCertificate {
                         certificate,
                         callback,
                     }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -208,8 +208,8 @@ pub enum WorkerError {
         height: BlockHeight,
         chain_id: ChainId,
     },
-    #[error("unexecuted_blocks entry at height {height} for chain {chain_id:8} not found")]
-    UnexecutedBlocksEntryNotFound {
+    #[error("other_blocks entry at height {height} for chain {chain_id:8} not found")]
+    OtherBlocksEntryNotFound {
         height: BlockHeight,
         chain_id: ChainId,
     },
@@ -890,7 +890,7 @@ where
             .await
     }
 
-    /// Applies an unexecuted block without executing it. This does not update the execution state, but
+    /// Applies a block without executing it. This does not update the execution state, but
     /// can create cross-chain messages and store blobs. It also does _not_ check the signatures;
     /// the caller is responsible for checking them using the correct committee.
     #[instrument(skip_all, fields(
@@ -898,7 +898,7 @@ where
         chain_id = format!("{:.8}", certificate.block().header.chain_id),
         height = %certificate.block().header.height,
     ))]
-    pub async fn fully_process_unexecuted_certificate_with_notifications(
+    pub async fn fully_process_certificate_with_notifications_without_executing(
         &self,
         certificate: ConfirmedBlockCertificate,
         notifier: &impl Notifier,
@@ -910,7 +910,7 @@ where
         linera_base::task::spawn(async move {
             let actions = this
                 .query_chain_worker(certificate.block().header.chain_id, move |callback| {
-                    ChainWorkerRequest::ProcessUnexecutedCertificate {
+                    ChainWorkerRequest::ProcessCertificateWithoutExecuting {
                         certificate,
                         callback,
                     }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -203,6 +203,16 @@ pub enum WorkerError {
     FastBlockUsingOracles,
     #[error("Blobs not found: {0:?}")]
     BlobsNotFound(Vec<BlobId>),
+    #[error("confirmed_log entry at height {height} for chain {chain_id:8} not found")]
+    ConfirmedLogEntryNotFound {
+        height: BlockHeight,
+        chain_id: ChainId,
+    },
+    #[error("loose_blocks entry at height {height} for chain {chain_id:8} not found")]
+    LooseBlocksEntryNotFound {
+        height: BlockHeight,
+        chain_id: ChainId,
+    },
     #[error("The block proposal is invalid: {0}")]
     InvalidBlockProposal(String),
     #[error("The worker is too busy to handle new chains")]

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -890,7 +890,7 @@ where
             .await
     }
 
-    /// Applies a loose block without executing it. This does not update the execution state, but
+    /// Applies an unexecuted block without executing it. This does not update the execution state, but
     /// can create cross-chain messages and store blobs. It also does _not_ check the signatures;
     /// the caller is responsible for checking them using the correct committee.
     #[instrument(skip_all, fields(

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -360,6 +360,10 @@ type ChainStateExtendedView {
 	We use a `RegisterView` to prioritize speed for small maps.
 	"""
 	outboxCounters: JSONObject!
+	"""
+	Blocks that have been verified but not processed yet, and that may not be contiguous.
+	"""
+	looseBlocks: MapView_BlockHeight_CryptoHash_1bae6d76!
 }
 
 """
@@ -465,6 +469,14 @@ A GraphQL-visible map item, complete with key.
 type Entry_BlobId_Blob_9f0b41f3 {
 	key: BlobId!
 	value: Blob
+}
+
+"""
+A GraphQL-visible map item, complete with key.
+"""
+type Entry_BlockHeight_CryptoHash_74e16b71 {
+	key: BlockHeight!
+	value: CryptoHash
 }
 
 """
@@ -610,6 +622,10 @@ input MapFilters_BlobId_4d2a0555 {
 	keys: [BlobId!]
 }
 
+input MapFilters_BlockHeight_e824a938 {
+	keys: [BlockHeight!]
+}
+
 input MapFilters_ChainId_37f83aa9 {
 	keys: [ChainId!]
 }
@@ -620,6 +636,10 @@ input MapInput_AccountOwner_d6668c53 {
 
 input MapInput_BlobId_4d2a0555 {
 	filters: MapFilters_BlobId_4d2a0555
+}
+
+input MapInput_BlockHeight_e824a938 {
+	filters: MapFilters_BlockHeight_e824a938
 }
 
 input MapInput_ChainId_37f83aa9 {
@@ -642,6 +662,12 @@ type MapView_BlobId_Blob_9f0b41f3 {
 	keys(count: Int): [BlobId!]!
 	entry(key: BlobId!): Entry_BlobId_Blob_50b95aa1!
 	entries(input: MapInput_BlobId_4d2a0555): [Entry_BlobId_Blob_50b95aa1!]!
+}
+
+type MapView_BlockHeight_CryptoHash_1bae6d76 {
+	keys(count: Int): [BlockHeight!]!
+	entry(key: BlockHeight!): Entry_BlockHeight_CryptoHash_74e16b71!
+	entries(input: MapInput_BlockHeight_e824a938): [Entry_BlockHeight_CryptoHash_74e16b71!]!
 }
 
 type MapView_ChainId_BlockHeight_f2e56e12 {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -361,9 +361,9 @@ type ChainStateExtendedView {
 	"""
 	outboxCounters: JSONObject!
 	"""
-	Blocks that have been verified but not processed yet, and that may not be contiguous.
+	Blocks that have been verified but not executed yet, and that may not be contiguous.
 	"""
-	looseBlocks: MapView_BlockHeight_CryptoHash_1bae6d76!
+	unexecutedBlocks: MapView_BlockHeight_CryptoHash_1bae6d76!
 }
 
 """

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -363,7 +363,7 @@ type ChainStateExtendedView {
 	"""
 	Blocks that have been verified but not executed yet, and that may not be contiguous.
 	"""
-	otherBlocks: MapView_BlockHeight_CryptoHash_1bae6d76!
+	preprocessedBlocks: MapView_BlockHeight_CryptoHash_1bae6d76!
 }
 
 """

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -363,7 +363,7 @@ type ChainStateExtendedView {
 	"""
 	Blocks that have been verified but not executed yet, and that may not be contiguous.
 	"""
-	unexecutedBlocks: MapView_BlockHeight_CryptoHash_1bae6d76!
+	otherBlocks: MapView_BlockHeight_CryptoHash_1bae6d76!
 }
 
 """

--- a/scripts/check_chain_loads.sh
+++ b/scripts/check_chain_loads.sh
@@ -24,6 +24,9 @@ sed -i -e '/linera-core\/src\/chain_worker\/state\/mod\.rs/d' "$USAGES_FILE"
 sed -i -e '/linera-core\/src\/unit_tests\/worker_tests\.rs/d' "$USAGES_FILE"
 sed -i -e '/linera-core\/src\/unit_tests\/test_utils\.rs/d' "$USAGES_FILE"
 
+# Client tests load chains to verify certain conditions
+sed -i -e '/linera-core\/src\/unit_tests\/wasm_client_tests\.rs/d' "$USAGES_FILE"
+
 # The SDK integration test framework uses `create_chain` to create a dummy admin chain before the
 # test (and the workers) start
 if [ "$(grep 'linera-sdk/src/test/validator.rs' "$USAGES_FILE" | wc -l)" -eq 1 ]; then


### PR DESCRIPTION
## Motivation

When the client verifies incoming messages to its own chains, it doesn't need the sender chain's execution state, so computing the block execution there is unnecessary work.

Eventually we want to go even further and avoid even downloading some of the sender chain's blocks (see https://github.com/linera-io/linera-protocol/issues/3969).

## Proposal

As a preparation for #3969, we introduce an `unexecuted_blocks` map to the chain state: It maps block heights that are higher than `next_block_height`, i.e. haven't been executed yet, to block hashes.

We don't purge empty outboxes anymore. When updating the outboxes, we make sure that we haven't skipped any messages and compare to the next height to schedule: That allows us to update some outboxes even for loose blocks, ahead of execution.

For now we still download all blocks of the sender chain. Skipping any will be done in a future PR.
However, we now add them as loose blocks and don't execute them.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/3270.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
