### PR TITLE
Fail earlier if re-proposal round is wrong.

### DIFF
--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -140,3 +140,13 @@ fn test_certificates() {
         .is_none());
     assert!(builder.append(v3.public_key, v3.signature).is_err());
 }
+
+#[test]
+fn round_ordering() {
+    assert!(Round::Fast < Round::MultiLeader(0));
+    assert!(Round::MultiLeader(1) < Round::MultiLeader(2));
+    assert!(Round::MultiLeader(2) < Round::SingleLeader(0));
+    assert!(Round::SingleLeader(1) < Round::SingleLeader(2));
+    assert!(Round::SingleLeader(2) < Round::Validator(0));
+    assert!(Round::Validator(1) < Round::Validator(2))
+}


### PR DESCRIPTION
## Motivation

We never explicitly check that a re-proposal's round is actually greater than the original proposal's. I couldn't find a way to actually exploit it because the checks inside the chain manager seem to implicitly cover all the cases, but it would be better to fail earlier, and it's a very cheap check.

Thanks, @deuszx, for pointing this out!

## Proposal

Add this to `BlockProposal::check_invariants`.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
