### PR TITLE
Make chains transfer to each other across benchmark processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5182,6 +5182,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde-wasm-bindgen 0.6.5",
+ "serde_yaml",
  "social",
  "tempfile",
  "test-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,6 +217,7 @@ serde_with = { version = "3", default-features = false, features = [
     "alloc",
     "macros",
 ] }
+serde_yaml = "0.9.34"
 sha3 = "0.10.8"
 similar-asserts = "1.5.0"
 static_assertions = "1.1.0"

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -21,6 +21,7 @@ benchmark = [
     "dep:anyhow",
     "dep:prometheus-parse",
     "dep:rand",
+    "dep:serde_yaml",
 ]
 wasmer = [
     "linera-core/wasmer",
@@ -74,6 +75,7 @@ prometheus-parse = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 serde.workspace = true
+serde_yaml = { workspace = true, optional = true }
 thiserror.workspace = true
 thiserror-context.workspace = true
 tokio.workspace = true

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -93,6 +93,11 @@ pub struct BenchmarkCommand {
     /// TPS all at once.
     #[arg(long)]
     pub delay_between_chains_ms: Option<u64>,
+
+    /// Path to YAML file containing chain IDs to send transfers to.
+    /// If not provided, only transfers between chains in the same wallet.
+    #[arg(long)]
+    pub config_path: Option<PathBuf>,
 }
 
 #[cfg(feature = "benchmark")]
@@ -110,6 +115,7 @@ impl Default for BenchmarkCommand {
             confirm_before_start: false,
             runtime_in_seconds: None,
             delay_between_chains_ms: None,
+            config_path: None,
         }
     }
 }
@@ -150,6 +156,11 @@ pub enum ClientCommand {
         /// balance.
         #[arg(long = "initial-balance", default_value = "0")]
         balance: Amount,
+
+        /// Whether to create a super owner for the new chain.
+        #[cfg(feature = "benchmark")]
+        #[arg(long)]
+        super_owner: bool,
     },
 
     /// Open (i.e. activate) a new multi-owner chain deriving the UID from an existing one.
@@ -486,8 +497,13 @@ pub enum ClientCommand {
         command: BenchmarkCommand,
 
         /// The delay between starting the benchmark processes, in seconds.
+        /// If --cross-wallet-transfers is true, this will be ignored.
         #[arg(long, default_value = "10")]
         delay_between_processes: u64,
+
+        /// Whether to send transfers between chains in different wallets.
+        #[arg(long)]
+        cross_wallet_transfers: bool,
     },
 
     /// Create genesis configuration for a Linera deployment.

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -61,16 +61,23 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn, Instrument as _};
 #[cfg(feature = "benchmark")]
 use {
-    linera_client::chain_listener::{ChainListener, ChainListenerConfig},
+    linera_base::identifiers::ChainId,
+    linera_client::{
+        benchmark::BenchmarkConfig,
+        chain_listener::{ChainListener, ChainListenerConfig},
+    },
+    linera_faucet_client::Faucet,
     linera_service::{
         cli::command::BenchmarkCommand,
         cli_wrappers::{local_net::PathProvider, ClientWrapper, Network, OnClientDrop},
     },
     std::time::Duration,
+    tempfile::NamedTempFile,
     tokio::{
         io::AsyncWriteExt,
         process::{ChildStdin, Command},
         sync::oneshot,
+        time,
     },
 };
 
