### PR TITLE
Explicitly set max_concurrent_streams to u32::MAX-1

### DIFF
--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -260,6 +260,9 @@ where
             .build_v1()?;
         let public_server = join_set.spawn_task(
             self.public_server()?
+                .max_concurrent_streams(Some(u32::MAX - 1)) // we subtract one to make sure
+                // that the value is not
+                // interpreted as "not set"
                 .layer(
                     ServiceBuilder::new()
                         .layer(PrometheusMetricsMiddlewareLayer)


### PR DESCRIPTION
## Motivation

In the absence of an explicitly set limit, the GCP load balancer was defaulting to 100, effectively limiting the maximum number of chains in the wallet to 100 (as the client starts one stream per chain in the wallet).

## Proposal

Explicitly set the limit to as high a value as possible.

## Test Plan

- CI
- Manually attempt to reproduce #3898 on the devnet after deploying the fix

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
