### PR TITLE
Don't require ancestor chains in validators.

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -103,12 +103,15 @@ pub trait ValidatorNode {
     async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError>;
 
     /// Uploads the blobs to the validator.
-    fn upload_blobs(&self, blobs: Vec<Blob>) -> impl futures::Future<Output = Result<(), NodeError>>
-    where
-        Self: Sync,
-    {
-        async {
-            let tasks = blobs.into_iter().map(|blob| self.upload_blob(blob.into()));
+    fn upload_blobs(
+        &self,
+        blobs: Vec<Blob>,
+    ) -> impl futures::Future<Output = Result<(), NodeError>> {
+        let tasks: Vec<_> = blobs
+            .into_iter()
+            .map(|blob| self.upload_blob(blob.into()))
+            .collect();
+        async move {
             futures::future::try_join_all(tasks).await?;
             Ok(())
         }

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -109,15 +109,12 @@ pub trait ValidatorNode {
     fn upload_blobs(
         &self,
         blobs: Vec<Blob>,
-    ) -> impl futures::Future<Output = Result<(), NodeError>> {
+    ) -> impl futures::Future<Output = Result<Vec<BlobId>, NodeError>> {
         let tasks: Vec<_> = blobs
             .into_iter()
             .map(|blob| self.upload_blob(blob.into()))
             .collect();
-        async move {
-            futures::future::try_join_all(tasks).await?;
-            Ok(())
-        }
+        futures::future::try_join_all(tasks)
     }
 
     /// Downloads a blob. Returns an error if the validator does not have the blob.

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -103,6 +103,9 @@ pub trait ValidatorNode {
     async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError>;
 
     /// Uploads the blobs to the validator.
+    // Unfortunately, this doesn't compile as an async function: async functions in traits
+    // don't play well with default implementations, apparently.
+    // See also https://github.com/rust-lang/impl-trait-utils/issues/17
     fn upload_blobs(
         &self,
         blobs: Vec<Blob>,

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -207,16 +207,6 @@ impl<N: ValidatorNode> RemoteNode<N> {
         Ok(certificate)
     }
 
-    /// Uploads the blobs to the validator.
-    #[instrument(level = "trace")]
-    pub(crate) async fn upload_blobs(&self, blobs: Vec<Blob>) -> Result<(), NodeError> {
-        let tasks = blobs
-            .into_iter()
-            .map(|blob| self.node.upload_blob(blob.into()));
-        try_join_all(tasks).await?;
-        Ok(())
-    }
-
     /// Sends a pending validated block's blobs to the validator.
     #[instrument(level = "trace")]
     pub(crate) async fn send_pending_blobs(

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -209,7 +209,7 @@ where
 
 impl<A, S> ValidatorUpdater<A, S>
 where
-    A: ValidatorNode + Clone + 'static,
+    A: ValidatorNode + Clone + Sync + 'static,
     S: Storage + Clone + Send + Sync + 'static,
 {
     async fn send_confirmed_certificate(
@@ -229,7 +229,7 @@ where
                 // The certificate is confirmed, so the blobs must be in storage.
                 let maybe_blobs = self.local_node.read_blobs_from_storage(blob_ids).await?;
                 let blobs = maybe_blobs.ok_or_else(|| original_err.clone())?;
-                self.remote_node.upload_blobs(blobs.clone()).await?;
+                self.remote_node.node.upload_blobs(blobs.clone()).await?;
                 self.remote_node
                     .handle_confirmed_certificate(certificate, delivery)
                     .await

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -209,7 +209,7 @@ where
 
 impl<A, S> ValidatorUpdater<A, S>
 where
-    A: ValidatorNode + Clone + Sync + 'static,
+    A: ValidatorNode + Clone + 'static,
     S: Storage + Clone + Send + Sync + 'static,
 {
     async fn send_confirmed_certificate(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -178,6 +178,8 @@ pub enum WorkerError {
         chain_epoch: Epoch,
         epoch: Epoch,
     },
+    #[error("Proposal on chain {chain_id:} claims an unknown epoch {epoch:}")]
+    UnknownEpoch { chain_id: ChainId, epoch: Epoch },
 
     // Other server-side errors
     #[error("Invalid cross-chain request")]


### PR DESCRIPTION
## Motivation

Currently a validator cannot process a child chain without syncing all the ancestor chains up to the point where the child chain was created.

## Proposal

When a client uploads the first block of a chain, the validator should look up the committee and verify the signatures. It should then, based on that, accept the chain description blob, even if it doesn't have the parent chain.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- closes #4085 
