### PR TITLE
Leave gaps between sender blocks.

### DIFF
--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -311,23 +311,23 @@ where
     }
 
     /// Given a list of chain IDs, returns a map that assigns to each of them the next block
-    /// height, i.e. the lowest block height that we have not processed in the local node yet.
+    /// height to schedule, i.e. the lowest block height for which we haven't added the messages
+    /// to `receiver_id` to the outbox yet.
     ///
     /// It makes at most `chain_worker_limit` requests to the local node in parallel.
-    pub async fn next_block_heights(
+    pub async fn next_outbox_heights(
         &self,
         chain_ids: impl IntoIterator<Item = &ChainId>,
         chain_worker_limit: usize,
+        receiver_id: ChainId,
     ) -> Result<BTreeMap<ChainId, BlockHeight>, LocalNodeError> {
         let futures = chain_ids
             .into_iter()
             .map(|chain_id| async move {
                 let chain = self.chain_state_view(*chain_id).await?;
                 let mut next_height = chain.tip_state.get().next_block_height;
-                // TODO(#3969): This is not great for performance, but the whole function will
-                // probably go away with #3969 anyway.
-                while chain.preprocessed_blocks.contains_key(&next_height).await? {
-                    next_height.try_add_assign_one()?;
+                if let Some(outbox) = chain.outboxes.try_load_entry(&receiver_id).await? {
+                    next_height = next_height.max(*outbox.next_height_to_schedule.get());
                 }
                 Ok::<_, LocalNodeError>((*chain_id, next_height))
             })

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -28,6 +28,7 @@ use linera_execution::{
     ExecutionError, Message, MessageKind, Operation, QueryOutcome, ResourceControlPolicy,
     SystemMessage, SystemQuery, SystemResponse,
 };
+use linera_storage::Storage;
 use rand::Rng;
 use test_case::test_case;
 use test_helpers::{
@@ -1286,6 +1287,70 @@ where
     // We have balance=3, we try to burn 3 tokens but the operation itself
     // costs 1 microtoken so we don't have enough balance to pay for it.
     assert_fees_exceed_funding(obtained_error);
+    Ok(())
+}
+
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
+#[test_log::test(tokio::test)]
+async fn test_sparse_sender_chain<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let receiver = builder.add_root_chain(2, Amount::ZERO).await?;
+    let receiver_id = receiver.chain_id();
+
+    let cert0 = sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(receiver_id),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    let cert1 = sender
+        .burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap()
+        .unwrap();
+    let cert2 = sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(receiver_id),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    receiver.synchronize_from_validators().await?;
+    receiver.process_inbox().await?;
+
+    // The first and last blocks sent something to the receiver. The middle one didn't.
+    // So the sender chain should have a gap.
+    assert!(
+        receiver
+            .storage_client()
+            .contains_certificate(cert0.hash())
+            .await?
+    );
+    assert!(
+        !receiver
+            .storage_client()
+            .contains_certificate(cert1.hash())
+            .await?
+    );
+    assert!(
+        receiver
+            .storage_client()
+            .contains_certificate(cert2.hash())
+            .await?
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
## Motivation

It's unnecessary to fully download all chains that sent a message to our own chain(s).

## Proposal

Only download the relevant blocks.

## Test Plan

A new client test verifies that we are leaving gaps.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/3969.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
