### PR TITLE
Replace unnecessary clone() with as_ref() in error handling

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -947,7 +947,7 @@ where
             ensure!(
                 app_permissions.can_execute_operations(&operation.application_id()),
                 ChainError::AuthorizedApplications(
-                    app_permissions.execute_operations.clone().unwrap()
+                    app_permissions.execute_operations.as_ref().unwrap()
                 )
             );
             if let Operation::User { application_id, .. } = operation {


### PR DESCRIPTION
## Motivation
Replace app_permissions.execute_operations.clone().unwrap() with app_permissions.execute_operations.as_ref().unwrap() to avoid unnecessary cloning when formatting error messages