### PR TITLE
`linera-views`: make the context an associated type

### DIFF
--- a/linera-indexer/lib/src/plugin.rs
+++ b/linera-indexer/lib/src/plugin.rs
@@ -63,7 +63,7 @@ pub fn route<Q: ObjectType + 'static>(name: &str, query: Q, app: axum::Router) -
     .layer(tower_http::cors::CorsLayer::permissive())
 }
 
-pub async fn load<S, V: View<ViewContext<(), S>>>(
+pub async fn load<S, V: View<Context = ViewContext<(), S>>>(
     store: S,
     name: &str,
 ) -> Result<Arc<Mutex<V>>, IndexerError>

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-2.snap
@@ -2,12 +2,12 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_clonable_view_code(input))
 ---
-impl<C, MyParam> linera_views::views::ClonableView<C> for TestView<C, MyParam>
+impl<C, MyParam> linera_views::views::ClonableView for TestView<C, MyParam>
 where
     C: linera_views::context::Context + Send + Sync + Clone + 'static,
     MyParam: Send + Sync + 'static,
-    RegisterView<C, usize>: ClonableView<C>,
-    CollectionView<C, usize, RegisterView<C, usize>>: ClonableView<C>,
+    RegisterView<C, usize>: ClonableView,
+    CollectionView<C, usize, RegisterView<C, usize>>: ClonableView,
     Self: Send + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-2.snap
@@ -4,11 +4,10 @@ expression: pretty(generate_clonable_view_code(input))
 ---
 impl<C, MyParam> linera_views::views::ClonableView for TestView<C, MyParam>
 where
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
     MyParam: Send + Sync + 'static,
     RegisterView<C, usize>: ClonableView,
     CollectionView<C, usize, RegisterView<C, usize>>: ClonableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-3.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-3.snap
@@ -2,14 +2,14 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_clonable_view_code(input))
 ---
-impl linera_views::views::ClonableView<CustomContext> for TestView
+impl linera_views::views::ClonableView for TestView
 where
-    RegisterView<CustomContext, usize>: ClonableView<CustomContext>,
+    RegisterView<CustomContext, usize>: ClonableView,
     CollectionView<
         CustomContext,
         usize,
         RegisterView<CustomContext, usize>,
-    >: ClonableView<CustomContext>,
+    >: ClonableView,
     Self: Send + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-3.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-3.snap
@@ -10,7 +10,7 @@ where
         usize,
         RegisterView<CustomContext, usize>,
     >: ClonableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-4.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-4.snap
@@ -11,7 +11,7 @@ where
         usize,
         RegisterView<CustomContext, usize>,
     >: ClonableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-4.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-4.snap
@@ -2,15 +2,15 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_clonable_view_code(input))
 ---
-impl<MyParam> linera_views::views::ClonableView<CustomContext> for TestView<MyParam>
+impl<MyParam> linera_views::views::ClonableView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    RegisterView<CustomContext, usize>: ClonableView<CustomContext>,
+    RegisterView<CustomContext, usize>: ClonableView,
     CollectionView<
         CustomContext,
         usize,
         RegisterView<CustomContext, usize>,
-    >: ClonableView<CustomContext>,
+    >: ClonableView,
     Self: Send + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-5.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-5.snap
@@ -10,7 +10,7 @@ where
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
     >: ClonableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-5.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-5.snap
@@ -2,17 +2,14 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_clonable_view_code(input))
 ---
-impl linera_views::views::ClonableView<custom::path::to::ContextType> for TestView
+impl linera_views::views::ClonableView for TestView
 where
-    RegisterView<
-        custom::path::to::ContextType,
-        usize,
-    >: ClonableView<custom::path::to::ContextType>,
+    RegisterView<custom::path::to::ContextType, usize>: ClonableView,
     CollectionView<
         custom::path::to::ContextType,
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
-    >: ClonableView<custom::path::to::ContextType>,
+    >: ClonableView,
     Self: Send + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-6.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-6.snap
@@ -2,19 +2,15 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_clonable_view_code(input))
 ---
-impl<MyParam> linera_views::views::ClonableView<custom::path::to::ContextType>
-for TestView<MyParam>
+impl<MyParam> linera_views::views::ClonableView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    RegisterView<
-        custom::path::to::ContextType,
-        usize,
-    >: ClonableView<custom::path::to::ContextType>,
+    RegisterView<custom::path::to::ContextType, usize>: ClonableView,
     CollectionView<
         custom::path::to::ContextType,
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
-    >: ClonableView<custom::path::to::ContextType>,
+    >: ClonableView,
     Self: Send + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-6.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-6.snap
@@ -11,7 +11,7 @@ where
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
     >: ClonableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-7.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-7.snap
@@ -10,7 +10,7 @@ where
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
     >: ClonableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-7.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-7.snap
@@ -2,17 +2,14 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_clonable_view_code(input))
 ---
-impl linera_views::views::ClonableView<custom::GenericContext<T>> for TestView
+impl linera_views::views::ClonableView for TestView
 where
-    RegisterView<
-        custom::GenericContext<T>,
-        usize,
-    >: ClonableView<custom::GenericContext<T>>,
+    RegisterView<custom::GenericContext<T>, usize>: ClonableView,
     CollectionView<
         custom::GenericContext<T>,
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
-    >: ClonableView<custom::GenericContext<T>>,
+    >: ClonableView,
     Self: Send + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-8.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-8.snap
@@ -2,19 +2,15 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_clonable_view_code(input))
 ---
-impl<MyParam> linera_views::views::ClonableView<custom::GenericContext<T>>
-for TestView<MyParam>
+impl<MyParam> linera_views::views::ClonableView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    RegisterView<
-        custom::GenericContext<T>,
-        usize,
-    >: ClonableView<custom::GenericContext<T>>,
+    RegisterView<custom::GenericContext<T>, usize>: ClonableView,
     CollectionView<
         custom::GenericContext<T>,
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
-    >: ClonableView<custom::GenericContext<T>>,
+    >: ClonableView,
     Self: Send + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-8.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-8.snap
@@ -11,7 +11,7 @@ where
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
     >: ClonableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code.snap
@@ -4,10 +4,9 @@ expression: pretty(generate_clonable_view_code(input))
 ---
 impl<C> linera_views::views::ClonableView for TestView<C>
 where
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
     RegisterView<C, usize>: ClonableView,
     CollectionView<C, usize, RegisterView<C, usize>>: ClonableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code.snap
@@ -2,11 +2,11 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_clonable_view_code(input))
 ---
-impl<C> linera_views::views::ClonableView<C> for TestView<C>
+impl<C> linera_views::views::ClonableView for TestView<C>
 where
     C: linera_views::context::Context + Send + Sync + Clone + 'static,
-    RegisterView<C, usize>: ClonableView<C>,
-    CollectionView<C, usize, RegisterView<C, usize>>: ClonableView<C>,
+    RegisterView<C, usize>: ClonableView,
+    CollectionView<C, usize, RegisterView<C, usize>>: ClonableView,
     Self: Send + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-2.snap
@@ -2,16 +2,12 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_crypto_hash_code(input))
 ---
-impl<C, MyParam> linera_views::views::CryptoHashView<C> for TestView<C, MyParam>
+impl<C, MyParam> linera_views::views::CryptoHashView for TestView<C, MyParam>
 where
     MyParam: Send + Sync + 'static,
     C: linera_views::context::Context + Send + Sync + Clone + 'static,
