### PR TITLE
`revoke-epochs`

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -22,7 +22,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera sync-validator`↴](#linera-sync-validator)
 * [`linera set-validator`↴](#linera-set-validator)
 * [`linera remove-validator`↴](#linera-remove-validator)
-* [`linera finalize-committee`↴](#linera-finalize-committee)
+* [`linera revoke-epochs`↴](#linera-revoke-epochs)
 * [`linera resource-control-policy`↴](#linera-resource-control-policy)
 * [`linera create-genesis-config`↴](#linera-create-genesis-config)
 * [`linera watch`↴](#linera-watch)
@@ -86,7 +86,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `sync-validator` — Synchronizes a validator with the local state of chains
 * `set-validator` — Add or modify a validator (admin only)
 * `remove-validator` — Remove a validator (admin only)
-* `finalize-committee` — Deprecates all committees except the last one
+* `revoke-epochs` — Deprecates all committees up to and including the specified one
 * `resource-control-policy` — View or update the resource control policy
 * `create-genesis-config` — Create genesis configuration for a Linera deployment. Create initial user chains and print information to be used for initialization of validator setup. This will also create an initial wallet for the owner of the initial "root" chains
 * `watch` — Watch the network for notifications
@@ -461,11 +461,15 @@ Remove a validator (admin only)
 
 
 
-## `linera finalize-committee`
+## `linera revoke-epochs`
 
-Deprecates all committees except the last one
+Deprecates all committees up to and including the specified one
 
-**Usage:** `linera finalize-committee`
+**Usage:** `linera revoke-epochs <EPOCH>`
+
+###### **Arguments:**
+
+* `<EPOCH>`
 
 
 

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -812,6 +812,13 @@ impl Epoch {
         Ok(Self(val))
     }
 
+    /// Tries to return an epoch with a number decreased by one. Returns an error if an underflow
+    /// happens.
+    pub fn try_sub_one(self) -> Result<Self, ArithmeticError> {
+        let val = self.0.checked_sub(1).ok_or(ArithmeticError::Underflow)?;
+        Ok(Self(val))
+    }
+
     /// Tries to add one to this epoch's number. Returns an error if an overflow happens.
     #[inline]
     pub fn try_add_assign_one(&mut self) -> Result<(), ArithmeticError> {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1192,6 +1192,16 @@ where
     user.process_inbox().await.unwrap();
     assert_eq!(user.chain_info().await?.epoch, Epoch::from(2));
 
+    // Revoking the current or an already revoked epoch fails.
+    assert_matches!(
+        admin.revoke_epochs(Epoch::ZERO).await,
+        Err(ChainClientError::EpochAlreadyRevoked)
+    );
+    assert_matches!(
+        admin.revoke_epochs(Epoch::from(3)).await,
+        Err(ChainClientError::CannotRevokeCurrentEpoch(Epoch(2)))
+    );
+
     // Have the admin chain deprecate the previous epoch.
     admin.revoke_epochs(Epoch::from(1)).await.unwrap();
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1147,7 +1147,7 @@ where
     user.synchronize_from_validators().await.unwrap();
     user.process_inbox().await.unwrap();
     assert_eq!(user.chain_info().await?.epoch, Epoch::from(1));
-    admin.finalize_committee().await.unwrap();
+    admin.revoke_epochs(Epoch::ZERO).await.unwrap();
 
     // Create a new committee.
     let committee = Committee::new(validators.clone(), ResourceControlPolicy::only_fuel());
@@ -1193,7 +1193,7 @@ where
     assert_eq!(user.chain_info().await?.epoch, Epoch::from(2));
 
     // Have the admin chain deprecate the previous epoch.
-    admin.finalize_committee().await.unwrap();
+    admin.revoke_epochs(Epoch::from(1)).await.unwrap();
 
     // Try to make a transfer back to the admin chain.
     let cert = user

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -6,7 +6,7 @@ use std::{borrow::Cow, num::NonZeroU16, path::PathBuf};
 use chrono::{DateTime, Utc};
 use linera_base::{
     crypto::{AccountPublicKey, CryptoHash, ValidatorPublicKey},
-    data_types::Amount,
+    data_types::{Amount, Epoch},
     identifiers::{Account, AccountOwner, ApplicationId, ChainId, ModuleId, StreamId},
     time::Duration,
     vm::VmRuntime,
@@ -309,8 +309,8 @@ pub enum ClientCommand {
         public_key: ValidatorPublicKey,
     },
 
-    /// Deprecates all committees except the last one.
-    FinalizeCommittee,
+    /// Deprecates all committees up to and including the specified one.
+    RevokeEpochs { epoch: Epoch },
 
     /// View or update the resource control policy
     ResourceControlPolicy {
@@ -902,7 +902,7 @@ impl ClientCommand {
             | ClientCommand::SetValidator { .. }
             | ClientCommand::RemoveValidator { .. }
             | ClientCommand::ResourceControlPolicy { .. }
-            | ClientCommand::FinalizeCommittee
+            | ClientCommand::RevokeEpochs { .. }
             | ClientCommand::CreateGenesisConfig { .. }
             | ClientCommand::PublishModule { .. }
             | ClientCommand::ListEventsFromIndex { .. }

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -701,10 +701,12 @@ impl Runnable for Job {
 
                 // Remove the old committee.
                 info!("Finalizing current committee");
+                let current_epoch = chain_client.chain_info().await?.epoch;
+                let revoked_epoch = current_epoch.try_sub_one()?;
                 context
                     .apply_client_command(&chain_client, |chain_client| {
                         let chain_client = chain_client.clone();
-                        async move { chain_client.finalize_committee().await }
+                        async move { chain_client.revoke_epochs(revoked_epoch).await }
                     })
                     .await
                     .context("Failed to finalize committee")?;

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -691,7 +691,7 @@ impl Runnable for Job {
                 info!("Operations confirmed after {} ms", time_total.as_millis());
             }
 
-            FinalizeCommittee => {
+            RevokeEpochs { epoch } => {
                 info!("Starting operations to remove old committees");
                 let time_start = Instant::now();
                 let mut context =
@@ -699,14 +699,12 @@ impl Runnable for Job {
 
                 let chain_client = context.make_chain_client(context.wallet.genesis_admin_chain());
 
-                // Remove the old committee.
-                info!("Finalizing current committee");
-                let current_epoch = chain_client.chain_info().await?.epoch;
-                let revoked_epoch = current_epoch.try_sub_one()?;
+                // Remove the old committees.
+                info!("Revoking epochs");
                 context
                     .apply_client_command(&chain_client, |chain_client| {
                         let chain_client = chain_client.clone();
-                        async move { chain_client.revoke_epochs(revoked_epoch).await }
+                        async move { chain_client.revoke_epochs(epoch).await }
                     })
                     .await
                     .context("Failed to finalize committee")?;
@@ -714,7 +712,7 @@ impl Runnable for Job {
 
                 let time_total = time_start.elapsed();
                 info!(
-                    "Finalizing committee confirmed after {} ms",
+                    "Revoking committees confirmed after {} ms",
                     time_total.as_millis()
                 );
             }

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -964,10 +964,11 @@ impl ClientWrapper {
         Ok(())
     }
 
-    pub async fn finalize_committee(&self) -> Result<()> {
+    pub async fn revoke_epochs(&self, epoch: Epoch) -> Result<()> {
         self.command()
             .await?
-            .arg("finalize-committee")
+            .arg("revoke-epochs")
+            .arg(epoch.to_string())
             .spawn_and_wait_for_stdout()
             .await?;
         Ok(())


### PR DESCRIPTION
## Motivation

`finalize-committee` currently revokes all but the latest epoch. But sometimes we may want to keep more than one epoch.

## Proposal

Change this to `revoke-epochs <EPOCH>` and revoke only up to the specified one.

## Test Plan

CI; tests were updated.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #3948
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
