### PR TITLE
Add tokio threads options to shard deployment

### DIFF
--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -57,6 +57,10 @@ spec:
           env:
             - name: RUST_LOG
               value: {{ .Values.logLevel }}
+            {{- if .Values.serverTokioThreads }}
+            - name: LINERA_SERVER_TOKIO_THREADS
+              value: "{{ .Values.serverTokioThreads }}"
+            {{- end }}
           volumeMounts:
             - name: config
               mountPath: "/config"

--- a/kubernetes/linera-validator/values-local.yaml.gotmpl
+++ b/kubernetes/linera-validator/values-local.yaml.gotmpl
@@ -8,6 +8,7 @@ proxyPort: 19100
 metricsPort: 21100
 numShards: {{ env "LINERA_HELMFILE_SET_NUM_SHARDS" | default 10 }}
 numProxies: {{ env "LINERA_HELMFILE_SET_NUM_PROXIES" | default 1 }}
+serverTokioThreads: {{ env "LINERA_HELMFILE_SET_SERVER_TOKIO_THREADS" | default "" }}
 # Size of the RocksDB storage per shard, IF using `DualStore`. Otherwise will be ignored.
 rocksdbStorageSize: {{ env "LINERA_HELMFILE_SET_ROCKSDB_STORAGE_SIZE" | default "2Gi" }}
 storage: {{ env "LINERA_HELMFILE_SET_STORAGE" | default "scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042" }}

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -70,7 +70,6 @@ where
         config: ChainWorkerConfig,
         storage: StorageClient,
         block_values: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
-
         execution_state_cache: Arc<
             ValueCache<CryptoHash, ExecutionStateView<StorageClient::Context>>,
         >,


### PR DESCRIPTION
## Motivation

We'll be starting to set the tokio worker threads in the server binary from `lineractl`.

## Proposal

Add option for tokio worker threads and blocking threads.

## Test Plan

Deployed a network locally with this, saw that it didn't set the env variable, as expected.
Deployed a network using `lineractl`, saw that it did set the env variable, as expected.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