@@ -142,6 +149,8 @@ impl Runnable for Job {
                 chain_id,
                 owner,
                 balance,
+                #[cfg(feature = "benchmark")]
+                super_owner,
             } => {
                 let new_owner = owner.unwrap_or_else(|| signer.generate_new().into());
                 signer.persist().await?;
@@ -157,7 +166,15 @@ impl Runnable for Job {
                 let time_start = Instant::now();
                 let (description, certificate) = context
                     .apply_client_command(&chain_client, |chain_client| {
+                        #[cfg(feature = "benchmark")]
+                        let ownership = if super_owner {
+                            ChainOwnership::single_super(new_owner)
+                        } else {
+                            ChainOwnership::single(new_owner)
+                        };
+                        #[cfg(not(feature = "benchmark"))]
                         let ownership = ChainOwnership::single(new_owner);
+
                         let chain_client = chain_client.clone();
                         async move {
                             chain_client
@@ -805,6 +822,7 @@ impl Runnable for Job {
                     confirm_before_start,
                     runtime_in_seconds,
                     delay_between_chains_ms,
+                    config_path,
                 } = benchmark_config;
                 assert!(
                     options.context_options.max_pending_message_bundles >= transactions_per_block,
@@ -851,6 +869,7 @@ impl Runnable for Job {
                         tokens_per_chain,
                         fungible_application_id,
                         pub_keys,
+                        config_path.as_deref(),
                     )
                     .await?;
 
@@ -2170,8 +2189,10 @@ Make sure to use a Linera client compatible with this network.
             client_state_dir,
             command,
             delay_between_processes,
+            cross_wallet_transfers,
         } => {
-            let faucet = linera_faucet_client::Faucet::new(faucet.clone());
+            let mut command = command.clone();
+            let faucet = Faucet::new(faucet.clone());
             let on_drop = if command.close_chains {
                 OnClientDrop::CloseChains
             } else {
@@ -2207,20 +2228,86 @@ Make sure to use a Linera client compatible with this network.
 
             info!("Initializing wallets...");
             let mut join_set = JoinSet::new();
-            for client in clients.clone() {
-                let faucet = faucet.clone();
-                join_set.spawn(async move {
-                    client.wallet_init(Some(&faucet)).await?;
-                    client.request_chain(&faucet, true).await?;
-                    Ok::<_, anyhow::Error>(())
-                });
-            }
 
-            join_set
-                .join_all()
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()?;
+            if *cross_wallet_transfers {
+                for client in &clients {
+                    let client = client.clone();
+                    let faucet = faucet.clone();
+                    join_set.spawn(async move {
+                        client.wallet_init(Some(&faucet)).await?;
+                        client.request_chain(&faucet, true).await?;
+                        Ok::<_, anyhow::Error>(())
+                    });
+                }
+
+                join_set
+                    .join_all()
+                    .await
+                    .into_iter()
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                let chains_per_wallet = command.num_chains;
+                info!(
+                    "Creating {} chains per wallet ({} total chains)...",
+                    chains_per_wallet,
+                    chains_per_wallet * processes
+                );
+
+                let mut join_set = JoinSet::new();
+                for client in &clients {
+                    let default_chain_id = client
+                        .default_chain()
+                        .ok_or_else(|| anyhow::anyhow!("No default chain found for client"))?;
+                    let client = client.clone();
+                    join_set.spawn(async move {
+                        let mut chain_ids = Vec::new();
+                        for _ in 0..chains_per_wallet {
+                            let (chain_id, _owner) = client
+                                .open_chain_super_owner(
+                                    default_chain_id,
+                                    None,
+                                    command.tokens_per_chain,
+                                )
+                                .await?;
+                            chain_ids.push(chain_id);
+                        }
+                        Ok::<Vec<ChainId>, anyhow::Error>(chain_ids)
+                    });
+                }
+
+                let all_chain_ids = join_set
+                    .join_all()
+                    .await
+                    .into_iter()
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>();
+
+                let config = BenchmarkConfig {
+                    chain_ids: all_chain_ids,
+                };
+
+                let (_, path) = NamedTempFile::new()?.keep()?;
+                config.save_to_file(&path)?;
+                info!("Saved chains configuration to {}", path.display());
+                command.config_path = Some(path);
+            } else {
+                for client in clients.clone() {
+                    let faucet = faucet.clone();
+                    join_set.spawn(async move {
+                        client.wallet_init(Some(&faucet)).await?;
+                        client.request_chain(&faucet, true).await?;
+                        Ok::<_, anyhow::Error>(())
+                    });
+                }
+
+                join_set
+                    .join_all()
+                    .await
+                    .into_iter()
+                    .collect::<Result<Vec<_>, _>>()?;
+            }
 
             info!("Starting benchmark processes...");
             let confirm_before_start = command.confirm_before_start;
@@ -2286,16 +2373,16 @@ Make sure to use a Linera client compatible with this network.
                     return Ok(1);
                 }
 
-                let mut previous = tokio::time::Instant::now();
+                let mut previous = time::Instant::now();
                 let mut first = true;
                 let mut started_count = 0;
                 for child in &mut children {
                     if first {
                         first = false;
-                    } else {
+                    } else if !*cross_wallet_transfers {
                         let time_elapsed = previous.elapsed();
                         if time_elapsed < Duration::from_secs(*delay_between_processes) {
-                            tokio::time::sleep(
+                            time::sleep(
                                 Duration::from_secs(*delay_between_processes) - time_elapsed,
                             )
                             .await;
@@ -2308,7 +2395,7 @@ Make sure to use a Linera client compatible with this network.
                     started_count += 1;
                     info!("{}/{} benchmarks started", started_count, processes);
 
-                    previous = tokio::time::Instant::now();
+                    previous = time::Instant::now();
                 }
             }
 


### PR DESCRIPTION
## Motivation

Right now the benchmark client processes only do transfer amongst chains in their wallets. We should have a way of these processes be able to send transfers to chains in other wallets.

## Proposal

Pass a file to the benchmark client processes with all the chain IDs (from across wallets) that we can send transfers to. Enable that via `multi-benchmark` with an option

## Test Plan

Ran this with the new option locally against a local network, seems to do what it's supposed to.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
