### PR TITLE
`linera-views`: make `Sync` a bound on `View`, except on the Web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5636,7 +5636,6 @@ dependencies = [
  "serde",
  "serde-reflection",
  "similar-asserts",
- "sync_wrapper 1.0.2",
  "test-strategy",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5636,6 +5636,7 @@ dependencies = [
  "serde",
  "serde-reflection",
  "similar-asserts",
+ "sync_wrapper 1.0.2",
  "test-strategy",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5715,6 +5715,7 @@ dependencies = [
  "serde",
  "sha3",
  "static_assertions",
+ "sync_wrapper 1.0.2",
  "sysinfo",
  "tempfile",
  "test-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,6 +220,7 @@ similar-asserts = "1.5.0"
 static_assertions = "1.1.0"
 stdext = "0.3.3"
 syn = "2.0.52"
+sync_wrapper = { version = "1.0.1", features = ["futures"] }
 sysinfo = "0.33.1"
 tempfile = "3.20.0"
 test-case = "3.3.1"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3900,7 +3900,6 @@ dependencies = [
  "linera-views",
  "prost",
  "serde",
- "sync_wrapper 1.0.1",
  "thiserror 1.0.65",
  "tokio",
  "tonic",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3953,6 +3953,7 @@ dependencies = [
  "serde",
  "sha3",
  "static_assertions",
+ "sync_wrapper 1.0.1",
  "sysinfo",
  "tempfile",
  "thiserror 1.0.65",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3900,6 +3900,7 @@ dependencies = [
  "linera-views",
  "prost",
  "serde",
+ "sync_wrapper 1.0.1",
  "thiserror 1.0.65",
  "tokio",
  "tonic",

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -32,6 +32,7 @@ linera-version.workspace = true
 linera-views.workspace = true
 prost.workspace = true
 serde.workspace = true
+sync_wrapper.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true, features = ["codegen", "prost", "transport"] }

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -32,7 +32,6 @@ linera-version.workspace = true
 linera-views.workspace = true
 prost.workspace = true
 serde.workspace = true
-sync_wrapper.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true, features = ["codegen", "prost", "transport"] }

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -341,7 +341,7 @@ impl ServiceStoreClientInternal {
             let channel = self.channel.clone();
             let mut client = StoreProcessorClient::new(channel);
             let _guard = self.acquire().await;
-            let _response = client.process_write_batch_extended(request).await?;
+            let _response = SyncFuture::new(client.process_write_batch_extended(request)).await?;
         }
         Ok(())
     }
@@ -459,8 +459,8 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
     async fn list_all(config: &Self::Config) -> Result<Vec<String>, ServiceStoreError> {
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
-        let mut client = StoreProcessorClient::connect(endpoint).await?;
-        let response = client.process_list_all(()).await?;
+        let mut client = SyncFuture::new(StoreProcessorClient::connect(endpoint)).await?;
+        let response = SyncFuture::new(client.process_list_all(())).await?;
         let response = response.into_inner();
         let ReplyListAll { namespaces } = response;
         let namespaces = namespaces
@@ -479,8 +479,8 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
         let request = tonic::Request::new(query);
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
-        let mut client = StoreProcessorClient::connect(endpoint).await?;
-        let response = client.process_list_root_keys(request).await?;
+        let mut client = SyncFuture::new(StoreProcessorClient::connect(endpoint)).await?;
+        let response = SyncFuture::new(client.process_list_root_keys(request)).await?;
         let response = response.into_inner();
         let ReplyListRootKeys { root_keys } = response;
         Ok(root_keys)
@@ -489,8 +489,8 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
     async fn delete_all(config: &Self::Config) -> Result<(), ServiceStoreError> {
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
-        let mut client = StoreProcessorClient::connect(endpoint).await?;
-        let _response = client.process_delete_all(()).await?;
+        let mut client = SyncFuture::new(StoreProcessorClient::connect(endpoint)).await?;
+        let _response = SyncFuture::new(client.process_delete_all(())).await?;
         Ok(())
     }
 
@@ -500,8 +500,8 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
         let request = tonic::Request::new(query);
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
-        let mut client = StoreProcessorClient::connect(endpoint).await?;
-        let response = client.process_exists_namespace(request).await?;
+        let mut client = SyncFuture::new(StoreProcessorClient::connect(endpoint)).await?;
+        let response = SyncFuture::new(client.process_exists_namespace(request)).await?;
         let response = response.into_inner();
         let ReplyExistsNamespace { exists } = response;
         Ok(exists)
@@ -516,8 +516,8 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
         let request = tonic::Request::new(query);
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
-        let mut client = StoreProcessorClient::connect(endpoint).await?;
-        let _response = client.process_create_namespace(request).await?;
+        let mut client = SyncFuture::new(StoreProcessorClient::connect(endpoint)).await?;
+        let _response = SyncFuture::new(client.process_create_namespace(request)).await?;
         Ok(())
     }
 
@@ -527,8 +527,8 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
         let request = tonic::Request::new(query);
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
-        let mut client = StoreProcessorClient::connect(endpoint).await?;
-        let _response = client.process_delete_namespace(request).await?;
+        let mut client = SyncFuture::new(StoreProcessorClient::connect(endpoint)).await?;
+        let _response = SyncFuture::new(client.process_delete_namespace(request)).await?;
         Ok(())
     }
 }

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -25,6 +25,7 @@ use linera_views::{
     },
 };
 use serde::de::DeserializeOwned;
+use sync_wrapper::SyncFuture;
 use tonic::transport::{Channel, Endpoint};
 
 #[cfg(with_testing)]
