### PR TITLE
Remove unnecessary `From` impl.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -486,13 +486,6 @@ impl TryFrom<BlockHeight> for usize {
     }
 }
 
-#[cfg(not(with_testing))]
-impl From<u64> for BlockHeight {
-    fn from(value: u64) -> Self {
-        Self(value)
-    }
-}
-
 impl_wrapped_number!(Amount, u128);
 impl_wrapped_number!(BlockHeight, u64);
 impl_wrapped_number!(TimeDelta, u64);

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -506,7 +506,7 @@ where
         let inbox = self.inboxes.try_load_entry(origin).await?;
         match inbox {
             Some(inbox) => inbox.next_block_height_to_receive(),
-            None => Ok(BlockHeight::from(0)),
+            None => Ok(BlockHeight::ZERO),
         }
     }
 

--- a/linera-service/src/linera-exporter/state.rs
+++ b/linera-service/src/linera-exporter/state.rs
@@ -54,7 +54,7 @@ where
 
     pub fn insert_destination(&mut self, destination: DestinationId) -> Result<(), ExporterError> {
         self.next_heights_to_process
-            .insert(&destination, 1.into())?;
+            .insert(&destination, BlockHeight(1))?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Motivation

There is a conditionally compiled `impl From<u64> for BlockHeight`, but `BlockHeight`'s field is public, and we're using that directly almost everywhere.

## Proposal

Remove the impl, directly use `BlockHeight(n)` everywhere.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
