### PR TITLE
Use NodeConfig to setup Scylla

### DIFF
--- a/kubernetes/linera-validator/helmfile.yaml
+++ b/kubernetes/linera-validator/helmfile.yaml
@@ -3,10 +3,10 @@ environments:
     values:
       - writeToGrafanaCloud: {{ env "LINERA_WRITE_TO_GRAFANA_CLOUD" | default "false" }}
         validatorLabel: {{ env "LINERA_VALIDATOR_LABEL" | default (printf "local-%s" (env "USER")) }}
-        usingLocalSsd: {{ env "LINERA_HELMFILE_SET_USING_LOCAL_SSD" | default "false" }}
-        usingRecommendedScyllaDbSettings: {{ env "LINERA_HELMFILE_SET_USING_RECOMMENDED_SCYLLA_DB_SETTINGS" | default "false" }}
+        gcpRun: {{ env "LINERA_HELMFILE_SET_GCP_RUN" | default "false" }}
         kubeContext: {{ env "LINERA_HELMFILE_SET_KUBE_CONTEXT" | default "" }}
         kubeConfigPath: {{ env "KUBECONFIG" | default "" }}
+        dualStore: {{ env "LINERA_HELMFILE_SET_DUAL_STORE" | default "false" }}
 
 helmDefaults:
   wait: true
@@ -23,7 +23,7 @@ hooks:
         set -euxo pipefail
         echo "Installing Prometheus ServiceMonitor CRD…"
         kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
-{{- if or .Values.usingLocalSsd .Values.usingRecommendedScyllaDbSettings }}
+{{- if and .Values.dualStore .Values.gcpRun }}
   - events: ["prepare"]
     showlogs: true
     command: bash
@@ -45,11 +45,6 @@ hooks:
 
         kubectl "${kube_args[@]}" apply -f ./scylla-setup/gke-daemonset-raid-disks.yaml
         kubectl "${kube_args[@]}" -n default rollout status daemonset/gke-raid-disks
-
-        kubectl "${kube_args[@]}" apply -f ./scylla-setup/local-csi-driver
-        kubectl "${kube_args[@]}" -n local-csi-driver rollout status daemonset.apps/local-csi-driver --timeout=5m
-
-        kubectl "${kube_args[@]}" apply -f ./scylla-setup/local-ssd-sc.yaml
 {{- end }}
 
 ---
@@ -91,6 +86,37 @@ releases:
       - scylla-operator/scylla-operator
     values:
       - {{ env "LINERA_HELMFILE_VALUES_SCYLLA" | default "scylla.values.yaml.gotmpl" }}
+    {{- if .Values.gcpRun }}
+    hooks:
+      - events: ["presync"]
+        showlogs: true
+        command: bash
+        args:
+          - -c
+          - |
+            set -euxo pipefail
+
+            kube_args=(
+              {{- if .Values.kubeContext }}
+              --context {{ .Values.kubeContext }}
+              {{- end }}
+              {{- if .Values.kubeConfigPath }}
+              --kubeconfig {{ .Values.kubeConfigPath }}
+              {{- end }}
+            )
+
+            echo "Deploy NodeConfig, Local-CSI driver and StorageClass"
+
+            kubectl "${kube_args[@]}" apply -f ./scylla-setup/nodeconfig.yaml
+            kubectl wait --for=condition=Progressing=False --timeout=10m nodeconfig/scylla-nvme
+            kubectl wait --for=condition=Degraded=False --timeout=10m nodeconfig/scylla-nvme
+            kubectl wait --for=condition=Available=True --timeout=10m nodeconfig/scylla-nvme
+
+            kubectl "${kube_args[@]}" apply -f ./scylla-setup/local-csi-driver
+            kubectl "${kube_args[@]}" -n local-csi-driver rollout status daemonset/local-csi-driver --timeout=5m
+
+            kubectl "${kube_args[@]}" apply -f ./scylla-setup/local-ssd-sc.yaml
+    {{- end }}
   - name: scylla-manager
     version: v1.16.0
     namespace: scylla-manager

--- a/kubernetes/linera-validator/scylla-setup/gke-daemonset-raid-disks.yaml
+++ b/kubernetes/linera-validator/scylla-setup/gke-daemonset-raid-disks.yaml
@@ -16,58 +16,53 @@ spec:
     spec:
       nodeSelector:
         cloud.google.com/gke-local-nvme-ssd: "true"
-      tolerations:
-        - key: "scylla-db"
-          operator: "Equal"
-          value: "true"
-          effect: "NoSchedule"
       hostPID: true
       containers:
-      - name: startup-script
-        image: registry.k8s.io/startup-script:v1
-        securityContext:
-          privileged: true
-        env:
-        - name: STARTUP_SCRIPT
-          value: |
-            set -o errexit
-            set -o nounset
-            set -o pipefail
+        - name: startup-script
+          image: registry.k8s.io/startup-script:v1
+          securityContext:
+            privileged: true
+          env:
+            - name: STARTUP_SCRIPT
+              value: |
+                set -o errexit
+                set -o nounset
+                set -o pipefail
 
-            # Ensure we have the XFS tools
-            if ! command -v mkfs.xfs >/dev/null; then
-              echo "mkfs.xfs not found! Installing xfsprogs..."
-              apt-get update
-              DEBIAN_FRONTEND=noninteractive \
-                apt-get install -y --no-install-recommends xfsprogs
-            fi
+                # Ensure we have the XFS tools
+                if ! command -v mkfs.xfs >/dev/null; then
+                  echo "mkfs.xfs not found! Installing xfsprogs..."
+                  apt-get update
+                  DEBIAN_FRONTEND=noninteractive \
+                    apt-get install -y --no-install-recommends xfsprogs
+                fi
 
