### PR TITLE
Detect early if a validator sent the wrong certificates.

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -250,6 +250,11 @@ pub enum NodeError {
     DuplicatesInBlobsNotFound,
     #[error("Node returned a BlobsNotFound error with unexpected blob IDs")]
     UnexpectedEntriesInBlobsNotFound,
+    #[error("Node returned certificates {returned:?}, but we requested {requested:?}")]
+    UnexpectedCertificates {
+        returned: Vec<CryptoHash>,
+        requested: Vec<CryptoHash>,
+    },
     #[error("Node returned a BlobsNotFound error with an empty list of missing blob IDs")]
     EmptyBlobsNotFound,
     #[error("Local error handling validator response: {error}")]

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -291,7 +291,19 @@ impl<N: ValidatorNode> RemoteNode<N> {
         if hashes.is_empty() {
             return Ok(Vec::new());
         }
-        self.node.download_certificates(hashes).await
+        let certificates = self.node.download_certificates(hashes.clone()).await?;
+        let returned = certificates
+            .iter()
+            .map(ConfirmedBlockCertificate::hash)
+            .collect();
+        ensure!(
+            returned == hashes,
+            NodeError::UnexpectedCertificates {
+                returned,
+                requested: hashes
+            }
+        );
+        Ok(certificates)
     }
 
     /// Downloads a blob, but does not verify if it has actually been published and

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -736,8 +736,17 @@ NodeError:
     22:
       UnexpectedEntriesInBlobsNotFound: UNIT
     23:
-      EmptyBlobsNotFound: UNIT
+      UnexpectedCertificates:
+        STRUCT:
+          - returned:
+              SEQ:
+                TYPENAME: CryptoHash
+          - requested:
+              SEQ:
+                TYPENAME: CryptoHash
     24:
+      EmptyBlobsNotFound: UNIT
+    25:
       ResponseHandlingError:
         STRUCT:
           - error: STR


### PR DESCRIPTION
## Motivation

We want to optimize how we download certificates and distribute work among the validators in the future. To cancel requests to other validators for the same certificate, we need to be sure that we got the certificate we requested.

## Proposal

Compare the downloaded certificate's hash with the requested hash immediately.

Also, remove a redundant argument from `download_certificates`: We always use it with `validator_nodes()`.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
