### PR TITLE
Truncate query output on query_node

### DIFF
--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -1281,7 +1281,10 @@ impl NodeService {
                 .send()
                 .await;
             if matches!(result, Err(ref error) if error.is_timeout()) {
-                warn!("Timeout when sending query {query:?} to the node service");
+                warn!(
+                    "Timeout when sending query {} to the node service",
+                    truncate_query_output(query)
+                );
                 continue;
             }
             let response = result.with_context(|| {


### PR DESCRIPTION
## Motivation

That graphQL query can contain mutation publishing modules, for example, where all the contract bytes are currently being printed, making the logs become huge.

## Proposal

Truncate the query on the warning as well

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
