### PR TITLE
Move metrics to ClientContext

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -144,6 +144,10 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
     Don't include any messages in blocks, and don't make any decision whether to accept or reject
 
 * `--restrict-chain-ids-to <RESTRICT_CHAIN_IDS_TO>` — A set of chains to restrict incoming messages from. By default, messages from all chains are accepted. To reject messages from all chains, specify an empty string
+* `--timings` — Enable timing reports during operations
+* `--timing-interval <TIMING_INTERVAL>` — Interval in seconds between timing reports (defaults to 5)
+
+  Default value: `5`
 * `--grace-period <GRACE_PERIOD>` — An additional delay, after reaching a quorum, to wait for additional validator signatures, as a fraction of time taken to reach quorum
 
   Default value: `0.2`

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -20,7 +20,6 @@ benchmark = [
     "dep:reqwest",
     "dep:anyhow",
     "dep:prometheus-parse",
-    "dep:hdrhistogram",
 ]
 wasmer = [
     "linera-core/wasmer",
@@ -58,7 +57,7 @@ anyhow = { workspace = true, optional = true }
 bcs.workspace = true
 clap.workspace = true
 futures.workspace = true
-hdrhistogram = { workspace = true, optional = true }
+hdrhistogram = { workspace = true }
 linera-base.workspace = true
 linera-chain.workspace = true
 linera-core.workspace = true

--- a/linera-client/src/client_metrics.rs
+++ b/linera-client/src/client_metrics.rs
@@ -1,0 +1,267 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use hdrhistogram::Histogram;
+use tokio::{sync::mpsc, task, time};
+use tracing::{debug, info, warn};
+
+#[derive(Debug, Clone)]
+pub struct TimingConfig {
+    pub enabled: bool,
+    pub report_interval_secs: u64,
+}
+
+#[cfg(not(web))]
+impl Default for TimingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            report_interval_secs: 5,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ClientMetricsError {
+    #[error("Failed to create histogram: {0}")]
+    HistogramCreationError(#[from] hdrhistogram::CreationError),
+    #[error("Failed to record histogram: {0}")]
+    HistogramRecordError(#[from] hdrhistogram::RecordError),
+}
+
+pub struct SubmitFastBlockProposalTimings {
+    pub creating_proposal_ms: u64,
+    pub stage_block_execution_ms: u64,
+    pub creating_confirmed_block_ms: u64,
+    pub submitting_block_proposal_ms: u64,
+}
+
+pub struct BlockTimeTimings {
+    pub get_pending_message_bundles_ms: u64,
+    pub submit_fast_block_proposal_ms: u64,
+    pub submit_fast_block_proposal_timings: SubmitFastBlockProposalTimings,
+    pub communicate_chain_updates_ms: u64,
+}
+
+pub struct BlockTimings {
+    pub block_time_ms: u64,
+    pub block_time_timings: BlockTimeTimings,
+}
+
+pub struct SubmitFastBlockProposalTimingsHistograms {
+    pub creating_proposal_histogram: Histogram<u64>,
+    pub stage_block_execution_histogram: Histogram<u64>,
+    pub creating_confirmed_block_histogram: Histogram<u64>,
+    pub submitting_block_proposal_histogram: Histogram<u64>,
+}
+
+impl SubmitFastBlockProposalTimingsHistograms {
+    pub fn new() -> Result<Self, ClientMetricsError> {
+        Ok(Self {
+            creating_proposal_histogram: Histogram::<u64>::new(2)?,
+            stage_block_execution_histogram: Histogram::<u64>::new(2)?,
+            creating_confirmed_block_histogram: Histogram::<u64>::new(2)?,
+            submitting_block_proposal_histogram: Histogram::<u64>::new(2)?,
+        })
+    }
+
+    pub fn record(
+        &mut self,
+        submit_fast_block_proposal_timings: SubmitFastBlockProposalTimings,
+    ) -> Result<(), ClientMetricsError> {
+        self.creating_proposal_histogram
+            .record(submit_fast_block_proposal_timings.creating_proposal_ms)?;
+        self.stage_block_execution_histogram
+            .record(submit_fast_block_proposal_timings.stage_block_execution_ms)?;
+        self.creating_confirmed_block_histogram
+            .record(submit_fast_block_proposal_timings.creating_confirmed_block_ms)?;
+        self.submitting_block_proposal_histogram
+            .record(submit_fast_block_proposal_timings.submitting_block_proposal_ms)?;
+        Ok(())
+    }
+}
+
+pub struct BlockTimeTimingsHistograms {
+    pub get_pending_message_bundles_histogram: Histogram<u64>,
+    pub submit_fast_block_proposal_histogram: Histogram<u64>,
+    pub submit_fast_block_proposal_timings_histograms: SubmitFastBlockProposalTimingsHistograms,
+    pub communicate_chain_updates_histogram: Histogram<u64>,
+}
+
+impl BlockTimeTimingsHistograms {
+    pub fn new() -> Result<Self, ClientMetricsError> {
+        Ok(Self {
+            get_pending_message_bundles_histogram: Histogram::<u64>::new(2)?,
+            submit_fast_block_proposal_histogram: Histogram::<u64>::new(2)?,
+            submit_fast_block_proposal_timings_histograms:
+                SubmitFastBlockProposalTimingsHistograms::new()?,
+            communicate_chain_updates_histogram: Histogram::<u64>::new(2)?,
+        })
+    }
+
+    pub fn record(
+        &mut self,
+        block_time_timings: BlockTimeTimings,
+    ) -> Result<(), ClientMetricsError> {
+        self.get_pending_message_bundles_histogram
+            .record(block_time_timings.get_pending_message_bundles_ms)?;
+        self.submit_fast_block_proposal_histogram
+            .record(block_time_timings.submit_fast_block_proposal_ms)?;
+        self.submit_fast_block_proposal_timings_histograms
+            .record(block_time_timings.submit_fast_block_proposal_timings)?;
+        self.communicate_chain_updates_histogram
+            .record(block_time_timings.communicate_chain_updates_ms)?;
+        Ok(())
+    }
+}
+
+pub struct BlockTimingsHistograms {
+    pub block_time_histogram: Histogram<u64>,
+    pub block_time_timings_histograms: BlockTimeTimingsHistograms,
+}
+
+impl BlockTimingsHistograms {
+    pub fn new() -> Result<Self, ClientMetricsError> {
+        Ok(Self {
+            block_time_histogram: Histogram::<u64>::new(2)?,
+            block_time_timings_histograms: BlockTimeTimingsHistograms::new()?,
+        })
+    }
+
+    pub fn record(&mut self, block_timings: BlockTimings) -> Result<(), ClientMetricsError> {
+        self.block_time_histogram
+            .record(block_timings.block_time_ms)?;
+        self.block_time_timings_histograms
+            .record(block_timings.block_time_timings)?;
+        Ok(())
+    }
+}
+
+#[cfg(not(web))]
+pub struct ClientMetrics {
+    pub timing_config: TimingConfig,
+    pub timing_sender: mpsc::UnboundedSender<BlockTimings>,
+    pub timing_task: task::JoinHandle<()>,
+}
+
+#[cfg(not(web))]
+impl ClientMetrics {
+    pub fn new(timing_config: TimingConfig) -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let timing_task = tokio::spawn(Self::timing_collection(
+            rx,
+            timing_config.report_interval_secs,
+        ));
+
+        Self {
+            timing_config,
+            timing_sender: tx,
+            timing_task,
+        }
+    }
+
+    async fn timing_collection(
+        mut receiver: mpsc::UnboundedReceiver<BlockTimings>,
+        report_interval_secs: u64,
+    ) {
+        let mut histograms =
+            BlockTimingsHistograms::new().expect("Failed to create timing histograms");
+
+        let mut report_timer = time::interval(time::Duration::from_secs(report_interval_secs));
+        report_timer.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                timing_data = receiver.recv() => {
+                    match timing_data {
+                        Some(block_timings) => {
+                            if let Err(e) = histograms.record(block_timings) {
+                                warn!("Failed to record timing data: {}", e);
+                            }
+                        }
+                        None => {
+                            debug!("Timing collection task shutting down - sender closed");
+                            break;
+                        }
+                    }
+                }
+                _ = report_timer.tick() => {
+                    Self::print_timing_report(&histograms);
+                }
+            }
+        }
+    }
+
+    fn print_timing_report(histograms: &BlockTimingsHistograms) {
+        for quantile in [0.99, 0.95, 0.90, 0.50] {
+            let formatted_quantile = (quantile * 100.0) as usize;
+
+            info!(
+                "Block time p{}: {} ms",
+                formatted_quantile,
+                histograms.block_time_histogram.value_at_quantile(quantile)
+            );
+
+            info!(
+                "  ├─ Get pending message bundles p{}: {} ms",
+                formatted_quantile,
+                histograms
+                    .block_time_timings_histograms
+                    .get_pending_message_bundles_histogram
+                    .value_at_quantile(quantile)
+            );
+            info!(
+                "  ├─ Submit fast block proposal p{}: {} ms",
+                formatted_quantile,
+                histograms
+                    .block_time_timings_histograms
+                    .submit_fast_block_proposal_histogram
+                    .value_at_quantile(quantile)
+            );
+            info!(
+                "  │  ├─ Creating proposal p{}: {} ms",
+                formatted_quantile,
+                histograms
+                    .block_time_timings_histograms
+                    .submit_fast_block_proposal_timings_histograms
+                    .creating_proposal_histogram
+                    .value_at_quantile(quantile)
+            );
+            info!(
+                "  │  ├─ Stage block execution p{}: {} ms",
+                formatted_quantile,
+                histograms
+                    .block_time_timings_histograms
+                    .submit_fast_block_proposal_timings_histograms
+                    .stage_block_execution_histogram
+                    .value_at_quantile(quantile)
+            );
+            info!(
+                "  │  ├─ Creating confirmed block p{}: {} ms",
+                formatted_quantile,
+                histograms
+                    .block_time_timings_histograms
+                    .submit_fast_block_proposal_timings_histograms
+                    .creating_confirmed_block_histogram
+                    .value_at_quantile(quantile)
+            );
+            info!(
+                "  │  └─ Submitting block proposal p{}: {} ms",
+                formatted_quantile,
+                histograms
+                    .block_time_timings_histograms
+                    .submit_fast_block_proposal_timings_histograms
+                    .submitting_block_proposal_histogram
+                    .value_at_quantile(quantile)
+            );
+            info!(
+                "  └─ Communicate chain updates p{}: {} ms",
+                formatted_quantile,
+                histograms
+                    .block_time_timings_histograms
+                    .communicate_chain_updates_histogram
+                    .value_at_quantile(quantile)
+            );
+        }
+    }
+}

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -16,6 +16,8 @@ use linera_core::{
 };
 use linera_execution::ResourceControlPolicy;
 
