### PR TITLE
Do fewer transfers in the benchmark.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v4

--- a/linera-service/benches/transfers.rs
+++ b/linera-service/benches/transfers.rs
@@ -18,9 +18,9 @@ use tokio::runtime::Runtime;
 
 /// Benchmarks several transactions transferring tokens across chains.
 fn cross_chain_native_token_transfers(criterion: &mut Criterion) {
-    let chain_count = 100;
+    let chain_count = 40;
     let accounts_per_chain = 1;
-    let transfers_per_account = 100;
+    let transfers_per_account = 40;
 
     criterion.bench_function("same_chain_native_token_transfers", |bencher| {
         bencher


### PR DESCRIPTION
## Motivation

The benchmark takes ~40 minutes because it does 10000 transfers in each iteration. I don't think that's really worth it, especially since it only really tests the worker code without the client code.

## Proposal

Do only 400 transfers. Reduce the timeout.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
