### PR TITLE
Add a utility function to map UInt8Array to Hex string

### DIFF
--- a/linera-web/signer/src/metamask.ts
+++ b/linera-web/signer/src/metamask.ts
@@ -60,7 +60,7 @@ export class MetaMask implements Signer {
     }
 
     // Encode message as hex string
-    const msgHex = `0x${Buffer.from(value).toString("hex")}`;
+    const msgHex = `0x${uint8ArrayToHex(value)}`;
     try {
       const signature = (await window.ethereum.request({
         method: "personal_sign",
@@ -94,4 +94,10 @@ export class MetaMask implements Signer {
     let address = await signer.getAddress();
     return address;
   }
+}
+
+function uint8ArrayToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b: number) => b.toString(16).padStart(2, '0'))
+    .join('');
 }


### PR DESCRIPTION
## Motivation

`linera-web` demos involving Metamask integration fail on devnet b/c we don't install the `buffer` dependency. 

## Proposal

Replace usage of `Buffer.from` with this simple utility. Otherwise all clients integrating with via the Metamask integration are required to install the `buffer` dependency and manually assigning the Buffer object to the browser's window object.

## Test Plan

Manually

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
