### PR TITLE
migrate to Rust 1.86.0

### DIFF
--- a/toolchains/stable/rust-toolchain.toml
+++ b/toolchains/stable/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.86.0"
 components = [ "clippy", "rustfmt", "rust-src" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
## Motivation

Migrate to the latest stable Rust toolchain. Also needed for upgrading async-graphql.

## Proposal

Update toolchain to Rust 1.86.0

## Test Plan

CI

## Release Plan

These changes should be backported to the latest `testnet` branch
