### PR TITLE
Add development environment in Docker

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
-{ crane, pkgs, rust-toolchain, libclang, rocksdb, git, system }:
+{ crane, pkgs, rust-toolchain, libclang, rocksdb, git, system, nix-gitignore }:
 ((crane.mkLib pkgs).overrideToolchain rust-toolchain).buildPackage {
   pname = "linera";
-  src = ./.;
+  src = nix-gitignore.gitignoreSource [] ./.;
   cargoExtraArgs = "-p linera-service";
   nativeBuildInputs = with pkgs; [
     clang

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,10 @@
 { crane, pkgs, rust-toolchain, libclang, rocksdb, git, system, nix-gitignore }:
 ((crane.mkLib pkgs).overrideToolchain rust-toolchain).buildPackage {
   pname = "linera";
-  src = nix-gitignore.gitignoreSource [] ./.;
+  src = nix-gitignore.gitignoreSource [] (builtins.path {
+    name = "source";
+    path = ./.;
+  });
   cargoExtraArgs = "-p linera-service";
   nativeBuildInputs = with pkgs; [
     clang

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ crane, pkgs, rust-toolchain, libclang, rocksdb, git }:
+{ crane, pkgs, rust-toolchain, libclang, rocksdb, git, system }:
 ((crane.mkLib pkgs).overrideToolchain rust-toolchain).buildPackage {
   pname = "linera";
   src = ./.;
@@ -20,13 +20,13 @@
     pnpm
   ];
   checkInputs = with pkgs; [
-    # for native testing
     jq
     kubernetes-helm
     kind
     kubectl
-
+  ] ++ lib.optionals (system != "arm64-apple-darwin") [
     # for Wasm testing
+    # Chromium doesn't build on macOS so we can't run these tests there
     chromium
     chromedriver
   ];

--- a/default.nix
+++ b/default.nix
@@ -30,6 +30,7 @@
     chromium
     chromedriver
   ];
+  doCheck = false;
   passthru = { inherit rust-toolchain; };
   RUST_SRC_PATH = rust-toolchain.availableComponents.rust-src;
   LIBCLANG_PATH = "${libclang.lib}/lib";

--- a/flake.lock
+++ b/flake.lock
@@ -96,11 +96,27 @@
         "type": "github"
       }
     },
+    "nixup": {
+      "locked": {
+        "lastModified": 1752796423,
+        "narHash": "sha256-k/kGtfcyIgVKV1K1U+jY+gE1q/tGy1l2CuUSdC7XFHY=",
+        "owner": "Twey",
+        "repo": "nixup",
+        "rev": "143252d16669dc019346c546ee5bb784a0f89c15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Twey",
+        "repo": "nixup",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "crane": "crane",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
+        "nixup": "nixup",
         "rust-overlay": "rust-overlay",
         "systems": "systems",
         "treefmt-nix": "treefmt-nix"

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
             export PATH=$PWD/target/debug:$PATH
             export RUST_SRC_PATH="${linera.RUST_SRC_PATH}"
             export LIBCLANG_PATH="${linera.LIBCLANG_PATH}"
-            export ROCKSDB_LIB_DIR="${linera.ROCKSDB_LIB_DIR}";
+            export ROCKSDB_LIB_DIR="${linera.ROCKSDB_LIB_DIR}"
           '';
           nativeBuildInputs = [ pkgs.rust-analyzer ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -68,8 +68,13 @@
 
         docker = pkgs.mkShell {
           shellHook = ''
-            docker images -q ${container.imageName}:${container.imageTag} || ${self'.packages.container-stream} | docker load
-            exec docker run --user $USER_ID:$GROUP_ID -v .:/build -it ${container.imageName}:${container.imageTag}
+            docker images \
+              -q ${container.imageName}:${container.imageTag} \
+              || ${self'.packages.container-stream} | docker load
+            exec docker run \
+              --user $USER_ID:$GROUP_ID \
+              -v .:/build \
+              -it ${container.imageName}:${container.imageTag}
           '';
         };
       };

--- a/linera-web/.envrc
+++ b/linera-web/.envrc
@@ -1,1 +1,0 @@
-use flake ..#nightly


### PR DESCRIPTION
## Motivation

We'd like people who like Docker to be able to use Docker to build our software.

## Proposal

Build a composite Rust toolchain using [`nixup`](https://github.com/Twey/nixup) that combines our stable and nightly Rust toolchains in a way that's compatible with rustup so we can combine both `devShell`s into one `devShell`.  Export a build output `packages.<arch>.container` that builds a Docker image containing the default development shell.

As an aside, clean up a couple of things in the Nix:
- fix macOS building
- filter the source with `nix-gitignore` to reduce the data copied to the Nix store

## Test Plan

This has been tested locally on my machine (`x86_64-linux`) and @deuszx' macOS machine (`aarch64-arm-darwin`).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
