### PR TITLE
Remove unnecessary check

### DIFF
--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -807,10 +807,6 @@ impl Runnable for Job {
                     "max_pending_message_bundles must be set to at least the same as the \
                      number of transactions per block ({transactions_per_block}) for benchmarking",
                 );
-                assert!(
-                    options.context_options.wait_for_outgoing_messages,
-                    "wait_for_outgoing_messages must be set to true for benchmarking",
-                );
                 let num_chain_groups = num_chain_groups.unwrap_or(num_cpus::get());
                 assert!(
                     num_chain_groups > 0,


### PR DESCRIPTION
## Motivation

We don't need `--wait-for-outgoing-messages` anymore. Forgot to remove it on https://github.com/linera-io/linera-protocol/pull/4177

## Proposal

Remove the check enforcing it

## Test Plan

Ran it

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
