### PR TITLE
Reduce length in `test_end_to_end_faucet_with_long_chains`.

### DIFF
--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -14,12 +14,13 @@ env:
   LINERA_STORAGE_SERVICE: 127.0.0.1:1235
   RUST_LOG: warn
   RUST_LOG_FORMAT: plain
+  LINERA_TEST_ITERATIONS: 100
 
 jobs:
   long-faucet-chain-test:
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 40
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -20,7 +20,7 @@ jobs:
   long-faucet-chain-test:
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 20
+    timeout-minutes: 40
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -14,7 +14,7 @@ env:
   LINERA_STORAGE_SERVICE: 127.0.0.1:1235
   RUST_LOG: warn
   RUST_LOG_FORMAT: plain
-  LINERA_TEST_ITERATIONS: 100
+  LINERA_TEST_ITERATIONS: 1000
 
 jobs:
   long-faucet-chain-test:


### PR DESCRIPTION
## Motivation

It's wasteful and slow to run this with 3000 blocks per chain in CI for every PR.

## Proposal

Run it with 1000 instead. Reduce the timeout.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
