### PR TITLE
Shard BPS per chain group to prevent oversending requests

### DIFF
--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -57,6 +57,10 @@ spec:
           env:
             - name: RUST_LOG
               value: {{ .Values.logLevel }}
+            {{- if .Values.serverTokioThreads }}
+            - name: LINERA_SERVER_TOKIO_THREADS
+              value: "{{ .Values.serverTokioThreads }}"
+            {{- end }}
           volumeMounts:
             - name: config
               mountPath: "/config"

--- a/kubernetes/linera-validator/values-local.yaml.gotmpl
+++ b/kubernetes/linera-validator/values-local.yaml.gotmpl
@@ -8,6 +8,7 @@ proxyPort: 19100
 metricsPort: 21100
 numShards: {{ env "LINERA_HELMFILE_SET_NUM_SHARDS" | default 10 }}
 numProxies: {{ env "LINERA_HELMFILE_SET_NUM_PROXIES" | default 1 }}
+serverTokioThreads: {{ env "LINERA_HELMFILE_SET_SERVER_TOKIO_THREADS" | default "" }}
 # Size of the RocksDB storage per shard, IF using `DualStore`. Otherwise will be ignored.
 rocksdbStorageSize: {{ env "LINERA_HELMFILE_SET_ROCKSDB_STORAGE_SIZE" | default "2Gi" }}
 storage: {{ env "LINERA_HELMFILE_SET_STORAGE" | default "scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042" }}

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -70,7 +70,6 @@ where
         config: ChainWorkerConfig,
         storage: StorageClient,
         block_values: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
-
         execution_state_cache: Arc<
             ValueCache<CryptoHash, ExecutionStateView<StorageClient::Context>>,
         >,


### PR DESCRIPTION
## Motivation

Right now we have a number of chain groups, all together trying to reach a certain BPS. They check if the BPS was reached by checking this one atomic variable.
However, you could reach a situation where one of the chain groups achieves the BPS, but the other `num_chain_groups - 1` chain groups all have block proposals in flight. Meaning that in the worse case we could be overshooting our BPS by 2 * BPS - 1 🤦🏻‍♂️

## Proposal

Make each chain group have a BPS share that they need to achieve, which is controlled by their own atomic variable.
The BPS control task will now sum all those atomic variables to make sure we reached the desired BPS/TPS.
This prevents the race condition that causes us to overshoot the BPS.

## Test Plan

Tested on a deployed network. Was seeing before that we were overshooting by 1.5x. Now we're back to normal.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
