### PR TITLE
Keep worker lock until chain state is dropped.

### DIFF
--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -39,7 +39,7 @@ use crate::{
 /// dropped.
 pub struct ChainWorkerStateWithAttemptedChanges<'state, StorageClient>
 where
-    StorageClient: Storage + Clone + Send + Sync + 'static,
+    StorageClient: Storage,
 {
     state: &'state mut ChainWorkerState<StorageClient>,
     succeeded: bool,
@@ -678,7 +678,7 @@ where
 
 impl<StorageClient> Drop for ChainWorkerStateWithAttemptedChanges<'_, StorageClient>
 where
-    StorageClient: Storage + Clone + Send + Sync + 'static,
+    StorageClient: Storage,
 {
     fn drop(&mut self) {
         if !self.succeeded {

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -46,7 +46,7 @@ use crate::{
 /// The state of the chain worker.
 pub struct ChainWorkerState<StorageClient>
 where
-    StorageClient: Storage + Clone + Send + Sync + 'static,
+    StorageClient: Storage,
 {
     config: ChainWorkerConfig,
     storage: StorageClient,
@@ -92,6 +92,11 @@ where
             delivery_notifier,
             knows_chain_is_active: false,
         })
+    }
+
+    /// Drops the service runtime endpoint.
+    pub fn drop_service_runtime_endpoint(&mut self) {
+        self.service_runtime_endpoint = None;
     }
 
     /// Returns the [`ChainId`] of the chain handled by this worker.

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -36,7 +36,7 @@ pub struct ChainWorkerStateWithTemporaryChanges<'state, StorageClient>(
     &'state mut ChainWorkerState<StorageClient>,
 )
 where
-    StorageClient: Storage + Clone + Send + Sync + 'static;
+    StorageClient: Storage;
 
 impl<'state, StorageClient> ChainWorkerStateWithTemporaryChanges<'state, StorageClient>
 where
@@ -368,7 +368,7 @@ where
 
 impl<StorageClient> Drop for ChainWorkerStateWithTemporaryChanges<'_, StorageClient>
 where
-    StorageClient: Storage + Clone + Send + Sync + 'static,
+    StorageClient: Storage,
 {
     fn drop(&mut self) {
         self.0.chain.rollback();


### PR DESCRIPTION
## Motivation

The root cause of https://github.com/linera-io/linera-protocol/issues/4178 seems to be that worker tasks in some cases are still handling requests after being evicted. If at that point another request for the same chain comes in, a new worker is created and there are two loaded `ChainStateView`s for the same chain at the same time.

## Proposal

Remove the worker tasks that handle requests in a loop. Instead, maintain a `Arc<RwLock<BTreeMap<ChainId, Arc<Mutex<ChainWorkerActor<StorageClient>>>>>>` where a lock for each actor is kept whenever any request is being handled, and also when it is removed from the map.

We could now consider removing the channel and the `ChainWorkerRequest` enum, and do some other simplifications, but I would like to separate them from the fix itself.

## Test Plan

With this change I cannot reproduce https://github.com/linera-io/linera-protocol/issues/4178 anymore.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/4178.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
