### PR TITLE
Rename EmbeddedSigner to PrivateKeySigner

### DIFF
--- a/linera-web/signer/src/index.ts
+++ b/linera-web/signer/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./private-key";
+export * from "./metamask";

--- a/linera-web/signer/src/index.ts
+++ b/linera-web/signer/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./in-memory";
+export * from "./local";

--- a/linera-web/signer/src/index.ts
+++ b/linera-web/signer/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./local";
+export * from "./private-key";

--- a/linera-web/signer/src/local.ts
+++ b/linera-web/signer/src/local.ts
@@ -1,16 +1,16 @@
 import { Wallet, ethers } from "ethers";
 import { Signer } from "@linera/client";
 
-export class EmbeddedEIP191Signer implements Signer {
+export class LocalSigner implements Signer {
   private wallet: Wallet;
 
   constructor(privateKeyHex: string) {
     this.wallet = new Wallet(privateKeyHex);
   }
 
-  static fromMnemonic(mnemonic: string): EmbeddedEIP191Signer {
+  static fromMnemonic(mnemonic: string): LocalSigner {
     const wallet = ethers.Wallet.fromPhrase(mnemonic);
-    return new EmbeddedEIP191Signer(wallet.privateKey);
+    return new LocalSigner(wallet.privateKey);
   }
 
   public address(): string {

--- a/linera-web/signer/src/local.ts
+++ b/linera-web/signer/src/local.ts
@@ -1,6 +1,19 @@
 import { Wallet, ethers } from "ethers";
 import { Signer } from "@linera/client";
 
+/**
+ * A signer implementation that holds the private key in memory.
+ * 
+ * ⚠️ WARNING: This class is intended **only for testing or development** purposes.
+ * It stores the private key directly in memory, which makes it unsuitable for
+ * production environments due to security risks.
+ * 
+ * The `LocalSigner` uses an in-memory `ethers.Wallet` to sign messages following
+ * the EIP-191 scheme. It verifies that the provided owner matches the wallet
+ * address before signing.
+ * 
+ * Supports key creation from both a raw private key and a mnemonic phrase.
+ */
 export class LocalSigner implements Signer {
   private wallet: Wallet;
 

--- a/linera-web/signer/src/metamask.ts
+++ b/linera-web/signer/src/metamask.ts
@@ -1,0 +1,80 @@
+import { ethers } from "ethers";
+import { Signer } from "@linera/client";
+
+import type { MetaMaskInpageProvider } from "@metamask/providers";
+
+declare global {
+  interface Window {
+    ethereum?: MetaMaskInpageProvider;
+  }
+}
+
+export class MetaMaskEIP191Signer implements Signer {
+  private provider: ethers.BrowserProvider;
+
+  constructor() {
+    if (typeof window === "undefined" || !window.ethereum) {
+      throw new Error("MetaMask is not available");
+    }
+    this.provider = new ethers.BrowserProvider(window.ethereum!);
+  }
+
+  async sign(owner: string, value: Uint8Array): Promise<string> {
+    if (!window.ethereum) {
+      throw new Error("MetaMask is not available");
+    }
+
+    // Explicitly type the result and check for undefined
+    const accounts = (await window.ethereum.request({
+      method: "eth_requestAccounts",
+    })) as string[] | undefined;
+
+    if (!accounts || accounts.length === 0) {
+      throw new Error("No MetaMask accounts connected");
+    }
+
+    const connected = accounts.find(
+      (acc) => acc.toLowerCase() === owner.toLowerCase(),
+    );
+    if (!connected) {
+      throw new Error(
+        `MetaMask is not connected with the requested owner: ${owner}`,
+      );
+    }
+
+    // Encode message as hex string
+    const msgHex = `0x${Buffer.from(value).toString("hex")}`;
+    try {
+      const signature = (await window.ethereum.request({
+        method: "personal_sign",
+        params: [msgHex, owner],
+      })) as string;
+
+      if (!signature) {
+        throw new Error("No signature returned");
+      }
+
+      return signature;
+    } catch (err: any) {
+      throw new Error(
+        `MetaMask signature request failed: ${err?.message || err}`,
+      );
+    }
+  }
+
+  async containsKey(owner: string): Promise<boolean> {
+    const accounts = await this.provider.send("eth_requestAccounts", []);
+    return accounts.some(
+      (acc: string) => acc.toLowerCase() === owner.toLowerCase(),
+    );
+  }
+
+  /**
+   * Returns the currently connected MetaMask account address.
+   */
+  async address(): Promise<string> {
+    const signer = await this.provider.getSigner();
+    let address = await signer.getAddress();
+    return address;
+  }
+}

--- a/linera-web/signer/src/private-key.ts
+++ b/linera-web/signer/src/private-key.ts
@@ -8,22 +8,22 @@ import { Signer } from "@linera/client";
  * It stores the private key directly in memory, which makes it unsuitable for
  * production environments due to security risks.
  * 
- * The `LocalSigner` uses an in-memory `ethers.Wallet` to sign messages following
+ * The `PrivateKeySigner` uses an in-memory `ethers.Wallet` to sign messages following
  * the EIP-191 scheme. It verifies that the provided owner matches the wallet
  * address before signing.
  * 
  * Supports key creation from both a raw private key and a mnemonic phrase.
  */
-export class LocalSigner implements Signer {
+export class PrivateKeySigner implements Signer {
   private wallet: Wallet;
 
   constructor(privateKeyHex: string) {
     this.wallet = new Wallet(privateKeyHex);
   }
 
-  static fromMnemonic(mnemonic: string): LocalSigner {
+  static fromMnemonic(mnemonic: string): PrivateKeySigner {
     const wallet = ethers.Wallet.fromPhrase(mnemonic);
-    return new LocalSigner(wallet.privateKey);
+    return new PrivateKeySigner(wallet.privateKey);
   }
 
   public address(): string {

--- a/linera-web/signer/tests/index.test.ts
+++ b/linera-web/signer/tests/index.test.ts
@@ -1,10 +1,10 @@
 import { ethers } from "ethers";
-import { EmbeddedEIP191Signer } from "../src";
+import { LocalSigner } from "../src";
 
 test("constructs signer from mnemonic correctly", async () => {
   const phrase = "test test test test test test test test test test test junk";
 
-  const signer = EmbeddedEIP191Signer.fromMnemonic(phrase);
+  const signer = LocalSigner.fromMnemonic(phrase);
   const expectedWallet = ethers.Wallet.fromPhrase(phrase);
 
   // In Linera EIP-191 compatible wallet, the owner is the wallet address.
@@ -18,7 +18,7 @@ test("constructs signer from mnemonic correctly", async () => {
 test("signs message correctly", async () => {
   const secretKey =
     "f77a21701522a03b01c111ad2d2cdaf2b8403b47507ee0aec3c2e52b765d7a66";
-  const signer = new EmbeddedEIP191Signer(secretKey);
+  const signer = new LocalSigner(secretKey);
   const cryptoHash =
     "c520e2b24b05e70c39c36d4aa98e9129ac0079ea002d4c382e6996ea11946d1e";
   const owner = signer.address().toLowerCase();

--- a/linera-web/signer/tests/index.test.ts
+++ b/linera-web/signer/tests/index.test.ts
@@ -1,10 +1,10 @@
 import { ethers } from "ethers";
-import { LocalSigner } from "../src";
+import { PrivateKeySigner } from "../src";
 
 test("constructs signer from mnemonic correctly", async () => {
   const phrase = "test test test test test test test test test test test junk";
 
-  const signer = LocalSigner.fromMnemonic(phrase);
+  const signer = PrivateKeySigner.fromMnemonic(phrase);
   const expectedWallet = ethers.Wallet.fromPhrase(phrase);
 
   // In Linera EIP-191 compatible wallet, the owner is the wallet address.
@@ -18,7 +18,7 @@ test("constructs signer from mnemonic correctly", async () => {
 test("signs message correctly", async () => {
   const secretKey =
     "f77a21701522a03b01c111ad2d2cdaf2b8403b47507ee0aec3c2e52b765d7a66";
-  const signer = new LocalSigner(secretKey);
+  const signer = new PrivateKeySigner(secretKey);
   const cryptoHash =
     "c520e2b24b05e70c39c36d4aa98e9129ac0079ea002d4c382e6996ea11946d1e";
   const owner = signer.address().toLowerCase();


### PR DESCRIPTION
## Motivation

EmbeddedSigner name wasn't liked by the team. 

## Proposal

Rename to PrivateKeySigner.

## Test Plan

None

## Release Plan

- Nothing to do 

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
