### PR TITLE
Change the API of read_blob_state to return options.

### DIFF
--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -317,8 +317,10 @@ where
                         .node
                         .missing_blob_ids(mem::take(&mut blob_ids))
                         .await?;
-                    let local_storage = self.local_node.storage_client();
-                    let blob_states = local_storage.read_blob_states(&missing_blob_ids).await?;
+                    let blob_states = self
+                        .local_node
+                        .read_blob_states_from_storage(&missing_blob_ids)
+                        .await?;
                     let mut chain_heights = BTreeMap::new();
                     for blob_state in blob_states {
                         let block_chain_id = blob_state.chain_id;

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -626,6 +626,8 @@ where
             .read_blob_state(blob_id)
             .await
             .map_err(Self::error_to_status)?;
+        let blob_state =
+            blob_state.ok_or(Status::not_found(format!("Blob not found {}", blob_id)))?;
         Ok(Response::new(blob_state.last_used_by.into()))
     }
 

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -346,9 +346,13 @@ where
                 let certificates = self.storage.read_certificates(hashes).await?;
                 Ok(Some(RpcMessage::DownloadCertificatesResponse(certificates)))
             }
-            BlobLastUsedBy(blob_id) => Ok(Some(RpcMessage::BlobLastUsedByResponse(Box::new(
-                self.storage.read_blob_state(*blob_id).await?.last_used_by,
-            )))),
+            BlobLastUsedBy(blob_id) => {
+                let blob_state = self.storage.read_blob_state(*blob_id).await?;
+                let blob_state = blob_state.ok_or(anyhow!("Blob not found {}", blob_id))?;
+                Ok(Some(RpcMessage::BlobLastUsedByResponse(Box::new(
+                    blob_state.last_used_by,
+                ))))
+            }
             MissingBlobIds(blob_ids) => Ok(Some(RpcMessage::MissingBlobIdsResponse(
                 self.storage.missing_blobs(&blob_ids).await?,
             ))),

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -93,10 +93,13 @@ pub trait Storage: Sized {
     async fn read_blobs(&self, blob_ids: &[BlobId]) -> Result<Vec<Option<Blob>>, ViewError>;
 
     /// Reads the blob state with the given blob ID.
-    async fn read_blob_state(&self, blob_id: BlobId) -> Result<BlobState, ViewError>;
+    async fn read_blob_state(&self, blob_id: BlobId) -> Result<Option<BlobState>, ViewError>;
 
     /// Reads the blob states with the given blob IDs.
-    async fn read_blob_states(&self, blob_ids: &[BlobId]) -> Result<Vec<BlobState>, ViewError>;
+    async fn read_blob_states(
+        &self,
+        blob_ids: &[BlobId],
+    ) -> Result<Vec<Option<BlobState>>, ViewError>;
 
     /// Reads the hashed certificate values in descending order from the given hash.
     async fn read_confirmed_blocks_downward(


### PR DESCRIPTION
## Motivation

Following PR https://github.com/linera-io/linera-protocol/pull/4014 we look at the `read_blob_state` and change their API as options. The same design considerations apply here.

## Proposal

The `read_blob_state(s)` were returning a ViewError that contained a `NotFound`. This is inadequate and in any
case the `NotFound` is never processed.

In all use cases of those functions, we had some `BlobsNotFound` variant in the relevant types, the error type was thus put there. It could change the behavior of some function. However, this is better than having some error buried in `ViewError`.

The `NotFound` cannot yet be changed because it is used by the `read_certificate(s)`. 

Other changes:
* After PR 4104, some of the metrics were placed before the storage calls. This has been corrected.
* In some of the accounting of the calls, the plural calls were sometimes counting several calls as one, and in other cases as the number of entries in the call. This has been corrected.

## Test Plan

The CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.