### PR TITLE
Send transactions to every other chain in the chain group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5178,6 +5178,7 @@ dependencies = [
  "num-format",
  "prometheus-parse",
  "proptest",
+ "rand 0.8.5",
  "reqwest 0.11.27",
  "serde",
  "serde-wasm-bindgen 0.6.5",

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -20,6 +20,7 @@ benchmark = [
     "dep:reqwest",
     "dep:anyhow",
     "dep:prometheus-parse",
+    "dep:rand",
 ]
 wasmer = [
     "linera-core/wasmer",
@@ -70,6 +71,7 @@ linera-version = { workspace = true }
 linera-views.workspace = true
 num-format = { workspace = true, optional = true }
 prometheus-parse = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 serde.workspace = true
 thiserror.workspace = true

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -27,6 +27,8 @@ const DEFAULT_TRANSACTIONS_PER_BLOCK: usize = 1;
 #[cfg(feature = "benchmark")]
 const DEFAULT_WRAP_UP_MAX_IN_FLIGHT: usize = 5;
 #[cfg(feature = "benchmark")]
+const DEFAULT_NUM_CHAINS_PER_CHAIN_GROUP: usize = 2;
+#[cfg(feature = "benchmark")]
 const DEFAULT_BPS: usize = 10;
 
 // Make sure that the default values are consts, and that they are used in the Default impl.
@@ -34,10 +36,9 @@ const DEFAULT_BPS: usize = 10;
 #[derive(Clone, clap::Args, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct BenchmarkCommand {
-    /// Wether to use cross chain messages in the transactions or not. This effectively sets the
-    /// chain group size to 1.
-    #[arg(long)]
-    pub dont_use_cross_chain_messages: bool,
+    /// How many chains to use in each chain group.
+    #[arg(long, default_value_t = DEFAULT_NUM_CHAINS_PER_CHAIN_GROUP)]
+    pub num_chains_per_chain_group: usize,
 
     /// How many chain groups to use. If not provided, the number of CPUs will be used.
     #[arg(long)]
@@ -102,7 +103,7 @@ pub struct BenchmarkCommand {
 impl Default for BenchmarkCommand {
     fn default() -> Self {
         Self {
-            dont_use_cross_chain_messages: false,
+            num_chains_per_chain_group: DEFAULT_NUM_CHAINS_PER_CHAIN_GROUP,
             num_chain_groups: None,
             tokens_per_chain: DEFAULT_TOKENS_PER_CHAIN,
             transactions_per_block: DEFAULT_TRANSACTIONS_PER_BLOCK,

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -790,7 +790,7 @@ impl Runnable for Job {
             #[cfg(feature = "benchmark")]
             Benchmark(benchmark_config) => {
                 let BenchmarkCommand {
-                    dont_use_cross_chain_messages,
+                    num_chains_per_chain_group,
                     num_chain_groups,
                     tokens_per_chain,
                     transactions_per_block,
@@ -814,11 +814,22 @@ impl Runnable for Job {
                     "Number of chain groups must be greater than 0"
                 );
                 assert!(
+                    num_chains_per_chain_group > 0,
+                    "Number of chains per chain group must be greater than 0"
+                );
+                assert!(
                     transactions_per_block > 0,
                     "Number of transactions per block must be greater than 0"
                 );
                 assert!(bps > 0, "BPS must be greater than 0");
-                let num_chains_per_chain_group = if dont_use_cross_chain_messages { 1 } else { 2 };
+                if num_chains_per_chain_group > 1 {
+                    assert!(
+                        transactions_per_block % (num_chains_per_chain_group - 1) == 0,
+                        "Number of transactions per block must be a multiple of the number of \
+                         chains per chain group minus 1, to make sure transactions always cancel \
+                         each other out"
+                    );
+                }
 
                 let listener_config = ChainListenerConfig {
                     skip_process_inbox: true,


### PR DESCRIPTION
## Motivation

Right now every chain sends a cross chain message to one other chain exclusively. So each chain needs to receive just one gRPC message from 1 other chain.

## Proposal

To make the benchmarks more realistic, we need to make it so that all chains send requests to all other chains, generating many more gRPC messages and network traffic.

## Test Plan

Ran locally and saw that things work as expected

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