-    RegisterView<C, usize>: linera_views::views::HashableView<C>,
-    CollectionView<
-        C,
-        usize,
-        RegisterView<C, usize>,
-    >: linera_views::views::HashableView<C>,
+    RegisterView<C, usize>: linera_views::views::HashableView,
+    CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     async fn crypto_hash(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-2.snap
@@ -4,9 +4,9 @@ expression: pretty(generate_crypto_hash_code(input))
 ---
 impl<C, MyParam> linera_views::views::CryptoHashView for TestView<C, MyParam>
 where
-    MyParam: Send + Sync + 'static,
     RegisterView<C, usize>: linera_views::views::HashableView,
     CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
+    MyParam: Send + Sync + 'static,
     Self: linera_views::views::View + Sync,
 {
     async fn crypto_hash(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-2.snap
@@ -5,10 +5,9 @@ expression: pretty(generate_crypto_hash_code(input))
 impl<C, MyParam> linera_views::views::CryptoHashView for TestView<C, MyParam>
 where
     MyParam: Send + Sync + 'static,
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
     RegisterView<C, usize>: linera_views::views::HashableView,
     CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-3.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-3.snap
@@ -2,14 +2,14 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_crypto_hash_code(input))
 ---
-impl linera_views::views::CryptoHashView<CustomContext> for TestView
+impl linera_views::views::CryptoHashView for TestView
 where
-    RegisterView<CustomContext, usize>: linera_views::views::HashableView<CustomContext>,
+    RegisterView<CustomContext, usize>: linera_views::views::HashableView,
     CollectionView<
         CustomContext,
         usize,
         RegisterView<CustomContext, usize>,
-    >: linera_views::views::HashableView<CustomContext>,
+    >: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     async fn crypto_hash(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-3.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-3.snap
@@ -10,7 +10,7 @@ where
         usize,
         RegisterView<CustomContext, usize>,
     >: linera_views::views::HashableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-4.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-4.snap
@@ -4,13 +4,13 @@ expression: pretty(generate_crypto_hash_code(input))
 ---
 impl<MyParam> linera_views::views::CryptoHashView for TestView<MyParam>
 where
-    MyParam: Send + Sync + 'static,
     RegisterView<CustomContext, usize>: linera_views::views::HashableView,
     CollectionView<
         CustomContext,
         usize,
         RegisterView<CustomContext, usize>,
     >: linera_views::views::HashableView,
+    MyParam: Send + Sync + 'static,
     Self: linera_views::views::View + Sync,
 {
     async fn crypto_hash(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-4.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-4.snap
@@ -2,15 +2,15 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_crypto_hash_code(input))
 ---
-impl<MyParam> linera_views::views::CryptoHashView<CustomContext> for TestView<MyParam>
+impl<MyParam> linera_views::views::CryptoHashView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    RegisterView<CustomContext, usize>: linera_views::views::HashableView<CustomContext>,
+    RegisterView<CustomContext, usize>: linera_views::views::HashableView,
     CollectionView<
         CustomContext,
         usize,
         RegisterView<CustomContext, usize>,
-    >: linera_views::views::HashableView<CustomContext>,
+    >: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     async fn crypto_hash(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-4.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-4.snap
@@ -11,7 +11,7 @@ where
         usize,
         RegisterView<CustomContext, usize>,
     >: linera_views::views::HashableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-5.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-5.snap
@@ -13,7 +13,7 @@ where
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
     >: linera_views::views::HashableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-5.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-5.snap
@@ -2,17 +2,17 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_crypto_hash_code(input))
 ---
-impl linera_views::views::CryptoHashView<custom::path::to::ContextType> for TestView
+impl linera_views::views::CryptoHashView for TestView
 where
     RegisterView<
         custom::path::to::ContextType,
         usize,
-    >: linera_views::views::HashableView<custom::path::to::ContextType>,
+    >: linera_views::views::HashableView,
     CollectionView<
         custom::path::to::ContextType,
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
-    >: linera_views::views::HashableView<custom::path::to::ContextType>,
+    >: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     async fn crypto_hash(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-6.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-6.snap
@@ -2,19 +2,18 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_crypto_hash_code(input))
 ---
-impl<MyParam> linera_views::views::CryptoHashView<custom::path::to::ContextType>
-for TestView<MyParam>
+impl<MyParam> linera_views::views::CryptoHashView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
     RegisterView<
         custom::path::to::ContextType,
         usize,
-    >: linera_views::views::HashableView<custom::path::to::ContextType>,
+    >: linera_views::views::HashableView,
     CollectionView<
         custom::path::to::ContextType,
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
-    >: linera_views::views::HashableView<custom::path::to::ContextType>,
+    >: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     async fn crypto_hash(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-6.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-6.snap
@@ -4,7 +4,6 @@ expression: pretty(generate_crypto_hash_code(input))
 ---
 impl<MyParam> linera_views::views::CryptoHashView for TestView<MyParam>
 where
-    MyParam: Send + Sync + 'static,
     RegisterView<
         custom::path::to::ContextType,
         usize,
@@ -14,6 +13,7 @@ where
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
     >: linera_views::views::HashableView,
+    MyParam: Send + Sync + 'static,
     Self: linera_views::views::View + Sync,
 {
     async fn crypto_hash(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-6.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-6.snap
@@ -14,7 +14,7 @@ where
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
     >: linera_views::views::HashableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-7.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-7.snap
@@ -10,7 +10,7 @@ where
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
     >: linera_views::views::HashableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-7.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-7.snap
@@ -2,17 +2,14 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_crypto_hash_code(input))
 ---
-impl linera_views::views::CryptoHashView<custom::GenericContext<T>> for TestView
+impl linera_views::views::CryptoHashView for TestView
 where
-    RegisterView<
-        custom::GenericContext<T>,
-        usize,
-    >: linera_views::views::HashableView<custom::GenericContext<T>>,
+    RegisterView<custom::GenericContext<T>, usize>: linera_views::views::HashableView,
     CollectionView<
         custom::GenericContext<T>,
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
-    >: linera_views::views::HashableView<custom::GenericContext<T>>,
+    >: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     async fn crypto_hash(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-8.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-8.snap
@@ -11,7 +11,7 @@ where
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
     >: linera_views::views::HashableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-8.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-8.snap
@@ -4,13 +4,13 @@ expression: pretty(generate_crypto_hash_code(input))
 ---
 impl<MyParam> linera_views::views::CryptoHashView for TestView<MyParam>
 where
-    MyParam: Send + Sync + 'static,
     RegisterView<custom::GenericContext<T>, usize>: linera_views::views::HashableView,
     CollectionView<
         custom::GenericContext<T>,
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
     >: linera_views::views::HashableView,
+    MyParam: Send + Sync + 'static,
     Self: linera_views::views::View + Sync,
 {
     async fn crypto_hash(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-8.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-8.snap
@@ -2,19 +2,15 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_crypto_hash_code(input))
 ---
-impl<MyParam> linera_views::views::CryptoHashView<custom::GenericContext<T>>
-for TestView<MyParam>
+impl<MyParam> linera_views::views::CryptoHashView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    RegisterView<
-        custom::GenericContext<T>,
-        usize,
-    >: linera_views::views::HashableView<custom::GenericContext<T>>,
+    RegisterView<custom::GenericContext<T>, usize>: linera_views::views::HashableView,
     CollectionView<
         custom::GenericContext<T>,
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
-    >: linera_views::views::HashableView<custom::GenericContext<T>>,
+    >: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     async fn crypto_hash(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code.snap
@@ -4,10 +4,9 @@ expression: pretty(generate_crypto_hash_code(input))
 ---
 impl<C> linera_views::views::CryptoHashView for TestView<C>
 where
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
     RegisterView<C, usize>: linera_views::views::HashableView,
     CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code.snap
@@ -2,15 +2,11 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_crypto_hash_code(input))
 ---
-impl<C> linera_views::views::CryptoHashView<C> for TestView<C>
+impl<C> linera_views::views::CryptoHashView for TestView<C>
 where
     C: linera_views::context::Context + Send + Sync + Clone + 'static,
-    RegisterView<C, usize>: linera_views::views::HashableView<C>,
-    CollectionView<
-        C,
-        usize,
-        RegisterView<C, usize>,
-    >: linera_views::views::HashableView<C>,
+    RegisterView<C, usize>: linera_views::views::HashableView,
+    CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     async fn crypto_hash(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C.snap
@@ -4,10 +4,11 @@ expression: pretty(generate_hash_view_code(input))
 ---
 impl<C> linera_views::views::HashableView for TestView<C>
 where
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
     RegisterView<C, usize>: linera_views::views::HashableView,
     CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
-    Self: Send + Sync,
+    RegisterView<C, usize>: linera_views::views::HashableView,
+    CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
+    Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C.snap
@@ -6,8 +6,6 @@ impl<C> linera_views::views::HashableView for TestView<C>
 where
     RegisterView<C, usize>: linera_views::views::HashableView,
     CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
-    RegisterView<C, usize>: linera_views::views::HashableView,
-    CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
     Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C.snap
@@ -2,15 +2,11 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_hash_view_code(input))
 ---
-impl<C> linera_views::views::HashableView<C> for TestView<C>
+impl<C> linera_views::views::HashableView for TestView<C>
 where
     C: linera_views::context::Context + Send + Sync + Clone + 'static,
-    RegisterView<C, usize>: linera_views::views::HashableView<C>,
-    CollectionView<
-        C,
-        usize,
-        RegisterView<C, usize>,
-    >: linera_views::views::HashableView<C>,
+    RegisterView<C, usize>: linera_views::views::HashableView,
+    CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C_with_where.snap
@@ -2,16 +2,12 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_hash_view_code(input))
 ---
-impl<C, MyParam> linera_views::views::HashableView<C> for TestView<C, MyParam>
+impl<C, MyParam> linera_views::views::HashableView for TestView<C, MyParam>
 where
     MyParam: Send + Sync + 'static,
     C: linera_views::context::Context + Send + Sync + Clone + 'static,
-    RegisterView<C, usize>: linera_views::views::HashableView<C>,
-    CollectionView<
-        C,
-        usize,
-        RegisterView<C, usize>,
-    >: linera_views::views::HashableView<C>,
+    RegisterView<C, usize>: linera_views::views::HashableView,
+    CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C_with_where.snap
@@ -4,11 +4,12 @@ expression: pretty(generate_hash_view_code(input))
 ---
 impl<C, MyParam> linera_views::views::HashableView for TestView<C, MyParam>
 where
-    MyParam: Send + Sync + 'static,
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
     RegisterView<C, usize>: linera_views::views::HashableView,
     CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
-    Self: Send + Sync,
+    MyParam: Send + Sync + 'static,
+    RegisterView<C, usize>: linera_views::views::HashableView,
+    CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
+    Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C_with_where.snap
@@ -7,8 +7,6 @@ where
     RegisterView<C, usize>: linera_views::views::HashableView,
     CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
     MyParam: Send + Sync + 'static,
-    RegisterView<C, usize>: linera_views::views::HashableView,
-    CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
     Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext.snap
@@ -10,7 +10,13 @@ where
         usize,
         RegisterView<CustomContext, usize>,
     >: linera_views::views::HashableView,
-    Self: Send + Sync,
+    RegisterView<CustomContext, usize>: linera_views::views::HashableView,
+    CollectionView<
+        CustomContext,
+        usize,
+        RegisterView<CustomContext, usize>,
+    >: linera_views::views::HashableView,
+    Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext.snap
@@ -10,12 +10,6 @@ where
         usize,
         RegisterView<CustomContext, usize>,
     >: linera_views::views::HashableView,
-    RegisterView<CustomContext, usize>: linera_views::views::HashableView,
-    CollectionView<
-        CustomContext,
-        usize,
-        RegisterView<CustomContext, usize>,
-    >: linera_views::views::HashableView,
     Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext.snap
@@ -2,14 +2,14 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_hash_view_code(input))
 ---
-impl linera_views::views::HashableView<CustomContext> for TestView
+impl linera_views::views::HashableView for TestView
 where
-    RegisterView<CustomContext, usize>: linera_views::views::HashableView<CustomContext>,
+    RegisterView<CustomContext, usize>: linera_views::views::HashableView,
     CollectionView<
         CustomContext,
         usize,
         RegisterView<CustomContext, usize>,
-    >: linera_views::views::HashableView<CustomContext>,
+    >: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext_with_where.snap
@@ -4,6 +4,12 @@ expression: pretty(generate_hash_view_code(input))
 ---
 impl<MyParam> linera_views::views::HashableView for TestView<MyParam>
 where
+    RegisterView<CustomContext, usize>: linera_views::views::HashableView,
+    CollectionView<
+        CustomContext,
+        usize,
+        RegisterView<CustomContext, usize>,
+    >: linera_views::views::HashableView,
     MyParam: Send + Sync + 'static,
     RegisterView<CustomContext, usize>: linera_views::views::HashableView,
     CollectionView<
@@ -11,7 +17,7 @@ where
         usize,
         RegisterView<CustomContext, usize>,
     >: linera_views::views::HashableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext_with_where.snap
@@ -11,12 +11,6 @@ where
         RegisterView<CustomContext, usize>,
     >: linera_views::views::HashableView,
     MyParam: Send + Sync + 'static,
-    RegisterView<CustomContext, usize>: linera_views::views::HashableView,
-    CollectionView<
-        CustomContext,
-        usize,
-        RegisterView<CustomContext, usize>,
-    >: linera_views::views::HashableView,
     Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext_with_where.snap
@@ -2,15 +2,15 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_hash_view_code(input))
 ---
-impl<MyParam> linera_views::views::HashableView<CustomContext> for TestView<MyParam>
+impl<MyParam> linera_views::views::HashableView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    RegisterView<CustomContext, usize>: linera_views::views::HashableView<CustomContext>,
+    RegisterView<CustomContext, usize>: linera_views::views::HashableView,
     CollectionView<
         CustomContext,
         usize,
         RegisterView<CustomContext, usize>,
-    >: linera_views::views::HashableView<CustomContext>,
+    >: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T_.snap
@@ -10,12 +10,6 @@ where
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
     >: linera_views::views::HashableView,
-    RegisterView<custom::GenericContext<T>, usize>: linera_views::views::HashableView,
-    CollectionView<
-        custom::GenericContext<T>,
-        usize,
-        RegisterView<custom::GenericContext<T>, usize>,
-    >: linera_views::views::HashableView,
     Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T_.snap
@@ -2,17 +2,14 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_hash_view_code(input))
 ---
-impl linera_views::views::HashableView<custom::GenericContext<T>> for TestView
+impl linera_views::views::HashableView for TestView
 where
-    RegisterView<
-        custom::GenericContext<T>,
-        usize,
-    >: linera_views::views::HashableView<custom::GenericContext<T>>,
+    RegisterView<custom::GenericContext<T>, usize>: linera_views::views::HashableView,
     CollectionView<
         custom::GenericContext<T>,
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
-    >: linera_views::views::HashableView<custom::GenericContext<T>>,
+    >: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T_.snap
@@ -10,7 +10,13 @@ where
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
     >: linera_views::views::HashableView,
-    Self: Send + Sync,
+    RegisterView<custom::GenericContext<T>, usize>: linera_views::views::HashableView,
+    CollectionView<
+        custom::GenericContext<T>,
+        usize,
+        RegisterView<custom::GenericContext<T>, usize>,
+    >: linera_views::views::HashableView,
+    Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T__with_where.snap
@@ -4,6 +4,12 @@ expression: pretty(generate_hash_view_code(input))
 ---
 impl<MyParam> linera_views::views::HashableView for TestView<MyParam>
 where
+    RegisterView<custom::GenericContext<T>, usize>: linera_views::views::HashableView,
+    CollectionView<
+        custom::GenericContext<T>,
+        usize,
+        RegisterView<custom::GenericContext<T>, usize>,
+    >: linera_views::views::HashableView,
     MyParam: Send + Sync + 'static,
     RegisterView<custom::GenericContext<T>, usize>: linera_views::views::HashableView,
     CollectionView<
@@ -11,7 +17,7 @@ where
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
     >: linera_views::views::HashableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T__with_where.snap
@@ -2,19 +2,15 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_hash_view_code(input))
 ---
-impl<MyParam> linera_views::views::HashableView<custom::GenericContext<T>>
-for TestView<MyParam>
+impl<MyParam> linera_views::views::HashableView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    RegisterView<
-        custom::GenericContext<T>,
-        usize,
-    >: linera_views::views::HashableView<custom::GenericContext<T>>,
+    RegisterView<custom::GenericContext<T>, usize>: linera_views::views::HashableView,
     CollectionView<
         custom::GenericContext<T>,
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
-    >: linera_views::views::HashableView<custom::GenericContext<T>>,
+    >: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T__with_where.snap
@@ -11,12 +11,6 @@ where
         RegisterView<custom::GenericContext<T>, usize>,
     >: linera_views::views::HashableView,
     MyParam: Send + Sync + 'static,
-    RegisterView<custom::GenericContext<T>, usize>: linera_views::views::HashableView,
-    CollectionView<
-        custom::GenericContext<T>,
-        usize,
-        RegisterView<custom::GenericContext<T>, usize>,
-    >: linera_views::views::HashableView,
     Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType.snap
@@ -2,17 +2,17 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_hash_view_code(input))
 ---
-impl linera_views::views::HashableView<custom::path::to::ContextType> for TestView
+impl linera_views::views::HashableView for TestView
 where
     RegisterView<
         custom::path::to::ContextType,
         usize,
-    >: linera_views::views::HashableView<custom::path::to::ContextType>,
+    >: linera_views::views::HashableView,
     CollectionView<
         custom::path::to::ContextType,
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
-    >: linera_views::views::HashableView<custom::path::to::ContextType>,
+    >: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType.snap
@@ -13,15 +13,6 @@ where
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
     >: linera_views::views::HashableView,
-    RegisterView<
-        custom::path::to::ContextType,
-        usize,
-    >: linera_views::views::HashableView,
-    CollectionView<
-        custom::path::to::ContextType,
-        usize,
-        RegisterView<custom::path::to::ContextType, usize>,
-    >: linera_views::views::HashableView,
     Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType.snap
@@ -13,7 +13,16 @@ where
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
     >: linera_views::views::HashableView,
-    Self: Send + Sync,
+    RegisterView<
+        custom::path::to::ContextType,
+        usize,
+    >: linera_views::views::HashableView,
+    CollectionView<
+        custom::path::to::ContextType,
+        usize,
+        RegisterView<custom::path::to::ContextType, usize>,
+    >: linera_views::views::HashableView,
+    Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType_with_where.snap
@@ -4,6 +4,15 @@ expression: pretty(generate_hash_view_code(input))
 ---
 impl<MyParam> linera_views::views::HashableView for TestView<MyParam>
 where
+    RegisterView<
+        custom::path::to::ContextType,
+        usize,
+    >: linera_views::views::HashableView,
+    CollectionView<
+        custom::path::to::ContextType,
+        usize,
+        RegisterView<custom::path::to::ContextType, usize>,
+    >: linera_views::views::HashableView,
     MyParam: Send + Sync + 'static,
     RegisterView<
         custom::path::to::ContextType,
@@ -14,7 +23,7 @@ where
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
     >: linera_views::views::HashableView,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType_with_where.snap
@@ -14,15 +14,6 @@ where
         RegisterView<custom::path::to::ContextType, usize>,
     >: linera_views::views::HashableView,
     MyParam: Send + Sync + 'static,
-    RegisterView<
-        custom::path::to::ContextType,
-        usize,
-    >: linera_views::views::HashableView,
-    CollectionView<
-        custom::path::to::ContextType,
-        usize,
-        RegisterView<custom::path::to::ContextType, usize>,
-    >: linera_views::views::HashableView,
     Self: linera_views::views::View + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType_with_where.snap
@@ -2,19 +2,18 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_hash_view_code(input))
 ---
-impl<MyParam> linera_views::views::HashableView<custom::path::to::ContextType>
-for TestView<MyParam>
+impl<MyParam> linera_views::views::HashableView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
     RegisterView<
         custom::path::to::ContextType,
         usize,
-    >: linera_views::views::HashableView<custom::path::to::ContextType>,
+    >: linera_views::views::HashableView,
     CollectionView<
         custom::path::to::ContextType,
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
-    >: linera_views::views::HashableView<custom::path::to::ContextType>,
+    >: linera_views::views::HashableView,
     Self: Send + Sync,
 {
     type Hasher = linera_views::sha3::Sha3_256;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C.snap
@@ -2,9 +2,9 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_root_view_code(input))
 ---
-impl<MyParam> linera_views::views::RootView for TestView<MyParam>
+impl<C> linera_views::views::RootView for TestView<C>
 where
-    MyParam: Send + Sync + 'static,
+    C: linera_views::context::Context + Send + Sync + Clone + 'static,
     Self: Send + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
@@ -12,12 +12,6 @@ where
             context::Context, batch::Batch, store::WritableKeyValueStore as _,
             views::View,
         };
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::SAVE_VIEW_COUNTER,
-            stringify!(TestView),
-            &self.context().base_key().bytes,
-        );
         let mut batch = Batch::new();
         self.register.flush(&mut batch)?;
         self.collection.flush(&mut batch)?;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C.snap
@@ -4,8 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl<C> linera_views::views::RootView for TestView<C>
 where
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -13,8 +12,7 @@ where
             views::View,
         };
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C_with_where.snap
@@ -2,9 +2,10 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_root_view_code(input))
 ---
-impl<MyParam> linera_views::views::RootView for TestView<MyParam>
+impl<C, MyParam> linera_views::views::RootView for TestView<C, MyParam>
 where
     MyParam: Send + Sync + 'static,
+    C: linera_views::context::Context + Send + Sync + Clone + 'static,
     Self: Send + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
@@ -12,12 +13,6 @@ where
             context::Context, batch::Batch, store::WritableKeyValueStore as _,
             views::View,
         };
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::SAVE_VIEW_COUNTER,
-            stringify!(TestView),
-            &self.context().base_key().bytes,
-        );
         let mut batch = Batch::new();
         self.register.flush(&mut batch)?;
         self.collection.flush(&mut batch)?;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C_with_where.snap
@@ -5,8 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<C, MyParam> linera_views::views::RootView for TestView<C, MyParam>
 where
     MyParam: Send + Sync + 'static,
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -14,8 +13,7 @@ where
             views::View,
         };
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext.snap
@@ -4,7 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl linera_views::views::RootView for TestView
 where
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -12,8 +12,7 @@ where
             views::View,
         };
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext.snap
@@ -2,9 +2,8 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_root_view_code(input))
 ---
-impl<MyParam> linera_views::views::RootView for TestView<MyParam>
+impl linera_views::views::RootView for TestView
 where
-    MyParam: Send + Sync + 'static,
     Self: Send + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
@@ -12,12 +11,6 @@ where
             context::Context, batch::Batch, store::WritableKeyValueStore as _,
             views::View,
         };
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::SAVE_VIEW_COUNTER,
-            stringify!(TestView),
-            &self.context().base_key().bytes,
-        );
         let mut batch = Batch::new();
         self.register.flush(&mut batch)?;
         self.collection.flush(&mut batch)?;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext_with_where.snap
@@ -5,7 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<MyParam> linera_views::views::RootView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -13,8 +13,7 @@ where
             views::View,
         };
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext_with_where.snap
@@ -12,12 +12,6 @@ where
             context::Context, batch::Batch, store::WritableKeyValueStore as _,
             views::View,
         };
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::SAVE_VIEW_COUNTER,
-            stringify!(TestView),
-            &self.context().base_key().bytes,
-        );
         let mut batch = Batch::new();
         self.register.flush(&mut batch)?;
         self.collection.flush(&mut batch)?;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T_.snap
@@ -4,7 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl linera_views::views::RootView for TestView
 where
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -12,8 +12,7 @@ where
             views::View,
         };
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T_.snap
@@ -2,9 +2,8 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_root_view_code(input))
 ---
-impl<MyParam> linera_views::views::RootView for TestView<MyParam>
+impl linera_views::views::RootView for TestView
 where
-    MyParam: Send + Sync + 'static,
     Self: Send + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
@@ -12,12 +11,6 @@ where
             context::Context, batch::Batch, store::WritableKeyValueStore as _,
             views::View,
         };
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::SAVE_VIEW_COUNTER,
-            stringify!(TestView),
-            &self.context().base_key().bytes,
-        );
         let mut batch = Batch::new();
         self.register.flush(&mut batch)?;
         self.collection.flush(&mut batch)?;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T__with_where.snap
@@ -5,7 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<MyParam> linera_views::views::RootView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -13,8 +13,7 @@ where
             views::View,
         };
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T__with_where.snap
@@ -12,12 +12,6 @@ where
             context::Context, batch::Batch, store::WritableKeyValueStore as _,
             views::View,
         };
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::SAVE_VIEW_COUNTER,
-            stringify!(TestView),
-            &self.context().base_key().bytes,
-        );
         let mut batch = Batch::new();
         self.register.flush(&mut batch)?;
         self.collection.flush(&mut batch)?;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType.snap
@@ -4,7 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl linera_views::views::RootView for TestView
 where
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -12,8 +12,7 @@ where
             views::View,
         };
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType.snap
@@ -2,9 +2,8 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_root_view_code(input))
 ---
