### PR TITLE
Only listen to faucet chain; not other chains in wallet.

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -124,8 +124,12 @@ impl<C: ClientContext> ChainListener<C> {
     }
 
     /// Runs the chain listener.
-    pub async fn run(self) {
-        let chain_ids = {
+    ///
+    /// Starts listening to all chains in the wallet, or the given ones, if specified.
+    pub async fn run(self, chain_ids: Option<Vec<ChainId>>) {
+        let chain_ids = if let Some(chain_ids) = chain_ids {
+            BTreeSet::from_iter(chain_ids)
+        } else {
             let guard = self.context.lock().await;
             let mut chain_ids = BTreeSet::from_iter(guard.wallet().chain_ids());
             chain_ids.insert(guard.wallet().genesis_admin_chain());

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -148,7 +148,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
         .await?;
     let context = Arc::new(Mutex::new(context));
     let listener = ChainListener::new(config, context, storage);
-    listener.run().await;
+    listener.run(None).await;
 
     // Transfer ownership of chain 0 to the chain listener and some other key. The listener will
     // be leader in ~10% of the rounds.

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -377,8 +377,12 @@ where
         info!("GraphiQL IDE: http://localhost:{}", port);
 
         let context = Arc::clone(&self.context);
+        let chain_ids = vec![
+            context.lock().await.wallet().genesis_admin_chain(),
+            self.main_chain_id,
+        ];
         let listener = ChainListener::new(self.config.clone(), context, self.storage.clone());
-        listener.run().await;
+        listener.run(Some(chain_ids)).await;
 
         axum::serve(
             tokio::net::TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], port))).await?,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -844,7 +844,7 @@ where
 
         info!("GraphiQL IDE: http://localhost:{}", port);
         ChainListener::new(self.config, Arc::clone(&self.context), self.storage.clone())
-            .run()
+            .run(None)
             .await;
         let serve_fut = axum::serve(
             tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], port))).await?,


### PR DESCRIPTION
## Motivation

In the testnet we sometimes use the faucet with a wallet with lots of chains. The chain listener then synchronizes them all, which is wasteful.

## Proposal

Allow specifying a different set of chains for the chain listener, so that it doesn't use all chains in the wallet.

In the faucet, start the chain listener with only the admin chain and the faucet's main chain.

## Test Plan

We should now be able to start the testnet faucet with the original wallet again, without it spending a lot of time downloading blocks.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
