### PR TITLE
Account for published blobs in the resource at the end of transaction execution rather than upfront.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1375,9 +1375,9 @@ impl Blob {
         Ok(Self::new_data(fs::read(path)?))
     }
 
-    /// Returns whether the blob is a "user blob".
-    pub fn is_user_blob(&self) -> bool {
-        self.content().blob_type().is_user_blob()
+    /// Returns whether the blob is of [`BlobType::Committee`] variant.
+    pub fn is_committee_blob(&self) -> bool {
+        self.content().blob_type().is_committee_blob()
     }
 }
 

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1374,6 +1374,11 @@ impl Blob {
     pub async fn load_data_blob_from_file(path: impl AsRef<Path>) -> io::Result<Self> {
         Ok(Self::new_data(fs::read(path)?))
     }
+
+    /// Returns whether the blob is a "user blob".
+    pub fn is_user_blob(&self) -> bool {
+        self.content().blob_type().is_user_blob()
+    }
 }
 
 impl Serialize for Blob {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -169,6 +169,21 @@ pub enum BlobType {
     ChainDescription,
 }
 
+impl BlobType {
+    /// Returns whether the blob is proposed by user.
+    pub fn is_user_blob(&self) -> bool {
+        match self {
+            BlobType::Data
+            | BlobType::ContractBytecode
+            | BlobType::ServiceBytecode
+            | BlobType::EvmBytecode
+            | BlobType::ApplicationDescription
+            | BlobType::ChainDescription => true,
+            BlobType::Committee => false,
+        }
+    }
+}
+
 impl fmt::Display for BlobType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -170,16 +170,16 @@ pub enum BlobType {
 }
 
 impl BlobType {
-    /// Returns whether the blob is proposed by user.
-    pub fn is_user_blob(&self) -> bool {
+    /// Returns whether the blob is of [`BlobType::Committee`] variant.
+    pub fn is_committee_blob(&self) -> bool {
         match self {
             BlobType::Data
             | BlobType::ContractBytecode
             | BlobType::ServiceBytecode
             | BlobType::EvmBytecode
             | BlobType::ApplicationDescription
-            | BlobType::ChainDescription => true,
-            BlobType::Committee => false,
+            | BlobType::ChainDescription => false,
+            BlobType::Committee => true,
         }
     }
 }

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -164,8 +164,6 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         // Account for blobs published indirectly but referenced by the transaction.
         for blob_id in &txn_outcome.blobs_published {
             if let Some(blob) = self.published_blobs.get(blob_id) {
-                // We don't check its sizes again, it was check at the beginning
-                // of the block processing.
                 resource_controller
                     .track_blob_published(blob)
                     .with_execution_context(context)?;

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -157,14 +157,8 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         // Account for blobs published by this transaction directly.
         for blob in &txn_outcome.blobs {
             resource_controller
-                .policy()
-                .check_blob_size(blob.content())
+                .track_blob_published(blob)
                 .with_execution_context(context)?;
-            if blob.content().blob_type().is_user_blob() {
-                resource_controller
-                    .track_blob_published(blob.content())
-                    .with_execution_context(context)?;
-            }
         }
 
         // Account for blobs published indirectly but referenced by the transaction.
@@ -172,11 +166,9 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
             if let Some(blob) = self.published_blobs.get(blob_id) {
                 // We don't check its sizes again, it was check at the beginning
                 // of the block processing.
-                if blob.content().blob_type().is_user_blob() {
-                    resource_controller
-                        .track_blob_published(blob.content())
-                        .with_execution_context(context)?;
-                }
+                resource_controller
+                    .track_blob_published(blob)
+                    .with_execution_context(context)?;
             } else {
                 return Err(ChainError::InternalError(format!(
                     "Missing published blob {blob_id}"

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -44,7 +44,7 @@ pub struct BlockExecutionTracker<'resources, 'blobs> {
     // Index of the currently executed transaction in a block.
     transaction_index: u32,
 
-    // Blobs publised in the block.
+    // Blobs published in the block.
     published_blobs: BTreeMap<BlobId, &'blobs Blob>,
 
     // We expect the number of outcomes to be equal to the number of transactions in the block.

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -341,7 +341,7 @@ where
     pub fn track_blob_published(&mut self, blob: &Blob) -> Result<(), ExecutionError> {
         self.policy.check_blob_size(blob.content())?;
         let size = blob.content().bytes().len() as u64;
-        if !blob.is_user_blob() {
+        if blob.is_committee_blob() {
             return Ok(());
         }
         {

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -7,7 +7,7 @@ use std::{sync::Arc, time::Duration};
 
 use custom_debug_derive::Debug;
 use linera_base::{
-    data_types::{Amount, ArithmeticError, BlobContent},
+    data_types::{Amount, ArithmeticError, Blob},
     ensure,
     identifiers::AccountOwner,
     vm::VmRuntime,
@@ -338,9 +338,12 @@ where
     }
 
     /// Tracks a number of blob bytes published.
-    pub fn track_blob_published(&mut self, content: &BlobContent) -> Result<(), ExecutionError> {
-        self.policy.check_blob_size(content)?;
-        let size = content.bytes().len() as u64;
+    pub fn track_blob_published(&mut self, blob: &Blob) -> Result<(), ExecutionError> {
+        self.policy.check_blob_size(blob.content())?;
+        let size = blob.content().bytes().len() as u64;
+        if !blob.is_user_blob() {
+            return Ok(());
+        }
         {
             let tracker = self.tracker.as_mut();
             tracker.blob_bytes_published = tracker

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -39,14 +39,14 @@ pub struct TransactionTracker {
     /// Blobs created by contracts.
     ///
     /// As of right now, blobs created by the contracts are one of the two:
-    /// - OpenChain
-    /// - CreateApplication
+    /// - [`OpenChain`]
+    /// - [`CreateApplication`]
     blobs: BTreeMap<BlobId, Blob>,
     /// Operation result.
     operation_result: Option<Vec<u8>>,
     /// Streams that have been updated but not yet processed during this transaction.
     streams_to_process: BTreeMap<ApplicationId, AppStreamUpdates>,
-    /// Published blobs this transaction refers to by BlobId.
+    /// Published blobs this transaction refers to by [`BlobId`].
     blobs_published: BTreeSet<BlobId>,
 }
 

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, mem, vec};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    mem, vec,
+};
 
 use custom_debug_derive::Debug;
 use linera_base::{
@@ -34,11 +37,17 @@ pub struct TransactionTracker {
     /// Events recorded by contracts' `emit` calls.
     events: Vec<Event>,
     /// Blobs created by contracts.
+    ///
+    /// As of right now, blobs created by the contracts are one of the two:
+    /// - OpenChain
+    /// - CreateApplication
     blobs: BTreeMap<BlobId, Blob>,
     /// Operation result.
     operation_result: Option<Vec<u8>>,
     /// Streams that have been updated but not yet processed during this transaction.
     streams_to_process: BTreeMap<ApplicationId, AppStreamUpdates>,
+    /// Published blobs this transaction refers to by BlobId.
+    blobs_published: BTreeSet<BlobId>,
 }
 
 /// The [`TransactionTracker`] contents after a transaction has finished.
@@ -57,6 +66,8 @@ pub struct TransactionOutcome {
     pub blobs: Vec<Blob>,
     /// Operation result.
     pub operation_result: Vec<u8>,
+    /// Blobs published by this transaction.
+    pub blobs_published: BTreeSet<BlobId>,
 }
 
 impl TransactionTracker {
@@ -144,6 +155,10 @@ impl TransactionTracker {
 
     pub fn add_created_blob(&mut self, blob: Blob) {
         self.blobs.insert(blob.id(), blob);
+    }
+
+    pub fn add_published_blob(&mut self, blob_id: BlobId) {
+        self.blobs_published.insert(blob_id);
     }
 
     pub fn created_blobs(&self) -> &BTreeMap<BlobId, Blob> {
@@ -266,6 +281,7 @@ impl TransactionTracker {
             blobs,
             operation_result,
             streams_to_process,
+            blobs_published,
         } = self;
         ensure!(
             streams_to_process.is_empty(),
@@ -286,6 +302,7 @@ impl TransactionTracker {
             events,
             blobs: blobs.into_values().collect(),
             operation_result: operation_result.unwrap_or_default(),
+            blobs_published,
         })
     }
 }


### PR DESCRIPTION
## Motivation

We are charging for all published blobs before we execute any operation in the block. This is wrong b/c we want the incoming grant to be able to cover the fees. The grants are processed during operation processing only so they are not taken into account at the beginning of the block processing.

## Proposal

Move the published blobs' resources tracking to the end of processing a transaction that published it. At this point any incoming grant is already processed. In order to do so, we track blob IDs referenced during transaction execution via `TransactionTracker.published_blobs` and consume it in `BlockExecutionTracker::process_txn_outcome`.

Also, charge for publishing user-created blobs only. `BlobType::Committee` is not accounted for.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
