### PR TITLE
New ScyllaDB key space partitioning

### DIFF
--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -3,7 +3,9 @@
 
 use linera_views::{
     lru_caching::StorageCacheConfig,
-    scylla_db::{ScyllaDbStore, ScyllaDbStoreConfig, ScyllaDbStoreInternalConfig},
+    scylla_db::{
+        ScyllaDbClientConfig, ScyllaDbStore, ScyllaDbStoreConfig, ScyllaDbStoreInternalConfig,
+    },
     store::AdminKeyValueStore,
 };
 
@@ -62,6 +64,7 @@ impl ScyllaDbRunner {
             max_stream_queries: config.client.max_stream_queries,
             max_concurrent_queries: config.client.max_concurrent_queries,
             replication_factor: config.client.replication_factor,
+            client_config: ScyllaDbClientConfig::default(),
         };
         let store_config = ScyllaDbStoreConfig {
             inner_config,

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -34,7 +34,9 @@ use {
 };
 #[cfg(feature = "scylladb")]
 use {
-    linera_views::scylla_db::{ScyllaDbStore, ScyllaDbStoreConfig, ScyllaDbStoreInternalConfig},
+    linera_views::scylla_db::{
+        ScyllaDbClientConfig, ScyllaDbStore, ScyllaDbStoreConfig, ScyllaDbStoreInternalConfig,
+    },
     std::num::NonZeroU16,
     tracing::debug,
 };
@@ -486,6 +488,7 @@ impl StorageConfig {
                     max_stream_queries: options.storage_max_stream_queries,
                     max_concurrent_queries: options.storage_max_concurrent_queries,
                     replication_factor: options.storage_replication_factor,
+                    client_config: ScyllaDbClientConfig::default(),
                 };
                 let config = ScyllaDbStoreConfig {
                     inner_config,
@@ -514,6 +517,7 @@ impl StorageConfig {
                     max_stream_queries: options.storage_max_stream_queries,
                     max_concurrent_queries: options.storage_max_concurrent_queries,
                     replication_factor: options.storage_replication_factor,
+                    client_config: ScyllaDbClientConfig::default(),
                 };
                 let second_config = ScyllaDbStoreConfig {
                     inner_config,

--- a/linera-views/src/views/unit_tests/views.rs
+++ b/linera-views/src/views/unit_tests/views.rs
@@ -243,6 +243,7 @@ impl TestContextFactory for ScyllaDbContextFactory {
         let config = ScyllaDbStore::new_test_config().await?;
         let namespace = generate_test_namespace();
         let store = ScyllaDbStore::recreate_and_connect(&config, &namespace).await?;
+        let store = store.open_exclusive(&[])?;
         let context = ViewContext::create_root_context(store, ()).await?;
         Ok(context)
     }

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -106,11 +106,19 @@ async fn test_reads_scylla_db() {
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_reads_scylla_db_no_root_key() {
-    for scenario in get_random_test_scenarios() {
-        let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
-            .await
-            .unwrap();
-        run_reads(store, scenario).await;
+    use linera_views::test_utils::{
+        get_random_byte_vector, get_random_test_scenarios_with_key_prefix,
+    };
+
+    let mut rng = make_deterministic_rng();
+    for _ in 0..3 {
+        let key_prefix = get_random_byte_vector(&mut rng, &[], 4);
+        for scenario in get_random_test_scenarios_with_key_prefix(&key_prefix) {
+            let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
+                .await
+                .unwrap();
+            run_reads(store, scenario).await;
+        }
     }
 }
 
@@ -184,9 +192,12 @@ async fn test_dynamo_db_writes_from_blank() {
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_writes_from_blank() {
+    use linera_views::store::AdminKeyValueStore as _;
+
     let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
         .await
         .unwrap();
+    let store = store.open_exclusive(&[]).unwrap();
     run_writes_from_blank(&store).await;
 }
 
@@ -333,9 +344,12 @@ async fn test_dynamo_db_writes_from_state() {
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_writes_from_state() {
+    use linera_views::store::AdminKeyValueStore as _;
+
     let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
         .await
         .unwrap();
+    let store = store.open_exclusive(&[]).unwrap();
     run_writes_from_state(&store).await;
 }
 


### PR DESCRIPTION
## Motivation

ScyllaDB hashes each partition key into a token. Each token range gets assigned to a shard. Each shard is pinned to a specific CPU by default. This means that having very few partitions is bad for ScyllaDB's performance.
Right now in the current scheme of things we have just one partition key, which is the `root_key`. For views, which is our mutable data in the DB, `root_key` will be set, and we'll be in "exclusive mode". For everything else (`Certificate`s, `ConfirmedBlock`s, `Blob`s, etc), everything is on the same partition. For example when we're doing 1M TPS, we'll have several thousands of blocks being created every second, as well as certificates. This current scheme won't scale for those numbers.

## Proposal

New schema proposal: instead of having a `root_key`, we'll have a `partition_key` instead. This `partition_key` will have two modes: exclusive mode (mutable data) and non exclusive mode (immutable data). The former will work exactly how the previous `root_key` schema worked.

For exclusive mode, the `partition_key`'s first byte will be `0`, indicating the mode. The rest of the bytes will be the `root_key` that was provided when calling `open_exclusive`. Everything else should work as it previously did.

For non exclusive mode, the `partition_key`'s first byte will be `1`. The rest of the partition key will be a prefix of the key of a predetermined length (through a configuration parameter). This mode we'll have some reservations:

- Batches with queries with keys across different partitions are not allowed (this also applies for exclusive mode by design)
- Batches with prefix deletes are not allowed (would require a full table scan in cases where the prefix is smaller than the `partition_key`'s prefix size)
- On `read_multi_values_internal` and `contains_keys_internal` we currently group the keys by `partition_key` and execute one query per `partition_key` in parallel. This is done to keep the queries token aware across partitions
- On `find_keys_by_prefix_internal` and `find_key_values_by_prefix_internal`, if the prefix is smaller than the `partition_key`'s prefix size, we'll do a full table scan. This happens infrequently enough that we're willing to take the performance hit.

## Test Plan

CI + will benchmark this to check performance. Some tests had to be altered as they didn't respect the invariant that if we're using a `root_key`, we should be in exclusive mode.

## Follow ups

There are several follow ups here:

- Bundle `Certificate` and `ConfirmedBlock` `BaseKey`s closer together, as well as `Blob` and `BlobState`
- Do the same thing that we did for `find_keys_by_prefix_internal` for prefix deletes, and take the perf hit of the full table scan, as these seem to be currently infrequent
- Enforce for `View`s (maybe on `load`) that they must always be on exclusive mode
- We have a lot of places in the code where we use batches of size 1. These should not be batches. More specifically `WritableKeyValueStore` should have `write_value` and `write_multi_values` methods, analogous to `ReadableKeyValueStore`. Batches should be used when atomicity is wanted, or when we want to save network requests to the DB

## Release Plan

- Nothing to do / These changes follow the usual release cycle.