### PR TITLE
`linera-web`: check in built Markdown docs

### DIFF
--- a/linera-web/.gitignore
+++ b/linera-web/.gitignore
@@ -1,3 +1,2 @@
-/docs/
 /target/
 pnpm-lock.yaml

--- a/linera-web/docs/README.md
+++ b/linera-web/docs/README.md
@@ -1,0 +1,25 @@
+**@linera/client**
+
+***
+
+# @linera/client
+
+## Classes
+
+- [Client](classes/Client.md)
+- [Frontend](classes/Frontend.md)
+- [Wallet](classes/Wallet.md)
+
+## Interfaces
+
+- [Signer](interfaces/Signer.md)
+
+## Type Aliases
+
+- [ReadableStreamType](type-aliases/ReadableStreamType.md)
+
+## Functions
+
+- [default](functions/default.md)
+- [initSync](functions/initSync.md)
+- [wasm\_thread\_entry\_point](functions/wasm_thread_entry_point.md)

--- a/linera-web/docs/classes/Client.md
+++ b/linera-web/docs/classes/Client.md
@@ -1,0 +1,126 @@
+[**@linera/client**](../README.md)
+
+***
+
+[@linera/client](../README.md) / Client
+
+# Class: Client
+
+Defined in: linera\_web.d.ts:68
+
+The full client API, exposed to the wallet implementation. Calls
+to this API can be trusted to have originated from the user's
+request. This struct is the backend for the extension itself
+(side panel, option page, et cetera).
+
+## Constructors
+
+### Constructor
+
+> **new Client**(`wallet`, `signer`): `Client`
+
+Defined in: linera\_web.d.ts:77
+
+Creates a new client and connects to the network.
+
+# Errors
+On transport or protocol error, or if persistent storage is
+unavailable.
+
+#### Parameters
+
+##### wallet
+
+[`Wallet`](Wallet.md)
+
+##### signer
+
+[`Signer`](../interfaces/Signer.md)
+
+#### Returns
+
+`Client`
+
+## Methods
+
+### frontend()
+
+> **frontend**(): [`Frontend`](Frontend.md)
+
+Defined in: linera\_web.d.ts:109
+
+Gets an object implementing the API for Web frontends.
+
+#### Returns
+
+[`Frontend`](Frontend.md)
+
+***
+
+### identity()
+
+> **identity**(): `Promise`\<`any`\>
+
+Defined in: linera\_web.d.ts:105
+
+Gets the identity of the default chain.
+
+# Errors
+If the chain couldn't be established.
+
+#### Returns
+
+`Promise`\<`any`\>
+
+***
+
+### onNotification()
+
+> **onNotification**(`handler`): `void`
+
+Defined in: linera\_web.d.ts:86
+
+Sets a callback to be called when a notification is received
+from the network.
+
+# Panics
+If the handler function fails or we fail to subscribe to the
+notification stream.
+
+#### Parameters
+
+##### handler
+
+`Function`
+
+#### Returns
+
+`void`
+
+***
+
+### transfer()
+
+> **transfer**(`options`): `Promise`\<`void`\>
+
+Defined in: linera\_web.d.ts:98
+
+Transfers funds from one account to another.
+
+`options` should be an options object of the form `{ donor,
+recipient, amount }`; omitting `donor` will cause the funds to
+come from the chain balance.
+
+# Errors
+- if the options object is of the wrong form
+- if the transfer fails
+
+#### Parameters
+
+##### options
+
+`any`
+
+#### Returns
+
+`Promise`\<`void`\>

--- a/linera-web/docs/classes/Frontend.md
+++ b/linera-web/docs/classes/Frontend.md
@@ -1,0 +1,58 @@
+[**@linera/client**](../README.md)
+
+***
+
+[@linera/client](../README.md) / Frontend
+
+# Class: Frontend
+
+Defined in: linera\_web.d.ts:141
+
+The subset of the client API that should be exposed to application
+frontends. Any function exported here with `wasm_bindgen` can be
+called by untrusted Web pages, and so inputs must be verified and
+outputs must not leak sensitive information without user
+confirmation.
+
+## Methods
+
+### application()
+
+> **application**(`id`): `Promise`\<`Application`\>
+
+Defined in: linera\_web.d.ts:160
+
+Retrieves an application for querying.
+
+# Errors
+If the application ID is invalid.
+
+#### Parameters
+
+##### id
+
+`string`
+
+#### Returns
+
+`Promise`\<`Application`\>
+
+***
+
+### validatorVersionInfo()
+
+> **validatorVersionInfo**(): `Promise`\<`any`\>
+
+Defined in: linera\_web.d.ts:153
+
+Gets the version information of the validators of the current network.
+
+# Errors
+If a validator is unreachable.
+
+# Panics
+If no default chain is set for the current wallet.
+
+#### Returns
+
+`Promise`\<`any`\>

--- a/linera-web/docs/classes/Wallet.md
+++ b/linera-web/docs/classes/Wallet.md
@@ -1,0 +1,11 @@
+[**@linera/client**](../README.md)
+
+***
+
+[@linera/client](../README.md) / Wallet
+
+# Class: Wallet
+
+Defined in: linera\_web.d.ts:187
+
+A wallet that stores the user's chains and keys in memory.

