### PR TITLE
Use `ChainClientOptions` in more places.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -152,7 +152,7 @@ where
 
     #[cfg(with_testing)]
     pub fn new_test_client_context(storage: S, wallet: W, signer: Si) -> Self {
-        use linera_core::{client::ClientOptions, node::CrossChainMessageDelivery};
+        use linera_core::{client::ChainClientOptions, node::CrossChainMessageDelivery};
 
         let send_recv_timeout = Duration::from_millis(4000);
         let retry_delay = Duration::from_millis(1000);
@@ -181,9 +181,9 @@ where
             chain_ids,
             name,
             NonZeroUsize::new(20).expect("Chain worker limit should not be zero"),
-            ClientOptions {
+            ChainClientOptions {
                 cross_chain_message_delivery: CrossChainMessageDelivery::Blocking,
-                ..ClientOptions::test_default()
+                ..ChainClientOptions::test_default()
             },
         );
 

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -136,7 +136,7 @@ where
             chain_ids,
             name,
             options.max_loaded_chains,
-            options.to_client_options(),
+            options.to_chain_client_options(),
         );
 
         ClientContext {

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -9,7 +9,11 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
     time::Duration,
 };
-use linera_core::{client::BlanketMessagePolicy, DEFAULT_GRACE_PERIOD};
+use linera_core::{
+    client::{BlanketMessagePolicy, ClientOptions, MessagePolicy},
+    node::CrossChainMessageDelivery,
+    DEFAULT_GRACE_PERIOD,
+};
 use linera_execution::ResourceControlPolicy;
 
 use crate::util;
@@ -110,6 +114,24 @@ pub struct ClientContextOptions {
         value_parser = util::parse_millis
     )]
     pub blob_download_timeout: Duration,
+}
+
+impl ClientContextOptions {
+    pub fn to_client_options(&self) -> ClientOptions {
+        let message_policy = MessagePolicy::new(
+            self.blanket_message_policy,
+            self.restrict_chain_ids_to.clone(),
+        );
+        let cross_chain_message_delivery =
+            CrossChainMessageDelivery::new(self.wait_for_outgoing_messages);
+        ClientOptions {
+            max_pending_message_bundles: self.max_pending_message_bundles,
+            message_policy,
+            cross_chain_message_delivery,
+            grace_period: self.grace_period,
+            blob_download_timeout: self.blob_download_timeout,
+        }
+    }
 }
 
 #[derive(Debug, Clone, clap::Args)]

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -10,7 +10,7 @@ use linera_base::{
     time::Duration,
 };
 use linera_core::{
-    client::{BlanketMessagePolicy, ClientOptions, MessagePolicy},
+    client::{BlanketMessagePolicy, ChainClientOptions, MessagePolicy},
     node::CrossChainMessageDelivery,
     DEFAULT_GRACE_PERIOD,
 };
