### PR TITLE
Check that downloaded sender chain blocks are relevant.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -807,9 +807,9 @@ impl<Env: Environment> Client<Env> {
         let remote_certificates = remote_node
             .download_certificates(certificate_hashes)
             .await?;
+        let mut certificates = BTreeMap::new();
 
         // Check the signatures and keep only the ones that are valid.
-        let mut certificates = Vec::new();
         for confirmed_block_certificate in remote_certificates {
             let block_header = &confirmed_block_certificate.inner().block().header;
             let sender_chain_id = block_header.chain_id;
@@ -832,20 +832,19 @@ impl<Env: Environment> Client<Env> {
                     warn!("Skipping received certificate from past epoch {epoch:?}");
                 }
                 CheckCertificateResult::New => {
-                    downloaded_heights
+                    certificates
                         .entry(sender_chain_id)
-                        .and_modify(|h| *h = height.max(*h))
-                        .or_insert(height);
-                    certificates.push(confirmed_block_certificate);
+                        .or_insert_with(BTreeMap::new)
+                        .insert(height, confirmed_block_certificate.clone());
                 }
             }
         }
 
         // Increase the tracker up to the first position we haven't downloaded.
         for entry in remote_log {
-            if downloaded_heights
+            if certificates
                 .get(&entry.chain_id)
-                .is_some_and(|h| *h >= entry.height)
+                .is_some_and(|certs| certs.contains_key(&entry.height))
             {
                 tracker += 1;
             } else {
@@ -853,10 +852,27 @@ impl<Env: Environment> Client<Env> {
             }
         }
 
+        for (sender_chain_id, certs) in &mut certificates {
+            if !certs
+                .values()
+                .last()
+                .is_some_and(|cert| cert.block().recipients().contains(&chain_id))
+            {
+                warn!(
+                    "Skipping received certificates from chain {sender_chain_id:.8}:
+                    No messages for {chain_id:.8}."
+                );
+                certs.clear();
+            }
+        }
+
         Ok(ReceivedCertificatesFromValidator {
             public_key: remote_node.public_key,
             tracker,
-            certificates,
+            certificates: certificates
+                .into_values()
+                .flat_map(BTreeMap::into_values)
+                .collect(),
             other_sender_chains,
         })
     }


### PR DESCRIPTION
## Motivation

When trying to find "received certificates", faulty validators might send us certificates that didn't actually send anything to the chain in question, causing the client to unnecessarily process valid but irrelevant blocks.

## Proposal

Check that they actually sent something.

## Test Plan

Since this only defends against some spam, isn't critical for security, and testing it would require considerably extending the test validators, I suggest not adding a test for this. CI will check if it _breaks_ anything (i.e. yields false positives).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/4025.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
