### PR TITLE
Error rates should use percentage as unit

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera/general.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/general.json
@@ -183,7 +183,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "percent"
         },
         "overrides": []
       },
@@ -698,7 +699,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "percent"
         },
         "overrides": []
       },
@@ -3407,7 +3409,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",


### PR DESCRIPTION
## Motivation

Error rates should be displayed as percentages. Now they're just a number.

## Proposal

Display them as percentages

## Test Plan

Before:

![Screenshot 2025-06-24 at 13.39.25.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/6c4886b1-5073-4df9-b549-4db2a2d936eb.png)

After:

![Screenshot 2025-06-24 at 13.39.40.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/e05d1a59-d5a3-471d-ae91-0e9653ed4ff6.png)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