-impl<MyParam> linera_views::views::RootView for TestView<MyParam>
+impl linera_views::views::RootView for TestView
 where
-    MyParam: Send + Sync + 'static,
     Self: Send + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
@@ -12,12 +11,6 @@ where
             context::Context, batch::Batch, store::WritableKeyValueStore as _,
             views::View,
         };
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::SAVE_VIEW_COUNTER,
-            stringify!(TestView),
-            &self.context().base_key().bytes,
-        );
         let mut batch = Batch::new();
         self.register.flush(&mut batch)?;
         self.collection.flush(&mut batch)?;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType_with_where.snap
@@ -5,7 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<MyParam> linera_views::views::RootView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -13,8 +13,7 @@ where
             views::View,
         };
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType_with_where.snap
@@ -12,12 +12,6 @@ where
             context::Context, batch::Batch, store::WritableKeyValueStore as _,
             views::View,
         };
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::SAVE_VIEW_COUNTER,
-            stringify!(TestView),
-            &self.context().base_key().bytes,
-        );
         let mut batch = Batch::new();
         self.register.flush(&mut batch)?;
         self.collection.flush(&mut batch)?;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C.snap
@@ -2,7 +2,7 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_root_view_code(input))
 ---
-impl<C> linera_views::views::RootView<C> for TestView<C>
+impl<C> linera_views::views::RootView for TestView<C>
 where
     C: linera_views::context::Context + Send + Sync + Clone + 'static,
     Self: Send + Sync,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C.snap
@@ -4,8 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl<C> linera_views::views::RootView for TestView<C>
 where
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -19,8 +18,7 @@ where
             &self.context().base_key().bytes,
         );
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C_with_where.snap
@@ -2,7 +2,7 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_root_view_code(input))
 ---
-impl<C, MyParam> linera_views::views::RootView<C> for TestView<C, MyParam>
+impl<C, MyParam> linera_views::views::RootView for TestView<C, MyParam>
 where
     MyParam: Send + Sync + 'static,
     C: linera_views::context::Context + Send + Sync + Clone + 'static,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C_with_where.snap
@@ -5,8 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<C, MyParam> linera_views::views::RootView for TestView<C, MyParam>
 where
     MyParam: Send + Sync + 'static,
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -20,8 +19,7 @@ where
             &self.context().base_key().bytes,
         );
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext.snap
@@ -2,7 +2,7 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_root_view_code(input))
 ---
-impl linera_views::views::RootView<CustomContext> for TestView
+impl linera_views::views::RootView for TestView
 where
     Self: Send + Sync,
 {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext.snap
@@ -4,7 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl linera_views::views::RootView for TestView
 where
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -18,8 +18,7 @@ where
             &self.context().base_key().bytes,
         );
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext_with_where.snap
@@ -5,7 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<MyParam> linera_views::views::RootView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -19,8 +19,7 @@ where
             &self.context().base_key().bytes,
         );
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T_.snap
@@ -2,7 +2,7 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_root_view_code(input))
 ---
-impl linera_views::views::RootView<custom::GenericContext<T>> for TestView
+impl linera_views::views::RootView for TestView
 where
     Self: Send + Sync,
 {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T_.snap
@@ -4,7 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl linera_views::views::RootView for TestView
 where
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -18,8 +18,7 @@ where
             &self.context().base_key().bytes,
         );
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T__with_where.snap
@@ -5,7 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<MyParam> linera_views::views::RootView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -19,8 +19,7 @@ where
             &self.context().base_key().bytes,
         );
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T__with_where.snap
@@ -2,8 +2,7 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_root_view_code(input))
 ---
-impl<MyParam> linera_views::views::RootView<custom::GenericContext<T>>
-for TestView<MyParam>
+impl<MyParam> linera_views::views::RootView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
     Self: Send + Sync,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType.snap
@@ -2,7 +2,7 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_root_view_code(input))
 ---
-impl linera_views::views::RootView<custom::path::to::ContextType> for TestView
+impl linera_views::views::RootView for TestView
 where
     Self: Send + Sync,
 {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType.snap
@@ -4,7 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl linera_views::views::RootView for TestView
 where
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -18,8 +18,7 @@ where
             &self.context().base_key().bytes,
         );
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType_with_where.snap
@@ -2,8 +2,7 @@
 source: linera-views-derive/src/lib.rs
 expression: pretty(generate_root_view_code(input))
 ---
-impl<MyParam> linera_views::views::RootView<custom::path::to::ContextType>
-for TestView<MyParam>
+impl<MyParam> linera_views::views::RootView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
     Self: Send + Sync,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType_with_where.snap
@@ -5,7 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<MyParam> linera_views::views::RootView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    Self: Send + Sync,
+    Self: linera_views::views::View + Sync,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{
@@ -19,8 +19,7 @@ where
             &self.context().base_key().bytes,
         );
         let mut batch = Batch::new();
-        self.register.flush(&mut batch)?;
-        self.collection.flush(&mut batch)?;
+        self.flush(&mut batch)?;
         if !batch.is_empty() {
             self.context().store().write_batch(batch).await?;
         }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
