### PR TITLE
Provide access to further linera functionalities in the EVM.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -17,6 +17,7 @@ use std::{
     str::FromStr,
 };
 
+use alloy_primitives::U256;
 use async_graphql::{InputObject, SimpleObject};
 use custom_debug_derive::Debug;
 use linera_witty::{WitLoad, WitStore, WitType};
@@ -76,6 +77,12 @@ impl<'de> Deserialize<'de> for Amount {
         } else {
             Ok(Amount(AmountU128::deserialize(deserializer)?.0))
         }
+    }
+}
+
+impl From<Amount> for U256 {
+    fn from(amount: Amount) -> U256 {
+        U256::from(amount.0)
     }
 }
 

--- a/linera-execution/solidity/Linera.sol
+++ b/linera-execution/solidity/Linera.sol
@@ -13,41 +13,381 @@ import "./LineraTypes.sol";
 
 library Linera {
 
-    function chain_id() internal returns (LineraTypes.ChainId memory) {
+    // Exported types
+
+    struct ChainId {
+        bytes32 value;
+    }
+
+    function chainid_from(LineraTypes.ChainId memory entry)
+        internal
+        pure
+        returns (ChainId memory)
+    {
+        return ChainId(entry.value.value);
+    }
+
+    struct AccountOwner {
+        uint8 choice;
+        // choice=0 corresponds to Reserved
+        uint8 reserved;
+        // choice=1 corresponds to Address32
+        bytes32 address32;
+        // choice=2 corresponds to Address20
+        bytes20 address20;
+    }
+
+    function accountowner_from(LineraTypes.AccountOwner memory owner)
+        internal
+        pure
+        returns (AccountOwner memory)
+    {
+        return AccountOwner(owner.choice, owner.reserved, owner.address32.value, owner.address20);
+    }
+
+    function accountowner_to(Linera.AccountOwner memory owner)
+        internal
+        pure
+        returns (LineraTypes.AccountOwner memory)
+    {
+        LineraTypes.CryptoHash memory hash = LineraTypes.CryptoHash(owner.address32);
+        return LineraTypes.AccountOwner(owner.choice, owner.reserved, hash, owner.address20);
+    }
+
+    struct AccountOwnerBalance {
+        Linera.AccountOwner account_owner;
+        uint256 balance;
+    }
+
+    function accountownerbalance_from(LineraTypes.AccountOwnerBalance memory entry)
+        internal
+        pure
+        returns (AccountOwnerBalance memory)
+    {
+        return AccountOwnerBalance(accountowner_from(entry.account_owner), entry.balance);
+    }
+
+    struct TimeDelta {
+        uint64 value;
+    }
+
+    function timedelta_from(LineraTypes.TimeDelta memory entry)
+        internal
+        pure
+        returns (TimeDelta memory)
+    {
+        return TimeDelta(entry.value);
+    }
+
+    struct opt_TimeDelta {
+        bool has_value;
+        uint64 value;
+    }
+
+    function opt_timedelta_from(LineraTypes.opt_TimeDelta memory entry)
+        internal
+        pure
+        returns (opt_TimeDelta memory)
+    {
+        return opt_TimeDelta(entry.has_value, entry.value.value);
+    }
+
+    struct TimeoutConfig {
+        opt_TimeDelta fast_round_duration;
+        TimeDelta base_timeout;
+        TimeDelta timeout_increment;
+        TimeDelta fallback_duration;
+    }
+
+    function timeoutconfig_from(LineraTypes.TimeoutConfig memory entry)
+        internal
+        pure
+        returns (TimeoutConfig memory)
+    {
+        return TimeoutConfig(opt_timedelta_from(entry.fast_round_duration),
+                             timedelta_from(entry.base_timeout),
+                             timedelta_from(entry.timeout_increment),
+                             timedelta_from(entry.fallback_duration));
+    }
+
+    struct AccountOwnerWeight {
+        Linera.AccountOwner account_owner;
+        uint64 weight;
+    }
+
+    function accountownerweight_from(LineraTypes.key_values_AccountOwner_uint64 memory entry)
+        internal
+        pure
+        returns (AccountOwnerWeight memory)
+    {
+        return AccountOwnerWeight(accountowner_from(entry.key), entry.value);
+    }
+
+    struct ChainOwnership {
+        AccountOwner[] super_owners;
+        AccountOwnerWeight[] owners;
+        uint32 multi_leader_rounds;
+        bool open_multi_leader_rounds;
+        TimeoutConfig timeout_config;
+    }
+
+    function chainownership_from(LineraTypes.ChainOwnership memory entry)
+        internal
+        pure
+        returns (ChainOwnership memory)
+    {
+        uint256 len1 = entry.super_owners.length;
+        AccountOwner[] memory super_owners;
+        super_owners = new AccountOwner[](len1);
+        for (uint256 i=0; i<len1; i++) {
+            super_owners[i] = accountowner_from(entry.super_owners[i]);
+        }
+        uint256 len2 = entry.owners.length;
+        AccountOwnerWeight[] memory owners;
+        owners = new AccountOwnerWeight[](len2);
+        for (uint256 i=0; i<len2; i++) {
+            owners[i] = accountownerweight_from(entry.owners[i]);
+        }
+        return ChainOwnership(super_owners, owners, entry.multi_leader_rounds, entry.open_multi_leader_rounds, timeoutconfig_from(entry.timeout_config));
+    }
+
+    struct opt_uint32 {
+        bool has_value;
+        uint32 value;
+    }
+
+    function opt_uint32_from(LineraTypes.opt_uint32 memory entry)
+        internal
+        pure
+        returns (opt_uint32 memory)
+    {
+        return opt_uint32(entry.has_value, entry.value);
+    }
+
+    struct ApplicationId {
+        bytes32 application_description_hash;
+    }
+
+    function applicationid_from(LineraTypes.ApplicationId memory entry)
+        internal
+        pure
+        returns (ApplicationId memory)
+    {
+        return ApplicationId(entry.application_description_hash.value);
+    }
+
+    struct opt_ApplicationId {
+        bool has_value;
+        ApplicationId value;
+    }
+
+    function opt_applicationid_from(LineraTypes.opt_ApplicationId memory entry)
+        internal
+        pure
+        returns (opt_ApplicationId memory)
+    {
+        return opt_ApplicationId(entry.has_value, applicationid_from(entry.value));
+    }
+
+    struct opt_AccountOwner {
+        bool has_value;
+        AccountOwner value;
+    }
+
+    function opt_accountowner_from(LineraTypes.opt_AccountOwner memory entry)
+        internal
+        pure
+        returns (opt_AccountOwner memory)
+    {
+        return opt_AccountOwner(entry.has_value, accountowner_from(entry.value));
+    }
+
+    enum OptionBool { None, True, False }
+
+    function optionbool_from(LineraTypes.MessageIsBouncing memory entry)
+        internal
+        pure
+        returns (OptionBool)
+    {
+        if (entry.value == LineraTypes.OptionBool.True) {
+            return OptionBool.True;
+        }
+        if (entry.value == LineraTypes.OptionBool.False) {
+            return OptionBool.False;
+        }
+        return OptionBool.None;
+    }
+
+    struct MessageId {
+        ChainId chain_id;
+        uint64 height;
+        uint32 index;
+    }
+
+    function messageid_from(LineraTypes.MessageId memory entry)
+        internal
+        pure
+        returns (MessageId memory)
+    {
+        return MessageId(chainid_from(entry.chain_id), entry.height.value, entry.index);
+    }
+
+    struct opt_MessageId {
+        bool has_value;
+        MessageId value;
+    }
+
+    function opt_messageid_from(LineraTypes.opt_MessageId memory entry)
+        internal
+        pure
+        returns (opt_MessageId memory)
+    {
+        return opt_MessageId(entry.has_value, messageid_from(entry.value));
+    }
+
+    struct StreamUpdate {
+        ChainId chain_id;
+        StreamId stream_id;
+        uint32 previous_index;
+        uint32 next_index;
+    }
+
+    struct StreamId {
+        GenericApplicationId application_id;
+        StreamName stream_name;
+    }
+
+    struct StreamName {
+        bytes value;
+    }
+
+    struct GenericApplicationId {
+        uint8 choice;
+        // choice=0 corresponds to System
+        // choice=1 corresponds to User
+        ApplicationId user;
+    }
+
+    // BaseRuntime functions
+
+    function chain_id() internal returns (Linera.ChainId memory) {
         address precompile = address(0x0b);
         LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_chain_id();
         LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_base(base);
         bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
-        (bool success, bytes memory output) = precompile.call(input2);
+        (bool success, bytes memory output1) = precompile.call(input2);
         require(success);
-        return LineraTypes.bcs_deserialize_ChainId(output);
+        LineraTypes.ChainId memory output2 = LineraTypes.bcs_deserialize_ChainId(output1);
+        return chainid_from(output2);
     }
 
-    function application_creator_chain_id() internal returns (LineraTypes.ChainId memory) {
+    function block_height() internal returns (uint64) {
+        address precompile = address(0x0b);
+        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_block_height();
+        LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_base(base);
+        bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
+        (bool success, bytes memory output) = precompile.call(input2);
+        require(success);
+        LineraTypes.BlockHeight memory output2 = LineraTypes.bcs_deserialize_BlockHeight(output);
+        return output2.value;
+    }
+
+    function application_creator_chain_id() internal returns (ChainId memory) {
         address precompile = address(0x0b);
         LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_application_creator_chain_id();
         LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_base(base);
         bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
-        (bool success, bytes memory output) = precompile.call(input2);
+        (bool success, bytes memory output1) = precompile.call(input2);
         require(success);
-        return LineraTypes.bcs_deserialize_ChainId(output);
+        LineraTypes.ChainId memory output2 = LineraTypes.bcs_deserialize_ChainId(output1);
+        return ChainId(output2.value.value);
     }
 
-    function chain_ownership() internal returns (LineraTypes.ChainOwnership memory) {
+    function read_system_timestamp() internal returns (uint64) {
         address precompile = address(0x0b);
-        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_chain_ownership();
+        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_read_system_timestamp();
         LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_base(base);
         bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
         (bool success, bytes memory output) = precompile.call(input2);
         require(success);
-        return LineraTypes.bcs_deserialize_ChainOwnership(output);
+        LineraTypes.Timestamp memory output2 = LineraTypes.bcs_deserialize_Timestamp(output);
+        return output2.value;
+    }
+
+    function read_chain_balance() internal returns (uint256) {
+        address precompile = address(0x0b);
+        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_read_chain_balance();
+        LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_base(base);
+        bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
+        (bool success, bytes memory output) = precompile.call(input2);
+        require(success);
+        LineraTypes.Amount memory output2 = LineraTypes.bcs_deserialize_Amount(output);
+        return uint256(output2.value);
+    }
+
+    function read_owner_balance(Linera.AccountOwner memory owner) internal returns (uint256) {
+        address precompile = address(0x0b);
+        LineraTypes.AccountOwner memory owner2 = accountowner_to(owner);
+        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_read_owner_balance(owner2);
+        LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_base(base);
+        bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
+        (bool success, bytes memory output) = precompile.call(input2);
+        require(success);
+        LineraTypes.Amount memory output2 = LineraTypes.bcs_deserialize_Amount(output);
+        return uint256(output2.value);
+    }
+
+    function read_owner_balances() internal returns (Linera.AccountOwnerBalance[] memory) {
+        address precompile = address(0x0b);
+        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_read_owner_balances();
+        LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_base(base);
+        bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
+        (bool success, bytes memory output) = precompile.call(input2);
+        require(success);
+        LineraTypes.ResponseReadOwnerBalances memory output2 = LineraTypes.bcs_deserialize_ResponseReadOwnerBalances(output);
+        uint256 len = output2.value.length;
+        Linera.AccountOwnerBalance[] memory elist;
+        elist = new Linera.AccountOwnerBalance[](len);
+        for (uint256 i=0; i<len; i++) {
+            uint256 balance = uint256(output2.value[i].balance_.value);
+            Linera.AccountOwner memory owner = accountowner_from(output2.value[i].account_owner);
+            elist[i] = Linera.AccountOwnerBalance(owner, balance);
+        }
+        return elist;
+    }
+
+    function read_balance_owners() internal returns (Linera.AccountOwner[] memory result) {
+        address precompile = address(0x0b);
+        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_read_balance_owners();
+        LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_base(base);
+        bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
+        (bool success, bytes memory output1) = precompile.call(input2);
+        require(success);
+        LineraTypes.ResponseReadBalanceOwners memory output2 = LineraTypes.bcs_deserialize_ResponseReadBalanceOwners(output1);
+        uint256 len = output2.value.length;
+        Linera.AccountOwner[] memory elist;
+        elist = new Linera.AccountOwner[](len);
+        for (uint256 i=0; i<len; i++) {
+            elist[i] = accountowner_from(output2.value[i]);
+        }
+        return elist;
+    }
+
+    function chain_ownership() internal returns (Linera.ChainOwnership memory) {
+        address precompile = address(0x0b);
+        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_chain_ownership();
+        LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_base(base);
+        bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
+        (bool success, bytes memory output1) = precompile.call(input2);
+        require(success);
+        LineraTypes.ChainOwnership memory output2 = LineraTypes.bcs_deserialize_ChainOwnership(output1);
+        return chainownership_from(output2);
     }
 
     function read_data_blob(bytes32 hash) internal returns (bytes memory) {
         address precompile = address(0x0b);
         LineraTypes.CryptoHash memory hash2 = LineraTypes.CryptoHash(hash);
-        LineraTypes.BaseRuntimePrecompile_ReadDataBlob memory read_data_blob_ = LineraTypes.BaseRuntimePrecompile_ReadDataBlob(hash2);
-        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_read_data_blob(read_data_blob_);
+        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_read_data_blob(hash2);
         LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_base(base);
         bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
         (bool success, bytes memory output) = precompile.call(input2);
@@ -58,8 +398,7 @@ library Linera {
     function assert_data_blob_exists(bytes32 hash) internal {
         address precompile = address(0x0b);
         LineraTypes.CryptoHash memory hash2 = LineraTypes.CryptoHash(hash);
-        LineraTypes.BaseRuntimePrecompile_AssertDataBlobExists memory assert_data_blob_exists_ = LineraTypes.BaseRuntimePrecompile_AssertDataBlobExists(hash2);
-        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_assert_data_blob_exists(assert_data_blob_exists_);
+        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_assert_data_blob_exists(hash2);
         LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_base(base);
         bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
         (bool success, bytes memory output) = precompile.call(input2);
@@ -67,26 +406,50 @@ library Linera {
         assert(output.length == 0);
     }
 
-    function try_call_application(bytes32 universal_address, bytes memory operation) internal returns (bytes memory) {
+    // ContractRuntime functions
+
+    function authenticated_signer() internal returns (Linera.opt_AccountOwner memory) {
         address precompile = address(0x0b);
-        LineraTypes.ApplicationId memory target = LineraTypes.ApplicationId(LineraTypes.CryptoHash(universal_address));
-        LineraTypes.ContractRuntimePrecompile_TryCallApplication memory try_call_application_ = LineraTypes.ContractRuntimePrecompile_TryCallApplication(target, operation);
-        LineraTypes.ContractRuntimePrecompile memory contract_ = LineraTypes.ContractRuntimePrecompile_case_try_call_application(try_call_application_);
+        LineraTypes.ContractRuntimePrecompile memory contract_ = LineraTypes.ContractRuntimePrecompile_case_authenticated_signer();
         LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_contract(contract_);
         bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
-        (bool success, bytes memory output) = precompile.call(input2);
+        (bool success, bytes memory output1) = precompile.call(input2);
         require(success);
-        return output;
+        LineraTypes.opt_AccountOwner memory output2 = LineraTypes.bcs_deserialize_opt_AccountOwner(output1);
+        return opt_accountowner_from(output2);
     }
 
-    function validation_round() internal returns (LineraTypes.opt_uint32 memory) {
+    function message_id() internal returns (Linera.opt_MessageId memory) {
         address precompile = address(0x0b);
-        LineraTypes.ContractRuntimePrecompile memory contract_ = LineraTypes.ContractRuntimePrecompile_case_validation_round();
+        LineraTypes.ContractRuntimePrecompile memory contract_ = LineraTypes.ContractRuntimePrecompile_case_message_id();
         LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_contract(contract_);
         bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
-        (bool success, bytes memory output) = precompile.call(input2);
+        (bool success, bytes memory output1) = precompile.call(input2);
         require(success);
-        return LineraTypes.bcs_deserialize_opt_uint32(output);
+        LineraTypes.opt_MessageId memory output2 = LineraTypes.bcs_deserialize_opt_MessageId(output1);
+        return opt_messageid_from(output2);
+    }
+
+    function message_is_bouncing() internal returns (OptionBool) {
+        address precompile = address(0x0b);
+        LineraTypes.ContractRuntimePrecompile memory contract_ = LineraTypes.ContractRuntimePrecompile_case_message_is_bouncing();
+        LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_contract(contract_);
+        bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
+        (bool success, bytes memory output1) = precompile.call(input2);
+        require(success);
+        LineraTypes.MessageIsBouncing memory output2 = LineraTypes.bcs_deserialize_MessageIsBouncing(output1);
+        return optionbool_from(output2);
+    }
+
+    function authenticated_caller_id() internal returns (Linera.opt_ApplicationId memory) {
+        address precompile = address(0x0b);
+        LineraTypes.ContractRuntimePrecompile memory contract_ = LineraTypes.ContractRuntimePrecompile_case_authenticated_caller_id();
+        LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_contract(contract_);
+        bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
+        (bool success, bytes memory output1) = precompile.call(input2);
+        require(success);
+        LineraTypes.opt_ApplicationId memory output2 = LineraTypes.bcs_deserialize_opt_ApplicationId(output1);
+        return opt_applicationid_from(output2);
     }
 
     function send_message(bytes32 chain_id1, bytes memory message) internal {
@@ -102,24 +465,16 @@ library Linera {
         require(output.length == 0);
     }
 
-    function message_id() internal returns (LineraTypes.opt_MessageId memory) {
+    function try_call_application(bytes32 universal_address, bytes memory operation) internal returns (bytes memory) {
         address precompile = address(0x0b);
-        LineraTypes.ContractRuntimePrecompile memory contract_ = LineraTypes.ContractRuntimePrecompile_case_message_id();
+        LineraTypes.ApplicationId memory target = LineraTypes.ApplicationId(LineraTypes.CryptoHash(universal_address));
+        LineraTypes.ContractRuntimePrecompile_TryCallApplication memory try_call_application_ = LineraTypes.ContractRuntimePrecompile_TryCallApplication(target, operation);
+        LineraTypes.ContractRuntimePrecompile memory contract_ = LineraTypes.ContractRuntimePrecompile_case_try_call_application(try_call_application_);
         LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_contract(contract_);
         bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
         (bool success, bytes memory output) = precompile.call(input2);
         require(success);
-        return LineraTypes.bcs_deserialize_opt_MessageId(output);
-    }
-
-    function message_is_bouncing() internal returns (LineraTypes.MessageIsBouncing memory) {
-        address precompile = address(0x0b);
-        LineraTypes.ContractRuntimePrecompile memory contract_ = LineraTypes.ContractRuntimePrecompile_case_message_is_bouncing();
-        LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_contract(contract_);
-        bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
-        (bool success, bytes memory output) = precompile.call(input2);
-        require(success);
-        return LineraTypes.bcs_deserialize_MessageIsBouncing(output);
+        return output;
     }
 
     function linera_emit(bytes memory stream_name, bytes memory value) internal returns (uint32) {
@@ -147,10 +502,10 @@ library Linera {
         return output;
     }
 
-    function subscribe_to_events(bytes32 chain_id1, bytes32 application_id, bytes memory stream_name) internal {
+    function subscribe_to_events(bytes32 chain_id1, bytes32 subscribed_application_id, bytes memory stream_name) internal {
         address precompile = address(0x0b);
         LineraTypes.ChainId memory chain_id2 = LineraTypes.ChainId(LineraTypes.CryptoHash(chain_id1));
-        LineraTypes.ApplicationId memory application_id2 = LineraTypes.ApplicationId(LineraTypes.CryptoHash(application_id));
+        LineraTypes.ApplicationId memory application_id2 = LineraTypes.ApplicationId(LineraTypes.CryptoHash(subscribed_application_id));
         LineraTypes.StreamName memory stream_name2 = LineraTypes.StreamName(stream_name);
         LineraTypes.ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events_ = LineraTypes.ContractRuntimePrecompile_SubscribeToEvents(chain_id2, application_id2, stream_name2);
         LineraTypes.ContractRuntimePrecompile memory contract_ = LineraTypes.ContractRuntimePrecompile_case_subscribe_to_events(subscribe_to_events_);
@@ -161,10 +516,10 @@ library Linera {
         require(output.length == 0);
     }
 
-    function unsubscribe_from_events(bytes32 chain_id1, bytes32 application_id, bytes memory stream_name) internal {
+    function unsubscribe_from_events(bytes32 chain_id1, bytes32 unsubscribe_application_id, bytes memory stream_name) internal {
         address precompile = address(0x0b);
         LineraTypes.ChainId memory chain_id2 = LineraTypes.ChainId(LineraTypes.CryptoHash(chain_id1));
-        LineraTypes.ApplicationId memory application_id2 = LineraTypes.ApplicationId(LineraTypes.CryptoHash(application_id));
+        LineraTypes.ApplicationId memory application_id2 = LineraTypes.ApplicationId(LineraTypes.CryptoHash(unsubscribe_application_id));
         LineraTypes.StreamName memory stream_name2 = LineraTypes.StreamName(stream_name);
         LineraTypes.ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events_ = LineraTypes.ContractRuntimePrecompile_UnsubscribeFromEvents(chain_id2, application_id2, stream_name2);
         LineraTypes.ContractRuntimePrecompile memory contract_ = LineraTypes.ContractRuntimePrecompile_case_unsubscribe_from_events(unsubscribe_from_events_);
@@ -174,6 +529,31 @@ library Linera {
         require(success);
         require(output.length == 0);
     }
+
+    function query_service(bytes32 universal_address, bytes memory query) internal returns (bytes memory) {
+        address precompile = address(0x0b);
+        LineraTypes.ApplicationId memory target = LineraTypes.ApplicationId(LineraTypes.CryptoHash(universal_address));
+        LineraTypes.ContractRuntimePrecompile_QueryService memory query_service_ = LineraTypes.ContractRuntimePrecompile_QueryService(target, query);
+        LineraTypes.ContractRuntimePrecompile memory contract_ = LineraTypes.ContractRuntimePrecompile_case_query_service(query_service_);
+        LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_contract(contract_);
+        bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
+        (bool success, bytes memory output) = precompile.call(input2);
+        require(success);
+        return output;
+    }
+
+    function validation_round() internal returns (Linera.opt_uint32 memory) {
+        address precompile = address(0x0b);
+        LineraTypes.ContractRuntimePrecompile memory contract_ = LineraTypes.ContractRuntimePrecompile_case_validation_round();
+        LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_contract(contract_);
+        bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
+        (bool success, bytes memory output) = precompile.call(input2);
+        require(success);
+        LineraTypes.opt_uint32 memory output2 = LineraTypes.bcs_deserialize_opt_uint32(output);
+        return opt_uint32_from(output2);
+    }
+
+    // ServiceRuntime functions.
 
     function try_query_application(bytes32 universal_address, bytes memory argument) internal returns (bytes memory) {
         address precompile = address(0x0b);

--- a/linera-execution/solidity/Linera.sol
+++ b/linera-execution/solidity/Linera.sol
@@ -55,16 +55,18 @@ library Linera {
     }
 
     struct AccountOwnerBalance {
-        Linera.AccountOwner account_owner;
+        AccountOwner account_owner;
         uint256 balance;
     }
 
-    function accountownerbalance_from(LineraTypes.AccountOwnerBalance memory entry)
+    function accountownerbalance_from(LineraTypes.AccountOwnerBalanceInner memory entry)
         internal
         pure
         returns (AccountOwnerBalance memory)
     {
-        return AccountOwnerBalance(accountowner_from(entry.account_owner), entry.balance);
+        uint256 balance = uint256(entry.balance_.value);
+        AccountOwner memory account_owner = accountowner_from(entry.account_owner);
+        return AccountOwnerBalance(account_owner, balance);
     }
 
     struct TimeDelta {
@@ -349,9 +351,7 @@ library Linera {
         Linera.AccountOwnerBalance[] memory elist;
         elist = new Linera.AccountOwnerBalance[](len);
         for (uint256 i=0; i<len; i++) {
-            uint256 balance = uint256(output2.value[i].balance_.value);
-            Linera.AccountOwner memory owner = accountowner_from(output2.value[i].account_owner);
-            elist[i] = Linera.AccountOwnerBalance(owner, balance);
+            elist[i] = accountownerbalance_from(output2.value[i]);
         }
         return elist;
     }

--- a/linera-execution/solidity/LineraTypes.sol
+++ b/linera-execution/solidity/LineraTypes.sol
@@ -144,6 +144,80 @@ library LineraTypes {
         return value;
     }
 
+    struct AccountOwnerBalanceInner {
+        AccountOwner account_owner;
+        Amount balance_;
+    }
+
+    function bcs_serialize_AccountOwnerBalanceInner(AccountOwnerBalanceInner memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        bytes memory result = bcs_serialize_AccountOwner(input.account_owner);
+        return abi.encodePacked(result, bcs_serialize_Amount(input.balance_));
+    }
+
+    function bcs_deserialize_offset_AccountOwnerBalanceInner(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, AccountOwnerBalanceInner memory)
+    {
+        uint256 new_pos;
+        AccountOwner memory account_owner;
+        (new_pos, account_owner) = bcs_deserialize_offset_AccountOwner(pos, input);
+        Amount memory balance_;
+        (new_pos, balance_) = bcs_deserialize_offset_Amount(new_pos, input);
+        return (new_pos, AccountOwnerBalanceInner(account_owner, balance_));
+    }
+
+    function bcs_deserialize_AccountOwnerBalanceInner(bytes memory input)
+        internal
+        pure
+        returns (AccountOwnerBalanceInner memory)
+    {
+        uint256 new_pos;
+        AccountOwnerBalanceInner memory value;
+        (new_pos, value) = bcs_deserialize_offset_AccountOwnerBalanceInner(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    struct Amount {
+        bytes32 value;
+    }
+
+    function bcs_serialize_Amount(Amount memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return bcs_serialize_bytes32(input.value);
+    }
+
+    function bcs_deserialize_offset_Amount(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, Amount memory)
+    {
+        uint256 new_pos;
+        bytes32 value;
+        (new_pos, value) = bcs_deserialize_offset_bytes32(pos, input);
+        return (new_pos, Amount(value));
+    }
+
+    function bcs_deserialize_Amount(bytes memory input)
+        internal
+        pure
+        returns (Amount memory)
+    {
+        uint256 new_pos;
+        Amount memory value;
+        (new_pos, value) = bcs_deserialize_offset_Amount(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
     struct ApplicationId {
         CryptoHash application_description_hash;
     }
@@ -182,12 +256,19 @@ library LineraTypes {
     struct BaseRuntimePrecompile {
         uint8 choice;
         // choice=0 corresponds to ChainId
-        // choice=1 corresponds to ApplicationCreatorChainId
-        // choice=2 corresponds to ChainOwnership
-        // choice=3 corresponds to ReadDataBlob
-        BaseRuntimePrecompile_ReadDataBlob read_data_blob;
-        // choice=4 corresponds to AssertDataBlobExists
-        BaseRuntimePrecompile_AssertDataBlobExists assert_data_blob_exists;
+        // choice=1 corresponds to BlockHeight
+        // choice=2 corresponds to ApplicationCreatorChainId
+        // choice=3 corresponds to ReadSystemTimestamp
+        // choice=4 corresponds to ReadChainBalance
+        // choice=5 corresponds to ReadOwnerBalance
+        AccountOwner read_owner_balance;
+        // choice=6 corresponds to ReadOwnerBalances
+        // choice=7 corresponds to ReadBalanceOwners
+        // choice=8 corresponds to ChainOwnership
+        // choice=9 corresponds to ReadDataBlob
+        CryptoHash read_data_blob;
+        // choice=10 corresponds to AssertDataBlobExists
+        CryptoHash assert_data_blob_exists;
     }
 
     function BaseRuntimePrecompile_case_chain_id()
@@ -195,9 +276,21 @@ library LineraTypes {
         pure
         returns (BaseRuntimePrecompile memory)
     {
-        BaseRuntimePrecompile_ReadDataBlob memory read_data_blob;
-        BaseRuntimePrecompile_AssertDataBlobExists memory assert_data_blob_exists;
-        return BaseRuntimePrecompile(uint8(0), read_data_blob, assert_data_blob_exists);
+        AccountOwner memory read_owner_balance;
+        CryptoHash memory read_data_blob;
+        CryptoHash memory assert_data_blob_exists;
+        return BaseRuntimePrecompile(uint8(0), read_owner_balance, read_data_blob, assert_data_blob_exists);
+    }
+
+    function BaseRuntimePrecompile_case_block_height()
+        internal
+        pure
+        returns (BaseRuntimePrecompile memory)
+    {
+        AccountOwner memory read_owner_balance;
+        CryptoHash memory read_data_blob;
+        CryptoHash memory assert_data_blob_exists;
+        return BaseRuntimePrecompile(uint8(1), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
     function BaseRuntimePrecompile_case_application_creator_chain_id()
@@ -205,9 +298,64 @@ library LineraTypes {
         pure
         returns (BaseRuntimePrecompile memory)
     {
-        BaseRuntimePrecompile_ReadDataBlob memory read_data_blob;
-        BaseRuntimePrecompile_AssertDataBlobExists memory assert_data_blob_exists;
-        return BaseRuntimePrecompile(uint8(1), read_data_blob, assert_data_blob_exists);
+        AccountOwner memory read_owner_balance;
+        CryptoHash memory read_data_blob;
+        CryptoHash memory assert_data_blob_exists;
+        return BaseRuntimePrecompile(uint8(2), read_owner_balance, read_data_blob, assert_data_blob_exists);
+    }
+
+    function BaseRuntimePrecompile_case_read_system_timestamp()
+        internal
+        pure
+        returns (BaseRuntimePrecompile memory)
+    {
+        AccountOwner memory read_owner_balance;
+        CryptoHash memory read_data_blob;
+        CryptoHash memory assert_data_blob_exists;
+        return BaseRuntimePrecompile(uint8(3), read_owner_balance, read_data_blob, assert_data_blob_exists);
+    }
+
+    function BaseRuntimePrecompile_case_read_chain_balance()
+        internal
+        pure
+        returns (BaseRuntimePrecompile memory)
+    {
+        AccountOwner memory read_owner_balance;
+        CryptoHash memory read_data_blob;
+        CryptoHash memory assert_data_blob_exists;
+        return BaseRuntimePrecompile(uint8(4), read_owner_balance, read_data_blob, assert_data_blob_exists);
+    }
+
+    function BaseRuntimePrecompile_case_read_owner_balance(AccountOwner memory read_owner_balance)
+        internal
+        pure
+        returns (BaseRuntimePrecompile memory)
+    {
+        CryptoHash memory read_data_blob;
+        CryptoHash memory assert_data_blob_exists;
+        return BaseRuntimePrecompile(uint8(5), read_owner_balance, read_data_blob, assert_data_blob_exists);
+    }
+
+    function BaseRuntimePrecompile_case_read_owner_balances()
+        internal
+        pure
+        returns (BaseRuntimePrecompile memory)
+    {
+        AccountOwner memory read_owner_balance;
+        CryptoHash memory read_data_blob;
+        CryptoHash memory assert_data_blob_exists;
+        return BaseRuntimePrecompile(uint8(6), read_owner_balance, read_data_blob, assert_data_blob_exists);
+    }
+
+    function BaseRuntimePrecompile_case_read_balance_owners()
+        internal
+        pure
+        returns (BaseRuntimePrecompile memory)
+    {
+        AccountOwner memory read_owner_balance;
+        CryptoHash memory read_data_blob;
+        CryptoHash memory assert_data_blob_exists;
+        return BaseRuntimePrecompile(uint8(7), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
     function BaseRuntimePrecompile_case_chain_ownership()
@@ -215,27 +363,30 @@ library LineraTypes {
         pure
         returns (BaseRuntimePrecompile memory)
     {
-        BaseRuntimePrecompile_ReadDataBlob memory read_data_blob;
-        BaseRuntimePrecompile_AssertDataBlobExists memory assert_data_blob_exists;
-        return BaseRuntimePrecompile(uint8(2), read_data_blob, assert_data_blob_exists);
+        AccountOwner memory read_owner_balance;
+        CryptoHash memory read_data_blob;
+        CryptoHash memory assert_data_blob_exists;
+        return BaseRuntimePrecompile(uint8(8), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
-    function BaseRuntimePrecompile_case_read_data_blob(BaseRuntimePrecompile_ReadDataBlob memory read_data_blob)
+    function BaseRuntimePrecompile_case_read_data_blob(CryptoHash memory read_data_blob)
         internal
         pure
         returns (BaseRuntimePrecompile memory)
     {
-        BaseRuntimePrecompile_AssertDataBlobExists memory assert_data_blob_exists;
-        return BaseRuntimePrecompile(uint8(3), read_data_blob, assert_data_blob_exists);
+        AccountOwner memory read_owner_balance;
+        CryptoHash memory assert_data_blob_exists;
+        return BaseRuntimePrecompile(uint8(9), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
-    function BaseRuntimePrecompile_case_assert_data_blob_exists(BaseRuntimePrecompile_AssertDataBlobExists memory assert_data_blob_exists)
+    function BaseRuntimePrecompile_case_assert_data_blob_exists(CryptoHash memory assert_data_blob_exists)
         internal
         pure
         returns (BaseRuntimePrecompile memory)
     {
-        BaseRuntimePrecompile_ReadDataBlob memory read_data_blob;
-        return BaseRuntimePrecompile(uint8(4), read_data_blob, assert_data_blob_exists);
+        AccountOwner memory read_owner_balance;
+        CryptoHash memory read_data_blob;
+        return BaseRuntimePrecompile(uint8(10), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
     function bcs_serialize_BaseRuntimePrecompile(BaseRuntimePrecompile memory input)
@@ -243,11 +394,14 @@ library LineraTypes {
         pure
         returns (bytes memory)
     {
-        if (input.choice == 3) {
-            return abi.encodePacked(input.choice, bcs_serialize_BaseRuntimePrecompile_ReadDataBlob(input.read_data_blob));
+        if (input.choice == 5) {
+            return abi.encodePacked(input.choice, bcs_serialize_AccountOwner(input.read_owner_balance));
         }
-        if (input.choice == 4) {
-            return abi.encodePacked(input.choice, bcs_serialize_BaseRuntimePrecompile_AssertDataBlobExists(input.assert_data_blob_exists));
+        if (input.choice == 9) {
+            return abi.encodePacked(input.choice, bcs_serialize_CryptoHash(input.read_data_blob));
+        }
+        if (input.choice == 10) {
+            return abi.encodePacked(input.choice, bcs_serialize_CryptoHash(input.assert_data_blob_exists));
         }
         return abi.encodePacked(input.choice);
     }
@@ -260,16 +414,20 @@ library LineraTypes {
         uint256 new_pos;
         uint8 choice;
         (new_pos, choice) = bcs_deserialize_offset_uint8(pos, input);
-        BaseRuntimePrecompile_ReadDataBlob memory read_data_blob;
-        if (choice == 3) {
-            (new_pos, read_data_blob) = bcs_deserialize_offset_BaseRuntimePrecompile_ReadDataBlob(new_pos, input);
+        AccountOwner memory read_owner_balance;
+        if (choice == 5) {
+            (new_pos, read_owner_balance) = bcs_deserialize_offset_AccountOwner(new_pos, input);
         }
-        BaseRuntimePrecompile_AssertDataBlobExists memory assert_data_blob_exists;
-        if (choice == 4) {
-            (new_pos, assert_data_blob_exists) = bcs_deserialize_offset_BaseRuntimePrecompile_AssertDataBlobExists(new_pos, input);
+        CryptoHash memory read_data_blob;
+        if (choice == 9) {
+            (new_pos, read_data_blob) = bcs_deserialize_offset_CryptoHash(new_pos, input);
         }
-        require(choice < 5);
-        return (new_pos, BaseRuntimePrecompile(choice, read_data_blob, assert_data_blob_exists));
+        CryptoHash memory assert_data_blob_exists;
+        if (choice == 10) {
+            (new_pos, assert_data_blob_exists) = bcs_deserialize_offset_CryptoHash(new_pos, input);
+        }
+        require(choice < 11);
+        return (new_pos, BaseRuntimePrecompile(choice, read_owner_balance, read_data_blob, assert_data_blob_exists));
     }
 
     function bcs_deserialize_BaseRuntimePrecompile(bytes memory input)
@@ -280,76 +438,6 @@ library LineraTypes {
         uint256 new_pos;
         BaseRuntimePrecompile memory value;
         (new_pos, value) = bcs_deserialize_offset_BaseRuntimePrecompile(0, input);
-        require(new_pos == input.length, "incomplete deserialization");
-        return value;
-    }
-
-    struct BaseRuntimePrecompile_AssertDataBlobExists {
-        CryptoHash hash;
-    }
-
-    function bcs_serialize_BaseRuntimePrecompile_AssertDataBlobExists(BaseRuntimePrecompile_AssertDataBlobExists memory input)
-        internal
-        pure
-        returns (bytes memory)
-    {
-        return bcs_serialize_CryptoHash(input.hash);
-    }
-
-    function bcs_deserialize_offset_BaseRuntimePrecompile_AssertDataBlobExists(uint256 pos, bytes memory input)
-        internal
-        pure
-        returns (uint256, BaseRuntimePrecompile_AssertDataBlobExists memory)
-    {
-        uint256 new_pos;
-        CryptoHash memory hash;
-        (new_pos, hash) = bcs_deserialize_offset_CryptoHash(pos, input);
-        return (new_pos, BaseRuntimePrecompile_AssertDataBlobExists(hash));
-    }
-
-    function bcs_deserialize_BaseRuntimePrecompile_AssertDataBlobExists(bytes memory input)
-        internal
-        pure
-        returns (BaseRuntimePrecompile_AssertDataBlobExists memory)
-    {
-        uint256 new_pos;
-        BaseRuntimePrecompile_AssertDataBlobExists memory value;
-        (new_pos, value) = bcs_deserialize_offset_BaseRuntimePrecompile_AssertDataBlobExists(0, input);
-        require(new_pos == input.length, "incomplete deserialization");
-        return value;
-    }
-
-    struct BaseRuntimePrecompile_ReadDataBlob {
-        CryptoHash hash;
-    }
-
-    function bcs_serialize_BaseRuntimePrecompile_ReadDataBlob(BaseRuntimePrecompile_ReadDataBlob memory input)
-        internal
-        pure
-        returns (bytes memory)
-    {
-        return bcs_serialize_CryptoHash(input.hash);
-    }
-
-    function bcs_deserialize_offset_BaseRuntimePrecompile_ReadDataBlob(uint256 pos, bytes memory input)
-        internal
-        pure
-        returns (uint256, BaseRuntimePrecompile_ReadDataBlob memory)
-    {
-        uint256 new_pos;
-        CryptoHash memory hash;
-        (new_pos, hash) = bcs_deserialize_offset_CryptoHash(pos, input);
-        return (new_pos, BaseRuntimePrecompile_ReadDataBlob(hash));
-    }
-
-    function bcs_deserialize_BaseRuntimePrecompile_ReadDataBlob(bytes memory input)
-        internal
-        pure
-        returns (BaseRuntimePrecompile_ReadDataBlob memory)
-    {
-        uint256 new_pos;
-        BaseRuntimePrecompile_ReadDataBlob memory value;
-        (new_pos, value) = bcs_deserialize_offset_BaseRuntimePrecompile_ReadDataBlob(0, input);
         require(new_pos == input.length, "incomplete deserialization");
         return value;
     }
@@ -477,48 +565,85 @@ library LineraTypes {
 
     struct ContractRuntimePrecompile {
         uint8 choice;
-        // choice=0 corresponds to TryCallApplication
-        ContractRuntimePrecompile_TryCallApplication try_call_application;
-        // choice=1 corresponds to ValidationRound
-        // choice=2 corresponds to SendMessage
+        // choice=0 corresponds to AuthenticatedSigner
+        // choice=1 corresponds to MessageId
+        // choice=2 corresponds to MessageIsBouncing
+        // choice=3 corresponds to AuthenticatedCallerId
+        // choice=4 corresponds to SendMessage
         ContractRuntimePrecompile_SendMessage send_message;
-        // choice=3 corresponds to MessageId
-        // choice=4 corresponds to MessageIsBouncing
-        // choice=5 corresponds to Emit
+        // choice=5 corresponds to TryCallApplication
+        ContractRuntimePrecompile_TryCallApplication try_call_application;
+        // choice=6 corresponds to Emit
         ContractRuntimePrecompile_Emit emit_;
-        // choice=6 corresponds to ReadEvent
+        // choice=7 corresponds to ReadEvent
         ContractRuntimePrecompile_ReadEvent read_event;
-        // choice=7 corresponds to SubscribeToEvents
+        // choice=8 corresponds to SubscribeToEvents
         ContractRuntimePrecompile_SubscribeToEvents subscribe_to_events;
-        // choice=8 corresponds to UnsubscribeFromEvents
+        // choice=9 corresponds to UnsubscribeFromEvents
         ContractRuntimePrecompile_UnsubscribeFromEvents unsubscribe_from_events;
+        // choice=10 corresponds to QueryService
+        ContractRuntimePrecompile_QueryService query_service;
+        // choice=11 corresponds to ValidationRound
     }
 
-    function ContractRuntimePrecompile_case_try_call_application(ContractRuntimePrecompile_TryCallApplication memory try_call_application)
+    function ContractRuntimePrecompile_case_authenticated_signer()
         internal
         pure
         returns (ContractRuntimePrecompile memory)
     {
         ContractRuntimePrecompile_SendMessage memory send_message;
-        ContractRuntimePrecompile_Emit memory emit_;
-        ContractRuntimePrecompile_ReadEvent memory read_event;
-        ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events;
-        ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events;
-        return ContractRuntimePrecompile(uint8(0), try_call_application, send_message, emit_, read_event, subscribe_to_events, unsubscribe_from_events);
-    }
-
-    function ContractRuntimePrecompile_case_validation_round()
-        internal
-        pure
-        returns (ContractRuntimePrecompile memory)
-    {
         ContractRuntimePrecompile_TryCallApplication memory try_call_application;
-        ContractRuntimePrecompile_SendMessage memory send_message;
         ContractRuntimePrecompile_Emit memory emit_;
         ContractRuntimePrecompile_ReadEvent memory read_event;
         ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events;
         ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events;
-        return ContractRuntimePrecompile(uint8(1), try_call_application, send_message, emit_, read_event, subscribe_to_events, unsubscribe_from_events);
+        ContractRuntimePrecompile_QueryService memory query_service;
+        return ContractRuntimePrecompile(uint8(0), send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service);
+    }
+
+    function ContractRuntimePrecompile_case_message_id()
+        internal
+        pure
+        returns (ContractRuntimePrecompile memory)
+    {
+        ContractRuntimePrecompile_SendMessage memory send_message;
+        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
+        ContractRuntimePrecompile_Emit memory emit_;
+        ContractRuntimePrecompile_ReadEvent memory read_event;
+        ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events;
+        ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events;
+        ContractRuntimePrecompile_QueryService memory query_service;
+        return ContractRuntimePrecompile(uint8(1), send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service);
+    }
+
+    function ContractRuntimePrecompile_case_message_is_bouncing()
+        internal
+        pure
+        returns (ContractRuntimePrecompile memory)
+    {
+        ContractRuntimePrecompile_SendMessage memory send_message;
+        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
+        ContractRuntimePrecompile_Emit memory emit_;
+        ContractRuntimePrecompile_ReadEvent memory read_event;
+        ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events;
+        ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events;
+        ContractRuntimePrecompile_QueryService memory query_service;
+        return ContractRuntimePrecompile(uint8(2), send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service);
+    }
+
+    function ContractRuntimePrecompile_case_authenticated_caller_id()
+        internal
+        pure
+        returns (ContractRuntimePrecompile memory)
+    {
+        ContractRuntimePrecompile_SendMessage memory send_message;
+        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
+        ContractRuntimePrecompile_Emit memory emit_;
+        ContractRuntimePrecompile_ReadEvent memory read_event;
+        ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events;
+        ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events;
+        ContractRuntimePrecompile_QueryService memory query_service;
+        return ContractRuntimePrecompile(uint8(3), send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service);
     }
 
     function ContractRuntimePrecompile_case_send_message(ContractRuntimePrecompile_SendMessage memory send_message)
@@ -531,35 +656,22 @@ library LineraTypes {
         ContractRuntimePrecompile_ReadEvent memory read_event;
         ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events;
         ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events;
-        return ContractRuntimePrecompile(uint8(2), try_call_application, send_message, emit_, read_event, subscribe_to_events, unsubscribe_from_events);
+        ContractRuntimePrecompile_QueryService memory query_service;
+        return ContractRuntimePrecompile(uint8(4), send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service);
     }
 
-    function ContractRuntimePrecompile_case_message_id()
+    function ContractRuntimePrecompile_case_try_call_application(ContractRuntimePrecompile_TryCallApplication memory try_call_application)
         internal
         pure
         returns (ContractRuntimePrecompile memory)
     {
-        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
         ContractRuntimePrecompile_SendMessage memory send_message;
         ContractRuntimePrecompile_Emit memory emit_;
         ContractRuntimePrecompile_ReadEvent memory read_event;
         ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events;
         ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events;
-        return ContractRuntimePrecompile(uint8(3), try_call_application, send_message, emit_, read_event, subscribe_to_events, unsubscribe_from_events);
-    }
-
-    function ContractRuntimePrecompile_case_message_is_bouncing()
-        internal
-        pure
-        returns (ContractRuntimePrecompile memory)
-    {
-        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
-        ContractRuntimePrecompile_SendMessage memory send_message;
-        ContractRuntimePrecompile_Emit memory emit_;
-        ContractRuntimePrecompile_ReadEvent memory read_event;
-        ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events;
-        ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events;
-        return ContractRuntimePrecompile(uint8(4), try_call_application, send_message, emit_, read_event, subscribe_to_events, unsubscribe_from_events);
+        ContractRuntimePrecompile_QueryService memory query_service;
+        return ContractRuntimePrecompile(uint8(5), send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service);
     }
 
     function ContractRuntimePrecompile_case_emit(ContractRuntimePrecompile_Emit memory emit_)
@@ -567,12 +679,13 @@ library LineraTypes {
         pure
         returns (ContractRuntimePrecompile memory)
     {
-        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
         ContractRuntimePrecompile_SendMessage memory send_message;
+        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
         ContractRuntimePrecompile_ReadEvent memory read_event;
         ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events;
         ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events;
-        return ContractRuntimePrecompile(uint8(5), try_call_application, send_message, emit_, read_event, subscribe_to_events, unsubscribe_from_events);
+        ContractRuntimePrecompile_QueryService memory query_service;
+        return ContractRuntimePrecompile(uint8(6), send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service);
     }
 
     function ContractRuntimePrecompile_case_read_event(ContractRuntimePrecompile_ReadEvent memory read_event)
@@ -580,12 +693,13 @@ library LineraTypes {
         pure
         returns (ContractRuntimePrecompile memory)
     {
-        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
         ContractRuntimePrecompile_SendMessage memory send_message;
+        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
         ContractRuntimePrecompile_Emit memory emit_;
         ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events;
         ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events;
-        return ContractRuntimePrecompile(uint8(6), try_call_application, send_message, emit_, read_event, subscribe_to_events, unsubscribe_from_events);
+        ContractRuntimePrecompile_QueryService memory query_service;
+        return ContractRuntimePrecompile(uint8(7), send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service);
     }
 
     function ContractRuntimePrecompile_case_subscribe_to_events(ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events)
@@ -593,12 +707,13 @@ library LineraTypes {
         pure
         returns (ContractRuntimePrecompile memory)
     {
-        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
         ContractRuntimePrecompile_SendMessage memory send_message;
+        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
         ContractRuntimePrecompile_Emit memory emit_;
         ContractRuntimePrecompile_ReadEvent memory read_event;
         ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events;
-        return ContractRuntimePrecompile(uint8(7), try_call_application, send_message, emit_, read_event, subscribe_to_events, unsubscribe_from_events);
+        ContractRuntimePrecompile_QueryService memory query_service;
+        return ContractRuntimePrecompile(uint8(8), send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service);
     }
 
     function ContractRuntimePrecompile_case_unsubscribe_from_events(ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events)
@@ -606,12 +721,42 @@ library LineraTypes {
         pure
         returns (ContractRuntimePrecompile memory)
     {
-        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
         ContractRuntimePrecompile_SendMessage memory send_message;
+        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
         ContractRuntimePrecompile_Emit memory emit_;
         ContractRuntimePrecompile_ReadEvent memory read_event;
         ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events;
-        return ContractRuntimePrecompile(uint8(8), try_call_application, send_message, emit_, read_event, subscribe_to_events, unsubscribe_from_events);
+        ContractRuntimePrecompile_QueryService memory query_service;
+        return ContractRuntimePrecompile(uint8(9), send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service);
+    }
+
+    function ContractRuntimePrecompile_case_query_service(ContractRuntimePrecompile_QueryService memory query_service)
+        internal
+        pure
+        returns (ContractRuntimePrecompile memory)
+    {
+        ContractRuntimePrecompile_SendMessage memory send_message;
+        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
+        ContractRuntimePrecompile_Emit memory emit_;
+        ContractRuntimePrecompile_ReadEvent memory read_event;
+        ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events;
+        ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events;
+        return ContractRuntimePrecompile(uint8(10), send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service);
+    }
+
+    function ContractRuntimePrecompile_case_validation_round()
+        internal
+        pure
+        returns (ContractRuntimePrecompile memory)
+    {
+        ContractRuntimePrecompile_SendMessage memory send_message;
+        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
+        ContractRuntimePrecompile_Emit memory emit_;
+        ContractRuntimePrecompile_ReadEvent memory read_event;
+        ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events;
+        ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events;
+        ContractRuntimePrecompile_QueryService memory query_service;
+        return ContractRuntimePrecompile(uint8(11), send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service);
     }
 
     function bcs_serialize_ContractRuntimePrecompile(ContractRuntimePrecompile memory input)
@@ -619,23 +764,26 @@ library LineraTypes {
         pure
         returns (bytes memory)
     {
-        if (input.choice == 0) {
-            return abi.encodePacked(input.choice, bcs_serialize_ContractRuntimePrecompile_TryCallApplication(input.try_call_application));
-        }
-        if (input.choice == 2) {
+        if (input.choice == 4) {
             return abi.encodePacked(input.choice, bcs_serialize_ContractRuntimePrecompile_SendMessage(input.send_message));
         }
         if (input.choice == 5) {
-            return abi.encodePacked(input.choice, bcs_serialize_ContractRuntimePrecompile_Emit(input.emit_));
+            return abi.encodePacked(input.choice, bcs_serialize_ContractRuntimePrecompile_TryCallApplication(input.try_call_application));
         }
         if (input.choice == 6) {
-            return abi.encodePacked(input.choice, bcs_serialize_ContractRuntimePrecompile_ReadEvent(input.read_event));
+            return abi.encodePacked(input.choice, bcs_serialize_ContractRuntimePrecompile_Emit(input.emit_));
         }
         if (input.choice == 7) {
-            return abi.encodePacked(input.choice, bcs_serialize_ContractRuntimePrecompile_SubscribeToEvents(input.subscribe_to_events));
+            return abi.encodePacked(input.choice, bcs_serialize_ContractRuntimePrecompile_ReadEvent(input.read_event));
         }
         if (input.choice == 8) {
+            return abi.encodePacked(input.choice, bcs_serialize_ContractRuntimePrecompile_SubscribeToEvents(input.subscribe_to_events));
+        }
+        if (input.choice == 9) {
             return abi.encodePacked(input.choice, bcs_serialize_ContractRuntimePrecompile_UnsubscribeFromEvents(input.unsubscribe_from_events));
+        }
+        if (input.choice == 10) {
+            return abi.encodePacked(input.choice, bcs_serialize_ContractRuntimePrecompile_QueryService(input.query_service));
         }
         return abi.encodePacked(input.choice);
     }
@@ -648,32 +796,36 @@ library LineraTypes {
         uint256 new_pos;
         uint8 choice;
         (new_pos, choice) = bcs_deserialize_offset_uint8(pos, input);
-        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
-        if (choice == 0) {
-            (new_pos, try_call_application) = bcs_deserialize_offset_ContractRuntimePrecompile_TryCallApplication(new_pos, input);
-        }
         ContractRuntimePrecompile_SendMessage memory send_message;
-        if (choice == 2) {
+        if (choice == 4) {
             (new_pos, send_message) = bcs_deserialize_offset_ContractRuntimePrecompile_SendMessage(new_pos, input);
         }
-        ContractRuntimePrecompile_Emit memory emit_;
+        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
         if (choice == 5) {
+            (new_pos, try_call_application) = bcs_deserialize_offset_ContractRuntimePrecompile_TryCallApplication(new_pos, input);
+        }
+        ContractRuntimePrecompile_Emit memory emit_;
+        if (choice == 6) {
             (new_pos, emit_) = bcs_deserialize_offset_ContractRuntimePrecompile_Emit(new_pos, input);
         }
         ContractRuntimePrecompile_ReadEvent memory read_event;
-        if (choice == 6) {
+        if (choice == 7) {
             (new_pos, read_event) = bcs_deserialize_offset_ContractRuntimePrecompile_ReadEvent(new_pos, input);
         }
         ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events;
-        if (choice == 7) {
+        if (choice == 8) {
             (new_pos, subscribe_to_events) = bcs_deserialize_offset_ContractRuntimePrecompile_SubscribeToEvents(new_pos, input);
         }
         ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events;
-        if (choice == 8) {
+        if (choice == 9) {
             (new_pos, unsubscribe_from_events) = bcs_deserialize_offset_ContractRuntimePrecompile_UnsubscribeFromEvents(new_pos, input);
         }
-        require(choice < 9);
-        return (new_pos, ContractRuntimePrecompile(choice, try_call_application, send_message, emit_, read_event, subscribe_to_events, unsubscribe_from_events));
+        ContractRuntimePrecompile_QueryService memory query_service;
+        if (choice == 10) {
+            (new_pos, query_service) = bcs_deserialize_offset_ContractRuntimePrecompile_QueryService(new_pos, input);
+        }
+        require(choice < 12);
+        return (new_pos, ContractRuntimePrecompile(choice, send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service));
     }
 
     function bcs_deserialize_ContractRuntimePrecompile(bytes memory input)
@@ -723,6 +875,45 @@ library LineraTypes {
         uint256 new_pos;
         ContractRuntimePrecompile_Emit memory value;
         (new_pos, value) = bcs_deserialize_offset_ContractRuntimePrecompile_Emit(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    struct ContractRuntimePrecompile_QueryService {
+        ApplicationId application_id;
+        bytes query;
+    }
+
+    function bcs_serialize_ContractRuntimePrecompile_QueryService(ContractRuntimePrecompile_QueryService memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        bytes memory result = bcs_serialize_ApplicationId(input.application_id);
+        return abi.encodePacked(result, bcs_serialize_bytes(input.query));
+    }
+
+    function bcs_deserialize_offset_ContractRuntimePrecompile_QueryService(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, ContractRuntimePrecompile_QueryService memory)
+    {
+        uint256 new_pos;
+        ApplicationId memory application_id;
+        (new_pos, application_id) = bcs_deserialize_offset_ApplicationId(pos, input);
+        bytes memory query;
+        (new_pos, query) = bcs_deserialize_offset_bytes(new_pos, input);
+        return (new_pos, ContractRuntimePrecompile_QueryService(application_id, query));
+    }
+
+    function bcs_deserialize_ContractRuntimePrecompile_QueryService(bytes memory input)
+        internal
+        pure
+        returns (ContractRuntimePrecompile_QueryService memory)
+    {
+        uint256 new_pos;
+        ContractRuntimePrecompile_QueryService memory value;
+        (new_pos, value) = bcs_deserialize_offset_ContractRuntimePrecompile_QueryService(0, input);
         require(new_pos == input.length, "incomplete deserialization");
         return value;
     }
@@ -1110,6 +1301,76 @@ library LineraTypes {
         return value;
     }
 
+    struct OptionAccountOwner {
+        opt_AccountOwner value;
+    }
+
+    function bcs_serialize_OptionAccountOwner(OptionAccountOwner memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return bcs_serialize_opt_AccountOwner(input.value);
+    }
+
+    function bcs_deserialize_offset_OptionAccountOwner(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, OptionAccountOwner memory)
+    {
+        uint256 new_pos;
+        opt_AccountOwner memory value;
+        (new_pos, value) = bcs_deserialize_offset_opt_AccountOwner(pos, input);
+        return (new_pos, OptionAccountOwner(value));
+    }
+
+    function bcs_deserialize_OptionAccountOwner(bytes memory input)
+        internal
+        pure
+        returns (OptionAccountOwner memory)
+    {
+        uint256 new_pos;
+        OptionAccountOwner memory value;
+        (new_pos, value) = bcs_deserialize_offset_OptionAccountOwner(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    struct OptionApplicationId {
+        opt_ApplicationId value;
+    }
+
+    function bcs_serialize_OptionApplicationId(OptionApplicationId memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return bcs_serialize_opt_ApplicationId(input.value);
+    }
+
+    function bcs_deserialize_offset_OptionApplicationId(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, OptionApplicationId memory)
+    {
+        uint256 new_pos;
+        opt_ApplicationId memory value;
+        (new_pos, value) = bcs_deserialize_offset_opt_ApplicationId(pos, input);
+        return (new_pos, OptionApplicationId(value));
+    }
+
+    function bcs_deserialize_OptionApplicationId(bytes memory input)
+        internal
+        pure
+        returns (OptionApplicationId memory)
+    {
+        uint256 new_pos;
+        OptionApplicationId memory value;
+        (new_pos, value) = bcs_deserialize_offset_OptionApplicationId(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
     enum OptionBool { None, True, False }
 
     function bcs_serialize_OptionBool(OptionBool input)
@@ -1224,6 +1485,76 @@ library LineraTypes {
         uint256 new_pos;
         OptionU32 memory value;
         (new_pos, value) = bcs_deserialize_offset_OptionU32(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    struct ResponseReadBalanceOwners {
+        AccountOwner[] value;
+    }
+
+    function bcs_serialize_ResponseReadBalanceOwners(ResponseReadBalanceOwners memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return bcs_serialize_seq_AccountOwner(input.value);
+    }
+
+    function bcs_deserialize_offset_ResponseReadBalanceOwners(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, ResponseReadBalanceOwners memory)
+    {
+        uint256 new_pos;
+        AccountOwner[] memory value;
+        (new_pos, value) = bcs_deserialize_offset_seq_AccountOwner(pos, input);
+        return (new_pos, ResponseReadBalanceOwners(value));
+    }
+
+    function bcs_deserialize_ResponseReadBalanceOwners(bytes memory input)
+        internal
+        pure
+        returns (ResponseReadBalanceOwners memory)
+    {
+        uint256 new_pos;
+        ResponseReadBalanceOwners memory value;
+        (new_pos, value) = bcs_deserialize_offset_ResponseReadBalanceOwners(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    struct ResponseReadOwnerBalances {
+        AccountOwnerBalanceInner[] value;
+    }
+
+    function bcs_serialize_ResponseReadOwnerBalances(ResponseReadOwnerBalances memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return bcs_serialize_seq_AccountOwnerBalanceInner(input.value);
+    }
+
+    function bcs_deserialize_offset_ResponseReadOwnerBalances(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, ResponseReadOwnerBalances memory)
+    {
+        uint256 new_pos;
+        AccountOwnerBalanceInner[] memory value;
+        (new_pos, value) = bcs_deserialize_offset_seq_AccountOwnerBalanceInner(pos, input);
+        return (new_pos, ResponseReadOwnerBalances(value));
+    }
+
+    function bcs_deserialize_ResponseReadOwnerBalances(bytes memory input)
+        internal
+        pure
+        returns (ResponseReadOwnerBalances memory)
+    {
+        uint256 new_pos;
+        ResponseReadOwnerBalances memory value;
+        (new_pos, value) = bcs_deserialize_offset_ResponseReadOwnerBalances(0, input);
         require(new_pos == input.length, "incomplete deserialization");
         return value;
     }
@@ -1651,6 +1982,41 @@ library LineraTypes {
         return value;
     }
 
+    struct Timestamp {
+        uint64 value;
+    }
+
+    function bcs_serialize_Timestamp(Timestamp memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return bcs_serialize_uint64(input.value);
+    }
+
+    function bcs_deserialize_offset_Timestamp(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, Timestamp memory)
+    {
+        uint256 new_pos;
+        uint64 value;
+        (new_pos, value) = bcs_deserialize_offset_uint64(pos, input);
+        return (new_pos, Timestamp(value));
+    }
+
+    function bcs_deserialize_Timestamp(bytes memory input)
+        internal
+        pure
+        returns (Timestamp memory)
+    {
+        uint256 new_pos;
+        Timestamp memory value;
+        (new_pos, value) = bcs_deserialize_offset_Timestamp(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
     function bcs_serialize_bool(bool input)
         internal
         pure
@@ -1798,6 +2164,94 @@ library LineraTypes {
         uint256 new_pos;
         key_values_AccountOwner_uint64 memory value;
         (new_pos, value) = bcs_deserialize_offset_key_values_AccountOwner_uint64(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    struct opt_AccountOwner {
+        bool has_value;
+        AccountOwner value;
+    }
+
+    function bcs_serialize_opt_AccountOwner(opt_AccountOwner memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        if (input.has_value) {
+            return abi.encodePacked(uint8(1), bcs_serialize_AccountOwner(input.value));
+        } else {
+            return abi.encodePacked(uint8(0));
+        }
+    }
+
+    function bcs_deserialize_offset_opt_AccountOwner(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, opt_AccountOwner memory)
+    {
+        uint256 new_pos;
+        bool has_value;
+        (new_pos, has_value) = bcs_deserialize_offset_bool(pos, input);
+        AccountOwner memory value;
+        if (has_value) {
+            (new_pos, value) = bcs_deserialize_offset_AccountOwner(new_pos, input);
+        }
+        return (new_pos, opt_AccountOwner(has_value, value));
+    }
+
+    function bcs_deserialize_opt_AccountOwner(bytes memory input)
+        internal
+        pure
+        returns (opt_AccountOwner memory)
+    {
+        uint256 new_pos;
+        opt_AccountOwner memory value;
+        (new_pos, value) = bcs_deserialize_offset_opt_AccountOwner(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    struct opt_ApplicationId {
+        bool has_value;
+        ApplicationId value;
+    }
+
+    function bcs_serialize_opt_ApplicationId(opt_ApplicationId memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        if (input.has_value) {
+            return abi.encodePacked(uint8(1), bcs_serialize_ApplicationId(input.value));
+        } else {
+            return abi.encodePacked(uint8(0));
+        }
+    }
+
+    function bcs_deserialize_offset_opt_ApplicationId(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, opt_ApplicationId memory)
+    {
+        uint256 new_pos;
+        bool has_value;
+        (new_pos, has_value) = bcs_deserialize_offset_bool(pos, input);
+        ApplicationId memory value;
+        if (has_value) {
+            (new_pos, value) = bcs_deserialize_offset_ApplicationId(new_pos, input);
+        }
+        return (new_pos, opt_ApplicationId(has_value, value));
+    }
+
+    function bcs_deserialize_opt_ApplicationId(bytes memory input)
+        internal
+        pure
+        returns (opt_ApplicationId memory)
+    {
+        uint256 new_pos;
+        opt_ApplicationId memory value;
+        (new_pos, value) = bcs_deserialize_offset_opt_ApplicationId(0, input);
         require(new_pos == input.length, "incomplete deserialization");
         return value;
     }
@@ -1973,6 +2427,49 @@ library LineraTypes {
         uint256 new_pos;
         AccountOwner[] memory value;
         (new_pos, value) = bcs_deserialize_offset_seq_AccountOwner(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    function bcs_serialize_seq_AccountOwnerBalanceInner(AccountOwnerBalanceInner[] memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        uint256 len = input.length;
+        bytes memory result = bcs_serialize_len(len);
+        for (uint256 i=0; i<len; i++) {
+            result = abi.encodePacked(result, bcs_serialize_AccountOwnerBalanceInner(input[i]));
+        }
+        return result;
+    }
+
+    function bcs_deserialize_offset_seq_AccountOwnerBalanceInner(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, AccountOwnerBalanceInner[] memory)
+    {
+        uint256 len;
+        uint256 new_pos;
+        (new_pos, len) = bcs_deserialize_offset_len(pos, input);
+        AccountOwnerBalanceInner[] memory result;
+        result = new AccountOwnerBalanceInner[](len);
+        AccountOwnerBalanceInner memory value;
+        for (uint256 i=0; i<len; i++) {
+            (new_pos, value) = bcs_deserialize_offset_AccountOwnerBalanceInner(new_pos, input);
+            result[i] = value;
+        }
+        return (new_pos, result);
+    }
+
+    function bcs_deserialize_seq_AccountOwnerBalanceInner(bytes memory input)
+        internal
+        pure
+        returns (AccountOwnerBalanceInner[] memory)
+    {
+        uint256 new_pos;
+        AccountOwnerBalanceInner[] memory value;
+        (new_pos, value) = bcs_deserialize_offset_seq_AccountOwnerBalanceInner(0, input);
         require(new_pos == input.length, "incomplete deserialization");
         return value;
     }

--- a/linera-execution/solidity/LineraTypes.yaml
+++ b/linera-execution/solidity/LineraTypes.yaml
@@ -41,6 +41,35 @@ AccountOwner:
           TUPLEARRAY:
             CONTENT: U8
             SIZE: 20
+Timestamp:
+  NEWTYPESTRUCT: U64
+Amount:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 32
+AccountOwnerBalanceInner:
+  STRUCT:
+    - account_owner:
+        TYPENAME: AccountOwner
+    - balance:
+        TYPENAME: Amount
+OptionAccountOwner:
+  NEWTYPESTRUCT:
+    OPTION:
+      TYPENAME: AccountOwner
+OptionApplicationId:
+  NEWTYPESTRUCT:
+    OPTION:
+      TYPENAME: ApplicationId
+ResponseReadOwnerBalances:
+  NEWTYPESTRUCT:
+    SEQ:
+      TYPENAME: AccountOwnerBalanceInner
+ResponseReadBalanceOwners:
+  NEWTYPESTRUCT:
+    SEQ:
+      TYPENAME: AccountOwner
 CryptoHash:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -58,6 +87,8 @@ BlockHeight:
 ChainId:
   NEWTYPESTRUCT:
     TYPENAME: CryptoHash
+BlockHeight:
+  NEWTYPESTRUCT: U64
 MessageIsBouncing:
   NEWTYPESTRUCT:
     OPTION: BOOL
@@ -82,46 +113,60 @@ BaseRuntimePrecompile:
     0:
       ChainId: UNIT
     1:
-      ApplicationCreatorChainId: UNIT
+      BlockHeight: UNIT
     2:
-      ChainOwnership: UNIT
+      ApplicationCreatorChainId: UNIT
     3:
-      ReadDataBlob:
-        STRUCT:
-          - hash:
-              TYPENAME: CryptoHash
+      ReadSystemTimestamp: UNIT
     4:
+      ReadChainBalance: UNIT
+    5:
+      ReadOwnerBalance:
+        NEWTYPE:
+          TYPENAME: AccountOwner
+    6:
+      ReadOwnerBalances: UNIT
+    7:
+      ReadBalanceOwners: UNIT
+    8:
+      ChainOwnership: UNIT
+    9:
+      ReadDataBlob:
+        NEWTYPE:
+          TYPENAME: CryptoHash
+    10:
       AssertDataBlobExists:
-        STRUCT:
-          - hash:
-              TYPENAME: CryptoHash
+        NEWTYPE:
+          TYPENAME: CryptoHash
 ContractRuntimePrecompile:
   ENUM:
     0:
-      TryCallApplication:
-        STRUCT:
-          - target:
-              TYPENAME: ApplicationId
-          - argument: BYTES
+      AuthenticatedSigner: UNIT
     1:
-      ValidationRound: UNIT
+      MessageId: UNIT
     2:
+      MessageIsBouncing: UNIT
+    3:
+      AuthenticatedCallerId: UNIT
+    4:
       SendMessage:
         STRUCT:
           - destination:
               TYPENAME: ChainId
           - message: BYTES
-    3:
-      MessageId: UNIT
-    4:
-      MessageIsBouncing: UNIT
     5:
+      TryCallApplication:
+        STRUCT:
+          - target:
+              TYPENAME: ApplicationId
+          - argument: BYTES
+    6:
       Emit:
         STRUCT:
           - stream_name:
               TYPENAME: StreamName
           - value: BYTES
-    6:
+    7:
       ReadEvent:
         STRUCT:
           - chain_id:
@@ -129,7 +174,7 @@ ContractRuntimePrecompile:
           - stream_name:
               TYPENAME: StreamName
           - index: U32
-    7:
+    8:
       SubscribeToEvents:
         STRUCT:
           - chain_id:
@@ -138,8 +183,7 @@ ContractRuntimePrecompile:
               TYPENAME: ApplicationId
           - stream_name:
               TYPENAME: StreamName
-
-    8:
+    9:
       UnsubscribeFromEvents:
         STRUCT:
           - chain_id:
@@ -148,6 +192,14 @@ ContractRuntimePrecompile:
               TYPENAME: ApplicationId
           - stream_name:
               TYPENAME: StreamName
+    10:
+      QueryService:
+        STRUCT:
+          - application_id:
+              TYPENAME: ApplicationId
+          - query: BYTES
+    11:
+      ValidationRound: UNIT
 ServiceRuntimePrecompile:
   ENUM:
     0:

--- a/linera-execution/src/evm/data_types.rs
+++ b/linera-execution/src/evm/data_types.rs
@@ -1,0 +1,60 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use alloy_primitives::U256;
+use linera_base::data_types::Amount;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug)]
+/// An encapsulation of U256 in order to have a specific serialization
+pub struct AmountU256(U256);
+
+impl Serialize for AmountU256 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeTuple;
+        let v: [u8; 32] = self.0.to_be_bytes();
+        let mut tuple = serializer.serialize_tuple(32)?;
+        for byte in v.iter() {
+            tuple.serialize_element(byte)?;
+        }
+        tuple.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for AmountU256 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes: [u8; 32] = Deserialize::deserialize(deserializer)?;
+        let value = U256::from_be_bytes(bytes);
+        Ok(AmountU256(value))
+    }
+}
+
+impl From<Amount> for AmountU256 {
+    fn from(amount: Amount) -> AmountU256 {
+        AmountU256(amount.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use linera_base::data_types::Amount;
+
+    use crate::evm::data_types::AmountU256;
+
+    #[test]
+    fn check_bcs_serialization() -> anyhow::Result<()> {
+        let value = 7837438347454859505557763535536363636;
+        let value = Amount::from_tokens(value);
+        let value = AmountU256::from(value);
+        let vec = bcs::to_bytes(&value)?;
+        assert_eq!(vec.len(), 32);
+        assert_eq!(value, bcs::from_bytes(&vec)?);
+        Ok(())
+    }
+}

--- a/linera-execution/src/evm/mod.rs
+++ b/linera-execution/src/evm/mod.rs
@@ -7,6 +7,7 @@
 
 #![cfg(with_revm)]
 
+mod data_types;
 mod database;
 pub mod revm;
 

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -336,7 +336,7 @@ async fn test_basic_evm_features() -> anyhow::Result<()> {
     sol! {
         function failing_function();
         function test_precompile_sha256();
-    function check_contract_address(address evm_address);
+        function check_contract_address(address evm_address);
     }
 
     let constructor_argument = Vec::<u8>::new();

--- a/linera-service/tests/fixtures/erc20_shared.sol
+++ b/linera-service/tests/fixtures/erc20_shared.sol
@@ -22,7 +22,6 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 import "./Linera.sol";
-import "./LineraTypes.sol";
 
 /**
  * @dev Implementation of the {IERC20} interface.
@@ -73,9 +72,9 @@ contract ERC20_shared is Context, IERC20, IERC20Errors {
      */
     function execute_message(bytes memory input) external {
         (address source, address destination, uint256 amount) = abi.decode(input, (address, address, uint256));
-        LineraTypes.OptionBool result = Linera.message_is_bouncing().value;
-        require(result != LineraTypes.OptionBool.None);
-        if (result == LineraTypes.OptionBool.True) {
+        Linera.OptionBool result = Linera.message_is_bouncing();
+        require(result != Linera.OptionBool.None);
+        if (result == Linera.OptionBool.True) {
             _mint(source, amount);
         } else {
             _mint(destination, amount);

--- a/linera-service/tests/fixtures/evm_example_execute_message.sol
+++ b/linera-service/tests/fixtures/evm_example_execute_message.sol
@@ -6,7 +6,7 @@ import "./Linera.sol";
 
 contract ExampleExecuteMessage {
     uint64 value;
-    LineraTypes.MessageId last_message_id;
+    Linera.MessageId last_message_id;
 
     constructor(uint64 test_value) {
        require(test_value == 42);
@@ -20,7 +20,7 @@ contract ExampleExecuteMessage {
     function execute_message(bytes memory input) external {
         uint64 increment = abi.decode(input, (uint64));
         value = value + increment;
-        LineraTypes.opt_MessageId memory opt_message_id = Linera.message_id();
+        Linera.opt_MessageId memory opt_message_id = Linera.message_id();
         require(opt_message_id.has_value);
         last_message_id = opt_message_id.value;
     }

--- a/linera-service/tests/fixtures/evm_example_process_streams.sol
+++ b/linera-service/tests/fixtures/evm_example_process_streams.sol
@@ -3,7 +3,6 @@
 pragma solidity ^0.8.0;
 
 import "./Linera.sol";
-import "./LineraTypes.sol";
 
 contract ExampleProcessStreams {
     uint64 total_value;
@@ -22,12 +21,12 @@ contract ExampleProcessStreams {
         Linera.linera_emit(stream_name, value);
     }
 
-    function process_streams(LineraTypes.StreamUpdate[] memory streams) external {
+    function process_streams(Linera.StreamUpdate[] memory streams) external {
         bytes memory stream_name = abi.encodePacked(stream_key);
         uint256 n_entries = streams.length;
         for (uint256 i=0; i<n_entries; i++) {
-            LineraTypes.StreamUpdate memory update = streams[i];
-            bytes32 chain_id = update.chain_id.value.value;
+            Linera.StreamUpdate memory update = streams[i];
+            bytes32 chain_id = update.chain_id.value;
             for (uint32 index=update.previous_index; index<update.next_index; index++) {
                 bytes memory result = Linera.read_event(chain_id, stream_name, index);
                 uint64 value = abi.decode(result, (uint64));

--- a/linera-service/tests/fixtures/evm_test_linera_features.sol
+++ b/linera-service/tests/fixtures/evm_test_linera_features.sol
@@ -6,9 +6,9 @@ import "./Linera.sol";
 
 contract ExampleLineraFeatures {
     function test_chain_id() external {
-        LineraTypes.ChainId memory chain_id = Linera.chain_id();
-        LineraTypes.ChainId memory creator_chain_id = Linera.application_creator_chain_id();
-        require(chain_id.value.value == creator_chain_id.value.value);
+        Linera.ChainId memory chain_id = Linera.chain_id();
+        Linera.ChainId memory creator_chain_id = Linera.application_creator_chain_id();
+        require(chain_id.value == creator_chain_id.value);
     }
 
     function test_read_data_blob(bytes32 hash, uint32 len) external {
@@ -21,8 +21,30 @@ contract ExampleLineraFeatures {
     }
 
     function test_chain_ownership() external {
-        LineraTypes.ChainOwnership memory chain_ownership = Linera.chain_ownership();
+        Linera.ChainOwnership memory chain_ownership = Linera.chain_ownership();
         require(chain_ownership.super_owners.length == 0);
         require(chain_ownership.owners.length == 1);
+    }
+
+    function test_authenticated_signer_caller_id() external {
+        Linera.opt_AccountOwner memory signer = Linera.authenticated_signer();
+        require(signer.has_value);
+        require(signer.value.choice == 2);
+        address signer_address = address(signer.value.address20);
+        require(signer_address == msg.sender);
+        Linera.opt_ApplicationId memory caller_id = Linera.authenticated_caller_id();
+        require(caller_id.has_value == false);
+    }
+
+    function test_chain_balance(uint256 expected_balance) external {
+        uint256 balance = Linera.read_chain_balance();
+        require(balance == expected_balance);
+    }
+
+    function test_read_owners() external {
+        Linera.AccountOwnerBalance[] memory owner_balances = Linera.read_owner_balances();
+        require(owner_balances.length == 0);
+        Linera.AccountOwner[] memory owners = Linera.read_balance_owners();
+        require(owners.length == 0);
     }
 }


### PR DESCRIPTION
## Motivation

We want the EVM applications to be able to fully access the Linera functionalities.
Here we extend it by adding access to the Linera balances, authenticated signer
as well as other features.

## Proposal

The work simply adds the following functionalities to EVM applications:
* chain_timestamp
* chain_balance
* owner_balance
* owner_balances
* balance_owners
* authenticated_signer
* authenticated_caller_id
* query_service

As it was it looked simple but several problems showed up:
* New types have to be added, but since we do not have a type `uint256` in YAML file, we have to use a `[u8; 32]`.
* This forces a conversion to `uint256` to do in the code. The problem is that this externalize some types, so we have an `AccountOwnerBalance` and `AccountOwnerBalanceInner`.
* In order to force having all the types in `LineraTypes` and so in order to have a `LineraTypes.AccountOwnerBalance` and not a `Linera.AccountOwnerBalance`, we patch the generated file. This is added to the CI.
* The serialization of the U256 is incorrect and returns 33 bytes instead of 32. In order to deal with that, a type `AmountU256` is introduced to encapsulate them.

## Test Plan

The CI and the additional tests.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.