### PR TITLE
`linera-web`: make location-independent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -285,6 +285,7 @@ linera-faucet-server = { version = "0.15.0", path = "linera-faucet/server" }
 linera-indexer = { version = "0.15.0", path = "./linera-indexer/lib" }
 linera-indexer-graphql-client = { version = "0.15.0", path = "./linera-indexer/graphql-client" }
 linera-indexer-plugins = { version = "0.15.0", path = "./linera-indexer/plugins" }
+linera-persistent = { version = "0.15.0", path = "./linera-persistent" }
 linera-rpc = { version = "0.15.0", path = "./linera-rpc" }
 linera-sdk = { version = "0.15.0", path = "./linera-sdk" }
 linera-sdk-derive = { version = "0.15.0", path = "./linera-sdk-derive" }

--- a/default.nix
+++ b/default.nix
@@ -16,6 +16,8 @@
     openssl
     protobuf
     git
+    wasm-bindgen-cli
+    pnpm
   ];
   checkInputs = with pkgs; [
     # for native testing
@@ -27,7 +29,6 @@
     # for Wasm testing
     chromium
     chromedriver
-    wasm-pack
   ];
   passthru = { inherit rust-toolchain; };
   RUST_SRC_PATH = rust-toolchain.availableComponents.rust-src;

--- a/linera-web/Cargo.toml
+++ b/linera-web/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 console_error_panic_hook.workspace = true
 futures.workspace = true
 js-sys.workspace = true
-linera-persistent = { version = "0.15.0", path = "../linera-persistent" }
+linera-persistent.workspace = true
 log.workspace = true
 nonzero_lit.workspace = true
 serde.workspace = true

--- a/linera-web/build.bash
+++ b/linera-web/build.bash
@@ -7,11 +7,8 @@ cd $(dirname -- "${BASH_SOURCE[0]}")
 wasm_bindgen_cli_version=$(wasm-bindgen --version)
 wasm_bindgen_cli_version=${wasm_bindgen_cli_version##* }
 
-wasm_bindgen_cargo_version=
-if type -P tomlq > /dev/null
-then
-    wasm_bindgen_cargo_version=$(tomlq -r < Cargo.lock '.package[]|select(.name == "wasm-bindgen")|.version')
-fi
+wasm_bindgen_cargo_version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "wasm-bindgen").version')
+target_dir=$(cargo metadata --format-version 1 | jq -r .target_directory)
 
 if [[ "$wasm_bindgen_cargo_version" != "$wasm_bindgen_cli_version" ]]
 then
@@ -30,9 +27,8 @@ fi
 cargo build --lib --target wasm32-unknown-unknown $profile_flag
 
 wasm-bindgen \
-    target/wasm32-unknown-unknown/$profile_dir/linera_web.wasm \
+    "$target_dir"/wasm32-unknown-unknown/$profile_dir/linera_web.wasm \
     --out-dir dist \
     --typescript \
     --target web \
     --split-linked-modules
-


### PR DESCRIPTION
## Motivation

When we merged `linera-web` into this repository, I left some relative paths in `build.bash` that break the build script.

It would be nice to migrate back to `wasm-pack`, a more standard tool in the Rust world, but so far `wasm-pack` hasn't made a release that contains the necessary PR https://github.com/rustwasm/wasm-pack/pull/1443.

## Proposal

Instead of using relative paths, extract the necessary paths from `cargo metadata`.

## Test Plan

Tested locally.  (We should really run `pnpm build` as part of the CI job, not just `cargo build`.)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
