### PR TITLE
Remove the "blst" dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,6 @@ revm = { version = "24.0.1", default-features = false, features = [
     "kzg-rs",
     "secp256k1",
     "portable",
-    "blst",
     "serde",
 ] }
 revm-context = { version = "5.0.0", default-features = false, features = [

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -64,7 +64,6 @@ revm = { workspace = true, optional = true, default-features = false, features =
     "kzg-rs",
     "secp256k1",
     "portable",
-    "blst",
     "serde",
 ] }
 revm-context = { workspace = true, optional = true, default-features = false, features = [


### PR DESCRIPTION
## Motivation

The `blst` library is used as a dependency in `revm`, but it has the disadvantage of being an encapsulation of a "C" library, which prevents its usage on Wasm.

## Proposal

Remove "blst" as a dependency. This is fine since an examination of the source code of "revm" reveals that if this feature is not enabled then "revm" uses the "ark-bls12-381" library. The name of the encapsulation being `crypto_backend`.

## Test Plan

The CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.