### PR TITLE
Remove CommonStoreInternalConfig and CommonStoreConfig

### DIFF
--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -68,7 +68,6 @@ impl RocksDbRunner {
             spawn_mode,
             path_with_guard,
             max_stream_queries: config.client.max_stream_queries,
-            max_concurrent_queries: config.client.max_concurrent_queries,
         };
         let store_config = RocksDbStoreConfig {
             inner_config,

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -3,8 +3,8 @@
 
 use linera_views::{
     lru_caching::StorageCacheConfig,
-    scylla_db::{ScyllaDbStore, ScyllaDbStoreConfig},
-    store::{AdminKeyValueStore, CommonStoreConfig},
+    scylla_db::{ScyllaDbStore, ScyllaDbStoreConfig, ScyllaDbStoreInternalConfig},
+    store::AdminKeyValueStore,
 };
 
 use crate::{
@@ -57,14 +57,17 @@ impl ScyllaDbRunner {
             max_entry_size: config.client.max_entry_size,
             max_cache_entries: config.client.max_cache_entries,
         };
-        let common_config = CommonStoreConfig {
-            max_concurrent_queries: config.client.max_concurrent_queries,
+        let inner_config = ScyllaDbStoreInternalConfig {
+            uri: config.client.uri.clone(),
             max_stream_queries: config.client.max_stream_queries,
-            storage_cache_config,
+            max_concurrent_queries: config.client.max_concurrent_queries,
             replication_factor: config.client.replication_factor,
         };
+        let store_config = ScyllaDbStoreConfig {
+            inner_config,
+            storage_cache_config,
+        };
         let namespace = config.client.table.clone();
-        let store_config = ScyllaDbStoreConfig::new(config.client.uri.clone(), common_config);
         let store = ScyllaDbStore::connect(&store_config, &namespace).await?;
         Self::new(config, store).await
     }

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -34,7 +34,7 @@ use {
 };
 #[cfg(feature = "scylladb")]
 use {
-    linera_views::scylla_db::{ScyllaDbStore, ScyllaDbStoreConfig},
+    linera_views::scylla_db::{ScyllaDbStore, ScyllaDbStoreConfig, ScyllaDbStoreInternalConfig},
     std::num::NonZeroU16,
     tracing::debug,
 };
@@ -492,8 +492,16 @@ impl StorageConfig {
             }
             #[cfg(feature = "scylladb")]
             InnerStorageConfig::ScyllaDb { uri } => {
-                let common_config = options.common_store_config();
-                let config = ScyllaDbStoreConfig::new(uri.to_string(), common_config);
+                let inner_config = ScyllaDbStoreInternalConfig {
+                    uri: uri.clone(),
+                    max_stream_queries: options.storage_max_stream_queries,
+                    max_concurrent_queries: options.storage_max_concurrent_queries,
+                    replication_factor: options.storage_replication_factor,
+                };
+                let config = ScyllaDbStoreConfig {
+                    inner_config,
+                    storage_cache_config: options.storage_cache_config(),
+                };
                 Ok(StoreConfig::ScyllaDb { config, namespace })
             }
             #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
@@ -513,8 +521,17 @@ impl StorageConfig {
                     storage_cache_config: options.storage_cache_config(),
                 };
 
-                let common_config = options.common_store_config();
-                let second_config = ScyllaDbStoreConfig::new(uri.to_string(), common_config);
+                let inner_config = ScyllaDbStoreInternalConfig {
+                    uri: uri.clone(),
+                    max_stream_queries: options.storage_max_stream_queries,
+                    max_concurrent_queries: options.storage_max_concurrent_queries,
+                    replication_factor: options.storage_replication_factor,
+                };
+                let second_config = ScyllaDbStoreConfig {
+                    inner_config,
+                    storage_cache_config: options.storage_cache_config(),
+                };
+
                 let config = DualStoreConfig {
                     first_config,
                     second_config,

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -450,15 +450,14 @@ impl StorageConfig {
             }
             #[cfg(feature = "storage-service")]
             InnerStorageConfig::Service { endpoint } => {
-                let common_config = options.common_store_config();
-                let endpoint = endpoint.clone();
                 let inner_config = ServiceStoreInternalConfig {
-                    endpoint,
-                    common_config: common_config.reduced(),
+                    endpoint: endpoint.clone(),
+                    max_concurrent_queries: options.storage_max_concurrent_queries,
+                    max_stream_queries: options.storage_max_stream_queries,
                 };
                 let config = ServiceStoreConfig {
                     inner_config,
-                    storage_cache_config: common_config.storage_cache_config,
+                    storage_cache_config: options.storage_cache_config(),
                 };
                 Ok(StoreConfig::Service { config, namespace })
             }

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -459,7 +459,6 @@ impl StorageConfig {
                     spawn_mode: *spawn_mode,
                     path_with_guard,
                     max_stream_queries: options.storage_max_stream_queries,
-                    max_concurrent_queries: options.storage_max_concurrent_queries,
                 };
                 let config = RocksDbStoreConfig {
                     inner_config,
@@ -504,7 +503,6 @@ impl StorageConfig {
                     spawn_mode: *spawn_mode,
                     path_with_guard: path_with_guard.clone(),
                     max_stream_queries: options.storage_max_stream_queries,
-                    max_concurrent_queries: options.storage_max_concurrent_queries,
                 };
                 let first_config = RocksDbStoreConfig {
                     inner_config,

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -450,9 +450,8 @@ impl StorageConfig {
                 Ok(StoreConfig::Service { config, namespace })
             }
             InnerStorageConfig::Memory { genesis_path } => {
-                let common_config = options.common_store_config();
                 let config = MemoryStoreConfig {
-                    common_config: common_config.reduced(),
+                    max_stream_queries: options.storage_max_stream_queries,
                 };
                 let genesis_path = genesis_path.clone();
                 Ok(StoreConfig::Memory {
@@ -593,9 +592,8 @@ impl StoreConfig {
                 namespace,
                 genesis_path,
             } => {
-                let store_config = MemoryStoreConfig::new(config.common_config.max_stream_queries);
                 let mut storage = DbStorage::<MemoryStore, _>::maybe_create_and_connect(
-                    &store_config,
+                    &config,
                     &namespace,
                     wasm_runtime,
                 )

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -22,7 +22,7 @@ use linera_views::rocks_db::{
 use linera_views::{
     lru_caching::StorageCacheConfig,
     memory::{MemoryStore, MemoryStoreConfig},
-    store::{CommonStoreConfig, KeyValueStore},
+    store::KeyValueStore,
 };
 use serde::{Deserialize, Serialize};
 use tracing::error;
@@ -72,15 +72,6 @@ impl CommonStorageOptions {
             max_cache_size: self.storage_max_cache_size,
             max_entry_size: self.storage_max_entry_size,
             max_cache_entries: self.storage_max_cache_entries,
-        }
-    }
-
-    pub fn common_store_config(&self) -> CommonStoreConfig {
-        CommonStoreConfig {
-            storage_cache_config: self.storage_cache_config(),
-            max_concurrent_queries: self.storage_max_concurrent_queries,
-            max_stream_queries: self.storage_max_stream_queries,
-            replication_factor: self.storage_replication_factor,
         }
     }
 }

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -4,10 +4,7 @@
 use std::path::PathBuf;
 
 use linera_base::command::resolve_binary;
-use linera_views::{
-    lru_caching::LruCachingConfig,
-    store::{CommonStoreInternalConfig, KeyValueStoreError},
-};
+use linera_views::{lru_caching::LruCachingConfig, store::KeyValueStoreError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tonic::Status;
@@ -85,8 +82,10 @@ pub fn storage_service_test_endpoint() -> Result<String, ServiceStoreError> {
 pub struct ServiceStoreInternalConfig {
     /// The endpoint used by the shared store
     pub endpoint: String,
-    /// The common configuration code
-    pub common_config: CommonStoreInternalConfig,
+    /// Maximum number of concurrent database queries allowed for this client.
+    pub max_concurrent_queries: Option<usize>,
+    /// Preferred buffer size for async streams.
+    pub max_stream_queries: usize,
 }
 
 /// The config type

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -262,7 +262,7 @@ enum ServiceStoreServerOptions {
         #[arg(long)]
         endpoint: String,
         /// Preferred buffer size for async streams.
-        #[arg(long)]
+        #[arg(long, default_value = "10")]
         max_stream_queries: usize,
     },
 
@@ -282,16 +282,16 @@ enum ServiceStoreServerOptions {
         #[arg(long)]
         max_concurrent_queries: Option<usize>,
         /// Preferred buffer size for async streams.
-        #[arg(long)]
+        #[arg(long, default_value = "10")]
         max_stream_queries: usize,
         /// The maximum size of the cache, in bytes (keys size + value sizes)
-        #[arg(long)]
+        #[arg(long, default_value = "10000000")]
         max_cache_size: usize,
         /// The maximum size of an entry size, in bytes
-        #[arg(long)]
+        #[arg(long, default_value = "1000000")]
         max_entry_size: usize,
         /// The maximum number of entries in the cache.
-        #[arg(long)]
+        #[arg(long, default_value = "1000")]
         max_cache_entries: usize,
     },
 }

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -261,7 +261,7 @@ enum ServiceStoreServerOptions {
         /// The storage service address.
         #[arg(long)]
         endpoint: String,
-        /// The number of streams used for the async streams.
+        /// Preferred buffer size for async streams.
         #[arg(long)]
         max_stream_queries: usize,
     },
@@ -278,10 +278,10 @@ enum ServiceStoreServerOptions {
         /// Path to the rocksdb database.
         #[arg(long)]
         path: String,
-        /// The number of concurrent to a database
+        /// Maximum number of concurrent database queries allowed for this client.
         #[arg(long)]
         max_concurrent_queries: Option<usize>,
-        /// The number of streams used for the async streams.
+        /// Preferred buffer size for async streams.
         #[arg(long)]
         max_stream_queries: usize,
         /// The maximum size of the cache, in bytes (keys size + value sizes)

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -278,9 +278,6 @@ enum ServiceStoreServerOptions {
         /// Path to the rocksdb database.
         #[arg(long)]
         path: String,
-        /// Maximum number of concurrent database queries allowed for this client.
-        #[arg(long)]
-        max_concurrent_queries: Option<usize>,
         /// Preferred buffer size for async streams.
         #[arg(long, default_value = "10")]
         max_stream_queries: usize,
@@ -644,7 +641,6 @@ async fn main() {
             endpoint,
             path,
             max_stream_queries,
-            max_concurrent_queries,
             max_cache_size,
             max_entry_size,
             max_cache_entries,
@@ -656,7 +652,6 @@ async fn main() {
                 spawn_mode,
                 path_with_guard,
                 max_stream_queries,
-                max_concurrent_queries,
             };
             let storage_cache_config = StorageCacheConfig {
                 max_cache_size,

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -321,9 +321,9 @@ pub struct DynamoDbStoreInternal {
 pub struct DynamoDbStoreInternalConfig {
     /// Whether to use DynamoDB local or not.
     pub use_dynamodb_local: bool,
-    /// The number of concurrent to a database
+    /// Maximum number of concurrent database queries allowed for this client.
     pub max_concurrent_queries: Option<usize>,
-    /// The number of streams used for the async streams.
+    /// Preferred buffer size for async streams.
     pub max_stream_queries: usize,
 }
 

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -22,7 +22,7 @@ use crate::{
 /// The initial configuration of the system
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexedDbStoreConfig {
-    /// The number of streams used for the async streams.
+    /// Preferred buffer size for async streams.
     pub max_stream_queries: usize,
 }
 

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -13,31 +13,17 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, WriteOperation},
     common::get_upper_bound_option,
-    lru_caching::DEFAULT_STORAGE_CACHE_CONFIG,
     store::{
-        AdminKeyValueStore, CommonStoreConfig, KeyValueStoreError, ReadableKeyValueStore,
-        WithError, WritableKeyValueStore,
+        AdminKeyValueStore, KeyValueStoreError, ReadableKeyValueStore, WithError,
+        WritableKeyValueStore,
     },
 };
 
 /// The initial configuration of the system
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexedDbStoreConfig {
-    /// The common configuration of the key value store
-    pub common_config: CommonStoreConfig,
-}
-
-impl IndexedDbStoreConfig {
-    /// Creates a `IndexedDbStoreConfig`. `max_concurrent_queries` and `storage_cache_config` are not used.
-    pub fn new(max_stream_queries: usize) -> Self {
-        let common_config = CommonStoreConfig {
-            max_concurrent_queries: None,
-            max_stream_queries,
-            storage_cache_config: DEFAULT_STORAGE_CACHE_CONFIG,
-            replication_factor: 1,
-        };
-        Self { common_config }
-    }
+    /// The number of streams used for the async streams.
+    pub max_stream_queries: usize,
 }
 
 /// The prefixes being used in the system
@@ -101,7 +87,7 @@ impl IndexedDbStore {
         Ok(IndexedDbStore {
             database,
             object_store_name,
-            max_stream_queries: config.common_config.max_stream_queries,
+            max_stream_queries: config.max_stream_queries,
             start_key,
         })
     }
@@ -343,7 +329,7 @@ mod testing {
     pub async fn create_indexed_db_store_stream_queries(
         max_stream_queries: usize,
     ) -> IndexedDbStore {
-        let config = IndexedDbStoreConfig::new(max_stream_queries);
+        let config = IndexedDbStoreConfig { max_stream_queries };
         let namespace = generate_test_namespace();
         IndexedDbStore::connect(&config, &namespace).await.unwrap()
     }

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -27,7 +27,7 @@ use crate::{
 /// The initial configuration of the system
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MemoryStoreConfig {
-    /// The number of streams used for the async streams.
+    /// Preferred buffer size for async streams.
     pub max_stream_queries: usize,
 }
 

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -273,8 +273,6 @@ pub struct RocksDbStoreInternalConfig {
     pub path_with_guard: PathWithGuard,
     /// The chosen spawn mode
     pub spawn_mode: RocksDbSpawnMode,
-    /// Maximum number of concurrent database queries allowed for this client.
-    pub max_concurrent_queries: Option<usize>,
     /// Preferred buffer size for async streams.
     pub max_stream_queries: usize,
 }
@@ -579,12 +577,10 @@ impl TestKeyValueStore for RocksDbStoreInternal {
     async fn new_test_config() -> Result<RocksDbStoreInternalConfig, RocksDbStoreInternalError> {
         let path_with_guard = PathWithGuard::new_testing();
         let spawn_mode = RocksDbSpawnMode::get_spawn_mode_from_runtime();
-        let max_concurrent_queries = None;
         let max_stream_queries = TEST_ROCKS_DB_MAX_STREAM_QUERIES;
         Ok(RocksDbStoreInternalConfig {
             path_with_guard,
             spawn_mode,
-            max_concurrent_queries,
             max_stream_queries,
         })
     }

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -273,9 +273,9 @@ pub struct RocksDbStoreInternalConfig {
     pub path_with_guard: PathWithGuard,
     /// The chosen spawn mode
     pub spawn_mode: RocksDbSpawnMode,
-    /// The number of concurrent to a database
+    /// Maximum number of concurrent database queries allowed for this client.
     pub max_concurrent_queries: Option<usize>,
-    /// The number of streams used for the async streams.
+    /// Preferred buffer size for async streams.
     pub max_stream_queries: usize,
 }
 

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -47,10 +47,7 @@ use crate::{
     common::{get_uleb128_size, get_upper_bound_option},
     journaling::{DirectWritableKeyValueStore, JournalConsistencyError, JournalingKeyValueStore},
     lru_caching::{LruCachingConfig, LruCachingStore},
-    store::{
-        AdminKeyValueStore, CommonStoreInternalConfig, KeyValueStoreError, ReadableKeyValueStore,
-        WithError,
-    },
+    store::{AdminKeyValueStore, KeyValueStoreError, ReadableKeyValueStore, WithError},
     value_splitting::{ValueSplittingError, ValueSplittingStore},
     FutureSyncExt as _,
 };
@@ -725,8 +722,12 @@ fn get_big_root_key(root_key: &[u8]) -> Vec<u8> {
 pub struct ScyllaDbStoreInternalConfig {
     /// The URL to which the requests have to be sent
     pub uri: String,
-    /// The common configuration of the key value store
-    common_config: CommonStoreInternalConfig,
+    /// Maximum number of concurrent database queries allowed for this client.
+    pub max_concurrent_queries: Option<usize>,
+    /// Preferred buffer size for async streams.
+    pub max_stream_queries: usize,
+    /// The replication factor.
+    pub replication_factor: u32,
 }
 
 impl AdminKeyValueStore for ScyllaDbStoreInternal {
@@ -745,10 +746,9 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
         let store = ScyllaDbClient::new(session, namespace).await?;
         let store = Arc::new(store);
         let semaphore = config
-            .common_config
             .max_concurrent_queries
             .map(|n| Arc::new(Semaphore::new(n)));
-        let max_stream_queries = config.common_config.max_stream_queries;
+        let max_stream_queries = config.max_stream_queries;
         let root_key = get_big_root_key(&[]);
         Ok(Self {
             store,
@@ -901,7 +901,7 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
                     'class' : 'NetworkTopologyStrategy', \
                     'replication_factor' : {} \
                 }}",
-                KEYSPACE, config.common_config.replication_factor
+                KEYSPACE, config.replication_factor
             ))
             .await?;
         session
@@ -980,24 +980,17 @@ impl ScyllaDbStoreInternal {
     }
 }
 
-/// We limit the number of connections that can be done for tests.
-#[cfg(with_testing)]
-const TEST_SCYLLA_DB_MAX_CONCURRENT_QUERIES: usize = 10;
-
-/// The number of connections in the stream is limited for tests.
-#[cfg(with_testing)]
-const TEST_SCYLLA_DB_MAX_STREAM_QUERIES: usize = 10;
-
 #[cfg(with_testing)]
 impl TestKeyValueStore for JournalingKeyValueStore<ScyllaDbStoreInternal> {
     async fn new_test_config() -> Result<ScyllaDbStoreInternalConfig, ScyllaDbStoreInternalError> {
+        // TODO(#4114): Read the port from an environment variable.
         let uri = "localhost:9042".to_string();
-        let common_config = CommonStoreInternalConfig {
-            max_concurrent_queries: Some(TEST_SCYLLA_DB_MAX_CONCURRENT_QUERIES),
-            max_stream_queries: TEST_SCYLLA_DB_MAX_STREAM_QUERIES,
+        Ok(ScyllaDbStoreInternalConfig {
+            uri,
+            max_concurrent_queries: Some(10),
+            max_stream_queries: 10,
             replication_factor: 1,
-        };
-        Ok(ScyllaDbStoreInternalConfig { uri, common_config })
+        })
     }
 }
 
@@ -1018,20 +1011,6 @@ pub type ScyllaDbStore =
 
 /// The `ScyllaDbStoreConfig` input type
 pub type ScyllaDbStoreConfig = LruCachingConfig<ScyllaDbStoreInternalConfig>;
-
-impl ScyllaDbStoreConfig {
-    /// Creates a `ScyllaDbStoreConfig` from the inputs.
-    pub fn new(uri: String, common_config: crate::store::CommonStoreConfig) -> ScyllaDbStoreConfig {
-        let inner_config = ScyllaDbStoreInternalConfig {
-            uri,
-            common_config: common_config.reduced(),
-        };
-        ScyllaDbStoreConfig {
-            inner_config,
-            storage_cache_config: common_config.storage_cache_config,
-        }
-    }
-}
 
 /// The combined error type for the `ScyllaDbStore`.
 pub type ScyllaDbStoreError = ValueSplittingError<ScyllaDbStoreInternalError>;

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -5,62 +5,11 @@
 
 use std::{fmt::Debug, future::Future};
 
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::de::DeserializeOwned;
 
 #[cfg(with_testing)]
 use crate::random::generate_test_namespace;
-use crate::{
-    batch::Batch,
-    common::from_bytes_option,
-    lru_caching::{StorageCacheConfig, DEFAULT_STORAGE_CACHE_CONFIG},
-    ViewError,
-};
-
-/// The common initialization parameters for the `KeyValueStore`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CommonStoreInternalConfig {
-    /// Maximum number of concurrent database queries allowed for this client.
-    pub max_concurrent_queries: Option<usize>,
-    /// Preferred buffer size for async streams.
-    pub max_stream_queries: usize,
-    /// The replication factor for the keyspace
-    pub replication_factor: u32,
-}
-
-/// The common initialization parameters for the `KeyValueStore`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CommonStoreConfig {
-    /// Maximum number of concurrent database queries allowed for this client.
-    pub max_concurrent_queries: Option<usize>,
-    /// Preferred buffer size for async streams.
-    pub max_stream_queries: usize,
-    /// The cache size being used.
-    pub storage_cache_config: StorageCacheConfig,
-    /// The replication factor for the keyspace
-    pub replication_factor: u32,
-}
-
-impl CommonStoreConfig {
-    /// Gets the reduced `CommonStoreInternalConfig`.
-    pub fn reduced(&self) -> CommonStoreInternalConfig {
-        CommonStoreInternalConfig {
-            max_concurrent_queries: self.max_concurrent_queries,
-            max_stream_queries: self.max_stream_queries,
-            replication_factor: self.replication_factor,
-        }
-    }
-}
-
-impl Default for CommonStoreConfig {
-    fn default() -> Self {
-        CommonStoreConfig {
-            max_concurrent_queries: None,
-            max_stream_queries: 10,
-            storage_cache_config: DEFAULT_STORAGE_CACHE_CONFIG,
-            replication_factor: 1,
-        }
-    }
-}
+use crate::{batch::Batch, common::from_bytes_option, ViewError};
 
 /// The error type for the key-value stores.
 pub trait KeyValueStoreError:

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -19,9 +19,9 @@ use crate::{
 /// The common initialization parameters for the `KeyValueStore`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommonStoreInternalConfig {
-    /// The number of concurrent to a database
+    /// Maximum number of concurrent database queries allowed for this client.
     pub max_concurrent_queries: Option<usize>,
-    /// The number of streams used for the async streams.
+    /// Preferred buffer size for async streams.
     pub max_stream_queries: usize,
     /// The replication factor for the keyspace
     pub replication_factor: u32,
@@ -30,9 +30,9 @@ pub struct CommonStoreInternalConfig {
 /// The common initialization parameters for the `KeyValueStore`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommonStoreConfig {
-    /// The number of concurrent to a database
+    /// Maximum number of concurrent database queries allowed for this client.
     pub max_concurrent_queries: Option<usize>,
-    /// The number of streams used for the async streams.
+    /// Preferred buffer size for async streams.
     pub max_stream_queries: usize,
     /// The cache size being used.
     pub storage_cache_config: StorageCacheConfig,

--- a/linera-web/src/lib.rs
+++ b/linera-web/src/lib.rs
@@ -45,7 +45,9 @@ type JsResult<T> = Result<T, JsError>;
 async fn get_storage() -> Result<WebStorage, <linera_views::memory::MemoryStore as WithError>::Error>
 {
     linera_storage::DbStorage::maybe_create_and_connect(
-        &linera_views::memory::MemoryStoreConfig::new(1),
+        &linera_views::memory::MemoryStoreConfig {
+            max_stream_queries: 1,
+        },
         "linera",
         Some(linera_execution::WasmRuntime::Wasmer),
     )


### PR DESCRIPTION
## Motivation

Storage backends should only receive configuration options that they actually use.

## Proposal

* Remove `CommonStoreInternalConfig` and `CommonStoreConfig` step by step
* Add missing CLI options to  `linera-storage-service`

Nothing changes from the user point of view.

This temporary creates a little more code duplication between `linera-service` and the binaries in `linera-indexer` and `linera-storage-service` but I think that's fine and should be fixed over time. 

Future work:
* We may re-evaluate whether `max_stream_queries` is best implemented as a method of `ReadableKeyValueStore`.
* I'm still conflicted about `max_concurrent_queries` and would very much like to remove it.
* It's not clear what happens if we pass the wrong replication factor for ScyllaDb.
* We may re-evaluate whether `linera-indexer` and `linera-storage-service` belong to separate crates.

Follows #4111

## Test Plan

CI