### PR TITLE
Adjust timezone and time range of ScyllaDB dashboards

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera/general.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/general.json
@@ -3379,7 +3379,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "browser",
   "title": "General",
   "uid": "d1c10f4e-acbf-4cb9-9abd-bade0adcbd13",
   "version": 1,

--- a/kubernetes/linera-validator/grafana-dashboards/scylla-manager/scylla-manager.2.2.json
+++ b/kubernetes/linera-validator/grafana-dashboards/scylla-manager/scylla-manager.2.2.json
@@ -1605,7 +1605,7 @@
         ]
     },
     "time": {
-        "from": "now-30m",
+        "from": "now-1h",
         "to": "now"
     },
     "timepicker": {
@@ -1634,7 +1634,7 @@
             "30d"
         ]
     },
-    "timezone": "utc",
+    "timezone": "browser",
     "title": "Scylla Manager Metrics",
     "uid": "manager-2-2",
     "version": 3

--- a/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-advanced.4.3.json
+++ b/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-advanced.4.3.json
@@ -3195,7 +3195,7 @@
         ]
     },
     "time": {
-        "from": "now-30m",
+        "from": "now-1h",
         "to": "now"
     },
     "timepicker": {
@@ -3224,7 +3224,7 @@
             "30d"
         ]
     },
-    "timezone": "utc",
+    "timezone": "browser",
     "title": "Advanced",
     "uid": "advanced-4-3",
     "version": 5

--- a/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-alternator.4.3.json
+++ b/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-alternator.4.3.json
@@ -5047,7 +5047,7 @@
         ]
     },
     "time": {
-        "from": "now-30m",
+        "from": "now-1h",
         "to": "now"
     },
     "timepicker": {
@@ -5076,7 +5076,7 @@
             "30d"
         ]
     },
-    "timezone": "utc",
+    "timezone": "browser",
     "title": "Alternator",
     "uid": "alternator-4-3",
     "version": 1

--- a/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-cql.4.3.json
+++ b/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-cql.4.3.json
@@ -4621,7 +4621,7 @@
         ]
     },
     "time": {
-        "from": "now-5m",
+        "from": "now-1h",
         "to": "now"
     },
     "timepicker": {
@@ -4650,7 +4650,7 @@
             "30d"
         ]
     },
-    "timezone": "utc",
+    "timezone": "browser",
     "title": "Scylla CQL",
     "uid": "cql-4-3",
     "version": 1

--- a/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-detailed.4.3.json
+++ b/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-detailed.4.3.json
@@ -9089,7 +9089,7 @@
         ]
     },
     "time": {
-        "from": "now-30m",
+        "from": "now-1h",
         "to": "now"
     },
     "timepicker": {
@@ -9118,7 +9118,7 @@
             "30d"
         ]
     },
-    "timezone": "utc",
+    "timezone": "browser",
     "title": "Detailed",
     "uid": "detailed-4-3",
     "version": 5

--- a/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-os.4.3.json
+++ b/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-os.4.3.json
@@ -1801,7 +1801,7 @@
         ]
     },
     "time": {
-        "from": "now-30m",
+        "from": "now-1h",
         "to": "now"
     },
     "timepicker": {
@@ -1830,7 +1830,7 @@
             "30d"
         ]
     },
-    "timezone": "utc",
+    "timezone": "browser",
     "title": "OS Metrics",
     "uid": "OS-4-3",
     "version": 5

--- a/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-overview.4.3.json
+++ b/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-overview.4.3.json
@@ -4263,7 +4263,7 @@
         ]
     },
     "time": {
-        "from": "now-30m",
+        "from": "now-1h",
         "to": "now"
     },
     "timepicker": {
@@ -4292,7 +4292,7 @@
             "30d"
         ]
     },
-    "timezone": "utc",
+    "timezone": "browser",
     "title": "Overview",
     "uid": "overview-4-3",
     "version": 1


### PR DESCRIPTION
## Motivation

These were different than the timezones for our own dashboards, making flipping through them a big confusing

## Proposal

Adjust the timezones and time ranges so that they're all the same

## Test Plan

Deploy network, see updated dasboards

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
