### PR TITLE
Return ResourceTracker from `execute_block` method

### DIFF
--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -393,6 +393,7 @@ impl<'blobs> BlockExecutionTracker<'blobs> {
             self.events,
             self.blobs,
             self.operation_results,
+            self.resource_controller.tracker,
         )
     }
 }
@@ -403,4 +404,5 @@ pub(crate) type FinalizeExecutionResult = (
     Vec<Vec<Event>>,
     Vec<Vec<Blob>>,
     Vec<OperationResult>,
+    ResourceTracker,
 );

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -115,7 +115,7 @@ impl<'blobs> BlockExecutionTracker<'blobs> {
                     .track_block_size_of(&incoming_bundle)
                     .with_execution_context(chain_execution_context)?;
                 for (message_id, posted_message) in incoming_bundle.messages_and_ids() {
-                    Box::pin(self.execute_message_in_block(
+                    Box::pin(self.execute_message(
                         chain,
                         message_id,
                         posted_message,
@@ -130,8 +130,7 @@ impl<'blobs> BlockExecutionTracker<'blobs> {
                 self.resource_controller_mut()
                     .track_block_size_of(&operation)
                     .with_execution_context(chain_execution_context)?;
-                Box::pin(self.execute_operation_in_block(chain, operation, &mut txn_tracker))
-                    .await?;
+                Box::pin(self.execute_operation(chain, operation, &mut txn_tracker)).await?;
             }
         }
 
@@ -156,7 +155,7 @@ impl<'blobs> BlockExecutionTracker<'blobs> {
     }
 
     /// Executes a message as part of an incoming bundle in a block.
-    async fn execute_message_in_block<C>(
+    async fn execute_message<C>(
         &mut self,
         chain: &mut ExecutionStateView<C>,
         message_id: MessageId,
@@ -232,7 +231,7 @@ impl<'blobs> BlockExecutionTracker<'blobs> {
         Ok(())
     }
 
-    async fn execute_operation_in_block<C>(
+    async fn execute_operation<C>(
         &mut self,
         chain: &mut ExecutionStateView<C>,
         operation: &Operation,

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -21,7 +21,6 @@ use linera_views::context::Context;
 #[cfg(with_metrics)]
 use crate::chain::metrics;
 use crate::{
-    chain::EMPTY_BLOCK_SIZE,
     data_types::{
         IncomingBundle, MessageAction, OperationResult, PostedMessage, ProposedBlock, Transaction,
     },
@@ -67,17 +66,13 @@ pub struct BlockExecutionTracker<'blobs> {
 impl<'blobs> BlockExecutionTracker<'blobs> {
     /// Creates a new BlockExecutionTracker.
     pub fn new(
-        mut resource_controller: ResourceController<Option<AccountOwner>, ResourceTracker>,
+        resource_controller: ResourceController<Option<AccountOwner>, ResourceTracker>,
         published_blobs: BTreeMap<BlobId, &'blobs Blob>,
         local_time: Timestamp,
         round: Option<u32>,
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
         proposal: &ProposedBlock,
     ) -> Result<Self, ChainError> {
-        resource_controller
-            .track_block_size(EMPTY_BLOCK_SIZE)
-            .with_execution_context(ChainExecutionContext::Block)?;
-
         Ok(Self {
             chain_id: proposal.chain_id,
             block_height: proposal.height,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -767,8 +767,11 @@ where
             local_time,
             round,
             replaying_oracle_responses,
-            block,
-        )?;
+            block.chain_id,
+            block.height,
+            block.timestamp,
+            block.authenticated_signer,
+        );
 
         for transaction in block.transactions() {
             block_execution_tracker
@@ -797,7 +800,7 @@ where
         };
 
         let (messages, oracle_responses, events, blobs, operation_results, resource_tracker) =
-            block_execution_tracker.finalize();
+            block_execution_tracker.finalize(block.incoming_bundles.len() + block.operations.len());
 
         let execution_outcome = BlockExecutionOutcome {
             messages,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -731,7 +731,7 @@ where
         round: Option<u32>,
         published_blobs: &[Blob],
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
-    ) -> Result<BlockExecutionOutcome, ChainError> {
+    ) -> Result<(BlockExecutionOutcome, ResourceTracker), ChainError> {
         #[cfg(with_metrics)]
         let _execution_latency = metrics::BLOCK_EXECUTION_LATENCY.measure_latency();
         chain.system.timestamp.set(block.timestamp);
@@ -824,7 +824,7 @@ where
         round: Option<u32>,
         published_blobs: &[Blob],
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
-    ) -> Result<BlockExecutionOutcome, ChainError> {
+    ) -> Result<(BlockExecutionOutcome, ResourceTracker), ChainError> {
         assert_eq!(
             block.chain_id,
             self.execution_state.context().extra().chain_id()

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -192,9 +192,6 @@ pub(crate) mod metrics {
     }
 }
 
-/// The BCS-serialized size of an empty [`Block`].
-pub(crate) const EMPTY_BLOCK_SIZE: usize = 94;
-
 /// An origin, cursor and timestamp of a unskippable bundle in our inbox.
 #[cfg_attr(with_graphql, derive(async_graphql::SimpleObject))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1077,16 +1074,4 @@ where
             .observe(self.outboxes.count().await? as f64);
         Ok(targets)
     }
-}
-
-#[test]
-fn empty_block_size() {
-    let size = bcs::serialized_size(&crate::block::Block::new(
-        crate::test::make_first_block(
-            linera_execution::test_utils::dummy_chain_description(0).id(),
-        ),
-        crate::data_types::BlockExecutionOutcome::default(),
-    ))
-    .unwrap();
-    assert_eq!(size, EMPTY_BLOCK_SIZE);
 }

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -224,7 +224,7 @@ async fn test_block_size_limit() -> anyhow::Result<()> {
     );
 
     // The valid block is accepted...
-    let outcome = chain
+    let (outcome, _resources) = chain
         .execute_block(&valid_block, time, None, &[], None)
         .await
         .unwrap();
@@ -325,7 +325,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
         .with_operation(app_operation.clone())
         .with_operation(another_app_operation.clone());
 
-    let outcome = chain
+    let (outcome, _resources) = chain
         .execute_block(&valid_block, time, None, &[], None)
         .await?;
 
@@ -358,7 +358,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     let valid_block = make_child_block(&value)
         .with_operation(app_operation.clone())
         .with_operation(another_app_operation.clone());
-    let outcome = chain
+    let (outcome, _resources) = chain
         .execute_block(&valid_block, time, None, &[], None)
         .await?;
     let value = ConfirmedBlock::new(outcome.with(valid_block));
@@ -565,7 +565,10 @@ async fn test_service_as_oracle_response_size_limit(
 
     application.expect_call(ExpectedCall::default_finalize());
 
-    chain.execute_block(&block, time, None, &[], None).await
+    chain
+        .execute_block(&block, time, None, &[], None)
+        .await
+        .map(|(outcome, _resources)| outcome)
 }
 
 /// Tests contract HTTP response size limit.
@@ -621,7 +624,10 @@ async fn test_contract_http_response_size_limit(
 
     application.expect_call(ExpectedCall::default_finalize());
 
-    chain.execute_block(&block, time, None, &[], None).await
+    chain
+        .execute_block(&block, time, None, &[], None)
+        .await
+        .map(|(outcome, _resources)| outcome)
 }
 
 /// Tests service HTTP response size limit.
@@ -677,7 +683,10 @@ async fn test_service_http_response_size_limit(
 
     application.expect_call(ExpectedCall::default_finalize());
 
-    chain.execute_block(&block, time, None, &[], None).await
+    chain
+        .execute_block(&block, time, None, &[], None)
+        .await
+        .map(|(outcome, _resources)| outcome)
 }
 
 /// Sets up a test with a dummy [`MockApplication`].

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -22,7 +22,7 @@ use linera_chain::{
     ChainStateView,
 };
 use linera_execution::{
-    ExecutionStateView, Query, QueryContext, QueryOutcome, ServiceRuntimeEndpoint,
+    ExecutionStateView, Query, QueryContext, QueryOutcome, ResourceTracker, ServiceRuntimeEndpoint,
     ServiceSyncRuntime,
 };
 use linera_storage::Storage;
@@ -88,7 +88,7 @@ where
         round: Option<u32>,
         published_blobs: Vec<Blob>,
         #[debug(skip)]
-        callback: oneshot::Sender<Result<(Block, ChainInfoResponse), WorkerError>>,
+        callback: oneshot::Sender<Result<(Block, ResourceTracker, ChainInfoResponse), WorkerError>>,
     },
 
     /// Process a leader timeout issued for this multi-owner chain.

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -367,7 +367,7 @@ where
             chain.execution_state = execution_state;
             outcome.clone()
         } else {
-            chain
+            let (outcome, _resources) = chain
                 .execute_block(
                     &proposed_block,
                     local_time,
@@ -375,7 +375,8 @@ where
                     &published_blobs,
                     oracle_responses,
                 )
-                .await?
+                .await?;
+            outcome
         };
         // We should always agree on the messages and state hash.
         ensure!(

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -25,7 +25,9 @@ use linera_chain::{
     types::{Block, ConfirmedBlockCertificate, TimeoutCertificate, ValidatedBlockCertificate},
     ChainError, ChainStateView,
 };
-use linera_execution::{ExecutionStateView, Query, QueryOutcome, ServiceRuntimeEndpoint};
+use linera_execution::{
+    ExecutionStateView, Query, QueryOutcome, ResourceTracker, ServiceRuntimeEndpoint,
+};
 use linera_storage::{Clock as _, ResultReadCertificates, Storage};
 use linera_views::views::ClonableView;
 use tokio::sync::{oneshot, OwnedRwLockReadGuard, RwLock};
@@ -175,12 +177,12 @@ where
         block: ProposedBlock,
         round: Option<u32>,
         published_blobs: &[Blob],
-    ) -> Result<(Block, ChainInfoResponse), WorkerError> {
-        let (block, response) = ChainWorkerStateWithTemporaryChanges::new(self)
+    ) -> Result<(Block, ResourceTracker, ChainInfoResponse), WorkerError> {
+        let (block, resources, response) = ChainWorkerStateWithTemporaryChanges::new(self)
             .await
             .stage_block_execution(block, round, published_blobs)
             .await?;
-        Ok((block, response))
+        Ok((block, resources, response))
     }
 
     /// Processes a leader timeout issued for this multi-owner chain.

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -16,7 +16,7 @@ use linera_chain::{
     manager,
     types::Block,
 };
-use linera_execution::{Query, QueryOutcome};
+use linera_execution::{Query, QueryOutcome, ResourceTracker};
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::{ClonableView, View};
 #[cfg(with_testing)]
@@ -127,14 +127,14 @@ where
         block: ProposedBlock,
         round: Option<u32>,
         published_blobs: &[Blob],
-    ) -> Result<(Block, ChainInfoResponse), WorkerError> {
+    ) -> Result<(Block, ResourceTracker, ChainInfoResponse), WorkerError> {
         self.0.ensure_is_active().await?;
         let local_time = self.0.storage.clock().current_time();
         let signer = block.authenticated_signer;
         let (_, committee) = self.0.chain.current_committee()?;
         block.check_proposal_size(committee.policy().maximum_block_proposal_size)?;
 
-        let outcome = self
+        let (outcome, resources) = self
             .execute_block(&block, local_time, round, published_blobs)
             .await?;
 
@@ -150,7 +150,7 @@ where
                 .await?;
         }
 
-        Ok((outcome.with(block), response))
+        Ok((outcome.with(block), resources, response))
     }
 
     /// Validates a proposal's signatures; returns `manager::Outcome::Skip` if we already voted
@@ -251,8 +251,10 @@ where
         let outcome = if let Some(outcome) = outcome {
             outcome.clone()
         } else {
-            self.execute_block(block, local_time, round.multi_leader(), published_blobs)
-                .await?
+            let (outcome, _resources) = self
+                .execute_block(block, local_time, round.multi_leader(), published_blobs)
+                .await?;
+            outcome
         };
 
         ensure!(
@@ -350,8 +352,8 @@ where
         local_time: Timestamp,
         round: Option<u32>,
         published_blobs: &[Blob],
-    ) -> Result<BlockExecutionOutcome, WorkerError> {
-        let outcome =
+    ) -> Result<(BlockExecutionOutcome, ResourceTracker), WorkerError> {
+        let (outcome, resources) =
             Box::pin(
                 self.0
                     .chain
@@ -362,7 +364,7 @@ where
             &outcome.state_hash,
             self.0.chain.execution_state.clone_unchecked()?,
         );
-        Ok(outcome)
+        Ok((outcome, resources))
     }
 }
 

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -18,7 +18,7 @@ use linera_chain::{
     types::{Block, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
     ChainStateView,
 };
-use linera_execution::{committee::Committee, BlobState, Query, QueryOutcome};
+use linera_execution::{committee::Committee, BlobState, Query, QueryOutcome, ResourceTracker};
 use linera_storage::Storage;
 use linera_views::ViewError;
 use thiserror::Error;
@@ -164,7 +164,7 @@ where
         block: ProposedBlock,
         round: Option<u32>,
         published_blobs: Vec<Blob>,
-    ) -> Result<(Block, ChainInfoResponse), LocalNodeError> {
+    ) -> Result<(Block, ResourceTracker, ChainInfoResponse), LocalNodeError> {
         Ok(self
             .node
             .state

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3077,7 +3077,7 @@ where
             timeout_config: TimeoutConfig::default(),
         })
         .with_authenticated_signer(Some(owner0));
-    let (block0, _) = env
+    let (block0, _resources, _) = env
         .worker()
         .stage_block_execution(proposed_block0, None, vec![])
         .await?;
@@ -3139,7 +3139,7 @@ where
     // Now owner 0 can propose a block, but owner 1 can't.
     let proposed_block1 =
         make_child_block(&value0.clone()).with_simple_transfer(chain_1, small_transfer);
-    let (block1, _) = env
+    let (block1, _resources, _) = env
         .worker()
         .stage_block_execution(proposed_block1.clone(), None, vec![])
         .await?;
@@ -3186,7 +3186,7 @@ where
     // Create block2, also at height 1, but different from block 1.
     let amount = Amount::from_tokens(1);
     let proposed_block2 = make_child_block(&value0.clone()).with_simple_transfer(chain_1, amount);
-    let (block2, _) = env
+    let (block2, _resources, _) = env
         .worker()
         .stage_block_execution(proposed_block2.clone(), None, vec![])
         .await?;
@@ -3320,7 +3320,7 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (block0, _) = env
+    let (block0, _resources, _) = env
         .worker()
         .stage_block_execution(proposed_block0, None, vec![])
         .await?;
@@ -3423,7 +3423,7 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (change_ownership_block, _) = env
+    let (change_ownership_block, _resources, _) = env
         .worker()
         .stage_block_execution(change_ownership_block, None, vec![])
         .await?;
@@ -3453,7 +3453,7 @@ where
         .into_proposal_with_round(owner, &signer, Round::MultiLeader(0))
         .await
         .unwrap();
-    let (block, _) = env
+    let (block, _resources, _) = env
         .worker()
         .stage_block_execution(proposal.content.block.clone(), None, vec![])
         .await?;
@@ -3502,7 +3502,7 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (block0, _) = env
+    let (block0, _resources, _) = env
         .worker()
         .stage_block_execution(proposed_block0, None, vec![])
         .await?;
@@ -3530,7 +3530,7 @@ where
         .into_proposal_with_round(owner0, &signer, Round::Fast)
         .await
         .unwrap();
-    let (block1, _) = env
+    let (block1, _resources, _) = env
         .worker()
         .stage_block_execution(proposed_block1.clone(), None, vec![])
         .await?;
@@ -3587,7 +3587,7 @@ where
     env.worker().handle_block_proposal(proposal3).await?;
 
     // A validated block certificate from a later round can override the locked fast block.
-    let (block2, _) = env
+    let (block2, _resources, _) = env
         .worker()
         .stage_block_execution(proposed_block2.clone(), None, vec![])
         .await?;
@@ -3658,7 +3658,7 @@ where
     let proposed_block = make_first_block(chain_id)
         .with_simple_transfer(chain_id, Amount::ONE)
         .with_authenticated_signer(Some(public_key.into()));
-    let (block, _) = env
+    let (block, _resources, _) = env
         .worker()
         .stage_block_execution(proposed_block, None, vec![])
         .await?;

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -28,7 +28,7 @@ use linera_chain::{
     },
     ChainError, ChainStateView,
 };
-use linera_execution::{ExecutionError, ExecutionStateView, Query, QueryOutcome};
+use linera_execution::{ExecutionError, ExecutionStateView, Query, QueryOutcome, ResourceTracker};
 use linera_storage::Storage;
 use linera_views::ViewError;
 use lru::LruCache;
@@ -525,7 +525,7 @@ where
         block: ProposedBlock,
         round: Option<u32>,
         published_blobs: Vec<Blob>,
-    ) -> Result<(Block, ChainInfoResponse), WorkerError> {
+    ) -> Result<(Block, ResourceTracker, ChainInfoResponse), WorkerError> {
         self.query_chain_worker(block.chain_id, move |callback| {
             ChainWorkerRequest::StageBlockExecution {
                 block,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -310,6 +310,7 @@ pub enum ExecutionError {
     UnauthenticatedTransferOwner,
     #[error("The transferred amount must not exceed the balance of the current account {account}: {balance}")]
     InsufficientBalance {
+        amount: Amount,
         balance: Amount,
         account: AccountOwner,
     },

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -684,6 +684,7 @@ where
         } else {
             self.balances.get_mut(account).await?.ok_or_else(|| {
                 ExecutionError::InsufficientBalance {
+                    amount,
                     balance: Amount::ZERO,
                     account: *account,
                 }
@@ -693,6 +694,7 @@ where
         balance
             .try_sub_assign(amount)
             .map_err(|_| ExecutionError::InsufficientBalance {
+                amount,
                 balance: *balance,
                 account: *account,
             })?;

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -212,7 +212,7 @@ impl BlockBuilder {
                     .clone()
             })
             .collect();
-        let (block, _) = self
+        let (block, _, _) = self
             .validator
             .worker()
             .stage_block_execution(self.block, None, published_blobs)


### PR DESCRIPTION
## Motivation

Messages may be sent with resource grants so that the message receiver doesn't have to pay any fees to receive the message. However, figuring out how much resources to include in the grant is not trivial.

## Proposal

Do that - i.e. return `ResourceTracker` back to the caller of `execute_block`.

As part of that work some refactor of `BlockExecutionTracker` was done. Including removal of `EMPTY_BLOCK_FEE` entirely - that was effectively a no-op.

## Test Plan

CI

## Release Plan


- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
