### PR TITLE
Correct a bug in the gas accounting of REVM

### DIFF
--- a/linera-execution/src/evm/mod.rs
+++ b/linera-execution/src/evm/mod.rs
@@ -31,11 +31,11 @@ pub enum EvmExecutionError {
     TransactError(String),
     #[error("Transact commit error {0}")]
     TransactCommitError(String),
-    #[error("The operation was reverted")]
+    #[error("The operation was reverted with {gas_used} gas used and output {output:?}")]
     Revert {
         gas_used: u64,
         output: revm_primitives::Bytes,
     },
-    #[error("The operation was halted")]
+    #[error("The operation was halted with {gas_used} gas used due to {reason:?}")]
     Halt { gas_used: u64, reason: HaltReason },
 }

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -324,12 +324,15 @@ enum PrecompileTag {
     Service(ServicePrecompileTag),
 }
 
-fn get_precompile_output(output: Vec<u8>) -> Result<Option<InterpreterResult>, String> {
+fn get_precompile_output(
+    output: Vec<u8>,
+    gas_limit: u64,
+) -> Result<Option<InterpreterResult>, String> {
     // The gas usage is set to zero since the proper accounting is done
     // by the called application
     let output = Bytes::copy_from_slice(&output);
     let result = InstructionResult::default();
-    let gas = Gas::new(0);
+    let gas = Gas::new(gas_limit);
     Ok(Some(InterpreterResult {
         result,
         output,
@@ -415,7 +418,7 @@ impl<'a, Runtime: ContractRuntime> PrecompileProvider<Ctx<'a, Runtime>> for Cont
         if address == &PRECOMPILE_ADDRESS {
             let input = get_precompile_argument(context, &inputs.input);
             let output = Self::call_or_fail(&input, gas_limit, context)?;
-            return get_precompile_output(output);
+            return get_precompile_output(output, gas_limit);
         }
         self.inner
             .run(context, address, inputs, is_static, gas_limit)
@@ -593,7 +596,7 @@ impl<'a, Runtime: ServiceRuntime> PrecompileProvider<Ctx<'a, Runtime>> for Servi
         if address == &PRECOMPILE_ADDRESS {
             let input = get_precompile_argument(context, &inputs.input);
             let output = Self::call_or_fail(&input, gas_limit, context)?;
-            return get_precompile_output(output);
+            return get_precompile_output(output, gas_limit);
         }
         self.inner
             .run(context, address, inputs, is_static, gas_limit)

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -328,8 +328,10 @@ fn get_precompile_output(
     output: Vec<u8>,
     gas_limit: u64,
 ) -> Result<Option<InterpreterResult>, String> {
-    // The gas usage is set to zero since the proper accounting is done
-    // by the called application
+    // The gas usage is set to `gas_limit` and no spending is being done on it.
+    // This means that for REVM, it looks like the precompile call costs nothing.
+    // This is because the costs of the EVM precompile calls is accounted for
+    // separately in Linera.
     let output = Bytes::copy_from_slice(&output);
     let result = InstructionResult::default();
     let gas = Gas::new(gas_limit);


### PR DESCRIPTION
## Motivation

There was an error in the gas accounting 

## Proposal

The following is done:
* The `Gas::new(0)` is replaced by a `Gas::new(gas_limit)`.
* The `EvmExecutionError` errors are now more precise.

## Test Plan

The CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None