### PR TITLE
Reintroduce the `chain_guard` in Linera.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5668,6 +5668,7 @@ dependencies = [
  "linera-views",
  "prometheus",
  "serde",
+ "tokio",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3893,6 +3893,7 @@ dependencies = [
  "linera-views",
  "prometheus",
  "serde",
+ "tokio",
 ]
 
 [[package]]

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -42,6 +42,7 @@ linera-execution.workspace = true
 linera-views.workspace = true
 prometheus.workspace = true
 serde.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -34,7 +34,7 @@ use {
     std::{cmp::Reverse, collections::BTreeMap},
 };
 
-use crate::{ChainRuntimeContext, Clock, Storage};
+use crate::{get_guard, ChainRuntimeContext, Clock, Storage};
 
 #[cfg(with_metrics)]
 pub mod metrics {
@@ -554,6 +554,7 @@ where
             execution_runtime_config: self.execution_runtime_config,
             user_contracts: self.user_contracts.clone(),
             user_services: self.user_services.clone(),
+            _chain_guard: Arc::new(get_guard(chain_id).await),
         };
         let root_key = bcs::to_bytes(&BaseKey::ChainState(chain_id))?;
         let store = self.store.open_exclusive(&root_key)?;

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -9,7 +9,7 @@ mod db_storage;
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::Arc,
+    sync::{Arc, Weak},
 };
 
 use async_trait::async_trait;
@@ -41,6 +41,7 @@ use linera_execution::{
 #[cfg(with_wasm_runtime)]
 use linera_execution::{WasmContractModule, WasmServiceModule};
 use linera_views::{context::Context, views::RootView, ViewError};
+use tokio::sync::{Mutex, OwnedMutexGuard};
 
 #[cfg(with_metrics)]
 pub use crate::db_storage::metrics;
@@ -416,6 +417,48 @@ impl ResultReadCertificates {
     }
 }
 
+use std::sync::LazyLock;
+type ChainGuardMap = DashMap<ChainId, Weak<Mutex<()>>>;
+
+#[derive(Default)]
+pub struct ChainGuards {
+    guards: Arc<ChainGuardMap>,
+}
+
+static OPENED_CHAINS: LazyLock<ChainGuards> = LazyLock::new(ChainGuards::default);
+
+struct ChainGuard {
+    _guard: OwnedMutexGuard<()>,
+}
+
+impl ChainGuards {
+    fn get_or_create_lock(&self, chain_id: ChainId) -> Arc<Mutex<()>> {
+        let mut new_guard_holder = None;
+        let mut guard_reference = self.guards.entry(chain_id).or_insert_with(|| {
+            let (new_guard, weak_reference) = Self::create_new_mutex();
+            new_guard_holder = Some(new_guard);
+            weak_reference
+        });
+        guard_reference.upgrade().unwrap_or_else(|| {
+            let (new_guard, weak_reference) = Self::create_new_mutex();
+            *guard_reference = weak_reference;
+            new_guard
+        })
+    }
+
+    fn create_new_mutex() -> (Arc<Mutex<()>>, Weak<Mutex<()>>) {
+        let new_guard = Arc::new(Mutex::new(()));
+        let weak_reference = Arc::downgrade(&new_guard);
+        (new_guard, weak_reference)
+    }
+}
+
+async fn get_guard(chain_id: ChainId) -> ChainGuard {
+    let mutex = OPENED_CHAINS.get_or_create_lock(chain_id);
+    let _guard = mutex.lock_owned().await;
+    ChainGuard { _guard }
+}
+
 /// An implementation of `ExecutionRuntimeContext` suitable for the core protocol.
 #[derive(Clone)]
 pub struct ChainRuntimeContext<S> {
@@ -424,6 +467,7 @@ pub struct ChainRuntimeContext<S> {
     execution_runtime_config: ExecutionRuntimeConfig,
     user_contracts: Arc<DashMap<ApplicationId, UserContractCode>>,
     user_services: Arc<DashMap<ApplicationId, UserServiceCode>>,
+    _chain_guard: Arc<ChainGuard>,
 }
 
 #[cfg_attr(not(web), async_trait)]


### PR DESCRIPTION
## Motivation

It has recently appeared that some bug are occurring in Linera. This PR addresses the bug, but it is not a definitive solution.

## Proposal

The bug is described in https://github.com/linera-io/linera-protocol/issues/4178

Further analysis revealed the following:
* There were two threads working on the same chain. This is visible not just from the logs, but also from having a Mutex based database in the code that keeps track of what is opened.
* By reintroducing the ChainGuards that were removed in https://github.com/linera-io/linera-protocol/pull/2330 we make the bug disappear.

## Test Plan

The CI.
The bug is not visible in the current CI. The effect can be visible by following the instructions in the GitHub Issue 4178.

## Release Plan

It is a little unclear how the solution should be implemented.

## Links

None