### PR TITLE
Eliminate the `NotFound` for the `read_confirmed_block*`.

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -238,7 +238,10 @@ impl<C: ClientContext> ChainListener<C> {
     /// If any new chains were created by the given block, and we have a key pair for them,
     /// add them to the wallet and start listening for notifications.
     async fn add_new_chains(&mut self, hash: CryptoHash) -> Result<(), Error> {
-        let block = self.storage.read_confirmed_block(hash).await?
+        let block = self
+            .storage
+            .read_confirmed_block(hash)
+            .await?
             .ok_or(ChainClientError::MissingConfirmedBlock(hash))?
             .into_block();
         let blobs = block.created_blobs().into_iter();

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -238,7 +238,9 @@ impl<C: ClientContext> ChainListener<C> {
     /// If any new chains were created by the given block, and we have a key pair for them,
     /// add them to the wallet and start listening for notifications.
     async fn add_new_chains(&mut self, hash: CryptoHash) -> Result<(), Error> {
-        let block = self.storage.read_confirmed_block(hash).await?.into_block();
+        let block = self.storage.read_confirmed_block(hash).await?
+            .ok_or(ChainClientError::MissingConfirmedBlock(hash))?
+            .into_block();
         let blobs = block.created_blobs().into_iter();
         let new_chains = blobs
             .filter_map(|(blob_id, blob)| {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -3483,20 +3483,6 @@ impl<Env: Environment> ChainClient<Env> {
         Ok(())
     }
 
-    #[instrument(level = "trace", skip(from, limit))]
-    pub async fn read_confirmed_blocks_downward(
-        &self,
-        from: CryptoHash,
-        limit: u32,
-    ) -> Result<Vec<ConfirmedBlock>, ChainClientError> {
-        let blocks = self
-            .client
-            .storage_client()
-            .read_confirmed_blocks_downward(from, limit)
-            .await?;
-        blocks.ok_or(ChainClientError::MissingConfirmedBlock(from))
-    }
-
     #[instrument(level = "trace", skip(local_node))]
     async fn local_chain_info(
         &self,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -3465,7 +3465,8 @@ impl<Env: Environment> ChainClient<Env> {
         &self,
         hash: CryptoHash,
     ) -> Result<ConfirmedBlock, ChainClientError> {
-        let block = self.client
+        let block = self
+            .client
             .storage_client()
             .read_confirmed_block(hash)
             .await?;
@@ -3488,7 +3489,8 @@ impl<Env: Environment> ChainClient<Env> {
         from: CryptoHash,
         limit: u32,
     ) -> Result<Vec<ConfirmedBlock>, ChainClientError> {
-        let blocks = self.client
+        let blocks = self
+            .client
             .storage_client()
             .read_confirmed_blocks_downward(from, limit)
             .await?;

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -338,7 +338,9 @@ where
             DownloadConfirmedBlock(hash) => {
                 let block = self.storage.read_confirmed_block(*hash).await?;
                 let block = block.ok_or_else(|| anyhow!("Missing confirmed block {hash}"))?;
-                Ok(Some(RpcMessage::DownloadConfirmedBlockResponse(Box::new(block))))
+                Ok(Some(RpcMessage::DownloadConfirmedBlockResponse(Box::new(
+                    block,
+                ))))
             }
             DownloadCertificates(hashes) => {
                 let certificates = self.storage.read_certificates(hashes.clone()).await?;

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -335,9 +335,11 @@ where
                 let content = blob.into_content();
                 Ok(Some(RpcMessage::DownloadBlobResponse(Box::new(content))))
             }
-            DownloadConfirmedBlock(hash) => Ok(Some(RpcMessage::DownloadConfirmedBlockResponse(
-                Box::new(self.storage.read_confirmed_block(*hash).await?),
-            ))),
+            DownloadConfirmedBlock(hash) => {
+                let block = self.storage.read_confirmed_block(*hash).await?;
+                let block = block.ok_or_else(|| anyhow!("Missing confirmed block {hash}"))?;
+                Ok(Some(RpcMessage::DownloadConfirmedBlockResponse(Box::new(block))))
+            }
             DownloadCertificates(hashes) => {
                 let certificates = self.storage.read_certificates(hashes.clone()).await?;
                 let certificates = match ResultReadCertificates::new(certificates, hashes) {

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -673,27 +673,6 @@ where
         Ok(blob_states)
     }
 
-    async fn read_confirmed_blocks_downward(
-        &self,
-        from: CryptoHash,
-        limit: u32,
-    ) -> Result<Option<Vec<ConfirmedBlock>>, ViewError> {
-        let mut hash = Some(from);
-        let mut values = Vec::new();
-        for _ in 0..limit {
-            let Some(next_hash) = hash else {
-                break;
-            };
-            let value = self.read_confirmed_block(next_hash).await?;
-            let Some(value) = value else {
-                return Ok(None);
-            };
-            hash = value.block().header.previous_block_hash;
-            values.push(value);
-        }
-        Ok(Some(values))
-    }
-
     async fn write_blob(&self, blob: &Blob) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         batch.add_blob(blob)?;

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -597,7 +597,10 @@ where
         Ok(test)
     }
 
-    async fn read_confirmed_block(&self, hash: CryptoHash) -> Result<Option<ConfirmedBlock>, ViewError> {
+    async fn read_confirmed_block(
+        &self,
+        hash: CryptoHash,
+    ) -> Result<Option<ConfirmedBlock>, ViewError> {
         let block_key = bcs::to_bytes(&BaseKey::ConfirmedBlock(hash))?;
         let value = self.store.read_value(&block_key).await?;
         #[cfg(with_metrics)]

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -86,7 +86,10 @@ pub trait Storage: Sized {
     async fn contains_blob_state(&self, blob_id: BlobId) -> Result<bool, ViewError>;
 
     /// Reads the hashed certificate value with the given hash.
-    async fn read_confirmed_block(&self, hash: CryptoHash) -> Result<Option<ConfirmedBlock>, ViewError>;
+    async fn read_confirmed_block(
+        &self,
+        hash: CryptoHash,
+    ) -> Result<Option<ConfirmedBlock>, ViewError>;
 
     /// Reads the blob with the given blob ID.
     async fn read_blob(&self, blob_id: BlobId) -> Result<Option<Blob>, ViewError>;

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -106,13 +106,6 @@ pub trait Storage: Sized {
         blob_ids: &[BlobId],
     ) -> Result<Vec<Option<BlobState>>, ViewError>;
 
-    /// Reads the hashed certificate values in descending order from the given hash.
-    async fn read_confirmed_blocks_downward(
-        &self,
-        from: CryptoHash,
-        limit: u32,
-    ) -> Result<Option<Vec<ConfirmedBlock>>, ViewError>;
-
     /// Writes the given blob.
     async fn write_blob(&self, blob: &Blob) -> Result<(), ViewError>;
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -86,7 +86,7 @@ pub trait Storage: Sized {
     async fn contains_blob_state(&self, blob_id: BlobId) -> Result<bool, ViewError>;
 
     /// Reads the hashed certificate value with the given hash.
-    async fn read_confirmed_block(&self, hash: CryptoHash) -> Result<ConfirmedBlock, ViewError>;
+    async fn read_confirmed_block(&self, hash: CryptoHash) -> Result<Option<ConfirmedBlock>, ViewError>;
 
     /// Reads the blob with the given blob ID.
     async fn read_blob(&self, blob_id: BlobId) -> Result<Option<Blob>, ViewError>;
@@ -108,7 +108,7 @@ pub trait Storage: Sized {
         &self,
         from: CryptoHash,
         limit: u32,
-    ) -> Result<Vec<ConfirmedBlock>, ViewError>;
+    ) -> Result<Option<Vec<ConfirmedBlock>>, ViewError>;
 
     /// Writes the given blob.
     async fn write_blob(&self, blob: &Blob) -> Result<(), ViewError>;

--- a/linera-views/src/error.rs
+++ b/linera-views/src/error.rs
@@ -61,10 +61,3 @@ pub enum ViewError {
     #[error("post load values error")]
     PostLoadValuesError,
 }
-
-impl ViewError {
-    /// Creates a `NotFound` error with the given message and key.
-    pub fn not_found<T: std::fmt::Debug>(msg: &str, key: T) -> Self {
-        ViewError::NotFound(format!("{msg} {key:?}"))
-    }
-}


### PR DESCRIPTION
## Motivation

The `ViewError::NotFound` was used in the query. We want to eliminate it from the `ViewError`. So, this case can be ironed out.

## Proposal

The following is done:
* The `ViewError::not_found` is removed.
* The `read_confirmed_block` returns an option.
* The `read_confirmed_blocks_downward` is eliminated from `linera-storage` and when needed it is inlined (two contexts, one being a test).
* The variant is added to the `ChainClientError`. There are no more functions in `ChainClient` whose error is `ViewError`. 

## Test Plan

The CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.