### PR TITLE
Script to translate addresses in executable to file names and line numbers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,7 @@ ARG copy=${binaries:+_copy}
 ARG build_flag=--release
 ARG build_folder=release
 ARG build_features=scylladb,metrics
+ARG rustflags="-C force-frame-pointers=yes"
 
 FROM rust:1.74-slim-bookworm AS builder
 ARG git_commit
@@ -33,6 +34,7 @@ ARG target
 ARG build_flag
 ARG build_folder
 ARG build_features
+ARG rustflags
 
 RUN apt-get update && apt-get install -y \
     pkg-config \
@@ -68,6 +70,7 @@ COPY scripts scripts
 COPY rust-toolchain* Cargo.* ./
 
 ENV GIT_COMMIT=${git_commit}
+ENV RUSTFLAGS=${rustflags}
 
 RUN cargo build ${build_flag:+"$build_flag"} \
     --target "$target" \

--- a/scripts/memleak_translate.sh
+++ b/scripts/memleak_translate.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# memleak_translate.sh <PID>
+#
+# Works with the default `memleak-libbpf`/`memleak` output that looks like
+#   0 [<0000aaaaeac54784>] [/linera-server]
+# and replaces the address line with the addr2line translated result, which should be the function
+# name, file name and line number.
+#
+# add2line takes a while to execute, so it is recommended to run `memleak` for a while, while
+# redirecting the output to a file. Then inspect the file for what you want (maybe only the last
+# few lines of the output), and then run this script while the binary is still running, from within
+# the same container.
+
+set -euo pipefail
+
+[[ $# -eq 1 ]] || { echo "usage: $0 <pid>" >&2; exit 1; }
+
+PID=$1
+exe="/proc/$PID/exe"
+
+BASE=$(awk -v bin="$(readlink -f /proc/$PID/exe)" '$NF==bin { split($1,a,"-"); print "0x"a[1]; exit }' /proc/$PID/maps)
+
+[[ -n $BASE ]] || { echo "could not find base address for $exe" >&2; exit 1; }
+
+# helper: translate <$addr> using addr2line, compensating for PIE base
+translate () {
+    local addr=$1
+    addr=${addr//[<>[\]]}
+    [[ $addr != 0x* ]] && addr="0x${addr}"
+    local rel=$(printf "0x%x" $(( addr - BASE )))
+    addr2line -e "$exe" -f -C -p "$rel" 2>/dev/null || echo "$addr"
+}
+
+while IFS= read -r line; do
+    if [[ $line =~ ([0-9]+)\ \[\<([0-9a-fA-F]+)\>\]\ \[([^]]+)\] ]]; then
+        stack_pos="${BASH_REMATCH[1]}"
+        addr="${BASH_REMATCH[2]}"
+        origin="${BASH_REMATCH[3]}"
+        echo "        $stack_pos $(translate "$addr") [$origin]"
+    else
+        echo "$line"
+    fi
+done


### PR DESCRIPTION
## Motivation

While using BPF's `memleak` to look into our server memory issue, I could not for the life of me get it to automatically translate the PC addresses into actual file names and file numbers.

## Proposal

Create a script that we can run with `memleak`'s output to translate these addresses for us using `addr2line`. Once we figure out how to do this in a more automated way (I'm assuming there must be a way), we can remove this. But for now, it is useful for debugging.

## Test Plan

Have used this while debugging the memory issue in the server, the stacks get translated correctly

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
