### PR TITLE
Increase benchmark job to 50 minutes

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 50
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation

This job times out after merging to `main`.

## Proposal

Increase timeout to 50 minutes (from 40).

## Test Plan

CI

## Release Plan

- Nothing to do
## Links


- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