+#[cfg(not(web))]
+use crate::client_metrics::TimingConfig;
 use crate::util;
 
 #[derive(Debug, thiserror::Error)]
@@ -106,6 +108,16 @@ pub struct ClientContextOptions {
     #[arg(long, value_parser = util::parse_chain_set)]
     pub restrict_chain_ids_to: Option<HashSet<ChainId>>,
 
+    /// Enable timing reports during operations
+    #[cfg(not(web))]
+    #[arg(long)]
+    pub timings: bool,
+
+    /// Interval in seconds between timing reports (defaults to 5)
+    #[cfg(not(web))]
+    #[arg(long, default_value = "5")]
+    pub timing_interval: u64,
+
     /// An additional delay, after reaching a quorum, to wait for additional validator signatures,
     /// as a fraction of time taken to reach quorum.
     #[arg(long, default_value_t = DEFAULT_GRACE_PERIOD)]
@@ -135,6 +147,15 @@ impl ClientContextOptions {
             cross_chain_message_delivery,
             grace_period: self.grace_period,
             blob_download_timeout: self.blob_download_timeout,
+        }
+    }
+
+    /// Creates [`TimingConfig`] with the corresponding values.
+    #[cfg(not(web))]
+    pub fn to_timing_config(&self) -> TimingConfig {
+        TimingConfig {
+            enabled: self.timings,
+            report_interval_secs: self.timing_interval,
         }
     }
 }