-            devices=()
-            for ssd in /dev/disk/by-id/google-local-ssd-block*; do
-              if [ -e "${ssd}" ]; then
-                devices+=("${ssd}")
-              fi
-            done
-            if [ "${#devices[@]}" -eq 0 ]; then
-              echo "No Local NVMe SSD disks found."
-              exit 1
-            fi
+                devices=()
+                for ssd in /dev/disk/by-id/google-local-ssd-block*; do
+                  if [ -e "${ssd}" ]; then
+                    devices+=("${ssd}")
+                  fi
+                done
+                if [ "${#devices[@]}" -eq 0 ]; then
+                  echo "No Local NVMe SSD disks found."
+                  exit 1
+                fi
 
-            seen_arrays=(/dev/md/*)
-            device=${seen_arrays[0]}
-            echo "Setting RAID array with Local SSDs on device ${device}"
-            if [ ! -e "$device" ]; then
-              device="/dev/md/0"
-              echo "y" | mdadm --create "${device}" --level=0 --force --raid-devices=${#devices[@]} "${devices[@]}"
-            fi
+                seen_arrays=(/dev/md/*)
+                device=${seen_arrays[0]}
+                echo "Setting RAID array with Local SSDs on device ${device}"
+                if [ ! -e "$device" ]; then
+                  device="/dev/md/0"
+                  echo "y" | mdadm --create "${device}" --level=0 --force --raid-devices=${#devices[@]} "${devices[@]}"
+                fi
 
-            if ! blkid "${device}" >/dev/null 2>&1 ; then
-              echo "Formatting '${device}'"
-              mkfs.xfs -f "${device}"
-            fi
+                if ! blkid "${device}" >/dev/null 2>&1 ; then
+                  echo "Formatting '${device}'"
+                  mkfs.xfs -f "${device}"
+                fi
 
-            mountpoint=/mnt/disks/raid
-            mkdir -p "${mountpoint}"
-            echo "Mounting '${device}' at '${mountpoint}'"
-            mount -o discard,prjquota,noatime,nodiratime "${device}" "${mountpoint}"
-            chmod a+w "${mountpoint}" 
+                mountpoint=/mnt/disks/raid
+                mkdir -p "${mountpoint}"
+                echo "Mounting '${device}' at '${mountpoint}'"
+                mount -o discard,prjquota,noatime,nodiratime "${device}" "${mountpoint}"
+                chmod a+w "${mountpoint}"

--- a/kubernetes/linera-validator/scylla-setup/local-ssd-sc.yaml
+++ b/kubernetes/linera-validator/scylla-setup/local-ssd-sc.yaml
@@ -4,5 +4,5 @@ metadata:
   name: nvme-ssd-block
 provisioner: local.csi.scylladb.com
 volumeBindingMode: WaitForFirstConsumer
-reclaimPolicy: Delete
-allowVolumeExpansion: false
+parameters:
+  csi.storage.k8s.io/fstype: xfs

--- a/kubernetes/linera-validator/scylla-setup/nodeconfig.yaml
+++ b/kubernetes/linera-validator/scylla-setup/nodeconfig.yaml
@@ -1,0 +1,29 @@
+apiVersion: scylla.scylladb.com/v1alpha1
+kind: NodeConfig
+metadata:
+  name: scylla-nvme
+spec:
+  localDiskSetup:
+    raids:
+      - name: nvmes
+        type: RAID0
+        RAID0:
+          devices:
+            nameRegex: ^/dev/nvme\d+n\d+$
+    filesystems:
+      - device: /dev/md/nvmes
+        type: xfs
+    mounts:
+      - device: /dev/md/nvmes
+        mountPoint: /mnt/disks/raid
+        unsupportedOptions:
+          - prjquota
+  placement:
+    nodeSelector:
+      cloud.google.com/gke-local-nvme-ssd: "true"
+      workload: scylla
+    tolerations:
+      - key: scylla-db
+        operator: Equal
+        value: "true"
+        effect: NoSchedule

--- a/kubernetes/linera-validator/values-local.yaml.gotmpl
+++ b/kubernetes/linera-validator/values-local.yaml.gotmpl
@@ -13,8 +13,7 @@ serverTokioThreads: {{ env "LINERA_HELMFILE_SET_SERVER_TOKIO_THREADS" | default 
 rocksdbStorageSize: {{ env "LINERA_HELMFILE_SET_ROCKSDB_STORAGE_SIZE" | default "2Gi" }}
 storage: {{ env "LINERA_HELMFILE_SET_STORAGE" | default "scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042" }}
 dualStore: {{ env "LINERA_HELMFILE_SET_DUAL_STORE" | default "false" }}
-usingLocalSsd: {{ env "LINERA_HELMFILE_SET_USING_LOCAL_SSD" | default "false" }}
-usingRecommendedScyllaDbSettings: {{ env "LINERA_HELMFILE_SET_USING_RECOMMENDED_SCYLLA_DB_SETTINGS" | default "false" }}
+gcpRun: {{ env "LINERA_HELMFILE_SET_GCP_RUN" | default "false" }}
 storageReplicationFactor: {{ env "LINERA_HELMFILE_SET_STORAGE_REPLICATION_FACTOR" | default 1 }}
 
 # Loki


### PR DESCRIPTION
## Motivation

There's this `NodeConfig` that we can use to setup the disks properly for Scylla, and do a few other optimizations to the setup.

## Proposal

Use the `NodeConfig` for Scylla, but continue using the existing hook script to setup local SSD for the shards, when using `DualStore`. Make sure the Scylla stuff only runs in the Scylla VMs by using placements.

## Test Plan

Deployed a network with these changes both using `DualStore` and using just `ScyllaDB`, both work.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
