### PR TITLE
Missed one rename still using CloneWithRootKey

### DIFF
--- a/linera-indexer/lib/src/common.rs
+++ b/linera-indexer/lib/src/common.rs
@@ -46,8 +46,8 @@ pub enum IndexerError {
     PluginAlreadyRegistered,
     #[error("Invalid certificate content: {0:?}")]
     InvalidCertificateValue(CryptoHash),
-    #[error("Clone with root key error")]
-    CloneWithRootKeyError,
+    #[error("Open exclusive error")]
+    OpenExclusiveError,
 
     #[cfg(feature = "rocksdb")]
     #[error(transparent)]

--- a/linera-indexer/lib/src/indexer.rs
+++ b/linera-indexer/lib/src/indexer.rs
@@ -66,7 +66,7 @@ where
         let root_key = "indexer".as_bytes().to_vec();
         let store = store
             .open_exclusive(&root_key)
-            .map_err(|_e| IndexerError::CloneWithRootKeyError)?;
+            .map_err(|_e| IndexerError::OpenExclusiveError)?;
         let context = ViewContext::create_root_context(store, ())
             .await
             .map_err(|e| IndexerError::ViewError(e.into()))?;

--- a/linera-indexer/lib/src/plugin.rs
+++ b/linera-indexer/lib/src/plugin.rs
@@ -74,7 +74,7 @@ where
     let root_key = name.as_bytes().to_vec();
     let store = store
         .open_exclusive(&root_key)
-        .map_err(|_e| IndexerError::CloneWithRootKeyError)?;
+        .map_err(|_e| IndexerError::OpenExclusiveError)?;
     let context = ViewContext::create_root_context(store, ())
         .await
         .map_err(|e| IndexerError::ViewError(e.into()))?;


### PR DESCRIPTION
## Motivation

When renaming `clone_with_root_key` to `open_exclusive`, one error name was missed.

## Proposal

Update it to the new name

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
