### PR TITLE
Leave gaps in sender chains on the validator side

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -345,7 +345,7 @@ pub struct BlockBody {
     /// The list of outgoing messages for each transaction.
     pub messages: Vec<Vec<OutgoingMessage>>,
     /// The hashes of previous blocks that sent messages to the same recipients.
-    pub previous_message_blocks: BTreeMap<ChainId, CryptoHash>,
+    pub previous_message_blocks: BTreeMap<ChainId, (CryptoHash, BlockHeight)>,
     /// The record of oracle responses for each transaction.
     pub oracle_responses: Vec<Vec<OracleResponse>>,
     /// The list of events produced by each transaction.
@@ -586,7 +586,7 @@ impl BcsHashable<'_> for Block {}
 
 #[derive(Serialize, Deserialize)]
 pub struct PreviousMessageBlocksMap<'a> {
-    inner: Cow<'a, BTreeMap<ChainId, CryptoHash>>,
+    inner: Cow<'a, BTreeMap<ChainId, (CryptoHash, BlockHeight)>>,
 }
 
 impl<'de> BcsHashable<'de> for PreviousMessageBlocksMap<'de> {}

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -426,6 +426,10 @@ where
         }
         if outbox.queue.count() == 0 {
             self.nonempty_outboxes.get_mut().remove(target);
+            // If the outbox is empty and not ahead of the executed blocks, remove it.
+            if *outbox.next_height_to_schedule.get() <= self.tip_state.get().next_block_height {
+                self.outboxes.remove_entry(target)?;
+            }
         }
         #[cfg(with_metrics)]
         metrics::NUM_OUTBOXES
@@ -784,7 +788,7 @@ where
                     .ok_or_else(|| {
                         ChainError::InternalError("missing entry in confirmed_log".into())
                     })?;
-                previous_message_blocks.insert(recipient, hash);
+                previous_message_blocks.insert(recipient, (hash, height));
             }
         }
 
@@ -965,8 +969,7 @@ where
         Ok(())
     }
 
