### PR TITLE
Small changes to speed up and trim down CI costs.

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -3,14 +3,6 @@ name: Docker Compose
 on:
   push:
     branches: [ main, 'devnet_*', 'testnet_*' ]
-  pull_request:
-    branches:
-      - "**"
-    paths:
-      - 'docker/**'
-      - 'Cargo.toml'
-      - '.github/workflows/docker-compose.yml'
-      - 'toolchains/**'
   workflow_dispatch:
 
 # This allows a subsequently queued workflow run to interrupt previous runs on pull-requests

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -2,7 +2,8 @@ name: Docker Compose
 
 on:
   push:
-    branches: [ main, 'devnet_*', 'testnet_*' ]
+    branches: [ 'devnet_*', 'testnet_*' ]
+    merge_group:
   workflow_dispatch:
 
 # This allows a subsequently queued workflow run to interrupt previous runs on pull-requests

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -6,7 +6,7 @@ on:
     merge_group:
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull-requests
+# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
   cancel-in-progress: true

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -1,11 +1,10 @@
-name: Run README tests
+name: Lint check all features
 
 on:
   push:
     branches: [ 'devnet_*', 'testnet_*' ]
     merge_group:
   workflow_dispatch:
-  
 
 # This allows a subsequently queued workflow run to interrupt previous runs on pull-requests
 concurrency:
@@ -16,39 +15,35 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
-  RUST_BACKTRACE: full
+  RUST_BACKTRACE: short
   # We allow redundant explicit links because `cargo rdme` doesn't know how to resolve implicit intra-crate links.
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
-  RUST_LOG: linera=debug
-  RUST_LOG_FORMAT: plain
-  LINERA_STORAGE_SERVICE: 127.0.0.1:1235
-  LINERA_WALLET: /tmp/local-linera-net/wallet_0.json
-  LINERA_KEYSTORE: /tmp/local-linera-net/keystore_0.json
-  LINERA_STORAGE: rocksdb:/tmp/local-linera-net/client_0.db
-  LINERA_FAUCET_URL: http://localhost:8079
+  RUST_LOG: warn
+  DOCKER_COMPOSE_WAIT: "true"
 
 permissions:
   contents: read
 
 jobs:
-  test-readme-scripts:
+  lint-check-all-features:
     runs-on: ubuntu-latest-16-cores
     timeout-minutes: 40
+
     steps:
     - uses: actions/checkout@v4
+    - name: Put lint toolchain file in place
+      run: |
+        ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: Install cargo-all-features
+      run: |
+        cargo install --git https://github.com/ma2bd/cargo-all-features --branch workspace_metadata --locked
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build example applications
+    - name: Run cargo check-all-features
       run: |
-        cd examples
-        cargo build --locked --release --target wasm32-unknown-unknown
-        cd ..
-        cargo build --locked -p linera-storage-service
-    - name: Run the storage-service instance and the README script tests
-      run: |
-        cargo test --locked -p linera-service --features storage-service -- test_script_in_readme --nocapture
+        cargo check-all-features --all-targets

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -110,7 +110,7 @@ jobs:
         cargo test --locked
 
   default-features-and-witty-integration-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -283,7 +283,7 @@ jobs:
         WASM_BINDGEN_TEST_TIMEOUT=300 wasm-pack test --chrome --headless -- --features web-default
 
   check-wit-files:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -445,24 +445,3 @@ jobs:
     - name: Check linera-service GraphQL schema
       run: |
         diff <(cargo run --locked --bin linera-schema-export) linera-service-graphql-client/gql/service_schema.graphql
-
-  lint-check-all-features:
-    runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 40
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Put lint toolchain file in place
-      run: |
-        ln -sf toolchains/nightly/rust-toolchain.toml
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - name: Install cargo-all-features
-      run: |
-        cargo install --git https://github.com/ma2bd/cargo-all-features --branch workspace_metadata --locked
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Run cargo check-all-features
-      run: |
-        cargo check-all-features --all-targets

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -234,26 +234,6 @@ jobs:
         cargo run --release -p linera-storage-service -- memory --endpoint $LINERA_STORAGE_SERVICE &
         cargo test --features storage-service -- storage_service --nocapture
 
-  test-readme-scripts:
-    runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 40
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build example applications
-      run: |
-        cd examples
-        cargo build --locked --release --target wasm32-unknown-unknown
-        cd ..
-        cargo build --locked -p linera-storage-service
-    - name: Run the storage-service instance and the README script tests
-      run: |
-        cargo test --locked -p linera-service --features storage-service -- test_script_in_readme --nocapture
-
   web:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull-requests
+# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
   cancel-in-progress: true

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -1,4 +1,5 @@
 name: Run README tests
+
 on:
   push:
     branches: [ main, 'devnet_*', 'testnet_*' ]

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -1,0 +1,59 @@
+name: Run README tests
+on:
+  push:
+    branches: [ main, 'devnet_*', 'testnet_*' ]
+  paths-ignore:
+    - 'CONTRIBUTING.md'
+    - 'INSTALL.md'
+    - 'docker/**'
+    - 'docker_scylla/**'
+    - 'configuration/**'
+    - 'kubernetes/**'
+  workflow_dispatch:
+  
+
+# This allows a subsequently queued workflow run to interrupt previous runs on pull-requests
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: full
+  # We allow redundant explicit links because `cargo rdme` doesn't know how to resolve implicit intra-crate links.
+  RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
+  RUSTFLAGS: -D warnings
+  RUSTUP_MAX_RETRIES: 10
+  RUST_LOG: linera=debug
+  RUST_LOG_FORMAT: plain
+  LINERA_STORAGE_SERVICE: 127.0.0.1:1235
+  LINERA_WALLET: /tmp/local-linera-net/wallet_0.json
+  LINERA_KEYSTORE: /tmp/local-linera-net/keystore_0.json
+  LINERA_STORAGE: rocksdb:/tmp/local-linera-net/client_0.db
+  LINERA_FAUCET_URL: http://localhost:8079
+
+permissions:
+  contents: read
+
+jobs:
+  test-readme-scripts:
+    runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 40
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build example applications
+      run: |
+        cd examples
+        cargo build --locked --release --target wasm32-unknown-unknown
+        cd ..
+        cargo build --locked -p linera-storage-service
+    - name: Run the storage-service instance and the README script tests
+      run: |
+        cargo test --locked -p linera-service --features storage-service -- test_script_in_readme --nocapture


### PR DESCRIPTION
## Motivation

Speed up and cut down CI costs.

## Proposal

`docker-compose` was ran on every push which seems unnecessary. It checks that our docker setup (that is expected to mimic validators' usage) is working. Since we care that it works on `main` and possibly release branches it doesn't have to run on every commit. **Now it runs on merge queue (before merge to `main`) and on release branches**


`test-readme-scripts` tests backwards compatibility. This is important but 95% of our PRs do not break them. We can detect it on `main` (and release branches) and fix right away. **Now it runs on merge queue (before merge to `main`) and on release branches**.

`lint-check-all-features` **runs on merge queue (before merge to `main`) and on release branches**.

`default-features-and-witty-integration-test` now runs on `ubuntu-latest-8-cores` : reason being this task already lasted 40+ minutes and is `cargo test` which should parallelize nicely.

`check-wit-files` runs on `ubuntu-latest` (rather than `*-16-cores`).

## Test Plan

CI testing CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
