### PR TITLE
Fixed a bug where shards could not resolve individual proxies.

### DIFF
--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -39,7 +39,7 @@ kind: StatefulSet
 metadata:
   name: proxy
 spec:
-  serviceName: "proxy"
+  serviceName: "proxy-internal"
   selector:
     matchLabels:
       app: proxy


### PR DESCRIPTION
## Motivation

An omission of the correct `Service` name in the `serviceName` definition of the proxy statefulset meant that proxy instances could not be uniquely resolved by ordinal.

## Proposal

Update the `serviceName`.

## Test Plan

Tested manually.

## Future Work

As was suggested by @Twey, it might be better to not use ordinals, but instead do DNS lookups to resolve individual IP addresses and use those instead. Since individual proxy instances are undifferentiated, ordering is unimportant (unlike the current shard setup for example).