-    /// Returns the hashes of all blocks in the given range. Returns an error if we are missing
-    /// any of those blocks.
+    /// Returns the hashes of all blocks we have in the given range.
     pub async fn block_hashes(
         &self,
         range: impl RangeBounds<BlockHeight>,
@@ -1031,7 +1034,8 @@ where
             if block_height > next_height {
                 // There may be a gap in the chain before this block. We can only add it to this
                 // outbox if the previous message to the same recipient has already been added.
-                let prev_hash = match outbox.next_height_to_schedule.get().try_sub_one().ok() {
+                let maybe_prev_hash = match outbox.next_height_to_schedule.get().try_sub_one().ok()
+                {
                     // The block with the last added message has already been executed; look up its
                     // hash in the confirmed_log.
                     Some(height) if height < next_height => {
@@ -1049,8 +1053,38 @@ where
                     None => None, // No message to that sender was added yet.
                 };
                 // Only schedule if this block contains the next message for that recipient.
-                if prev_hash.as_ref() != block.body.previous_message_blocks.get(target) {
-                    continue;
+                match (
+                    maybe_prev_hash,
+                    block.body.previous_message_blocks.get(target),
+                ) {
+                    (None, None) => {
+                        // No previous message block expected and none indicated by the outbox -
+                        // all good
+                    }
+                    (Some(_), None) => {
+                        // Outbox indicates there was a previous message block, but
+                        // previous_message_blocks has no idea about it - possible bug
+                        return Err(ChainError::InternalError(
+                            "block indicates no previous message block,\
+                            but we have one in the outbox"
+                                .into(),
+                        ));
+                    }
+                    (None, Some((_, prev_msg_block_height))) => {
+                        // We have no previously processed block in the outbox, but we are
+                        // expecting one - this could be due to an empty outbox having been pruned.
+                        // Only process the outbox if the height of the previous message block is
+                        // lower than the tip
+                        if *prev_msg_block_height >= next_height {
+                            continue;
+                        }
+                    }
+                    (Some(ref prev_hash), Some((prev_msg_block_hash, _))) => {
+                        // Only process the outbox if the hashes match.
+                        if prev_hash != prev_msg_block_hash {
+                            continue;
+                        }
+                    }
                 }
             }
             if outbox.schedule_message(block_height)? {

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -296,7 +296,7 @@ pub struct BlockExecutionOutcome {
     /// The list of outgoing messages for each transaction.
     pub messages: Vec<Vec<OutgoingMessage>>,
     /// The hashes of previous blocks that sent messages to the same recipients.
-    pub previous_message_blocks: BTreeMap<ChainId, CryptoHash>,
+    pub previous_message_blocks: BTreeMap<ChainId, (CryptoHash, BlockHeight)>,
     /// The hash of the chain's execution state after this block.
     pub state_hash: CryptoHash,
     /// The record of oracle responses for each transaction.

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -290,11 +290,6 @@ where
 
         // Check that the chain is active and ready for this confirmation.
         let tip = self.state.chain.tip_state.get().clone();
-        if tip.next_block_height < height {
-            return Err(WorkerError::MissingEarlierBlocks {
-                current_block_height: tip.next_block_height,
-            });
-        }
         if tip.next_block_height > height {
             // We already processed this block.
             let actions = self.state.create_network_actions().await?;
@@ -304,6 +299,7 @@ where
             return Ok((info, actions));
         }
 
+        // We haven't processed the block - verify the certificate first
         if height == BlockHeight::ZERO {
             // For the initial proposal on a chain, we read the committee directly from
             // storage. If the certificate is good for this committee, we will accept it -
@@ -325,6 +321,15 @@ where
             check_block_epoch(epoch, chain_id, block.header.epoch)?;
             certificate.check(committee)?;
         }
+
+        if tip.next_block_height < height {
+            let actions = self.preprocess_certificate(certificate).await?;
+            self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
+                .await;
+            let info = ChainInfoResponse::new(&self.state.chain, self.state.config.key_pair());
+            return Ok((info, actions));
+        }
+
         // This should always be true for valid certificates.
         ensure!(
             tip.block_hash == block.header.previous_block_hash,

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -322,6 +322,8 @@ where
             certificate.check(committee)?;
         }
 
+        // If this block is higher than the next expected block in this chain, we're going
+        // to have a gap: do not process this block fully, only preprocess it.
         if tip.next_block_height < height {
             let actions = self.preprocess_certificate(certificate).await?;
             self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -507,7 +507,7 @@ impl<Env: Environment> Client<Env> {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub async fn preprocess_certificate(
+    async fn preprocess_certificate(
         &self,
         certificate: Box<ConfirmedBlockCertificate>,
     ) -> Result<(), LocalNodeError> {

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -928,12 +928,12 @@ where
                 .with_authenticated_signer(Some(sender_owner)),
         ),
     ));
-    // Missing earlier blocks
+    // Missing earlier blocks, but the certificate will be preprocessed.
     assert_matches!(
         env.worker()
             .handle_confirmed_certificate(certificate1.clone(), None)
             .await,
-        Err(WorkerError::MissingEarlierBlocks { .. })
+        Ok(_)
     );
 
     // Run transfers

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -422,7 +422,15 @@ where
                     .flat_map(|block| block.inner().block().body.messages.iter().flatten())
                     .any(|message| message.destination == *recipient)
             })
-            .map(|recipient| (recipient, previous_confirmed_block.unwrap().hash()))
+            .map(|recipient| {
+                (
+                    recipient,
+                    (
+                        previous_confirmed_block.unwrap().hash(),
+                        previous_confirmed_block.unwrap().block().header.height,
+                    ),
+                )
+            })
             .collect();
         let value = ConfirmedBlock::new(
             BlockExecutionOutcome {
@@ -910,7 +918,10 @@ where
     let certificate1 = env.make_certificate(ConfirmedBlock::new(
         BlockExecutionOutcome {
             messages: vec![vec![direct_credit_message(chain_2, Amount::from_tokens(3))]],
-            previous_message_blocks: BTreeMap::from([(chain_2, certificate0.hash())]),
+            previous_message_blocks: BTreeMap::from([(
+                chain_2,
+                (certificate0.hash(), BlockHeight(0)),
+            )]),
             events: vec![Vec::new()],
             blobs: vec![Vec::new()],
             state_hash: SystemExecutionState {

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -275,7 +275,7 @@ where
         amount: Amount,
         incoming_bundles: Vec<IncomingBundle>,
         balance: Amount,
-        previous_confirmed_block: Option<&ConfirmedBlockCertificate>,
+        previous_confirmed_blocks: Vec<&ConfirmedBlockCertificate>,
     ) -> ConfirmedBlockCertificate {
         self.make_transfer_certificate_for_epoch(
             chain_description,
@@ -288,7 +288,7 @@ where
             Epoch::ZERO,
             balance,
             BTreeMap::new(),
-            previous_confirmed_block,
+            previous_confirmed_blocks,
         )
         .await
     }
@@ -305,7 +305,7 @@ where
         incoming_bundles: Vec<IncomingBundle>,
         balance: Amount,
         balances: BTreeMap<AccountOwner, Amount>,
-        previous_confirmed_block: Option<&ConfirmedBlockCertificate>,
+        previous_confirmed_blocks: Vec<&ConfirmedBlockCertificate>,
     ) -> ConfirmedBlockCertificate {
         self.make_transfer_certificate_for_epoch(
             chain_description,
@@ -318,7 +318,7 @@ where
             Epoch::ZERO,
             balance,
             balances,
-            previous_confirmed_block,
+            previous_confirmed_blocks,
         )
         .await
     }
@@ -340,7 +340,7 @@ where
         epoch: Epoch,
         balance: Amount,
         balances: BTreeMap<AccountOwner, Amount>,
-        previous_confirmed_block: Option<&ConfirmedBlockCertificate>,
+        previous_confirmed_blocks: Vec<&ConfirmedBlockCertificate>,
     ) -> ConfirmedBlockCertificate {
         let chain_id = chain_description.id();
         let system_state = SystemExecutionState {
@@ -351,7 +351,7 @@ where
             admin_id: Some(self.admin_id()),
             ..SystemExecutionState::new(chain_description)
         };
-        let block_template = match &previous_confirmed_block {
+        let block_template = match previous_confirmed_blocks.first() {
             None => make_first_block(chain_id),
             Some(cert) => make_child_block(cert.value()),
         };
@@ -416,20 +416,25 @@ where
             .iter()
             .flatten()
             .map(|message| message.destination)
-            .filter(|recipient| {
-                previous_confirmed_block
+            .filter_map(|recipient| {
+                previous_confirmed_blocks
                     .iter()
-                    .flat_map(|block| block.inner().block().body.messages.iter().flatten())
-                    .any(|message| message.destination == *recipient)
-            })
-            .map(|recipient| {
-                (
-                    recipient,
-                    (
-                        previous_confirmed_block.unwrap().hash(),
-                        previous_confirmed_block.unwrap().block().header.height,
-                    ),
-                )
+                    .find(|block| {
+                        block
+                            .inner()
+                            .block()
+                            .body
+                            .messages
+                            .iter()
+                            .flatten()
+                            .any(|message| message.destination == recipient)
+                    })
+                    .map(|block| {
+                        (
+                            recipient,
+                            (block.hash(), block.inner().block().header.height),
+                        )
+                    })
             })
             .collect();
         let value = ConfirmedBlock::new(
@@ -790,7 +795,7 @@ where
             Amount::ONE,
             Vec::new(),
             Amount::from_tokens(4),
-            None,
+            vec![],
         )
         .await;
     let block_proposal1 = make_child_block(certificate0.value())
@@ -861,6 +866,127 @@ where
                 found_block_height: BlockHeight(0),
             })
     );
+    Ok(())
+}
+
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_handle_block_proposal_sparse_chain<B>(mut storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let mut signer = InMemorySigner::new(None);
+    let sender_public_key = signer.generate_new();
+    let sender_owner = sender_public_key.into();
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false).await;
+    let chain_desc = env
+        .add_root_chain(1, sender_owner, Amount::from_tokens(5))
+        .await;
+    let chain_1 = chain_desc.id();
+    let chain_2 = env.add_root_chain(2, sender_owner, Amount::ZERO).await.id();
+
+    let certificate0 = env
+        .make_simple_transfer_certificate(
+            chain_desc.clone(),
+            sender_public_key,
+            chain_2,
+            Amount::ONE,
+            Vec::new(),
+            Amount::from_tokens(4),
+            vec![],
+        )
+        .await;
+
+    let certificate1 = env
+        .make_simple_transfer_certificate(
+            chain_desc.clone(),
+            sender_public_key,
+            chain_1,
+            Amount::ONE,
+            Vec::new(),
+            Amount::from_tokens(3),
+            vec![&certificate0],
+        )
+        .await;
+
+    let certificate2 = env
+        .make_simple_transfer_certificate(
+            chain_desc.clone(),
+            sender_public_key,
+            chain_2,
+            Amount::ONE,
+            Vec::new(),
+            Amount::from_tokens(2),
+            vec![&certificate1, &certificate0],
+        )
+        .await;
+
+    let block_proposal1 = make_child_block(certificate2.value())
+        .with_simple_transfer(chain_2, Amount::from_tokens(1))
+        .into_first_proposal(sender_owner, &signer)
+        .await
+        .unwrap();
+
+    // The worker handles certificates 0 and 2 - this should succeed, and the worker
+    // should now have block 0 fully processed, and block 2 preprocessed.
+    env.worker()
+        .handle_confirmed_certificate(certificate0, None)
+        .await?;
+
+    env.worker()
+        .handle_confirmed_certificate(certificate2.clone(), None)
+        .await?;
+
+    let chain = env.worker().chain_state_view(chain_1).await?;
+    assert!(chain.is_active());
+    assert_eq!(chain.tip_state.get().next_block_height, BlockHeight(1));
+    drop(chain);
+
+    // The proposal is at height 3 - it should fail until the chain is fully processed up
+    // to height 2.
+    let proposal_result = env
+        .worker()
+        .handle_block_proposal(block_proposal1.clone())
+        .await;
+    assert_matches!(
+        proposal_result,
+        Err(WorkerError::ChainError(err)) if matches!(*err, ChainError::UnexpectedBlockHeight {
+            expected_block_height: BlockHeight(1),
+            found_block_height: BlockHeight(3)
+        })
+    );
+
+    // Handle the certificate in the gap.
+    env.worker()
+        .handle_confirmed_certificate(certificate1, None)
+        .await?;
+
+    let chain = env.worker().chain_state_view(chain_1).await?;
+    assert!(chain.is_active());
+    assert_eq!(chain.tip_state.get().next_block_height, BlockHeight(2));
+    drop(chain);
+
+    // ...and the one that has been preprocessed before, again, as it is not automatically
+    // re-processed.
+    env.worker()
+        .handle_confirmed_certificate(certificate2, None)
+        .await?;
+
+    let chain = env.worker().chain_state_view(chain_1).await?;
+    assert!(chain.is_active());
+    assert_eq!(chain.tip_state.get().next_block_height, BlockHeight(3));
+    drop(chain);
+
+    // The proposal should now succeed.
+    let proposal_result = env
+        .worker()
+        .handle_block_proposal(block_proposal1.clone())
+        .await;
+    assert_matches!(proposal_result, Ok(_));
+
     Ok(())
 }
 
@@ -1380,7 +1506,7 @@ where
             Amount::from_tokens(5),
             Vec::new(),
             Amount::from_tokens(5),
-            None,
+            vec![],
         )
         .await;
     assert_matches!(
@@ -1470,7 +1596,7 @@ where
             Epoch::ZERO,
             Amount::ZERO,
             BTreeMap::new(),
-            None,
+            vec![],
         )
         .await;
     // This fails because `make_simple_transfer_certificate` uses `sender_key_pair.public()` to
@@ -1510,7 +1636,7 @@ where
             Amount::from_tokens(5),
             Vec::new(),
             Amount::ZERO,
-            None,
+            vec![],
         )
         .await;
     // Replays are ignored.
@@ -1568,7 +1694,7 @@ where
                 action: MessageAction::Accept,
             }],
             Amount::ZERO,
-            None,
+            vec![],
         )
         .await;
     env.worker()
@@ -1650,7 +1776,7 @@ where
             Amount::ONE,
             Vec::new(),
             Amount::ZERO,
-            None,
+            vec![],
         )
         .await;
     env.worker()
@@ -1706,7 +1832,7 @@ where
             Amount::ONE,
             Vec::new(),
             Amount::ZERO,
-            None,
+            vec![],
         )
         .await;
     env.worker()