--- a/linera-client/src/lib.rs
+++ b/linera-client/src/lib.rs
@@ -9,6 +9,8 @@
 
 pub mod chain_listener;
 pub mod client_context;
+#[cfg(not(web))]
+pub mod client_metrics;
 pub mod client_options;
 pub mod config;
 mod error;

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -867,6 +867,7 @@ impl Runnable for Job {
                     health_check_endpoints,
                     runtime_in_seconds,
                     delay_between_chain_groups_ms,
+                    context.client_metrics().map(|m| m.timing_sender.clone()),
                 )
                 .await?;
 
@@ -2154,7 +2155,11 @@ Make sure to use a Linera client compatible with this network.
                         None,
                         n,
                         on_drop,
-                        vec!["--storage-max-stream-queries".to_string(), "50".to_string()],
+                        vec![
+                            "--storage-max-stream-queries".to_string(),
+                            "50".to_string(),
+                            "--timings".to_string(),
+                        ],
                     )))
                 })
                 .collect::<Result<Vec<_>, anyhow::Error>>()?;


### PR DESCRIPTION
## Motivation

Until we have a Control Pane cluster that has a Prometheus Server that we can use to export client metrics to, we need another way to track timings on the client

## Proposal

This PR moves the functionality of the existing timings specific to `benchmark` into `ClientContext`, so we can keep track of more stuff moving forward. It also makes the timings optional. We can add more to this, then make them into Prometheus metrics in the future.

## Test Plan

Ran the client locally, saw the timings printed

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
