### PR TITLE
Always add admin chain to listener.

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -193,7 +193,9 @@ impl<C: ClientContext> ChainListener<C> {
     pub async fn run(mut self) -> Result<(), Error> {
         let chain_ids = {
             let guard = self.context.lock().await;
-            BTreeSet::from_iter(guard.wallet().chain_ids())
+            let mut chain_ids = BTreeSet::from_iter(guard.wallet().chain_ids());
+            chain_ids.insert(guard.wallet().genesis_admin_chain());
+            chain_ids
         };
         self.listen_recursively(chain_ids).await?;
         loop {


### PR DESCRIPTION
## Motivation

The chain listener currently panics if it has an empty list of chains.

Also, it doesn't even listen to the admin chain if no chain is in the wallet.

## Proposal

Always listen to the admin chain.

## Test Plan

A unit test for this was added.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/4037.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