@@ -117,14 +117,14 @@ pub struct ClientContextOptions {
 }
 
 impl ClientContextOptions {
-    pub fn to_client_options(&self) -> ClientOptions {
+    pub fn to_client_options(&self) -> ChainClientOptions {
         let message_policy = MessagePolicy::new(
             self.blanket_message_policy,
             self.restrict_chain_ids_to.clone(),
         );
         let cross_chain_message_delivery =
             CrossChainMessageDelivery::new(self.wait_for_outgoing_messages);
-        ClientOptions {
+        ChainClientOptions {
             max_pending_message_bundles: self.max_pending_message_bundles,
             message_policy,
             cross_chain_message_delivery,

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -117,7 +117,8 @@ pub struct ClientContextOptions {
 }
 
 impl ClientContextOptions {
-    pub fn to_client_options(&self) -> ChainClientOptions {
+    /// Creates [`ChainClientOptions`] with the corresponding values.
+    pub fn to_chain_client_options(&self) -> ChainClientOptions {
         let message_policy = MessagePolicy::new(
             self.blanket_message_policy,
             self.restrict_chain_ids_to.clone(),

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -13,11 +13,9 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_core::{
-    client::{ChainClient, Client, MessagePolicy},
+    client::{ChainClient, Client, ClientOptions},
     environment,
-    node::CrossChainMessageDelivery,
     test_utils::{MemoryStorageBuilder, StorageBuilder as _, TestBuilder},
-    DEFAULT_GRACE_PERIOD,
 };
 use linera_execution::system::Recipient;
 use linera_storage::Storage;
@@ -102,7 +100,6 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     let genesis_config = make_genesis_config(&builder);
     let admin_id = genesis_config.admin_id();
     let storage = builder.make_storage().await?;
-    let delivery = CrossChainMessageDelivery::NonBlocking;
 
     let mut context = ClientContext {
         wallet: Wallet::new(genesis_config),
@@ -112,16 +109,12 @@ async fn test_chain_listener() -> anyhow::Result<()> {
                 network: builder.make_node_provider(),
                 signer,
             },
-            10,
             admin_id,
-            MessagePolicy::new_accept_all(),
-            delivery,
             false,
             [chain_id0],
             format!("Client node for {:.8}", chain_id0),
             NonZeroUsize::new(20).expect("Chain worker LRU cache size must be non-zero"),
-            DEFAULT_GRACE_PERIOD,
-            Duration::from_secs(1),
+            ClientOptions::test_default(),
         )),
     };
     context
@@ -191,7 +184,6 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
     let genesis_config = make_genesis_config(&builder);
     let admin_id = genesis_config.admin_id();
     let storage = builder.make_storage().await?;
-    let delivery = CrossChainMessageDelivery::NonBlocking;
 
     let context = ClientContext {
         wallet: Wallet::new(genesis_config),
@@ -201,16 +193,12 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
                 network: builder.make_node_provider(),
                 signer,
             },
-            10,
             admin_id,
-            MessagePolicy::new_accept_all(),
-            delivery,
             false,
             [],
             "Client node with no chains".to_string(),
             NonZeroUsize::new(20).expect("Chain worker LRU cache size must be non-zero"),
-            DEFAULT_GRACE_PERIOD,
-            Duration::from_secs(1),
+            ClientOptions::test_default(),
         )),
     };
     let context = Arc::new(Mutex::new(context));

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -13,7 +13,7 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_core::{
-    client::{ChainClient, Client, ClientOptions},
+    client::{ChainClient, ChainClientOptions, Client},
     environment,
     test_utils::{MemoryStorageBuilder, StorageBuilder as _, TestBuilder},
 };
@@ -114,7 +114,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
             [chain_id0],
             format!("Client node for {:.8}", chain_id0),
             NonZeroUsize::new(20).expect("Chain worker LRU cache size must be non-zero"),
-            ClientOptions::test_default(),
+            ChainClientOptions::test_default(),
         )),
     };
     context
@@ -198,7 +198,7 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
             [],
             "Client node with no chains".to_string(),
             NonZeroUsize::new(20).expect("Chain worker LRU cache size must be non-zero"),
-            ClientOptions::test_default(),
+            ChainClientOptions::test_default(),
         )),
     };
     let context = Arc::new(Mutex::new(context));

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -161,7 +161,7 @@ pub struct Client<Env: Environment> {
     /// The maximum active chain workers.
     max_loaded_chains: NonZeroUsize,
     /// Configuration options.
-    options: ClientOptions,
+    options: ChainClientOptions,
 }
 
 impl<Env: Environment> Client<Env> {
@@ -174,7 +174,7 @@ impl<Env: Environment> Client<Env> {
         tracked_chains: impl IntoIterator<Item = ChainId>,
         name: impl Into<String>,
         max_loaded_chains: NonZeroUsize,
-        options: ClientOptions,
+        options: ChainClientOptions,
     ) -> Self {
         let tracked_chains = Arc::new(RwLock::new(tracked_chains.into_iter().collect()));
         let state = WorkerState::new_for_client(
@@ -1278,7 +1278,7 @@ impl MessagePolicy {
 }
 
 #[derive(Debug, Clone)]
-pub struct ClientOptions {
+pub struct ChainClientOptions {
     /// Maximum number of pending message bundles processed at a time in a block.
     pub max_pending_message_bundles: usize,
     /// The policy for automatically handling incoming messages.
@@ -1293,11 +1293,11 @@ pub struct ClientOptions {
 }
 
 #[cfg(with_testing)]
-impl ClientOptions {
+impl ChainClientOptions {
     pub fn test_default() -> Self {
         use crate::DEFAULT_GRACE_PERIOD;
 
-        ClientOptions {
+        ChainClientOptions {
             max_pending_message_bundles: 10,
             message_policy: MessagePolicy::new_accept_all(),
             cross_chain_message_delivery: CrossChainMessageDelivery::NonBlocking,
@@ -1321,7 +1321,7 @@ pub struct ChainClient<Env: Environment> {
     chain_id: ChainId,
     /// The client options.
     #[debug(skip)]
-    options: ClientOptions,
+    options: ChainClientOptions,
     /// The preferred owner of the chain used to sign proposals.
     /// `None` if we cannot propose on this chain.
     preferred_owner: Option<AccountOwner>,
@@ -1503,13 +1503,13 @@ impl<Env: Environment> ChainClient<Env> {
 
     /// Gets a mutable reference to the per-`ChainClient` options.
     #[instrument(level = "trace", skip(self))]
-    pub fn options_mut(&mut self) -> &mut ClientOptions {
+    pub fn options_mut(&mut self) -> &mut ChainClientOptions {
         &mut self.options
     }
 
     /// Gets a reference to the per-`ChainClient` options.
     #[instrument(level = "trace", skip(self))]
-    pub fn options(&self) -> &ClientOptions {
+    pub fn options(&self) -> &ChainClientOptions {
         &self.options
     }
 

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -5,7 +5,6 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     num::NonZeroUsize,
     sync::Arc,
-    time::Duration,
     vec,
 };
 
@@ -49,14 +48,13 @@ use {
 };
 
 use crate::{
-    client::{Client, MessagePolicy},
+    client::{Client, ClientOptions},
     data_types::*,
     node::{
         CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
         ValidatorNodeProvider,
     },
     notifier::ChannelNotifier,
-    updater::DEFAULT_GRACE_PERIOD,
     worker::{NetworkActions, Notification, ProcessableCertificate, WorkerState},
 };
 
@@ -950,16 +948,12 @@ where
                 storage,
                 signer: self.signer.clone(),
             },
-            10,
             self.admin_id(),
-            MessagePolicy::new_accept_all(),
-            CrossChainMessageDelivery::NonBlocking,
             false,
             [chain_id],
             format!("Client node for {:.8}", chain_id),
             NonZeroUsize::new(20).expect("Chain worker limit should not be zero"),
-            DEFAULT_GRACE_PERIOD,
-            Duration::from_secs(1),
+            ClientOptions::test_default(),
         ));
         Ok(client.create_chain_client(
             chain_id,

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -48,7 +48,7 @@ use {
 };
 
 use crate::{
-    client::{Client, ClientOptions},
+    client::{ChainClientOptions, Client},
     data_types::*,
     node::{
         CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
@@ -953,7 +953,7 @@ where
             [chain_id],
             format!("Client node for {:.8}", chain_id),
             NonZeroUsize::new(20).expect("Chain worker limit should not be zero"),
-            ClientOptions::test_default(),
+            ChainClientOptions::test_default(),
         ));
         Ok(client.create_chain_client(
             chain_id,


### PR DESCRIPTION
## Motivation

Clippy rightly thinks that `Client::new` has `too_many_arguments`.

## Proposal

Use `ChainClientOptions` instead of passing in individual parameters.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
