### PR TITLE
Fix merge queue trigger for CI

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -3,7 +3,7 @@ name: Docker Compose
 on:
   push:
     branches: [ 'devnet_*', 'testnet_*' ]
-    merge_group:
+  merge_group:
   workflow_dispatch:
 
 # This allows a subsequently queued workflow run to interrupt previous runs on pull-requests

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -3,7 +3,7 @@ name: Lint check all features
 on:
   push:
     branches: [ 'devnet_*', 'testnet_*' ]
-    merge_group:
+  merge_group:
   workflow_dispatch:
 
 # This allows a subsequently queued workflow run to interrupt previous runs on pull requests

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -2,7 +2,8 @@ name: Long Faucet chain test
 
 on:
   push:
-    branches: [ main, 'devnet_*', 'testnet_*' ]
+    branches: [ 'devnet_*', 'testnet_*' ]
+  merge_group:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -3,7 +3,7 @@ name: Run README tests
 on:
   push:
     branches: [ 'devnet_*', 'testnet_*' ]
-    merge_group:
+  merge_group:
   workflow_dispatch:
   
 


### PR DESCRIPTION
## Motivation

Wrong indentation for `merge_group`

## Proposal

Fix the identation.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
