### PR TITLE
Pass message policy to `Client::new`; add default impl for `make_chain_client`.

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -28,7 +28,10 @@ use linera_storage::{Clock as _, Storage as _};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, instrument, warn, Instrument as _};
 
-use crate::{wallet::Wallet, Error};
+use crate::{
+    wallet::{UserChain, Wallet},
+    Error,
+};
 
 #[derive(Debug, Default, Clone, clap::Args)]
 pub struct ChainListenerConfig {
@@ -68,9 +71,22 @@ pub trait ClientContext {
 
     fn storage(&self) -> &<Self::Environment as linera_core::Environment>::Storage;
 
-    fn make_chain_client(&self, chain_id: ChainId) -> ContextChainClient<Self>;
+    fn client(&self) -> &Arc<linera_core::client::Client<Self::Environment>>;
 
-    fn client(&self) -> &linera_core::client::Client<Self::Environment>;
+    fn make_chain_client(&self, chain_id: ChainId) -> ChainClient<Self::Environment> {
+        let chain = self
+            .wallet()
+            .get(chain_id)
+            .cloned()
+            .unwrap_or_else(|| UserChain::make_other(chain_id, Timestamp::from(0)));
+        self.client().create_chain_client(
+            chain_id,
+            chain.block_hash,
+            chain.next_block_height,
+            chain.pending_proposal,
+            chain.owner,
+        )
+    }
 
     async fn update_wallet_for_new_chain(
         &mut self,

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -13,7 +13,7 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_core::{
-    client::{ChainClient, Client},
+    client::{ChainClient, Client, MessagePolicy},
     environment,
     node::CrossChainMessageDelivery,
     test_utils::{MemoryStorageBuilder, StorageBuilder as _, TestBuilder},
@@ -129,6 +129,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
             },
             10,
             admin_id,
+            MessagePolicy::new_accept_all(),
             delivery,
             false,
             [chain_id0],
@@ -217,6 +218,7 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
             },
             10,
             admin_id,
+            MessagePolicy::new_accept_all(),
             delivery,
             false,
             [],

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -46,23 +46,8 @@ impl chain_listener::ClientContext for ClientContext {
         self.client.storage_client()
     }
 
-    fn client(&self) -> &linera_core::client::Client<Self::Environment> {
+    fn client(&self) -> &Arc<linera_core::client::Client<Self::Environment>> {
         &self.client
-    }
-
-    fn make_chain_client(&self, chain_id: ChainId) -> ChainClient<environment::Test> {
-        let chain = self
-            .wallet
-            .get(chain_id)
-            .cloned()
-            .unwrap_or_else(|| UserChain::make_other(chain_id, Timestamp::from(0)));
-        self.client.create_chain_client(
-            chain_id,
-            chain.block_hash,
-            chain.next_block_height,
-            chain.pending_proposal.clone(),
-            chain.owner,
-        )
     }
 
     async fn update_wallet_for_new_chain(

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -181,6 +181,7 @@ impl<Env: Environment> Client<Env> {
         environment: Env,
         max_pending_message_bundles: usize,
         admin_id: ChainId,
+        message_policy: MessagePolicy,
         cross_chain_message_delivery: CrossChainMessageDelivery,
         long_lived_services: bool,
         tracked_chains: impl IntoIterator<Item = ChainId>,
@@ -207,7 +208,7 @@ impl<Env: Environment> Client<Env> {
             chains: DashMap::new(),
             max_pending_message_bundles,
             admin_id,
-            message_policy: MessagePolicy::new(BlanketMessagePolicy::Accept, None),
+            message_policy,
             cross_chain_message_delivery,
             grace_period,
             tracked_chains,
@@ -1256,6 +1257,14 @@ impl MessagePolicy {
         Self {
             blanket,
             restrict_chain_ids_to,
+        }
+    }
+
+    #[cfg(with_testing)]
+    pub fn new_accept_all() -> Self {
+        Self {
+            blanket: BlanketMessagePolicy::Accept,
+            restrict_chain_ids_to: None,
         }
     }
 

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -49,7 +49,7 @@ use {
 };
 
 use crate::{
-    client::Client,
+    client::{Client, MessagePolicy},
     data_types::*,
     node::{
         CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
@@ -952,6 +952,7 @@ where
             },
             10,
             self.admin_id(),
+            MessagePolicy::new_accept_all(),
             CrossChainMessageDelivery::NonBlocking,
             false,
             [chain_id],

--- a/linera-faucet/server/src/tests.rs
+++ b/linera-faucet/server/src/tests.rs
@@ -36,7 +36,7 @@ impl chain_listener::ClientContext for ClientContext {
         self.client.storage_client()
     }
 
-    fn client(&self) -> &linera_core::client::Client<environment::Test> {
+    fn client(&self) -> &Arc<linera_core::client::Client<environment::Test>> {
         unimplemented!()
     }
 

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use linera_base::{
     crypto::CryptoHash,
     data_types::{BlobContent, NetworkDescription, Timestamp},
@@ -180,11 +182,7 @@ impl ClientContext for DummyContext {
         unimplemented!()
     }
 
-    fn client(&self) -> &linera_core::client::Client<Self::Environment> {
-        unimplemented!()
-    }
-
-    fn make_chain_client(&self, _: ChainId) -> ChainClient<Self::Environment> {
+    fn client(&self) -> &Arc<linera_core::client::Client<Self::Environment>> {
         unimplemented!()
     }
 


### PR DESCRIPTION
## Motivation

`Client::new` uses a default value for the message policy, and we explicitly set it each time `make_chain_client` is called.

## Proposal

Pass the correct policy into `Client::new` directly, so we can have a default impl for `make_chain_client`.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
