### PR TITLE
Remove Rust jobs from running on main branch.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,8 @@ name: Rust
 
 on:
   push:
-    branches: [ main, 'devnet_*', 'testnet_*' ]
+    branches: [ 'devnet_*', 'testnet_*' ]
+  merge_group:
   pull_request:
     branches:
       - "**"


### PR DESCRIPTION
## Motivation

Rust workflow already runs on every commit and also on merge queue right now. There's no point in running it on `main` as well.

## Proposal

Remove `main` from branches for which `rust.yml` is ran.

## Test Plan

CI

## Release Plan

- Nothing to do 

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
