### PR TITLE
Add `--sync` option to `follow-chain`.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -857,11 +857,15 @@ Request a new chain from a faucet and add it to the wallet
 
 Add a new followed chain (i.e. a chain without keypair) to the wallet
 
-**Usage:** `linera wallet follow-chain <CHAIN_ID>`
+**Usage:** `linera wallet follow-chain [OPTIONS] <CHAIN_ID>`
 
 ###### **Arguments:**
 
 * `<CHAIN_ID>` — The chain ID
+
+###### **Options:**
+
+* `--sync` — Synchronize the new chain and download all its blocks from the validators
 
 
 

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -1117,6 +1117,9 @@ pub enum WalletCommand {
     FollowChain {
         /// The chain ID.
         chain_id: ChainId,
+        /// Synchronize the new chain and download all its blocks from the validators.
+        #[arg(long)]
+        sync: bool,
     },
 
     /// Forgets the specified chain's keys. The chain will still be followed by the

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1178,6 +1178,24 @@ impl Runnable for Job {
                 );
             }
 
+            Wallet(WalletCommand::FollowChain {
+                chain_id,
+                sync: true,
+            }) => {
+                let mut context =
+                    ClientContext::new(storage, options.inner.clone(), wallet, signer.into_value());
+                let chain_client = context.make_chain_client(chain_id);
+                info!("Synchronizing chain information");
+                let time_start = Instant::now();
+                chain_client.synchronize_from_validators().await?;
+                context.update_wallet_from_client(&chain_client).await?;
+                let time_total = time_start.elapsed();
+                info!(
+                    "Synchronized chain information in {} ms",
+                    time_total.as_millis()
+                );
+            }
+
             #[cfg(feature = "benchmark")]
             MultiBenchmark { .. } => {
                 unreachable!()
@@ -1933,7 +1951,7 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                 Ok(0)
             }
 
-            WalletCommand::FollowChain { chain_id } => {
+            WalletCommand::FollowChain { chain_id, sync } => {
                 let start_time = Instant::now();
                 options
                     .wallet()
@@ -1942,6 +1960,9 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                         wallet.extend([UserChain::make_other(*chain_id, Timestamp::now())])
                     })
                     .await?;
+                if *sync {
+                    options.run_with_storage(Job(options.clone())).await??;
+                }
                 info!(
                     "Chain followed and added in {} ms",
                     start_time.elapsed().as_millis()

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -836,11 +836,14 @@ impl ClientWrapper {
     }
 
     /// Runs `linera wallet follow-chain CHAIN_ID`.
-    pub async fn follow_chain(&self, chain_id: ChainId) -> Result<()> {
+    pub async fn follow_chain(&self, chain_id: ChainId, sync: bool) -> Result<()> {
         let mut command = self.command().await?;
         command
             .args(["wallet", "follow-chain"])
             .arg(chain_id.to_string());
+        if sync {
+            command.arg("--sync");
+        }
         command.spawn_and_wait_for_stdout().await?;
         Ok(())
     }

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -3306,8 +3306,7 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     assert!(client2.local_balance(account2).await? > Amount::ZERO);
 
     // Verify that a third party can also follow the chain.
-    client3.follow_chain(chain2).await?;
-    client3.sync(chain2).await?;
+    client3.follow_chain(chain2, true).await?;
     assert!(client3.local_balance(account2).await? > Amount::ZERO);
 
     net.ensure_is_running().await?;
@@ -3389,7 +3388,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
     let chain_id = client3.request_chain(&faucet, false).await?.0;
     assert!(chain_id != client3.load_wallet()?.default_chain().unwrap());
     client3.forget_chain(chain_id).await?;
-    client3.follow_chain(chain_id).await?;
+    client3.follow_chain(chain_id, false).await?;
 
     let chain3 = client3.request_chain(&faucet, true).await?.0;
     assert_eq!(chain3, client3.load_wallet()?.default_chain().unwrap());

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -468,7 +468,7 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetConfig) -> Re
     let client2 = net.make_client().await;
     let mut height = 0;
     client2.wallet_init(None).await?;
-    client2.follow_chain(chain).await?;
+    client2.follow_chain(chain, false).await?;
 
     // Listen for updates on root chain 0. There are no blocks on that chain yet.
     let port = get_node_port().await;


### PR DESCRIPTION
## Motivation

Often after `follow-chain`, the user also wants to synchronize the chain. Adding this as an option allows doing that in the same command.

## Proposal

Add a `--sync` option.

## Test Plan

In one test I used this instead of the `sync` command.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #3889.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
