### PR TITLE
`linera-web`: fix external build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
           ];
           shellHook = ''
             # For rust-analyzer 'hover' tooltips to work.
-            export PATH=$PWD/target/debug:~/.cargo/bin:$PATH
+            export PATH=$PWD/target/debug:$PATH:~/.cargo/bin
             export RUST_SRC_PATH="${linera'.RUST_SRC_PATH}"
             export LIBCLANG_PATH="${linera'.LIBCLANG_PATH}"
             export ROCKSDB_LIB_DIR="${linera'.ROCKSDB_LIB_DIR}";

--- a/linera-web/package.json
+++ b/linera-web/package.json
@@ -12,7 +12,7 @@
     "install": "true",
     "build": "bash build.bash --release",
     "prepare": "pnpm build",
-    "lint": "cargo fmt --check && cargo clippy -- -W clippy::pedantic",
+    "lint": "cargo fmt --check && cargo clippy -- -W clippy::pedantic --no-deps",
     "ci": "pnpm lint",
     "format": "pnpm exec prettier . --write"
   },

--- a/linera-web/signer/package.json
+++ b/linera-web/signer/package.json
@@ -9,10 +9,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "pnpm exec tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
     "test": "jest",
-    "prepare": "npm run build"
+    "prepare": "pnpm run build"
   },
   "dependencies": {
     "@linera/client": "workspace:*",


### PR DESCRIPTION
## Motivation

`@linera/signer` was tested in an impure environment, so accidentally relies `npm` and `tsc` from outside the build environment.

Also, the shell hook I wrote in `flake.nix` puts `~/.cargo/bin` ahead of `$PATH`, so `.cargo/bin` can override tools from the build environment.

## Proposal

Use our existing `pnpm` instead of `npm`, and use `pnpm exec` to get `tsc` from the `devDependencies`.

Put `~/.cargo/bin` at the end of `PATH` instead of the front.

## Test Plan

This CI and `linera-web`'s.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
