### PR TITLE
Multiple proxies infrastructure

### DIFF
--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -16,9 +16,24 @@ spec:
       name: metrics
   selector:
     app: proxy
-  type: NodePort
+  clusterIp: None
 
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxy-internal
+  labels:
+    app: proxy
+spec:
+  ports:
+    - port: 20100
+      name: proxy-internal
+  clusterIP: None
+  selector:
+    app: proxy
+---
+
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -54,7 +69,7 @@ spec:
             - containerPort: {{ .Values.proxyPort }}
               name: linera-port
             - containerPort: 20100
-              name: linera-port-int
+              name: private-port
           command: ["./proxy-entrypoint.sh", {{ .Values.storageReplicationFactor | quote }}]
           env:
             - name: RUST_LOG

--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -19,27 +19,12 @@ spec:
   type: NodePort
 
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: proxy-internal
-  labels:
-    app: proxy-internal
-spec:
-  ports:
-    - port: 20100
-      name: linera-port-int
-      targetPort: 20100
-  selector:
-    app: proxy
-  type: NodePort
-
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: proxy
 spec:
+  serviceName: "proxy"
   selector:
     matchLabels:
       app: proxy

--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -36,14 +36,15 @@ spec:
 
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: proxy
 spec:
   selector:
     matchLabels:
       app: proxy
-  replicas: 1
+  replicas: {{ .Values.numProxies }}
+  podManagementPolicy: Parallel
   template:
     metadata:
       labels:

--- a/kubernetes/linera-validator/values-local.yaml.gotmpl
+++ b/kubernetes/linera-validator/values-local.yaml.gotmpl
@@ -7,6 +7,7 @@ logLevel: "debug"
 proxyPort: 19100
 metricsPort: 21100
 numShards: {{ env "LINERA_HELMFILE_SET_NUM_SHARDS" | default 10 }}
+numProxies: {{ env "LINERA_HELMFILE_SET_NUM_PROXIES" | default 1 }}
 # Size of the RocksDB storage per shard, IF using `DualStore`. Otherwise will be ignored.
 rocksdbStorageSize: {{ env "LINERA_HELMFILE_SET_ROCKSDB_STORAGE_SIZE" | default "2Gi" }}
 storage: {{ env "LINERA_HELMFILE_SET_STORAGE" | default "scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042" }}

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -380,21 +380,14 @@ impl LocalKubernetesNet {
                 Grpc = "ClearText"
                 [internal_protocol]
                 Grpc = "ClearText"
-            "#
-        );
-
-        for k in 0..3 {
-            content.push_str(&format!(
-                r#"
 
                 [[proxies]]
-                host = "proxy-{k}.default.svc.cluster.local"
+                host = "proxy-0.default.svc.cluster.local"
                 public_port = {port}
                 private_port = {internal_port}
                 metrics_port = {metrics_port}
-                "#
-            ));
-        }
+            "#
+        );
 
         for k in 0..self.num_shards {
             let shard_port = 19100;


### PR DESCRIPTION
## Motivation

Supporting multiple proxies requires making corresponding changes to Kube infrastructure. Primarily introducing a second headless service to act as a static DNS for proxy ordinal naming.

## Proposal

Add the headless service (no cluster IP) which enables cluster-wide DNS name resolution for members of a statefulset. (we did the same thing for shards).

## Test Plan

Tested manually.

## Release Plan
- Nothing to do / These changes follow the usual release cycle.


