### PR TITLE
Don't overwrite wallet entries on follow-chain.

### DIFF
--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -24,7 +24,9 @@ pub struct Wallet {
 impl Extend<UserChain> for Wallet {
     fn extend<Chains: IntoIterator<Item = UserChain>>(&mut self, chains: Chains) {
         for chain in chains.into_iter() {
-            self.insert(chain);
+            if !self.chains.contains_key(&chain.chain_id) {
+                self.insert(chain);
+            }
         }
     }
 }


### PR DESCRIPTION
## Motivation

If the user accidentally calls `follow-chain` for an existing chain, it overwrites the entry in the wallet.

## Proposal

Only write it if it doesn't exist yet.

## Test Plan

(It's not an important issue, so I don't think it's worth adding another test for this edge case that slows down CI.)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Fixes https://github.com/linera-io/linera-protocol/issues/4132.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
