### PR TITLE
Remove redundant synchronization.

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -311,11 +311,6 @@ impl<C: ClientContext> ChainListener<C> {
         }
         let client = self.context.lock().await.make_chain_client(chain_id);
         let (listener, abort_handle, notification_stream) = client.listen().await?;
-        if client.is_tracked() {
-            client.synchronize_from_validators().await?;
-        } else {
-            client.synchronize_chain_state(chain_id).await?;
-        }
         let join_handle = linera_base::task::spawn(listener.in_current_span());
         let listening_client =
             ListeningClient::new(client, abort_handle, join_handle, notification_stream);

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -3640,7 +3640,12 @@ impl<Env: Environment> ChainClient<Env> {
         let mut senders = HashMap::new(); // Senders to cancel notification streams.
         let notifications = self.subscribe().await?;
         let (abortable_notifications, abort) = stream::abortable(self.subscribe().await?);
-        if let Err(error) = self.synchronize_from_validators().await {
+        let sync_result = if self.is_tracked() {
+            self.synchronize_from_validators().await
+        } else {
+            self.synchronize_chain_state(self.chain_id).await
+        };
+        if let Err(error) = sync_result {
             error!("Failed to synchronize from validators: {}", error);
         }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1000,6 +1000,7 @@ impl<Env: Environment> Client<Env> {
 
         let (_, committee) = self.admin_committee().await?;
         let validators = self.make_nodes(&committee)?;
+        Box::pin(self.fetch_chain_info(chain_id, &validators)).await?;
         communicate_with_quorum(
             &validators,
             &committee,

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -252,7 +252,7 @@ pub enum NodeError {
     UnexpectedEntriesInBlobsNotFound,
     #[error("Node returned a BlobsNotFound error with an empty list of missing blob IDs")]
     EmptyBlobsNotFound,
-    #[error("Local error handling validator response")]
+    #[error("Local error handling validator response: {error}")]
     ResponseHandlingError { error: String },
 }
 


### PR DESCRIPTION
## Motivation

`synchronize_from_validators` is potentially expensive, and makes several chain info queries to the validators.

We call it for each chain when we start the chain listener. However, the chain listener also calls `ChainClient::listen`, which synchronizes again. Also, the latter calls `synchronize_from_validators` even for chains that are not tracked.

## Proposal

Remove the redundant calls.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/4100.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
