### PR TITLE
Remove dependency to genawaiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3156,7 +3156,7 @@ dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
- "proc-macro-error 1.0.4",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3785,36 +3785,6 @@ name = "gcd"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
-
-[[package]]
-name = "genawaiter"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
-dependencies = [
- "genawaiter-macro",
- "genawaiter-proc-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "genawaiter-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
-
-[[package]]
-name = "genawaiter-proc-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784f84eebc366e15251c4a8c3acee82a6a6f427949776ecb88377362a9621738"
-dependencies = [
- "proc-macro-error 0.4.12",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "generic-array"
@@ -5970,7 +5940,6 @@ dependencies = [
  "cfg_aliases",
  "either",
  "frunk",
- "genawaiter",
  "insta",
  "linera-wasmer",
  "linera-witty",
@@ -5988,7 +5957,7 @@ version = "0.15.0"
 dependencies = [
  "cfg_aliases",
  "heck 0.4.1",
- "proc-macro-error 1.0.4",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -7175,40 +7144,14 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
-dependencies = [
- "proc-macro-error-attr 0.4.12",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "proc-macro-error-attr 1.0.4",
+ "proc-macro-error-attr",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "syn-mid",
  "version_check",
 ]
 
@@ -7244,12 +7187,6 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -9165,17 +9102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn-mid"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "syn-solidity"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10431,7 +10357,7 @@ version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c5875633aea92153b6a561cb07363785ca9e07792ca6cd7c1cc371761001d8f"
 dependencies = [
- "proc-macro-error 1.0.4",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,6 @@ fs-err = "2.11.0"
 fs4 = "0.8.2"
 fs_extra = "1.3.0"
 futures = "0.3.30"
-genawaiter = "0.99.1"
 generic-array = { version = "0.14.7", features = ["serde"] }
 getrandom = "0.2.12"
 git2 = "0.19.0"

--- a/linera-execution/src/bin/wit_generator.rs
+++ b/linera-execution/src/bin/wit_generator.rs
@@ -12,13 +12,15 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{ensure, Context, Result};
+use anyhow::{Context, Result};
 use clap::Parser as _;
 use linera_execution::{
     BaseRuntimeApi, ContractEntrypoints, ContractRuntimeApi, ContractSyncRuntimeHandle,
     RuntimeApiData, ServiceEntrypoints, ServiceRuntimeApi, ServiceSyncRuntimeHandle,
 };
-use linera_witty::wit_generation::{StubInstance, WitInterfaceWriter, WitWorldWriter};
+use linera_witty::wit_generation::{
+    FileContentGenerator, StubInstance, WitInterfaceWriter, WitWorldWriter,
+};
 
 /// Command line parameters for the WIT generator.
 #[derive(Debug, clap::Parser)]
@@ -71,34 +73,28 @@ fn run_operation(options: WitGeneratorOptions, mut operation: impl Operation) ->
 
     operation.run_for_file(
         &options.base_directory.join("contract-entrypoints.wit"),
-        contract_entrypoints.generate_file_contents(),
+        contract_entrypoints,
     )?;
     operation.run_for_file(
         &options.base_directory.join("service-entrypoints.wit"),
-        service_entrypoints.generate_file_contents(),
+        service_entrypoints,
     )?;
 
     operation.run_for_file(
         &options.base_directory.join("base-runtime-api.wit"),
-        base_runtime_api.generate_file_contents(),
+        base_runtime_api,
     )?;
     operation.run_for_file(
         &options.base_directory.join("contract-runtime-api.wit"),
-        contract_runtime_api.generate_file_contents(),
+        contract_runtime_api,
     )?;
     operation.run_for_file(
         &options.base_directory.join("service-runtime-api.wit"),
-        service_runtime_api.generate_file_contents(),
+        service_runtime_api,
     )?;
 
-    operation.run_for_file(
-        &options.base_directory.join("contract.wit"),
-        contract_world.generate_file_contents(),
-    )?;
-    operation.run_for_file(
-        &options.base_directory.join("service.wit"),
-        service_world.generate_file_contents(),
-    )?;
+    operation.run_for_file(&options.base_directory.join("contract.wit"), contract_world)?;
+    operation.run_for_file(&options.base_directory.join("service.wit"), service_world)?;
 
     Ok(())
 }
@@ -106,31 +102,21 @@ fn run_operation(options: WitGeneratorOptions, mut operation: impl Operation) ->
 /// An operation that this WIT generator binary can perform.
 trait Operation {
     /// Executes the operation for a file at `path`, using the WIT `contents`.
-    fn run_for_file<'c>(
-        &mut self,
-        path: &Path,
-        contents: impl Iterator<Item = &'c str>,
-    ) -> Result<()>;
+    fn run_for_file(&mut self, path: &Path, generator: impl FileContentGenerator) -> Result<()>;
 }
 
 /// Writes out the WIT file.
 pub struct WriteToFile;
 
 impl Operation for WriteToFile {
-    fn run_for_file<'c>(
-        &mut self,
-        path: &Path,
-        contents: impl Iterator<Item = &'c str>,
-    ) -> Result<()> {
+    fn run_for_file(&mut self, path: &Path, generator: impl FileContentGenerator) -> Result<()> {
         let mut file = BufWriter::new(
             File::create(path)
                 .with_context(|| format!("Failed to create file at {}", path.display()))?,
         );
-
-        for part in contents {
-            file.write_all(part.as_bytes())
-                .with_context(|| format!("Failed to write to {}", path.display()))?;
-        }
+        generator
+            .generate_file_contents(&mut file)
+            .with_context(|| format!("Failed to write to {}", path.display()))?;
 
         file.flush()
             .with_context(|| format!("Failed to flush to {}", path.display()))?;
@@ -142,34 +128,51 @@ impl Operation for WriteToFile {
 /// Checks that a WIT file has the expected contents.
 pub struct CheckFile;
 
+struct FileComparer {
+    buffer: Vec<u8>,
+    file: BufReader<File>,
+}
+
+impl FileComparer {
+    fn new(file: File) -> Self {
+        Self {
+            buffer: Vec::new(),
+            file: BufReader::new(file),
+        }
+    }
+}
+
+impl Write for FileComparer {
+    fn write(&mut self, part: &[u8]) -> std::io::Result<usize> {
+        self.buffer.resize(part.len(), 0);
+        self.file.read_exact(&mut self.buffer)?;
+        if self.buffer != part {
+            return Err(std::io::Error::other("file does not match"));
+        }
+        Ok(part.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.buffer.resize(1, 0);
+        if self.file.read(&mut self.buffer)? != 0 {
+            return Err(std::io::Error::other("file has extra contents"));
+        }
+        Ok(())
+    }
+}
+
 impl Operation for CheckFile {
-    fn run_for_file<'c>(
-        &mut self,
-        path: &Path,
-        contents: impl Iterator<Item = &'c str>,
-    ) -> Result<()> {
-        let mut buffer = Vec::new();
-        let mut file = BufReader::new(
+    fn run_for_file(&mut self, path: &Path, generator: impl FileContentGenerator) -> Result<()> {
+        let mut file_comparer = FileComparer::new(
             File::open(path)
                 .with_context(|| format!("Failed to open file at {}", path.display()))?,
         );
-
-        for part in contents {
-            buffer.resize(part.len(), 0);
-            file.read_exact(&mut buffer)
-                .with_context(|| format!("Failed to read from {}", path.display()))?;
-
-            ensure!(
-                buffer == part.as_bytes(),
-                format!("WIT file {} does not match", path.display())
-            );
-        }
-
-        buffer.resize(1, 0);
-        ensure!(
-            file.read(&mut buffer)? == 0,
-            format!("WIT file {} has extra contents", path.display())
-        );
+        generator
+            .generate_file_contents(&mut file_comparer)
+            .with_context(|| format!("Comparison with {} failed", path.display()))?;
+        file_comparer
+            .flush()
+            .with_context(|| format!("Comparison with {} failed", path.display()))?;
 
         Ok(())
     }

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -23,7 +23,6 @@ wasmtime = ["dep:wasmtime", "linera-witty-macros?/wasmtime"]
 anyhow.workspace = true
 either.workspace = true
 frunk.workspace = true
-genawaiter.workspace = true
 linera-witty-macros = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 thiserror.workspace = true

--- a/linera-witty/src/wit_generation/mod.rs
+++ b/linera-witty/src/wit_generation/mod.rs
@@ -5,9 +5,7 @@
 
 mod stub_instance;
 
-use std::collections::BTreeMap;
-
-use genawaiter::{rc::gen, yield_};
+use std::{collections::BTreeMap, io::Write};
 
 pub use self::stub_instance::StubInstance;
 pub use crate::type_traits::RegisterWitTypes;
@@ -25,6 +23,12 @@ pub trait WitInterface {
 
     /// The WIT definitions of each function in this interface.
     fn wit_functions() -> Vec<String>;
+}
+
+/// Trait for content generation.
+pub trait FileContentGenerator {
+    /// Generate file contents.
+    fn generate_file_contents(&self, writer: impl Write) -> std::io::Result<()>;
 }
 
 /// Helper type to write a [`WitInterface`] to a file.
@@ -53,33 +57,27 @@ impl WitInterfaceWriter {
             functions: Interface::wit_functions(),
         }
     }
+}
 
-    /// Returns an [`Iterator`] with the file contents of the WIT interface file.
-    pub fn generate_file_contents(&self) -> impl Iterator<Item = &str> {
-        gen!({
-            yield_!("package ");
-            yield_!(self.package);
-            yield_!(";\n\n");
+impl FileContentGenerator for WitInterfaceWriter {
+    fn generate_file_contents(&self, mut writer: impl Write) -> std::io::Result<()> {
+        writeln!(writer, "package {};\n", self.package)?;
 
-            yield_!("interface ");
-            yield_!(self.name);
-            yield_!(" {\n");
+        writeln!(writer, "interface {} {{", self.name)?;
 
-            for function in &self.functions {
-                yield_!(&function);
-                yield_!("\n");
+        for function in &self.functions {
+            writeln!(writer, "{}", &function)?;
+        }
+
+        for type_declaration in self.types.values() {
+            if !type_declaration.is_empty() {
+                writeln!(writer)?;
+                write!(writer, "{}", &type_declaration)?;
             }
+        }
 
-            for type_declaration in self.types.values() {
-                if !type_declaration.is_empty() {
-                    yield_!("\n");
-                    yield_!(&type_declaration);
-                }
-            }
-
-            yield_!("}\n");
-        })
-        .into_iter()
+        writeln!(writer, "}}")?;
+        Ok(())
     }
 }
 
@@ -121,39 +119,29 @@ impl WitWorldWriter {
         self.exports.push(Interface::wit_name());
         self
     }
+}
 
-    /// Returns an [`Iterator`] with the file contents of the WIT world file, optionally including
-    /// a package header.
-    pub fn generate_file_contents(&self) -> impl Iterator<Item = &str> {
-        gen!({
-            if let Some(package) = &self.package {
-                yield_!("package ");
-                yield_!(package);
-                yield_!(";\n\n");
-            }
+impl FileContentGenerator for WitWorldWriter {
+    fn generate_file_contents(&self, mut writer: impl Write) -> std::io::Result<()> {
+        if let Some(package) = &self.package {
+            writeln!(writer, "package {};\n", package)?;
+        }
 
-            yield_!("world ");
-            yield_!(&self.name);
-            yield_!(" {\n");
+        writeln!(writer, "world {} {{", &self.name)?;
 
-            for import in &self.imports {
-                yield_!("    import ");
-                yield_!(import);
-                yield_!(";\n");
-            }
+        for import in &self.imports {
+            writeln!(writer, "    import {};", import)?;
+        }
 
-            if !self.imports.is_empty() {
-                yield_!("\n");
-            }
+        if !self.imports.is_empty() {
+            writeln!(writer)?;
+        }
 
-            for export in &self.exports {
-                yield_!("    export ");
-                yield_!(export);
-                yield_!(";\n");
-            }
+        for export in &self.exports {
+            writeln!(writer, "    export {};", export)?;
+        }
 
-            yield_!("}\n");
-        })
-        .into_iter()
+        writeln!(writer, "}}")?;
+        Ok(())
     }
 }

--- a/linera-witty/tests/reentrancy.rs
+++ b/linera-witty/tests/reentrancy.rs
@@ -19,7 +19,7 @@ use std::{
 use insta::assert_snapshot;
 use linera_witty::{
     wit_export,
-    wit_generation::{WitInterface, WitInterfaceWriter, WitWorldWriter},
+    wit_generation::{FileContentGenerator as _, WitInterface, WitInterfaceWriter, WitWorldWriter},
     wit_import, ExportTo, Instance, MockInstance, Runtime, RuntimeError, RuntimeMemory,
 };
 use test_case::test_case;
@@ -519,30 +519,30 @@ fn test_wit_interface_file<Interface>(_: PhantomData<Interface>, name: &str)
 where
     Interface: WitInterface,
 {
-    assert_snapshot!(
-        name,
-        WitInterfaceWriter::new::<Interface>()
-            .generate_file_contents()
-            .collect::<String>()
-    );
+    let mut buffer = Vec::new();
+    WitInterfaceWriter::new::<Interface>()
+        .generate_file_contents(&mut buffer)
+        .unwrap();
+    assert_snapshot!(name, String::from_utf8(buffer).unwrap());
 }
 
 /// Tests the generated file contents for a WIT world containing all the interfaces used in this
 /// test.
 #[test]
 fn test_wit_world_file() {
-    assert_snapshot!(
-        WitWorldWriter::new("witty-macros:test-modules", "test-world")
-            .export::<Entrypoint<MockInstance<()>>>()
-            .export::<ImportedSimpleFunction<MockInstance<()>>>()
-            .export::<ImportedGetters<MockInstance<()>>>()
-            .export::<ImportedSetters<MockInstance<()>>>()
-            .export::<ImportedOperations<MockInstance<()>>>()
-            .import::<ExportedSimpleFunction>()
-            .import::<ExportedGetters<MockInstance<()>>>()
-            .import::<ExportedSetters<MockInstance<()>>>()
-            .import::<ExportedOperations<MockInstance<()>>>()
-            .generate_file_contents()
-            .collect::<String>()
-    );
+    let mut buffer = Vec::new();
+    WitWorldWriter::new("witty-macros:test-modules", "test-world")
+        .export::<Entrypoint<MockInstance<()>>>()
+        .export::<ImportedSimpleFunction<MockInstance<()>>>()
+        .export::<ImportedGetters<MockInstance<()>>>()
+        .export::<ImportedSetters<MockInstance<()>>>()
+        .export::<ImportedOperations<MockInstance<()>>>()
+        .import::<ExportedSimpleFunction>()
+        .import::<ExportedGetters<MockInstance<()>>>()
+        .import::<ExportedSetters<MockInstance<()>>>()
+        .import::<ExportedOperations<MockInstance<()>>>()
+        .generate_file_contents(&mut buffer)
+        .unwrap();
+
+    assert_snapshot!(String::from_utf8(buffer).unwrap());
 }

--- a/linera-witty/tests/wit_export.rs
+++ b/linera-witty/tests/wit_export.rs
@@ -13,7 +13,7 @@ use std::marker::PhantomData;
 use insta::assert_snapshot;
 use linera_witty::{
     wit_export,
-    wit_generation::{WitInterface, WitInterfaceWriter, WitWorldWriter},
+    wit_generation::{FileContentGenerator as _, WitInterface, WitInterfaceWriter, WitWorldWriter},
     wit_import, ExportTo, Instance, MockInstance, Runtime, RuntimeMemory,
 };
 use test_case::test_case;
@@ -300,26 +300,26 @@ fn test_wit_interface_file<Interface>(_: PhantomData<Interface>, name: &str)
 where
     Interface: WitInterface,
 {
-    assert_snapshot!(
-        name,
-        WitInterfaceWriter::new::<Interface>()
-            .generate_file_contents()
-            .collect::<String>()
-    );
+    let mut buffer = Vec::new();
+    WitInterfaceWriter::new::<Interface>()
+        .generate_file_contents(&mut buffer)
+        .unwrap();
+    assert_snapshot!(name, String::from_utf8(buffer).unwrap());
 }
 
 /// Tests the generated file contents for a WIT world containing all the interfaces used in this
 /// test.
 #[test]
 fn test_wit_world_file() {
-    assert_snapshot!(
-        WitWorldWriter::new("witty-macros:test-modules", "test-world")
-            .export::<Entrypoint<MockInstance<()>>>()
-            .import::<SimpleFunction>()
-            .import::<Getters>()
-            .import::<Setters>()
-            .import::<Operations>()
-            .generate_file_contents()
-            .collect::<String>()
-    );
+    let mut buffer = Vec::new();
+    WitWorldWriter::new("witty-macros:test-modules", "test-world")
+        .export::<Entrypoint<MockInstance<()>>>()
+        .import::<SimpleFunction>()
+        .import::<Getters>()
+        .import::<Setters>()
+        .import::<Operations>()
+        .generate_file_contents(&mut buffer)
+        .unwrap();
+
+    assert_snapshot!(String::from_utf8(buffer).unwrap());
 }

--- a/linera-witty/tests/wit_import.rs
+++ b/linera-witty/tests/wit_import.rs
@@ -14,7 +14,7 @@ use std::marker::PhantomData;
 
 use insta::assert_snapshot;
 use linera_witty::{
-    wit_generation::{WitInterface, WitInterfaceWriter, WitWorldWriter},
+    wit_generation::{FileContentGenerator as _, WitInterface, WitInterfaceWriter, WitWorldWriter},
     wit_import, Instance, MockInstance, Runtime, RuntimeMemory,
 };
 use test_case::test_case;
@@ -353,25 +353,24 @@ fn test_wit_interface_file<Interface>(_: PhantomData<Interface>, name: &str)
 where
     Interface: WitInterface,
 {
-    assert_snapshot!(
-        name,
-        WitInterfaceWriter::new::<Interface>()
-            .generate_file_contents()
-            .collect::<String>()
-    );
+    let mut buffer = Vec::new();
+    WitInterfaceWriter::new::<Interface>()
+        .generate_file_contents(&mut buffer)
+        .unwrap();
+    assert_snapshot!(name, String::from_utf8(buffer).unwrap());
 }
 
 /// Tests the generated file contents for a WIT world containing all the interfaces used in this
 /// test.
 #[test]
 fn test_wit_world_file() {
-    assert_snapshot!(
-        WitWorldWriter::new("witty-macros:test-modules", "test-world")
-            .export::<SimpleFunction<MockInstance<()>>>()
-            .export::<Getters<MockInstance<()>>>()
-            .export::<Setters<MockInstance<()>>>()
-            .export::<Operations<MockInstance<()>>>()
-            .generate_file_contents()
-            .collect::<String>()
-    );
+    let mut buffer = Vec::new();
+    WitWorldWriter::new("witty-macros:test-modules", "test-world")
+        .export::<SimpleFunction<MockInstance<()>>>()
+        .export::<Getters<MockInstance<()>>>()
+        .export::<Setters<MockInstance<()>>>()
+        .export::<Operations<MockInstance<()>>>()
+        .generate_file_contents(&mut buffer)
+        .unwrap();
+    assert_snapshot!(String::from_utf8(buffer).unwrap());
 }


### PR DESCRIPTION
## Motivation

* `genawaiter` is not maintained
* Use idiomatic Rust code

## Proposal

* Use the good old `Write` trait.
* Use a trait `FileContentGenerator` with a generic method

## Test Plan

CI

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.
- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- Backporting is not possible but we may want to deploy a new `devnet` and release a new
      SDK soon.
