### PR TITLE
Fix witty handling of array20

### DIFF
--- a/linera-base/src/unit_tests.rs
+++ b/linera-base/src/unit_tests.rs
@@ -32,6 +32,7 @@ use crate::{
 #[test_case(module_id_test_case(); "of_module_id")]
 #[test_case(timeout_config_test_case(); "of_timeout_config")]
 #[test_case(chain_ownership_test_case(); "of_chain_ownership")]
+#[test_case([5u8; 20]; "array20")]
 fn test_wit_roundtrip<T>(input: T)
 where
     T: Debug + Eq + WitLoad + WitStore,

--- a/linera-sdk/src/base/conversions_from_wit.rs
+++ b/linera-sdk/src/base/conversions_from_wit.rs
@@ -32,9 +32,9 @@ macro_rules! impl_from_wit {
         impl From<$wit_base_api::Array20> for [u8; 20] {
             fn from(ethereum_address: $wit_base_api::Array20) -> Self {
                 let mut bytes = [0u8; 20];
-                bytes[0..8].copy_from_slice(&ethereum_address.part1.to_le_bytes());
-                bytes[8..16].copy_from_slice(&ethereum_address.part2.to_le_bytes());
-                bytes[16..20].copy_from_slice(&ethereum_address.part3.to_le_bytes());
+                bytes[0..8].copy_from_slice(&ethereum_address.part1.to_be_bytes());
+                bytes[8..16].copy_from_slice(&ethereum_address.part2.to_be_bytes());
+                bytes[16..20].copy_from_slice(&ethereum_address.part3.to_be_bytes()[0..4]);
                 bytes
             }
         }

--- a/linera-sdk/src/base/conversions_to_wit.rs
+++ b/linera-sdk/src/base/conversions_to_wit.rs
@@ -35,7 +35,7 @@ macro_rules! impl_to_wit {
                 $wit_base_api::Array20 {
                     part1: u64::from_be_bytes(bytes[0..8].try_into().unwrap()),
                     part2: u64::from_be_bytes(bytes[8..16].try_into().unwrap()),
-                    part3: u64::from_be_bytes(bytes[16..20].try_into().unwrap()),
+                    part3: (u32::from_be_bytes(bytes[16..20].try_into().unwrap()) as u64) << 32,
                 }
             }
         }

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -33,9 +33,9 @@ impl From<wit_contract_api::CryptoHash> for CryptoHash {
 impl From<wit_contract_api::Array20> for [u8; 20] {
     fn from(ethereum_address: wit_contract_api::Array20) -> Self {
         let mut bytes = [0u8; 20];
-        bytes[0..8].copy_from_slice(&ethereum_address.part1.to_le_bytes());
-        bytes[8..16].copy_from_slice(&ethereum_address.part2.to_le_bytes());
-        bytes[16..20].copy_from_slice(&ethereum_address.part3.to_le_bytes());
+        bytes[0..8].copy_from_slice(&ethereum_address.part1.to_be_bytes());
+        bytes[8..16].copy_from_slice(&ethereum_address.part2.to_be_bytes());
+        bytes[16..20].copy_from_slice(&ethereum_address.part3.to_be_bytes()[0..4]);
         bytes
     }
 }

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -40,7 +40,7 @@ impl From<[u8; 20]> for wit_contract_api::Array20 {
         wit_contract_api::Array20 {
             part1: u64::from_be_bytes(bytes[0..8].try_into().unwrap()),
             part2: u64::from_be_bytes(bytes[8..16].try_into().unwrap()),
-            part3: u64::from_be_bytes(bytes[16..20].try_into().unwrap()),
+            part3: (u32::from_be_bytes(bytes[16..20].try_into().unwrap()) as u64) << 32,
         }
     }
 }

--- a/linera-witty/src/primitive_types/array.rs
+++ b/linera-witty/src/primitive_types/array.rs
@@ -42,7 +42,7 @@ impl WitLoad for [u8; 20] {
         let mut dest = [0u8; 20];
         dest[0..8].copy_from_slice(&part1.to_be_bytes());
         dest[8..16].copy_from_slice(&part2.to_be_bytes());
-        dest[16..20].copy_from_slice(&part3.to_be_bytes());
+        dest[16..20].copy_from_slice(&part3.to_be_bytes()[0..4]);
         Ok(dest)
     }
 
@@ -58,7 +58,7 @@ impl WitLoad for [u8; 20] {
         let mut dest = [0u8; 20];
         dest[0..8].copy_from_slice(&part1.to_be_bytes());
         dest[8..16].copy_from_slice(&part2.to_be_bytes());
-        dest[16..20].copy_from_slice(&part3.to_be_bytes());
+        dest[16..20].copy_from_slice(&part3.to_be_bytes()[0..4]);
         Ok(dest)
     }
 }
@@ -75,7 +75,7 @@ impl WitStore for [u8; 20] {
     {
         let part1 = u64::from_be_bytes(self[0..8].try_into().unwrap());
         let part2 = u64::from_be_bytes(self[8..16].try_into().unwrap());
-        let part3 = u64::from_be_bytes(self[16..20].try_into().unwrap());
+        let part3 = (u32::from_be_bytes(self[16..20].try_into().unwrap()) as u64) << 32;
         (part1, part2, part3).store(memory, location)
     }
 
@@ -89,7 +89,7 @@ impl WitStore for [u8; 20] {
     {
         let part1 = u64::from_be_bytes(self[0..8].try_into().unwrap());
         let part2 = u64::from_be_bytes(self[8..16].try_into().unwrap());
-        let part3 = u64::from_be_bytes(self[16..20].try_into().unwrap());
+        let part3 = (u32::from_be_bytes(self[16..20].try_into().unwrap()) as u64) << 32;
         (part1, part2, part3).lower(memory)
     }
 }


### PR DESCRIPTION
## Motivation

@Twey found a bug in the handling of `[u8; 20]` in Witty.

## Proposal

Fix. Add a unit test.

## Test Plan

CI

## Release Plan


- Nothing to do / These changes follow the usual release cycle.
## Links

Fixes https://github.com/linera-io/linera-protocol/issues/4182
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