@@ -1776,7 +1902,7 @@ where
             Amount::from_tokens(10),
             Vec::new(),
             Amount::ZERO,
-            None,
+            vec![],
         )
         .await;
     env.worker()
@@ -1849,7 +1975,7 @@ where
             Amount::from_tokens(10),
             Vec::new(),
             Amount::ZERO,
-            None,
+            vec![],
         )
         .await;
     assert!(env
@@ -1891,7 +2017,7 @@ where
             Amount::from_tokens(10),
             Vec::new(),
             Amount::ZERO,
-            None,
+            vec![],
         )
         .await;
     // An inactive target chain is created and it acknowledges the message.
@@ -1977,7 +2103,7 @@ where
             Amount::from_tokens(5),
             Vec::new(),
             Amount::ZERO,
-            None,
+            vec![],
         )
         .await;
 
@@ -2024,7 +2150,7 @@ where
                 action: MessageAction::Accept,
             }],
             Amount::from_tokens(4),
-            None,
+            vec![],
         )
         .await;
     env.worker()
@@ -2105,7 +2231,7 @@ where
             Amount::from_tokens(5),
             Vec::new(),
             Amount::ZERO,
-            None,
+            vec![],
         )
         .await;
 
@@ -2173,7 +2299,7 @@ where
             Vec::new(),
             Amount::ONE,
             BTreeMap::new(),
