### PR TITLE
Include pending message bundles in benchmark block proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5091,7 +5091,6 @@ dependencies = [
  "cfg_aliases",
  "clap",
  "counter",
- "crossbeam-channel",
  "crowd-funding",
  "ethereum-tracker",
  "flarch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,6 @@ comfy-table = "7.1.0"
 console_error_panic_hook = "0.1.7"
 convert_case = "0.6.0"
 criterion = { version = "0.5.1", default-features = false }
-crossbeam-channel = "0.5.14"
 custom_debug_derive = "0.6.1"
 dashmap = "5.5.3"
 deluxe = "0.5.0"

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -16,7 +16,6 @@ test = ["linera-views/test", "linera-execution/test"]
 benchmark = [
     "linera-base/test",
     "dep:linera-sdk",
-    "dep:crossbeam-channel",
     "dep:num-format",
     "dep:reqwest",
     "dep:anyhow",
@@ -58,7 +57,6 @@ web-default = ["web", "wasmer", "indexed-db"]
 anyhow = { workspace = true, optional = true }
 bcs.workspace = true
 clap.workspace = true
-crossbeam-channel = { workspace = true, optional = true }
 futures.workspace = true
 hdrhistogram = { workspace = true, optional = true }
 linera-base.workspace = true

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -32,7 +32,7 @@ use {
     futures::{stream, StreamExt, TryStreamExt},
     linera_base::{
         crypto::AccountPublicKey,
-        data_types::{Amount, Epoch},
+        data_types::Amount,
         identifiers::{ApplicationId, BlobType},
     },
     linera_core::client::ChainClientError,
@@ -652,7 +652,6 @@ where
     ) -> Result<
         (
             Vec<Vec<ChainClient<Env>>>,
-            Epoch,
             Vec<Vec<(Vec<Operation>, AccountOwner)>>,
             Committee,
         ),
@@ -706,14 +705,14 @@ where
             .default_chain()
             .expect("should have default chain");
         let default_chain_client = self.make_chain_client(default_chain_id);
-        let (epoch, committee) = default_chain_client.admin_committee().await?;
+        let committee = default_chain_client.admin_committee().await?.1;
         let blocks_infos = Benchmark::<Env>::make_benchmark_block_info(
             benchmark_chains,
             transactions_per_block,
             fungible_application_id,
         );
 
-        Ok((chain_clients, epoch, blocks_infos, committee))
+        Ok((chain_clients, blocks_infos, committee))
     }
 
     pub async fn wrap_up_benchmark(

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -801,6 +801,15 @@ impl Runnable for Job {
                     confirm_before_start,
                     runtime_in_seconds,
                 } = benchmark_config;
+                assert!(
+                    options.context_options.max_pending_message_bundles >= transactions_per_block,
+                    "max_pending_message_bundles must be set to at least the same as the \
+                     number of transactions per block ({transactions_per_block}) for benchmarking",
+                );
+                assert!(
+                    options.context_options.wait_for_outgoing_messages,
+                    "wait_for_outgoing_messages must be set to true for benchmarking",
+                );
                 let num_chain_groups = num_chain_groups.unwrap_or(num_cpus::get());
                 assert!(
                     num_chain_groups > 0,
@@ -824,7 +833,7 @@ impl Runnable for Job {
                     wallet,
                     signer.into_value(),
                 );
-                let (chain_clients, epoch, blocks_infos, committee) = context
+                let (chain_clients, blocks_infos, committee) = context
                     .prepare_for_benchmark(
                         num_chain_groups,
                         num_chains_per_chain_group,
@@ -856,7 +865,6 @@ impl Runnable for Job {
                     transactions_per_block,
                     bps,
                     chain_clients.clone(),
-                    epoch,
                     blocks_infos,
                     committee,
                     health_check_endpoints,
@@ -2143,6 +2151,7 @@ Make sure to use a Linera client compatible with this network.
                             "50".to_string(),
                             "--tokio-blocking-threads".to_string(),
                             "10000".to_string(),
+                            "--wait-for-outgoing-messages".to_string(),
                         ],
                     )))
                 })


### PR DESCRIPTION
## Motivation

We were not processing the inboxes during the benchmarks, which caused the inboxes to just grow indefinitely.

## Proposal

Include the pending messages with the block proposals. This will cause each block to do a bit more work, which will likely force us to use smaller block sizes in the benchmarks to control latency, but will prevent the server's memory from growing indefinitely. 

## Test Plan

Will deploy a network and make sure memory isn't linearly increasing anymore, as well as track the inbox sizes.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
