### PR TITLE
Make REVM address coincide with the one of Linera

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,14 +97,14 @@ dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
- "alloy-eips 1.0.3",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-node-bindings",
  "alloy-provider",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
@@ -128,10 +128,10 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9835a7b6216cb8118323581e58a18b1a5014fce55ce718635aaea7fa07bd700"
 dependencies = [
- "alloy-eips 1.0.3",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "alloy-trie",
  "auto_impl",
  "c-kzg",
@@ -153,10 +153,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "621e9f7d76ed95d21825286b180fcb89895d34244e41c89714da6d70398a16bc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 1.0.3",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "serde",
 ]
 
@@ -236,35 +236,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804cefe429015b4244966c006d25bda5545fa9db5990e9c9079faf255052f50a"
+checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "k256",
  "serde",
  "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-eips"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609515c1955b33af3d78d26357540f68c5551a90ef58fd53def04f2aa074ec43"
-dependencies = [
- "alloy-eip2124",
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.14.0",
- "auto_impl",
- "c-kzg",
- "derive_more 2.0.1",
- "either",
- "serde",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -278,7 +258,7 @@ dependencies = [
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "auto_impl",
  "c-kzg",
  "derive_more 2.0.1",
@@ -293,9 +273,9 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cf47e07c0dbcb8f1fa2c903d9eb32b14fec3dc04e60e7fee29fc0d3799fba34"
 dependencies = [
- "alloy-eips 1.0.3",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "alloy-trie",
  "serde",
 ]
@@ -347,13 +327,13 @@ checksum = "049a9022caa0c0a2dcd2bc2ea23fa098508f4a81d5dda774d753570a41e6acdb"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 1.0.3",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -372,9 +352,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c6fb35478d017304f4e9188daaebe5f206d44c77dbba749158427a50fdafc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 1.0.3",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "serde",
 ]
 
@@ -401,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a12fe11d0b8118e551c29e1a67ccb6d01cc07ef08086df30f07487146de6fa1"
+checksum = "18c35fc4b03ace65001676358ffbbaefe2a2b27ee50fe777c345082c7c888be8"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -434,7 +414,7 @@ checksum = "959aedfc417737e2a59961c95e92c59726386748d85ef516a0d0687b440d3184"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 1.0.3",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -522,7 +502,7 @@ checksum = "88d2981f41486264b2e254bc51b2691bbef9ed87d0545d11f31cb26af3109cc4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "serde",
 ]
 
@@ -534,7 +514,7 @@ checksum = "6895febd23a9fd75a58d2fb8fa27e6ed84f4aaada309c6905e156af37afbb6e6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "serde",
 ]
 
@@ -546,7 +526,7 @@ checksum = "380a951cddc3a46d4b8755f2c5ebde9ae0da373736b64222833c5f3a0773a1cc"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
- "alloy-serde 1.0.5",
+ "alloy-serde",
 ]
 
 [[package]]
