### PR TITLE
Use latest admin chain committee when synchronizing.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -743,7 +743,7 @@ where
             .default_chain()
             .expect("should have default chain");
         let default_chain_client = self.make_chain_client(default_chain_id);
-        let (epoch, committee) = default_chain_client.latest_committee().await?;
+        let (epoch, committee) = default_chain_client.admin_committee().await?;
         let blocks_infos = Benchmark::<Env>::make_benchmark_block_info(
             key_pairs,
             transactions_per_block,


### PR DESCRIPTION
## Motivation

When synchronizing, i.e. downloading blocks and blobs from the validators, in principle any set of validators or even other full nodes could be used. However, we currently sometimes use the latest validators from the admin chain, or from another chain.

## Proposal

Always use the latest validators from the admin chain: These are the most recent and should be the most likely to have all the data.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/3926.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
