### PR TITLE
Use full client flow on benchmarks

### DIFF
--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -48,6 +48,12 @@ impl chain_listener::ClientContext for ClientContext {
         &self.client
     }
 
+    fn timing_sender(
+        &self,
+    ) -> Option<tokio::sync::mpsc::UnboundedSender<(u64, linera_core::client::TimingType)>> {
+        None
+    }
+
     async fn update_wallet_for_new_chain(
         &mut self,
         chain_id: ChainId,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -63,7 +63,7 @@ use linera_views::ViewError;
 use rand::prelude::SliceRandom as _;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::sync::OwnedRwLockReadGuard;
+use tokio::sync::{mpsc, OwnedRwLockReadGuard};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, info, instrument, warn, Instrument as _};
 
@@ -235,6 +235,7 @@ impl<Env: Environment> Client<Env> {
         next_block_height: BlockHeight,
         pending_proposal: Option<PendingProposal>,
         preferred_owner: Option<AccountOwner>,
+        timing_sender: Option<mpsc::UnboundedSender<(u64, TimingType)>>,
     ) -> ChainClient<Env> {
         // If the entry already exists we assume that the entry is more up to date than
         // the arguments: If they were read from the wallet file, they might be stale.
@@ -249,6 +250,7 @@ impl<Env: Environment> Client<Env> {
             preferred_owner,
             initial_block_hash: block_hash,
             initial_next_block_height: next_block_height,
+            timing_sender,
         }
     }
 