--- a/linera-web/docs/functions/default.md
+++ b/linera-web/docs/functions/default.md
@@ -1,0 +1,32 @@
+[**@linera/client**](../README.md)
+
+***
+
+[@linera/client](../README.md) / default
+
+# Function: default()
+
+> **default**(`module_or_path?`, `memory?`): `Promise`\<`InitOutput`\>
+
+Defined in: linera\_web.d.ts:268
+
+If `module_or_path` is {RequestInfo} or {URL}, makes a request and
+for everything else, calls `WebAssembly.instantiate` directly.
+
+## Parameters
+
+### module\_or\_path?
+
+Passing `InitInput` directly is deprecated.
+
+`InitInput` | `Promise`\<`InitInput`\> | \{ `memory?`: `Memory`; `module_or_path`: InitInput \| Promise\<InitInput\>; `thread_stack_size?`: `number`; \}
+
+### memory?
+
+`Memory`
+
+Deprecated.
+
+## Returns
+
+`Promise`\<`InitOutput`\>

--- a/linera-web/docs/functions/initSync.md
+++ b/linera-web/docs/functions/initSync.md
@@ -1,0 +1,32 @@
+[**@linera/client**](../README.md)
+
+***
+
+[@linera/client](../README.md) / initSync
+
+# Function: initSync()
+
+> **initSync**(`module`, `memory?`): `InitOutput`
+
+Defined in: linera\_web.d.ts:257
+
+Instantiates the given `module`, which can either be bytes or
+a precompiled `WebAssembly.Module`.
+
+## Parameters
+
+### module
+
+Passing `SyncInitInput` directly is deprecated.
+
+`SyncInitInput` | \{ `memory?`: `Memory`; `module`: `SyncInitInput`; `thread_stack_size?`: `number`; \}
+
+### memory?
+
+`Memory`
+
+Deprecated.
+
+## Returns
+
+`InitOutput`

--- a/linera-web/docs/functions/wasm_thread_entry_point.md
+++ b/linera-web/docs/functions/wasm_thread_entry_point.md
@@ -1,0 +1,23 @@
+[**@linera/client**](../README.md)
+
+***
+
+[@linera/client](../README.md) / wasm\_thread\_entry\_point
+
+# Function: wasm\_thread\_entry\_point()
+
+> **wasm\_thread\_entry\_point**(`ptr`): `Promise`\<`void`\>
+
+Defined in: linera\_web.d.ts:7
+
+Entry point for web workers
+
+## Parameters
+
+### ptr
+
+`number`
+
+## Returns
+
+`Promise`\<`void`\>

--- a/linera-web/docs/interfaces/Signer.md
+++ b/linera-web/docs/interfaces/Signer.md
@@ -1,0 +1,66 @@
+[**@linera/client**](../README.md)
+
+***
+
+[@linera/client](../README.md) / Signer
+
+# Interface: Signer
+
+Defined in: linera\_web.d.ts:26
+
+Interface for signing and key management compatible with Ethereum (EVM) addresses.
+
+## Methods
+
+### containsKey()
+
+> **containsKey**(`owner`): `Promise`\<`boolean`\>
+
+Defined in: linera\_web.d.ts:43
+
+Checks whether the instance holds a key whose associated address matches the given EVM address.
+
+#### Parameters
+
+##### owner
+
+`string`
+
+The EVM address to check for.
+
+#### Returns
+
+`Promise`\<`boolean`\>
+
+A promise that resolves to `true` if the key exists and matches the given address, otherwise `false`.
+
+***
+
+### sign()
+
+> **sign**(`owner`, `value`): `Promise`\<`string`\>
+
+Defined in: linera\_web.d.ts:35
+
+Signs a given value using the private key associated with the specified EVM address.
+The signing process must follow the EIP-191 standard.
+
+#### Parameters
+
+##### owner
+
+`string`
+
+The EVM address whose private key will be used to sign the value.
+
+##### value
+
+`Uint8Array`
+
+The data to be signed, as a `Uint8Array`.
+
+#### Returns
+
+`Promise`\<`string`\>
+
+A promise that resolves to the EIP-191-compatible signature in hexadecimal string format.

--- a/linera-web/docs/type-aliases/ReadableStreamType.md
+++ b/linera-web/docs/type-aliases/ReadableStreamType.md
@@ -1,0 +1,15 @@
+[**@linera/client**](../README.md)
+
+***
+
+[@linera/client](../README.md) / ReadableStreamType
+
+# Type Alias: ReadableStreamType
+
+> **ReadableStreamType** = `"bytes"`
+
+Defined in: linera\_web.d.ts:22
+
+The `ReadableStreamType` enum.
+
+*This API requires the following crate features to be activated: `ReadableStreamType`*

--- a/linera-web/package.json
+++ b/linera-web/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/linera-io/linera-web#readme",
   "devDependencies": {
     "prettier": "3.5.3",
-    "typedoc": "^0.28.5"
+    "typedoc": "^0.28.5",
+    "typedoc-plugin-markdown": "^4.7.0"
   }
 }


### PR DESCRIPTION
## Motivation

Make the docs available in [`linera-documentation`](https://github.com/linera-io/linera-documentation/) without having to build them there.

## Proposal

Check them in.  It would be nice to check in CI that they haven't changed, but this is left as future work.

## Test Plan

Use in `linera-documentation`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
