### PR TITLE
`linera-web`: fix Clippy warnings and check Clippy in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -248,9 +248,10 @@ jobs:
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - name: Compile `linera-web` for the browser
-      run:  |
+    - name: Check `linera-web` for the browser
+      run: |
         cd linera-web
+        cargo clippy
         cargo build
     - name: Install chromedriver
       uses: nanasess/setup-chromedriver@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5930,6 +5930,7 @@ dependencies = [
  "linera-views",
  "log",
  "nonzero_lit",
+ "num-traits",
  "serde",
  "serde-wasm-bindgen 0.6.5",
  "tokio-util",

--- a/linera-web/Cargo.toml
+++ b/linera-web/Cargo.toml
@@ -20,6 +20,7 @@ js-sys.workspace = true
 linera-persistent.workspace = true
 log.workspace = true
 nonzero_lit.workspace = true
+num-traits.workspace = true
 serde.workspace = true
 serde-wasm-bindgen.workspace = true
 tokio-util.workspace = true

--- a/linera-web/src/lib.rs
+++ b/linera-web/src/lib.rs
@@ -199,6 +199,8 @@ impl Client {
             .genesis_config()
             .initialize_storage(&mut storage)
             .await?;
+        // The `Arc` here is useless, but it is required by the `ChainListener` API.
+        #[expect(clippy::arc_with_non_send_sync)]
         let client_context = Arc::new(AsyncMutex::new(ClientContext::new(
             storage.clone(),
             OPTIONS,


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/issues/4113.  Specifically,

```
$ nix develop ..#nightly -c cargo clippy 
warning: unstable feature specified for `-Ctarget-feature`: `atomics`
  |
  = note: this feature is not stably supported; its behavior can change in the future

warning: `linera-witty` (lib) generated 1 warning
warning: `linera-base` (lib) generated 1 warning (1 duplicate)
warning: `linera-views` (lib) generated 1 warning (1 duplicate)
warning: `linera-execution` (lib) generated 1 warning (1 duplicate)
warning: `linera-chain` (lib) generated 1 warning (1 duplicate)
warning: `linera-storage` (lib) generated 1 warning (1 duplicate)
warning: `linera-version` (lib) generated 1 warning (1 duplicate)
warning: `linera-persistent` (lib) generated 1 warning (1 duplicate)
warning: `linera-core` (lib) generated 1 warning (1 duplicate)
warning: `linera-rpc` (lib) generated 1 warning (1 duplicate)
warning: `linera-client` (lib) generated 1 warning (1 duplicate)
warning: `linera-faucet-client` (lib) generated 1 warning (1 duplicate)
    Checking linera-web v0.14.0 (/home/twey/dev/linera/protocol/main/linera-web)
warning: casting `f64` to `u8` may truncate the value
  --> linera-web/src/signer.rs:51:19
   |
51 |             match fnum as u8 {
   |                   ^^^^^^^^^^
   |
   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
   = note: `-W clippy::cast-possible-truncation` implied by `-W clippy::pedantic`
   = help: to override `-W clippy::pedantic` add `#[allow(clippy::cast_possible_truncation)]`

warning: question mark operator is useless here
  --> linera-web/src/signer.rs:98:9
   |
98 |         Ok(serde_wasm_bindgen::from_value(js_bool).map_err(|_| JsSignerError::JsConversion)?)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try removing question mark and `Ok()`: `serde_wasm_bindgen::from_value(js_bool).map_err(|_| JsSignerError::JsConversion)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_question_mark
   = note: `#[warn(clippy::needless_question_mark)]` on by default

warning: usage of an `Arc` that is not `Send` and `Sync`
   --> linera-web/src/lib.rs:202:30
    |
202 |           let client_context = Arc::new(AsyncMutex::new(ClientContext::new(
    |  ______________________________^
203 | |             storage.clone(),
204 | |             OPTIONS,
205 | |             wallet.0,
206 | |             signer,
207 | |         )));
    | |___________^
    |
    = note: `Arc<Mutex<ClientContext<Impl<DbStorage<MemoryStore>, NodeProvider, JsSigner>, Memory<Wallet>>>>` is not `Send` and `Sync` as `Mutex<ClientContext<Impl<DbStorage<MemoryStore>, NodeProvider, JsSigner>, Memory<Wallet>>>` is neither `Send` nor `Sync`
    = help: if the `Arc` will not used be across threads replace it with an `Rc`
    = help: otherwise make `Mutex<ClientContext<Impl<DbStorage<MemoryStore>, NodeProvider, JsSigner>, Memory<Wallet>>>` `Send` and `Sync` or consider a wrapper type such as `Mutex`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
    = note: `#[warn(clippy::arc_with_non_send_sync)]` on by default
```

## Proposal

Fix the lints:
- use `num_traits` to do the cast safely
- remove the redundant question mark
- disable the warning, which requires a new type parameter on `ChainListener` to fix (we're hoping `ChainListener` won't be around much longer anyway)

Add Clippy on the Web to CI to prevent this in the future.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Fixes #4113.