### PR TITLE
Test the generation of the code in the CI.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -242,7 +242,7 @@ jobs:
         serdegen --language solidity --module-name LineraTypes --target-source-dir dest linera-execution/solidity/LineraTypes.yaml
     - name: Check for generated LineraTypes.sol
       run: |
-        if ! diff dest/LineraTypes.sol  < linera-execution/solidity/LineraTypes.sol
+        if ! diff dest/LineraTypes.sol linera-execution/solidity/LineraTypes.sol
         then
           echo '`LineraTypes.sol` differs from the output of `serdegen`'
           exit 1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -242,7 +242,7 @@ jobs:
         serdegen --language solidity --module-name LineraTypes --target-source-dir dest linera-execution/solidity/LineraTypes.yaml
     - name: Check for generated LineraTypes.sol
       run: |
-        if ! diff des/LineraTypes.sol  < linera-execution/solidity/LineraTypes.sol
+        if ! diff dest/LineraTypes.sol  < linera-execution/solidity/LineraTypes.sol
         then
           echo '`LineraTypes.sol` differs from the output of `serdegen`'
           exit 1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -234,6 +234,19 @@ jobs:
       uses: arduino/setup-protoc@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install serde-generate-bin
+      run: |
+        cargo install serde-generate-bin@0.8.0 --locked
+    - name: Compile the LineraTypes.yaml
+      run: |
+        serdegen --language solidity --module-name LineraTypes --target-source-dir dest linera-execution/solidity/LineraTypes.yaml
+    - name: Check for generated LineraTypes.sol
+      run: |
+        if ! diff des/LineraTypes.sol  < linera-execution/solidity/LineraTypes.sol
+        then
+          echo '`LineraTypes.sol` differs from the output of `serdegen`'
+          exit 1
+        fi
     - name: Run the storage-service instance
       run: |
         cargo run --release -p linera-storage-service -- memory --endpoint $LINERA_STORAGE_SERVICE &


### PR DESCRIPTION
## Motivation

The file `LineraTypes.sol` is generated from the `LineraTypes.yaml` but this is not tested in the CI.

## Proposal

The `serdegen` is installed by using `cargo`. Then the file is generated and then tested for equality.

## Test Plan

The CI is precisely the point.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.