### PR TITLE
Make `ContractRuntime::transfer` synchronous for local transfers.

### DIFF
--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -622,7 +622,7 @@ pub enum ExecutionRequest {
         signer: Option<AccountOwner>,
         application_id: ApplicationId,
         #[debug(skip)]
-        callback: Sender<OutgoingMessage>,
+        callback: Sender<Option<OutgoingMessage>>,
     },
 
     SystemTimestamp {

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1308,7 +1308,8 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
                 callback,
             })?
             .recv_response()?;
-        this.transaction_tracker.add_outgoing_messages(maybe_message);
+        this.transaction_tracker
+            .add_outgoing_messages(maybe_message);
         Ok(())
     }
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1297,7 +1297,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         let application_id = current_application.id;
         let signer = current_application.signer;
 
-        let message = this
+        let maybe_message = this
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::Claim {
                 source,
@@ -1308,7 +1308,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
                 callback,
             })?
             .recv_response()?;
-        this.transaction_tracker.add_outgoing_message(message);
+        this.transaction_tracker.add_outgoing_messages(maybe_message);
         Ok(())
     }
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -438,7 +438,7 @@ where
                 recipient,
                 amount,
             } => {
-                let message = self
+                let maybe_message = self
                     .claim(
                         context.authenticated_signer,
                         None,
@@ -448,7 +448,7 @@ where
                         amount,
                     )
                     .await?;
-                txn_tracker.add_outgoing_message(message);
+                txn_tracker.add_outgoing_messages(maybe_message);
             }
             Admin(admin_operation) => {
                 ensure!(
@@ -648,6 +648,48 @@ where
         Ok(())
     }
 
+    async fn credit(&mut self, owner: &AccountOwner, amount: Amount) -> Result<(), ExecutionError> {
+        if owner == &AccountOwner::CHAIN {
+            let new_balance = self.balance.get().saturating_add(amount);
+            self.balance.set(new_balance);
+        } else {
+            let balance = self.balances.get_mut_or_default(owner).await?;
+            *balance = balance.saturating_add(amount);
+        }
+        Ok(())
+    }
+
+    async fn credit_or_send_message(
+        &mut self,
+        source: AccountOwner,
+        recipient: Recipient,
+        amount: Amount,
+    ) -> Result<Option<OutgoingMessage>, ExecutionError> {
+        match recipient {
+            Recipient::Account(account) => {
+                let source_chain_id = self.context().extra().chain_id();
+                if account.chain_id == source_chain_id {
+                    // Handle same-chain transfer locally.
+                    let target = account.owner;
+                    self.credit(&target, amount).await?;
+                    Ok(None)
+                } else {
+                    // Handle cross-chain transfer with message.
+                    let message = SystemMessage::Credit {
+                        amount,
+                        source,
+                        target: account.owner,
+                    };
+                    Ok(Some(
+                        OutgoingMessage::new(account.chain_id, message)
+                            .with_kind(MessageKind::Tracked),
+                    ))
+                }
+            }
+            Recipient::Burn => Ok(None),
+        }
+    }
+
     pub async fn transfer(
         &mut self,
         authenticated_signer: Option<AccountOwner>,
@@ -677,30 +719,18 @@ where
             ExecutionError::IncorrectTransferAmount
         );
         self.debit(&source, amount).await?;
-        match recipient {
-            Recipient::Account(account) => {
-                let message = SystemMessage::Credit {
-                    amount,
-                    source,
-                    target: account.owner,
-                };
-                Ok(Some(
-                    OutgoingMessage::new(account.chain_id, message).with_kind(MessageKind::Tracked),
-                ))
-            }
-            Recipient::Burn => Ok(None),
-        }
+        self.credit_or_send_message(source, recipient, amount).await
     }
 
     pub async fn claim(
-        &self,
+        &mut self,
         authenticated_signer: Option<AccountOwner>,
         authenticated_application_id: Option<ApplicationId>,
         source: AccountOwner,
         target_id: ChainId,
         recipient: Recipient,
         amount: Amount,
-    ) -> Result<OutgoingMessage, ExecutionError> {
+    ) -> Result<Option<OutgoingMessage>, ExecutionError> {
         ensure!(
             authenticated_signer == Some(source)
                 || authenticated_application_id.map(AccountOwner::from) == Some(source),
@@ -708,15 +738,23 @@ where
         );
         ensure!(amount > Amount::ZERO, ExecutionError::IncorrectClaimAmount);
 
-        let message = SystemMessage::Withdraw {
-            amount,
-            owner: source,
-            recipient,
-        };
-        Ok(
-            OutgoingMessage::new(target_id, message)
-                .with_authenticated_signer(authenticated_signer),
-        )
+        let current_chain_id = self.context().extra().chain_id();
+        if target_id == current_chain_id {
+            // Handle same-chain claim locally by processing the withdraw operation directly
+            self.debit(&source, amount).await?;
+            self.credit_or_send_message(source, recipient, amount).await
+        } else {
+            // Handle cross-chain claim with Withdraw message
+            let message = SystemMessage::Withdraw {
+                amount,
+                owner: source,
+                recipient,
+            };
+            Ok(Some(
+                OutgoingMessage::new(target_id, message)
+                    .with_authenticated_signer(authenticated_signer),
+            ))
+        }
     }
 
     /// Debits an [`Amount`] of tokens from an account's balance.
