### PR TITLE
Replace double `unwrap` with `unwrap_ok_committed`.

### DIFF
--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -363,15 +363,3 @@ impl<T> ClientOutcome<T> {
         }
     }
 }
-
-#[cfg(with_testing)]
-pub trait ClientOutcomeResultExt<T, E> {
-    fn unwrap_ok_committed(self) -> T;
-}
-
-#[cfg(with_testing)]
-impl<T, E: std::fmt::Debug> ClientOutcomeResultExt<T, E> for Result<ClientOutcome<T>, E> {
-    fn unwrap_ok_committed(self) -> T {
-        self.unwrap().unwrap()
-    }
-}

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -49,13 +49,14 @@ use crate::{
         BlanketMessagePolicy, ChainClient, ChainClientError, ClientOutcome, MessageAction,
         MessagePolicy,
     },
-    data_types::ClientOutcomeResultExt as _,
     local_node::LocalNodeError,
     node::{
         NodeError::{self, ClientIoError},
         ValidatorNode,
     },
-    test_utils::{FaultType, MemoryStorageBuilder, StorageBuilder, TestBuilder},
+    test_utils::{
+        ClientOutcomeResultExt as _, FaultType, MemoryStorageBuilder, StorageBuilder, TestBuilder,
+    },
     updater::CommunicationError,
     worker::{Notification, Reason, WorkerError},
     Environment,

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -1324,3 +1324,13 @@ impl StorageBuilder for ScyllaDbStorageBuilder {
         &self.clock
     }
 }
+
+pub trait ClientOutcomeResultExt<T, E> {
+    fn unwrap_ok_committed(self) -> T;
+}
+
+impl<T, E: std::fmt::Debug> ClientOutcomeResultExt<T, E> for Result<ClientOutcome<T>, E> {
+    fn unwrap_ok_committed(self) -> T {
+        self.unwrap().unwrap()
+    }
+}

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -48,9 +48,8 @@ use crate::{
         client_tests::{MemoryStorageBuilder, StorageBuilder, TestBuilder},
         ChainClientError,
     },
-    data_types::ClientOutcomeResultExt as _,
     local_node::LocalNodeError,
-    test_utils::FaultType,
+    test_utils::{ClientOutcomeResultExt as _, FaultType},
     worker::WorkerError,
 };
 


### PR DESCRIPTION
## Motivation

Many client methods return `Result<ClientOutcome<_>, _>`. In the tests, we often `unwrap` both the result and the outcome.

## Proposal

Introduce an extension trait and an `unwrap_ok_committed` method to unwrap both at once.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