@@ -69,15 +69,6 @@ where
     }
     async fn load(context: C) -> Result<Self, linera_views::ViewError> {
         use linera_views::{context::Context as _, store::ReadableKeyValueStore as _};
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::LOAD_VIEW_COUNTER,
-            stringify!(TestView),
-            &context.base_key().bytes,
-        );
-        #[cfg(not(target_arch = "wasm32"))]
-        use linera_views::metrics::prometheus_util::MeasureLatency as _;
-        let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])
         } else {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
@@ -4,11 +4,23 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl<C> linera_views::views::View for TestView<C>
 where
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
-    Self: Send + Sync,
+    C: linera_views::context::Context,
+    RegisterView<C, usize>: linera_views::views::View<Context = C>,
+    CollectionView<
+        C,
+        usize,
+        RegisterView<C, usize>,
+    >: linera_views::views::View<Context = C>,
 {
-    const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
-        + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        C,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
+            C,
+            usize,
+            RegisterView<C, usize>,
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = C;
     fn context(&self) -> &C {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
@@ -2,8 +2,9 @@
 source: linera-views-derive/src/lib.rs
 expression: "pretty(generate_view_code(input, true))"
 ---
-impl<C> linera_views::views::View for TestView<C>
+impl<C, MyParam> linera_views::views::View for TestView<C, MyParam>
 where
+    MyParam: Send + Sync + 'static,
     C: linera_views::context::Context + Send + Sync + Clone + 'static,
     Self: Send + Sync,
 {
@@ -69,15 +70,6 @@ where
     }
     async fn load(context: C) -> Result<Self, linera_views::ViewError> {
         use linera_views::{context::Context as _, store::ReadableKeyValueStore as _};
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::LOAD_VIEW_COUNTER,
-            stringify!(TestView),
-            &context.base_key().bytes,
-        );
-        #[cfg(not(target_arch = "wasm32"))]
-        use linera_views::metrics::prometheus_util::MeasureLatency as _;
-        let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])
         } else {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
@@ -4,12 +4,24 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl<C, MyParam> linera_views::views::View for TestView<C, MyParam>
 where
+    C: linera_views::context::Context,
     MyParam: Send + Sync + 'static,
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
-    Self: Send + Sync,
+    RegisterView<C, usize>: linera_views::views::View<Context = C>,
+    CollectionView<
+        C,
+        usize,
+        RegisterView<C, usize>,
+    >: linera_views::views::View<Context = C>,
 {
-    const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
-        + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        C,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
+            C,
+            usize,
+            RegisterView<C, usize>,
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = C;
     fn context(&self) -> &C {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
@@ -4,14 +4,26 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl linera_views::views::View for TestView
 where
-    Self: Send + Sync,
+    CustomContext: linera_views::context::Context,
+    RegisterView<
+        CustomContext,
+        usize,
+    >: linera_views::views::View<Context = CustomContext>,
+    CollectionView<
+        CustomContext,
+        usize,
+        RegisterView<CustomContext, usize>,
+    >: linera_views::views::View<Context = CustomContext>,
 {
-    const NUM_INIT_KEYS: usize = RegisterView::<CustomContext, usize>::NUM_INIT_KEYS
-        + CollectionView::<
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        CustomContext,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
             CustomContext,
             usize,
             RegisterView<CustomContext, usize>,
-        >::NUM_INIT_KEYS;
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = CustomContext;
     fn context(&self) -> &CustomContext {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
@@ -2,19 +2,24 @@
 source: linera-views-derive/src/lib.rs
 expression: "pretty(generate_view_code(input, true))"
 ---
-impl<C> linera_views::views::View for TestView<C>
+impl linera_views::views::View for TestView
 where
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
     Self: Send + Sync,
 {
-    const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
-        + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
-    type Context = C;
-    fn context(&self) -> &C {
+    const NUM_INIT_KEYS: usize = RegisterView::<CustomContext, usize>::NUM_INIT_KEYS
+        + CollectionView::<
+            CustomContext,
+            usize,
+            RegisterView<CustomContext, usize>,
+        >::NUM_INIT_KEYS;
+    type Context = CustomContext;
+    fn context(&self) -> &CustomContext {
         use linera_views::views::View;
         self.register.context()
     }
-    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
+    fn pre_load(
+        context: &CustomContext,
+    ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
         let index = 0;
@@ -22,7 +27,10 @@ where
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         keys.extend(
-            RegisterView::<C, usize>::pre_load(&context.clone_with_base_key(base_key))?,
+            RegisterView::<
+                CustomContext,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
         );
         let index = 1;
         let base_key = context
@@ -30,54 +38,49 @@ where
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         keys.extend(
             CollectionView::<
-                C,
+                CustomContext,
                 usize,
-                RegisterView<C, usize>,
+                RegisterView<CustomContext, usize>,
             >::pre_load(&context.clone_with_base_key(base_key))?,
         );
         Ok(keys)
     }
     fn post_load(
-        context: C,
+        context: CustomContext,
         values: &[Option<Vec<u8>>],
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut pos = 0;
         let index = 0;
-        let pos_next = pos + RegisterView::<C, usize>::NUM_INIT_KEYS;
+        let pos_next = pos + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
         let base_key = context
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         let register = RegisterView::<
-            C,
+            CustomContext,
             usize,
         >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
         pos = pos_next;
         let index = 1;
         let pos_next = pos
-            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+            + CollectionView::<
+                CustomContext,
+                usize,
+                RegisterView<CustomContext, usize>,
+            >::NUM_INIT_KEYS;
         let base_key = context
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         let collection = CollectionView::<
-            C,
+            CustomContext,
             usize,
-            RegisterView<C, usize>,
+            RegisterView<CustomContext, usize>,
         >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
         pos = pos_next;
         Ok(Self { register, collection })
     }
-    async fn load(context: C) -> Result<Self, linera_views::ViewError> {
+    async fn load(context: CustomContext) -> Result<Self, linera_views::ViewError> {
         use linera_views::{context::Context as _, store::ReadableKeyValueStore as _};
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::LOAD_VIEW_COUNTER,
-            stringify!(TestView),
-            &context.base_key().bytes,
-        );
-        #[cfg(not(target_arch = "wasm32"))]
-        use linera_views::metrics::prometheus_util::MeasureLatency as _;
-        let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])
         } else {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
@@ -2,19 +2,25 @@
 source: linera-views-derive/src/lib.rs
 expression: "pretty(generate_view_code(input, true))"
 ---
-impl<C> linera_views::views::View for TestView<C>
+impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
+    MyParam: Send + Sync + 'static,
     Self: Send + Sync,
 {
-    const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
-        + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
-    type Context = C;
-    fn context(&self) -> &C {
+    const NUM_INIT_KEYS: usize = RegisterView::<CustomContext, usize>::NUM_INIT_KEYS
+        + CollectionView::<
+            CustomContext,
+            usize,
+            RegisterView<CustomContext, usize>,
+        >::NUM_INIT_KEYS;
+    type Context = CustomContext;
+    fn context(&self) -> &CustomContext {
         use linera_views::views::View;
         self.register.context()
     }
-    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
+    fn pre_load(
+        context: &CustomContext,
+    ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
         let index = 0;
@@ -22,7 +28,10 @@ where
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         keys.extend(
-            RegisterView::<C, usize>::pre_load(&context.clone_with_base_key(base_key))?,
+            RegisterView::<
+                CustomContext,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
         );
         let index = 1;
         let base_key = context
@@ -30,54 +39,49 @@ where
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         keys.extend(
             CollectionView::<
-                C,
+                CustomContext,
                 usize,
-                RegisterView<C, usize>,
+                RegisterView<CustomContext, usize>,
             >::pre_load(&context.clone_with_base_key(base_key))?,
         );
         Ok(keys)
     }
     fn post_load(
-        context: C,
+        context: CustomContext,
         values: &[Option<Vec<u8>>],
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut pos = 0;
         let index = 0;
-        let pos_next = pos + RegisterView::<C, usize>::NUM_INIT_KEYS;
+        let pos_next = pos + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
         let base_key = context
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         let register = RegisterView::<
-            C,
+            CustomContext,
             usize,
         >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
         pos = pos_next;
         let index = 1;
         let pos_next = pos
-            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+            + CollectionView::<
+                CustomContext,
+                usize,
+                RegisterView<CustomContext, usize>,
+            >::NUM_INIT_KEYS;
         let base_key = context
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         let collection = CollectionView::<
-            C,
+            CustomContext,
             usize,
-            RegisterView<C, usize>,
+            RegisterView<CustomContext, usize>,
         >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
         pos = pos_next;
         Ok(Self { register, collection })
     }
-    async fn load(context: C) -> Result<Self, linera_views::ViewError> {
+    async fn load(context: CustomContext) -> Result<Self, linera_views::ViewError> {
         use linera_views::{context::Context as _, store::ReadableKeyValueStore as _};
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::LOAD_VIEW_COUNTER,
-            stringify!(TestView),
-            &context.base_key().bytes,
-        );
-        #[cfg(not(target_arch = "wasm32"))]
-        use linera_views::metrics::prometheus_util::MeasureLatency as _;
-        let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])
         } else {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
@@ -4,15 +4,27 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
+    CustomContext: linera_views::context::Context,
     MyParam: Send + Sync + 'static,
-    Self: Send + Sync,
+    RegisterView<
+        CustomContext,
+        usize,
+    >: linera_views::views::View<Context = CustomContext>,
+    CollectionView<
+        CustomContext,
+        usize,
+        RegisterView<CustomContext, usize>,
+    >: linera_views::views::View<Context = CustomContext>,
 {
-    const NUM_INIT_KEYS: usize = RegisterView::<CustomContext, usize>::NUM_INIT_KEYS
-        + CollectionView::<
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        CustomContext,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
             CustomContext,
             usize,
             RegisterView<CustomContext, usize>,
-        >::NUM_INIT_KEYS;
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = CustomContext;
     fn context(&self) -> &CustomContext {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
@@ -4,17 +4,26 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl linera_views::views::View for TestView
 where
-    Self: Send + Sync,
-{
-    const NUM_INIT_KEYS: usize = RegisterView::<
+    custom::GenericContext<T>: linera_views::context::Context,
+    RegisterView<
         custom::GenericContext<T>,
         usize,
-    >::NUM_INIT_KEYS
-        + CollectionView::<
+    >: linera_views::views::View<Context = custom::GenericContext<T>>,
+    CollectionView<
+        custom::GenericContext<T>,
+        usize,
+        RegisterView<custom::GenericContext<T>, usize>,
+    >: linera_views::views::View<Context = custom::GenericContext<T>>,
+{
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        custom::GenericContext<T>,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
             custom::GenericContext<T>,
             usize,
             RegisterView<custom::GenericContext<T>, usize>,
-        >::NUM_INIT_KEYS;
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = custom::GenericContext<T>;
     fn context(&self) -> &custom::GenericContext<T> {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
@@ -2,19 +2,27 @@
 source: linera-views-derive/src/lib.rs
 expression: "pretty(generate_view_code(input, true))"
 ---
-impl<C> linera_views::views::View for TestView<C>
+impl linera_views::views::View for TestView
 where
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
     Self: Send + Sync,
 {
-    const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
-        + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
-    type Context = C;
-    fn context(&self) -> &C {
+    const NUM_INIT_KEYS: usize = RegisterView::<
+        custom::GenericContext<T>,
+        usize,
+    >::NUM_INIT_KEYS
+        + CollectionView::<
+            custom::GenericContext<T>,
+            usize,
+            RegisterView<custom::GenericContext<T>, usize>,
+        >::NUM_INIT_KEYS;
+    type Context = custom::GenericContext<T>;
+    fn context(&self) -> &custom::GenericContext<T> {
         use linera_views::views::View;
         self.register.context()
     }
-    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
+    fn pre_load(
+        context: &custom::GenericContext<T>,
+    ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
         let index = 0;
@@ -22,7 +30,10 @@ where
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         keys.extend(
-            RegisterView::<C, usize>::pre_load(&context.clone_with_base_key(base_key))?,
+            RegisterView::<
+                custom::GenericContext<T>,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
         );
         let index = 1;
         let base_key = context
@@ -30,54 +41,52 @@ where
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         keys.extend(
             CollectionView::<
-                C,
+                custom::GenericContext<T>,
                 usize,
-                RegisterView<C, usize>,
+                RegisterView<custom::GenericContext<T>, usize>,
             >::pre_load(&context.clone_with_base_key(base_key))?,
         );
         Ok(keys)
     }
     fn post_load(
-        context: C,
+        context: custom::GenericContext<T>,
         values: &[Option<Vec<u8>>],
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut pos = 0;
         let index = 0;
-        let pos_next = pos + RegisterView::<C, usize>::NUM_INIT_KEYS;
+        let pos_next = pos
+            + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
         let base_key = context
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         let register = RegisterView::<
-            C,
+            custom::GenericContext<T>,
             usize,
         >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
         pos = pos_next;
         let index = 1;
         let pos_next = pos
-            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+            + CollectionView::<
+                custom::GenericContext<T>,
+                usize,
+                RegisterView<custom::GenericContext<T>, usize>,
+            >::NUM_INIT_KEYS;
         let base_key = context
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         let collection = CollectionView::<
-            C,
+            custom::GenericContext<T>,
             usize,
-            RegisterView<C, usize>,
+            RegisterView<custom::GenericContext<T>, usize>,
         >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
         pos = pos_next;
         Ok(Self { register, collection })
     }
-    async fn load(context: C) -> Result<Self, linera_views::ViewError> {
+    async fn load(
+        context: custom::GenericContext<T>,
+    ) -> Result<Self, linera_views::ViewError> {
         use linera_views::{context::Context as _, store::ReadableKeyValueStore as _};
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::LOAD_VIEW_COUNTER,
-            stringify!(TestView),
-            &context.base_key().bytes,
-        );
-        #[cfg(not(target_arch = "wasm32"))]
-        use linera_views::metrics::prometheus_util::MeasureLatency as _;
-        let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])
         } else {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
@@ -2,19 +2,28 @@
 source: linera-views-derive/src/lib.rs
 expression: "pretty(generate_view_code(input, true))"
 ---
-impl<C> linera_views::views::View for TestView<C>
+impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
+    MyParam: Send + Sync + 'static,
     Self: Send + Sync,
 {
-    const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
-        + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
-    type Context = C;
-    fn context(&self) -> &C {
+    const NUM_INIT_KEYS: usize = RegisterView::<
+        custom::GenericContext<T>,
+        usize,
+    >::NUM_INIT_KEYS
+        + CollectionView::<
+            custom::GenericContext<T>,
+            usize,
+            RegisterView<custom::GenericContext<T>, usize>,
+        >::NUM_INIT_KEYS;
+    type Context = custom::GenericContext<T>;
+    fn context(&self) -> &custom::GenericContext<T> {
         use linera_views::views::View;
         self.register.context()
     }
-    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
+    fn pre_load(
+        context: &custom::GenericContext<T>,
+    ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
         let index = 0;
@@ -22,7 +31,10 @@ where
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         keys.extend(
-            RegisterView::<C, usize>::pre_load(&context.clone_with_base_key(base_key))?,
+            RegisterView::<
+                custom::GenericContext<T>,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
         );
         let index = 1;
         let base_key = context
@@ -30,54 +42,52 @@ where
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         keys.extend(
             CollectionView::<
-                C,
+                custom::GenericContext<T>,
                 usize,
-                RegisterView<C, usize>,
+                RegisterView<custom::GenericContext<T>, usize>,
             >::pre_load(&context.clone_with_base_key(base_key))?,
         );
         Ok(keys)
     }
     fn post_load(
-        context: C,
+        context: custom::GenericContext<T>,
         values: &[Option<Vec<u8>>],
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut pos = 0;
         let index = 0;
-        let pos_next = pos + RegisterView::<C, usize>::NUM_INIT_KEYS;
+        let pos_next = pos
+            + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
         let base_key = context
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         let register = RegisterView::<
-            C,
+            custom::GenericContext<T>,
             usize,
         >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
         pos = pos_next;
         let index = 1;
         let pos_next = pos
-            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+            + CollectionView::<
+                custom::GenericContext<T>,
+                usize,
+                RegisterView<custom::GenericContext<T>, usize>,
+            >::NUM_INIT_KEYS;
         let base_key = context
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         let collection = CollectionView::<
-            C,
+            custom::GenericContext<T>,
             usize,
-            RegisterView<C, usize>,
+            RegisterView<custom::GenericContext<T>, usize>,
         >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
         pos = pos_next;
         Ok(Self { register, collection })
     }
-    async fn load(context: C) -> Result<Self, linera_views::ViewError> {
+    async fn load(
+        context: custom::GenericContext<T>,
+    ) -> Result<Self, linera_views::ViewError> {
         use linera_views::{context::Context as _, store::ReadableKeyValueStore as _};
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::LOAD_VIEW_COUNTER,
-            stringify!(TestView),
-            &context.base_key().bytes,
-        );
-        #[cfg(not(target_arch = "wasm32"))]
-        use linera_views::metrics::prometheus_util::MeasureLatency as _;
-        let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])
         } else {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
@@ -4,18 +4,27 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
+    custom::GenericContext<T>: linera_views::context::Context,
     MyParam: Send + Sync + 'static,
-    Self: Send + Sync,
-{
-    const NUM_INIT_KEYS: usize = RegisterView::<
+    RegisterView<
         custom::GenericContext<T>,
         usize,
-    >::NUM_INIT_KEYS
-        + CollectionView::<
+    >: linera_views::views::View<Context = custom::GenericContext<T>>,
+    CollectionView<
+        custom::GenericContext<T>,
+        usize,
+        RegisterView<custom::GenericContext<T>, usize>,
+    >: linera_views::views::View<Context = custom::GenericContext<T>>,
+{
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        custom::GenericContext<T>,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
             custom::GenericContext<T>,
             usize,
             RegisterView<custom::GenericContext<T>, usize>,
-        >::NUM_INIT_KEYS;
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = custom::GenericContext<T>;
     fn context(&self) -> &custom::GenericContext<T> {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
@@ -2,19 +2,27 @@
 source: linera-views-derive/src/lib.rs
 expression: "pretty(generate_view_code(input, true))"
 ---
-impl<C> linera_views::views::View for TestView<C>
+impl linera_views::views::View for TestView
 where
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
     Self: Send + Sync,
 {
-    const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
-        + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
-    type Context = C;
-    fn context(&self) -> &C {
+    const NUM_INIT_KEYS: usize = RegisterView::<
+        custom::path::to::ContextType,
+        usize,
+    >::NUM_INIT_KEYS
+        + CollectionView::<
+            custom::path::to::ContextType,
+            usize,
+            RegisterView<custom::path::to::ContextType, usize>,
+        >::NUM_INIT_KEYS;
+    type Context = custom::path::to::ContextType;
+    fn context(&self) -> &custom::path::to::ContextType {
         use linera_views::views::View;
         self.register.context()
     }
-    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
+    fn pre_load(
+        context: &custom::path::to::ContextType,
+    ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
         let index = 0;
@@ -22,7 +30,10 @@ where
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         keys.extend(
-            RegisterView::<C, usize>::pre_load(&context.clone_with_base_key(base_key))?,
+            RegisterView::<
+                custom::path::to::ContextType,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
         );
         let index = 1;
         let base_key = context
@@ -30,54 +41,52 @@ where
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         keys.extend(
             CollectionView::<
-                C,
+                custom::path::to::ContextType,
                 usize,
-                RegisterView<C, usize>,
+                RegisterView<custom::path::to::ContextType, usize>,
             >::pre_load(&context.clone_with_base_key(base_key))?,
         );
         Ok(keys)
     }
     fn post_load(
-        context: C,
+        context: custom::path::to::ContextType,
         values: &[Option<Vec<u8>>],
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut pos = 0;
         let index = 0;
-        let pos_next = pos + RegisterView::<C, usize>::NUM_INIT_KEYS;
+        let pos_next = pos
+            + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
         let base_key = context
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         let register = RegisterView::<
-            C,
+            custom::path::to::ContextType,
             usize,
         >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
         pos = pos_next;
         let index = 1;
         let pos_next = pos
-            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+            + CollectionView::<
+                custom::path::to::ContextType,
+                usize,
+                RegisterView<custom::path::to::ContextType, usize>,
+            >::NUM_INIT_KEYS;
         let base_key = context
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         let collection = CollectionView::<
-            C,
+            custom::path::to::ContextType,
             usize,
-            RegisterView<C, usize>,
+            RegisterView<custom::path::to::ContextType, usize>,
         >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
         pos = pos_next;
         Ok(Self { register, collection })
     }
-    async fn load(context: C) -> Result<Self, linera_views::ViewError> {
+    async fn load(
+        context: custom::path::to::ContextType,
+    ) -> Result<Self, linera_views::ViewError> {
         use linera_views::{context::Context as _, store::ReadableKeyValueStore as _};
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::LOAD_VIEW_COUNTER,
-            stringify!(TestView),
-            &context.base_key().bytes,
-        );
-        #[cfg(not(target_arch = "wasm32"))]
-        use linera_views::metrics::prometheus_util::MeasureLatency as _;
-        let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])
         } else {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
@@ -4,17 +4,26 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl linera_views::views::View for TestView
 where
-    Self: Send + Sync,
-{
-    const NUM_INIT_KEYS: usize = RegisterView::<
+    custom::path::to::ContextType: linera_views::context::Context,
+    RegisterView<
         custom::path::to::ContextType,
         usize,
-    >::NUM_INIT_KEYS
-        + CollectionView::<
+    >: linera_views::views::View<Context = custom::path::to::ContextType>,
+    CollectionView<
+        custom::path::to::ContextType,
+        usize,
+        RegisterView<custom::path::to::ContextType, usize>,
+    >: linera_views::views::View<Context = custom::path::to::ContextType>,
+{
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        custom::path::to::ContextType,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
             custom::path::to::ContextType,
             usize,
             RegisterView<custom::path::to::ContextType, usize>,
-        >::NUM_INIT_KEYS;
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = custom::path::to::ContextType;
     fn context(&self) -> &custom::path::to::ContextType {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
@@ -4,18 +4,27 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
+    custom::path::to::ContextType: linera_views::context::Context,
     MyParam: Send + Sync + 'static,
-    Self: Send + Sync,
-{
-    const NUM_INIT_KEYS: usize = RegisterView::<
+    RegisterView<
         custom::path::to::ContextType,
         usize,
-    >::NUM_INIT_KEYS
-        + CollectionView::<
+    >: linera_views::views::View<Context = custom::path::to::ContextType>,
+    CollectionView<
+        custom::path::to::ContextType,
+        usize,
+        RegisterView<custom::path::to::ContextType, usize>,
+    >: linera_views::views::View<Context = custom::path::to::ContextType>,
+{
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        custom::path::to::ContextType,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
             custom::path::to::ContextType,
             usize,
             RegisterView<custom::path::to::ContextType, usize>,
-        >::NUM_INIT_KEYS;
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = custom::path::to::ContextType;
     fn context(&self) -> &custom::path::to::ContextType {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
@@ -2,19 +2,28 @@
 source: linera-views-derive/src/lib.rs
 expression: "pretty(generate_view_code(input, true))"
 ---
-impl<C> linera_views::views::View for TestView<C>
+impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
+    MyParam: Send + Sync + 'static,
     Self: Send + Sync,
 {
-    const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
-        + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
-    type Context = C;
-    fn context(&self) -> &C {
+    const NUM_INIT_KEYS: usize = RegisterView::<
+        custom::path::to::ContextType,
+        usize,
+    >::NUM_INIT_KEYS
+        + CollectionView::<
+            custom::path::to::ContextType,
+            usize,
+            RegisterView<custom::path::to::ContextType, usize>,
+        >::NUM_INIT_KEYS;
+    type Context = custom::path::to::ContextType;
+    fn context(&self) -> &custom::path::to::ContextType {
         use linera_views::views::View;
         self.register.context()
     }
-    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
+    fn pre_load(
+        context: &custom::path::to::ContextType,
+    ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
         let index = 0;
@@ -22,7 +31,10 @@ where
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         keys.extend(
-            RegisterView::<C, usize>::pre_load(&context.clone_with_base_key(base_key))?,
+            RegisterView::<
+                custom::path::to::ContextType,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
         );
         let index = 1;
         let base_key = context
@@ -30,54 +42,52 @@ where
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         keys.extend(
             CollectionView::<
-                C,
+                custom::path::to::ContextType,
                 usize,
-                RegisterView<C, usize>,
+                RegisterView<custom::path::to::ContextType, usize>,
             >::pre_load(&context.clone_with_base_key(base_key))?,
         );
         Ok(keys)
     }
     fn post_load(
-        context: C,
+        context: custom::path::to::ContextType,
         values: &[Option<Vec<u8>>],
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut pos = 0;
         let index = 0;
-        let pos_next = pos + RegisterView::<C, usize>::NUM_INIT_KEYS;
+        let pos_next = pos
+            + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
         let base_key = context
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         let register = RegisterView::<
-            C,
+            custom::path::to::ContextType,
             usize,
         >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
         pos = pos_next;
         let index = 1;
         let pos_next = pos
-            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+            + CollectionView::<
+                custom::path::to::ContextType,
+                usize,
+                RegisterView<custom::path::to::ContextType, usize>,
+            >::NUM_INIT_KEYS;
         let base_key = context
             .base_key()
             .derive_tag_key(linera_views::views::MIN_VIEW_TAG, &index)?;
         let collection = CollectionView::<
-            C,
+            custom::path::to::ContextType,
             usize,
-            RegisterView<C, usize>,
+            RegisterView<custom::path::to::ContextType, usize>,
         >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
         pos = pos_next;
         Ok(Self { register, collection })
     }
-    async fn load(context: C) -> Result<Self, linera_views::ViewError> {
+    async fn load(
+        context: custom::path::to::ContextType,
+    ) -> Result<Self, linera_views::ViewError> {
         use linera_views::{context::Context as _, store::ReadableKeyValueStore as _};
-        #[cfg(not(target_arch = "wasm32"))]
-        linera_views::metrics::increment_counter(
-            &linera_views::metrics::LOAD_VIEW_COUNTER,
-            stringify!(TestView),
-            &context.base_key().bytes,
-        );
-        #[cfg(not(target_arch = "wasm32"))]
-        use linera_views::metrics::prometheus_util::MeasureLatency as _;
-        let _latency = linera_views::metrics::LOAD_VIEW_LATENCY.measure_latency();
         if Self::NUM_INIT_KEYS == 0 {
             Self::post_load(context, &[])
         } else {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
@@ -4,11 +4,23 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl<C> linera_views::views::View for TestView<C>
 where
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
-    Self: Send + Sync,
+    C: linera_views::context::Context,
+    RegisterView<C, usize>: linera_views::views::View<Context = C>,
+    CollectionView<
+        C,
+        usize,
+        RegisterView<C, usize>,
+    >: linera_views::views::View<Context = C>,
 {
-    const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
-        + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        C,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
+            C,
+            usize,
+            RegisterView<C, usize>,
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = C;
     fn context(&self) -> &C {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
@@ -2,16 +2,15 @@
 source: linera-views-derive/src/lib.rs
 expression: "pretty(generate_view_code(input, true))"
 ---
-impl<C, MyParam> linera_views::views::View<C> for TestView<C, MyParam>
+impl<C, MyParam> linera_views::views::View for TestView<C, MyParam>
 where
     MyParam: Send + Sync + 'static,
     C: linera_views::context::Context + Send + Sync + Clone + 'static,
-    RegisterView<C, usize>: linera_views::views::View<C>,
-    CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::View<C>,
     Self: Send + Sync,
 {
     const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
         + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+    type Context = C;
     fn context(&self) -> &C {
         use linera_views::views::View;
         self.register.context()

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
@@ -4,12 +4,24 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl<C, MyParam> linera_views::views::View for TestView<C, MyParam>
 where
+    C: linera_views::context::Context,
     MyParam: Send + Sync + 'static,
-    C: linera_views::context::Context + Send + Sync + Clone + 'static,
-    Self: Send + Sync,
+    RegisterView<C, usize>: linera_views::views::View<Context = C>,
+    CollectionView<
+        C,
+        usize,
+        RegisterView<C, usize>,
+    >: linera_views::views::View<Context = C>,
 {
-    const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
-        + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        C,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
+            C,
+            usize,
+            RegisterView<C, usize>,
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = C;
     fn context(&self) -> &C {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
@@ -2,14 +2,8 @@
 source: linera-views-derive/src/lib.rs
 expression: "pretty(generate_view_code(input, true))"
 ---
-impl linera_views::views::View<CustomContext> for TestView
+impl linera_views::views::View for TestView
 where
-    RegisterView<CustomContext, usize>: linera_views::views::View<CustomContext>,
-    CollectionView<
-        CustomContext,
-        usize,
-        RegisterView<CustomContext, usize>,
-    >: linera_views::views::View<CustomContext>,
     Self: Send + Sync,
 {
     const NUM_INIT_KEYS: usize = RegisterView::<CustomContext, usize>::NUM_INIT_KEYS
@@ -18,6 +12,7 @@ where
             usize,
             RegisterView<CustomContext, usize>,
         >::NUM_INIT_KEYS;
+    type Context = CustomContext;
     fn context(&self) -> &CustomContext {
         use linera_views::views::View;
         self.register.context()

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
@@ -4,14 +4,26 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl linera_views::views::View for TestView
 where
-    Self: Send + Sync,
+    CustomContext: linera_views::context::Context,
+    RegisterView<
+        CustomContext,
+        usize,
+    >: linera_views::views::View<Context = CustomContext>,
+    CollectionView<
+        CustomContext,
+        usize,
+        RegisterView<CustomContext, usize>,
+    >: linera_views::views::View<Context = CustomContext>,
 {
-    const NUM_INIT_KEYS: usize = RegisterView::<CustomContext, usize>::NUM_INIT_KEYS
-        + CollectionView::<
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        CustomContext,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
             CustomContext,
             usize,
             RegisterView<CustomContext, usize>,
-        >::NUM_INIT_KEYS;
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = CustomContext;
     fn context(&self) -> &CustomContext {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
@@ -2,15 +2,9 @@
 source: linera-views-derive/src/lib.rs
 expression: "pretty(generate_view_code(input, true))"
 ---
-impl<MyParam> linera_views::views::View<CustomContext> for TestView<MyParam>
+impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    RegisterView<CustomContext, usize>: linera_views::views::View<CustomContext>,
-    CollectionView<
-        CustomContext,
-        usize,
-        RegisterView<CustomContext, usize>,
-    >: linera_views::views::View<CustomContext>,
     Self: Send + Sync,
 {
     const NUM_INIT_KEYS: usize = RegisterView::<CustomContext, usize>::NUM_INIT_KEYS
@@ -19,6 +13,7 @@ where
             usize,
             RegisterView<CustomContext, usize>,
         >::NUM_INIT_KEYS;
+    type Context = CustomContext;
     fn context(&self) -> &CustomContext {
         use linera_views::views::View;
         self.register.context()

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
@@ -4,15 +4,27 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
+    CustomContext: linera_views::context::Context,
     MyParam: Send + Sync + 'static,
-    Self: Send + Sync,
+    RegisterView<
+        CustomContext,
+        usize,
+    >: linera_views::views::View<Context = CustomContext>,
+    CollectionView<
+        CustomContext,
+        usize,
+        RegisterView<CustomContext, usize>,
+    >: linera_views::views::View<Context = CustomContext>,
 {
-    const NUM_INIT_KEYS: usize = RegisterView::<CustomContext, usize>::NUM_INIT_KEYS
-        + CollectionView::<
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        CustomContext,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
             CustomContext,
             usize,
             RegisterView<CustomContext, usize>,
-        >::NUM_INIT_KEYS;
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = CustomContext;
     fn context(&self) -> &CustomContext {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
@@ -4,17 +4,26 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl linera_views::views::View for TestView
 where
-    Self: Send + Sync,
-{
-    const NUM_INIT_KEYS: usize = RegisterView::<
+    custom::GenericContext<T>: linera_views::context::Context,
+    RegisterView<
         custom::GenericContext<T>,
         usize,
-    >::NUM_INIT_KEYS
-        + CollectionView::<
+    >: linera_views::views::View<Context = custom::GenericContext<T>>,
+    CollectionView<
+        custom::GenericContext<T>,
+        usize,
+        RegisterView<custom::GenericContext<T>, usize>,
+    >: linera_views::views::View<Context = custom::GenericContext<T>>,
+{
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        custom::GenericContext<T>,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
             custom::GenericContext<T>,
             usize,
             RegisterView<custom::GenericContext<T>, usize>,
-        >::NUM_INIT_KEYS;
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = custom::GenericContext<T>;
     fn context(&self) -> &custom::GenericContext<T> {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
@@ -2,17 +2,8 @@
 source: linera-views-derive/src/lib.rs
 expression: "pretty(generate_view_code(input, true))"
 ---
-impl linera_views::views::View<custom::GenericContext<T>> for TestView
+impl linera_views::views::View for TestView
 where
-    RegisterView<
-        custom::GenericContext<T>,
-        usize,
-    >: linera_views::views::View<custom::GenericContext<T>>,
-    CollectionView<
-        custom::GenericContext<T>,
-        usize,
-        RegisterView<custom::GenericContext<T>, usize>,
-    >: linera_views::views::View<custom::GenericContext<T>>,
     Self: Send + Sync,
 {
     const NUM_INIT_KEYS: usize = RegisterView::<
@@ -24,6 +15,7 @@ where
             usize,
             RegisterView<custom::GenericContext<T>, usize>,
         >::NUM_INIT_KEYS;
+    type Context = custom::GenericContext<T>;
     fn context(&self) -> &custom::GenericContext<T> {
         use linera_views::views::View;
         self.register.context()

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
@@ -2,18 +2,9 @@
 source: linera-views-derive/src/lib.rs
 expression: "pretty(generate_view_code(input, true))"
 ---
-impl<MyParam> linera_views::views::View<custom::GenericContext<T>> for TestView<MyParam>
+impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    RegisterView<
-        custom::GenericContext<T>,
-        usize,
-    >: linera_views::views::View<custom::GenericContext<T>>,
-    CollectionView<
-        custom::GenericContext<T>,
-        usize,
-        RegisterView<custom::GenericContext<T>, usize>,
-    >: linera_views::views::View<custom::GenericContext<T>>,
     Self: Send + Sync,
 {
     const NUM_INIT_KEYS: usize = RegisterView::<
@@ -25,6 +16,7 @@ where
             usize,
             RegisterView<custom::GenericContext<T>, usize>,
         >::NUM_INIT_KEYS;
+    type Context = custom::GenericContext<T>;
     fn context(&self) -> &custom::GenericContext<T> {
         use linera_views::views::View;
         self.register.context()

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
@@ -4,18 +4,27 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
+    custom::GenericContext<T>: linera_views::context::Context,
     MyParam: Send + Sync + 'static,
-    Self: Send + Sync,
-{
-    const NUM_INIT_KEYS: usize = RegisterView::<
+    RegisterView<
         custom::GenericContext<T>,
         usize,
-    >::NUM_INIT_KEYS
-        + CollectionView::<
+    >: linera_views::views::View<Context = custom::GenericContext<T>>,
+    CollectionView<
+        custom::GenericContext<T>,
+        usize,
+        RegisterView<custom::GenericContext<T>, usize>,
+    >: linera_views::views::View<Context = custom::GenericContext<T>>,
+{
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        custom::GenericContext<T>,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
             custom::GenericContext<T>,
             usize,
             RegisterView<custom::GenericContext<T>, usize>,
-        >::NUM_INIT_KEYS;
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = custom::GenericContext<T>;
     fn context(&self) -> &custom::GenericContext<T> {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
@@ -2,17 +2,8 @@
 source: linera-views-derive/src/lib.rs
 expression: "pretty(generate_view_code(input, true))"
 ---
-impl linera_views::views::View<custom::path::to::ContextType> for TestView
+impl linera_views::views::View for TestView
 where
-    RegisterView<
-        custom::path::to::ContextType,
-        usize,
-    >: linera_views::views::View<custom::path::to::ContextType>,
-    CollectionView<
-        custom::path::to::ContextType,
-        usize,
-        RegisterView<custom::path::to::ContextType, usize>,
-    >: linera_views::views::View<custom::path::to::ContextType>,
     Self: Send + Sync,
 {
     const NUM_INIT_KEYS: usize = RegisterView::<
@@ -24,6 +15,7 @@ where
             usize,
             RegisterView<custom::path::to::ContextType, usize>,
         >::NUM_INIT_KEYS;
+    type Context = custom::path::to::ContextType;
     fn context(&self) -> &custom::path::to::ContextType {
         use linera_views::views::View;
         self.register.context()

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
@@ -4,17 +4,26 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl linera_views::views::View for TestView
 where
-    Self: Send + Sync,
-{
-    const NUM_INIT_KEYS: usize = RegisterView::<
+    custom::path::to::ContextType: linera_views::context::Context,
+    RegisterView<
         custom::path::to::ContextType,
         usize,
-    >::NUM_INIT_KEYS
-        + CollectionView::<
+    >: linera_views::views::View<Context = custom::path::to::ContextType>,
+    CollectionView<
+        custom::path::to::ContextType,
+        usize,
+        RegisterView<custom::path::to::ContextType, usize>,
+    >: linera_views::views::View<Context = custom::path::to::ContextType>,
+{
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        custom::path::to::ContextType,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
             custom::path::to::ContextType,
             usize,
             RegisterView<custom::path::to::ContextType, usize>,
-        >::NUM_INIT_KEYS;
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = custom::path::to::ContextType;
     fn context(&self) -> &custom::path::to::ContextType {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
@@ -4,18 +4,27 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
+    custom::path::to::ContextType: linera_views::context::Context,
     MyParam: Send + Sync + 'static,
-    Self: Send + Sync,
-{
-    const NUM_INIT_KEYS: usize = RegisterView::<
+    RegisterView<
         custom::path::to::ContextType,
         usize,
-    >::NUM_INIT_KEYS
-        + CollectionView::<
+    >: linera_views::views::View<Context = custom::path::to::ContextType>,
+    CollectionView<
+        custom::path::to::ContextType,
+        usize,
+        RegisterView<custom::path::to::ContextType, usize>,
+    >: linera_views::views::View<Context = custom::path::to::ContextType>,
+{
+    const NUM_INIT_KEYS: usize = <RegisterView<
+        custom::path::to::ContextType,
+        usize,
+    > as linera_views::views::View>::NUM_INIT_KEYS
+        + <CollectionView<
             custom::path::to::ContextType,
             usize,
             RegisterView<custom::path::to::ContextType, usize>,
-        >::NUM_INIT_KEYS;
+        > as linera_views::views::View>::NUM_INIT_KEYS;
     type Context = custom::path::to::ContextType;
     fn context(&self) -> &custom::path::to::ContextType {
         use linera_views::views::View;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
@@ -2,19 +2,9 @@
 source: linera-views-derive/src/lib.rs
 expression: "pretty(generate_view_code(input, true))"
 ---
-impl<MyParam> linera_views::views::View<custom::path::to::ContextType>
-for TestView<MyParam>
+impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    RegisterView<
-        custom::path::to::ContextType,
-        usize,
-    >: linera_views::views::View<custom::path::to::ContextType>,
-    CollectionView<
-        custom::path::to::ContextType,
-        usize,
-        RegisterView<custom::path::to::ContextType, usize>,
-    >: linera_views::views::View<custom::path::to::ContextType>,
     Self: Send + Sync,
 {
     const NUM_INIT_KEYS: usize = RegisterView::<
@@ -26,6 +16,7 @@ where
             usize,
             RegisterView<custom::path::to::ContextType, usize>,
         >::NUM_INIT_KEYS;
+    type Context = custom::path::to::ContextType;
     fn context(&self) -> &custom::path::to::ContextType {
         use linera_views::views::View;
         self.register.context()

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -140,7 +140,7 @@ pub trait ReadableKeyValueStore: WithError {
     }
 
     /// Reads multiple `keys` and deserializes the results if present.
-    fn read_multi_values<V: DeserializeOwned + Send>(
+    fn read_multi_values<V: DeserializeOwned + Send + Sync>(
         &self,
         keys: Vec<Vec<u8>>,
     ) -> impl Future<Output = Result<Vec<Option<V>>, Self::Error>>

--- a/linera-views/src/test_utils/test_views.rs
+++ b/linera-views/src/test_utils/test_views.rs
@@ -23,9 +23,7 @@ use crate::{
 };
 
 /// A [`View`][`crate::views::View`] to be used in test cases.
-pub trait TestView:
-    RootView<MemoryContext<()>> + ClonableView<MemoryContext<()>> + Send + Sync + 'static
-{
+pub trait TestView: RootView<Context = MemoryContext<()>> + ClonableView {
     /// Representation of the view's state.
     type State: Debug + Eq + Send;
 

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -514,7 +514,10 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
     /// assert_eq!(queue.back().await.unwrap(), Some(37));
     /// # })
     /// ```
-    pub async fn back(&mut self) -> Result<Option<T>, ViewError> where T: Clone {
+    pub async fn back(&mut self) -> Result<Option<T>, ViewError>
+    where
+        T: Clone,
+    {
         if let Some(value) = self.new_back_values.back() {
             return Ok(Some(value.clone()));
         }
@@ -689,7 +692,8 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
     }
 }
 
-impl<C: Context, T: Serialize + DeserializeOwned + Send + Sync + Clone, const N: usize> HashableView for BucketQueueView<C, T, N>
+impl<C: Context, T: Serialize + DeserializeOwned + Send + Sync + Clone, const N: usize> HashableView
+    for BucketQueueView<C, T, N>
 where
     Self: View,
 {

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -141,12 +141,14 @@ pub struct BucketQueueView<C, T, const N: usize> {
     delete_storage_first: bool,
 }
 
-impl<C, T, const N: usize> View<C> for BucketQueueView<C, T, N>
+impl<C, T, const N: usize> View for BucketQueueView<C, T, N>
 where
-    C: Context + Send + Sync,
+    C: Context,
     T: Send + Sync + Clone + Serialize + DeserializeOwned,
 {
     const NUM_INIT_KEYS: usize = 2;
+
+    type Context = C;
 
     fn context(&self) -> &C {
         &self.context
@@ -292,10 +294,9 @@ where
     }
 }
 
-impl<C, T, const N: usize> ClonableView<C> for BucketQueueView<C, T, N>
+impl<C: Clone, T: Clone, const N: usize> ClonableView for BucketQueueView<C, T, N>
 where
-    C: Context + Send + Sync,
-    T: Clone + Send + Sync + Serialize + DeserializeOwned,
+    Self: View,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         Ok(BucketQueueView {
@@ -309,10 +310,7 @@ where
     }
 }
 
-impl<C, T, const N: usize> BucketQueueView<C, T, N>
-where
-    C: Context + Send + Sync,
-{
+impl<C: Context, T, const N: usize> BucketQueueView<C, T, N> {
     /// Gets the key corresponding to the index
     fn get_index_key(&self, index: usize) -> Result<Vec<u8>, ViewError> {
         Ok(if index == 0 {
@@ -369,11 +367,7 @@ where
     }
 }
 
-impl<C, T, const N: usize> BucketQueueView<C, T, N>
-where
-    C: Context + Send + Sync,
-    T: Send + Sync + Clone + Serialize + DeserializeOwned,
-{
+impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C, T, N> {
     /// Gets a reference on the front value if any.
     /// ```rust
     /// # tokio_test::block_on(async {
@@ -520,7 +514,7 @@ where
     /// assert_eq!(queue.back().await.unwrap(), Some(37));
     /// # })
     /// ```
-    pub async fn back(&mut self) -> Result<Option<T>, ViewError> {
+    pub async fn back(&mut self) -> Result<Option<T>, ViewError> where T: Clone {
         if let Some(value) = self.new_back_values.back() {
             return Ok(Some(value.clone()));
         }
@@ -695,10 +689,9 @@ where
     }
 }
 
-impl<C, T, const N: usize> HashableView<C> for BucketQueueView<C, T, N>
+impl<C: Context, T: Serialize + DeserializeOwned + Send + Sync + Clone, const N: usize> HashableView for BucketQueueView<C, T, N>
 where
-    C: Context + Send + Sync,
-    T: Send + Sync + Clone + Serialize + DeserializeOwned,
+    Self: View,
 {
     type Hasher = sha3::Sha3_256;
 

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -1090,7 +1090,9 @@ impl<I: Send + Sync, W: View + Sync> View for CustomCollectionView<W::Context, I
     }
 }
 
-impl<I: Send + Sync, W: ClonableView + Sync> ClonableView for CustomCollectionView<W::Context, I, W> {
+impl<I: Send + Sync, W: ClonableView + Sync> ClonableView
+    for CustomCollectionView<W::Context, I, W>
+{
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         Ok(CustomCollectionView {
             collection: self.collection.clone_unchecked()?,

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -82,22 +82,20 @@ enum KeyTag {
     Subview,
 }
 
-impl<C, W> View<C> for ByteCollectionView<C, W>
-where
-    C: Context + Send + Sync,
-    W: View<C> + Send + Sync,
-{
+impl<W: View + Sync> View for ByteCollectionView<W::Context, W> {
     const NUM_INIT_KEYS: usize = 0;
 
-    fn context(&self) -> &C {
+    type Context = W::Context;
+
+    fn context(&self) -> &Self::Context {
         &self.context
     }
 
-    fn pre_load(_context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+    fn pre_load(_context: &Self::Context) -> Result<Vec<Vec<u8>>, ViewError> {
         Ok(vec![])
     }
 
-    fn post_load(context: C, _values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+    fn post_load(context: Self::Context, _values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
         Ok(Self {
             context,
             delete_storage_first: false,
@@ -105,7 +103,7 @@ where
         })
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
+    async fn load(context: Self::Context) -> Result<Self, ViewError> {
         Self::post_load(context, &[])
     }
 
@@ -160,11 +158,7 @@ where
     }
 }
 
-impl<C, W> ClonableView<C> for ByteCollectionView<C, W>
-where
-    C: Context + Send + Sync,
-    W: ClonableView<C> + Send + Sync,
-{
+impl<W: ClonableView + Sync> ClonableView for ByteCollectionView<W::Context, W> {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         let cloned_updates = self
             .updates
@@ -187,11 +181,7 @@ where
     }
 }
 
-impl<C, W> ByteCollectionView<C, W>
-where
-    C: Context + Send,
-    W: View<C>,
-{
+impl<W: View + Sync> ByteCollectionView<W::Context, W> {
     fn get_index_key(&self, index: &[u8]) -> Vec<u8> {
         self.context
             .base_key()
@@ -418,7 +408,7 @@ where
     }
 
     /// Gets the extra data.
-    pub fn extra(&self) -> &C::Extra {
+    pub fn extra(&self) -> &<W::Context as Context>::Extra {
         self.context.extra()
     }
 
@@ -464,11 +454,7 @@ where
     }
 }
 
-impl<C, W> ByteCollectionView<C, W>
-where
-    C: Context + Send,
-    W: View<C> + Sync,
-{
+impl<W: View + Sync> ByteCollectionView<W::Context, W> {
     /// Applies a function f on each index (aka key). Keys are visited in the
     /// lexicographic order. If the function returns false, then the loop
     /// ends prematurely.
@@ -630,11 +616,7 @@ where
     }
 }
 
-impl<C, W> HashableView<C> for ByteCollectionView<C, W>
-where
-    C: Context + Send + Sync,
-    W: HashableView<C> + Send + Sync + 'static,
-{
+impl<W: HashableView + Sync> HashableView for ByteCollectionView<W::Context, W> {
     type Hasher = sha3::Sha3_256;
 
     async fn hash_mut(&mut self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
@@ -710,23 +692,23 @@ pub struct CollectionView<C, I, W> {
     _phantom: PhantomData<I>,
 }
 
-impl<C, I, W> View<C> for CollectionView<C, I, W>
+impl<W: View + Sync, I> View for CollectionView<W::Context, I, W>
 where
-    C: Context + Send + Sync,
     I: Send + Sync + Serialize + DeserializeOwned,
-    W: View<C> + Send + Sync,
 {
-    const NUM_INIT_KEYS: usize = ByteCollectionView::<C, W>::NUM_INIT_KEYS;
+    const NUM_INIT_KEYS: usize = ByteCollectionView::<W::Context, W>::NUM_INIT_KEYS;
 
-    fn context(&self) -> &C {
+    type Context = W::Context;
+
+    fn context(&self) -> &Self::Context {
         self.collection.context()
     }
 
-    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
-        ByteCollectionView::<C, W>::pre_load(context)
+    fn pre_load(context: &Self::Context) -> Result<Vec<Vec<u8>>, ViewError> {
+        ByteCollectionView::<W::Context, W>::pre_load(context)
     }
 
-    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+    fn post_load(context: Self::Context, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
         let collection = ByteCollectionView::post_load(context, values)?;
         Ok(CollectionView {
             collection,
@@ -734,7 +716,7 @@ where
         })
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
+    async fn load(context: Self::Context) -> Result<Self, ViewError> {
         Self::post_load(context, &[])
     }
 
@@ -755,11 +737,9 @@ where
     }
 }
 
-impl<C, I, W> ClonableView<C> for CollectionView<C, I, W>
+impl<I, W: ClonableView + Sync> ClonableView for CollectionView<W::Context, I, W>
 where
-    C: Context + Send + Sync,
     I: Send + Sync + Serialize + DeserializeOwned,
-    W: ClonableView<C> + Send + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         Ok(CollectionView {
@@ -769,12 +749,7 @@ where
     }
 }
 
-impl<C, I, W> CollectionView<C, I, W>
-where
-    C: Context + Send,
-    I: Serialize,
-    W: View<C>,
-{
+impl<I: Serialize, W: View + Sync> CollectionView<W::Context, I, W> {
     /// Loads a subview for the data at the given index in the collection. If an entry
     /// is absent then a default entry is added to the collection. The resulting view
     /// can be modified.
@@ -920,16 +895,14 @@ where
     }
 
     /// Gets the extra data.
-    pub fn extra(&self) -> &C::Extra {
+    pub fn extra(&self) -> &<W::Context as Context>::Extra {
         self.collection.extra()
     }
 }
 
-impl<C, I, W> CollectionView<C, I, W>
+impl<I, W: View + Sync> CollectionView<W::Context, I, W>
 where
-    C: Context + Send,
     I: Sync + Clone + Send + Serialize + DeserializeOwned,
-    W: View<C> + Sync,
 {
     /// Returns the list of indices in the collection in the order determined by
     /// the serialization.
@@ -978,12 +951,7 @@ where
     }
 }
 
-impl<C, I, W> CollectionView<C, I, W>
-where
-    C: Context + Send,
-    I: DeserializeOwned,
-    W: View<C> + Sync,
-{
+impl<I: DeserializeOwned, W: View + Sync> CollectionView<W::Context, I, W> {
     /// Applies a function f on each index. Indices are visited in an order
     /// determined by the serialization. If the function returns false then
     /// the loop ends prematurely.
@@ -1058,11 +1026,9 @@ where
     }
 }
 
-impl<C, I, W> HashableView<C> for CollectionView<C, I, W>
+impl<I, W: HashableView + Sync> HashableView for CollectionView<W::Context, I, W>
 where
-    C: Context + Send + Sync,
     I: Clone + Send + Sync + Serialize + DeserializeOwned,
-    W: HashableView<C> + Send + Sync + 'static,
 {
     type Hasher = sha3::Sha3_256;
 
@@ -1082,23 +1048,20 @@ pub struct CustomCollectionView<C, I, W> {
     _phantom: PhantomData<I>,
 }
 
-impl<C, I, W> View<C> for CustomCollectionView<C, I, W>
-where
-    C: Context + Send + Sync,
-    I: Send + Sync,
-    W: View<C> + Send + Sync,
-{
-    const NUM_INIT_KEYS: usize = ByteCollectionView::<C, W>::NUM_INIT_KEYS;
+impl<I: Send + Sync, W: View + Sync> View for CustomCollectionView<W::Context, I, W> {
+    const NUM_INIT_KEYS: usize = ByteCollectionView::<W::Context, W>::NUM_INIT_KEYS;
 
-    fn context(&self) -> &C {
+    type Context = W::Context;
+
+    fn context(&self) -> &Self::Context {
         self.collection.context()
     }
 
-    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
-        ByteCollectionView::<C, W>::pre_load(context)
+    fn pre_load(context: &Self::Context) -> Result<Vec<Vec<u8>>, ViewError> {
+        ByteCollectionView::<_, W>::pre_load(context)
     }
 
-    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+    fn post_load(context: Self::Context, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
         let collection = ByteCollectionView::post_load(context, values)?;
         Ok(CustomCollectionView {
             collection,
@@ -1106,7 +1069,7 @@ where
         })
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
+    async fn load(context: Self::Context) -> Result<Self, ViewError> {
         Self::post_load(context, &[])
     }
 
@@ -1127,12 +1090,7 @@ where
     }
 }
 
-impl<C, I, W> ClonableView<C> for CustomCollectionView<C, I, W>
-where
-    C: Context + Send + Sync,
-    I: Send + Sync,
-    W: ClonableView<C> + Send + Sync,
-{
+impl<I: Send + Sync, W: ClonableView + Sync> ClonableView for CustomCollectionView<W::Context, I, W> {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         Ok(CustomCollectionView {
             collection: self.collection.clone_unchecked()?,
@@ -1141,12 +1099,7 @@ where
     }
 }
 
-impl<C, I, W> CustomCollectionView<C, I, W>
-where
-    C: Context + Send,
-    I: CustomSerialize,
-    W: View<C>,
-{
+impl<I: CustomSerialize, W: View + Sync> CustomCollectionView<W::Context, I, W> {
     /// Loads a subview for the data at the given index in the collection. If an entry
     /// is absent then a default entry is added to the collection. The resulting view
     /// can be modified.
@@ -1292,17 +1245,12 @@ where
     }
 
     /// Gets the extra data.
-    pub fn extra(&self) -> &C::Extra {
+    pub fn extra(&self) -> &<W::Context as Context>::Extra {
         self.collection.extra()
     }
 }
 
-impl<C, I, W> CustomCollectionView<C, I, W>
-where
-    C: Context + Send,
-    I: Send + CustomSerialize,
-    W: View<C> + Sync,
-{
+impl<I: CustomSerialize + Send, W: View + Sync> CustomCollectionView<W::Context, I, W> {
     /// Returns the list of indices in the collection in the order determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
@@ -1349,12 +1297,7 @@ where
     }
 }
 
-impl<C, I, W> CustomCollectionView<C, I, W>
-where
-    C: Context + Send,
-    I: CustomSerialize,
-    W: View<C> + Sync,
-{
+impl<I: CustomSerialize, W: View + Sync> CustomCollectionView<W::Context, I, W> {
     /// Applies a function f on each index. Indices are visited in an order
     /// determined by the custom serialization. If the function f returns false,
     /// then the loop ends prematurely.
@@ -1431,11 +1374,9 @@ where
     }
 }
 
-impl<C, I, W> HashableView<C> for CustomCollectionView<C, I, W>
+impl<I, W: HashableView + Sync> HashableView for CustomCollectionView<W::Context, I, W>
 where
-    C: Context + Send + Sync,
-    I: Clone + Send + Sync + CustomSerialize,
-    W: HashableView<C> + Send + Sync + 'static,
+    Self: View + Sync,
 {
     type Hasher = sha3::Sha3_256;
 
@@ -1466,7 +1407,6 @@ mod graphql {
 
     use super::{CollectionView, CustomCollectionView, ReadGuardedView};
     use crate::{
-        context::Context,
         graphql::{hash_name, mangle, missing_key_error, Entry, MapFilters, MapInput},
         views::View,
     };
@@ -1504,16 +1444,15 @@ mod graphql {
     }
 
     #[async_graphql::Object(cache_control(no_cache), name_type)]
-    impl<C, K, V> CollectionView<C, K, V>
+    impl<K, V> CollectionView<V::Context, K, V>
     where
-        C: Send + Sync + Context,
         K: async_graphql::InputType
             + async_graphql::OutputType
             + serde::ser::Serialize
             + serde::de::DeserializeOwned
             + std::fmt::Debug
             + Clone,
-        V: View<C> + async_graphql::OutputType,
+        V: View + async_graphql::OutputType,
         MapInput<K>: async_graphql::InputType,
         MapFilters<K>: async_graphql::InputType,
     {
@@ -1558,7 +1497,7 @@ mod graphql {
         }
     }
 
-    impl<C: Send + Sync, K: async_graphql::OutputType, V: async_graphql::OutputType>
+    impl<C: Send + Sync, K: async_graphql::InputType, V: async_graphql::OutputType>
         async_graphql::TypeName for CustomCollectionView<C, K, V>
     {
         fn type_name() -> Cow<'static, str> {
@@ -1573,14 +1512,13 @@ mod graphql {
     }
 
     #[async_graphql::Object(cache_control(no_cache), name_type)]
-    impl<C, K, V> CustomCollectionView<C, K, V>
+    impl<K, V> CustomCollectionView<V::Context, K, V>
     where
-        C: Send + Sync + Context,
         K: async_graphql::InputType
             + async_graphql::OutputType
             + crate::common::CustomSerialize
             + std::fmt::Debug,
-        V: View<C> + async_graphql::OutputType,
+        V: View + async_graphql::OutputType,
         MapInput<K>: async_graphql::InputType,
         MapFilters<K>: async_graphql::InputType,
     {

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -210,11 +210,10 @@ pub struct KeyValueStoreView<C> {
     hash: Mutex<Option<HasherOutput>>,
 }
 
-impl<C> View<C> for KeyValueStoreView<C>
-where
-    C: Context + Send + Sync,
-{
+impl<C: Context> View for KeyValueStoreView<C> {
     const NUM_INIT_KEYS: usize = 2 + ByteMapView::<C, u32>::NUM_INIT_KEYS;
+
+    type Context = C;
 
     fn context(&self) -> &C {
         &self.context
@@ -347,10 +346,7 @@ where
     }
 }
 
-impl<C> ClonableView<C> for KeyValueStoreView<C>
-where
-    C: Context + Send + Sync,
-{
+impl<C: Context> ClonableView for KeyValueStoreView<C> {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         Ok(KeyValueStoreView {
             context: self.context.clone(),
@@ -365,10 +361,7 @@ where
     }
 }
 
-impl<C> KeyValueStoreView<C>
-where
-    C: Send + Context + Sync,
-{
+impl<C: Context> KeyValueStoreView<C> {
     fn max_key_size(&self) -> usize {
         let prefix_len = self.context.base_key().bytes.len();
         <C::Store as ReadableKeyValueStore>::MAX_KEY_SIZE - 1 - prefix_len
@@ -1159,10 +1152,7 @@ where
     }
 }
 
-impl<C> HashableView<C> for KeyValueStoreView<C>
-where
-    C: Context + Send + Sync,
-{
+impl<C: Context> HashableView for KeyValueStoreView<C> {
     type Hasher = sha3::Sha3_256;
 
     async fn hash_mut(&mut self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
@@ -1223,10 +1213,7 @@ impl KeyValueStoreError for ViewContainerError {
 }
 
 #[cfg(with_testing)]
-impl<C> ReadableKeyValueStore for ViewContainer<C>
-where
-    C: Context + Sync + Send + Clone,
-{
+impl<C: Context> ReadableKeyValueStore for ViewContainer<C> {
     const MAX_KEY_SIZE: usize = <C::Store as ReadableKeyValueStore>::MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -1276,10 +1263,7 @@ where
 }
 
 #[cfg(with_testing)]
-impl<C> WritableKeyValueStore for ViewContainer<C>
-where
-    C: Context + Sync + Send + Clone,
-{
+impl<C: Context> WritableKeyValueStore for ViewContainer<C> {
     const MAX_VALUE_SIZE: usize = <C::Store as WritableKeyValueStore>::MAX_VALUE_SIZE;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), ViewContainerError> {
@@ -1301,10 +1285,7 @@ where
 }
 
 #[cfg(with_testing)]
-impl<C> ViewContainer<C>
-where
-    C: Context + Sync + Send + Clone,
-{
+impl<C: Context> ViewContainer<C> {
     /// Creates a [`ViewContainer`].
     pub async fn new(context: C) -> Result<Self, ViewError> {
         let view = KeyValueStoreView::load(context).await?;

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -192,7 +192,7 @@ where
 
 impl<C, T> LogView<C, T>
 where
-    C: Context + Send + Sync,
+    C: Context,
     T: Clone + DeserializeOwned + Serialize + Send + Sync,
 {
     /// Reads the logged value with the given index (including staged ones).

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -52,12 +52,14 @@ pub struct LogView<C, T> {
     new_values: Vec<T>,
 }
 
-impl<C, T> View<C> for LogView<C, T>
+impl<C, T> View for LogView<C, T>
 where
-    C: Context + Send + Sync,
+    C: Context,
     T: Send + Sync + Serialize,
 {
     const NUM_INIT_KEYS: usize = 1;
+
+    type Context = C;
 
     fn context(&self) -> &C {
         &self.context
@@ -127,9 +129,9 @@ where
     }
 }
 
-impl<C, T> ClonableView<C> for LogView<C, T>
+impl<C, T> ClonableView for LogView<C, T>
 where
-    C: Context + Send + Sync,
+    C: Context,
     T: Clone + Send + Sync + Serialize,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
@@ -191,7 +193,7 @@ where
 impl<C, T> LogView<C, T>
 where
     C: Context + Send + Sync,
-    T: Clone + DeserializeOwned + Serialize + Send,
+    T: Clone + DeserializeOwned + Serialize + Send + Sync,
 {
     /// Reads the logged value with the given index (including staged ones).
     /// ```rust
@@ -346,9 +348,9 @@ where
     }
 }
 
-impl<C, T> HashableView<C> for LogView<C, T>
+impl<C, T> HashableView for LogView<C, T>
 where
-    C: Context + Send + Sync,
+    C: Context,
     T: Send + Sync + Clone + Serialize + DeserializeOwned,
 {
     type Hasher = sha3::Sha3_256;
@@ -394,7 +396,6 @@ mod graphql {
     #[async_graphql::Object(cache_control(no_cache), name_type)]
     impl<C: Context, T: async_graphql::OutputType> LogView<C, T>
     where
-        C: Send + Sync,
         T: serde::ser::Serialize + serde::de::DeserializeOwned + Clone + Send + Sync,
     {
         async fn entries(

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -289,7 +289,7 @@ where
 
 impl<C, V> ByteMapView<C, V>
 where
-    C: Context + Sync,
+    C: Context,
     V: Clone + DeserializeOwned + 'static,
 {
     /// Reads the value at the given position, if any.
@@ -861,7 +861,7 @@ where
 
 impl<C, V> ByteMapView<C, V>
 where
-    C: Context + Sync,
+    C: Context,
     V: Default + DeserializeOwned + 'static,
 {
     /// Obtains a mutable reference to a value at a given position.
@@ -1017,7 +1017,7 @@ where
 
 impl<C, I, V> MapView<C, I, V>
 where
-    C: Context + Sync,
+    C: Context,
     I: Serialize,
 {
     /// Inserts or resets a value at an index.
@@ -1339,7 +1339,7 @@ where
 
 impl<C, I, V> MapView<C, I, V>
 where
-    C: Context + Sync,
+    C: Context,
     I: Send + DeserializeOwned,
     V: Clone + Sync + Send + Serialize + DeserializeOwned + 'static,
 {
@@ -1578,7 +1578,7 @@ impl<C: Context, I: CustomSerialize, V> CustomMapView<C, I, V> {
 
 impl<C, I, V> CustomMapView<C, I, V>
 where
-    C: Context + Sync,
+    C: Context,
     I: CustomSerialize,
     V: Clone + DeserializeOwned + 'static,
 {
@@ -1636,7 +1636,7 @@ where
 
 impl<C, I, V> CustomMapView<C, I, V>
 where
-    C: Context + Sync,
+    C: Context,
     I: Send + CustomSerialize,
     V: Clone + Serialize + DeserializeOwned + 'static,
 {
@@ -1823,7 +1823,7 @@ where
 
 impl<C, I, V> CustomMapView<C, I, V>
 where
-    C: Context + Sync,
+    C: Context,
     I: Send + CustomSerialize,
     V: Clone + Sync + Send + Serialize + DeserializeOwned + 'static,
 {
@@ -1874,7 +1874,7 @@ where
 
 impl<C, I, V> CustomMapView<C, I, V>
 where
-    C: Context + Sync,
+    C: Context,
     I: CustomSerialize,
     V: Default + DeserializeOwned + 'static,
 {
@@ -1905,7 +1905,7 @@ where
 
 impl<C, I, V> HashableView for CustomMapView<C, I, V>
 where
-    C: Context + Send + Sync,
+    C: Context,
     I: Send + Sync + CustomSerialize,
     V: Clone + Send + Sync + Serialize + DeserializeOwned + 'static,
 {

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -51,21 +51,24 @@ pub const MIN_VIEW_TAG: u8 = 1;
 /// A view gives exclusive access to read and write the data stored at an underlying
 /// address in storage.
 #[cfg_attr(not(web), trait_variant::make(Send))]
-pub trait View<C>: Sized {
+pub trait View: Sized {
     /// The number of keys used for the initialization
     const NUM_INIT_KEYS: usize;
 
+    /// The type of context stored in this view
+    type Context: crate::context::Context;
+
     /// Obtains a mutable reference to the internal context.
-    fn context(&self) -> &C;
+    fn context(&self) -> &Self::Context;
 
     /// Creates the keys needed for loading the view
-    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError>;
+    fn pre_load(context: &Self::Context) -> Result<Vec<Vec<u8>>, ViewError>;
 
     /// Loads a view from the values
-    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError>;
+    fn post_load(context: Self::Context, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError>;
 
     /// Loads a view
-    async fn load(context: C) -> Result<Self, ViewError>;
+    async fn load(context: Self::Context) -> Result<Self, ViewError>;
 
     /// Discards all pending changes. After that `flush` should have no effect to storage.
     fn rollback(&mut self);
@@ -85,7 +88,7 @@ pub trait View<C>: Sized {
     fn flush(&mut self, batch: &mut Batch) -> Result<bool, ViewError>;
 
     /// Builds a trivial view that is already deleted
-    fn new(context: C) -> Result<Self, ViewError> {
+    fn new(context: Self::Context) -> Result<Self, ViewError> {
         let values = vec![None; Self::NUM_INIT_KEYS];
         let mut view = Self::post_load(context, &values)?;
         view.clear();
@@ -95,7 +98,7 @@ pub trait View<C>: Sized {
 
 /// A view that supports hashing its values.
 #[cfg_attr(not(web), trait_variant::make(Send))]
-pub trait HashableView<C>: View<C> {
+pub trait HashableView: View {
     /// How to compute hashes.
     type Hasher: Hasher;
 
@@ -145,14 +148,14 @@ impl Hasher for sha3::Sha3_256 {
 
 /// A [`View`] whose staged modifications can be saved in storage.
 #[cfg_attr(not(web), trait_variant::make(Send))]
-pub trait RootView<C>: View<C> {
+pub trait RootView: View {
     /// Saves the root view to the database context
     async fn save(&mut self) -> Result<(), ViewError>;
 }
 
 /// A [`View`] that also supports crypto hash
 #[cfg_attr(not(web), trait_variant::make(Send))]
-pub trait CryptoHashView<C>: HashableView<C> {
+pub trait CryptoHashView: HashableView {
     /// Computing the hash and attributing the type to it.
     async fn crypto_hash(&self) -> Result<CryptoHash, ViewError>;
 
@@ -162,7 +165,7 @@ pub trait CryptoHashView<C>: HashableView<C> {
 
 /// A [`RootView`] that also supports crypto hash
 #[cfg_attr(not(web), trait_variant::make(Send))]
-pub trait CryptoHashRootView<C>: RootView<C> + CryptoHashView<C> {}
+pub trait CryptoHashRootView: RootView + CryptoHashView {}
 
 /// A [`ClonableView`] supports being shared (unsafely) by cloning it.
 ///
@@ -171,7 +174,7 @@ pub trait CryptoHashRootView<C>: RootView<C> + CryptoHashView<C> {}
 ///
 /// Sharing the view is guaranteed to not cause data races if only one of the shared view instances
 /// is used for writing at any given point in time.
-pub trait ClonableView<C>: View<C> {
+pub trait ClonableView: View {
     /// Creates a clone of this view, sharing the underlying storage context but prone to
     /// data races which can corrupt the view state.
     fn clone_unchecked(&mut self) -> Result<Self, ViewError>;

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -56,12 +56,14 @@ pub struct QueueView<C, T> {
     new_back_values: VecDeque<T>,
 }
 
-impl<C, T> View<C> for QueueView<C, T>
+impl<C, T> View for QueueView<C, T>
 where
-    C: Context + Send + Sync,
-    T: Send + Sync + Serialize,
+    C: Context,
+    T: Serialize + Send + Sync,
 {
     const NUM_INIT_KEYS: usize = 1;
+
+    type Context = C;
 
     fn context(&self) -> &C {
         &self.context
@@ -153,9 +155,9 @@ where
     }
 }
 
-impl<C, T> ClonableView<C> for QueueView<C, T>
+impl<C, T> ClonableView for QueueView<C, T>
 where
-    C: Context + Send + Sync,
+    C: Context,
     T: Clone + Send + Sync + Serialize,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
@@ -451,9 +453,9 @@ where
     }
 }
 
-impl<C, T> HashableView<C> for QueueView<C, T>
+impl<C, T> HashableView for QueueView<C, T>
 where
-    C: Context + Send + Sync,
+    C: Context,
     T: Send + Sync + Clone + Serialize + DeserializeOwned,
 {
     type Hasher = sha3::Sha3_256;

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -183,7 +183,7 @@ impl<C, T> QueueView<C, T> {
 
 impl<'a, C, T> QueueView<C, T>
 where
-    C: Context + Send + Sync,
+    C: Context,
     T: Send + Sync + Clone + Serialize + DeserializeOwned,
 {
     async fn get(&self, index: usize) -> Result<Option<T>, ViewError> {

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -1072,8 +1072,9 @@ pub struct ReentrantCollectionView<C, I, W> {
     _phantom: PhantomData<I>,
 }
 
-impl<I, W: View + Sync> View for ReentrantCollectionView<W::Context, I, W>
+impl<I, W> View for ReentrantCollectionView<W::Context, I, W>
 where
+    W: View + Sync,
     I: Send + Sync + Serialize + DeserializeOwned,
 {
     const NUM_INIT_KEYS: usize = ReentrantByteCollectionView::<W::Context, W>::NUM_INIT_KEYS;
@@ -1117,8 +1118,9 @@ where
     }
 }
 
-impl<I, W: ClonableView + Sync> ClonableView for ReentrantCollectionView<W::Context, I, W>
+impl<I, W> ClonableView for ReentrantCollectionView<W::Context, I, W>
 where
+    W: ClonableView + Sync,
     I: Send + Sync + Serialize + DeserializeOwned,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
@@ -1129,8 +1131,9 @@ where
     }
 }
 
-impl<I, W: View + Sync> ReentrantCollectionView<W::Context, I, W>
+impl<I, W> ReentrantCollectionView<W::Context, I, W>
 where
+    W: View + Sync,
     I: Sync + Clone + Send + Serialize + DeserializeOwned,
 {
     /// Loads a subview for the data at the given index in the collection. If an entry
@@ -1281,8 +1284,9 @@ where
     }
 }
 
-impl<I, W: View + Sync> ReentrantCollectionView<W::Context, I, W>
+impl<I, W> ReentrantCollectionView<W::Context, I, W>
 where
+    W: View + Sync,
     I: Sync + Clone + Send + Serialize + DeserializeOwned,
 {
     /// Load multiple entries for writing at once.
@@ -1426,8 +1430,9 @@ where
     }
 }
 
-impl<I, W: View + Sync> ReentrantCollectionView<W::Context, I, W>
+impl<I, W> ReentrantCollectionView<W::Context, I, W>
 where
+    W: View + Sync,
     I: Sync + Clone + Send + Serialize + DeserializeOwned,
 {
     /// Returns the list of indices in the collection in an order determined
@@ -1550,8 +1555,9 @@ where
     }
 }
 
-impl<I, W: HashableView + Sync> HashableView for ReentrantCollectionView<W::Context, I, W>
+impl<I, W> HashableView for ReentrantCollectionView<W::Context, I, W>
 where
+    W: HashableView + Sync,
     I: Send + Sync + Serialize + DeserializeOwned,
 {
     type Hasher = sha3::Sha3_256;
@@ -1573,8 +1579,9 @@ pub struct ReentrantCustomCollectionView<C, I, W> {
     _phantom: PhantomData<I>,
 }
 
-impl<I, W: View + Sync> View for ReentrantCustomCollectionView<W::Context, I, W>
+impl<I, W> View for ReentrantCustomCollectionView<W::Context, I, W>
 where
+    W: View + Sync,
     I: Send + Sync + CustomSerialize,
 {
     const NUM_INIT_KEYS: usize = ReentrantByteCollectionView::<W::Context, W>::NUM_INIT_KEYS;
@@ -1618,8 +1625,9 @@ where
     }
 }
 
-impl<I, W: ClonableView + Sync> ClonableView for ReentrantCustomCollectionView<W::Context, I, W>
+impl<I, W> ClonableView for ReentrantCustomCollectionView<W::Context, I, W>
 where
+    W: ClonableView + Sync,
     Self: View,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
@@ -1630,8 +1638,9 @@ where
     }
 }
 
-impl<I, W: View + Sync> ReentrantCustomCollectionView<W::Context, I, W>
+impl<I, W> ReentrantCustomCollectionView<W::Context, I, W>
 where
+    W: View + Sync,
     I: Sync + Clone + Send + CustomSerialize,
 {
     /// Loads a subview for the data at the given index in the collection. If an entry
@@ -1926,8 +1935,9 @@ where
     }
 }
 
-impl<I, W: View + Sync> ReentrantCustomCollectionView<W::Context, I, W>
+impl<I, W> ReentrantCustomCollectionView<W::Context, I, W>
 where
+    W: View + Sync,
     I: Sync + Clone + Send + CustomSerialize,
 {
     /// Returns the list of indices in the collection. The order is determined by
@@ -2052,8 +2062,9 @@ where
     }
 }
 
-impl<I, W: HashableView + Sync> HashableView for ReentrantCustomCollectionView<W::Context, I, W>
+impl<I, W> HashableView for ReentrantCustomCollectionView<W::Context, I, W>
 where
+    W: HashableView + Sync,
     I: Send + Sync + CustomSerialize,
 {
     type Hasher = sha3::Sha3_256;

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -100,22 +100,20 @@ enum KeyTag {
     Subview,
 }
 
-impl<C, W> View<C> for ReentrantByteCollectionView<C, W>
-where
-    C: Context + Send + Sync,
-    W: View<C> + Send + Sync,
-{
+impl<W: View + Sync> View for ReentrantByteCollectionView<W::Context, W> {
     const NUM_INIT_KEYS: usize = 0;
 
-    fn context(&self) -> &C {
+    type Context = W::Context;
+
+    fn context(&self) -> &Self::Context {
         &self.context
     }
 
-    fn pre_load(_context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+    fn pre_load(_context: &Self::Context) -> Result<Vec<Vec<u8>>, ViewError> {
         Ok(Vec::new())
     }
 
-    fn post_load(context: C, _values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+    fn post_load(context: Self::Context, _values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
         Ok(Self {
             context,
             delete_storage_first: false,
@@ -124,7 +122,7 @@ where
         })
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
+    async fn load(context: Self::Context) -> Result<Self, ViewError> {
         Self::post_load(context, &[])
     }
 
@@ -185,11 +183,7 @@ where
     }
 }
 
-impl<C, W> ClonableView<C> for ReentrantByteCollectionView<C, W>
-where
-    C: Context + Send + Sync,
-    W: ClonableView<C> + Send + Sync,
-{
+impl<W: ClonableView + Sync> ClonableView for ReentrantByteCollectionView<W::Context, W> {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         let cloned_updates = self
             .updates
@@ -237,14 +231,10 @@ impl<C: Context, W> ReentrantByteCollectionView<C, W> {
     }
 }
 
-impl<C, W> ReentrantByteCollectionView<C, W>
-where
-    C: Context + Send,
-    W: View<C> + Send + Sync,
-{
+impl<W: View + Sync> ReentrantByteCollectionView<W::Context, W> {
     /// Reads the view and if missing returns the default view
     async fn wrapped_view(
-        context: &C,
+        context: &W::Context,
         delete_storage_first: bool,
         short_key: &[u8],
     ) -> Result<Arc<RwLock<W>>, ViewError> {
@@ -483,16 +473,12 @@ where
     }
 
     /// Gets the extra data.
-    pub fn extra(&self) -> &C::Extra {
+    pub fn extra(&self) -> &<W::Context as Context>::Extra {
         self.context.extra()
     }
 }
 
-impl<C, W> ReentrantByteCollectionView<C, W>
-where
-    C: Context + Send + Clone + 'static,
-    W: View<C> + Send + Sync + 'static,
-{
+impl<W: View + Sync> ReentrantByteCollectionView<W::Context, W> {
     /// Loads multiple entries for writing at once.
     /// The entries in `short_keys` have to be all distinct.
     /// ```rust
@@ -833,11 +819,7 @@ where
     }
 }
 
-impl<C, W> ReentrantByteCollectionView<C, W>
-where
-    C: Context + Send,
-    W: View<C> + Send + Sync,
-{
+impl<W: View + Sync> ReentrantByteCollectionView<W::Context, W> {
     /// Returns the list of indices in the collection in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
@@ -998,11 +980,7 @@ where
     }
 }
 
-impl<C, W> HashableView<C> for ReentrantByteCollectionView<C, W>
-where
-    C: Context + Send + Sync,
-    W: HashableView<C> + Send + Sync + 'static,
-{
+impl<W: HashableView + Sync> HashableView for ReentrantByteCollectionView<W::Context, W> {
     type Hasher = sha3::Sha3_256;
 
     async fn hash_mut(&mut self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
@@ -1094,23 +1072,23 @@ pub struct ReentrantCollectionView<C, I, W> {
     _phantom: PhantomData<I>,
 }
 
-impl<C, I, W> View<C> for ReentrantCollectionView<C, I, W>
+impl<I, W: View + Sync> View for ReentrantCollectionView<W::Context, I, W>
 where
-    C: Context + Send + Sync,
     I: Send + Sync + Serialize + DeserializeOwned,
-    W: View<C> + Send + Sync,
 {
-    const NUM_INIT_KEYS: usize = ReentrantByteCollectionView::<C, W>::NUM_INIT_KEYS;
+    const NUM_INIT_KEYS: usize = ReentrantByteCollectionView::<W::Context, W>::NUM_INIT_KEYS;
 
-    fn context(&self) -> &C {
+    type Context = W::Context;
+
+    fn context(&self) -> &Self::Context {
         self.collection.context()
     }
 
-    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
-        ReentrantByteCollectionView::<C, W>::pre_load(context)
+    fn pre_load(context: &Self::Context) -> Result<Vec<Vec<u8>>, ViewError> {
+        ReentrantByteCollectionView::<W::Context, W>::pre_load(context)
     }
 
-    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+    fn post_load(context: Self::Context, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
         let collection = ReentrantByteCollectionView::post_load(context, values)?;
         Ok(ReentrantCollectionView {
             collection,
@@ -1118,7 +1096,7 @@ where
         })
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
+    async fn load(context: Self::Context) -> Result<Self, ViewError> {
         Self::post_load(context, &[])
     }
 
@@ -1139,11 +1117,9 @@ where
     }
 }
 
-impl<C, I, W> ClonableView<C> for ReentrantCollectionView<C, I, W>
+impl<I, W: ClonableView + Sync> ClonableView for ReentrantCollectionView<W::Context, I, W>
 where
-    C: Context + Send + Sync,
     I: Send + Sync + Serialize + DeserializeOwned,
-    W: ClonableView<C> + Send + Sync,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         Ok(ReentrantCollectionView {
@@ -1153,11 +1129,9 @@ where
     }
 }
 
-impl<C, I, W> ReentrantCollectionView<C, I, W>
+impl<I, W: View + Sync> ReentrantCollectionView<W::Context, I, W>
 where
-    C: Context + Send,
     I: Sync + Clone + Send + Serialize + DeserializeOwned,
-    W: View<C> + Send + Sync,
 {
     /// Loads a subview for the data at the given index in the collection. If an entry
     /// is absent then a default entry is put on the collection. The obtained view can
@@ -1302,16 +1276,14 @@ where
     }
 
     /// Gets the extra data.
-    pub fn extra(&self) -> &C::Extra {
+    pub fn extra(&self) -> &<W::Context as Context>::Extra {
         self.collection.extra()
     }
 }
 
-impl<C, I, W> ReentrantCollectionView<C, I, W>
+impl<I, W: View + Sync> ReentrantCollectionView<W::Context, I, W>
 where
-    C: Context + Send + Clone + 'static,
     I: Sync + Clone + Send + Serialize + DeserializeOwned,
-    W: View<C> + Send + Sync + 'static,
 {
     /// Load multiple entries for writing at once.
     /// The entries in indices have to be all distinct.
@@ -1454,11 +1426,9 @@ where
     }
 }
 
-impl<C, I, W> ReentrantCollectionView<C, I, W>
+impl<I, W: View + Sync> ReentrantCollectionView<W::Context, I, W>
 where
-    C: Context + Send,
     I: Sync + Clone + Send + Serialize + DeserializeOwned,
-    W: View<C> + Send + Sync,
 {
     /// Returns the list of indices in the collection in an order determined
     /// by serialization.
@@ -1580,11 +1550,9 @@ where
     }
 }
 
-impl<C, I, W> HashableView<C> for ReentrantCollectionView<C, I, W>
+impl<I, W: HashableView + Sync> HashableView for ReentrantCollectionView<W::Context, I, W>
 where
-    C: Context + Send + Sync,
     I: Send + Sync + Serialize + DeserializeOwned,
-    W: HashableView<C> + Send + Sync + 'static,
 {
     type Hasher = sha3::Sha3_256;
 
@@ -1605,23 +1573,23 @@ pub struct ReentrantCustomCollectionView<C, I, W> {
     _phantom: PhantomData<I>,
 }
 
-impl<C, I, W> View<C> for ReentrantCustomCollectionView<C, I, W>
+impl<I, W: View + Sync> View for ReentrantCustomCollectionView<W::Context, I, W>
 where
-    C: Context + Send + Sync,
     I: Send + Sync + CustomSerialize,
-    W: View<C> + Send + Sync,
 {
-    const NUM_INIT_KEYS: usize = ReentrantByteCollectionView::<C, W>::NUM_INIT_KEYS;
+    const NUM_INIT_KEYS: usize = ReentrantByteCollectionView::<W::Context, W>::NUM_INIT_KEYS;
 
-    fn context(&self) -> &C {
+    type Context = W::Context;
+
+    fn context(&self) -> &Self::Context {
         self.collection.context()
     }
 
-    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
-        ReentrantByteCollectionView::<C, W>::pre_load(context)
+    fn pre_load(context: &Self::Context) -> Result<Vec<Vec<u8>>, ViewError> {
+        ReentrantByteCollectionView::<_, W>::pre_load(context)
     }
 
-    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+    fn post_load(context: Self::Context, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
         let collection = ReentrantByteCollectionView::post_load(context, values)?;
         Ok(ReentrantCustomCollectionView {
             collection,
@@ -1629,7 +1597,7 @@ where
         })
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
+    async fn load(context: Self::Context) -> Result<Self, ViewError> {
         Self::post_load(context, &[])
     }
 
@@ -1650,11 +1618,9 @@ where
     }
 }
 
-impl<C, I, W> ClonableView<C> for ReentrantCustomCollectionView<C, I, W>
+impl<I, W: ClonableView + Sync> ClonableView for ReentrantCustomCollectionView<W::Context, I, W>
 where
-    C: Context + Send + Sync,
-    I: Send + Sync + CustomSerialize,
-    W: ClonableView<C> + Send + Sync,
+    Self: View,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         Ok(ReentrantCustomCollectionView {
@@ -1664,11 +1630,9 @@ where
     }
 }
 
-impl<C, I, W> ReentrantCustomCollectionView<C, I, W>
+impl<I, W: View + Sync> ReentrantCustomCollectionView<W::Context, I, W>
 where
-    C: Context + Send,
     I: Sync + Clone + Send + CustomSerialize,
-    W: View<C> + Send + Sync,
 {
     /// Loads a subview for the data at the given index in the collection. If an entry
     /// is absent then a default entry is put in the collection on this index.
@@ -1814,16 +1778,14 @@ where
     }
 
     /// Gets the extra data.
-    pub fn extra(&self) -> &C::Extra {
+    pub fn extra(&self) -> &<W::Context as Context>::Extra {
         self.collection.extra()
     }
 }
 
-impl<C, I, W> ReentrantCustomCollectionView<C, I, W>
+impl<I, W: View + Sync> ReentrantCustomCollectionView<W::Context, I, W>
 where
-    C: Context + Send + Clone + 'static,
     I: Sync + Clone + Send + CustomSerialize,
-    W: View<C> + Send + Sync + 'static,
 {
     /// Load multiple entries for writing at once.
     /// The entries in indices have to be all distinct.
@@ -1964,11 +1926,9 @@ where
     }
 }
 
-impl<C, I, W> ReentrantCustomCollectionView<C, I, W>
+impl<I, W: View + Sync> ReentrantCustomCollectionView<W::Context, I, W>
 where
-    C: Context + Send,
     I: Sync + Clone + Send + CustomSerialize,
-    W: View<C> + Send + Sync,
 {
     /// Returns the list of indices in the collection. The order is determined by
     /// the custom serialization.
@@ -2092,11 +2052,9 @@ where
     }
 }
 
-impl<C, I, W> HashableView<C> for ReentrantCustomCollectionView<C, I, W>
+impl<I, W: HashableView + Sync> HashableView for ReentrantCustomCollectionView<W::Context, I, W>
 where
-    C: Context + Send + Sync,
     I: Send + Sync + CustomSerialize,
-    W: HashableView<C> + Send + Sync + 'static,
 {
     type Hasher = sha3::Sha3_256;
 
@@ -2127,7 +2085,6 @@ mod graphql {
 
     use super::{ReadGuardedView, ReentrantCollectionView};
     use crate::{
-        context::Context,
         graphql::{hash_name, mangle, missing_key_error, Entry, MapFilters, MapInput},
         views::View,
     };
@@ -2165,16 +2122,15 @@ mod graphql {
     }
 
     #[async_graphql::Object(cache_control(no_cache), name_type)]
-    impl<C, K, V> ReentrantCollectionView<C, K, V>
+    impl<K, V> ReentrantCollectionView<V::Context, K, V>
     where
-        C: Send + Sync + Context,
         K: async_graphql::InputType
             + async_graphql::OutputType
             + serde::ser::Serialize
             + serde::de::DeserializeOwned
             + std::fmt::Debug
             + Clone,
-        V: View<C> + async_graphql::OutputType,
+        V: View + async_graphql::OutputType,
         MapInput<K>: async_graphql::InputType,
         MapFilters<K>: async_graphql::InputType,
     {
@@ -2235,15 +2191,14 @@ mod graphql {
     }
 
     #[async_graphql::Object(cache_control(no_cache), name_type)]
-    impl<C, K, V> ReentrantCustomCollectionView<C, K, V>
+    impl<K, V> ReentrantCustomCollectionView<V::Context, K, V>
     where
-        C: Send + Sync + Context,
         K: async_graphql::InputType
             + async_graphql::OutputType
             + crate::common::CustomSerialize
             + std::fmt::Debug
             + Clone,
-        V: View<C> + async_graphql::OutputType,
+        V: View + async_graphql::OutputType,
         MapInput<K>: async_graphql::InputType,
         MapFilters<K>: async_graphql::InputType,
     {

--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -230,6 +230,7 @@ where
 pub type HashedRegisterView<C, T> =
     WrappedHashableContainerView<C, RegisterView<C, T>, HasherOutput>;
 
+#[cfg(with_graphql)]
 mod graphql {
     use std::borrow::Cow;
 
@@ -238,7 +239,7 @@ mod graphql {
 
     impl<C, T> async_graphql::OutputType for RegisterView<C, T>
     where
-        C: Context,
+        C: Context + Send + Sync,
         T: async_graphql::OutputType + Send + Sync,
     {
         fn type_name() -> Cow<'static, str> {

--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -42,12 +42,14 @@ pub struct RegisterView<C, T> {
     update: Option<Box<T>>,
 }
 
-impl<C, T> View<C> for RegisterView<C, T>
+impl<C, T> View for RegisterView<C, T>
 where
-    C: Context + Send + Sync,
+    C: Context,
     T: Default + Send + Sync + Serialize + DeserializeOwned,
 {
     const NUM_INIT_KEYS: usize = 1;
+
+    type Context = C;
 
     fn context(&self) -> &C {
         &self.context
@@ -109,9 +111,9 @@ where
     }
 }
 
-impl<C, T> ClonableView<C> for RegisterView<C, T>
+impl<C, T> ClonableView for RegisterView<C, T>
 where
-    C: Context + Send + Sync,
+    C: Context,
     T: Clone + Default + Send + Sync + Serialize + DeserializeOwned,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
@@ -208,9 +210,9 @@ where
     }
 }
 
-impl<C, T> HashableView<C> for RegisterView<C, T>
+impl<C, T> HashableView for RegisterView<C, T>
 where
-    C: Context + Send + Sync,
+    C: Context,
     T: Clone + Default + Send + Sync + Serialize + DeserializeOwned,
 {
     type Hasher = sha3::Sha3_256;
@@ -236,7 +238,7 @@ mod graphql {
 
     impl<C, T> async_graphql::OutputType for RegisterView<C, T>
     where
-        C: Context + Send + Sync,
+        C: Context,
         T: async_graphql::OutputType + Send + Sync,
     {
         fn type_name() -> Cow<'static, str> {

--- a/linera-views/src/views/unit_tests/views.rs
+++ b/linera-views/src/views/unit_tests/views.rs
@@ -500,10 +500,7 @@ async fn test_flushing_cleared_view<V: TestView>(_view_type: PhantomData<V>) -> 
 }
 
 /// Saves a [`View`] into the [`MemoryContext<()>`] storage simulation.
-async fn save_view<C>(context: &C, view: &mut impl View<C>) -> anyhow::Result<()>
-where
-    C: Context<Error: Send + Sync>,
-{
+async fn save_view<V: View>(context: &V::Context, view: &mut V) -> anyhow::Result<()> {
     let mut batch = Batch::new();
     view.flush(&mut batch)?;
     context.store().write_batch(batch).await?;


### PR DESCRIPTION
## Motivation

Since I'm working with `linera-views` pretty heavily, I'd like to make it easier to modify.  One source of pain is that we parameterize the `View` trait by its context type.  This is semantically incorrect, as each view can have only a single context type that is fully determined by its fully-instantiated type (specifically, by the type of the context contained within the view), and pragmatically speaking means we can't write down the requirements on that context in the `View` trait itself, and have to duplicate them at use sites, which makes modifying those bounds painful.

## Proposal

Make the `Context` an associated type on the `View` trait, with all necessary bounds (except some `Sync`s: see below).

## Test Plan

CI.

## Release Plan
- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

## Future work

There remains a `V: View + Sync` bound on some of the implementers (e.g. `MapView`) that forbids using those implementers on the Web, where views are not `Sync` as the `IndexedDbStore` is not `Sync`.  Removing this bound is non-trivial because there is a `ReadKeyValueStore` implementation for `storage-service` that is decidedly not `Sync`.  I will need to make that implementation `Sync`, remove the need for the `Sync` bound, or do some complex conditional compilation, but this is at least a step in the right direction.