### PR TITLE
Avoid redundant chain info requests; fix event oracles.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1042,6 +1042,8 @@ pub enum OracleResponse {
     Round(Option<u32>),
     /// An event was read.
     Event(EventId, Vec<u8>),
+    /// An event exists.
+    EventExists(EventId),
 }
 
 impl BcsHashable<'_> for OracleResponse {}

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -287,10 +287,7 @@ where
                 .await
             {
                 Ok(info) => return Ok(info),
-                Err(NodeError::MissingCrossChainUpdate { .. })
-                | Err(NodeError::InactiveChain(_))
-                    if !sent_cross_chain_updates =>
-                {
+                Err(NodeError::MissingCrossChainUpdate { .. }) if !sent_cross_chain_updates => {
                     sent_cross_chain_updates = true;
                     // Some received certificates may be missing for this validator
                     // (e.g. to create the chain or make the balance sufficient) so we are going to
@@ -319,7 +316,9 @@ where
                     )
                     .await?;
                 }
-                Err(NodeError::BlobsNotFound(_)) if !blob_ids.is_empty() => {
+                Err(NodeError::BlobsNotFound(_) | NodeError::InactiveChain(_))
+                    if !blob_ids.is_empty() =>
+                {
                     // For `BlobsNotFound`, we assume that the local node should already be
                     // updated with the needed blobs, so sending the chain information about the
                     // certificates that last used the blobs to the validator node should be enough.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -88,6 +88,14 @@ mod metrics {
             &["validator_name"],
         )
     });
+
+    pub static CHAIN_INFO_QUERIES: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "chain_info_queries",
+            "Number of chain info queries processed",
+            &[],
+        )
+    });
 }
 
 /// Instruct the networking layer to send cross-chain requests and/or push notifications.
@@ -917,6 +925,8 @@ where
         query: ChainInfoQuery,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname, query);
+        #[cfg(with_metrics)]
+        metrics::CHAIN_INFO_QUERIES.with_label_values(&[]).inc();
         let result = self
             .query_chain_worker(query.chain_id, move |callback| {
                 ChainWorkerRequest::HandleChainInfoQuery { query, callback }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -821,6 +821,10 @@ OracleResponse:
         TUPLE:
           - TYPENAME: EventId
           - SEQ: U8
+    6:
+      EventExists:
+        NEWTYPE:
+          TYPENAME: EventId
 OriginalProposal:
   ENUM:
     0:


### PR DESCRIPTION
## Motivation

The client makes a lot of chain info queries, causing unnecessary round trips. One example is `ValidatorUpdater::send_chain_information`, where we always first request the chain info from the validator, to learn which blocks they are missing.

When reading events we are not always using the oracle mechanism. that can cause confirmed blocks to fail even though the proposal succeeded.

## Proposal

* In `send_chain_information`, always send the highest block right away. Often that is enough, and the response will confirm that.
* In `send_chain_information`, only send the timeout certificate if it is relevant for the validator.
* On `NodeError::InactiveChain`, send blobs, not certificates. (This may be unreachable anyway; needs a closer look: https://github.com/linera-io/linera-protocol/issues/3927)
* Use the oracle mechanism where appropriate.
* Add chain info queries to the worker metrics.

## Test Plan

CI

Locally, it reduces the number of chain info queries handled by the validators in the `test_open_chain_then_close_it` test from 75 to 72.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Should partially address #4231, but needs verification.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