-            None,
+            vec![],
         )
         .await;
 
@@ -2207,7 +2333,7 @@ where
             }],
             Amount::ZERO,
             BTreeMap::from_iter([(sender, Amount::from_tokens(5))]),
-            Some(&certificate00),
+            vec![&certificate00],
         )
         .await;
 
@@ -2233,7 +2359,7 @@ where
             Vec::new(),
             Amount::ZERO,
             BTreeMap::from_iter([(sender, Amount::from_tokens(2))]),
-            Some(&certificate01),
+            vec![&certificate01, &certificate00],
         )
         .await;
 
@@ -2252,7 +2378,7 @@ where
             Vec::new(),
             Amount::ZERO,
             BTreeMap::new(),
-            Some(&certificate1),
+            vec![&certificate1, &certificate01, &certificate00],
         )
         .await;
 
@@ -2305,7 +2431,7 @@ where
             ],
             Amount::ZERO,
             BTreeMap::from_iter([(recipient, Amount::from_tokens(1))]),
-            None,
+            vec![],
         )
         .await;
 
@@ -2346,7 +2472,7 @@ where
             }],
             Amount::ZERO,
             BTreeMap::new(),
-            Some(&certificate2),
+            vec![&certificate2, &certificate1, &certificate01, &certificate00],
         )
         .await;
 
