### PR TITLE
Add delay between chain groups for TPS ramp up

### DIFF
--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -90,6 +90,14 @@ pub struct BenchmarkCommand {
     /// it is interrupted.
     #[arg(long)]
     pub runtime_in_seconds: Option<u64>,
+
+    /// The delay between chain groups, in milliseconds. For example, if set to 200ms, the first
+    /// chain group will start, then the second will start 200 ms after the first one, the third
+    /// 200 ms after the second one, and so on.
+    /// This is used for slowly ramping up the TPS, so we don't pound the validators with the full
+    /// TPS all at once.
+    #[arg(long)]
+    pub delay_between_chain_groups_ms: Option<u64>,
 }
 
 #[cfg(feature = "benchmark")]
@@ -107,6 +115,7 @@ impl Default for BenchmarkCommand {
             health_check_endpoints: None,
             confirm_before_start: false,
             runtime_in_seconds: None,
+            delay_between_chain_groups_ms: None,
         }
     }
 }

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -800,6 +800,7 @@ impl Runnable for Job {
                     wrap_up_max_in_flight,
                     confirm_before_start,
                     runtime_in_seconds,
+                    delay_between_chain_groups_ms,
                 } = benchmark_config;
                 assert!(
                     options.context_options.max_pending_message_bundles >= transactions_per_block,
@@ -869,6 +870,7 @@ impl Runnable for Job {
                     committee,
                     health_check_endpoints,
                     runtime_in_seconds,
+                    delay_between_chain_groups_ms,
                 )
                 .await?;
 


### PR DESCRIPTION
## Motivation

When running benchmarks, if we're sending a very large TPS amount, it is useful to be able to ramp up that TPS.

## Proposal

Add an option to add a delay for subsequent chain groups to be started. This should be set proportionally to the amount of work (TPS) each chain group will be doing.

## Test Plan

Tested against a local network, saw that the delay works as expected.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
