### PR TITLE
Stop setting tokio blocking threads manually for multi-benchmark

### DIFF
--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -2151,8 +2151,6 @@ Make sure to use a Linera client compatible with this network.
                             "1000".to_string(),
                             "--storage-max-stream-queries".to_string(),
                             "50".to_string(),
-                            "--tokio-blocking-threads".to_string(),
-                            "10000".to_string(),
                             "--wait-for-outgoing-messages".to_string(),
                         ],
                     )))


### PR DESCRIPTION
## Motivation

Since we redesigned the benchmark client, we don't use blocking threads there anymore, so setting this to a large number is no longer required.

## Proposal

Stop manually setting the number of blocking tokio threads

## Test Plan

Have been testing this during my benchmarking

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