@@ -1370,6 +1372,14 @@ impl MessagePolicy {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum TimingType {
+    ExecuteOperations,
+    ExecuteBlock,
+    SubmitBlockProposal,
+    UpdateValidators,
+}
+
 #[derive(Debug, Clone)]
 pub struct ChainClientOptions {
     /// Maximum number of pending message bundles processed at a time in a block.
@@ -1422,6 +1432,8 @@ pub struct ChainClient<Env: Environment> {
     initial_next_block_height: BlockHeight,
     /// The last block hash as read from the wallet.
     initial_block_hash: Option<CryptoHash>,
+    /// Optional timing sender for benchmarking.
+    timing_sender: Option<mpsc::UnboundedSender<(u64, TimingType)>>,
 }
 
 impl<Env: Environment> Clone for ChainClient<Env> {
@@ -1433,6 +1445,7 @@ impl<Env: Environment> Clone for ChainClient<Env> {
             preferred_owner: self.preferred_owner,
             initial_next_block_height: self.initial_next_block_height,
             initial_block_hash: self.initial_block_hash,
+            timing_sender: self.timing_sender.clone(),
         }
     }
 }
@@ -1625,6 +1638,11 @@ impl<Env: Environment> ChainClient<Env> {
     #[instrument(level = "trace", skip(self))]
     pub fn chain_id(&self) -> ChainId {
         self.chain_id
+    }
+
+    /// Gets a clone of the timing sender for benchmarking.
+    pub fn timing_sender(&self) -> Option<mpsc::UnboundedSender<(u64, TimingType)>> {
+        self.timing_sender.clone()
     }
 
     /// Gets the ID of the admin chain.
@@ -2291,14 +2309,23 @@ impl<Env: Environment> ChainClient<Env> {
         operations: Vec<Operation>,
         blobs: Vec<Blob>,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
-        loop {
+        let timing_start = std::time::Instant::now();
+
+        let result = loop {
+            let execute_block_start = std::time::Instant::now();
             // TODO(#2066): Remove boxing once the call-stack is shallower
             match Box::pin(self.execute_block(operations.clone(), blobs.clone())).await? {
                 ExecuteBlockOutcome::Executed(certificate) => {
-                    return Ok(ClientOutcome::Committed(certificate));
+                    if let Some(sender) = &self.timing_sender {
+                        let _ = sender.send((
+                            execute_block_start.elapsed().as_millis() as u64,
+                            TimingType::ExecuteBlock,
+                        ));
+                    }
+                    break Ok(ClientOutcome::Committed(certificate));
                 }
                 ExecuteBlockOutcome::WaitForTimeout(timeout) => {
-                    return Ok(ClientOutcome::WaitForTimeout(timeout));
+                    break Ok(ClientOutcome::WaitForTimeout(timeout));
                 }
                 ExecuteBlockOutcome::Conflict(certificate) => {
                     info!(
@@ -2307,7 +2334,16 @@ impl<Env: Environment> ChainClient<Env> {
                     );
                 }
             };
+        };
+
+        if let Some(sender) = &self.timing_sender {
+            let _ = sender.send((
+                timing_start.elapsed().as_millis() as u64,
+                TimingType::ExecuteOperations,
+            ));
         }
+
+        result
     }
 
     /// Executes an operation.
@@ -2820,6 +2856,7 @@ impl<Env: Environment> ChainClient<Env> {
         let committee = self.local_committee().await?;
         let block = Block::new(proposed_block, outcome);
         // Send the query to validators.
+        let submit_block_proposal_start = std::time::Instant::now();
         let certificate = if round.is_fast() {
             let hashed_value = ConfirmedBlock::new(block);
             let certificate = self
@@ -2836,10 +2873,22 @@ impl<Env: Environment> ChainClient<Env> {
                 .await?;
             self.client.finalize_block(&committee, certificate).await?
         };
-        debug!(
-            round = %certificate.round,
-            "Sending confirmed block to validators",
-        );
+        if let Some(sender) = &self.timing_sender {
+            let _ = sender.send((
+                submit_block_proposal_start.elapsed().as_millis() as u64,
+                TimingType::SubmitBlockProposal,
+            ));
+        }
+
+        debug!(round = %certificate.round, "Sending confirmed block to validators");
+        let update_validators_start = std::time::Instant::now();
+        self.update_validators(Some(&committee)).await?;
+        if let Some(sender) = &self.timing_sender {
+            let _ = sender.send((
+                update_validators_start.elapsed().as_millis() as u64,
+                TimingType::UpdateValidators,
+            ));
+        }
         Ok(ClientOutcome::Committed(Some(certificate)))
     }
 

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -1009,6 +1009,7 @@ where
             block_height,
             None,
             self.chain_owners.get(&chain_id).copied(),
+            None,
         ))
     }
 

--- a/linera-faucet/server/src/tests.rs
+++ b/linera-faucet/server/src/tests.rs
@@ -40,6 +40,12 @@ impl chain_listener::ClientContext for ClientContext {
         unimplemented!()
     }
 
+    fn timing_sender(
+        &self,
+    ) -> Option<tokio::sync::mpsc::UnboundedSender<(u64, linera_core::client::TimingType)>> {
+        None
+    }
+
     fn make_chain_client(&self, chain_id: ChainId) -> ChainClient<environment::Test> {
         assert_eq!(chain_id, self.client.chain_id());
         self.client.clone()

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -19,8 +19,6 @@ use linera_client::{
     util,
 };
 use linera_rpc::config::CrossChainConfig;
-#[cfg(feature = "benchmark")]
-use serde::Serialize;
 
 #[cfg(feature = "benchmark")]
 const DEFAULT_TOKENS_PER_CHAIN: Amount = Amount::from_millis(100);
@@ -33,7 +31,7 @@ const DEFAULT_BPS: usize = 10;
 
 // Make sure that the default values are consts, and that they are used in the Default impl.
 #[cfg(feature = "benchmark")]
-#[derive(Clone, Serialize, clap::Args)]
+#[derive(Clone, clap::Args, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct BenchmarkCommand {
     /// Wether to use cross chain messages in the transactions or not. This effectively sets the

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -186,6 +186,12 @@ impl ClientContext for DummyContext {
         unimplemented!()
     }
 
+    fn timing_sender(
+        &self,
+    ) -> Option<tokio::sync::mpsc::UnboundedSender<(u64, linera_core::client::TimingType)>> {
+        None
+    }
+
     async fn update_wallet_for_new_chain(
         &mut self,
         _: ChainId,


### PR DESCRIPTION
## Motivation

We're changing things to use the full client flow from benchmarks. This is part of a whole refactor to make the benchmarks more "realistic".

## Proposal

By using the full flow, we also had to rewrite how we do the client logging of timing metrics. We'll have a timing tokio task running that will manage the histograms, and whoever wants to log the time of something sends a message to this tokio task.
Then every some number of seconds we print that information to the screen for the user.

## Test Plan

Ran locally, saw the metrics being correctly printed

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
