### PR TITLE
Send missing events to validators.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -632,14 +632,6 @@ where
         self.execution_state.system.ownership.get()
     }
 
-    pub fn admin_id(&self) -> Result<ChainId, ChainError> {
-        self.execution_state
-            .system
-            .admin_id
-            .get()
-            .ok_or_else(|| ChainError::InactiveChain(self.chain_id()))
-    }
-
     /// Removes the incoming message bundles in the block from the inboxes.
     pub async fn remove_bundles_from_inboxes(
         &mut self,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -632,6 +632,14 @@ where
         self.execution_state.system.ownership.get()
     }
 
+    pub fn admin_id(&self) -> Result<ChainId, ChainError> {
+        self.execution_state
+            .system
+            .admin_id
+            .get()
+            .ok_or_else(|| ChainError::InactiveChain(self.chain_id()))
+    }
+
     /// Removes the incoming message bundles in the block from the inboxes.
     pub async fn remove_bundles_from_inboxes(
         &mut self,

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -10,7 +10,7 @@ use linera_base::{
     crypto::ValidatorPublicKey,
     data_types::{Blob, BlockHeight, Epoch, Timestamp},
     ensure,
-    identifiers::ChainId,
+    identifiers::{ChainId, EventId, StreamId},
 };
 use linera_chain::{
     data_types::{
@@ -20,7 +20,7 @@ use linera_chain::{
     types::{ConfirmedBlockCertificate, TimeoutCertificate, ValidatedBlockCertificate},
     ChainExecutionContext, ChainStateView, ExecutionResultExt as _,
 };
-use linera_execution::committee::Committee;
+use linera_execution::{committee::Committee, system::EPOCH_STREAM_NAME};
 use linera_storage::{Clock as _, Storage};
 use linera_views::{
     context::Context,
@@ -316,7 +316,11 @@ where
             let committees = self.state.storage.committees_for(epoch..=epoch).await?;
             let committee = committees
                 .get(&epoch)
-                .ok_or(WorkerError::UnknownEpoch { chain_id, epoch })?;
+                .ok_or(WorkerError::EventsNotFound(vec![EventId {
+                    chain_id: self.state.chain.admin_id()?,
+                    stream_id: StreamId::system(EPOCH_STREAM_NAME),
+                    index: epoch.0,
+                }]))?;
             // This line is duplicated, but this avoids cloning and a lifetimes error.
             certificate.check(committee)?;
         }

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -317,7 +317,13 @@ where
             let committee = committees
                 .get(&epoch)
                 .ok_or(WorkerError::EventsNotFound(vec![EventId {
-                    chain_id: self.state.chain.admin_id()?,
+                    chain_id: self
+                        .state
+                        .storage
+                        .read_network_description()
+                        .await?
+                        .unwrap()
+                        .admin_chain_id,
                     stream_id: StreamId::system(EPOCH_STREAM_NAME),
                     index: epoch.0,
                 }]))?;

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -303,7 +303,7 @@ where
                         .iter()
                         .map(|event_id| event_id.chain_id)
                         .filter(|chain_id| !publisher_chain_ids_sent.contains(chain_id))
-                        .collect::<Vec<_>>();
+                        .collect::<BTreeSet<_>>();
                     ensure!(
                         !new_chain_ids.is_empty(),
                         NodeError::EventsNotFound(event_ids)

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -14,7 +14,7 @@ use linera_base::{
     data_types::{ApplicationDescription, ArithmeticError, Blob, BlockHeight, Epoch, Round},
     doc_scalar,
     hashed::Hashed,
-    identifiers::{AccountOwner, ApplicationId, BlobId, ChainId},
+    identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, EventId},
     time::timer::{sleep, timeout},
 };
 #[cfg(with_testing)]
@@ -174,8 +174,9 @@ pub enum WorkerError {
         chain_epoch: Epoch,
         epoch: Epoch,
     },
-    #[error("Proposal on chain {chain_id:} claims an unknown epoch {epoch:}")]
-    UnknownEpoch { chain_id: ChainId, epoch: Epoch },
+
+    #[error("Events not found: {0:?}")]
+    EventsNotFound(Vec<EventId>),
 
     // Other server-side errors
     #[error("Invalid cross-chain request")]

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -222,6 +222,8 @@ pub enum WorkerError {
     UnexpectedBlob,
     #[error("Number of published blobs per block must not exceed {0}")]
     TooManyPublishedBlobs(u64),
+    #[error("Missing network description")]
+    MissingNetworkDescription,
 }
 
 impl From<ChainError> for WorkerError {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -335,8 +335,6 @@ pub enum ExecutionError {
     UnprocessedStreams,
     #[error("Internal error: {0}")]
     InternalError(&'static str),
-    #[error("UpdateStreams contains an unknown event")]
-    EventNotFound(EventId),
     #[error("UpdateStreams is outdated")]
     OutdatedUpdateStreams,
 }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -695,51 +695,56 @@ NodeError:
           SEQ:
             TYPENAME: BlobId
     8:
-      MissingCertificateValue: UNIT
+      EventsNotFound:
+        NEWTYPE:
+          SEQ:
+            TYPENAME: EventId
     9:
+      MissingCertificateValue: UNIT
+    10:
       MissingCertificates:
         NEWTYPE:
           SEQ:
             TYPENAME: CryptoHash
-    10:
-      MissingVoteInValidatorResponse: UNIT
     11:
-      InvalidChainInfoResponse: UNIT
+      MissingVoteInValidatorResponse: UNIT
     12:
-      UnexpectedCertificateValue: UNIT
+      InvalidChainInfoResponse: UNIT
     13:
-      InvalidDecoding: UNIT
+      UnexpectedCertificateValue: UNIT
     14:
-      UnexpectedMessage: UNIT
+      InvalidDecoding: UNIT
     15:
+      UnexpectedMessage: UNIT
+    16:
       GrpcError:
         STRUCT:
           - error: STR
-    16:
+    17:
       ClientIoError:
         STRUCT:
           - error: STR
-    17:
+    18:
       CannotResolveValidatorAddress:
         STRUCT:
           - address: STR
-    18:
+    19:
       SubscriptionError:
         STRUCT:
           - transport: STR
-    19:
+    20:
       SubscriptionFailed:
         STRUCT:
           - status: STR
-    20:
+    21:
       InvalidCertificateForBlob:
         NEWTYPE:
           TYPENAME: BlobId
-    21:
-      DuplicatesInBlobsNotFound: UNIT
     22:
-      UnexpectedEntriesInBlobsNotFound: UNIT
+      DuplicatesInBlobsNotFound: UNIT
     23:
+      UnexpectedEntriesInBlobsNotFound: UNIT
+    24:
       UnexpectedCertificates:
         STRUCT:
           - returned:
@@ -748,9 +753,9 @@ NodeError:
           - requested:
               SEQ:
                 TYPENAME: CryptoHash
-    24:
-      EmptyBlobsNotFound: UNIT
     25:
+      EmptyBlobsNotFound: UNIT
+    26:
       ResponseHandlingError:
         STRUCT:
           - error: STR


### PR DESCRIPTION
## Motivation

The client will only send a block proposal to the validators if it has all events that were read during execution. Validators that don't have any of the events return an error.

## Proposal

* Unify all missing event errors: `EventsNotFound(Vec<EventId>)`.
* In the `ValidatorUpdater`, when making a proposal, send the publisher chains and retry.

## Test Plan

A client test using the social example was extended. The new test fails without this functionality.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/4254.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
