### PR TITLE
TypeScript signers cleanups.

### DIFF
--- a/linera-web/signer/package.json
+++ b/linera-web/signer/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@linera/client": "file:../",
-    "ethers": "^6.14.3",
-    "@metamask/providers": "^22.1.0"
+    "@metamask/providers": "^22.1.0",
+    "ethers": "^6.14.3"
   },
   "keywords": [],
   "author": "Linera <contact@linera.io>",
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/linera-io/linera-protocol/linera-web/signer/#readme",
   "devDependencies": {
     "@types/jest": "^29.5.14",
+    "@types/node": "^24.0.1",
     "@types/readable-stream": "^4.0.21",
     "jest": "^29.7.0",
     "ts-jest": "^29.3.4",

--- a/linera-web/signer/src/metamask.ts
+++ b/linera-web/signer/src/metamask.ts
@@ -9,7 +9,24 @@ declare global {
   }
 }
 
-export class MetaMaskEIP191Signer implements Signer {
+/**
+ * A signer implementation that uses the MetaMask browser extension for signing.
+ * 
+ * This class relies on the global `window.ethereum` object injected by MetaMask
+ * and interacts with it using EIP-1193-compliant requests. It provides a secure
+ * mechanism for message signing through the user's MetaMask wallet.
+ * 
+ * ⚠️ WARNING: This signer requires MetaMask to be installed and unlocked in the browser.
+ * It will throw errors if MetaMask is unavailable, the user rejects a request, or
+ * if the requested signer is not among the connected accounts.
+ * 
+ * The `MetaMask` signer verifies that the connected account matches the specified
+ * owner address before signing a message. All messages are encoded as hexadecimal
+ * strings and signed using the `personal_sign` method.
+ * 
+ * Suitable for production use where MetaMask is the expected signer interface.
+ */
+export class MetaMask implements Signer {
   private provider: ethers.BrowserProvider;
 
   constructor() {

--- a/linera-web/signer/src/private-key.ts
+++ b/linera-web/signer/src/private-key.ts
@@ -14,16 +14,16 @@ import { Signer } from "@linera/client";
  * 
  * Supports key creation from both a raw private key and a mnemonic phrase.
  */
-export class PrivateKeySigner implements Signer {
+export class PrivateKey implements Signer {
   private wallet: Wallet;
 
   constructor(privateKeyHex: string) {
     this.wallet = new Wallet(privateKeyHex);
   }
 
-  static fromMnemonic(mnemonic: string): PrivateKeySigner {
+  static fromMnemonic(mnemonic: string): PrivateKey {
     const wallet = ethers.Wallet.fromPhrase(mnemonic);
-    return new PrivateKeySigner(wallet.privateKey);
+    return new PrivateKey(wallet.privateKey);
   }
 
   public address(): string {

--- a/linera-web/signer/tests/index.test.ts
+++ b/linera-web/signer/tests/index.test.ts
@@ -1,10 +1,10 @@
 import { ethers } from "ethers";
-import { PrivateKeySigner } from "../src";
+import { PrivateKey } from "../src";
 
 test("constructs signer from mnemonic correctly", async () => {
   const phrase = "test test test test test test test test test test test junk";
 
-  const signer = PrivateKeySigner.fromMnemonic(phrase);
+  const signer = PrivateKey.fromMnemonic(phrase);
   const expectedWallet = ethers.Wallet.fromPhrase(phrase);
 
   // In Linera EIP-191 compatible wallet, the owner is the wallet address.
@@ -18,7 +18,7 @@ test("constructs signer from mnemonic correctly", async () => {
 test("signs message correctly", async () => {
   const secretKey =
     "f77a21701522a03b01c111ad2d2cdaf2b8403b47507ee0aec3c2e52b765d7a66";
-  const signer = new PrivateKeySigner(secretKey);
+  const signer = new PrivateKey(secretKey);
   const cryptoHash =
     "c520e2b24b05e70c39c36d4aa98e9129ac0079ea002d4c382e6996ea11946d1e";
   const owner = signer.address().toLowerCase();

--- a/linera-web/signer/tsconfig.build.json
+++ b/linera-web/signer/tsconfig.build.json
@@ -5,7 +5,8 @@
     "noEmit": false,
     "declaration": true,
     "declarationMap": true,
-    "emitDeclarationOnly": false
+    "emitDeclarationOnly": false,
+    "skipLibCheck": true
   },
   "exclude": ["tests", "*/*.test.ts"]
 }


### PR DESCRIPTION
## Motivation

In various places some misc needs came up:
- rename `MetaMaskEIP191Signer` to simply `MetaMask`
- rename `PrivateKeySigner` to `PrivateKey` (signer is silent)
- when built, `@metamask/utils` throws errors about invalid symbols - this is fixed by `skipLibraryCheck: true` in `tsconfig.build.json` - the problem does not show up in the runtime

## Proposal

Do all of that.

## Test Plan

Manual

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
