### PR TITLE
Restructure the error types of `linera-views`.

### DIFF
--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -349,9 +349,9 @@ where
             ViewError::KeyTooLong | ViewError::ArithmeticError(_) => {
                 Status::out_of_range(err.to_string())
             }
-            ViewError::NotFound(_) | ViewError::MissingEntries => {
-                Status::not_found(err.to_string())
-            }
+            ViewError::NotFound(_)
+            | ViewError::CannotAcquireCollectionEntry
+            | ViewError::MissingEntries => Status::not_found(err.to_string()),
         };
         status.set_source(Arc::new(err));
         status

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -339,7 +339,7 @@ where
     /// Returns the appropriate gRPC status for the given [`ViewError`].
     fn error_to_status(err: ViewError) -> Status {
         let mut status = match &err {
-            ViewError::TooLargeValue | ViewError::BcsError(_) => {
+            ViewError::BcsError(_) => {
                 Status::invalid_argument(err.to_string())
             }
             ViewError::StoreError { .. }
@@ -352,7 +352,6 @@ where
                 Status::out_of_range(err.to_string())
             }
             ViewError::NotFound(_)
-            | ViewError::CannotAcquireCollectionEntry
             | ViewError::MissingEntries => Status::not_found(err.to_string()),
         };
         status.set_source(Arc::new(err));

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -339,9 +339,7 @@ where
     /// Returns the appropriate gRPC status for the given [`ViewError`].
     fn error_to_status(err: ViewError) -> Status {
         let mut status = match &err {
-            ViewError::BcsError(_) => {
-                Status::invalid_argument(err.to_string())
-            }
+            ViewError::BcsError(_) => Status::invalid_argument(err.to_string()),
             ViewError::StoreError { .. }
             | ViewError::TokioJoinError(_)
             | ViewError::TryLockError(_)
@@ -351,8 +349,9 @@ where
             ViewError::KeyTooLong | ViewError::ArithmeticError(_) => {
                 Status::out_of_range(err.to_string())
             }
-            ViewError::NotFound(_)
-            | ViewError::MissingEntries => Status::not_found(err.to_string()),
+            ViewError::NotFound(_) | ViewError::MissingEntries => {
+                Status::not_found(err.to_string())
+            }
         };
         status.set_source(Arc::new(err));
         status

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -16,10 +16,8 @@ use async_lock::{Semaphore, SemaphoreGuard};
 use aws_sdk_dynamodb::{
     error::SdkError,
     operation::{
-        batch_write_item::BatchWriteItemError,
         create_table::CreateTableError,
         delete_table::DeleteTableError,
-        describe_table::DescribeTableError,
         get_item::GetItemError,
         list_tables::ListTablesError,
         query::{QueryError, QueryOutput},
@@ -1007,10 +1005,6 @@ pub enum DynamoDbStoreInternalError {
     #[error(transparent)]
     Get(#[from] Box<SdkError<GetItemError>>),
 
-    /// An error occurred while writing a batch of items.
-    #[error(transparent)]
-    BatchWriteItem(#[from] Box<SdkError<BatchWriteItemError>>),
-
     /// An error occurred while writing a transaction of items.
     #[error(transparent)]
     TransactWriteItem(#[from] Box<SdkError<TransactWriteItemsError>>),
@@ -1026,10 +1020,6 @@ pub enum DynamoDbStoreInternalError {
     /// An error occurred while listing tables
     #[error(transparent)]
     ListTables(#[from] Box<SdkError<ListTablesError>>),
-
-    /// An error occurred while describing tables
-    #[error(transparent)]
-    DescribeTables(#[from] Box<SdkError<DescribeTableError>>),
 
     /// The transact maximum size is `MAX_TRANSACT_WRITE_ITEM_SIZE`.
     #[error("The transact must have length at most MAX_TRANSACT_WRITE_ITEM_SIZE")]
@@ -1050,10 +1040,6 @@ pub enum DynamoDbStoreInternalError {
     /// Key prefixes have to be of non-zero length.
     #[error("The key_prefix must be of strictly positive length")]
     ZeroLengthKeyPrefix,
-
-    /// The recovery failed.
-    #[error("The DynamoDB database recovery failed")]
-    DatabaseRecoveryFailed,
 
     /// The journal is not coherent
     #[error(transparent)]

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -365,10 +365,6 @@ pub enum IndexedDbStoreError {
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
 
-    /// The value is too large for the `IndexedDbStore`
-    #[error("The value is too large for the IndexedDbStore")]
-    TooLargeValue,
-
     /// A DOM exception occurred in the IndexedDB operations
     #[error("DOM exception: {0:?}")]
     Dom(gloo_utils::errors::JsError),

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -412,10 +412,6 @@ pub enum MemoryStoreError {
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
 
-    /// The value is too large for the `MemoryStore`
-    #[error("The value is too large for the MemoryStore")]
-    TooLargeValue,
-
     /// The namespace does not exist
     #[error("The namespace does not exist")]
     NamespaceNotFound,

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -454,10 +454,9 @@ impl WritableKeyValueStore for LimitedTestMemoryStore {
     const MAX_VALUE_SIZE: usize = 100;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), MemoryStoreError> {
-        ensure!(
-            batch.check_value_size(Self::MAX_VALUE_SIZE),
-            MemoryStoreError::TooLargeValue
-        );
+        if !batch.check_value_size(Self::MAX_VALUE_SIZE) {
+            panic!("The batch size is not adequate for this test");
+        }
         self.store.write_batch(batch).await
     }
 

--- a/linera-views/src/error.rs
+++ b/linera-views/src/error.rs
@@ -20,9 +20,9 @@ pub enum ViewError {
     #[error(transparent)]
     ArithmeticError(#[from] linera_base::data_types::ArithmeticError),
 
-    /// An failed to lock a reentrant collection entry since it currently being accessed
+    /// Failed to lock a reentrant collection entry since it is currently being accessed
     #[error(
-        "failed to lock a reentrant collection entry since it currently being accessed: {0:?}"
+        "failed to lock a reentrant collection entry since it is currently being accessed: {0:?}"
     )]
     TryLockError(Vec<u8>),
 

--- a/linera-views/src/error.rs
+++ b/linera-views/src/error.rs
@@ -17,7 +17,9 @@ pub enum ViewError {
     ArithmeticError(#[from] linera_base::data_types::ArithmeticError),
 
     /// An failed to lock a reentrant collection entry since it currently being accessed
-    #[error("failed to lock a reentrant collection entry since it currently being accessed: {0:?}")]
+    #[error(
+        "failed to lock a reentrant collection entry since it currently being accessed: {0:?}"
+    )]
     TryLockError(Vec<u8>),
 
     /// Tokio errors can happen while joining.

--- a/linera-views/src/error.rs
+++ b/linera-views/src/error.rs
@@ -8,6 +8,10 @@ pub enum ViewError {
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
 
+    /// We failed to acquire an entry in a `CollectionView`.
+    #[error("trying to access a collection view while some entries are still being accessed")]
+    CannotAcquireCollectionEntry,
+
     /// Input output error.
     #[error("I/O error")]
     IoError(#[from] std::io::Error),

--- a/linera-views/src/error.rs
+++ b/linera-views/src/error.rs
@@ -8,10 +8,6 @@ pub enum ViewError {
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
 
-    /// We failed to acquire an entry in a `CollectionView` or a `ReentrantCollectionView`.
-    #[error("trying to access a collection view or reentrant collection view while some entries are still being accessed")]
-    CannotAcquireCollectionEntry,
-
     /// Input output error.
     #[error("I/O error")]
     IoError(#[from] std::io::Error),
@@ -20,8 +16,8 @@ pub enum ViewError {
     #[error(transparent)]
     ArithmeticError(#[from] linera_base::data_types::ArithmeticError),
 
-    /// An error happened while trying to lock.
-    #[error("failed to lock collection entry: {0:?}")]
+    /// An failed to lock a reentrant collection entry since it currently being accessed
+    #[error("failed to lock a reentrant collection entry since it currently being accessed: {0:?}")]
     TryLockError(Vec<u8>),
 
     /// Tokio errors can happen while joining.
@@ -58,10 +54,6 @@ pub enum ViewError {
     /// The values are incoherent.
     #[error("post load values error")]
     PostLoadValuesError,
-
-    /// The value is too large for the client
-    #[error("the value is too large for the client")]
-    TooLargeValue,
 }
 
 impl ViewError {

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -269,10 +269,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
         &self,
         short_key: &[u8],
     ) -> Result<Option<ReadGuardedView<W>>, ViewError> {
-        let mut updates = self
-            .updates
-            .try_write()
-            .ok_or(ViewError::CannotAcquireCollectionEntry)?;
+        let mut updates = self.updates.write().await;
         match updates.entry(short_key.to_vec()) {
             btree_map::Entry::Occupied(entry) => {
                 let entry = entry.into_mut();

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -269,7 +269,10 @@ impl<W: View> ByteCollectionView<W::Context, W> {
         &self,
         short_key: &[u8],
     ) -> Result<Option<ReadGuardedView<W>>, ViewError> {
-        let mut updates = self.updates.write().await;
+        let mut updates = self
+            .updates
+            .try_write()
+            .ok_or(ViewError::CannotAcquireCollectionEntry)?;
         match updates.entry(short_key.to_vec()) {
             btree_map::Entry::Occupied(entry) => {
                 let entry = entry.into_mut();

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -146,7 +146,7 @@ impl<W: View> View for ReentrantByteCollectionView<W::Context, W> {
             for (index, update) in mem::take(&mut self.updates) {
                 if let Update::Set(view) = update {
                     let mut view = Arc::try_unwrap(view)
-                        .map_err(|_| ViewError::CannotAcquireCollectionEntry)?
+                        .map_err(|_| ViewError::TryLockError(index.clone()))?
                         .into_inner();
                     view.flush(batch)?;
                     self.add_index(batch, &index);
@@ -158,7 +158,7 @@ impl<W: View> View for ReentrantByteCollectionView<W::Context, W> {
                 match update {
                     Update::Set(view) => {
                         let mut view = Arc::try_unwrap(view)
-                            .map_err(|_| ViewError::CannotAcquireCollectionEntry)?
+                            .map_err(|_| ViewError::TryLockError(index.clone()))?
                             .into_inner();
                         view.flush(batch)?;
                         self.add_index(batch, &index);
@@ -194,7 +194,7 @@ impl<W: ClonableView> ClonableView for ReentrantByteCollectionView<W::Context, W
                     Update::Set(view_lock) => {
                         let mut view = view_lock
                             .try_write()
-                            .ok_or(ViewError::CannotAcquireCollectionEntry)?;
+                            .ok_or(ViewError::TryLockError(key.to_vec()))?;
 
                         Update::Set(Arc::new(RwLock::new(view.clone_unchecked()?)))
                     }


### PR DESCRIPTION
## Motivation

Several entries in the `ViewError` and `DynamoDbStoreInternalError` can be removed.

## Proposal

The following is done:
* The `TooLargeValue` is removed from `IndexedDbError` as it is unused.
* The `TooLargeValue` is removed from `MemoryStoreError`. This requires changing one test, which ought to be fine.
* The `TooLargeValue` is removed from `ViewError`.
* The unused errors for `DynamoDbStoreInternalError` are removed.
* No other unused errors were found.

## Test Plan

The CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.