@@ -97,7 +98,7 @@ impl ReadableKeyValueStore for ServiceStoreClientInternal {
         let channel = self.channel.clone();
         let mut client = StoreProcessorClient::new(channel);
         let _guard = self.acquire().await;
-        let response = client.process_read_value(request).await?;
+        let response = SyncFuture::new(client.process_read_value(request)).await?;
         let response = response.into_inner();
         let ReplyReadValue {
             value,
@@ -120,7 +121,7 @@ impl ReadableKeyValueStore for ServiceStoreClientInternal {
         let channel = self.channel.clone();
         let mut client = StoreProcessorClient::new(channel);
         let _guard = self.acquire().await;
-        let response = client.process_contains_key(request).await?;
+        let response = SyncFuture::new(client.process_contains_key(request)).await?;
         let response = response.into_inner();
         let ReplyContainsKey { test } = response;
         Ok(test)
@@ -139,7 +140,7 @@ impl ReadableKeyValueStore for ServiceStoreClientInternal {
         let channel = self.channel.clone();
         let mut client = StoreProcessorClient::new(channel);
         let _guard = self.acquire().await;
-        let response = client.process_contains_keys(request).await?;
+        let response = SyncFuture::new(client.process_contains_keys(request)).await?;
         let response = response.into_inner();
         let ReplyContainsKeys { tests } = response;
         Ok(tests)
@@ -161,7 +162,7 @@ impl ReadableKeyValueStore for ServiceStoreClientInternal {
         let channel = self.channel.clone();
         let mut client = StoreProcessorClient::new(channel);
         let _guard = self.acquire().await;
-        let response = client.process_read_multi_values(request).await?;
+        let response = SyncFuture::new(client.process_read_multi_values(request)).await?;
         let response = response.into_inner();
         let ReplyReadMultiValues {
             values,
@@ -193,7 +194,7 @@ impl ReadableKeyValueStore for ServiceStoreClientInternal {
         let channel = self.channel.clone();
         let mut client = StoreProcessorClient::new(channel);
         let _guard = self.acquire().await;
-        let response = client.process_find_keys_by_prefix(request).await?;
+        let response = SyncFuture::new(client.process_find_keys_by_prefix(request)).await?;
         let response = response.into_inner();
         let ReplyFindKeysByPrefix {
             keys,
@@ -224,7 +225,7 @@ impl ReadableKeyValueStore for ServiceStoreClientInternal {
         let channel = self.channel.clone();
         let mut client = StoreProcessorClient::new(channel);
         let _guard = self.acquire().await;
-        let response = client.process_find_key_values_by_prefix(request).await?;
+        let response = SyncFuture::new(client.process_find_key_values_by_prefix(request)).await?;
         let response = response.into_inner();
         let ReplyFindKeyValuesByPrefix {
             key_values,
@@ -383,7 +384,7 @@ impl ServiceStoreClientInternal {
         };
         let request = tonic::Request::new(query);
         let mut client = StoreProcessorClient::new(channel);
-        let response = client.process_specific_chunk(request).await?;
+        let response = SyncFuture::new(client.process_specific_chunk(request)).await?;
         let response = response.into_inner();
         let ReplySpecificChunk { chunk } = response;
         Ok(chunk)

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -23,9 +23,9 @@ use linera_views::{
         AdminKeyValueStore, CommonStoreInternalConfig, ReadableKeyValueStore, WithError,
         WritableKeyValueStore,
     },
+    FutureSyncExt,
 };
 use serde::de::DeserializeOwned;
-use sync_wrapper::SyncFuture;
 use tonic::transport::{Channel, Endpoint};
 
 #[cfg(with_testing)]
@@ -98,7 +98,7 @@ impl ReadableKeyValueStore for ServiceStoreClientInternal {
         let channel = self.channel.clone();
         let mut client = StoreProcessorClient::new(channel);
         let _guard = self.acquire().await;
-        let response = SyncFuture::new(client.process_read_value(request)).await?;
+        let response = client.process_read_value(request).make_sync().await?;
         let response = response.into_inner();
         let ReplyReadValue {
             value,
@@ -121,7 +121,7 @@ impl ReadableKeyValueStore for ServiceStoreClientInternal {
         let channel = self.channel.clone();
         let mut client = StoreProcessorClient::new(channel);
         let _guard = self.acquire().await;
-        let response = SyncFuture::new(client.process_contains_key(request)).await?;
+        let response = client.process_contains_key(request).make_sync().await?;
         let response = response.into_inner();
         let ReplyContainsKey { test } = response;
         Ok(test)
@@ -140,7 +140,7 @@ impl ReadableKeyValueStore for ServiceStoreClientInternal {
         let channel = self.channel.clone();
         let mut client = StoreProcessorClient::new(channel);
         let _guard = self.acquire().await;
-        let response = SyncFuture::new(client.process_contains_keys(request)).await?;
+        let response = client.process_contains_keys(request).make_sync().await?;
         let response = response.into_inner();
         let ReplyContainsKeys { tests } = response;
         Ok(tests)
@@ -162,7 +162,10 @@ impl ReadableKeyValueStore for ServiceStoreClientInternal {
         let channel = self.channel.clone();
         let mut client = StoreProcessorClient::new(channel);
         let _guard = self.acquire().await;
-        let response = SyncFuture::new(client.process_read_multi_values(request)).await?;
+        let response = client
+            .process_read_multi_values(request)
+            .make_sync()
+            .await?;
         let response = response.into_inner();
         let ReplyReadMultiValues {
             values,
@@ -194,7 +197,10 @@ impl ReadableKeyValueStore for ServiceStoreClientInternal {
         let channel = self.channel.clone();
         let mut client = StoreProcessorClient::new(channel);
         let _guard = self.acquire().await;
-        let response = SyncFuture::new(client.process_find_keys_by_prefix(request)).await?;
+        let response = client
+            .process_find_keys_by_prefix(request)
+            .make_sync()
+            .await?;
         let response = response.into_inner();
         let ReplyFindKeysByPrefix {
             keys,
@@ -225,7 +231,10 @@ impl ReadableKeyValueStore for ServiceStoreClientInternal {
         let channel = self.channel.clone();
         let mut client = StoreProcessorClient::new(channel);
         let _guard = self.acquire().await;
-        let response = SyncFuture::new(client.process_find_key_values_by_prefix(request)).await?;
+        let response = client
+            .process_find_key_values_by_prefix(request)
+            .make_sync()
+            .await?;
         let response = response.into_inner();
         let ReplyFindKeyValuesByPrefix {
             key_values,
@@ -341,7 +350,10 @@ impl ServiceStoreClientInternal {
             let channel = self.channel.clone();
             let mut client = StoreProcessorClient::new(channel);
             let _guard = self.acquire().await;
-            let _response = SyncFuture::new(client.process_write_batch_extended(request)).await?;
+            let _response = client
+                .process_write_batch_extended(request)
+                .make_sync()
+                .await?;
         }
         Ok(())
     }
@@ -384,7 +396,7 @@ impl ServiceStoreClientInternal {
         };
         let request = tonic::Request::new(query);
         let mut client = StoreProcessorClient::new(channel);
-        let response = SyncFuture::new(client.process_specific_chunk(request)).await?;
+        let response = client.process_specific_chunk(request).make_sync().await?;
         let response = response.into_inner();
         let ReplySpecificChunk { chunk } = response;
         Ok(chunk)
@@ -459,8 +471,8 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
     async fn list_all(config: &Self::Config) -> Result<Vec<String>, ServiceStoreError> {
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
-        let mut client = SyncFuture::new(StoreProcessorClient::connect(endpoint)).await?;
-        let response = SyncFuture::new(client.process_list_all(())).await?;
+        let mut client = StoreProcessorClient::connect(endpoint).make_sync().await?;
+        let response = client.process_list_all(()).make_sync().await?;
         let response = response.into_inner();
         let ReplyListAll { namespaces } = response;
         let namespaces = namespaces
@@ -479,8 +491,8 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
         let request = tonic::Request::new(query);
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
-        let mut client = SyncFuture::new(StoreProcessorClient::connect(endpoint)).await?;
-        let response = SyncFuture::new(client.process_list_root_keys(request)).await?;
+        let mut client = StoreProcessorClient::connect(endpoint).make_sync().await?;
+        let response = client.process_list_root_keys(request).make_sync().await?;
         let response = response.into_inner();
         let ReplyListRootKeys { root_keys } = response;
         Ok(root_keys)
@@ -489,8 +501,8 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
     async fn delete_all(config: &Self::Config) -> Result<(), ServiceStoreError> {
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
-        let mut client = SyncFuture::new(StoreProcessorClient::connect(endpoint)).await?;
-        let _response = SyncFuture::new(client.process_delete_all(())).await?;
+        let mut client = StoreProcessorClient::connect(endpoint).make_sync().await?;
+        let _response = client.process_delete_all(()).make_sync().await?;
         Ok(())
     }
 
@@ -500,8 +512,8 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
         let request = tonic::Request::new(query);
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
-        let mut client = SyncFuture::new(StoreProcessorClient::connect(endpoint)).await?;
-        let response = SyncFuture::new(client.process_exists_namespace(request)).await?;
+        let mut client = StoreProcessorClient::connect(endpoint).make_sync().await?;
+        let response = client.process_exists_namespace(request).make_sync().await?;
         let response = response.into_inner();
         let ReplyExistsNamespace { exists } = response;
         Ok(exists)
@@ -516,8 +528,8 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
         let request = tonic::Request::new(query);
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
-        let mut client = SyncFuture::new(StoreProcessorClient::connect(endpoint)).await?;
-        let _response = SyncFuture::new(client.process_create_namespace(request)).await?;
+        let mut client = StoreProcessorClient::connect(endpoint).make_sync().await?;
+        let _response = client.process_create_namespace(request).make_sync().await?;
         Ok(())
     }
 
@@ -527,8 +539,8 @@ impl AdminKeyValueStore for ServiceStoreClientInternal {
         let request = tonic::Request::new(query);
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
-        let mut client = SyncFuture::new(StoreProcessorClient::connect(endpoint)).await?;
-        let _response = SyncFuture::new(client.process_delete_namespace(request)).await?;
+        let mut client = StoreProcessorClient::connect(endpoint).make_sync().await?;
+        let _response = client.process_delete_namespace(request).make_sync().await?;
         Ok(())
     }
 }

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -217,7 +217,7 @@ fn generate_root_view_code(input: ItemStruct) -> TokenStream2 {
         impl #impl_generics linera_views::views::RootView for #struct_name #type_generics
         where
             #(#input_constraints,)*
-            Self: linera_views::views::View + Sync,
+            Self: linera_views::views::View,
         {
             async fn save(&mut self) -> Result<(), linera_views::ViewError> {
                 use linera_views::{context::Context, batch::Batch, store::WritableKeyValueStore as _, views::View};
@@ -255,7 +255,7 @@ fn generate_hash_view_code(input: ItemStruct) -> TokenStream2 {
         where
             #(#field_types: linera_views::views::HashableView,)*
             #(#input_constraints,)*
-            Self: linera_views::views::View + Sync,
+            Self: linera_views::views::View,
         {
             type Hasher = linera_views::sha3::Sha3_256;
 
@@ -293,7 +293,7 @@ fn generate_crypto_hash_code(input: ItemStruct) -> TokenStream2 {
         where
             #(#field_types: linera_views::views::HashableView,)*
             #(#input_constraints,)*
-            Self: linera_views::views::View + Sync,
+            Self: linera_views::views::View,
         {
             async fn crypto_hash(&self) -> Result<linera_base::crypto::CryptoHash, linera_views::ViewError> {
                 use linera_base::crypto::{BcsHashable, CryptoHash};
@@ -353,7 +353,7 @@ fn generate_clonable_view_code(input: ItemStruct) -> TokenStream2 {
         where
             #(#input_constraints,)*
             #(#clone_constraints,)*
-            Self: linera_views::views::View + Sync,
+            Self: linera_views::views::View,
         {
             fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
                 Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-2.snap
@@ -7,7 +7,7 @@ where
     MyParam: Send + Sync + 'static,
     RegisterView<C, usize>: ClonableView,
     CollectionView<C, usize, RegisterView<C, usize>>: ClonableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-3.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-3.snap
@@ -10,7 +10,7 @@ where
         usize,
         RegisterView<CustomContext, usize>,
     >: ClonableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-4.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-4.snap
@@ -11,7 +11,7 @@ where
         usize,
         RegisterView<CustomContext, usize>,
     >: ClonableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-5.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-5.snap
@@ -10,7 +10,7 @@ where
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
     >: ClonableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-6.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-6.snap
@@ -11,7 +11,7 @@ where
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
     >: ClonableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-7.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-7.snap
@@ -10,7 +10,7 @@ where
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
     >: ClonableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-8.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-8.snap
@@ -11,7 +11,7 @@ where
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
     >: ClonableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code.snap
@@ -6,7 +6,7 @@ impl<C> linera_views::views::ClonableView for TestView<C>
 where
     RegisterView<C, usize>: ClonableView,
     CollectionView<C, usize, RegisterView<C, usize>>: ClonableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-2.snap
@@ -7,7 +7,7 @@ where
     RegisterView<C, usize>: linera_views::views::HashableView,
     CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-3.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-3.snap
@@ -10,7 +10,7 @@ where
         usize,
         RegisterView<CustomContext, usize>,
     >: linera_views::views::HashableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-4.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-4.snap
@@ -11,7 +11,7 @@ where
         RegisterView<CustomContext, usize>,
     >: linera_views::views::HashableView,
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-5.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-5.snap
@@ -13,7 +13,7 @@ where
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
     >: linera_views::views::HashableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-6.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-6.snap
@@ -14,7 +14,7 @@ where
         RegisterView<custom::path::to::ContextType, usize>,
     >: linera_views::views::HashableView,
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-7.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-7.snap
@@ -10,7 +10,7 @@ where
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
     >: linera_views::views::HashableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-8.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-8.snap
@@ -11,7 +11,7 @@ where
         RegisterView<custom::GenericContext<T>, usize>,
     >: linera_views::views::HashableView,
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code.snap
@@ -6,7 +6,7 @@ impl<C> linera_views::views::CryptoHashView for TestView<C>
 where
     RegisterView<C, usize>: linera_views::views::HashableView,
     CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C.snap
@@ -6,7 +6,7 @@ impl<C> linera_views::views::HashableView for TestView<C>
 where
     RegisterView<C, usize>: linera_views::views::HashableView,
     CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C_with_where.snap
@@ -7,7 +7,7 @@ where
     RegisterView<C, usize>: linera_views::views::HashableView,
     CollectionView<C, usize, RegisterView<C, usize>>: linera_views::views::HashableView,
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext.snap
@@ -10,7 +10,7 @@ where
         usize,
         RegisterView<CustomContext, usize>,
     >: linera_views::views::HashableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_CustomContext_with_where.snap
@@ -11,7 +11,7 @@ where
         RegisterView<CustomContext, usize>,
     >: linera_views::views::HashableView,
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T_.snap
@@ -10,7 +10,7 @@ where
         usize,
         RegisterView<custom::GenericContext<T>, usize>,
     >: linera_views::views::HashableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__GenericContext_T__with_where.snap
@@ -11,7 +11,7 @@ where
         RegisterView<custom::GenericContext<T>, usize>,
     >: linera_views::views::HashableView,
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType.snap
@@ -13,7 +13,7 @@ where
         usize,
         RegisterView<custom::path::to::ContextType, usize>,
     >: linera_views::views::HashableView,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_custom__path__to__ContextType_with_where.snap
@@ -14,7 +14,7 @@ where
         RegisterView<custom::path::to::ContextType, usize>,
     >: linera_views::views::HashableView,
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C.snap
@@ -4,7 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl<C> linera_views::views::RootView for TestView<C>
 where
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C_with_where.snap
@@ -5,7 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<C, MyParam> linera_views::views::RootView for TestView<C, MyParam>
 where
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext.snap
@@ -4,7 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl linera_views::views::RootView for TestView
 where
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext_with_where.snap
@@ -5,7 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<MyParam> linera_views::views::RootView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T_.snap
@@ -4,7 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl linera_views::views::RootView for TestView
 where
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T__with_where.snap
@@ -5,7 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<MyParam> linera_views::views::RootView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType.snap
@@ -4,7 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl linera_views::views::RootView for TestView
 where
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType_with_where.snap
@@ -5,7 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<MyParam> linera_views::views::RootView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C.snap
@@ -4,7 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl<C> linera_views::views::RootView for TestView<C>
 where
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C_with_where.snap
@@ -5,7 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<C, MyParam> linera_views::views::RootView for TestView<C, MyParam>
 where
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext.snap
@@ -4,7 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl linera_views::views::RootView for TestView
 where
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext_with_where.snap
@@ -5,7 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<MyParam> linera_views::views::RootView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T_.snap
@@ -4,7 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl linera_views::views::RootView for TestView
 where
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T__with_where.snap
@@ -5,7 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<MyParam> linera_views::views::RootView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType.snap
@@ -4,7 +4,7 @@ expression: pretty(generate_root_view_code(input))
 ---
 impl linera_views::views::RootView for TestView
 where
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType_with_where.snap
@@ -5,7 +5,7 @@ expression: pretty(generate_root_view_code(input))
 impl<MyParam> linera_views::views::RootView for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
-    Self: linera_views::views::View + Sync,
+    Self: linera_views::views::View,
 {
     async fn save(&mut self) -> Result<(), linera_views::ViewError> {
         use linera_views::{

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -25,7 +25,12 @@ web = ["linera-base/web", "gloo-utils"]
 indexeddb = ["indexed_db_futures", "wasm-bindgen"]
 web-default = ["web", "indexeddb"]
 
-dynamodb = ["aws-config", "aws-sdk-dynamodb", "aws-smithy-types"]
+dynamodb = [
+    "aws-config",
+    "aws-sdk-dynamodb",
+    "aws-smithy-types",
+    "sync_wrapper/futures",
+]
 scylladb = ["scylla"]
 
 [dependencies]
@@ -53,6 +58,7 @@ scylla = { workspace = true, optional = true }
 serde.workspace = true
 sha3.workspace = true
 static_assertions.workspace = true
+sync_wrapper.workspace = true
 sysinfo.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -25,12 +25,7 @@ web = ["linera-base/web", "gloo-utils"]
 indexeddb = ["indexed_db_futures", "wasm-bindgen"]
 web-default = ["web", "indexeddb"]
 
-dynamodb = [
-    "aws-config",
-    "aws-sdk-dynamodb",
-    "aws-smithy-types",
-    "sync_wrapper/futures",
-]
+dynamodb = ["aws-config", "aws-sdk-dynamodb", "aws-smithy-types"]
 scylladb = ["scylla"]
 
 [dependencies]

--- a/linera-views/benches/queue_view.rs
+++ b/linera-views/benches/queue_view.rs
@@ -55,12 +55,9 @@ pub struct QueueStateView<C> {
     pub queue: QueueView<C, u8>,
 }
 
-pub async fn performance_queue_view<S: TestKeyValueStore + Clone + Sync + 'static>(
+pub async fn performance_queue_view<S: TestKeyValueStore + Clone + 'static>(
     iterations: u64,
-) -> Duration
-where
-    S::Error: Send + Sync,
-{
+) -> Duration {
     let store = S::new_test_store().await.unwrap();
     let context = ViewContext::<(), S>::create_root_context(store, ())
         .await
@@ -135,12 +132,9 @@ pub struct BucketQueueStateView<C> {
     pub queue: BucketQueueView<C, u8, 100>,
 }
 
-pub async fn performance_bucket_queue_view<S: TestKeyValueStore + Clone + Sync + 'static>(
+pub async fn performance_bucket_queue_view<S: TestKeyValueStore + Clone + 'static>(
     iterations: u64,
-) -> Duration
-where
-    S::Error: Send + Sync,
-{
+) -> Duration {
     let store = S::new_test_store().await.unwrap();
     let context = ViewContext::<(), S>::create_root_context(store, ())
         .await

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -6,6 +6,8 @@
 use std::{
     collections::HashMap,
     env,
+    future::Future,
+    pin::Pin,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -33,7 +35,7 @@ use aws_sdk_dynamodb::{
     Client,
 };
 use aws_smithy_types::error::operation::BuildError;
-use futures::future::{join_all, FutureExt as _};
+use futures::future::join_all;
 use linera_base::ensure;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -57,10 +59,18 @@ use crate::{
 /// Name of the environment variable with the address to a DynamoDB local instance.
 const DYNAMODB_LOCAL_ENDPOINT: &str = "DYNAMODB_LOCAL_ENDPOINT";
 
+trait FutureSyncExt: Future + Sized {
+    fn boxed_sync(self) -> Pin<Box<sync_wrapper::SyncFuture<Self>>> {
+        Box::pin(sync_wrapper::SyncFuture::new(self))
+    }
+}
+
+impl<F: Future> FutureSyncExt for F {}
+
 /// Gets the AWS configuration from the environment
 async fn get_base_config() -> Result<aws_sdk_dynamodb::Config, DynamoDbStoreInternalError> {
     let base_config = aws_config::load_defaults(aws_config::BehaviorVersion::latest())
-        .boxed()
+        .boxed_sync()
         .await;
     Ok((&base_config).into())
 }
@@ -73,7 +83,7 @@ fn get_endpoint_address() -> Option<String> {
 async fn get_dynamodb_local_config() -> Result<aws_sdk_dynamodb::Config, DynamoDbStoreInternalError>
 {
     let base_config = aws_config::load_defaults(aws_config::BehaviorVersion::latest())
-        .boxed()
+        .boxed_sync()
         .await;
     let endpoint_address = get_endpoint_address().unwrap();
     let config = aws_sdk_dynamodb::config::Builder::from(&base_config)
@@ -393,7 +403,7 @@ impl AdminKeyValueStore for DynamoDbStoreInternal {
                 .list_tables()
                 .set_exclusive_start_table_name(start_table)
                 .send()
-                .boxed()
+                .boxed_sync()
                 .await?;
             if let Some(namespaces_blk) = response.table_names {
                 namespaces.extend(namespaces_blk);
@@ -432,7 +442,7 @@ impl AdminKeyValueStore for DynamoDbStoreInternal {
                 .delete_table()
                 .table_name(&table)
                 .send()
-                .boxed()
+                .boxed_sync()
                 .await?;
         }
         Ok(())
@@ -450,7 +460,7 @@ impl AdminKeyValueStore for DynamoDbStoreInternal {
             .table_name(namespace)
             .set_key(Some(key_db))
             .send()
-            .boxed()
+            .boxed_sync()
             .await;
         let Err(error) = response else {
             return Ok(true);
@@ -512,7 +522,7 @@ impl AdminKeyValueStore for DynamoDbStoreInternal {
                     .build()?,
             )
             .send()
-            .boxed()
+            .boxed_sync()
             .await?;
         Ok(())
     }
@@ -527,7 +537,7 @@ impl AdminKeyValueStore for DynamoDbStoreInternal {
             .delete_table()
             .table_name(namespace)
             .send()
-            .boxed()
+            .boxed_sync()
             .await?;
         Ok(())
     }
@@ -615,7 +625,7 @@ impl DynamoDbStoreInternal {
             .expression_attribute_values(":prefix", AttributeValue::B(Blob::new(key_prefix)))
             .set_exclusive_start_key(start_key_map)
             .send()
-            .boxed()
+            .boxed_sync()
             .await?;
         Ok(response)
     }
@@ -631,7 +641,7 @@ impl DynamoDbStoreInternal {
             .table_name(&self.namespace)
             .set_key(Some(key_db))
             .send()
-            .boxed()
+            .boxed_sync()
             .await?;
 
         match response.item {
@@ -655,7 +665,7 @@ impl DynamoDbStoreInternal {
             .set_key(Some(key_db))
             .projection_expression(PARTITION_ATTRIBUTE)
             .send()
-            .boxed()
+            .boxed_sync()
             .await?;
 
         Ok(response.item.is_some())
@@ -960,7 +970,7 @@ impl DirectWritableKeyValueStore for DynamoDbStoreInternal {
                 .transact_write_items()
                 .set_transact_items(Some(builder.transactions))
                 .send()
-                .boxed()
+                .boxed_sync()
                 .await?;
         }
         let mut builder = TransactionBuilder::new(&self.start_key);
@@ -976,7 +986,7 @@ impl DirectWritableKeyValueStore for DynamoDbStoreInternal {
                 .transact_write_items()
                 .set_transact_items(Some(builder.transactions))
                 .send()
-                .boxed()
+                .boxed_sync()
                 .await?;
         }
         Ok(())

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -6,8 +6,6 @@
 use std::{
     collections::HashMap,
     env,
-    future::Future,
-    pin::Pin,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -54,18 +52,11 @@ use crate::{
         KeyValueStoreError, ReadableKeyValueStore, WithError,
     },
     value_splitting::{ValueSplittingError, ValueSplittingStore},
+    FutureSyncExt as _,
 };
 
 /// Name of the environment variable with the address to a DynamoDB local instance.
 const DYNAMODB_LOCAL_ENDPOINT: &str = "DYNAMODB_LOCAL_ENDPOINT";
-
-trait FutureSyncExt: Future + Sized {
-    fn boxed_sync(self) -> Pin<Box<sync_wrapper::SyncFuture<Self>>> {
-        Box::pin(sync_wrapper::SyncFuture::new(self))
-    }
-}
-
-impl<F: Future> FutureSyncExt for F {}
 
 /// Gets the AWS configuration from the environment
 async fn get_base_config() -> Result<aws_sdk_dynamodb::Config, DynamoDbStoreInternalError> {

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -110,7 +110,7 @@ pub struct JournalingKeyValueStore<K> {
 
 impl<K> DeletePrefixExpander for &JournalingKeyValueStore<K>
 where
-    K: DirectKeyValueStore + Send + Sync,
+    K: DirectKeyValueStore,
 {
     type Error = K::Error;
     async fn expand_delete_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {
@@ -131,7 +131,7 @@ where
 
 impl<K> ReadableKeyValueStore for JournalingKeyValueStore<K>
 where
-    K: ReadableKeyValueStore + Send + Sync,
+    K: ReadableKeyValueStore,
     K::Error: From<JournalConsistencyError>,
 {
     /// The size constant do not change
@@ -178,7 +178,7 @@ where
 
 impl<K> AdminKeyValueStore for JournalingKeyValueStore<K>
 where
-    K: AdminKeyValueStore + Send + Sync,
+    K: AdminKeyValueStore,
 {
     type Config = K::Config;
 
@@ -232,7 +232,7 @@ where
 
 impl<K> WritableKeyValueStore for JournalingKeyValueStore<K>
 where
-    K: DirectKeyValueStore + Send + Sync,
+    K: DirectKeyValueStore,
     K::Error: From<JournalConsistencyError>,
 {
     /// The size constant do not change
@@ -263,7 +263,7 @@ where
 
 impl<K> JournalingKeyValueStore<K>
 where
-    K: DirectKeyValueStore + Send + Sync,
+    K: DirectKeyValueStore,
     K::Error: From<JournalConsistencyError>,
 {
     /// Resolves the pending operations that were previously stored in the database

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -64,7 +64,7 @@ fn get_journaling_key(tag: u8, pos: u32) -> Result<Vec<u8>, bcs::Error> {
 }
 
 /// Low-level, asynchronous direct write key-value operations with simplified batch
-#[cfg_attr(not(web), trait_variant::make(Send))]
+#[cfg_attr(not(web), trait_variant::make(Send + Sync))]
 pub trait DirectWritableKeyValueStore: WithError {
     /// The maximal number of items in a batch.
     const MAX_BATCH_SIZE: usize;

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -264,7 +264,7 @@ where
 
 impl<K> ReadableKeyValueStore for LruCachingStore<K>
 where
-    K: ReadableKeyValueStore + Send + Sync,
+    K: ReadableKeyValueStore,
 {
     // The LRU cache does not change the underlying store's size limits.
     const MAX_KEY_SIZE: usize = K::MAX_KEY_SIZE;
@@ -424,7 +424,7 @@ where
 
 impl<K> WritableKeyValueStore for LruCachingStore<K>
 where
-    K: WritableKeyValueStore + Send + Sync,
+    K: WritableKeyValueStore,
 {
     // The LRU cache does not change the underlying store's size limits.
     const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
@@ -471,7 +471,7 @@ pub struct LruCachingConfig<C> {
 
 impl<K> AdminKeyValueStore for LruCachingStore<K>
 where
-    K: AdminKeyValueStore + Send + Sync,
+    K: AdminKeyValueStore,
 {
     type Config = LruCachingConfig<K::Config>;
 
@@ -525,7 +525,7 @@ where
 #[cfg(with_testing)]
 impl<K> TestKeyValueStore for LruCachingStore<K>
 where
-    K: TestKeyValueStore + Send + Sync,
+    K: TestKeyValueStore,
 {
     async fn new_test_config() -> Result<LruCachingConfig<K::Config>, K::Error> {
         let inner_config = K::new_test_config().await?;

--- a/linera-views/src/backends/metering.rs
+++ b/linera-views/src/backends/metering.rs
@@ -285,7 +285,7 @@ where
 
 impl<K> ReadableKeyValueStore for MeteredStore<K>
 where
-    K: ReadableKeyValueStore + Send + Sync,
+    K: ReadableKeyValueStore,
 {
     const MAX_KEY_SIZE: usize = K::MAX_KEY_SIZE;
     type Keys = K::Keys;
@@ -417,7 +417,7 @@ where
 
 impl<K> WritableKeyValueStore for MeteredStore<K>
 where
-    K: WritableKeyValueStore + Send + Sync,
+    K: WritableKeyValueStore,
 {
     const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
 
@@ -438,7 +438,7 @@ where
 
 impl<K> AdminKeyValueStore for MeteredStore<K>
 where
-    K: AdminKeyValueStore + Send + Sync,
+    K: AdminKeyValueStore,
 {
     type Config = K::Config;
 
@@ -522,7 +522,7 @@ where
 #[cfg(with_testing)]
 impl<K> TestKeyValueStore for MeteredStore<K>
 where
-    K: TestKeyValueStore + Send + Sync,
+    K: TestKeyValueStore,
 {
     async fn new_test_config() -> Result<K::Config, Self::Error> {
         K::new_test_config().await

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -15,7 +15,7 @@ use std::{
 
 use async_lock::{Semaphore, SemaphoreGuard};
 use dashmap::{mapref::entry::Entry, DashMap};
-use futures::{future::join_all, FutureExt as _, StreamExt};
+use futures::{future::join_all, StreamExt as _};
 use linera_base::ensure;
 use scylla::{
     client::{
@@ -52,6 +52,7 @@ use crate::{
         WithError,
     },
     value_splitting::{ValueSplittingError, ValueSplittingStore},
+    FutureSyncExt as _,
 };
 
 /// Fundamental constant in ScyllaDB: The maximum size of a multi keys query
@@ -233,7 +234,7 @@ impl ScyllaDbClient {
                 Self::build_default_policy(),
             ))
             .build()
-            .boxed()
+            .boxed_sync()
             .await
             .map_err(Into::into)
     }

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -73,7 +73,7 @@ where
 
 impl<K> ReadableKeyValueStore for ValueSplittingStore<K>
 where
-    K: ReadableKeyValueStore + Send + Sync,
+    K: ReadableKeyValueStore,
     K::Error: 'static,
 {
     const MAX_KEY_SIZE: usize = K::MAX_KEY_SIZE - 4;
@@ -235,7 +235,7 @@ where
 
 impl<K> WritableKeyValueStore for ValueSplittingStore<K>
 where
-    K: WritableKeyValueStore + Send + Sync,
+    K: WritableKeyValueStore,
     K::Error: 'static,
 {
     const MAX_VALUE_SIZE: usize = usize::MAX;
@@ -280,7 +280,7 @@ where
 
 impl<K> AdminKeyValueStore for ValueSplittingStore<K>
 where
-    K: AdminKeyValueStore + Send + Sync,
+    K: AdminKeyValueStore,
     K::Error: 'static,
 {
     type Config = K::Config;
@@ -330,7 +330,7 @@ where
 #[cfg(with_testing)]
 impl<K> TestKeyValueStore for ValueSplittingStore<K>
 where
-    K: TestKeyValueStore + Send + Sync,
+    K: TestKeyValueStore,
     K::Error: 'static,
 {
     async fn new_test_config() -> Result<K::Config, Self::Error> {

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -367,7 +367,7 @@ impl Batch {
 /// Certain databases (e.g. DynamoDB) do not support the deletion by prefix.
 /// Thus we need to access the databases in order to replace a `DeletePrefix`
 /// by a vector of the keys to be removed.
-#[cfg_attr(not(web), trait_variant::make(Send))]
+#[cfg_attr(not(web), trait_variant::make(Send + Sync))]
 pub trait DeletePrefixExpander {
     /// The error type that can happen when expanding the key prefix.
     type Error: Debug;
@@ -376,7 +376,7 @@ pub trait DeletePrefixExpander {
     async fn expand_delete_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error>;
 }
 
-#[cfg_attr(not(web), trait_variant::make(Send))]
+#[cfg_attr(not(web), trait_variant::make(Send + Sync))]
 /// A notion of batch useful for certain computations (notably journaling).
 pub trait SimplifiedBatch: Sized + Send + Sync {
     /// The iterator type used to process values from the batch.
@@ -414,6 +414,7 @@ pub trait SimplifiedBatch: Sized + Send + Sync {
 
 /// An iterator-like object that can write values one by one to a batch while updating the
 /// total size of the batch.
+#[cfg_attr(not(web), trait_variant::make(Send + Sync))]
 pub trait BatchValueWriter<Batch>: Send + Sync {
     /// Returns true if there are no more values to write.
     fn is_empty(&self) -> bool;

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -383,10 +383,7 @@ pub trait SimplifiedBatch: Sized + Send + Sync {
     type Iter: BatchValueWriter<Self>;
 
     /// Creates a simplified batch from a standard one.
-    async fn from_batch<S: DeletePrefixExpander + Send + Sync>(
-        store: S,
-        batch: Batch,
-    ) -> Result<Self, S::Error>;
+    async fn from_batch<S: DeletePrefixExpander>(store: S, batch: Batch) -> Result<Self, S::Error>;
 
     /// Returns an owning iterator over the values in the batch.
     fn into_iter(self) -> Self::Iter;
@@ -415,7 +412,7 @@ pub trait SimplifiedBatch: Sized + Send + Sync {
 /// An iterator-like object that can write values one by one to a batch while updating the
 /// total size of the batch.
 #[cfg_attr(not(web), trait_variant::make(Send + Sync))]
-pub trait BatchValueWriter<Batch>: Send + Sync {
+pub trait BatchValueWriter<Batch> {
     /// Returns true if there are no more values to write.
     fn is_empty(&self) -> bool;
 
@@ -482,10 +479,7 @@ impl SimplifiedBatch for SimpleUnorderedBatch {
         self.insertions.push((key, value))
     }
 
-    async fn from_batch<S: DeletePrefixExpander + Send + Sync>(
-        store: S,
-        batch: Batch,
-    ) -> Result<Self, S::Error> {
+    async fn from_batch<S: DeletePrefixExpander>(store: S, batch: Batch) -> Result<Self, S::Error> {
         let unordered_batch = batch.simplify();
         unordered_batch.expand_delete_prefixes(&store).await
     }
@@ -584,10 +578,7 @@ impl SimplifiedBatch for UnorderedBatch {
         self.simple_unordered_batch.add_insert(key, value)
     }
 
-    async fn from_batch<S: DeletePrefixExpander + Send + Sync>(
-        store: S,
-        batch: Batch,
-    ) -> Result<Self, S::Error> {
+    async fn from_batch<S: DeletePrefixExpander>(store: S, batch: Batch) -> Result<Self, S::Error> {
         let mut unordered_batch = batch.simplify();
         unordered_batch
             .expand_colliding_prefix_deletions(&store)

--- a/linera-views/src/context.rs
+++ b/linera-views/src/context.rs
@@ -86,11 +86,7 @@ where
     crate::ViewError: From<Self::Error>,
 {
     /// The type of the key-value store used by this context.
-    type Store: ReadableKeyValueStore
-        + WritableKeyValueStore
-        + WithError<Error = Self::Error>
-        + Send
-        + Sync;
+    type Store: ReadableKeyValueStore + WritableKeyValueStore + WithError<Error = Self::Error>;
 
     /// User-provided data to be carried along.
     type Extra: Clone + Send + Sync;
@@ -160,7 +156,7 @@ impl<E, S> ViewContext<E, S> {
 impl<E, S> Context for ViewContext<E, S>
 where
     E: Clone + Send + Sync,
-    S: ReadableKeyValueStore + WritableKeyValueStore + Clone + Send + Sync,
+    S: ReadableKeyValueStore + WritableKeyValueStore + Clone,
     S::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
 {
     type Extra = E;

--- a/linera-views/src/future_sync_ext.rs
+++ b/linera-views/src/future_sync_ext.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{future::Future, pin::Pin};
+
+use sync_wrapper::SyncFuture;
+
+/// An extension trait to box futures and make them `Sync`.
+pub trait FutureSyncExt: Future + Sized {
+    /// Wrap the future so that it implements `Sync`
+    fn make_sync(self) -> SyncFuture<Self> {
+        SyncFuture::new(self)
+    }
+
+    /// Box the future without losing `Sync`ness
+    fn boxed_sync(self) -> Pin<Box<SyncFuture<Self>>> {
+        Box::pin(self.make_sync())
+    }
+}
+
+impl<F: Future> FutureSyncExt for F {}

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -76,6 +76,10 @@ pub mod common;
 mod error;
 pub use error::ViewError;
 
+mod future_sync_ext;
+#[doc(hidden)]
+pub use future_sync_ext::FutureSyncExt;
+
 /// Elementary data-structures implementing the [`views::View`] trait.
 pub mod views;
 

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -86,7 +86,7 @@ pub trait WithError {
 }
 
 /// Low-level, asynchronous read key-value operations. Useful for storage APIs not based on views.
-#[cfg_attr(not(web), trait_variant::make(Send))]
+#[cfg_attr(not(web), trait_variant::make(Send + Sync))]
 pub trait ReadableKeyValueStore: WithError {
     /// The maximal size of keys that can be stored.
     const MAX_KEY_SIZE: usize;
@@ -132,10 +132,7 @@ pub trait ReadableKeyValueStore: WithError {
     fn read_value<V: DeserializeOwned>(
         &self,
         key: &[u8],
-    ) -> impl Future<Output = Result<Option<V>, Self::Error>>
-    where
-        Self: Sync,
-    {
+    ) -> impl Future<Output = Result<Option<V>, Self::Error>> {
         async { Ok(from_bytes_option(&self.read_value_bytes(key).await?)?) }
     }
 
@@ -143,10 +140,7 @@ pub trait ReadableKeyValueStore: WithError {
     fn read_multi_values<V: DeserializeOwned + Send + Sync>(
         &self,
         keys: Vec<Vec<u8>>,
-    ) -> impl Future<Output = Result<Vec<Option<V>>, Self::Error>>
-    where
-        Self: Sync,
-    {
+    ) -> impl Future<Output = Result<Vec<Option<V>>, Self::Error>> {
         async {
             let mut values = Vec::with_capacity(keys.len());
             for entry in self.read_multi_values_bytes(keys).await? {

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -152,7 +152,7 @@ pub trait ReadableKeyValueStore: WithError {
 }
 
 /// Low-level, asynchronous write key-value operations. Useful for storage APIs not based on views.
-#[cfg_attr(not(web), trait_variant::make(Send))]
+#[cfg_attr(not(web), trait_variant::make(Send + Sync))]
 pub trait WritableKeyValueStore: WithError {
     /// The maximal size of values that can be stored.
     const MAX_VALUE_SIZE: usize;
@@ -166,7 +166,7 @@ pub trait WritableKeyValueStore: WithError {
 }
 
 /// Low-level trait for the administration of stores and their namespaces.
-#[cfg_attr(not(web), trait_variant::make(Send))]
+#[cfg_attr(not(web), trait_variant::make(Send + Sync))]
 pub trait AdminKeyValueStore: WithError + Sized {
     /// The configuration needed to interact with a new store.
     type Config: Send + Sync;

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -82,7 +82,7 @@ enum KeyTag {
     Subview,
 }
 
-impl<W: View + Sync> View for ByteCollectionView<W::Context, W> {
+impl<W: View> View for ByteCollectionView<W::Context, W> {
     const NUM_INIT_KEYS: usize = 0;
 
     type Context = W::Context;
@@ -158,7 +158,7 @@ impl<W: View + Sync> View for ByteCollectionView<W::Context, W> {
     }
 }
 
-impl<W: ClonableView + Sync> ClonableView for ByteCollectionView<W::Context, W> {
+impl<W: ClonableView> ClonableView for ByteCollectionView<W::Context, W> {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         let cloned_updates = self
             .updates
@@ -181,7 +181,7 @@ impl<W: ClonableView + Sync> ClonableView for ByteCollectionView<W::Context, W> 
     }
 }
 
-impl<W: View + Sync> ByteCollectionView<W::Context, W> {
+impl<W: View> ByteCollectionView<W::Context, W> {
     fn get_index_key(&self, index: &[u8]) -> Vec<u8> {
         self.context
             .base_key()
@@ -454,7 +454,7 @@ impl<W: View + Sync> ByteCollectionView<W::Context, W> {
     }
 }
 
-impl<W: View + Sync> ByteCollectionView<W::Context, W> {
+impl<W: View> ByteCollectionView<W::Context, W> {
     /// Applies a function f on each index (aka key). Keys are visited in the
     /// lexicographic order. If the function returns false, then the loop
     /// ends prematurely.
@@ -616,7 +616,7 @@ impl<W: View + Sync> ByteCollectionView<W::Context, W> {
     }
 }
 
-impl<W: HashableView + Sync> HashableView for ByteCollectionView<W::Context, W> {
+impl<W: HashableView> HashableView for ByteCollectionView<W::Context, W> {
     type Hasher = sha3::Sha3_256;
 
     async fn hash_mut(&mut self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
@@ -692,7 +692,7 @@ pub struct CollectionView<C, I, W> {
     _phantom: PhantomData<I>,
 }
 
-impl<W: View + Sync, I> View for CollectionView<W::Context, I, W>
+impl<W: View, I> View for CollectionView<W::Context, I, W>
 where
     I: Send + Sync + Serialize + DeserializeOwned,
 {
@@ -737,7 +737,7 @@ where
     }
 }
 
-impl<I, W: ClonableView + Sync> ClonableView for CollectionView<W::Context, I, W>
+impl<I, W: ClonableView> ClonableView for CollectionView<W::Context, I, W>
 where
     I: Send + Sync + Serialize + DeserializeOwned,
 {
@@ -749,7 +749,7 @@ where
     }
 }
 
-impl<I: Serialize, W: View + Sync> CollectionView<W::Context, I, W> {
+impl<I: Serialize, W: View> CollectionView<W::Context, I, W> {
     /// Loads a subview for the data at the given index in the collection. If an entry
     /// is absent then a default entry is added to the collection. The resulting view
     /// can be modified.
@@ -900,7 +900,7 @@ impl<I: Serialize, W: View + Sync> CollectionView<W::Context, I, W> {
     }
 }
 
-impl<I, W: View + Sync> CollectionView<W::Context, I, W>
+impl<I, W: View> CollectionView<W::Context, I, W>
 where
     I: Sync + Clone + Send + Serialize + DeserializeOwned,
 {
@@ -951,7 +951,7 @@ where
     }
 }
 
-impl<I: DeserializeOwned, W: View + Sync> CollectionView<W::Context, I, W> {
+impl<I: DeserializeOwned, W: View> CollectionView<W::Context, I, W> {
     /// Applies a function f on each index. Indices are visited in an order
     /// determined by the serialization. If the function returns false then
     /// the loop ends prematurely.
@@ -1026,7 +1026,7 @@ impl<I: DeserializeOwned, W: View + Sync> CollectionView<W::Context, I, W> {
     }
 }
 
-impl<I, W: HashableView + Sync> HashableView for CollectionView<W::Context, I, W>
+impl<I, W: HashableView> HashableView for CollectionView<W::Context, I, W>
 where
     I: Clone + Send + Sync + Serialize + DeserializeOwned,
 {
@@ -1048,7 +1048,7 @@ pub struct CustomCollectionView<C, I, W> {
     _phantom: PhantomData<I>,
 }
 
-impl<I: Send + Sync, W: View + Sync> View for CustomCollectionView<W::Context, I, W> {
+impl<I: Send + Sync, W: View> View for CustomCollectionView<W::Context, I, W> {
     const NUM_INIT_KEYS: usize = ByteCollectionView::<W::Context, W>::NUM_INIT_KEYS;
 
     type Context = W::Context;
@@ -1090,9 +1090,7 @@ impl<I: Send + Sync, W: View + Sync> View for CustomCollectionView<W::Context, I
     }
 }
 
-impl<I: Send + Sync, W: ClonableView + Sync> ClonableView
-    for CustomCollectionView<W::Context, I, W>
-{
+impl<I: Send + Sync, W: ClonableView> ClonableView for CustomCollectionView<W::Context, I, W> {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         Ok(CustomCollectionView {
             collection: self.collection.clone_unchecked()?,
@@ -1101,7 +1099,7 @@ impl<I: Send + Sync, W: ClonableView + Sync> ClonableView
     }
 }
 
-impl<I: CustomSerialize, W: View + Sync> CustomCollectionView<W::Context, I, W> {
+impl<I: CustomSerialize, W: View> CustomCollectionView<W::Context, I, W> {
     /// Loads a subview for the data at the given index in the collection. If an entry
     /// is absent then a default entry is added to the collection. The resulting view
     /// can be modified.
@@ -1252,7 +1250,7 @@ impl<I: CustomSerialize, W: View + Sync> CustomCollectionView<W::Context, I, W> 
     }
 }
 
-impl<I: CustomSerialize + Send, W: View + Sync> CustomCollectionView<W::Context, I, W> {
+impl<I: CustomSerialize + Send, W: View> CustomCollectionView<W::Context, I, W> {
     /// Returns the list of indices in the collection in the order determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
@@ -1299,7 +1297,7 @@ impl<I: CustomSerialize + Send, W: View + Sync> CustomCollectionView<W::Context,
     }
 }
 
-impl<I: CustomSerialize, W: View + Sync> CustomCollectionView<W::Context, I, W> {
+impl<I: CustomSerialize, W: View> CustomCollectionView<W::Context, I, W> {
     /// Applies a function f on each index. Indices are visited in an order
     /// determined by the custom serialization. If the function f returns false,
     /// then the loop ends prematurely.
@@ -1376,9 +1374,9 @@ impl<I: CustomSerialize, W: View + Sync> CustomCollectionView<W::Context, I, W> 
     }
 }
 
-impl<I, W: HashableView + Sync> HashableView for CustomCollectionView<W::Context, I, W>
+impl<I, W: HashableView> HashableView for CustomCollectionView<W::Context, I, W>
 where
-    Self: View + Sync,
+    Self: View,
 {
     type Hasher = sha3::Sha3_256;
 

--- a/linera-views/src/views/hashable_wrapper.rs
+++ b/linera-views/src/views/hashable_wrapper.rs
@@ -37,7 +37,7 @@ enum KeyTag {
 
 impl<W: HashableView, O> View for WrappedHashableContainerView<W::Context, W, O>
 where
-    W: HashableView<Hasher: Hasher<Output = O>> + Sync,
+    W: HashableView<Hasher: Hasher<Output = O>>,
     O: Serialize + DeserializeOwned + Send + Sync + Copy + PartialEq,
 {
     const NUM_INIT_KEYS: usize = 1 + W::NUM_INIT_KEYS;
@@ -121,7 +121,7 @@ where
 
 impl<W, O> ClonableView for WrappedHashableContainerView<W::Context, W, O>
 where
-    W: HashableView + ClonableView + Sync,
+    W: HashableView + ClonableView,
     O: Serialize + DeserializeOwned + Send + Sync + Copy + PartialEq,
     W::Hasher: Hasher<Output = O>,
 {
@@ -137,7 +137,7 @@ where
 
 impl<W, O> HashableView for WrappedHashableContainerView<W::Context, W, O>
 where
-    W: HashableView + Sync,
+    W: HashableView,
     O: Serialize + DeserializeOwned + Send + Sync + Copy + PartialEq,
     W::Hasher: Hasher<Output = O>,
 {

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -1419,7 +1419,7 @@ where
 
 impl<C, I, V> HashableView for MapView<C, I, V>
 where
-    Self: View + Sync,
+    Self: View,
     ByteMapView<C, V>: HashableView,
 {
     type Hasher = <ByteMapView<C, V> as HashableView>::Hasher;
@@ -1954,7 +1954,7 @@ mod graphql {
     #[async_graphql::Object(cache_control(no_cache), name_type)]
     impl<C, V> ByteMapView<C, V>
     where
-        C: Context + Send + Sync,
+        C: Context,
         V: async_graphql::OutputType
             + serde::ser::Serialize
             + serde::de::DeserializeOwned
@@ -2026,7 +2026,7 @@ mod graphql {
     #[async_graphql::Object(cache_control(no_cache), name_type)]
     impl<C, I, V> MapView<C, I, V>
     where
-        C: Context + Send + Sync,
+        C: Context,
         I: async_graphql::OutputType
             + async_graphql::InputType
             + serde::ser::Serialize
@@ -2097,7 +2097,7 @@ mod graphql {
     #[async_graphql::Object(cache_control(no_cache), name_type)]
     impl<C, I, V> CustomMapView<C, I, V>
     where
-        C: Context + Send + Sync,
+        C: Context,
         I: async_graphql::OutputType
             + async_graphql::InputType
             + crate::common::CustomSerialize

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -50,7 +50,7 @@ pub const MIN_VIEW_TAG: u8 = 1;
 
 /// A view gives exclusive access to read and write the data stored at an underlying
 /// address in storage.
-#[cfg_attr(not(web), trait_variant::make(Send))]
+#[cfg_attr(not(web), trait_variant::make(Send + Sync))]
 pub trait View: Sized {
     /// The number of keys used for the initialization
     const NUM_INIT_KEYS: usize;

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -501,7 +501,6 @@ mod graphql {
     #[async_graphql::Object(cache_control(no_cache), name_type)]
     impl<C: Context, T: async_graphql::OutputType> QueueView<C, T>
     where
-        C: Send + Sync,
         T: serde::ser::Serialize + serde::de::DeserializeOwned + Clone + Send + Sync,
     {
         async fn entries(&self, count: Option<usize>) -> async_graphql::Result<Vec<T>> {

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -100,7 +100,7 @@ enum KeyTag {
     Subview,
 }
 
-impl<W: View + Sync> View for ReentrantByteCollectionView<W::Context, W> {
+impl<W: View> View for ReentrantByteCollectionView<W::Context, W> {
     const NUM_INIT_KEYS: usize = 0;
 
     type Context = W::Context;
@@ -183,7 +183,7 @@ impl<W: View + Sync> View for ReentrantByteCollectionView<W::Context, W> {
     }
 }
 
-impl<W: ClonableView + Sync> ClonableView for ReentrantByteCollectionView<W::Context, W> {
+impl<W: ClonableView> ClonableView for ReentrantByteCollectionView<W::Context, W> {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         let cloned_updates = self
             .updates
@@ -231,7 +231,7 @@ impl<C: Context, W> ReentrantByteCollectionView<C, W> {
     }
 }
 
-impl<W: View + Sync> ReentrantByteCollectionView<W::Context, W> {
+impl<W: View> ReentrantByteCollectionView<W::Context, W> {
     /// Reads the view and if missing returns the default view
     async fn wrapped_view(
         context: &W::Context,
@@ -478,7 +478,7 @@ impl<W: View + Sync> ReentrantByteCollectionView<W::Context, W> {
     }
 }
 
-impl<W: View + Sync> ReentrantByteCollectionView<W::Context, W> {
+impl<W: View> ReentrantByteCollectionView<W::Context, W> {
     /// Loads multiple entries for writing at once.
     /// The entries in `short_keys` have to be all distinct.
     /// ```rust
@@ -819,7 +819,7 @@ impl<W: View + Sync> ReentrantByteCollectionView<W::Context, W> {
     }
 }
 
-impl<W: View + Sync> ReentrantByteCollectionView<W::Context, W> {
+impl<W: View> ReentrantByteCollectionView<W::Context, W> {
     /// Returns the list of indices in the collection in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
@@ -980,7 +980,7 @@ impl<W: View + Sync> ReentrantByteCollectionView<W::Context, W> {
     }
 }
 
-impl<W: HashableView + Sync> HashableView for ReentrantByteCollectionView<W::Context, W> {
+impl<W: HashableView> HashableView for ReentrantByteCollectionView<W::Context, W> {
     type Hasher = sha3::Sha3_256;
 
     async fn hash_mut(&mut self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
@@ -1074,7 +1074,7 @@ pub struct ReentrantCollectionView<C, I, W> {
 
 impl<I, W> View for ReentrantCollectionView<W::Context, I, W>
 where
-    W: View + Sync,
+    W: View,
     I: Send + Sync + Serialize + DeserializeOwned,
 {
     const NUM_INIT_KEYS: usize = ReentrantByteCollectionView::<W::Context, W>::NUM_INIT_KEYS;
@@ -1120,7 +1120,7 @@ where
 
 impl<I, W> ClonableView for ReentrantCollectionView<W::Context, I, W>
 where
-    W: ClonableView + Sync,
+    W: ClonableView,
     I: Send + Sync + Serialize + DeserializeOwned,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
@@ -1133,7 +1133,7 @@ where
 
 impl<I, W> ReentrantCollectionView<W::Context, I, W>
 where
-    W: View + Sync,
+    W: View,
     I: Sync + Clone + Send + Serialize + DeserializeOwned,
 {
     /// Loads a subview for the data at the given index in the collection. If an entry
@@ -1286,7 +1286,7 @@ where
 
 impl<I, W> ReentrantCollectionView<W::Context, I, W>
 where
-    W: View + Sync,
+    W: View,
     I: Sync + Clone + Send + Serialize + DeserializeOwned,
 {
     /// Load multiple entries for writing at once.
@@ -1432,7 +1432,7 @@ where
 
 impl<I, W> ReentrantCollectionView<W::Context, I, W>
 where
-    W: View + Sync,
+    W: View,
     I: Sync + Clone + Send + Serialize + DeserializeOwned,
 {
     /// Returns the list of indices in the collection in an order determined
@@ -1557,7 +1557,7 @@ where
 
 impl<I, W> HashableView for ReentrantCollectionView<W::Context, I, W>
 where
-    W: HashableView + Sync,
+    W: HashableView,
     I: Send + Sync + Serialize + DeserializeOwned,
 {
     type Hasher = sha3::Sha3_256;
@@ -1581,7 +1581,7 @@ pub struct ReentrantCustomCollectionView<C, I, W> {
 
 impl<I, W> View for ReentrantCustomCollectionView<W::Context, I, W>
 where
-    W: View + Sync,
+    W: View,
     I: Send + Sync + CustomSerialize,
 {
     const NUM_INIT_KEYS: usize = ReentrantByteCollectionView::<W::Context, W>::NUM_INIT_KEYS;
@@ -1627,7 +1627,7 @@ where
 
 impl<I, W> ClonableView for ReentrantCustomCollectionView<W::Context, I, W>
 where
-    W: ClonableView + Sync,
+    W: ClonableView,
     Self: View,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
@@ -1640,7 +1640,7 @@ where
 
 impl<I, W> ReentrantCustomCollectionView<W::Context, I, W>
 where
-    W: View + Sync,
+    W: View,
     I: Sync + Clone + Send + CustomSerialize,
 {
     /// Loads a subview for the data at the given index in the collection. If an entry
@@ -1792,7 +1792,7 @@ where
     }
 }
 
-impl<I, W: View + Sync> ReentrantCustomCollectionView<W::Context, I, W>
+impl<I, W: View> ReentrantCustomCollectionView<W::Context, I, W>
 where
     I: Sync + Clone + Send + CustomSerialize,
 {
@@ -1937,7 +1937,7 @@ where
 
 impl<I, W> ReentrantCustomCollectionView<W::Context, I, W>
 where
-    W: View + Sync,
+    W: View,
     I: Sync + Clone + Send + CustomSerialize,
 {
     /// Returns the list of indices in the collection. The order is determined by
@@ -2064,7 +2064,7 @@ where
 
 impl<I, W> HashableView for ReentrantCustomCollectionView<W::Context, I, W>
 where
-    W: HashableView + Sync,
+    W: HashableView,
     I: Send + Sync + CustomSerialize,
 {
     type Hasher = sha3::Sha3_256;

--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -239,7 +239,7 @@ mod graphql {
 
     impl<C, T> async_graphql::OutputType for RegisterView<C, T>
     where
-        C: Context + Send + Sync,
+        C: Context,
         T: async_graphql::OutputType + Send + Sync,
     {
         fn type_name() -> Cow<'static, str> {

--- a/linera-views/src/views/set_view.rs
+++ b/linera-views/src/views/set_view.rs
@@ -610,7 +610,7 @@ impl<C: Context, I: Serialize + DeserializeOwned + Send> SetView<C, I> {
 
 impl<C, I> HashableView for SetView<C, I>
 where
-    Self: View + Sync,
+    Self: View,
     ByteSetView<C>: HashableView,
 {
     type Hasher = <ByteSetView<C> as HashableView>::Hasher;
@@ -890,7 +890,7 @@ where
 
 impl<C: Context, I> HashableView for CustomSetView<C, I>
 where
-    Self: View + Sync,
+    Self: View,
 {
     type Hasher = sha3::Sha3_256;
 

--- a/linera-views/src/views/unit_tests/views.rs
+++ b/linera-views/src/views/unit_tests/views.rs
@@ -132,7 +132,7 @@ async fn run_test_queue_operations<C>(
     context: C,
 ) -> Result<(), anyhow::Error>
 where
-    C: Context<Error: Send + Sync> + Clone + Send + Sync + 'static,
+    C: Context + 'static,
 {
     let mut expected_state = VecDeque::new();
     let mut queue = QueueView::load(context.clone()).await?;
@@ -166,7 +166,7 @@ async fn check_queue_state<C>(
     expected_state: &VecDeque<usize>,
 ) -> Result<(), anyhow::Error>
 where
-    C: Context<Error: Send + Sync> + Clone + Send + Sync,
+    C: Context,
 {
     let count = expected_state.len();
 
@@ -185,7 +185,7 @@ fn check_contents(contents: Vec<usize>, expected: &VecDeque<usize>) {
 }
 
 trait TestContextFactory {
-    type Context: Context<Error: Send + Sync> + Clone + Send + Sync + 'static;
+    type Context: Context + 'static;
 
     async fn new_context(&mut self) -> Result<Self::Context, anyhow::Error>;
 }
@@ -513,7 +513,7 @@ async fn populate_reentrant_collection_view<C, Key, Value>(
     entries: impl IntoIterator<Item = (Key, Value)>,
 ) -> anyhow::Result<()>
 where
-    C: Context + Send + Sync,
+    C: Context,
     Key: Serialize + DeserializeOwned + Clone + Debug + Default + Send + Sync,
     Value: Serialize + DeserializeOwned + Default + Send + Sync,
 {

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -25,7 +25,7 @@ struct CollectionStateView<C> {
 
 impl<C> CollectionStateView<C>
 where
-    C: Send + Context + Sync,
+    C: Context,
 {
     async fn key_values(&self) -> BTreeMap<u8, u32> {
         let mut map = BTreeMap::new();
@@ -607,7 +607,7 @@ struct ReentrantCollectionStateView<C> {
 
 impl<C> ReentrantCollectionStateView<C>
 where
-    C: Send + Context + Sync,
+    C: Context,
 {
     async fn key_values(&self) -> Result<BTreeMap<u8, u32>> {
         let mut map = BTreeMap::new();

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -60,7 +60,7 @@ pub struct StateView<C> {
 
 #[allow(async_fn_in_trait)]
 pub trait StateStorage {
-    type Context: Context<Extra = usize, Error: Send + Sync> + Clone + Send + Sync + 'static;
+    type Context: Context<Extra = usize> + 'static;
 
     async fn new() -> Self;
 


### PR DESCRIPTION
## Motivation

Currently we have a lot of implementations in `linera-views` that don't work on the Web because they require `Sync` bounds.  For example, `MapView` and `QueueView` are not usable on the Web.

## Proposal

Conditionally use `trait-variant` to add bounds to the traits themselves rather than the implementations.  [Futures should ‘always’ be `Sync`](https://internals.rust-lang.org/t/what-shall-sync-mean-across-an-await/12020/18) anyway.

`linera_storage_service::client` contains an implementation of `KeyValueStore` that is not `Sync` even though it isn't on the Web, due to a trait object inside `tonic` that [has](https://github.com/hyperium/tonic/issues/81) [caused](https://github.com/hyperium/tonic/pull/82) [some](https://github.com/hyperium/tonic/pull/84) [contention](https://github.com/hyperium/tonic/issues/117).  For that implementation, follow the solution [given there](https://github.com/hyperium/tonic/issues/117#issuecomment-748009137) and use [`sync_wrapper::SyncFuture`](https://docs.rs/sync_wrapper/latest/sync_wrapper/struct.SyncFuture.html) to make the futures `Sync` based on the fact that they can only be used through `Pin<&mut Self>` anyway.

Ditto `aws-smithy-async`.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
