### PR TITLE
Avoid loading empty outboxes when creating network actions.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -423,6 +423,12 @@ where
                 self.outbox_counters.get_mut().remove(&update);
             }
         }
+        // If the outbox is empty and not ahead of the tip of executed blocks, remove it.
+        if outbox.queue.count() == 0
+            && *outbox.next_height_to_schedule.get() <= self.tip_state.get().next_block_height
+        {
+            self.outboxes.remove_entry(target)?;
+        }
         #[cfg(with_metrics)]
         metrics::NUM_OUTBOXES
             .with_label_values(&[])

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -361,6 +361,10 @@ type ChainStateExtendedView {
 	"""
 	outboxCounters: JSONObject!
 	"""
+	Outboxes with at least one pending message. This allows us to avoid loading all outboxes.
+	"""
+	nonemptyOutboxes: [ChainId!]!
+	"""
 	Blocks that have been verified but not executed yet, and that may not be contiguous.
 	"""
 	preprocessedBlocks: MapView_BlockHeight_CryptoHash_1bae6d76!


### PR DESCRIPTION
## Motivation

In https://github.com/linera-io/linera-protocol/pull/3989 I had to remove the code that deletes empty outboxes. However, we can actually still do that in some cases, and we can keep a separate list of nonempty outboxes to avoid reading empty ones.

## Proposal

Delete empty outboxes if that outbox is not ahead of chain execution.

Keep a list of nonempty outboxes in the chain state to avoid loading empty ones.

## Test Plan

This improved the benchmark for me again:

```
same_chain_native_token_transfers
                        time:   [152.54 ms 155.17 ms 158.41 ms]
                        change: [-27.026% -24.383% -21.712%] (p = 0.00 < 0.05)
                        Performance has improved.
```

CI should catch regressions.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/4064.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
