### PR TITLE
Remove associated types Keys and KeyValues in KV store traits

### DIFF
--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -106,8 +106,6 @@ impl ReadableKeyValueStore for KeyValueStore {
     // The KeyValueStore of the system_api does not have limits
     // on the size of its values.
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
-    type Keys = Vec<Vec<u8>>;
-    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
     fn max_stream_queries(&self) -> usize {
         1
@@ -163,7 +161,7 @@ impl ReadableKeyValueStore for KeyValueStore {
     async fn find_keys_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::Keys, KeyValueStoreError> {
+    ) -> Result<Vec<Vec<u8>>, KeyValueStoreError> {
         ensure!(
             key_prefix.len() <= Self::MAX_KEY_SIZE,
             KeyValueStoreError::KeyTooLong
@@ -176,7 +174,7 @@ impl ReadableKeyValueStore for KeyValueStore {
     async fn find_key_values_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, KeyValueStoreError> {
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, KeyValueStoreError> {
         ensure!(
             key_prefix.len() <= Self::MAX_KEY_SIZE,
             KeyValueStoreError::KeyTooLong

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -79,8 +79,6 @@ impl WithError for ServiceStoreClientInternal {
 
 impl ReadableKeyValueStore for ServiceStoreClientInternal {
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
-    type Keys = Vec<Vec<u8>>;
-    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
     fn max_stream_queries(&self) -> usize {
         self.max_stream_queries

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -22,7 +22,7 @@ use linera_execution::{
 use linera_views::{
     backends::dual::{DualStoreRootKeyAssignment, StoreInUse},
     context::ViewContext,
-    store::{AdminKeyValueStore, KeyIterable as _, KeyValueStore},
+    store::{AdminKeyValueStore, KeyValueStore},
     views::View,
     ViewError,
 };
@@ -837,9 +837,8 @@ where
         prefix.extend(bcs::to_bytes(stream_id).unwrap());
         let mut keys = Vec::new();
         let mut indices = Vec::new();
-        for short_key in self.store.find_keys_by_prefix(&prefix).await?.iterator() {
-            let short_key = short_key?;
-            let index = bcs::from_bytes::<u32>(short_key)?;
+        for short_key in self.store.find_keys_by_prefix(&prefix).await? {
+            let index = bcs::from_bytes::<u32>(&short_key)?;
             if index >= start_index {
                 let mut key = prefix.clone();
                 key.extend(short_key);
@@ -1001,8 +1000,7 @@ where
         let prefix = &[INDEX_BLOB_ID];
         let keys = store.find_keys_by_prefix(prefix).await?;
         let mut blob_ids = Vec::new();
-        for key in keys.iterator() {
-            let key = key?;
+        for key in keys {
             let key_red = &key[..BLOB_ID_LENGTH];
             let blob_id = bcs::from_bytes(key_red)?;
             blob_ids.push(blob_id);

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -114,8 +114,6 @@ impl WithError for IndexedDbStore {
 
 impl ReadableKeyValueStore for IndexedDbStore {
     const MAX_KEY_SIZE: usize = usize::MAX;
-    type Keys = Vec<Vec<u8>>;
-    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
     fn max_stream_queries(&self) -> usize {
         self.max_stream_queries

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -25,9 +25,7 @@ use thiserror::Error;
 
 use crate::{
     batch::{Batch, BatchValueWriter, DeletePrefixExpander, SimplifiedBatch},
-    store::{
-        AdminKeyValueStore, KeyIterable, ReadableKeyValueStore, WithError, WritableKeyValueStore,
-    },
+    store::{AdminKeyValueStore, ReadableKeyValueStore, WithError, WritableKeyValueStore},
     views::MIN_VIEW_TAG,
 };
 
@@ -113,12 +111,9 @@ where
     K: DirectKeyValueStore,
 {
     type Error = K::Error;
+
     async fn expand_delete_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {
-        let mut vector_list = Vec::new();
-        for key in self.store.find_keys_by_prefix(key_prefix).await?.iterator() {
-            vector_list.push(key?.to_vec());
-        }
-        Ok(vector_list)
+        self.store.find_keys_by_prefix(key_prefix).await
     }
 }
 
@@ -136,9 +131,6 @@ where
 {
     /// The size constant do not change
     const MAX_KEY_SIZE: usize = K::MAX_KEY_SIZE;
-    /// The basic types do not change
-    type Keys = K::Keys;
-    type KeyValues = K::KeyValues;
 
     /// The read stuff does not change
     fn max_stream_queries(&self) -> usize {
@@ -164,14 +156,14 @@ where
         self.store.read_multi_values_bytes(keys).await
     }
 
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error> {
+    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {
         self.store.find_keys_by_prefix(key_prefix).await
     }
 
     async fn find_key_values_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, Self::Error> {
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error> {
         self.store.find_key_values_by_prefix(key_prefix).await
     }
 }

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -268,8 +268,6 @@ where
 {
     // The LRU cache does not change the underlying store's size limits.
     const MAX_KEY_SIZE: usize = K::MAX_KEY_SIZE;
-    type Keys = K::Keys;
-    type KeyValues = K::KeyValues;
 
     fn max_stream_queries(&self) -> usize {
         self.store.max_stream_queries()
@@ -410,14 +408,14 @@ where
         Ok(result)
     }
 
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error> {
+    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {
         self.store.find_keys_by_prefix(key_prefix).await
     }
 
     async fn find_key_values_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, Self::Error> {
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error> {
         self.store.find_key_values_by_prefix(key_prefix).await
     }
 }

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -133,8 +133,6 @@ impl WithError for MemoryStore {
 
 impl ReadableKeyValueStore for MemoryStore {
     const MAX_KEY_SIZE: usize = usize::MAX;
-    type Keys = Vec<Vec<u8>>;
-    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
     fn max_stream_queries(&self) -> usize {
         self.max_stream_queries

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -366,8 +366,6 @@ impl WithError for RocksDbStoreInternal {
 
 impl ReadableKeyValueStore for RocksDbStoreInternal {
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
-    type Keys = Vec<Vec<u8>>;
-    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
     fn max_stream_queries(&self) -> usize {
         self.max_stream_queries
@@ -427,7 +425,7 @@ impl ReadableKeyValueStore for RocksDbStoreInternal {
     async fn find_keys_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::Keys, RocksDbStoreInternalError> {
+    ) -> Result<Vec<Vec<u8>>, RocksDbStoreInternalError> {
         let executor = self.executor.clone();
         let key_prefix = key_prefix.to_vec();
         self.spawn_mode
@@ -441,7 +439,7 @@ impl ReadableKeyValueStore for RocksDbStoreInternal {
     async fn find_key_values_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, RocksDbStoreInternalError> {
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, RocksDbStoreInternalError> {
         let executor = self.executor.clone();
         let key_prefix = key_prefix.to_vec();
         self.spawn_mode

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -600,8 +600,6 @@ impl WithError for ScyllaDbStoreInternal {
 
 impl ReadableKeyValueStore for ScyllaDbStoreInternal {
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
-    type Keys = Vec<Vec<u8>>;
-    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
     fn max_stream_queries(&self) -> usize {
         self.max_stream_queries
@@ -667,7 +665,7 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
     async fn find_keys_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::Keys, ScyllaDbStoreInternalError> {
+    ) -> Result<Vec<Vec<u8>>, ScyllaDbStoreInternalError> {
         let store = self.store.deref();
         let _guard = self.acquire().await;
         store
@@ -678,7 +676,7 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
     async fn find_key_values_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, ScyllaDbStoreInternalError> {
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ScyllaDbStoreInternalError> {
         let store = self.store.deref();
         let _guard = self.acquire().await;
         store

--- a/linera-views/src/context.rs
+++ b/linera-views/src/context.rs
@@ -6,9 +6,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use crate::{
     batch::DeletePrefixExpander,
     memory::MemoryStore,
-    store::{
-        KeyIterable, KeyValueStoreError, ReadableKeyValueStore, WithError, WritableKeyValueStore,
-    },
+    store::{KeyValueStoreError, ReadableKeyValueStore, WithError, WritableKeyValueStore},
     views::MIN_VIEW_TAG,
 };
 
@@ -204,12 +202,6 @@ impl DeletePrefixExpander for MemoryContext<()> {
     type Error = crate::memory::MemoryStoreError;
 
     async fn expand_delete_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {
-        let mut vector_list = Vec::new();
-        for key in <Vec<Vec<u8>> as KeyIterable<Self::Error>>::iterator(
-            &self.store().find_keys_by_prefix(key_prefix).await?,
-        ) {
-            vector_list.push(key?.to_vec());
-        }
-        Ok(vector_list)
+        self.store().find_keys_by_prefix(key_prefix).await
     }
 }

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -40,12 +40,6 @@ pub trait ReadableKeyValueStore: WithError {
     /// The maximal size of keys that can be stored.
     const MAX_KEY_SIZE: usize;
 
-    /// Returns type for key search operations.
-    type Keys: KeyIterable<Self::Error>;
-
-    /// Returns type for key-value search operations.
-    type KeyValues: KeyValueIterable<Self::Error>;
-
     /// Retrieve the number of stream queries.
     fn max_stream_queries(&self) -> usize;
 
@@ -65,13 +59,13 @@ pub trait ReadableKeyValueStore: WithError {
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error>;
 
     /// Finds the `key` matching the prefix. The prefix is not included in the returned keys.
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error>;
+    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error>;
 
     /// Finds the `(key,value)` pairs matching the prefix. The prefix is not included in the returned keys.
     async fn find_key_values_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, Self::Error>;
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error>;
 
     // We can't use `async fn` here in the below implementations due to
     // https://github.com/rust-lang/impl-trait-utils/issues/17, but once that bug is fixed
@@ -219,110 +213,4 @@ pub trait TestKeyValueStore: KeyValueStore {
         let namespace = generate_test_namespace();
         Self::recreate_and_connect(&config, &namespace).await
     }
-}
-
-#[doc(hidden)]
-/// Iterates keys by reference in a vector of keys.
-/// Inspired by https://depth-first.com/articles/2020/06/22/returning-rust-iterators/
-pub struct SimpleKeyIterator<'a, E> {
-    iter: std::slice::Iter<'a, Vec<u8>>,
-    _error_type: std::marker::PhantomData<E>,
-}
-
-impl<'a, E> Iterator for SimpleKeyIterator<'a, E> {
-    type Item = Result<&'a [u8], E>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|key| Result::Ok(key.as_ref()))
-    }
-}
-
-impl<E> KeyIterable<E> for Vec<Vec<u8>> {
-    type Iterator<'a> = SimpleKeyIterator<'a, E>;
-
-    fn iterator(&self) -> Self::Iterator<'_> {
-        SimpleKeyIterator {
-            iter: self.iter(),
-            _error_type: std::marker::PhantomData,
-        }
-    }
-}
-
-#[doc(hidden)]
-/// Same as `SimpleKeyIterator` but for key-value pairs.
-pub struct SimpleKeyValueIterator<'a, E> {
-    iter: std::slice::Iter<'a, (Vec<u8>, Vec<u8>)>,
-    _error_type: std::marker::PhantomData<E>,
-}
-
-impl<'a, E> Iterator for SimpleKeyValueIterator<'a, E> {
-    type Item = Result<(&'a [u8], &'a [u8]), E>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter
-            .next()
-            .map(|entry| Ok((&entry.0[..], &entry.1[..])))
-    }
-}
-
-#[doc(hidden)]
-/// Same as `SimpleKeyValueIterator` but key-value pairs are passed by value.
-pub struct SimpleKeyValueIteratorOwned<E> {
-    iter: std::vec::IntoIter<(Vec<u8>, Vec<u8>)>,
-    _error_type: std::marker::PhantomData<E>,
-}
-
-impl<E> Iterator for SimpleKeyValueIteratorOwned<E> {
-    type Item = Result<(Vec<u8>, Vec<u8>), E>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(Result::Ok)
-    }
-}
-
-impl<E> KeyValueIterable<E> for Vec<(Vec<u8>, Vec<u8>)> {
-    type Iterator<'a> = SimpleKeyValueIterator<'a, E>;
-    type IteratorOwned = SimpleKeyValueIteratorOwned<E>;
-
-    fn iterator(&self) -> Self::Iterator<'_> {
-        SimpleKeyValueIterator {
-            iter: self.iter(),
-            _error_type: std::marker::PhantomData,
-        }
-    }
-
-    fn into_iterator_owned(self) -> Self::IteratorOwned {
-        SimpleKeyValueIteratorOwned {
-            iter: self.into_iter(),
-            _error_type: std::marker::PhantomData,
-        }
-    }
-}
-
-/// How to iterate over the keys returned by a search query.
-pub trait KeyIterable<Error> {
-    /// The iterator returning keys by reference.
-    type Iterator<'a>: Iterator<Item = Result<&'a [u8], Error>>
-    where
-        Self: 'a;
-
-    /// Iterates keys by reference.
-    fn iterator(&self) -> Self::Iterator<'_>;
-}
-
-/// How to iterate over the key-value pairs returned by a search query.
-pub trait KeyValueIterable<Error> {
-    /// The iterator that returns key-value pairs by reference.
-    type Iterator<'a>: Iterator<Item = Result<(&'a [u8], &'a [u8]), Error>>
-    where
-        Self: 'a;
-
-    /// The iterator that returns key-value pairs by value.
-    type IteratorOwned: Iterator<Item = Result<(Vec<u8>, Vec<u8>), Error>>;
-
-    /// Iterates keys and values by reference.
-    fn iterator(&self) -> Self::Iterator<'_>;
-
-    /// Iterates keys and values by value.
-    fn into_iterator_owned(self) -> Self::IteratorOwned;
 }

--- a/linera-views/src/test_utils/performance.rs
+++ b/linera-views/src/test_utils/performance.rs
@@ -101,7 +101,7 @@ where
 /// Benchmarks the `find_keys_by_prefix` operation.
 pub async fn find_keys_by_prefix<S: TestKeyValueStore, F>(iterations: u64, f: F) -> Duration
 where
-    F: Fn(S::Keys) -> S::Keys,
+    F: Fn(Vec<Vec<u8>>) -> Vec<Vec<u8>>,
 {
     let store = S::new_test_store().await.unwrap();
     let mut total_time = Duration::ZERO;
@@ -129,7 +129,7 @@ where
 /// Benchmarks the `find_keys_by_prefix` operation.
 pub async fn find_key_values_by_prefix<S: TestKeyValueStore, F>(iterations: u64, f: F) -> Duration
 where
-    F: Fn(S::KeyValues) -> S::KeyValues,
+    F: Fn(Vec<(Vec<u8>, Vec<u8>)>) -> Vec<(Vec<u8>, Vec<u8>)>,
 {
     let store = S::new_test_store().await.unwrap();
     let mut total_time = Duration::ZERO;

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -19,7 +19,7 @@ use crate::{
     common::{CustomSerialize, HasherOutput, Update},
     context::{BaseKey, Context},
     hashable_wrapper::WrappedHashableContainerView,
-    store::{KeyIterable, ReadableKeyValueStore as _},
+    store::ReadableKeyValueStore as _,
     views::{ClonableView, HashableView, Hasher, View, ViewError, MIN_VIEW_TAG},
 };
 
@@ -488,29 +488,22 @@ impl<W: View> ByteCollectionView<W::Context, W> {
         let mut update = updates.next();
         if !self.delete_storage_first {
             let base = self.get_index_key(&[]);
-            for index in self
-                .context
-                .store()
-                .find_keys_by_prefix(&base)
-                .await?
-                .iterator()
-            {
-                let index = index?;
+            for index in self.context.store().find_keys_by_prefix(&base).await? {
                 loop {
                     match update {
-                        Some((key, value)) if key.as_slice() <= index => {
+                        Some((key, value)) if key <= &index => {
                             if let Update::Set(_) = value {
                                 if !f(key)? {
                                     return Ok(());
                                 }
                             }
                             update = updates.next();
-                            if key == index {
+                            if key == &index {
                                 break;
                             }
                         }
                         _ => {
-                            if !f(index)? {
+                            if !f(&index)? {
                                 return Ok(());
                             }
                             break;

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -20,7 +20,7 @@ use crate::{
     common::{CustomSerialize, HasherOutput, Update},
     context::{BaseKey, Context},
     hashable_wrapper::WrappedHashableContainerView,
-    store::{KeyIterable, ReadableKeyValueStore as _},
+    store::ReadableKeyValueStore as _,
     views::{ClonableView, HashableView, Hasher, View, ViewError, MIN_VIEW_TAG},
 };
 
@@ -903,29 +903,22 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
         let mut update = updates.next();
         if !self.delete_storage_first {
             let base = self.get_index_key(&[]);
-            for index in self
-                .context
-                .store()
-                .find_keys_by_prefix(&base)
-                .await?
-                .iterator()
-            {
-                let index = index?;
+            for index in self.context.store().find_keys_by_prefix(&base).await? {
                 loop {
                     match update {
-                        Some((key, value)) if key.as_slice() <= index => {
+                        Some((key, value)) if key <= &index => {
                             if let Update::Set(_) = value {
                                 if !f(key)? {
                                     return Ok(());
                                 }
                             }
                             update = updates.next();
-                            if key == index {
+                            if key == &index {
                                 break;
                             }
                         }
                         _ => {
-                            if !f(index)? {
+                            if !f(&index)? {
                                 return Ok(());
                             }
                             break;


### PR DESCRIPTION
## Motivation

* Simplify code.

As pointed out by teammates, this optimization is only used for `DynamoDb` and doesn't apply to the databases that we use in production.

## Proposal

* Remove associated types Keys and KeyValues
* Remove the traits

I stop short of removing the iterator objects in DynamoDb. We could probably simplify the code some more but it's non-trivial and could be slightly slower. 

## Test Plan

CI