@@ -765,13 +803,7 @@ where
                 target,
             } => {
                 let receiver = if context.is_bouncing { source } else { target };
-                if receiver == AccountOwner::CHAIN {
-                    let new_balance = self.balance.get().saturating_add(amount);
-                    self.balance.set(new_balance);
-                } else {
-                    let balance = self.balances.get_mut_or_default(&receiver).await?;
-                    *balance = balance.saturating_add(amount);
-                }
+                self.credit(&receiver, amount).await?;
             }
             Withdraw {
                 amount,
@@ -779,19 +811,11 @@ where
                 recipient,
             } => {
                 self.debit(&owner, amount).await?;
-                match recipient {
-                    Recipient::Account(account) => {
-                        let message = SystemMessage::Credit {
-                            amount,
-                            source: owner,
-                            target: account.owner,
-                        };
-                        outcome.push(
-                            OutgoingMessage::new(account.chain_id, message)
-                                .with_kind(MessageKind::Tracked),
-                        );
-                    }
-                    Recipient::Burn => (),
+                if let Some(message) = self
+                    .credit_or_send_message(owner, recipient, amount)
+                    .await?
+                {
+                    outcome.push(message);
                 }
             }
         }

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2201,16 +2201,6 @@ async fn test_wasm_end_to_end_fungible(
             .await?,
     );
 
-    // Needed synchronization though removing it does not get error in 100% of cases.
-    assert_eq!(
-        node_service1.process_inbox(&chain1).await?.len(),
-        if example_name == "native-fungible" {
-            1
-        } else {
-            0
-        }
-    );
-
     let expected_balances = [
         (account_owner1, Amount::from_tokens(5)),
         (account_owner2, Amount::from_tokens(2)),
@@ -2363,16 +2353,6 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
         node_service
             .make_application(&chain1, &application_id)
             .await?,
-    );
-
-    // Needed synchronization though removing it does not get error in 100% of cases.
-    assert_eq!(
-        node_service.process_inbox(&chain1).await?.len(),
-        if example_name == "native-fungible" {
-            1
-        } else {
-            0
-        }
     );
 
     let expected_balances: Vec<(AccountOwner, Amount)> = state.accounts.into_iter().collect();


### PR DESCRIPTION
## Motivation

During the implementation of `transfer` operations in the EVM, we face the problem that while the 
`ContractRuntime::transfer` immediately debits the source, and the destination receives the amount
only on the next block.

While this makes complete sense if the destination chain is different from the source chain, there is a use
case for transfer operations within the same chain that are done immediately without emitting messages.

Fixes #3486 

## Proposal

The code of `SystemExecutionStateView::transfer` has been changed so that it does not emit a message if the source chain is the same as the destination chain.

The operations that have been corrected are:
* `Claim`
* `Transfer`
* `Withdraw`

## Test Plan

The CI.

Several tests in `worker_test.rs` had to be changed because the emission of messages had changed.

The end-to-end tests are also unified because now `fungible` and the native token have the same behavior for the emission of messages.

More tests for `Claim`, `Withdraw`, and `Credit` would be useful to do in subsequent PRs.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.