### PR TITLE
Add process ID to multi-benchmark in case we want to run several multi-benchmark processes in the same machine

### DIFF
--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -474,17 +474,18 @@ pub enum ClientCommand {
     #[cfg(feature = "benchmark")]
     MultiBenchmark {
         /// The number of `linera benchmark` processes to run in parallel.
-        #[arg(long = "processes", default_value = "1")]
+        #[arg(long, default_value = "1")]
         processes: usize,
 
         /// The faucet (which implicitly defines the network)
-        #[arg(long = "faucet")]
+        #[arg(long)]
         faucet: String,
 
-        /// If running on local SSD, specify the directory to store the storage and wallet.
+        /// If specified, a directory named after the process ID will be created in this directory,
+        /// and the client state will be stored there.
         /// If not specified, a temporary directory will be used for each client.
-        #[arg(long = "ssd-dir")]
-        ssd_dir: Option<String>,
+        #[arg(long)]
+        client_state_dir: Option<String>,
 
         /// The benchmark command to run.
         #[clap(flatten)]

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -2126,7 +2126,7 @@ Make sure to use a Linera client compatible with this network.
         ClientCommand::MultiBenchmark {
             processes,
             faucet,
-            ssd_dir,
+            client_state_dir,
             command,
             delay_between_processes,
         } => {
@@ -2139,7 +2139,14 @@ Make sure to use a Linera client compatible with this network.
 
             let clients = (0..*processes)
                 .map(|n| {
-                    let path_provider = PathProvider::new(ssd_dir)?;
+                    let path_provider = if let Some(client_state_dir) = client_state_dir {
+                        let pid = std::process::id();
+                        let subdir = PathBuf::from(client_state_dir).join(pid.to_string());
+                        std::fs::create_dir_all(&subdir)?;
+                        PathProvider::new(&Some(subdir.to_string_lossy().to_string()))?
+                    } else {
+                        PathProvider::new(client_state_dir)?
+                    };
                     Ok(Arc::new(ClientWrapper::new_with_extra_args(
                         path_provider,
                         Network::Grpc,


### PR DESCRIPTION
## Motivation

Using the same benchy instance with local SSD to benchmark different networks at the same time is currently not possible because it assumes one runner per machine (which is the most common use case). However, I have needed to benchmark different networks at the same time to save time.

## Proposal

Create a PID directory for each instance of the `multi-benchmark` that is running, within the local ssd directory, to save the client state (wallet and DB)

## Test Plan

Using this to benchmark several networks at the same time

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
