### PR TITLE
Generate docs for `linera-web` using TypeDoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,8 @@
 .idea/
 
 # VSCode
-.vscode
-/.direnv
+.vscode/
+.direnv/
 
 # Cursor
 .cursor

--- a/linera-web/.envrc
+++ b/linera-web/.envrc
@@ -1,0 +1,1 @@
+use flake ..#nightly

--- a/linera-web/.gitignore
+++ b/linera-web/.gitignore
@@ -1,2 +1,3 @@
 /docs/
 /target/
+pnpm-lock.yaml

--- a/linera-web/.gitignore
+++ b/linera-web/.gitignore
@@ -1,2 +1,2 @@
-/target
-/pkg
+/docs/
+/target/

--- a/linera-web/package.json
+++ b/linera-web/package.json
@@ -12,9 +12,10 @@
     "install": "true",
     "build": "bash build.bash --release",
     "prepare": "pnpm build",
-    "lint": "cargo fmt --check && cargo clippy -- -W clippy::pedantic --no-deps",
-    "ci": "pnpm lint",
-    "format": "pnpm exec prettier . --write"
+    "lint": "pnpm build && pnpm exec tsc && cargo fmt --check && cargo clippy",
+    "ci": "pnpm lint && pnpm doc",
+    "format": "pnpm exec prettier . --write",
+    "doc": "pnpm exec typedoc"
   },
   "keywords": [],
   "author": "Linera <contact@linera.io>",

--- a/linera-web/package.json
+++ b/linera-web/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/linera-io/linera-web#readme",
   "devDependencies": {
-    "prettier": "3.5.3"
+    "prettier": "3.5.3",
+    "typedoc": "^0.28.5"
   }
 }

--- a/linera-web/signer/typedoc.json
+++ b/linera-web/signer/typedoc.json
@@ -1,0 +1,4 @@
+{
+    "entryPoints": ["src/index.ts"],
+    "excludeNotDocumented": true
+}

--- a/linera-web/tsconfig.json
+++ b/linera-web/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "files": ["dist/linera_web.d.ts"]
+}

--- a/linera-web/typedoc.json
+++ b/linera-web/typedoc.json
@@ -1,0 +1,4 @@
+{
+    "entryPoints": ["dist/linera_web.d.ts"],
+    "excludeNotDocumented": true
+}


### PR DESCRIPTION
## Motivation

Externals would like to see docs for the APIs they will need to integrate with.

## Proposal

Add configuration files to document source with [TypeDoc](https://typedoc.org/).

## Test Plan

Generated docs locally and they look okay.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

## Future work

I tried to document `@linera/signer` as well, which contains example implementations of the signer interface, but it currently doesn't typecheck, so TypeDoc can't document it.