### PR TITLE
Unify confirmed certificate processing between clients and validators

### DIFF
--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -121,13 +121,6 @@ where
         callback: oneshot::Sender<Result<(ChainInfoResponse, NetworkActions), WorkerError>>,
     },
 
-    /// Preprocess a block without executing it.
-    PreprocessCertificate {
-        certificate: ConfirmedBlockCertificate,
-        #[debug(skip)]
-        callback: oneshot::Sender<Result<NetworkActions, WorkerError>>,
-    },
-
     /// Process a cross-chain update.
     ProcessCrossChainUpdate {
         origin: ChainId,
@@ -399,12 +392,6 @@ where
                         .await,
                 )
                 .is_ok(),
-            ChainWorkerRequest::PreprocessCertificate {
-                certificate,
-                callback,
-            } => callback
-                .send(self.worker.preprocess_certificate(certificate).await)
-                .is_ok(),
             ChainWorkerRequest::ProcessCrossChainUpdate {
                 origin,
                 bundles,
@@ -491,9 +478,6 @@ where
                 callback.send(Err(error)).is_ok()
             }
             ChainWorkerRequest::ProcessConfirmedBlock { callback, .. } => {
-                callback.send(Err(error)).is_ok()
-            }
-            ChainWorkerRequest::PreprocessCertificate { callback, .. } => {
                 callback.send(Err(error)).is_ok()
             }
             ChainWorkerRequest::ProcessCrossChainUpdate { callback, .. } => {

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -449,7 +449,7 @@ where
 
     /// Stores a block's blobs, and adds its messages to the outbox where possible.
     /// Does not execute the block.
-    pub(super) async fn preprocess_certificate(
+    async fn preprocess_certificate(
         &mut self,
         certificate: ConfirmedBlockCertificate,
     ) -> Result<NetworkActions, WorkerError> {

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -260,18 +260,6 @@ where
             .await
     }
 
-    /// Preprocesses a block without executing it.
-    #[tracing::instrument(level = "debug", skip(self))]
-    pub(super) async fn preprocess_certificate(
-        &mut self,
-        certificate: ConfirmedBlockCertificate,
-    ) -> Result<NetworkActions, WorkerError> {
-        ChainWorkerStateWithAttemptedChanges::new(self)
-            .await
-            .preprocess_certificate(certificate)
-            .await
-    }
-
     /// Updates the chain's inboxes, receiving messages from a cross-chain update.
     #[tracing::instrument(level = "debug", skip(self))]
     pub(super) async fn process_cross_chain_update(

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -15,7 +15,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{BlockProposal, ProposedBlock},
-    types::{Block, ConfirmedBlockCertificate, GenericCertificate, LiteCertificate},
+    types::{Block, GenericCertificate, LiteCertificate},
     ChainStateView,
 };
 use linera_execution::{committee::Committee, BlobState, Query, QueryOutcome};
@@ -120,20 +120,6 @@ where
                 .fully_handle_certificate_with_notifications(certificate, notifier),
         )
         .await?)
-    }
-
-    /// Preprocesses a block without executing it.
-    #[instrument(level = "trace", skip_all)]
-    pub async fn preprocess_certificate(
-        &self,
-        certificate: ConfirmedBlockCertificate,
-        notifier: &impl Notifier,
-    ) -> Result<(), LocalNodeError> {
-        self.node
-            .state
-            .fully_preprocess_certificate_with_notifications(certificate, notifier)
-            .await?;
-        Ok(())
     }
 
     #[instrument(level = "trace", skip_all)]


### PR DESCRIPTION
## Motivation

Now that validators allow for gaps in chains, we can unify the way confirmed certificate are processed on the client and on the validator.

## Proposal

Remove the `PreprocessCertificate` worker request and use `ProcessConfirmedBlock` instead (which can still call `preprocess_certificate` under the hood if there are gaps).

Moreover, always use the committee from storage for certificate validation. We used to get the current committee from the chain state for nonzero-height blocks, but this can be incorrect if there are gaps, because the committee might have changed within the gap, or we might not even have a committee in the chain state. Thus, we should always use the block epoch to get the committee from storage, but if the block is going to be fully processed, we should also verify that the epoch in it matches the current epoch on the chain.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
