### PR TITLE
`linera-base`: remove `Send` and `Sync` bounds from signer errors on the Web

### DIFF
--- a/linera-base/src/crypto/mod.rs
+++ b/linera-base/src/crypto/mod.rs
@@ -8,7 +8,7 @@ mod ed25519;
 mod hash;
 #[allow(dead_code)]
 mod secp256k1;
-mod signer;
+pub mod signer;
 use std::{fmt::Display, io, num::ParseIntError, str::FromStr};
 
 use alloy_primitives::FixedBytes;

--- a/linera-base/src/crypto/signer.rs
+++ b/linera-base/src/crypto/signer.rs
@@ -1,6 +1,12 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/*!
+An interface for cryptographic signers that can be used by the Linera client to sign blocks.
+*/
+
+use std::error::Error as StdError;
+
 pub use in_mem::InMemorySigner;
 
 use super::CryptoHash;
@@ -9,11 +15,33 @@ use crate::{
     identifiers::AccountOwner,
 };
 
+cfg_if::cfg_if! {
+    if #[cfg(web)] {
+        #[doc(hidden)]
+        pub trait TaskSendable {}
+        impl<T> TaskSendable for T {}
+    } else {
+        #[doc(hidden)]
+        pub trait TaskSendable: Send + Sync {}
+        impl<T: Send + Sync> TaskSendable for T {}
+    }
+}
+
+/// Errors that can be returned from signers.
+pub trait Error: StdError + TaskSendable + 'static {}
+impl<T: StdError + TaskSendable + 'static> Error for T {}
+
+impl StdError for Box<dyn Error + '_> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        (**self).source()
+    }
+}
+
 /// A trait for signing keys.
 #[cfg_attr(not(web), trait_variant::make(Send))]
 pub trait Signer {
     /// The type of errors arising from operations on this `Signer`.
-    type Error: std::error::Error + Send + Sync + 'static;
+    type Error: Error;
 
     /// Creates a signature for the given `value` using the provided `owner`.
     // DEV: We sign `CryptoHash` type, rather than `&[u8]` to make sure we don't sign

--- a/linera-base/src/crypto/signer.rs
+++ b/linera-base/src/crypto/signer.rs
@@ -28,8 +28,8 @@ cfg_if::cfg_if! {
 }
 
 /// Errors that can be returned from signers.
-pub trait Error: StdError + TaskSendable + 'static {}
-impl<T: StdError + TaskSendable + 'static> Error for T {}
+pub trait Error: StdError + TaskSendable {}
+impl<T: StdError + TaskSendable> Error for T {}
 
 impl StdError for Box<dyn Error + '_> {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1524,7 +1524,7 @@ impl From<Infallible> for ChainClientError {
 }
 
 impl ChainClientError {
-    pub fn signer_failure(err: impl signer::Error) -> Self {
+    pub fn signer_failure(err: impl signer::Error + 'static) -> Self {
         Self::Signer(Box::new(err))
     }
 }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -26,7 +26,7 @@ use futures::{
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     abi::Abi,
-    crypto::{AccountPublicKey, CryptoHash, Signer, ValidatorPublicKey},
+    crypto::{signer, AccountPublicKey, CryptoHash, Signer, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight, Epoch,
         Round, Timestamp,
@@ -1508,7 +1508,7 @@ pub enum ChainClientError {
     },
 
     #[error("signer error: {0:?}")]
-    Signer(#[source] Box<dyn std::error::Error + Send + Sync>),
+    Signer(#[source] Box<dyn signer::Error>),
 
     #[error("Cannot revoke the current epoch {0}")]
     CannotRevokeCurrentEpoch(Epoch),
@@ -1524,7 +1524,7 @@ impl From<Infallible> for ChainClientError {
 }
 
 impl ChainClientError {
-    pub fn signer_failure(err: impl std::error::Error + Send + Sync + 'static) -> Self {
+    pub fn signer_failure(err: impl signer::Error) -> Self {
         Self::Signer(Box::new(err))
     }
 }

--- a/linera-persistent/src/lib.rs
+++ b/linera-persistent/src/lib.rs
@@ -51,19 +51,18 @@ pub trait Persist: Deref {
         Self::Target: Sized;
 }
 
-#[cfg_attr(not(web), trait_variant::make(Send))]
 pub trait PersistExt: Persist {
     /// Applies a mutation to the value, persisting when done.
-    async fn mutate<R: Send>(
+    async fn mutate<R>(
         &mut self,
-        mutation: impl FnOnce(&mut Self::Target) -> R + Send,
+        mutation: impl FnOnce(&mut Self::Target) -> R,
     ) -> Result<R, Self::Error>;
 }
 
 impl<T: Persist> PersistExt for T {
     async fn mutate<R>(
         &mut self,
-        mutation: impl FnOnce(&mut Self::Target) -> R + Send,
+        mutation: impl FnOnce(&mut Self::Target) -> R,
     ) -> Result<R, Self::Error> {
         let output = mutation(self.as_mut());
         self.persist().await?;


### PR DESCRIPTION
## Motivation

We'd like to be able to use JavaScript exceptions as signer errors when JavaScript signers throw them, but currently these bounds prohibit this.

## Proposal

Make them conditionally compiled.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
