### PR TITLE
Remove the `next_message_index` as it is not used.

### DIFF
--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -40,7 +40,6 @@ pub struct BlockExecutionTracker<'resources, 'blobs> {
     local_time: Timestamp,
     #[debug(skip_if = Option::is_none)]
     pub replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
-    pub next_message_index: u32,
     pub next_application_index: u32,
     pub next_chain_index: u32,
     #[debug(skip_if = Vec::is_empty)]
@@ -87,7 +86,6 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
             resource_controller,
             local_time,
             replaying_oracle_responses,
-            next_message_index: 0,
             next_application_index: 0,
             next_chain_index: 0,
             oracle_responses: Vec::new(),
@@ -177,7 +175,6 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         Ok(TransactionTracker::new(
             self.local_time,
             self.transaction_index,
-            self.next_message_index,
             self.next_application_index,
             self.next_chain_index,
             self.oracle_responses()?,
@@ -288,7 +285,6 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
     where
         C: Context + Clone + Send + Sync + 'static,
     {
-        self.next_message_index = txn_outcome.next_message_index;
         self.next_application_index = txn_outcome.next_application_index;
         self.next_chain_index = txn_outcome.next_chain_index;
         self.oracle_responses

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -278,7 +278,6 @@ where
                 0,
                 0,
                 0,
-                0,
                 Some(vec![OracleResponse::Blob(application_description_blob_id)]),
             ),
             &mut controller,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -84,7 +84,6 @@ where
         };
 
         let action = UserAction::Instantiate(context, instantiation_argument);
-        let next_message_index = 0;
         let next_application_index = application_description.application_index + 1;
         let next_chain_index = 0;
 
@@ -115,7 +114,6 @@ where
         let mut txn_tracker = TransactionTracker::new(
             local_time,
             0,
-            next_message_index,
             next_application_index,
             next_chain_index,
             None,

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -31,7 +31,6 @@ pub struct TransactionTracker {
     local_time: Timestamp,
     /// The index of the current transaction in the block.
     transaction_index: u32,
-    next_message_index: u32,
     next_application_index: u32,
     next_chain_index: u32,
     /// Events recorded by contracts' `emit` calls.
@@ -57,7 +56,6 @@ pub struct TransactionOutcome {
     pub oracle_responses: Vec<OracleResponse>,
     #[debug(skip_if = Vec::is_empty)]
     pub outgoing_messages: Vec<OutgoingMessage>,
-    pub next_message_index: u32,
     pub next_application_index: u32,
     pub next_chain_index: u32,
     /// Events recorded by contracts' `emit` calls.
@@ -74,7 +72,6 @@ impl TransactionTracker {
     pub fn new(
         local_time: Timestamp,
         transaction_index: u32,
-        next_message_index: u32,
         next_application_index: u32,
         next_chain_index: u32,
         oracle_responses: Option<Vec<OracleResponse>>,
@@ -82,7 +79,6 @@ impl TransactionTracker {
         TransactionTracker {
             local_time,
             transaction_index,
-            next_message_index,
             next_application_index,
             next_chain_index,
             replaying_oracle_responses: oracle_responses.map(Vec::into_iter),
@@ -107,10 +103,6 @@ impl TransactionTracker {
         self.transaction_index
     }
 
-    pub fn next_message_index(&self) -> u32 {
-        self.next_message_index
-    }
-
     pub fn next_application_index(&mut self) -> u32 {
         let index = self.next_application_index;
         self.next_application_index += 1;
@@ -127,10 +119,6 @@ impl TransactionTracker {
         &mut self,
         message: OutgoingMessage,
     ) -> Result<(), ArithmeticError> {
-        self.next_message_index = self
-            .next_message_index
-            .checked_add(1)
-            .ok_or(ArithmeticError::Overflow)?;
         self.outgoing_messages.push(message);
         Ok(())
     }
@@ -274,7 +262,6 @@ impl TransactionTracker {
             outgoing_messages,
             local_time: _,
             transaction_index: _,
-            next_message_index,
             next_application_index,
             next_chain_index,
             events,
@@ -296,7 +283,6 @@ impl TransactionTracker {
         Ok(TransactionOutcome {
             outgoing_messages,
             oracle_responses,
-            next_message_index,
             next_application_index,
             next_chain_index,
             events,
@@ -312,7 +298,7 @@ impl TransactionTracker {
     /// Creates a new [`TransactionTracker`] for testing, with default values and the given
     /// oracle responses.
     pub fn new_replaying(oracle_responses: Vec<OracleResponse>) -> Self {
-        TransactionTracker::new(Timestamp::from(0), 0, 0, 0, 0, Some(oracle_responses))
+        TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(oracle_responses))
     }
 
     /// Creates a new [`TransactionTracker`] for testing, with default values and oracle responses

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -98,12 +98,10 @@ async fn test_transfer_system_api(
     let TransactionOutcome {
         outgoing_messages,
         oracle_responses,
-        next_message_index,
         ..
     } = tracker.into_outcome()?;
     assert_eq!(outgoing_messages.len(), 1);
     assert_eq!(oracle_responses.len(), 3);
-    assert_eq!(next_message_index, 1);
     assert!(matches!(outgoing_messages[0].message, Message::System(_)));
 
     view.execute_message(
@@ -274,12 +272,10 @@ async fn test_claim_system_api(
     let TransactionOutcome {
         outgoing_messages,
         oracle_responses,
-        next_message_index,
         ..
     } = tracker.into_outcome()?;
     assert_eq!(outgoing_messages.len(), 1);
     assert_eq!(oracle_responses.len(), 3);
-    assert_eq!(next_message_index, 1);
     assert!(matches!(outgoing_messages[0].message, Message::System(_)));
 
     let mut tracker = TransactionTracker::new_replaying(Vec::new());
@@ -308,12 +304,10 @@ async fn test_claim_system_api(
     let TransactionOutcome {
         outgoing_messages,
         oracle_responses,
-        next_message_index,
         ..
     } = tracker.into_outcome()?;
     assert_eq!(outgoing_messages.len(), 1);
     assert!(oracle_responses.is_empty());
-    assert_eq!(next_message_index, 1);
     assert!(matches!(outgoing_messages[0].message, Message::System(_)));
 
     let mut tracker = TransactionTracker::new_replaying(Vec::new());

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1226,7 +1226,6 @@ async fn test_open_chain() -> anyhow::Result<()> {
         1,
         first_message_index,
         0,
-        0,
         Some(blob_oracle_responses(blobs.iter())),
     );
     view.execute_operation(context, operation, &mut txn_tracker, &mut controller)


### PR DESCRIPTION
## Motivation

An examination of the source code reveals that the variable `next_message_index` is never used.

## Proposal

Eliminate it completely.

## Test Plan

The CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.