### PR TITLE
Explicitly set max_concurrent_streams to u32::MAX-1

### DIFF
--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -261,9 +261,8 @@ where
             .build_v1()?;
         let public_server = join_set.spawn_task(
             self.public_server()?
-                .max_concurrent_streams(Some(u32::MAX - 1)) // we subtract one to make sure
-                // that the value is not
-                // interpreted as "not set"
+                // we subtract one to make sure that the value is not interpreted as "not set"
+                .max_concurrent_streams(Some(u32::MAX - 1))
                 .layer(
                     ServiceBuilder::new()
                         .layer(PrometheusMetricsMiddlewareLayer)

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -261,6 +261,9 @@ where
             .build_v1()?;
         let public_server = join_set.spawn_task(
             self.public_server()?
+                .max_concurrent_streams(Some(u32::MAX - 1)) // we subtract one to make sure
+                // that the value is not
+                // interpreted as "not set"
                 .layer(
                     ServiceBuilder::new()
                         .layer(PrometheusMetricsMiddlewareLayer)


### PR DESCRIPTION
Backport of #4237 to the testnet branch