### PR TITLE
Fix: update contribution guide link in README to local CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,4 +146,4 @@ We welcome contributions from the community! If you'd like to contribute to the 
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 
-For detailed guidelines, see our [contribution guide](https://linera.dev/getting-started/contributing).
+For detailed guidelines, see our [contribution guide](./CONTRIBUTING.md).


### PR DESCRIPTION
Replaced the outdated external link to the contribution guide (which returned 404) with a local reference to CONTRIBUTING.md. This ensures contributors always have access to the latest guidelines without encountering broken links.