### PR TITLE
Fix typos in Grafana dashboard and update test function in linera_net_tests.rs

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-alternator.6.2.json
+++ b/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-alternator.6.2.json
@@ -3313,7 +3313,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "description": "The avarage batch size of BatchWriteItem",
+        "description": "The average batch size of BatchWriteItem",
         "editable": true,
         "error": false,
         "fieldConfig": {
@@ -3635,7 +3635,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "description": "The avarage batch size of BatchGetItem",
+        "description": "The average batch size of BatchGetItem",
         "editable": true,
         "error": false,
         "fieldConfig": {

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -1004,7 +1004,7 @@ impl ClientWrapper {
     }
 
     /// Runs `linera set-preferred-owner` for `chain_id`.
-    pub async fn set_preffered_owner(
+    pub async fn set_preferred_owner(
         &self,
         chain_id: ChainId,
         owner: Option<AccountOwner>,

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -3540,7 +3540,7 @@ async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Resul
 
     // Make owner2 the only (super) owner.
     client.change_ownership(chain, vec![owner2], vec![]).await?;
-    client.set_preffered_owner(chain, Some(owner2)).await?;
+    client.set_preferred_owner(chain, Some(owner2)).await?;
     // Now we're not the owner anymore.
     let result = client.change_ownership(chain, vec![], vec![owner1]).await;
     assert_matches::assert_matches!(result, Err(_));


### PR DESCRIPTION


Description:  
This pull request addresses the following changes:
- Corrects the typo "avarage" to "average" in the description fields of the Grafana dashboard JSON for Scylla Alternator.
- Updates the test in linera_net_tests.rs by renaming the method call from set_preferred_owner to set_preferred_owner (fixing the function name to match the correct one).

