### PR TITLE
Make sure that blobs downloaded by the client are validated

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -15,7 +15,7 @@ use futures::{
 use linera_base::{
     crypto::{CryptoHash, Signer},
     data_types::{ChainDescription, Timestamp},
-    identifiers::{AccountOwner, BlobId, BlobType, ChainId},
+    identifiers::{AccountOwner, BlobType, ChainId},
     task::NonBlockingFuture,
 };
 use linera_core::{
@@ -107,24 +107,6 @@ pub trait ClientContextExt: ClientContext {
             clients.push(self.make_chain_client(chain_id));
         }
         clients
-    }
-
-    async fn chain_description(&mut self, chain_id: ChainId) -> Result<ChainDescription, Error> {
-        let blob_id = BlobId::new(chain_id.0, BlobType::ChainDescription);
-
-        let blob = match self.storage().read_blob(blob_id).await {
-            Ok(Some(blob)) => blob,
-            Ok(None) => {
-                // we're missing the blob describing the chain we're assigning - try to
-                // get it
-                self.client().ensure_has_chain_description(chain_id).await?
-            }
-            Err(err) => {
-                return Err(err.into());
-            }
-        };
-
-        Ok(bcs::from_bytes(blob.bytes())?)
     }
 }
 

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -56,7 +56,7 @@ use {
 };
 
 use crate::{
-    chain_listener::{self, ClientContext as _, ClientContextExt as _},
+    chain_listener::{self, ClientContext as _},
     client_options::{ChainOwnershipConfig, ClientContextOptions},
     error, util,
     wallet::{UserChain, Wallet},
@@ -346,7 +346,8 @@ impl<Env: Environment, W: Persist<Target = Wallet>> ClientContext<Env, W> {
         owner: AccountOwner,
     ) -> Result<(), Error> {
         self.client.track_chain(chain_id);
-        let chain_description = self.chain_description(chain_id).await?;
+        let client = self.make_chain_client(chain_id);
+        let chain_description = client.ensure_has_chain_description().await?;
         let config = chain_description.config();
 
         if !config.ownership.verify_owner(&owner) {

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -305,7 +305,6 @@ where
             return Ok((info, actions));
         }
         let local_time = self.state.storage.clock().current_time();
-        // TODO(#2351): This sets the committee and then checks that committee's signatures.
         self.state.ensure_is_active().await?;
         // Verify the certificate.
         let (epoch, committee) = self.state.chain.current_committee()?;

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -231,20 +231,6 @@ impl<N: ValidatorNode> RemoteNode<N> {
         Ok(())
     }
 
-    /// Tries to download the given blobs from this node. Returns `None` if not all could be found.
-    #[instrument(level = "trace")]
-    pub(crate) async fn try_download_blobs(&self, blob_ids: &[BlobId]) -> Option<Vec<Blob>> {
-        let mut stream = blob_ids
-            .iter()
-            .map(|blob_id| self.try_download_blob(*blob_id))
-            .collect::<FuturesUnordered<_>>();
-        let mut blobs = Vec::new();
-        while let Some(maybe_blob) = stream.next().await {
-            blobs.push(maybe_blob?);
-        }
-        Some(blobs)
-    }
-
     #[instrument(level = "trace")]
     async fn try_download_blob(&self, blob_id: BlobId) -> Option<Blob> {
         match self.node.download_blob(blob_id).await {

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -797,7 +797,6 @@ where
             })
             .collect();
         self.committees.set(committees);
-        // If `admin_id` is `None`, this chain is its own admin chain.
         let admin_id = self
             .context()
             .extra()

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -16,7 +16,7 @@ use linera_base::{
     ownership::ChainOwnership,
 };
 use linera_client::{
-    chain_listener::{ChainListener, ChainListenerConfig, ClientContext, ClientContextExt as _},
+    chain_listener::{ChainListener, ChainListenerConfig, ClientContext},
     config::GenesisConfig,
 };
 use linera_core::data_types::ClientOutcome;
@@ -165,7 +165,8 @@ where
             .context
             .lock()
             .await
-            .chain_description(chain_id)
+            .make_chain_client(chain_id)
+            .ensure_has_chain_description()
             .await?)
     }
 }


### PR DESCRIPTION
This is a completion of @bart-linera's #4075:

## Motivation

#3787 left a potential security issue: when a client was downloading a missing `ChainDescription` blob, it would just download a blob, but wouldn't make sure that it was legitimately created on another chain.

## Proposal

Whenever a `ChainDescription` is fetched, fetch the certificate for the block that created it and validate it against committees known from the admin chain.

## Test Plan

CI should catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #2351 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

## Notes

The `TODO` in `attempted_changes.rs` has been removed after verifying that the safety issue is no longer present there: the committees are taken from a blob, but that blob can only exist on the validator if it has been legitimately created on another chain.