@@ -557,27 +537,16 @@ checksum = "0d2c0dad584b1556528ca651f4ae17bef82734b499ccfcee69f117fea66c3293"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 1.0.3",
+ "alloy-eips",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dba6ff08916bc0a9cbba121ce21f67c0b554c39cf174bc7b9df6c651bd3c3b"
-dependencies = [
- "alloy-primitives",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -5231,7 +5200,6 @@ dependencies = [
  "revm-context",
  "revm-context-interface",
  "revm-database",
- "revm-database-interface",
  "revm-handler",
  "revm-interpreter",
  "revm-primitives",
@@ -7714,9 +7682,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "23.1.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1eb83c8652836bc0422f9a144522179134d8befcc7ab595c1ada60dac39e51"
+checksum = "6d3ae9d1b08303eb5150dcf820a29e14235cf3f24f6c09024458a4dcbffe6695"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -7733,9 +7701,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a052afe63f2211d0b8be342ba4eff04b143be4bc77c2a96067ab6b90a90865d7"
+checksum = "d91f9b90b3bab18942252de2d970ee8559794c49ca7452b2cc1774456040f8fb"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -7746,9 +7714,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd6faa992a1a10b84723326d6117203764c040d3519fd1ba34950d049389eb7"
+checksum = "b181214eb2bbb76ee9d6195acba19857d991d2cdb9a65b7cb6939c30250a3966"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -7762,9 +7730,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2b42cac141cd388c38db420d3d18e7b23013c5747d5ed648d2d9a225263d51"
+checksum = "1b844f48a411e62c7dde0f757bf5cce49c85b86d6fc1d3b2722c07f2bec4c3ce"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -7778,11 +7746,11 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16e1a58d5614bef333402ae8682d0ea7ba4f4b0563b3a58a6c0ad9d392db4f6"
+checksum = "ad3fbe34f6bb00a9c3155723b3718b9cb9f17066ba38f9eb101b678cd3626775"
 dependencies = [
- "alloy-eips 0.14.0",
+ "alloy-eips",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -7792,9 +7760,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6839eb2e1667d3acd9cba59f77299fae8802c229fae50bc6f0435ed4c4ef398e"
+checksum = "7b8acd36784a6d95d5b9e1b7be3ce014f1e759abb59df1fa08396b30f71adc2a"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -7804,9 +7772,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511e50a8c7f14e97681ec96266ee53bf8316c0dea1d4a6633ff6f37c5c0fe9d0"
+checksum = "08a9204e3ac1a8edb850cc441a6a1d0f2251c0089e5fffdaba11566429e6c64e"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -7822,9 +7790,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f6c88fcf481f8e315bfd87377aa0ae83e1159dd381430122cbf431474ce39c"
+checksum = "ae4881eeae6ff35417c8569bc7cc03b6c0969869ee2c9b3945a39b4f9fa58bc5"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -7839,9 +7807,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "19.1.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b7d75106333808bc97df3cd6a1864ced4ffec9be28fd3e459733813f3c300e"
+checksum = "b5ee65e57375c6639b0f50555e92a4f1b2434349dd32f52e2176f5c711171697"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -7851,9 +7819,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "20.1.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06769068a34fd237c74193118530af3912e1b16922137a96fc302f29c119966"
+checksum = "0f9311e735123d8d53a02af2aa81877bba185be7c141be7f931bb3d2f3af449c"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -7877,9 +7845,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "19.0.0"
+version = "19.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d8369df999a4d5d7e53fd866c43a19d38213a00e1c86f72b782bbe7b19cb30"
+checksum = "18ea2ea0134568ee1e14281ce52f60e2710d42be316888d464c53e37ff184fd8"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -7888,9 +7856,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac26c71bf0fe5a9cd9fe6adaa13487afedbf8c2ee6e228132eae074cb3c2b58"
+checksum = "0040c61c30319254b34507383ba33d85f92949933adf6525a2cede05d165e1fa"
 dependencies = [
  "bitflags 2.9.0",
  "revm-bytecode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ rcgen = "0.12.1"
 reqwest = { version = "0.11.24", default-features = false, features = [
     "rustls-tls",
 ] }
-revm = { version = "23.1.0", default-features = false, features = [
+revm = { version = "24.0.0", default-features = false, features = [
     "std",
     "kzg-rs",
     "secp256k1",
@@ -179,28 +179,25 @@ revm = { version = "23.1.0", default-features = false, features = [
     "blst",
     "serde",
 ] }
-revm-context = { version = "4.1.0", default-features = false, features = [
+revm-context = { version = "5.0.0", default-features = false, features = [
     "serde",
 ] }
-revm-context-interface = { version = "4.1.0", default-features = false, features = [
+revm-context-interface = { version = "5.0.0", default-features = false, features = [
     "serde",
 ] }
-revm-database = { version = "4.0.0", default-features = false, features = [
+revm-database = { version = "4.0.1", default-features = false, features = [
     "serde",
 ] }
-revm-database-interface = { version = "4.0.0", default-features = false, features = [
+revm-handler = { version = "5.0.0", default-features = false, features = [
     "serde",
 ] }
-revm-handler = { version = "4.1.0", default-features = false, features = [
+revm-interpreter = { version = "20.0.0", default-features = false, features = [
     "serde",
 ] }
-revm-interpreter = { version = "19.1.0", default-features = false, features = [
+revm-primitives = { version = "19.1.0", default-features = false, features = [
     "serde",
 ] }
-revm-primitives = { version = "19.0.0", default-features = false, features = [
-    "serde",
-] }
-revm-state = { version = "4.0.0", default-features = false, features = [
+revm-state = { version = "4.0.1", default-features = false, features = [
     "serde",
 ] }
 rocksdb = "0.21.0"

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -18,7 +18,6 @@ revm = [
     "dep:revm-context",
     "dep:revm-context-interface",
     "dep:revm-database",
-    "dep:revm-database-interface",
     "dep:revm-handler",
     "dep:revm-interpreter",
     "dep:revm-primitives",
@@ -74,9 +73,6 @@ revm-context-interface = { workspace = true, optional = true, default-features =
     "serde",
 ] }
 revm-database = { workspace = true, optional = true, default-features = false, features = [
-    "serde",
-] }
-revm-database-interface = { workspace = true, optional = true, default-features = false, features = [
     "serde",
 ] }
 revm-handler = { workspace = true, optional = true, default-features = false, features = [

--- a/linera-execution/src/evm/database.rs
+++ b/linera-execution/src/evm/database.rs
@@ -41,6 +41,8 @@ const SSTORE_COST_RESET: u64 = 2900;
 /// The refund from releasing data.
 const SSTORE_REFUND_RELEASE: u64 = 4800;
 
+/// The number of key writes, reads, release, and no change in EVM has to be accounted for.
+/// Then we remove those costs from the final bill.
 #[derive(Clone, Default)]
 pub(crate) struct StorageStats {
     key_no_operation: u64,
@@ -65,10 +67,12 @@ impl StorageStats {
     }
 }
 
+/// This is the encapsulation of the `Runtime` corresponding to the contract.
 pub(crate) struct DatabaseRuntime<Runtime> {
-    /// This is the storage statistics.
+    /// This is the storage statistics of the read/write in order to adjust gas costs.
     storage_stats: Arc<Mutex<StorageStats>>,
-    /// This is the EVM address of the contract
+    /// This is the EVM address of the contract.
+    /// At the creation, is is set to `Address::ZERO` and then later set to the correct value.
     pub contract_address: Address,
     /// The runtime of the contract.
     pub runtime: Arc<Mutex<Runtime>>,

--- a/linera-execution/src/evm/database.rs
+++ b/linera-execution/src/evm/database.rs
@@ -18,7 +18,7 @@ use revm_database::{AccountState, DBErrorMarker};
 use revm_primitives::{address, Address, B256, U256};
 use revm_state::{AccountInfo, Bytecode, EvmState};
 
-use crate::{ApplicationId, BaseRuntime, Batch, ContractRuntime, ExecutionError, ServiceRuntime, ViewError};
+use crate::{ApplicationId, BaseRuntime, Batch, ContractRuntime, ExecutionError, ServiceRuntime};
 
 // The runtime costs are not available in service operations.
 // We need to set a limit to gas usage in order to avoid blocking

--- a/linera-execution/src/evm/mod.rs
+++ b/linera-execution/src/evm/mod.rs
@@ -25,6 +25,8 @@ pub enum EvmExecutionError {
     OperationCallExecuteMessage,
     #[error("It is illegal to call instantiate from an operation")]
     OperationCallInstantiate,
+    #[error("Incorrect contract creation: {0}")]
+    IncorrectContractCreation(String),
     #[error("The operation should contain the evm selector and so have length 4 or more")]
     OperationIsTooShort,
     #[error("Transact error {0}")]

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -661,7 +661,7 @@ fn get_interpreter_result(
 
 struct CallInterceptorContract<Runtime> {
     db: DatabaseRuntime<Runtime>,
-    // This is the caller contract address
+    // This is the contract address of the contract being created.
     contract_address: Address,
     precompile_addresses: BTreeSet<Address>,
 }
@@ -769,7 +769,7 @@ impl<Runtime: ContractRuntime> CallInterceptorContract<Runtime> {
 
 struct CallInterceptorService<Runtime> {
     db: DatabaseRuntime<Runtime>,
-    // This is the caller contract address
+    // This is the contract address of the contract being created.
     contract_address: Address,
     precompile_addresses: BTreeSet<Address>,
 }

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -4,7 +4,7 @@
 //! Code specific to the usage of the [Revm](https://bluealloy.github.io/revm/) runtime.
 
 use core::ops::Range;
-use std::convert::TryFrom;
+use std::{collections::BTreeSet, convert::TryFrom};
 
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
@@ -20,12 +20,13 @@ use revm_context::{
     result::{ExecutionResult, Output, SuccessReason},
     BlockEnv, Cfg, ContextTr, Evm, Journal, LocalContextTr, TxEnv,
 };
-use revm_database_interface::WrapDatabaseRef;
+use revm_database::WrapDatabaseRef;
 use revm_handler::{
     instructions::EthInstructions, EthPrecompiles, MainnetContext, PrecompileProvider,
 };
 use revm_interpreter::{
-    CallInput, CallInputs, CallOutcome, Gas, InputsImpl, InstructionResult, InterpreterResult,
+    CallInput, CallInputs, CallOutcome, CreateInputs, CreateOutcome, CreateScheme, Gas, InputsImpl,
+    InstructionResult, InterpreterResult,
 };
 use revm_primitives::{address, hardfork::SpecId, Address, Log, TxKind};
 use revm_state::EvmState;
@@ -404,6 +405,15 @@ fn base_runtime_call<Runtime: BaseRuntime>(
 
 type Ctx<'a, Runtime> = MainnetContext<WrapDatabaseRef<&'a mut DatabaseRuntime<Runtime>>>;
 
+fn precompile_addresses() -> BTreeSet<Address> {
+    let mut addresses = BTreeSet::new();
+    for address in EthPrecompiles::default().warm_addresses() {
+        addresses.insert(address);
+    }
+    addresses.insert(PRECOMPILE_ADDRESS);
+    addresses
+}
+
 #[derive(Debug, Default)]
 struct ContractPrecompile {
     inner: EthPrecompiles,
@@ -651,12 +661,17 @@ fn get_interpreter_result(
 
 struct CallInterceptorContract<Runtime> {
     db: DatabaseRuntime<Runtime>,
+    // This is the caller contract address
+    contract_address: Address,
+    precompile_addresses: BTreeSet<Address>,
 }
 
 impl<Runtime> Clone for CallInterceptorContract<Runtime> {
     fn clone(&self) -> Self {
         Self {
             db: self.db.clone(),
+            contract_address: self.contract_address,
+            precompile_addresses: self.precompile_addresses.clone(),
         }
     }
 }
@@ -689,6 +704,17 @@ fn get_precompile_argument<Ctx: ContextTr>(context: &mut Ctx, input: &CallInput)
 impl<'a, Runtime: ContractRuntime> Inspector<Ctx<'a, Runtime>>
     for CallInterceptorContract<Runtime>
 {
+    fn create(
+        &mut self,
+        _context: &mut Ctx<'a, Runtime>,
+        inputs: &mut CreateInputs,
+    ) -> Option<CreateOutcome> {
+        inputs.scheme = CreateScheme::Custom {
+            address: self.contract_address,
+        };
+        None
+    }
+
     fn call(
         &mut self,
         context: &mut Ctx<'a, Runtime>,
@@ -713,11 +739,19 @@ impl<Runtime: ContractRuntime> CallInterceptorContract<Runtime> {
         context: &mut Ctx<'_, Runtime>,
         inputs: &mut CallInputs,
     ) -> Result<Option<CallOutcome>, ExecutionError> {
-        let contract_address = Address::ZERO.create(0);
-        if inputs.target_address == PRECOMPILE_ADDRESS || inputs.target_address == contract_address
+        // Every call to a contract passes by this function.
+        // Three kinds:
+        // --- Call to the PRECOMPILE smart contract.
+        // --- Call to the EVM smart contract itself
+        // --- Call to other EVM smart contract
+        if self.precompile_addresses.contains(&inputs.target_address)
+            || inputs.target_address == self.contract_address
         {
+            // Precompile calls are handled by the precompile code.
+            // The EVM smart contract is being called
             return Ok(None);
         }
+        // Other smart contracts calls are handled by the runtime
         let target = address_to_user_application_id(inputs.target_address);
         let argument = get_call_argument(context, &inputs.input);
         let authenticated = true;
@@ -735,17 +769,33 @@ impl<Runtime: ContractRuntime> CallInterceptorContract<Runtime> {
 
 struct CallInterceptorService<Runtime> {
     db: DatabaseRuntime<Runtime>,
+    // This is the caller contract address
+    contract_address: Address,
+    precompile_addresses: BTreeSet<Address>,
 }
 
 impl<Runtime> Clone for CallInterceptorService<Runtime> {
     fn clone(&self) -> Self {
         Self {
             db: self.db.clone(),
+            contract_address: self.contract_address,
+            precompile_addresses: self.precompile_addresses.clone(),
         }
     }
 }
 
 impl<'a, Runtime: ServiceRuntime> Inspector<Ctx<'a, Runtime>> for CallInterceptorService<Runtime> {
+    fn create(
+        &mut self,
+        _context: &mut Ctx<'a, Runtime>,
+        inputs: &mut CreateInputs,
+    ) -> Option<CreateOutcome> {
+        inputs.scheme = CreateScheme::Custom {
+            address: self.contract_address,
+        };
+        None
+    }
+
     fn call(
         &mut self,
         context: &mut Ctx<'a, Runtime>,
@@ -770,11 +820,19 @@ impl<Runtime: ServiceRuntime> CallInterceptorService<Runtime> {
         context: &mut Ctx<'_, Runtime>,
         inputs: &mut CallInputs,
     ) -> Result<Option<CallOutcome>, ExecutionError> {
-        let contract_address = Address::ZERO.create(0);
-        if inputs.target_address == PRECOMPILE_ADDRESS || inputs.target_address == contract_address
+        // Every call to a contract passes by this function.
+        // Three kinds:
+        // --- Call to the PRECOMPILE smart contract.
+        // --- Call to the EVM smart contract itself
+        // --- Call to other EVM smart contract
+        if self.precompile_addresses.contains(&inputs.target_address)
+            || inputs.target_address == self.contract_address
         {
+            // Precompile calls are handled by the precompile code.
+            // The EVM smart contract is being called
             return Ok(None);
         }
+        // Other smart contracts calls are handled by the runtime
         let target = address_to_user_application_id(inputs.target_address);
         let argument = get_call_argument(context, &inputs.input);
         let result = {
@@ -813,7 +871,7 @@ impl ExecutionResultSuccess {
     fn interpreter_result_and_logs(self) -> Result<(u64, Vec<u8>, Vec<Log>), ExecutionError> {
         let result: InstructionResult = self.reason.into();
         let Output::Call(output) = self.output else {
-            unreachable!("The Output is not a call which is impossible");
+            unreachable!("The output should have been created from a Choice::Call");
         };
         let gas = Gas::new(0);
         let result = InterpreterResult {
@@ -827,10 +885,26 @@ impl ExecutionResultSuccess {
 
     fn output_and_logs(self) -> (u64, Vec<u8>, Vec<Log>) {
         let Output::Call(output) = self.output else {
-            unreachable!("It is impossible for a Choice::Call to lead to an Output::Create");
+            unreachable!("The output should have been created from a Choice::Call");
         };
         let output = output.as_ref().to_vec();
         (self.gas_final, output, self.logs)
+    }
+
+    // Checks that the contract has been correctly instantiated
+    fn check_contract_initialization(&self, expected_address: Address) -> Result<(), String> {
+        // Checks that the output is the expected one.
+        let Output::Create(_, contract_address) = self.output else {
+            return Err("Input should be Choice::Create".to_string());
+        };
+        // Checks that the contract address exists.
+        let contract_address = contract_address.ok_or("Deployment failed")?;
+        // Checks that the created contract address is the one of the `ApplicationId`.
+        if contract_address == expected_address {
+            Ok(())
+        } else {
+            Err("Contract address is not the same as ApplicationId".to_string())
+        }
     }
 }
 
@@ -839,6 +913,7 @@ where
     Runtime: ContractRuntime,
 {
     fn instantiate(&mut self, argument: Vec<u8>) -> Result<(), ExecutionError> {
+        self.db.set_contract_address()?;
         self.initialize_contract()?;
         if has_instantiation_function(&self.module) {
             let instantiation_argument = serde_json::from_slice::<Vec<u8>>(&argument)?;
@@ -850,6 +925,7 @@ where
     }
 
     fn execute_operation(&mut self, operation: Vec<u8>) -> Result<Vec<u8>, ExecutionError> {
+        self.db.set_contract_address()?;
         ensure_message_length(operation.len(), 4)?;
         let (gas_final, output, logs) = if &operation[..4] == INTERPRETER_RESULT_SELECTOR {
             ensure_message_length(operation.len(), 8)?;
@@ -868,6 +944,7 @@ where
     }
 
     fn execute_message(&mut self, message: Vec<u8>) -> Result<(), ExecutionError> {
+        self.db.set_contract_address()?;
         let operation = get_revm_execute_message_bytes(message);
         let result = self.init_transact_commit(Choice::Call, &operation)?;
         let (gas_final, output, logs) = result.output_and_logs();
@@ -950,6 +1027,11 @@ where
         let constructor_argument = self.db.constructor_argument()?;
         vec_init.extend_from_slice(&constructor_argument);
         let result = self.transact_commit(Choice::Create, &vec_init)?;
+        result
+            .check_contract_initialization(self.db.contract_address)
+            .map_err(|error| {
+                ExecutionError::EvmError(EvmExecutionError::IncorrectContractCreation(error))
+            })?;
         self.write_logs(result.logs, "deploy")
     }
 
@@ -962,11 +1044,13 @@ where
             Choice::Create => (TxKind::Create, Bytes::copy_from_slice(input)),
             Choice::Call => {
                 let data = Bytes::copy_from_slice(input);
-                (TxKind::Call(Address::ZERO.create(0)), data)
+                (TxKind::Call(self.db.contract_address), data)
             }
         };
         let inspector = CallInterceptorContract {
             db: self.db.clone(),
+            contract_address: self.db.contract_address,
+            precompile_addresses: precompile_addresses(),
         };
         let block_env = self.db.get_contract_block_env()?;
         let gas_limit = {
@@ -1056,6 +1140,7 @@ where
     Runtime: ServiceRuntime,
 {
     fn handle_query(&mut self, argument: Vec<u8>) -> Result<Vec<u8>, ExecutionError> {
+        self.db.set_contract_address()?;
         let evm_query = serde_json::from_slice(&argument)?;
         let query = match evm_query {
             EvmQuery::Query(vec) => vec,
@@ -1096,16 +1181,21 @@ where
                 let mut vec_init = self.module.clone();
                 let constructor_argument = self.db.constructor_argument()?;
                 vec_init.extend_from_slice(&constructor_argument);
-                let kind = TxKind::Create;
-                let (_, changes) = self.transact(kind, &vec_init)?;
+                let (result, changes) = self.transact(TxKind::Create, &vec_init)?;
+                result
+                    .check_contract_initialization(self.db.contract_address)
+                    .map_err(|error| {
+                        ExecutionError::EvmError(EvmExecutionError::IncorrectContractCreation(
+                            error,
+                        ))
+                    })?;
                 changes
             };
             self.db.changes = changes;
         }
         ensure_message_length(vec.len(), 4)?;
         forbid_execute_operation_origin(&vec[..4])?;
-        let contract_address = Address::ZERO.create(0);
-        let kind = TxKind::Call(contract_address);
+        let kind = TxKind::Call(self.db.contract_address);
         let (execution_result, _) = self.transact(kind, vec)?;
         Ok(execution_result)
     }
@@ -1120,6 +1210,8 @@ where
         let block_env = self.db.get_service_block_env()?;
         let inspector = CallInterceptorService {
             db: self.db.clone(),
+            contract_address: self.db.contract_address,
+            precompile_addresses: precompile_addresses(),
         };
         let nonce = self.db.get_nonce(&ZERO_ADDRESS)?;
         let result_state = {

--- a/linera-service/tests/fixtures/evm_basic_check.sol
+++ b/linera-service/tests/fixtures/evm_basic_check.sol
@@ -1,0 +1,25 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+contract BasicCheck {
+
+    function failing_function() external view returns (uint64) {
+        require(false);
+        return 0;
+    }
+
+    function test_precompile_sha256() external view returns (uint64) {
+        bytes memory v;
+        bytes32 ret_zero;
+        bytes32 ret_val = sha256(v);
+        require(ret_zero != ret_val);
+        return 0;
+    }
+
+    function check_contract_address(address address2) external view returns (uint64) {
+      address address1 = address(this);
+      require(address1 == address2);
+      return 49;
+    }
+}

--- a/linera-service/tests/fixtures/evm_example_counter.sol
+++ b/linera-service/tests/fixtures/evm_example_counter.sol
@@ -17,9 +17,4 @@ contract ExampleCounter {
     function get_value() external view returns (uint64) {
         return value;
     }
-
-    function failing_function() external view returns (uint64) {
-        require(false);
-        return 0;
-    }
 }

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -337,6 +337,84 @@ impl AmmApp {
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
+async fn test_evm_end_to_end_basic_check(config: impl LineraNetConfig) -> Result<()> {
+    use alloy_sol_types::{sol, SolCall};
+    use linera_base::vm::EvmQuery;
+    use linera_execution::test_utils::solidity::{get_evm_contract_path, read_evm_u64_entry};
+    use linera_sdk::abis::evm::EvmAbi;
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let (mut net, client) = config.instantiate().await?;
+
+    sol! {
+        function failing_function();
+        function test_precompile_sha256();
+        function check_contract_address(address evm_address);
+    }
+    let chain = client.load_wallet()?.default_chain().unwrap();
+
+    let (evm_contract, _dir) = get_evm_contract_path("tests/fixtures/evm_basic_check.sol")?;
+
+    let constructor_argument = Vec::new();
+    let instantiation_argument = Vec::new();
+    let application_id = client
+        .publish_and_create::<EvmAbi, Vec<u8>, Vec<u8>>(
+            evm_contract.clone(),
+            evm_contract,
+            VmRuntime::Evm,
+            &constructor_argument,
+            &instantiation_argument,
+            &[],
+            None,
+        )
+        .await?;
+
+    let evm_address = application_id.evm_address();
+
+    let port = get_node_port().await;
+    let mut node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
+
+    let application = node_service
+        .make_application(&chain, &application_id)
+        .await?;
+
+    // Checking that failing function lead to an error
+    let failing_function = failing_functionCall {};
+    let failing_function = failing_function.abi_encode();
+    let failing_function = EvmQuery::Query(failing_function);
+    let result = application.run_json_query(failing_function).await;
+    assert!(result.is_err());
+
+    // Checking that failing function lead to an error
+    let test_sha256 = test_precompile_sha256Call {};
+    let test_sha256 = test_sha256.abi_encode();
+    let test_sha256 = EvmQuery::Query(test_sha256);
+    let result = application.run_json_query(test_sha256).await?;
+    assert_eq!(read_evm_u64_entry(result), 0);
+
+    // Checking that the EVM contract address matches the one of Linera
+    let check_contract_address = check_contract_addressCall { evm_address };
+    let check_contract_address = check_contract_address.abi_encode();
+    let check_contract_address = EvmQuery::Query(check_contract_address);
+    let result = application.run_json_query(check_contract_address).await?;
+    assert_eq!(read_evm_u64_entry(result), 49);
+
+    node_service.ensure_is_running()?;
+
+    net.ensure_is_running().await?;
+    net.terminate().await?;
+
+    Ok(())
+}
+
+#[cfg(with_revm)]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
+#[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
+#[test_log::test(tokio::test)]
 async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()> {
     use alloy_sol_types::{sol, SolCall, SolValue};
     use linera_base::vm::EvmQuery;
@@ -353,7 +431,6 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
         }
         function increment(uint64 input);
         function get_value();
-        function failing_function();
     }
 
     let original_counter_value = 35;
@@ -387,12 +464,6 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
     let application = node_service
         .make_application(&chain, &application_id)
         .await?;
-
-    let failing_function = failing_functionCall {};
-    let failing_function = failing_function.abi_encode();
-    let failing_function = EvmQuery::Query(failing_function);
-    let result = application.run_json_query(failing_function).await;
-    assert!(result.is_err());
 
     let query = get_valueCall {};
     let query = query.abi_encode();


### PR DESCRIPTION
## Motivation

The smart contract addresses that we are using in the EVM are internally all the same: `Address::ZERO.create(0)`.
This creates consistency problems between Ethereum and Linera.

This internal address is available in solidity-based EVM smart contracts as `address(this)`.

## Proposal

We use the `CreateScheme::Custom { address }` that was previously introduced in REVM and merged in REVM-23.1.0.
We also switched to version 24.0.0 of REVM.

Next steps:
* Add the create/create2 functionality to the code.
* Add the transfer functionalities to the code and unify them with Linera.

## Test Plan

* A CI test of the `address(this)` feature is being introduced.
* Also, additional checks are done for the contract address in `fn check_contract_initialization`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.