### PR TITLE
End-to-end test of block proposal execution with grant only.

### DIFF
--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1269,11 +1269,8 @@ where
     B: StorageBuilder,
 {
     let signer = InMemorySigner::new(None);
-    let mut policy = ResourceControlPolicy::only_fuel();
-    // Set the price for outoing messages - otherwise the transfer will succeed
-    // because system operations are free (and transfer is one).
-    policy.message = Amount::from_micros(1);
-    let mut builder = TestBuilder::new(storage_builder, 2, 0, signer)
+    let policy = ResourceControlPolicy::only_fuel();
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, signer)
         .await?
         .with_policy(policy);
     let balance = Amount::from_tokens(3);

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -194,27 +194,6 @@ where
         txn_tracker: &mut TransactionTracker,
         resource_controller: &mut ResourceController<Option<AccountOwner>>,
     ) -> Result<(), ExecutionError> {
-        let ExecutionRuntimeConfig {} = self.context().extra().execution_runtime_config();
-        self.run_user_action_with_runtime(
-            application_id,
-            action,
-            refund_grant_to,
-            grant,
-            txn_tracker,
-            resource_controller,
-        )
-        .await
-    }
-
-    async fn run_user_action_with_runtime(
-        &mut self,
-        application_id: ApplicationId,
-        action: UserAction,
-        refund_grant_to: Option<Account>,
-        grant: Option<&mut Amount>,
-        txn_tracker: &mut TransactionTracker,
-        resource_controller: &mut ResourceController<Option<AccountOwner>>,
-    ) -> Result<(), ExecutionError> {
         let chain_id = self.context().extra().chain_id();
         let mut cloned_grant = grant.as_ref().map(|x| **x);
         let initial_balance = resource_controller

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -48,8 +48,6 @@ pub struct ResourceControlPolicy {
     /// The price of increasing storage by a byte.
     // TODO(#1536): This is not fully supported.
     pub byte_stored: Amount,
-    /// The base price of adding an operation to a block.
-    pub operation: Amount,
     /// The additional price for each byte in the argument of a user operation.
     pub operation_byte: Amount,
     /// The additional price for each byte in the argument of a user message.
@@ -106,7 +104,6 @@ impl fmt::Display for ResourceControlPolicy {
             blob_byte_read,
             blob_byte_published,
             byte_stored,
-            operation,
             operation_byte,
             message_byte,
             service_as_oracle_query,
@@ -140,7 +137,6 @@ impl fmt::Display for ResourceControlPolicy {
             {blob_byte_read:.2} cost of reading blobs, per byte\n\
             {blob_byte_published:.2} cost of publishing blobs, per byte\n\
             {byte_stored:.2} cost per byte stored\n\
-            {operation:.2} per operation\n\
             {operation_byte:.2} per byte in the argument of an operation\n\
             {service_as_oracle_query:.2} per query to a service as an oracle\n\
             {message_byte:.2} per byte in the argument of an outgoing messages\n\
@@ -188,7 +184,6 @@ impl ResourceControlPolicy {
             blob_byte_read: Amount::ZERO,
             blob_byte_published: Amount::ZERO,
             byte_stored: Amount::ZERO,
-            operation: Amount::ZERO,
             operation_byte: Amount::ZERO,
             message_byte: Amount::ZERO,
             service_as_oracle_query: Amount::ZERO,
@@ -242,7 +237,6 @@ impl ResourceControlPolicy {
             blob_published: Amount::from_nanos(10),
             blob_byte_read: Amount::from_attos(100),
             blob_byte_published: Amount::from_attos(1_000),
-            operation: Amount::from_attos(10),
             operation_byte: Amount::from_attos(1),
             message_byte: Amount::from_attos(1),
             http_request: Amount::from_micros(1),
@@ -266,7 +260,6 @@ impl ResourceControlPolicy {
             byte_stored: Amount::from_nanos(10),
             message_byte: Amount::from_nanos(100),
             operation_byte: Amount::from_nanos(10),
-            operation: Amount::from_micros(10),
             service_as_oracle_query: Amount::from_millis(10),
             http_request: Amount::from_micros(50),
             maximum_wasm_fuel_per_block: 100_000_000,

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -52,8 +52,6 @@ pub struct ResourceControlPolicy {
     pub operation: Amount,
     /// The additional price for each byte in the argument of a user operation.
     pub operation_byte: Amount,
-    /// The base price of sending a message from a block.
-    pub message: Amount,
     /// The additional price for each byte in the argument of a user message.
     pub message_byte: Amount,
     /// The price per query to a service as an oracle.
@@ -110,7 +108,6 @@ impl fmt::Display for ResourceControlPolicy {
             byte_stored,
             operation,
             operation_byte,
-            message,
             message_byte,
             service_as_oracle_query,
             http_request,
@@ -146,7 +143,6 @@ impl fmt::Display for ResourceControlPolicy {
             {operation:.2} per operation\n\
             {operation_byte:.2} per byte in the argument of an operation\n\
             {service_as_oracle_query:.2} per query to a service as an oracle\n\
-            {message:.2} per outgoing messages\n\
             {message_byte:.2} per byte in the argument of an outgoing messages\n\
             {http_request:.2} per HTTP request performed\n\
             {maximum_wasm_fuel_per_block} maximum Wasm fuel per block\n\
@@ -194,7 +190,6 @@ impl ResourceControlPolicy {
             byte_stored: Amount::ZERO,
             operation: Amount::ZERO,
             operation_byte: Amount::ZERO,
-            message: Amount::ZERO,
             message_byte: Amount::ZERO,
             service_as_oracle_query: Amount::ZERO,
             http_request: Amount::ZERO,
@@ -249,7 +244,6 @@ impl ResourceControlPolicy {
             blob_byte_published: Amount::from_attos(1_000),
             operation: Amount::from_attos(10),
             operation_byte: Amount::from_attos(1),
-            message: Amount::from_attos(10),
             message_byte: Amount::from_attos(1),
             http_request: Amount::from_micros(1),
             ..Self::no_fees()
@@ -273,7 +267,6 @@ impl ResourceControlPolicy {
             message_byte: Amount::from_nanos(100),
             operation_byte: Amount::from_nanos(10),
             operation: Amount::from_micros(10),
-            message: Amount::from_micros(10),
             service_as_oracle_query: Amount::from_millis(10),
             http_request: Amount::from_micros(50),
             maximum_wasm_fuel_per_block: 100_000_000,
@@ -314,7 +307,6 @@ impl ResourceControlPolicy {
                         .try_mul(resources.blobs_to_publish as u128)?,
                 )?,
         )?;
-        amount.try_add_assign(self.message.try_mul(resources.messages as u128)?)?;
         amount.try_add_assign(self.message_bytes_price(resources.message_size as u64)?)?;
         amount.try_add_assign(self.bytes_stored_price(resources.storage_size_delta as u64)?)?;
         amount.try_add_assign(

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -180,7 +180,6 @@ where
             .operations
             .checked_add(1)
             .ok_or(ArithmeticError::Overflow)?;
-        self.update_balance(self.policy.operation)?;
         match operation {
             Operation::System(_) => Ok(()),
             Operation::User { bytes, .. } => {
@@ -205,7 +204,6 @@ where
             .messages
             .checked_add(1)
             .ok_or(ArithmeticError::Overflow)?;
-        self.update_balance(self.policy.message)?;
         match message {
             Message::System(_) => Ok(()),
             Message::User { bytes, .. } => {

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -180,6 +180,19 @@ use test_case::test_case;
     Some(Amount::from_tokens(1_000));
     "with all fee spend operations"
 )]
+#[test_case(
+    vec![
+        FeeSpend::Fuel(11),
+        FeeSpend::HttpRequest,
+        FeeSpend::Read(vec![0, 1], None),
+        FeeSpend::Fuel(23),
+        FeeSpend::HttpRequest,
+    ],
+    Amount::ZERO,
+    Some(Amount::ZERO),
+    Some(Amount::from_tokens(250));
+    "with just a grant; no chain balance or owner balance"
+)]
 // TODO(#1601): Add more test cases
 #[tokio::test]
 async fn test_fee_consumption(

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -228,7 +228,6 @@ async fn test_fee_consumption(
         byte_stored: Amount::from_tokens(13),
         operation: Amount::from_tokens(17),
         operation_byte: Amount::from_tokens(19),
-        message: Amount::from_tokens(23),
         message_byte: Amount::from_tokens(29),
         service_as_oracle_query: Amount::from_millis(31),
         http_request: Amount::from_tokens(37),

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -226,7 +226,6 @@ async fn test_fee_consumption(
         byte_read: Amount::from_tokens(7),
         byte_written: Amount::from_tokens(11),
         byte_stored: Amount::from_tokens(13),
-        operation: Amount::from_tokens(17),
         operation_byte: Amount::from_tokens(19),
         message_byte: Amount::from_tokens(29),
         service_as_oracle_query: Amount::from_millis(31),

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -366,10 +366,6 @@ pub enum ClientCommand {
         #[arg(long)]
         operation_byte: Option<Amount>,
 
-        /// Set the base price of sending a message from a block..
-        #[arg(long)]
-        message: Option<Amount>,
-
         /// Set the additional price for each byte in the argument of a user message.
         #[arg(long)]
         message_byte: Option<Amount>,
@@ -561,11 +557,6 @@ pub enum ClientCommand {
         /// (This will overwrite value from `--policy-config`)
         #[arg(long)]
         operation_byte_price: Option<Amount>,
-
-        /// Set the base price of sending a message from a block..
-        /// (This will overwrite value from `--policy-config`)
-        #[arg(long)]
-        message_price: Option<Amount>,
 
         /// Set the additional price for each byte in the argument of a user message.
         /// (This will overwrite value from `--policy-config`)

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -358,10 +358,6 @@ pub enum ClientCommand {
         #[arg(long)]
         byte_stored: Option<Amount>,
 
-        /// Set the base price of sending an operation from a block..
-        #[arg(long)]
-        operation: Option<Amount>,
-
         /// Set the additional price for each byte in the argument of a user operation.
         #[arg(long)]
         operation_byte: Option<Amount>,
@@ -547,11 +543,6 @@ pub enum ClientCommand {
         /// (This will overwrite value from `--policy-config`)
         #[arg(long)]
         byte_stored_price: Option<Amount>,
-
-        /// Set the base price of sending an operation from a block..
-        /// (This will overwrite value from `--policy-config`)
-        #[arg(long)]
-        operation_price: Option<Amount>,
 
         /// Set the additional price for each byte in the argument of a user operation.
         /// (This will overwrite value from `--policy-config`)

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -639,7 +639,6 @@ impl Runnable for Job {
                                     byte_stored,
                                     operation,
                                     operation_byte,
-                                    message,
                                     message_byte,
                                     service_as_oracle_query,
                                     http_request,
@@ -683,7 +682,6 @@ impl Runnable for Job {
                                         operation: operation.unwrap_or(existing_policy.operation),
                                         operation_byte: operation_byte
                                             .unwrap_or(existing_policy.operation_byte),
-                                        message: message.unwrap_or(existing_policy.message),
                                         message_byte: message_byte
                                             .unwrap_or(existing_policy.message_byte),
                                         service_as_oracle_query: service_as_oracle_query
@@ -1691,7 +1689,6 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
             blob_byte_published_price,
             operation_price,
             operation_byte_price,
-            message_price,
             message_byte_price,
             service_as_oracle_query_price,
             http_request_price,
@@ -1731,7 +1728,6 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                 byte_stored: byte_stored_price.unwrap_or(existing_policy.byte_stored),
                 operation: operation_price.unwrap_or(existing_policy.operation),
                 operation_byte: operation_byte_price.unwrap_or(existing_policy.operation_byte),
-                message: message_price.unwrap_or(existing_policy.message),
                 message_byte: message_byte_price.unwrap_or(existing_policy.message_byte),
                 service_as_oracle_query: service_as_oracle_query_price
                     .unwrap_or(existing_policy.service_as_oracle_query),

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -637,7 +637,6 @@ impl Runnable for Job {
                                     blob_byte_read,
                                     blob_byte_published,
                                     byte_stored,
-                                    operation,
                                     operation_byte,
                                     message_byte,
                                     service_as_oracle_query,
@@ -679,7 +678,6 @@ impl Runnable for Job {
                                             .unwrap_or(existing_policy.blob_byte_published),
                                         byte_stored: byte_stored
                                             .unwrap_or(existing_policy.byte_stored),
-                                        operation: operation.unwrap_or(existing_policy.operation),
                                         operation_byte: operation_byte
                                             .unwrap_or(existing_policy.operation_byte),
                                         message_byte: message_byte
@@ -1687,7 +1685,6 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
             blob_published_price,
             blob_byte_read_price,
             blob_byte_published_price,
-            operation_price,
             operation_byte_price,
             message_byte_price,
             service_as_oracle_query_price,
@@ -1726,7 +1723,6 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                 blob_byte_published: blob_byte_published_price
                     .unwrap_or(existing_policy.blob_byte_published),
                 byte_stored: byte_stored_price.unwrap_or(existing_policy.byte_stored),
-                operation: operation_price.unwrap_or(existing_policy.operation),
                 operation_byte: operation_byte_price.unwrap_or(existing_policy.operation_byte),
                 message_byte: message_byte_price.unwrap_or(existing_policy.message_byte),
                 service_as_oracle_query: service_as_oracle_query_price


### PR DESCRIPTION
## Motivation

While working on exposing this feature from the `BlockExecutionTracker` I wanted to test whether a grant can cover execution of the message. This test uncovered a bug - we were charging a "base" fee for outgoing messages (and operation execution) which made that test fail. 


## Proposal

This base fee charging was removed (both for operation and a message). After that, we never use that cost/policy entry anywhere anymore so they are removed.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

Closes https://github.com/linera-io/linera-protocol/issues/4173
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