@@ -2917,7 +3043,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
             Epoch::ZERO,
             Amount::ONE,
             BTreeMap::new(),
-            None,
+            vec![],
         )
         .await;
     let certificate1 = env
@@ -2932,7 +3058,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
             Epoch::ZERO,
             Amount::ONE,
             BTreeMap::new(),
-            Some(&certificate0),
+            vec![&certificate0],
         )
         .await;
     let certificate2 = env
@@ -2947,7 +3073,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
             Epoch::from(1),
             Amount::ONE,
             BTreeMap::new(),
-            Some(&certificate1),
+            vec![&certificate1, &certificate0],
         )
         .await;
     // Weird case: epoch going backward.
@@ -2963,7 +3089,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
             Epoch::ZERO,
             Amount::ONE,
             BTreeMap::new(),
-            Some(&certificate2),
+            vec![&certificate2, &certificate1, &certificate0],
         )
         .await;
     let bundles0 = certificate0.message_bundles_for(id1).collect::<Vec<_>>();

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -170,8 +170,6 @@ pub enum WorkerError {
         expected_block_height: BlockHeight,
         found_block_height: BlockHeight,
     },
-    #[error("Cannot confirm a block before its predecessors: {current_block_height:?}")]
-    MissingEarlierBlocks { current_block_height: BlockHeight },
     #[error("Unexpected epoch {epoch:}: chain {chain_id:} is at {chain_epoch:}")]
     InvalidEpoch {
         chain_id: ChainId,

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -160,7 +160,9 @@ BlockBody:
           KEY:
             TYPENAME: ChainId
           VALUE:
-            TYPENAME: CryptoHash
+            TUPLE:
+              - TYPENAME: CryptoHash
+              - TYPENAME: BlockHeight
     - oracle_responses:
         SEQ:
           SEQ:
@@ -187,7 +189,9 @@ BlockExecutionOutcome:
           KEY:
             TYPENAME: ChainId
           VALUE:
-            TYPENAME: CryptoHash
+            TUPLE:
+              - TYPENAME: CryptoHash
+              - TYPENAME: BlockHeight
     - state_hash:
         TYPENAME: CryptoHash
     - oracle_responses:


### PR DESCRIPTION
## Motivation

If a client creates a block receiving messages from a chain with gaps, and a validator doesn't have that chain yet, the client currently has no way of convincing the validator that the proposal is correct, because the validator expects the whole sender chain as proof of the sent messages.

## Proposal

Make validators accept confirmed certificates for blocks on chains with gaps. If there is a gap, blocks should only be preprocessed, instead of fully processed - like on the clients.

## Test Plan

CI with an added test exercising the problematic scenario

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- closes #4160 
