### PR TITLE
`linera-web`: add config for automatic nightly toolchain selection

### DIFF
--- a/linera-web/.envrc
+++ b/linera-web/.envrc
@@ -1,0 +1,1 @@
+use flake ..#nightly

--- a/linera-web/rust-toolchain.toml
+++ b/linera-web/rust-toolchain.toml
@@ -1,0 +1,1 @@
+../toolchains/nightly/rust-toolchain.toml


### PR DESCRIPTION
## Motivation

It's annoying to have to remember to select the nightly toolchain when building `linera-web`.

## Proposal

Add a `.envrc` for direnv/Nix and a `rust-toolchain.toml` symlink for rustup so that invoking Rust inside `linera-web` will get the right toolchain by default for users of those tools.

## Test Plan

Tested locally by me (Nix) and @deuszx (rustup).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
