### PR TITLE
Synchronicity of balances between Linera and the EVM.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -17,6 +17,7 @@ use std::{
     str::FromStr,
 };
 
+use alloy_primitives::U256;
 use async_graphql::{InputObject, SimpleObject};
 use custom_debug_derive::Debug;
 use linera_witty::{WitLoad, WitStore, WitType};
@@ -76,6 +77,38 @@ impl<'de> Deserialize<'de> for Amount {
         } else {
             Ok(Amount(AmountU128::deserialize(deserializer)?.0))
         }
+    }
+}
+
+impl From<Amount> for U256 {
+    fn from(amount: Amount) -> U256 {
+        U256::from(amount.0)
+    }
+}
+
+/// Converting amount from U256 to Amount can fail since
+/// Amount is a u128.
+#[derive(Error, Debug)]
+pub struct AmountConversionError(U256);
+
+impl fmt::Display for AmountConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Amount conversion error for {}", self.0)
+    }
+}
+
+impl TryFrom<U256> for Amount {
+    type Error = AmountConversionError;
+    fn try_from(value: U256) -> Result<Amount, Self::Error> {
+        let vec: [u8; 32] = value.to_be_bytes();
+        for val in vec.iter().take(16) {
+            if *val != 0 {
+                return Err(AmountConversionError(value));
+            }
+        }
+        let value: [u8; 16] = vec[16..].try_into().expect("value should be of length 16");
+        let value = u128::from_be_bytes(value);
+        Ok(Amount(value))
     }
 }
 
@@ -1572,6 +1605,8 @@ mod metrics {
 mod tests {
     use std::str::FromStr;
 
+    use alloy_primitives::U256;
+
     use super::Amount;
 
     #[test]
@@ -1598,5 +1633,13 @@ mod tests {
             "~+12.34~~",
             format!("{:~^+9.1}", Amount::from_str("12.34").unwrap())
         );
+    }
+
+    #[test]
+    fn test_conversion_amount_u256() {
+        let value_amount = Amount::from_tokens(15656565652209004332);
+        let value_u256: U256 = value_amount.into();
+        let value_amount_rev = Amount::try_from(value_u256).expect("Failed conversion");
+        assert_eq!(value_amount, value_amount_rev);
     }
 }

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -70,6 +70,14 @@ impl AccountOwner {
     }
 }
 
+#[cfg(with_revm)]
+impl From<Address> for AccountOwner {
+    fn from(address: Address) -> Self {
+        let address = address.into_array();
+        AccountOwner::Address20(address)
+    }
+}
+
 #[cfg(with_testing)]
 impl From<CryptoHash> for AccountOwner {
     fn from(address: CryptoHash) -> Self {

--- a/linera-execution/src/evm/database.rs
+++ b/linera-execution/src/evm/database.rs
@@ -23,7 +23,7 @@ use revm_state::{AccountInfo, Bytecode, EvmState};
 
 use crate::{
     evm::{read_amount, inputs::ZERO_ADDRESS},
-    ApplicationId, BaseRuntime, Batch, ContractRuntime, EvmExecutionError, ExecutionError,
+    BaseRuntime, Batch, ContractRuntime, EvmExecutionError, ExecutionError,
     ServiceRuntime,
 };
 
@@ -112,12 +112,6 @@ pub enum KeyCategory {
     AccountInfo,
     AccountState,
     Storage,
-}
-
-fn application_id_to_address(application_id: ApplicationId) -> Address {
-    let application_id: [u64; 4] = <[u64; 4]>::from(application_id.application_description_hash);
-    let application_id: [u8; 32] = linera_base::crypto::u64_array_to_be_bytes(application_id);
-    Address::from_slice(&application_id[0..20])
 }
 
 impl<Runtime: BaseRuntime> DatabaseRuntime<Runtime> {
@@ -230,7 +224,12 @@ where
             return Ok(Some(account.info.clone()));
         }
         let mut runtime = self.runtime.lock().expect("The lock should be possible");
-        let account_owner = address.into();
+        let account_owner = if address == self.contract_address {
+            let application_id = runtime.application_id()?;
+            application_id.into()
+        } else {
+            address.into()
+        };
         tracing::info!("basic_ref, account_owner = {account_owner}");
         // The balances being used are the ones of Linera. So, we need to
         // access them at first.
@@ -389,7 +388,7 @@ where
     pub fn set_contract_address(&mut self) -> Result<(), ExecutionError> {
         let mut runtime = self.runtime.lock().expect("The lock should be possible");
         let application_id = runtime.application_id()?;
-        self.contract_address = application_id_to_address(application_id);
+        self.contract_address = application_id.evm_address();
         Ok(())
     }
 

--- a/linera-execution/src/evm/database.rs
+++ b/linera-execution/src/evm/database.rs
@@ -216,29 +216,36 @@ where
     type Error = ExecutionError;
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, ExecutionError> {
+        tracing::info!("basic_ref, address = {address}");
         if !self.changes.is_empty() {
             let account = self.changes.get(&address).unwrap();
             return Ok(Some(account.info.clone()));
         }
         let mut runtime = self.runtime.lock().expect("The lock should be possible");
         let account_owner = address.into();
+        tracing::info!("basic_ref, account_owner = {account_owner}");
         let balance = runtime.read_owner_balance(account_owner)?;
+        tracing::info!("basic_ref, balance = {balance}");
+
         let balance: U256 = balance.into();
         let key_info = Self::get_address_key(KeyCategory::AccountInfo as u8, address);
         let promise = runtime.read_value_bytes_new(key_info)?;
         let result = runtime.read_value_bytes_wait(&promise)?;
         let account_info = from_bytes_option::<AccountInfo>(&result)?;
         if balance == U256::ZERO || address == self.contract_address {
+            tracing::info!("basic_ref, return(A) account_info = {account_info:?}");
             return Ok(account_info);
         }
         if let Some(mut account_info) = account_info {
             account_info.balance = balance;
+            tracing::info!("basic_ref, return(B) account_info = {account_info:?}");
             return Ok(Some(account_info));
         }
         // The balance is non-zero. Therefore, the account exists.đ
         // However, the state is None. Therefore, we need to create
         // a default account first.
         let account_info = AccountInfo { balance, ..Default::default() };
+        tracing::info!("basic_ref, return(C) account_info = {account_info:?}");
         Ok(Some(account_info))
     }
 
@@ -292,6 +299,7 @@ where
             if !account.is_touched() {
                 continue;
             }
+            tracing::info!("commit_changes, address = {address} account_info = {:?}", account.info);
             let key_prefix = Self::get_address_key(KeyCategory::Storage as u8, *address);
             let key_info = Self::get_address_key(KeyCategory::AccountInfo as u8, *address);
             let key_state = Self::get_address_key(KeyCategory::AccountState as u8, *address);
@@ -474,7 +482,9 @@ where
             let application_id = runtime.application_id()?;
             let owner: AccountOwner = application_id.into();
             let destination = Account { chain_id, owner };
-            return runtime.transfer(source, destination, amount);
+            tracing::info!("deposit_funds, runtime.transfer, before");
+            runtime.transfer(source, destination, amount)?;
+            tracing::info!("deposit_funds, runtime.transfer, after");
         }
         Ok(())
     }

--- a/linera-execution/src/evm/database.rs
+++ b/linera-execution/src/evm/database.rs
@@ -9,7 +9,11 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use linera_base::vm::VmRuntime;
+use linera_base::{
+    data_types::Amount,
+    identifiers::{Account, AccountOwner},
+    vm::VmRuntime,
+};
 use linera_views::common::from_bytes_option;
 use revm::{primitives::keccak256, Database, DatabaseCommit, DatabaseRef};
 use revm_context::BlockEnv;
@@ -18,7 +22,11 @@ use revm_database::{AccountState, DBErrorMarker};
 use revm_primitives::{address, Address, B256, U256};
 use revm_state::{AccountInfo, Bytecode, EvmState};
 
-use crate::{ApplicationId, BaseRuntime, Batch, ContractRuntime, ExecutionError, ServiceRuntime};
+use crate::{
+    evm::{read_amount, inputs::EvmMutation},
+    ApplicationId, BaseRuntime, Batch, ContractRuntime, EvmExecutionError, ExecutionError,
+    ServiceRuntime,
+};
 
 // The runtime costs are not available in service operations.
 // We need to set a limit to gas usage in order to avoid blocking
@@ -78,6 +86,8 @@ pub(crate) struct DatabaseRuntime<Runtime> {
     pub runtime: Arc<Mutex<Runtime>>,
     /// The uncommitted changes to the contract.
     pub changes: EvmState,
+    /// The error that can occur during runtime.
+    pub error: Arc<Mutex<Option<String>>>,
 }
 
 impl<Runtime> Clone for DatabaseRuntime<Runtime> {
@@ -87,6 +97,7 @@ impl<Runtime> Clone for DatabaseRuntime<Runtime> {
             contract_address: self.contract_address,
             runtime: self.runtime.clone(),
             changes: self.changes.clone(),
+            error: self.error.clone(),
         }
     }
 }
@@ -107,14 +118,14 @@ fn application_id_to_address(application_id: ApplicationId) -> Address {
 impl<Runtime: BaseRuntime> DatabaseRuntime<Runtime> {
     /// Encode the `index` of the EVM storage associated to the smart contract
     /// in a linera key.
-    fn get_linera_key(key_prefix: &[u8], index: U256) -> Result<Vec<u8>, ExecutionError> {
+    fn get_linera_key(key_prefix: &[u8], index: U256) -> Vec<u8> {
         let mut key = key_prefix.to_vec();
-        bcs::serialize_into(&mut key, &index)?;
-        Ok(key)
+        key.extend(index.as_le_slice());
+        key
     }
 
     /// Returns the tag associated to the contract.
-    fn get_address_key(&self, prefix: u8, address: Address) -> Vec<u8> {
+    fn get_address_key(prefix: u8, address: Address) -> Vec<u8> {
         let mut key = vec![prefix];
         key.extend(address);
         key
@@ -131,6 +142,7 @@ impl<Runtime: BaseRuntime> DatabaseRuntime<Runtime> {
             contract_address: Address::ZERO,
             runtime: Arc::new(Mutex::new(runtime)),
             changes: HashMap::new(),
+            error: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -143,6 +155,23 @@ impl<Runtime: BaseRuntime> DatabaseRuntime<Runtime> {
         let storage_stats = storage_stats_read.clone();
         *storage_stats_read = StorageStats::default();
         storage_stats
+    }
+
+    /// Insert error into the database
+    pub fn insert_error(&self, exec_error: ExecutionError) {
+        let mut error = self.error.lock().expect("The lock should be possible");
+        *error = Some(format!("Runtime error {:?}", exec_error));
+    }
+
+    /// Process the error.
+    pub fn process_any_error(&self) -> Result<(), EvmExecutionError> {
+        let error = self.error.lock().expect("The lock should be possible");
+        if error.is_some() {
+            if let Some(error) = error.clone() {
+                return Err(EvmExecutionError::RuntimeError(error));
+            }
+        }
+        Ok(())
     }
 }
 
@@ -192,11 +221,25 @@ where
             return Ok(Some(account.info.clone()));
         }
         let mut runtime = self.runtime.lock().expect("The lock should be possible");
-        let key_info = self.get_address_key(KeyCategory::AccountInfo as u8, address);
+        let account_owner = address.into();
+        let balance = runtime.read_owner_balance(account_owner)?;
+        let balance: U256 = balance.into();
+        let key_info = Self::get_address_key(KeyCategory::AccountInfo as u8, address);
         let promise = runtime.read_value_bytes_new(key_info)?;
         let result = runtime.read_value_bytes_wait(&promise)?;
         let account_info = from_bytes_option::<AccountInfo>(&result)?;
-        Ok(account_info)
+        if balance == U256::ZERO || address == self.contract_address {
+            return Ok(account_info);
+        }
+        if let Some(mut account_info) = account_info {
+            account_info.balance = balance;
+            return Ok(Some(account_info));
+        }
+        // The balance is non-zero. Therefore, the account exists.đ
+        // However, the state is None. Therefore, we need to create
+        // a default account first.
+        let account_info = AccountInfo { balance, ..Default::default() };
+        Ok(Some(account_info))
     }
 
     fn code_by_hash_ref(&self, _code_hash: B256) -> Result<Bytecode, ExecutionError> {
@@ -211,8 +254,8 @@ where
                 Some(slot) => slot.present_value(),
             });
         }
-        let key_prefix = self.get_address_key(KeyCategory::Storage as u8, address);
-        let key = Self::get_linera_key(&key_prefix, index)?;
+        let key_prefix = Self::get_address_key(KeyCategory::Storage as u8, address);
+        let key = Self::get_linera_key(&key_prefix, index);
         {
             let mut storage_stats = self
                 .storage_stats
@@ -249,9 +292,9 @@ where
             if !account.is_touched() {
                 continue;
             }
-            let key_prefix = self.get_address_key(KeyCategory::Storage as u8, *address);
-            let key_info = self.get_address_key(KeyCategory::AccountInfo as u8, *address);
-            let key_state = self.get_address_key(KeyCategory::AccountState as u8, *address);
+            let key_prefix = Self::get_address_key(KeyCategory::Storage as u8, *address);
+            let key_info = Self::get_address_key(KeyCategory::AccountInfo as u8, *address);
+            let key_state = Self::get_address_key(KeyCategory::AccountState as u8, *address);
             if account.is_selfdestructed() {
                 batch.delete_key_prefix(key_prefix);
                 batch.put_key_value(key_info, &AccountInfo::default())?;
@@ -278,7 +321,7 @@ where
                     if value.present_value() == value.original_value() {
                         storage_stats.key_no_operation += 1;
                     } else {
-                        let key = Self::get_linera_key(&key_prefix, *index)?;
+                        let key = Self::get_linera_key(&key_prefix, *index);
                         if value.original_value() == U256::ZERO {
                             batch.put_key_value(key, &value.present_value())?;
                             storage_stats.key_set += 1;
@@ -303,6 +346,30 @@ impl<Runtime> DatabaseRuntime<Runtime>
 where
     Runtime: BaseRuntime,
 {
+    /// Gets the contract address balance
+    pub fn get_balance_increase(&self) -> Result<U256, ExecutionError> {
+        let existing_evm_balance = {
+            let account_info = self.basic_ref(self.contract_address)?;
+            match account_info {
+                None => U256::ZERO,
+                Some(account_info) => account_info.balance,
+            }
+        };
+        let linera_balance = {
+            let mut runtime = self.runtime.lock().expect("The lock should be possible");
+            let application_id = runtime.application_id()?;
+            let account_owner: AccountOwner = application_id.into();
+            let balance = runtime.read_owner_balance(account_owner)?;
+            let balance: U256 = balance.into();
+            balance
+        };
+        if existing_evm_balance > linera_balance {
+            return Err(EvmExecutionError::IncoherentBalance.into());
+        }
+        let increment = linera_balance - existing_evm_balance;
+        Ok(increment)
+    }
+
     /// Reads the nonce of the user
     pub fn get_nonce(&self, address: &Address) -> Result<u64, ExecutionError> {
         let account_info = self.basic_ref(*address)?;
@@ -326,7 +393,7 @@ where
     pub fn is_initialized(&self) -> Result<bool, ExecutionError> {
         let mut runtime = self.runtime.lock().expect("The lock should be possible");
         let evm_address = runtime.application_id()?.evm_address();
-        let key_info = self.get_address_key(KeyCategory::AccountInfo as u8, evm_address);
+        let key_info = Self::get_address_key(KeyCategory::AccountInfo as u8, evm_address);
         let promise = runtime.contains_key_new(key_info)?;
         let result = runtime.contains_key_wait(&promise)?;
         Ok(result)
@@ -393,6 +460,30 @@ where
         let gas_limit = runtime.maximum_fuel_per_block(VmRuntime::Evm)?;
         block_env.gas_limit = gas_limit;
         Ok(block_env)
+    }
+
+    pub fn deposit_funds(&self, amount: Amount) -> Result<(), ExecutionError> {
+        if amount != Amount::ZERO {
+            let mut runtime = self.runtime.lock().expect("The lock should be possible");
+            let signer = runtime.authenticated_signer()?;
+            let Some(source) = signer else {
+                let error = EvmExecutionError::UnknownSigner;
+                return Err(error.into());
+            };
+            let chain_id = runtime.chain_id()?;
+            let application_id = runtime.application_id()?;
+            let owner: AccountOwner = application_id.into();
+            let destination = Account { chain_id, owner };
+            return runtime.transfer(source, destination, amount);
+        }
+        Ok(())
+    }
+
+    pub fn get_execute_operation_argument(&self, operation: &[u8]) -> Result<Vec<u8>, ExecutionError> {
+        let evm_call = bcs::from_bytes::<EvmMutation>(operation)?;
+        let value = read_amount(evm_call.value)?;
+        self.deposit_funds(value)?;
+        Ok(evm_call.argument)
     }
 }
 

--- a/linera-execution/src/evm/database.rs
+++ b/linera-execution/src/evm/database.rs
@@ -9,7 +9,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use linera_base::vm::VmRuntime;
+use linera_base::{
+    identifiers::{Account, AccountOwner},
+    vm::VmRuntime,
+};
 use linera_views::common::from_bytes_option;
 use revm::{primitives::keccak256, Database, DatabaseCommit, DatabaseRef};
 use revm_context::BlockEnv;
@@ -19,6 +22,7 @@ use revm_primitives::{address, Address, B256, U256};
 use revm_state::{AccountInfo, Bytecode, EvmState};
 
 use crate::{
+    evm::{read_amount, inputs::ZERO_ADDRESS},
     ApplicationId, BaseRuntime, Batch, ContractRuntime, EvmExecutionError, ExecutionError,
     ServiceRuntime,
 };
@@ -77,6 +81,10 @@ pub(crate) struct DatabaseRuntime<Runtime> {
     /// This is the EVM address of the contract.
     /// At the creation, it is set to `Address::ZERO` and then later set to the correct value.
     pub contract_address: Address,
+    /// The caller to the smart contract
+    pub caller: Address,
+    /// The value of the smart contract
+    pub value: U256,
     /// The runtime of the contract.
     pub runtime: Arc<Mutex<Runtime>>,
     /// The uncommitted changes to the contract.
@@ -90,6 +98,8 @@ impl<Runtime> Clone for DatabaseRuntime<Runtime> {
         Self {
             storage_stats: self.storage_stats.clone(),
             contract_address: self.contract_address,
+            caller: self.caller,
+            value: self.value,
             runtime: self.runtime.clone(),
             changes: self.changes.clone(),
             error: self.error.clone(),
@@ -135,6 +145,8 @@ impl<Runtime: BaseRuntime> DatabaseRuntime<Runtime> {
         Self {
             storage_stats: Arc::new(Mutex::new(storage_stats)),
             contract_address: Address::ZERO,
+            caller: Address::ZERO,
+            value: U256::ZERO,
             runtime: Arc::new(Mutex::new(runtime)),
             changes: HashMap::new(),
             error: Arc::new(Mutex::new(None)),
@@ -220,6 +232,8 @@ where
         let mut runtime = self.runtime.lock().expect("The lock should be possible");
         let account_owner = address.into();
         tracing::info!("basic_ref, account_owner = {account_owner}");
+        // The balances being used are the ones of Linera. So, we need to
+        // access them at first.
         let balance = runtime.read_owner_balance(account_owner)?;
         tracing::info!("basic_ref, balance = {balance}");
 
@@ -227,20 +241,27 @@ where
         let key_info = Self::get_address_key(KeyCategory::AccountInfo as u8, address);
         let promise = runtime.read_value_bytes_new(key_info)?;
         let result = runtime.read_value_bytes_wait(&promise)?;
-        let account_info = from_bytes_option::<AccountInfo>(&result)?;
-        if balance == U256::ZERO || address == self.contract_address {
-            tracing::info!("basic_ref, return(A) account_info = {account_info:?}");
-            return Ok(account_info);
-        }
-        if let Some(mut account_info) = account_info {
-            account_info.balance = balance;
-            tracing::info!("basic_ref, return(B) account_info = {account_info:?}");
-            return Ok(Some(account_info));
-        }
+        let mut account_info = match result {
+            None => AccountInfo::default(),
+            Some(bytes) => bcs::from_bytes(&bytes)?,
+        };
+        // The funds have been immediately deposited in deposit_funds.
+        // The EVM will do the same before even the execution of
+        // the constructor or function.
+        // Therefore, we need to adjust the values.
+        // This will ensure that at any time the balances in EVM
+        // and Linera are exactly matching during the execution.
+        let start_balance = if self.caller == address {
+            balance + self.value
+        } else if self.contract_address == address {
+            balance - self.value
+        } else {
+            balance
+        };
+        account_info.balance = start_balance;
         // The balance is non-zero. Therefore, the account exists.đ
         // However, the state is None. Therefore, we need to create
         // a default account first.
-        let account_info = AccountInfo { balance, ..Default::default() };
         tracing::info!("basic_ref, return(C) account_info = {account_info:?}");
         Ok(Some(account_info))
     }
@@ -441,6 +462,26 @@ where
         let gas_limit = runtime.maximum_fuel_per_block(VmRuntime::Evm)?;
         block_env.gas_limit = gas_limit;
         Ok(block_env)
+    }
+
+    pub fn deposit_funds(&self) -> Result<(), ExecutionError> {
+        if self.value != U256::ZERO {
+            let mut runtime = self.runtime.lock().expect("The lock should be possible");
+            if self.caller == ZERO_ADDRESS {
+                let error = EvmExecutionError::UnknownSigner;
+                return Err(error.into());
+            }
+            let source: AccountOwner = self.caller.into();
+            let chain_id = runtime.chain_id()?;
+            let application_id = runtime.application_id()?;
+            let owner: AccountOwner = application_id.into();
+            let destination = Account { chain_id, owner };
+            let amount = read_amount(self.value)?;
+            tracing::info!("deposit_funds, runtime.transfer, before, ");
+            runtime.transfer(source, destination, amount)?;
+            tracing::info!("deposit_funds, runtime.transfer, after");
+        }
+        Ok(())
     }
 }
 

--- a/linera-execution/src/evm/database.rs
+++ b/linera-execution/src/evm/database.rs
@@ -206,7 +206,6 @@ where
     Runtime: BaseRuntime,
 {
     fn commit(&mut self, changes: EvmState) {
-        tracing::info!("commit, changes={:?}", changes);
         self.changes = changes;
     }
 }
@@ -218,7 +217,6 @@ where
     type Error = ExecutionError;
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, ExecutionError> {
-        tracing::info!("basic_ref, START, address = {address}");
         if !self.changes.is_empty() {
             let account = self.changes.get(&address).unwrap();
             return Ok(Some(account.info.clone()));
@@ -230,11 +228,9 @@ where
         } else {
             address.into()
         };
-        tracing::info!("basic_ref, account_owner = {account_owner}");
         // The balances being used are the ones of Linera. So, we need to
         // access them at first.
         let balance = runtime.read_owner_balance(account_owner)?;
-        tracing::info!("basic_ref, balance = {balance} self.value={}", self.value);
 
         let balance: U256 = balance.into();
         let key_info = Self::get_address_key(KeyCategory::AccountInfo as u8, address);
@@ -251,20 +247,16 @@ where
         // This will ensure that at any time the balances in EVM
         // and Linera are exactly matching during the execution.
         let start_balance = if self.caller == address {
-            tracing::info!("caller case");
             balance + self.value
         } else if self.contract_address == address {
-            tracing::info!("contract case");
             balance - self.value
         } else {
-            tracing::info!("other case");
             balance
         };
         account_info.balance = start_balance;
         // The balance is non-zero. Therefore, the account exists.đ
         // However, the state is None. Therefore, we need to create
         // a default account first.
-        tracing::info!("basic_ref, return(C) account_info = {account_info:?}");
         Ok(Some(account_info))
     }
 
@@ -273,7 +265,6 @@ where
     }
 
     fn storage_ref(&self, address: Address, index: U256) -> Result<U256, ExecutionError> {
-        tracing::info!("storage_ref, address={address} index={index}");
         if !self.changes.is_empty() {
             let account = self.changes.get(&address).unwrap();
             return Ok(match account.storage.get(&index) {
@@ -319,7 +310,6 @@ where
             if !account.is_touched() {
                 continue;
             }
-            tracing::info!("commit_changes, address = {address} account_info = {:?}", account.info);
             let key_prefix = Self::get_address_key(KeyCategory::Storage as u8, *address);
             let key_info = Self::get_address_key(KeyCategory::AccountInfo as u8, *address);
             let key_state = Self::get_address_key(KeyCategory::AccountState as u8, *address);
@@ -479,20 +469,8 @@ where
             let owner: AccountOwner = application_id.into();
             let destination = Account { chain_id, owner };
             let amount = read_amount(self.value)?;
-            let source_balance_before = runtime.read_owner_balance(source)?;
-            let owner_balance_before = runtime.read_owner_balance(owner)?;
-            tracing::info!("deposit_funds, source_balance_before={source_balance_before}");
-            tracing::info!("deposit_funds, owner_balance_before={owner_balance_before}");
 
-            tracing::info!("deposit_funds, source = {source}");
-            tracing::info!("deposit_funds, destination = {destination}");
-            tracing::info!("deposit_funds, runtime.transfer, before, amount={amount}");
             runtime.transfer(source, destination, amount)?;
-            tracing::info!("deposit_funds, runtime.transfer, after");
-            let source_balance_after = runtime.read_owner_balance(source)?;
-            let owner_balance_after = runtime.read_owner_balance(owner)?;
-            tracing::info!("deposit_funds, source_balance_after={source_balance_after}");
-            tracing::info!("deposit_funds, owner_balance_after={owner_balance_after}");
         }
         Ok(())
     }

--- a/linera-execution/src/evm/database.rs
+++ b/linera-execution/src/evm/database.rs
@@ -235,7 +235,7 @@ where
         // The balances being used are the ones of Linera. So, we need to
         // access them at first.
         let balance = runtime.read_owner_balance(account_owner)?;
-        tracing::info!("basic_ref, balance = {balance}");
+        tracing::info!("basic_ref, balance = {balance} self.value={}", self.value);
 
         let balance: U256 = balance.into();
         let key_info = Self::get_address_key(KeyCategory::AccountInfo as u8, address);
@@ -252,10 +252,13 @@ where
         // This will ensure that at any time the balances in EVM
         // and Linera are exactly matching during the execution.
         let start_balance = if self.caller == address {
+            tracing::info!("caller case");
             balance + self.value
         } else if self.contract_address == address {
+            tracing::info!("contract case");
             balance - self.value
         } else {
+            tracing::info!("other case");
             balance
         };
         account_info.balance = start_balance;
@@ -477,9 +480,20 @@ where
             let owner: AccountOwner = application_id.into();
             let destination = Account { chain_id, owner };
             let amount = read_amount(self.value)?;
-            tracing::info!("deposit_funds, runtime.transfer, before, ");
+            let source_balance_before = runtime.read_owner_balance(source)?;
+            let owner_balance_before = runtime.read_owner_balance(owner)?;
+            tracing::info!("deposit_funds, source_balance_before={source_balance_before}");
+            tracing::info!("deposit_funds, owner_balance_before={owner_balance_before}");
+
+            tracing::info!("deposit_funds, source = {source}");
+            tracing::info!("deposit_funds, destination = {destination}");
+            tracing::info!("deposit_funds, runtime.transfer, before, amount={amount}");
             runtime.transfer(source, destination, amount)?;
             tracing::info!("deposit_funds, runtime.transfer, after");
+            let source_balance_after = runtime.read_owner_balance(source)?;
+            let owner_balance_after = runtime.read_owner_balance(owner)?;
+            tracing::info!("deposit_funds, source_balance_after={source_balance_after}");
+            tracing::info!("deposit_funds, owner_balance_after={owner_balance_after}");
         }
         Ok(())
     }

--- a/linera-execution/src/evm/database.rs
+++ b/linera-execution/src/evm/database.rs
@@ -9,11 +9,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use linera_base::{
-    data_types::Amount,
-    identifiers::{Account, AccountOwner},
-    vm::VmRuntime,
-};
+use linera_base::vm::VmRuntime;
 use linera_views::common::from_bytes_option;
 use revm::{primitives::keccak256, Database, DatabaseCommit, DatabaseRef};
 use revm_context::BlockEnv;
@@ -23,7 +19,6 @@ use revm_primitives::{address, Address, B256, U256};
 use revm_state::{AccountInfo, Bytecode, EvmState};
 
 use crate::{
-    evm::{read_amount, inputs::EvmMutation},
     ApplicationId, BaseRuntime, Batch, ContractRuntime, EvmExecutionError, ExecutionError,
     ServiceRuntime,
 };
@@ -205,6 +200,7 @@ where
     Runtime: BaseRuntime,
 {
     fn commit(&mut self, changes: EvmState) {
+        tracing::info!("commit, changes={:?}", changes);
         self.changes = changes;
     }
 }
@@ -216,7 +212,7 @@ where
     type Error = ExecutionError;
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, ExecutionError> {
-        tracing::info!("basic_ref, address = {address}");
+        tracing::info!("basic_ref, START, address = {address}");
         if !self.changes.is_empty() {
             let account = self.changes.get(&address).unwrap();
             return Ok(Some(account.info.clone()));
@@ -254,6 +250,7 @@ where
     }
 
     fn storage_ref(&self, address: Address, index: U256) -> Result<U256, ExecutionError> {
+        tracing::info!("storage_ref, address={address} index={index}");
         if !self.changes.is_empty() {
             let account = self.changes.get(&address).unwrap();
             return Ok(match account.storage.get(&index) {
@@ -354,30 +351,6 @@ impl<Runtime> DatabaseRuntime<Runtime>
 where
     Runtime: BaseRuntime,
 {
-    /// Gets the contract address balance
-    pub fn get_balance_increase(&self) -> Result<U256, ExecutionError> {
-        let existing_evm_balance = {
-            let account_info = self.basic_ref(self.contract_address)?;
-            match account_info {
-                None => U256::ZERO,
-                Some(account_info) => account_info.balance,
-            }
-        };
-        let linera_balance = {
-            let mut runtime = self.runtime.lock().expect("The lock should be possible");
-            let application_id = runtime.application_id()?;
-            let account_owner: AccountOwner = application_id.into();
-            let balance = runtime.read_owner_balance(account_owner)?;
-            let balance: U256 = balance.into();
-            balance
-        };
-        if existing_evm_balance > linera_balance {
-            return Err(EvmExecutionError::IncoherentBalance.into());
-        }
-        let increment = linera_balance - existing_evm_balance;
-        Ok(increment)
-    }
-
     /// Reads the nonce of the user
     pub fn get_nonce(&self, address: &Address) -> Result<u64, ExecutionError> {
         let account_info = self.basic_ref(*address)?;
@@ -468,32 +441,6 @@ where
         let gas_limit = runtime.maximum_fuel_per_block(VmRuntime::Evm)?;
         block_env.gas_limit = gas_limit;
         Ok(block_env)
-    }
-
-    pub fn deposit_funds(&self, amount: Amount) -> Result<(), ExecutionError> {
-        if amount != Amount::ZERO {
-            let mut runtime = self.runtime.lock().expect("The lock should be possible");
-            let signer = runtime.authenticated_signer()?;
-            let Some(source) = signer else {
-                let error = EvmExecutionError::UnknownSigner;
-                return Err(error.into());
-            };
-            let chain_id = runtime.chain_id()?;
-            let application_id = runtime.application_id()?;
-            let owner: AccountOwner = application_id.into();
-            let destination = Account { chain_id, owner };
-            tracing::info!("deposit_funds, runtime.transfer, before");
-            runtime.transfer(source, destination, amount)?;
-            tracing::info!("deposit_funds, runtime.transfer, after");
-        }
-        Ok(())
-    }
-
-    pub fn get_execute_operation_argument(&self, operation: &[u8]) -> Result<Vec<u8>, ExecutionError> {
-        let evm_call = bcs::from_bytes::<EvmMutation>(operation)?;
-        let value = read_amount(evm_call.value)?;
-        self.deposit_funds(value)?;
-        Ok(evm_call.argument)
     }
 }
 

--- a/linera-execution/src/evm/inputs.rs
+++ b/linera-execution/src/evm/inputs.rs
@@ -1,0 +1,311 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Code specific to the input of functions, that is selectors,
+//! constructor argument and instantiation argument.
+
+use alloy_sol_types::SolCall;
+use linera_base::{
+    crypto::CryptoHash,
+    data_types::{StreamUpdate, Amount},
+    ensure,
+    identifiers::{ApplicationId, ChainId, StreamName},
+};
+use revm_primitives::U256;
+use serde::{Deserialize, Serialize};
+use crate::{ExecutionError, EvmExecutionError};
+
+/// This is the selector of the `execute_message` that should be called
+/// only from a submitted message
+pub(crate) const EXECUTE_MESSAGE_SELECTOR: &[u8] = &[173, 125, 234, 205];
+
+/// This is the selector of the `process_streams` that should be called
+/// only from a submitted message
+pub(crate) const PROCESS_STREAMS_SELECTOR: &[u8] = &[227, 9, 189, 153];
+
+/// This is the selector of the `instantiate` that should be called
+/// only when creating a new instance of a shared contract
+pub(crate) const INSTANTIATE_SELECTOR: &[u8] = &[156, 163, 60, 158];
+
+pub(crate) fn forbid_execute_operation_origin(vec: &[u8]) -> Result<(), EvmExecutionError> {
+    if vec == EXECUTE_MESSAGE_SELECTOR {
+        return Err(EvmExecutionError::IllegalOperationCall(
+            "function execute_message".to_string(),
+        ));
+    }
+    if vec == PROCESS_STREAMS_SELECTOR {
+        return Err(EvmExecutionError::IllegalOperationCall(
+            "function process_streams".to_string(),
+        ));
+    }
+    if vec == INSTANTIATE_SELECTOR {
+        return Err(EvmExecutionError::IllegalOperationCall(
+            "function instantiate".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_message_length(
+    actual_length: usize,
+    min_length: usize,
+) -> Result<(), EvmExecutionError> {
+    ensure!(
+        actual_length >= min_length,
+        EvmExecutionError::OperationIsTooShort
+    );
+    Ok(())
+}
+
+pub(crate) fn ensure_selector_presence(
+    module: &[u8],
+    selector: &[u8],
+    fct_name: &str,
+) -> Result<(), EvmExecutionError> {
+    if !has_selector(module, selector) {
+        return Err(EvmExecutionError::MissingFunction(fct_name.to_string()));
+    }
+    Ok(())
+}
+
+pub(crate) fn has_selector(module: &[u8], selector: &[u8]) -> bool {
+    let push4 = 0x63; // An EVM instruction
+    let mut vec = vec![push4];
+    vec.extend(selector);
+    module.windows(5).any(|window| window == vec)
+}
+
+pub(crate) fn get_revm_instantiation_bytes(value: Vec<u8>) -> Vec<u8> {
+    use alloy_primitives::Bytes;
+    use alloy_sol_types::{sol, SolCall};
+    sol! {
+        function instantiate(bytes value);
+    }
+    let bytes = Bytes::from(value);
+    let argument = instantiateCall { value: bytes };
+    argument.abi_encode()
+}
+
+pub(crate) fn get_revm_execute_message_bytes(value: Vec<u8>) -> Vec<u8> {
+    use alloy_primitives::Bytes;
+    use alloy_sol_types::{sol, SolCall};
+    sol! {
+        function execute_message(bytes value);
+    }
+    let value = Bytes::from(value);
+    let argument = execute_messageCall { value };
+    argument.abi_encode()
+}
+
+pub(crate) fn get_revm_process_streams_bytes(streams: Vec<StreamUpdate>) -> Vec<u8> {
+    // See TODO(#3966) for a better support of the input.
+    use alloy_primitives::{Bytes, B256};
+    use alloy_sol_types::{sol, SolCall};
+    use linera_base::identifiers::{GenericApplicationId, StreamId};
+    sol! {
+        struct InternalCryptoHash {
+            bytes32 value;
+        }
+
+        struct InternalApplicationId {
+            InternalCryptoHash application_description_hash;
+        }
+
+        struct InternalGenericApplicationId {
+            uint8 choice;
+            InternalApplicationId user;
+        }
+
+        struct InternalStreamName {
+            bytes stream_name;
+        }
+
+        struct InternalStreamId {
+            InternalGenericApplicationId application_id;
+            InternalStreamName stream_name;
+        }
+
+        struct InternalChainId {
+            InternalCryptoHash value;
+        }
+
+        struct InternalStreamUpdate {
+            InternalChainId chain_id;
+            InternalStreamId stream_id;
+            uint32 previous_index;
+            uint32 next_index;
+        }
+
+        function process_streams(InternalStreamUpdate[] internal_streams);
+    }
+
+    fn crypto_hash_to_internal_crypto_hash(hash: CryptoHash) -> InternalCryptoHash {
+        let hash: [u64; 4] = <[u64; 4]>::from(hash);
+        let hash: [u8; 32] = linera_base::crypto::u64_array_to_be_bytes(hash);
+        let value: B256 = hash.into();
+        InternalCryptoHash { value }
+    }
+
+    fn chain_id_to_internal_chain_id(chain_id: ChainId) -> InternalChainId {
+        let value = crypto_hash_to_internal_crypto_hash(chain_id.0);
+        InternalChainId { value }
+    }
+
+    fn application_id_to_internal_application_id(
+        application_id: ApplicationId,
+    ) -> InternalApplicationId {
+        let application_description_hash =
+            crypto_hash_to_internal_crypto_hash(application_id.application_description_hash);
+        InternalApplicationId {
+            application_description_hash,
+        }
+    }
+
+    fn stream_name_to_internal_stream_name(stream_name: StreamName) -> InternalStreamName {
+        let stream_name = Bytes::from(stream_name.0);
+        InternalStreamName { stream_name }
+    }
+
+    fn generic_application_id_to_internal_generic_application_id(
+        generic_application_id: GenericApplicationId,
+    ) -> InternalGenericApplicationId {
+        match generic_application_id {
+            GenericApplicationId::System => {
+                let application_description_hash = InternalCryptoHash { value: B256::ZERO };
+                InternalGenericApplicationId {
+                    choice: 0,
+                    user: InternalApplicationId {
+                        application_description_hash,
+                    },
+                }
+            }
+            GenericApplicationId::User(application_id) => InternalGenericApplicationId {
+                choice: 1,
+                user: application_id_to_internal_application_id(application_id),
+            },
+        }
+    }
+
+    fn stream_id_to_internal_stream_id(stream_id: StreamId) -> InternalStreamId {
+        let application_id =
+            generic_application_id_to_internal_generic_application_id(stream_id.application_id);
+        let stream_name = stream_name_to_internal_stream_name(stream_id.stream_name);
+        InternalStreamId {
+            application_id,
+            stream_name,
+        }
+    }
+
+    fn stream_update_to_internal_stream_update(
+        stream_update: StreamUpdate,
+    ) -> InternalStreamUpdate {
+        let chain_id = chain_id_to_internal_chain_id(stream_update.chain_id);
+        let stream_id = stream_id_to_internal_stream_id(stream_update.stream_id);
+        InternalStreamUpdate {
+            chain_id,
+            stream_id,
+            previous_index: stream_update.previous_index,
+            next_index: stream_update.next_index,
+        }
+    }
+
+    let internal_streams = streams
+        .into_iter()
+        .map(stream_update_to_internal_stream_update)
+        .collect::<Vec<_>>();
+
+    let fct_call = process_streamsCall { internal_streams };
+    fct_call.abi_encode()
+}
+
+/// The instantiation argument to evm smart contracts.
+/// value is the amount being transfered.
+#[derive(Default, Serialize, Deserialize)]
+pub struct EvmInstantiation {
+    pub value: Amount,
+    pub argument: Vec<u8>,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+pub(crate) struct EvmMutation {
+    pub value: U256,
+    pub argument: Vec<u8>,
+}
+
+pub(crate) fn get_internal_mutation(value: U256, argument: Vec<u8>) -> Result<Vec<u8>, ExecutionError> {
+    let evm_mutation = EvmMutation { value, argument };
+    Ok(bcs::to_bytes(&evm_mutation)?)
+}
+
+pub fn get_mutation(amount: Amount, mutation: impl SolCall) -> Result<Vec<u8>, ExecutionError> {
+    get_internal_mutation(amount.into(), mutation.abi_encode())
+}
+
+#[cfg(test)]
+mod tests {
+    use revm_primitives::keccak256;
+
+    use crate::evm::inputs::{
+        EXECUTE_MESSAGE_SELECTOR, INSTANTIATE_SELECTOR, PROCESS_STREAMS_SELECTOR,
+    };
+
+    // The function keccak256 is not const so we cannot build the execute_message
+    // selector directly.
+    #[test]
+    fn check_execute_message_selector() {
+        let selector = &keccak256("execute_message(bytes)".as_bytes())[..4];
+        assert_eq!(selector, EXECUTE_MESSAGE_SELECTOR);
+    }
+
+    #[test]
+    fn check_process_streams_selector() {
+        use alloy_sol_types::{sol, SolCall};
+        sol! {
+            struct InternalCryptoHash {
+                bytes32 value;
+            }
+
+            struct InternalApplicationId {
+                InternalCryptoHash application_description_hash;
+            }
+
+            struct InternalGenericApplicationId {
+                uint8 choice;
+                InternalApplicationId user;
+            }
+
+            struct InternalStreamName {
+                bytes stream_name;
+            }
+
+            struct InternalStreamId {
+                InternalGenericApplicationId application_id;
+                InternalStreamName stream_name;
+            }
+
+            struct InternalChainId {
+                InternalCryptoHash value;
+            }
+
+            struct InternalStreamUpdate {
+                InternalChainId chain_id;
+                InternalStreamId stream_id;
+                uint32 previous_index;
+                uint32 next_index;
+            }
+
+            function process_streams(InternalStreamUpdate[] internal_streams);
+        }
+        assert_eq!(
+            process_streamsCall::SIGNATURE,
+            "process_streams((((bytes32)),((uint8,((bytes32))),(bytes)),uint32,uint32)[])"
+        );
+        assert_eq!(process_streamsCall::SELECTOR, PROCESS_STREAMS_SELECTOR);
+    }
+
+    #[test]
+    fn check_instantiate_selector() {
+        let selector = &keccak256("instantiate(bytes)".as_bytes())[..4];
+        assert_eq!(selector, INSTANTIATE_SELECTOR);
+    }
+}

--- a/linera-execution/src/evm/inputs.rs
+++ b/linera-execution/src/evm/inputs.rs
@@ -11,9 +11,21 @@ use linera_base::{
     ensure,
     identifiers::{ApplicationId, ChainId, StreamName},
 };
-use revm_primitives::U256;
+use revm_primitives::{address, Address, U256};
 use serde::{Deserialize, Serialize};
 use crate::{ExecutionError, EvmExecutionError};
+
+// This is the precompile address that contains the Linera specific
+// functionalities accessed from the EVM.
+pub(crate) const PRECOMPILE_ADDRESS: Address = address!("000000000000000000000000000000000000000b");
+
+// This is the zero address used when no address can be obtained from `authenticated_signer`
+// and `authenticated_caller_id`. This scenario does not occur if an Address20 user calls or
+// if an EVM contract calls another EVM contract.
+pub(crate) const ZERO_ADDRESS: Address = address!("0000000000000000000000000000000000000000");
+
+// This is the address being used for service calls.
+pub(crate) const SERVICE_ADDRESS: Address = address!("0000000000000000000000000000000000002000");
 
 /// This is the selector of the `execute_message` that should be called
 /// only from a submitted message

--- a/linera-execution/src/evm/mod.rs
+++ b/linera-execution/src/evm/mod.rs
@@ -8,14 +8,18 @@
 #![cfg(with_revm)]
 
 mod database;
+pub mod inputs;
 pub mod revm;
 
+use linera_base::data_types::{Amount, AmountConversionError};
 use revm_context::result::{HaltReason, Output, SuccessReason};
-use revm_primitives::Log;
+use revm_primitives::{Log, U256};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum EvmExecutionError {
+    #[error(transparent)]
+    AmountConversionError(#[from] AmountConversionError),
     #[error("Failed to load contract EVM module: {_0}")]
     LoadContractModule(#[source] anyhow::Error),
     #[error("Failed to load service EVM module: {_0}")]
@@ -24,6 +28,18 @@ pub enum EvmExecutionError {
     CommitError(String),
     #[error("It is illegal to call {0} from an operation")]
     IllegalOperationCall(String),
+    #[error("runtime error")]
+    RuntimeError(String),
+    #[error("The balances are incoherent")]
+    IncoherentBalance,
+    #[error("Unknown signer")]
+    UnknownSigner,
+    #[error("No delegate call")]
+    NoDelegateCall,
+    #[error("No transfer in services")]
+    NoTransferInServices,
+    #[error("No transfer in wasm application call")]
+    NoTransferInRuntimeCall,
     #[error("The function {0} is being called but is missing from the bytecode API")]
     MissingFunction(String),
     #[error("Incorrect contract creation: {0}")]
@@ -52,4 +68,8 @@ pub enum EvmExecutionError {
         logs: Vec<Log>,
         output: Output,
     },
+}
+
+fn read_amount(value: U256) -> Result<Amount, EvmExecutionError> {
+    Ok(Amount::try_from(value)?)
 }

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -40,7 +40,7 @@ use crate::{
     evm::{
         database::{DatabaseRuntime, StorageStats, EVM_SERVICE_GAS_LIMIT},
         inputs::{
-            get_internal_mutation, EvmInstantiation, ensure_message_length, ensure_selector_presence, forbid_execute_operation_origin,
+            get_internal_mutation, EvmInstantiation, EvmMutation, ensure_message_length, ensure_selector_presence, forbid_execute_operation_origin,
             get_revm_execute_message_bytes, get_revm_instantiation_bytes,
             get_revm_process_streams_bytes, has_selector, EXECUTE_MESSAGE_SELECTOR,
             INSTANTIATE_SELECTOR, PROCESS_STREAMS_SELECTOR,
@@ -701,10 +701,12 @@ impl<Runtime: ContractRuntime> CallInterceptorContract<Runtime> {
         if self.precompile_addresses.contains(&inputs.target_address)
             || inputs.target_address == self.contract_address
         {
+            tracing::info!("CallInterceptorContract :: call_or_fail, exiting early");
             // Precompile calls are handled by the precompile code.
             // The EVM smart contract is being called
             return Ok(None);
         }
+        tracing::info!("CallInterceptorContract :: call_or_fail, more complicated");
         // Handling the balances.
         if let CallValue::Transfer(value) = inputs.value {
             if value != U256::ZERO {
@@ -883,11 +885,11 @@ where
         self.db.set_contract_address()?;
         let caller = self.get_msg_address()?;
         let instantiation_argument = serde_json::from_slice::<EvmInstantiation>(&argument)?;
-        self.db.deposit_funds(instantiation_argument.value)?;
-        self.initialize_contract(caller)?;
+        let value = instantiation_argument.value.into();
+        self.initialize_contract(value, caller)?;
         if has_selector(&self.module, INSTANTIATE_SELECTOR) {
             let argument = get_revm_instantiation_bytes(instantiation_argument.argument);
-            let result = self.transact_commit(EvmTxKind::Call, argument, caller)?;
+            let result = self.transact_commit(EvmTxKind::Call, argument, U256::ZERO, caller)?;
             self.write_logs(result.logs, "instantiate")?;
         }
         Ok(())
@@ -900,13 +902,13 @@ where
         let (gas_final, output, logs) = if &operation[..4] == INTERPRETER_RESULT_SELECTOR {
             ensure_message_length(operation.len(), 8)?;
             forbid_execute_operation_origin(&operation[4..8])?;
-            let operation = self.db.get_execute_operation_argument(&operation[4..])?;
-            let result = self.init_transact_commit(operation, caller)?;
+            let evm_call = bcs::from_bytes::<EvmMutation>(&operation[4..])?;
+            let result = self.init_transact_commit(evm_call.argument, evm_call.value, caller)?;
             result.interpreter_result_and_logs()?
         } else {
             forbid_execute_operation_origin(&operation[..4])?;
-            let operation = self.db.get_execute_operation_argument(&operation)?;
-            let result = self.init_transact_commit(operation, caller)?;
+            let evm_call = bcs::from_bytes::<EvmMutation>(&operation)?;
+            let result = self.init_transact_commit(evm_call.argument, evm_call.value, caller)?;
             result.output_and_logs()
         };
         self.consume_fuel(gas_final)?;
@@ -923,7 +925,8 @@ where
         )?;
         let operation = get_revm_execute_message_bytes(message);
         let caller = self.get_msg_address()?;
-        self.execute_no_return_operation(operation, "message", caller)
+        let value = U256::ZERO;
+        self.execute_no_return_operation(operation, "message", value, caller)
     }
 
     fn process_streams(&mut self, streams: Vec<StreamUpdate>) -> Result<(), ExecutionError> {
@@ -936,7 +939,8 @@ where
         )?;
         // For process_streams, authenticated_signer and authenticated_called_id are None.
         let caller = Address::ZERO;
-        self.execute_no_return_operation(operation, "process_streams", caller)
+        let value = U256::ZERO;
+        self.execute_no_return_operation(operation, "process_streams", value, caller)
     }
 
     fn finalize(&mut self) -> Result<(), ExecutionError> {
@@ -998,9 +1002,10 @@ where
         &mut self,
         operation: Vec<u8>,
         origin: &str,
+        value: U256,
         caller: Address,
     ) -> Result<(), ExecutionError> {
-        let result = self.init_transact_commit(operation, caller)?;
+        let result = self.init_transact_commit(operation, value, caller)?;
         let (gas_final, output, logs) = result.output_and_logs();
         self.consume_fuel(gas_final)?;
         self.write_logs(logs, origin)?;
@@ -1012,23 +1017,24 @@ where
     fn init_transact_commit(
         &mut self,
         vec: Vec<u8>,
+        value: U256,
         caller: Address,
     ) -> Result<ExecutionResultSuccess, ExecutionError> {
         // An application can be instantiated in Linera sense, but not in EVM sense,
         // that is the contract entries corresponding to the deployed contract may
         // be missing.
         if !self.db.is_initialized()? {
-            self.initialize_contract(caller)?;
+            self.initialize_contract(U256::ZERO, caller)?;
         }
-        self.transact_commit(EvmTxKind::Call, vec, caller)
+        self.transact_commit(EvmTxKind::Call, vec, value, caller)
     }
 
     /// Initializes the contract.
-    fn initialize_contract(&mut self, caller: Address) -> Result<(), ExecutionError> {
+    fn initialize_contract(&mut self, value: U256, caller: Address) -> Result<(), ExecutionError> {
         let mut vec_init = self.module.clone();
         let constructor_argument = self.db.constructor_argument()?;
         vec_init.extend_from_slice(&constructor_argument);
-        let result = self.transact_commit(EvmTxKind::Create, vec_init, caller)?;
+        let result = self.transact_commit(EvmTxKind::Create, vec_init, value, caller)?;
         result
             .check_contract_initialization(self.db.contract_address)
             .map_err(EvmExecutionError::IncorrectContractCreation)?;
@@ -1068,6 +1074,7 @@ where
         &mut self,
         ch: EvmTxKind,
         input: Vec<u8>,
+        value: U256,
         caller: Address,
     ) -> Result<ExecutionResultSuccess, ExecutionError> {
         let data = Bytes::from(input);
@@ -1087,7 +1094,6 @@ where
             runtime.remaining_fuel(VmRuntime::Evm)?
         };
         let nonce = self.db.get_nonce(&caller)?;
-        let value = self.db.get_balance_increase()?;
         tracing::info!("transact_commit, caller = {caller}");
         tracing::info!("transact_commit, value = {value}");
         let result = {
@@ -1130,6 +1136,7 @@ where
         self.db.process_any_error()?;
         let storage_stats = self.db.take_storage_stats();
         self.db.commit_changes()?;
+        tracing::info!("transact_commit, after commit_changes");
         let result = process_execution_result(storage_stats, result)?;
         Ok(result)
     }
@@ -1245,6 +1252,7 @@ where
         };
         let caller = SERVICE_ADDRESS;
         let nonce = self.db.get_nonce(&caller)?;
+        let value = U256::ZERO;
         let result_state = {
             let ctx: revm_context::Context<
                 BlockEnv,
@@ -1270,6 +1278,7 @@ where
                     kind,
                     data,
                     nonce,
+                    value,
                     caller,
                     gas_limit: EVM_SERVICE_GAS_LIMIT,
                     ..TxEnv::default()

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -720,7 +720,9 @@ impl<Runtime: ContractRuntime> CallInterceptorContract<Runtime> {
                 let chain_id = runtime.chain_id()?;
                 let owner: AccountOwner = inputs.bytecode_address.into();
                 let destination = Account { chain_id, owner };
+                tracing::info!("call_or_fail, runtime.transfer, before, value={value}");
                 runtime.transfer(source, destination, value)?;
+                tracing::info!("call_or_fail, runtime.transfer, after");
             }
         }
         // Other smart contracts calls are handled by the runtime
@@ -1086,6 +1088,8 @@ where
         };
         let nonce = self.db.get_nonce(&caller)?;
         let value = self.db.get_balance_increase()?;
+        tracing::info!("transact_commit, caller = {caller}");
+        tracing::info!("transact_commit, value = {value}");
         let result = {
             let ctx: revm_context::Context<
                 BlockEnv,

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -4,15 +4,19 @@
 //! Code specific to the usage of the [Revm](https://bluealloy.github.io/revm/) runtime.
 
 use core::ops::Range;
-use std::{collections::BTreeSet, convert::TryFrom};
+use std::{
+    collections::BTreeSet,
+    convert::TryFrom,
+    sync::{Arc, Mutex},
+};
 
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
+    ensure,
     crypto::CryptoHash,
     data_types::{Bytecode, Resources, SendMessageRequest, StreamUpdate},
-    ensure,
-    identifiers::{AccountOwner, ApplicationId, ChainId, StreamName},
+    identifiers::{Account, AccountOwner, ApplicationId, ChainId, StreamName},
     vm::{EvmQuery, VmRuntime},
 };
 use revm::{primitives::Bytes, InspectCommitEvm, InspectEvm, Inspector};
@@ -25,149 +29,32 @@ use revm_handler::{
     instructions::EthInstructions, EthPrecompiles, MainnetContext, PrecompileProvider,
 };
 use revm_interpreter::{
-    CallInput, CallInputs, CallOutcome, CreateInputs, CreateOutcome, CreateScheme, Gas, InputsImpl,
-    InstructionResult, InterpreterResult,
+    CallInput, CallInputs, CallOutcome, CallValue, CreateInputs, CreateOutcome, CreateScheme, Gas,
+    InputsImpl, InstructionResult, InterpreterResult,
 };
-use revm_primitives::{address, hardfork::SpecId, Address, Log, TxKind};
+use revm_primitives::{address, hardfork::SpecId, Address, Log, TxKind, U256};
 use revm_state::EvmState;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    evm::database::{DatabaseRuntime, StorageStats, EVM_SERVICE_GAS_LIMIT},
+    evm::{
+        database::{DatabaseRuntime, StorageStats, EVM_SERVICE_GAS_LIMIT},
+        inputs::{
+            get_internal_mutation, EvmInstantiation, ensure_message_length, ensure_selector_presence, forbid_execute_operation_origin,
+            get_revm_execute_message_bytes, get_revm_instantiation_bytes,
+            get_revm_process_streams_bytes, has_selector, EXECUTE_MESSAGE_SELECTOR,
+            INSTANTIATE_SELECTOR, PROCESS_STREAMS_SELECTOR,
+        },
+        read_amount,
+    },
     BaseRuntime, ContractRuntime, ContractSyncRuntimeHandle, EvmExecutionError, EvmRuntime,
     ExecutionError, ServiceRuntime, ServiceSyncRuntimeHandle, UserContract, UserContractInstance,
     UserContractModule, UserService, UserServiceInstance, UserServiceModule,
 };
 
-/// This is the selector of the `execute_message` that should be called
-/// only from a submitted message
-const EXECUTE_MESSAGE_SELECTOR: &[u8] = &[173, 125, 234, 205];
-
-/// This is the selector of the `process_streams` that should be called
-/// only from a submitted message
-const PROCESS_STREAMS_SELECTOR: &[u8] = &[227, 9, 189, 153];
-
-/// This is the selector of the `instantiate` that should be called
-/// only when creating a new instance of a shared contract
-const INSTANTIATE_SELECTOR: &[u8] = &[156, 163, 60, 158];
-
-fn forbid_execute_operation_origin(vec: &[u8]) -> Result<(), EvmExecutionError> {
-    if vec == EXECUTE_MESSAGE_SELECTOR {
-        return Err(EvmExecutionError::IllegalOperationCall(
-            "function execute_message".to_string(),
-        ));
-    }
-    if vec == PROCESS_STREAMS_SELECTOR {
-        return Err(EvmExecutionError::IllegalOperationCall(
-            "function process_streams".to_string(),
-        ));
-    }
-    if vec == INSTANTIATE_SELECTOR {
-        return Err(EvmExecutionError::IllegalOperationCall(
-            "function instantiate".to_string(),
-        ));
-    }
-    Ok(())
-}
-
-fn ensure_message_length(actual_length: usize, min_length: usize) -> Result<(), EvmExecutionError> {
-    ensure!(
-        actual_length >= min_length,
-        EvmExecutionError::OperationIsTooShort
-    );
-    Ok(())
-}
-
-fn ensure_selector_presence(
-    module: &[u8],
-    selector: &[u8],
-    fct_name: &str,
-) -> Result<(), EvmExecutionError> {
-    if !has_selector(module, selector) {
-        return Err(EvmExecutionError::MissingFunction(fct_name.to_string()));
-    }
-    Ok(())
-}
-
 /// The selector when calling for `InterpreterResult`. This is a fictional
 /// selector that does not correspond to a real function.
 const INTERPRETER_RESULT_SELECTOR: &[u8] = &[1, 2, 3, 4];
-
-#[cfg(test)]
-mod tests {
-    use revm_primitives::keccak256;
-
-    use crate::evm::revm::{
-        EXECUTE_MESSAGE_SELECTOR, INSTANTIATE_SELECTOR, PROCESS_STREAMS_SELECTOR,
-    };
-
-    // The function keccak256 is not const so we cannot build the execute_message
-    // selector directly.
-    #[test]
-    fn check_execute_message_selector() {
-        let selector = &keccak256("execute_message(bytes)".as_bytes())[..4];
-        assert_eq!(selector, EXECUTE_MESSAGE_SELECTOR);
-    }
-
-    #[test]
-    fn check_process_streams_selector() {
-        use alloy_sol_types::{sol, SolCall};
-        sol! {
-            struct InternalCryptoHash {
-                bytes32 value;
-            }
-
-            struct InternalApplicationId {
-                InternalCryptoHash application_description_hash;
-            }
-
-            struct InternalGenericApplicationId {
-                uint8 choice;
-                InternalApplicationId user;
-            }
-
-            struct InternalStreamName {
-                bytes stream_name;
-            }
-
-            struct InternalStreamId {
-                InternalGenericApplicationId application_id;
-                InternalStreamName stream_name;
-            }
-
-            struct InternalChainId {
-                InternalCryptoHash value;
-            }
-
-            struct InternalStreamUpdate {
-                InternalChainId chain_id;
-                InternalStreamId stream_id;
-                uint32 previous_index;
-                uint32 next_index;
-            }
-
-            function process_streams(InternalStreamUpdate[] internal_streams);
-        }
-        assert_eq!(
-            process_streamsCall::SIGNATURE,
-            "process_streams((((bytes32)),((uint8,((bytes32))),(bytes)),uint32,uint32)[])"
-        );
-        assert_eq!(process_streamsCall::SELECTOR, PROCESS_STREAMS_SELECTOR);
-    }
-
-    #[test]
-    fn check_instantiate_selector() {
-        let selector = &keccak256("instantiate(bytes)".as_bytes())[..4];
-        assert_eq!(selector, INSTANTIATE_SELECTOR);
-    }
-}
-
-fn has_selector(module: &[u8], selector: &[u8]) -> bool {
-    let push4 = 0x63; // An EVM instruction
-    let mut vec = vec![push4];
-    vec.extend(selector);
-    module.windows(5).any(|window| window == vec)
-}
 
 #[cfg(with_metrics)]
 mod metrics {
@@ -193,149 +80,6 @@ mod metrics {
             exponential_bucket_latencies(1.0),
         )
     });
-}
-
-fn get_revm_instantiation_bytes(value: Vec<u8>) -> Vec<u8> {
-    use alloy_primitives::Bytes;
-    use alloy_sol_types::{sol, SolCall};
-    sol! {
-        function instantiate(bytes value);
-    }
-    let bytes = Bytes::from(value);
-    let argument = instantiateCall { value: bytes };
-    argument.abi_encode()
-}
-
-fn get_revm_execute_message_bytes(value: Vec<u8>) -> Vec<u8> {
-    use alloy_primitives::Bytes;
-    use alloy_sol_types::{sol, SolCall};
-    sol! {
-        function execute_message(bytes value);
-    }
-    let value = Bytes::from(value);
-    let argument = execute_messageCall { value };
-    argument.abi_encode()
-}
-
-fn get_revm_process_streams_bytes(streams: Vec<StreamUpdate>) -> Vec<u8> {
-    // See TODO(#3966) for a better support of the input.
-    use alloy_primitives::{Bytes, B256};
-    use alloy_sol_types::{sol, SolCall};
-    use linera_base::identifiers::{GenericApplicationId, StreamId};
-    sol! {
-        struct InternalCryptoHash {
-            bytes32 value;
-        }
-
-        struct InternalApplicationId {
-            InternalCryptoHash application_description_hash;
-        }
-
-        struct InternalGenericApplicationId {
-            uint8 choice;
-            InternalApplicationId user;
-        }
-
-        struct InternalStreamName {
-            bytes stream_name;
-        }
-
-        struct InternalStreamId {
-            InternalGenericApplicationId application_id;
-            InternalStreamName stream_name;
-        }
-
-        struct InternalChainId {
-            InternalCryptoHash value;
-        }
-
-        struct InternalStreamUpdate {
-            InternalChainId chain_id;
-            InternalStreamId stream_id;
-            uint32 previous_index;
-            uint32 next_index;
-        }
-
-        function process_streams(InternalStreamUpdate[] internal_streams);
-    }
-
-    fn crypto_hash_to_internal_crypto_hash(hash: CryptoHash) -> InternalCryptoHash {
-        let hash: [u64; 4] = <[u64; 4]>::from(hash);
-        let hash: [u8; 32] = linera_base::crypto::u64_array_to_be_bytes(hash);
-        let value: B256 = hash.into();
-        InternalCryptoHash { value }
-    }
-
-    fn chain_id_to_internal_chain_id(chain_id: ChainId) -> InternalChainId {
-        let value = crypto_hash_to_internal_crypto_hash(chain_id.0);
-        InternalChainId { value }
-    }
-
-    fn application_id_to_internal_application_id(
-        application_id: ApplicationId,
-    ) -> InternalApplicationId {
-        let application_description_hash =
-            crypto_hash_to_internal_crypto_hash(application_id.application_description_hash);
-        InternalApplicationId {
-            application_description_hash,
-        }
-    }
-
-    fn stream_name_to_internal_stream_name(stream_name: StreamName) -> InternalStreamName {
-        let stream_name = Bytes::from(stream_name.0);
-        InternalStreamName { stream_name }
-    }
-
-    fn generic_application_id_to_internal_generic_application_id(
-        generic_application_id: GenericApplicationId,
-    ) -> InternalGenericApplicationId {
-        match generic_application_id {
-            GenericApplicationId::System => {
-                let application_description_hash = InternalCryptoHash { value: B256::ZERO };
-                InternalGenericApplicationId {
-                    choice: 0,
-                    user: InternalApplicationId {
-                        application_description_hash,
-                    },
-                }
-            }
-            GenericApplicationId::User(application_id) => InternalGenericApplicationId {
-                choice: 1,
-                user: application_id_to_internal_application_id(application_id),
-            },
-        }
-    }
-
-    fn stream_id_to_internal_stream_id(stream_id: StreamId) -> InternalStreamId {
-        let application_id =
-            generic_application_id_to_internal_generic_application_id(stream_id.application_id);
-        let stream_name = stream_name_to_internal_stream_name(stream_id.stream_name);
-        InternalStreamId {
-            application_id,
-            stream_name,
-        }
-    }
-
-    fn stream_update_to_internal_stream_update(
-        stream_update: StreamUpdate,
-    ) -> InternalStreamUpdate {
-        let chain_id = chain_id_to_internal_chain_id(stream_update.chain_id);
-        let stream_id = stream_id_to_internal_stream_id(stream_update.stream_id);
-        InternalStreamUpdate {
-            chain_id,
-            stream_id,
-            previous_index: stream_update.previous_index,
-            next_index: stream_update.next_index,
-        }
-    }
-
-    let internal_streams = streams
-        .into_iter()
-        .map(stream_update_to_internal_stream_update)
-        .collect::<Vec<_>>();
-
-    let fct_call = process_streamsCall { internal_streams };
-    fct_call.abi_encode()
 }
 
 #[derive(Clone)]
@@ -574,10 +318,46 @@ fn get_precompile_output(
     }))
 }
 
-fn get_precompile_argument<Ctx: ContextTr>(context: &mut Ctx, input: &CallInput) -> Vec<u8> {
-    let mut argument = Vec::new();
-    get_argument(context, &mut argument, input);
-    argument
+fn get_argument<Ctx: ContextTr>(context: &mut Ctx, input: &CallInput) -> Vec<u8> {
+    match input {
+        CallInput::Bytes(bytes) => {
+            bytes.to_vec()
+        }
+        CallInput::SharedBuffer(range) => {
+            match context.local().shared_memory_buffer_slice(range.clone()) {
+                None => Vec::new(),
+                Some(slice) => slice.to_vec(),
+            }
+        }
+    }
+}
+
+fn get_value(call_value: &CallValue) -> Result<U256, EvmExecutionError> {
+    match call_value {
+        CallValue::Transfer(value) => Ok(*value),
+        CallValue::Apparent(_) => Err(EvmExecutionError::NoDelegateCall),
+    }
+}
+
+fn get_precompile_argument<Ctx: ContextTr>(context: &mut Ctx, inputs: &InputsImpl) -> Result<Vec<u8>, ExecutionError> {
+    ensure!(inputs.call_value == U256::ZERO, EvmExecutionError::NoTransferInRuntimeCall);
+    Ok(get_argument(context, &inputs.input))
+}
+
+fn get_call_service_argument<Ctx: ContextTr>(context: &mut Ctx, inputs: &CallInputs) -> Result<Vec<u8>, ExecutionError> {
+    ensure!(get_value(&inputs.value)? == U256::ZERO, EvmExecutionError::NoTransferInServices);
+    let mut argument = INTERPRETER_RESULT_SELECTOR.to_vec();
+    argument.extend(&get_argument(context, &inputs.input));
+    Ok(argument)
+}
+
+fn get_call_contract_argument<Ctx: ContextTr>(context: &mut Ctx, inputs: &CallInputs) -> Result<Vec<u8>, ExecutionError> {
+    let mut final_argument = INTERPRETER_RESULT_SELECTOR.to_vec();
+    let value = get_value(&inputs.value)?;
+    let argument = get_argument(context, &inputs.input);
+    let argument = get_internal_mutation(value, argument)?;
+    final_argument.extend(&argument);
+    Ok(final_argument)
 }
 
 fn base_runtime_call<Runtime: BaseRuntime>(
@@ -641,8 +421,7 @@ impl<'a, Runtime: ContractRuntime> PrecompileProvider<Ctx<'a, Runtime>> for Cont
         gas_limit: u64,
     ) -> Result<Option<InterpreterResult>, String> {
         if address == &PRECOMPILE_ADDRESS {
-            let input = get_precompile_argument(context, &inputs.input);
-            let output = Self::call_or_fail(&input, context)
+            let output = Self::call_or_fail(inputs, context)
                 .map_err(|error| format!("ContractPrecompile error: {error}"))?;
             return get_precompile_output(output, gas_limit);
         }
@@ -735,10 +514,11 @@ impl<'a> ContractPrecompile {
     }
 
     fn call_or_fail<Runtime: ContractRuntime>(
-        input: &[u8],
+        inputs: &InputsImpl,
         context: &mut Ctx<'a, Runtime>,
     ) -> Result<Vec<u8>, ExecutionError> {
-        match bcs::from_bytes(input)? {
+        let input = get_precompile_argument(context, inputs)?;
+        match bcs::from_bytes(&input)? {
             RuntimePrecompile::Base(base_tag) => base_runtime_call(base_tag, context),
             RuntimePrecompile::Contract(contract_tag) => {
                 Self::contract_runtime_call(contract_tag, context)
@@ -775,10 +555,11 @@ impl<'a> ServicePrecompile {
     }
 
     fn call_or_fail<Runtime: ServiceRuntime>(
-        input: &[u8],
+        inputs: &InputsImpl,
         context: &mut Ctx<'a, Runtime>,
     ) -> Result<Vec<u8>, ExecutionError> {
-        match bcs::from_bytes(input)? {
+        let input = get_precompile_argument(context, inputs)?;
+        match bcs::from_bytes(&input)? {
             RuntimePrecompile::Base(base_tag) => base_runtime_call(base_tag, context),
             RuntimePrecompile::Contract(_) => Err(EvmExecutionError::PrecompileError(
                 "Contract calls are not available in GeneralServiceCall".to_string(),
@@ -807,8 +588,7 @@ impl<'a, Runtime: ServiceRuntime> PrecompileProvider<Ctx<'a, Runtime>> for Servi
         gas_limit: u64,
     ) -> Result<Option<InterpreterResult>, String> {
         if address == &PRECOMPILE_ADDRESS {
-            let input = get_precompile_argument(context, &inputs.input);
-            let output = Self::call_or_fail(&input, context)
+            let output = Self::call_or_fail(inputs, context)
                 .map_err(|error| format!("ServicePrecompile error: {error}"))?;
             return get_precompile_output(output, gas_limit);
         }
@@ -827,14 +607,14 @@ impl<'a, Runtime: ServiceRuntime> PrecompileProvider<Ctx<'a, Runtime>> for Servi
     }
 }
 
-fn map_result_call_outcome(
+fn map_result_call_outcome<Runtime: BaseRuntime>(
+    database: &DatabaseRuntime<Runtime>,
     result: Result<Option<CallOutcome>, ExecutionError>,
 ) -> Option<CallOutcome> {
     match result {
-        Err(_error) => {
-            // An alternative way would be to return None, which would induce
-            // Revm to call the smart contract in its database, where it is
-            // non-existent.
+        Err(error) => {
+            database.insert_error(error);
+            // The use of Revert immediately stops the execution.
             let result = InstructionResult::Revert;
             let output = Bytes::default();
             let gas = Gas::default();
@@ -869,6 +649,7 @@ struct CallInterceptorContract<Runtime> {
     // This is the contract address of the contract being created.
     contract_address: Address,
     precompile_addresses: BTreeSet<Address>,
+    error: Arc<Mutex<Option<U256>>>,
 }
 
 impl<Runtime> Clone for CallInterceptorContract<Runtime> {
@@ -877,27 +658,9 @@ impl<Runtime> Clone for CallInterceptorContract<Runtime> {
             db: self.db.clone(),
             contract_address: self.contract_address,
             precompile_addresses: self.precompile_addresses.clone(),
+            error: self.error.clone(),
         }
     }
-}
-
-fn get_argument<Ctx: ContextTr>(context: &mut Ctx, argument: &mut Vec<u8>, input: &CallInput) {
-    match input {
-        CallInput::Bytes(bytes) => {
-            argument.extend(bytes.to_vec());
-        }
-        CallInput::SharedBuffer(range) => {
-            if let Some(slice) = context.local().shared_memory_buffer_slice(range.clone()) {
-                argument.extend(&*slice);
-            }
-        }
-    };
-}
-
-fn get_call_argument<Ctx: ContextTr>(context: &mut Ctx, inputs: &CallInputs) -> Vec<u8> {
-    let mut argument = INTERPRETER_RESULT_SELECTOR.to_vec();
-    get_argument(context, &mut argument, &inputs.input);
-    argument
 }
 
 impl<'a, Runtime: ContractRuntime> Inspector<Ctx<'a, Runtime>>
@@ -920,7 +683,7 @@ impl<'a, Runtime: ContractRuntime> Inspector<Ctx<'a, Runtime>>
         inputs: &mut CallInputs,
     ) -> Option<CallOutcome> {
         let result = self.call_or_fail(context, inputs);
-        map_result_call_outcome(result)
+        map_result_call_outcome(&self.db, result)
     }
 }
 
@@ -942,9 +705,27 @@ impl<Runtime: ContractRuntime> CallInterceptorContract<Runtime> {
             // The EVM smart contract is being called
             return Ok(None);
         }
+        // Handling the balances.
+        if let CallValue::Transfer(value) = inputs.value {
+            if value != U256::ZERO {
+                let value = read_amount(value)?;
+                let mut runtime = context
+                    .db()
+                    .0
+                    .runtime
+                    .lock()
+                    .expect("The lock should be possible");
+                let source = runtime.application_id()?;
+                let source: AccountOwner = source.into();
+                let chain_id = runtime.chain_id()?;
+                let owner: AccountOwner = inputs.bytecode_address.into();
+                let destination = Account { chain_id, owner };
+                runtime.transfer(source, destination, value)?;
+            }
+        }
         // Other smart contracts calls are handled by the runtime
         let target = address_to_user_application_id(inputs.target_address);
-        let argument = get_call_argument(context, inputs);
+        let argument = get_call_contract_argument(context, inputs)?;
         let authenticated = true;
         let result = {
             let mut runtime = self.db.runtime.lock().expect("The lock should be possible");
@@ -993,7 +774,7 @@ impl<'a, Runtime: ServiceRuntime> Inspector<Ctx<'a, Runtime>> for CallIntercepto
         inputs: &mut CallInputs,
     ) -> Option<CallOutcome> {
         let result = self.call_or_fail(context, inputs);
-        map_result_call_outcome(result)
+        map_result_call_outcome(&self.db, result)
     }
 }
 
@@ -1017,7 +798,7 @@ impl<Runtime: ServiceRuntime> CallInterceptorService<Runtime> {
         }
         // Other smart contracts calls are handled by the runtime
         let target = address_to_user_application_id(inputs.target_address);
-        let argument = get_call_argument(context, inputs);
+        let argument = get_call_service_argument(context, inputs)?;
         let result = {
             let evm_query = EvmQuery::Query(argument);
             let evm_query = serde_json::to_vec(&evm_query)?;
@@ -1099,10 +880,11 @@ where
     fn instantiate(&mut self, argument: Vec<u8>) -> Result<(), ExecutionError> {
         self.db.set_contract_address()?;
         let caller = self.get_msg_address()?;
+        let instantiation_argument = serde_json::from_slice::<EvmInstantiation>(&argument)?;
+        self.db.deposit_funds(instantiation_argument.value)?;
         self.initialize_contract(caller)?;
         if has_selector(&self.module, INSTANTIATE_SELECTOR) {
-            let instantiation_argument = serde_json::from_slice::<Vec<u8>>(&argument)?;
-            let argument = get_revm_instantiation_bytes(instantiation_argument);
+            let argument = get_revm_instantiation_bytes(instantiation_argument.argument);
             let result = self.transact_commit(EvmTxKind::Call, argument, caller)?;
             self.write_logs(result.logs, "instantiate")?;
         }
@@ -1116,11 +898,12 @@ where
         let (gas_final, output, logs) = if &operation[..4] == INTERPRETER_RESULT_SELECTOR {
             ensure_message_length(operation.len(), 8)?;
             forbid_execute_operation_origin(&operation[4..8])?;
-            let result = self.init_transact_commit(operation[4..].to_vec(), caller)?;
+            let operation = self.db.get_execute_operation_argument(&operation[4..])?;
+            let result = self.init_transact_commit(operation, caller)?;
             result.interpreter_result_and_logs()?
         } else {
-            ensure_message_length(operation.len(), 4)?;
             forbid_execute_operation_origin(&operation[..4])?;
+            let operation = self.db.get_execute_operation_argument(&operation)?;
             let result = self.init_transact_commit(operation, caller)?;
             result.output_and_logs()
         };
@@ -1294,6 +1077,7 @@ where
             db: self.db.clone(),
             contract_address: self.db.contract_address,
             precompile_addresses: precompile_addresses(),
+            error: Arc::new(Mutex::new(None)),
         };
         let block_env = self.db.get_contract_block_env()?;
         let gas_limit = {
@@ -1301,6 +1085,7 @@ where
             runtime.remaining_fuel(VmRuntime::Evm)?
         };
         let nonce = self.db.get_nonce(&caller)?;
+        let value = self.db.get_balance_increase()?;
         let result = {
             let ctx: revm_context::Context<
                 BlockEnv,
@@ -1328,15 +1113,17 @@ where
                     nonce,
                     gas_limit,
                     caller,
+                    value,
                     ..TxEnv::default()
                 },
-                inspector,
+                inspector.clone(),
             )
             .map_err(|error| {
                 let error = format!("{:?}", error);
                 EvmExecutionError::TransactCommitError(error)
             })
         }?;
+        self.db.process_any_error()?;
         let storage_stats = self.db.take_storage_stats();
         self.db.commit_changes()?;
         let result = process_execution_result(storage_stats, result)?;
@@ -1490,6 +1277,7 @@ where
                 EvmExecutionError::TransactCommitError(error)
             })
         }?;
+        self.db.process_any_error()?;
         let storage_stats = self.db.take_storage_stats();
         Ok((
             process_execution_result(storage_stats, result_state.result)?,

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -342,15 +342,10 @@ fn get_call_service_argument<Ctx: ContextTr>(context: &mut Ctx, inputs: &CallInp
 
 fn get_call_contract_argument<Ctx: ContextTr>(context: &mut Ctx, inputs: &CallInputs) -> Result<(Vec<u8>, usize), ExecutionError> {
     let mut final_argument = INTERPRETER_RESULT_SELECTOR.to_vec();
-    tracing::info!("get_call_contract_argument, inputs.value={:?}", inputs.value);
     let value = get_value(&inputs.value)?;
-    tracing::info!("get_call_contract_argument, value={}", value);
-    tracing::info!("get_call_contract_argument, inputs.input={:?}", inputs.input);
     let argument = get_argument(context, &inputs.input);
     let n_input = argument.len();
-    tracing::info!("get_call_contract_argument, argument={:?} n_input={n_input}", argument);
     let argument = get_internal_mutation(value, argument)?;
-    tracing::info!("get_call_contract_argument, argument={:?}", argument);
     final_argument.extend(&argument);
     Ok((final_argument, n_input))
 }
@@ -696,12 +691,10 @@ impl<Runtime: ContractRuntime> CallInterceptorContract<Runtime> {
         if self.precompile_addresses.contains(&inputs.target_address)
             || inputs.target_address == self.contract_address
         {
-            tracing::info!("CallInterceptorContract :: call_or_fail, exiting early");
             // Precompile calls are handled by the precompile code.
             // The EVM smart contract is being called
             return Ok(None);
         }
-        tracing::info!("CallInterceptorContract :: call_or_fail, more complicated");
         // Handling the balances.
         if let CallValue::Transfer(value) = inputs.value {
             if value != U256::ZERO {
@@ -717,18 +710,23 @@ impl<Runtime: ContractRuntime> CallInterceptorContract<Runtime> {
                 let chain_id = runtime.chain_id()?;
                 let owner: AccountOwner = inputs.bytecode_address.into();
                 let destination = Account { chain_id, owner };
-                tracing::info!("call_or_fail, runtime.transfer, before, value={value}");
                 runtime.transfer(source, destination, value)?;
-                tracing::info!("call_or_fail, runtime.transfer, after");
             }
         }
-        tracing::info!("CallInterceptorContract :: target_address={}", inputs.target_address);
         // Other smart contracts calls are handled by the runtime
         let target = address_to_user_application_id(inputs.target_address);
         let (argument, n_input) = get_call_contract_argument(context, inputs)?;
-        tracing::info!("CallInterceptorContract :: argument={argument:?}, n_input={n_input}");
         let result = if n_input > 0 {
-            // The input is non-trivial, we are calling a real contract
+            // The input is non-trivial, we assume that we are calling a contract.
+            //
+            // The correct behavior is the following:
+            // * If a contract exists and input is empty, then the fallback function is called
+            //   if existing. Otherwise failure.
+            // * If not, then it is a user account and no execution occurs.
+            //
+            // So, the correct way is instead to test the existence of the application
+            // given the application_id. So, we need following function in BaseRuntime:
+            //  fn is_existing_application(&mut self, application_id: ApplicationId) -> Result<bool, ExecutionError>;
             let authenticated = true;
             let result = {
                 let mut runtime = self.db.runtime.lock().expect("The lock should be possible");
@@ -736,6 +734,7 @@ impl<Runtime: ContractRuntime> CallInterceptorContract<Runtime> {
             };
             get_interpreter_result(&result, inputs)?
         } else {
+            // User account, no call needed.
             InterpreterResult {
                 result: InstructionResult::Stop,
                 output: Bytes::default(),
@@ -904,7 +903,6 @@ where
 
     fn execute_operation(&mut self, operation: Vec<u8>) -> Result<Vec<u8>, ExecutionError> {
         self.db.set_contract_address()?;
-        tracing::info!("execute_operation, operation = {operation:?}");
         ensure_message_length(operation.len(), 4)?;
         let caller = self.get_msg_address()?;
         let (gas_final, output, logs) = if &operation[..4] == INTERPRETER_RESULT_SELECTOR {
@@ -952,7 +950,6 @@ where
     }
 
     fn finalize(&mut self) -> Result<(), ExecutionError> {
-        tracing::info!("-------------------------------------------------");
         Ok(())
     }
 }
@@ -1088,8 +1085,6 @@ where
     ) -> Result<ExecutionResultSuccess, ExecutionError> {
         self.db.caller = caller;
         self.db.value = value;
-        tracing::info!("transact_commit, caller = {caller}");
-        tracing::info!("transact_commit, value = {value}");
         self.db.deposit_funds()?;
         let data = Bytes::from(input);
         let kind = match ch {
@@ -1108,8 +1103,6 @@ where
             runtime.remaining_fuel(VmRuntime::Evm)?
         };
         let nonce = self.db.get_nonce(&caller)?;
-        tracing::info!("transact_commit, caller = {caller}");
-        tracing::info!("transact_commit, value = {value}");
         let result = {
             let ctx: revm_context::Context<
                 BlockEnv,
@@ -1150,7 +1143,6 @@ where
         self.db.process_any_error()?;
         let storage_stats = self.db.take_storage_stats();
         self.db.commit_changes()?;
-        tracing::info!("transact_commit, after commit_changes");
         let result = process_execution_result(storage_stats, result)?;
         Ok(result)
     }
@@ -1196,7 +1188,6 @@ where
     Runtime: ServiceRuntime,
 {
     fn handle_query(&mut self, argument: Vec<u8>) -> Result<Vec<u8>, ExecutionError> {
-        tracing::info!("RevmServiceInstance :: handle_query");
         self.db.set_contract_address()?;
         let evm_query = serde_json::from_slice(&argument)?;
         let query = match evm_query {

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -1068,6 +1068,8 @@ where
     ) -> Result<ExecutionResultSuccess, ExecutionError> {
         self.db.caller = caller;
         self.db.value = value;
+        tracing::info!("transact_commit, caller = {caller}");
+        tracing::info!("transact_commit, value = {value}");
         self.db.deposit_funds()?;
         let data = Bytes::from(input);
         let kind = match ch {

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -32,7 +32,7 @@ use revm_interpreter::{
     CallInput, CallInputs, CallOutcome, CallValue, CreateInputs, CreateOutcome, CreateScheme, Gas,
     InputsImpl, InstructionResult, InterpreterResult,
 };
-use revm_primitives::{address, hardfork::SpecId, Address, Log, TxKind, U256};
+use revm_primitives::{hardfork::SpecId, Address, Log, TxKind, U256};
 use revm_state::EvmState;
 use serde::{Deserialize, Serialize};
 
@@ -43,7 +43,8 @@ use crate::{
             get_internal_mutation, EvmInstantiation, EvmMutation, ensure_message_length, ensure_selector_presence, forbid_execute_operation_origin,
             get_revm_execute_message_bytes, get_revm_instantiation_bytes,
             get_revm_process_streams_bytes, has_selector, EXECUTE_MESSAGE_SELECTOR,
-            INSTANTIATE_SELECTOR, PROCESS_STREAMS_SELECTOR,
+            INSTANTIATE_SELECTOR, PROCESS_STREAMS_SELECTOR, SERVICE_ADDRESS,
+            ZERO_ADDRESS, PRECOMPILE_ADDRESS,
         },
         read_amount,
     },
@@ -204,18 +205,6 @@ impl UserServiceModule for EvmServiceModule {
 }
 
 type Ctx<'a, Runtime> = MainnetContext<WrapDatabaseRef<&'a mut DatabaseRuntime<Runtime>>>;
-
-// This is the precompile address that contains the Linera specific
-// functionalities accessed from the EVM.
-const PRECOMPILE_ADDRESS: Address = address!("000000000000000000000000000000000000000b");
-
-// This is the zero address used when no address can be obtained from `authenticated_signer`
-// and `authenticated_caller_id`. This scenario does not occur if an Address20 user calls or
-// if an EVM contract calls another EVM contract.
-const ZERO_ADDRESS: Address = address!("0000000000000000000000000000000000000000");
-
-// This is the address being used for service calls.
-const SERVICE_ADDRESS: Address = address!("0000000000000000000000000000000000002000");
 
 fn address_to_user_application_id(address: Address) -> ApplicationId {
     let mut vec = vec![0_u8; 32];
@@ -1077,6 +1066,9 @@ where
         value: U256,
         caller: Address,
     ) -> Result<ExecutionResultSuccess, ExecutionError> {
+        self.db.caller = caller;
+        self.db.value = value;
+        self.db.deposit_funds()?;
         let data = Bytes::from(input);
         let kind = match ch {
             EvmTxKind::Create => TxKind::Create,
@@ -1243,6 +1235,10 @@ where
         kind: TxKind,
         input: Vec<u8>,
     ) -> Result<(ExecutionResultSuccess, EvmState), ExecutionError> {
+        let caller = SERVICE_ADDRESS;
+        let value = U256::ZERO;
+        self.db.caller = caller;
+        self.db.value = value;
         let data = Bytes::from(input);
         let block_env = self.db.get_service_block_env()?;
         let inspector = CallInterceptorService {
@@ -1250,9 +1246,7 @@ where
             contract_address: self.db.contract_address,
             precompile_addresses: precompile_addresses(),
         };
-        let caller = SERVICE_ADDRESS;
         let nonce = self.db.get_nonce(&caller)?;
-        let value = U256::ZERO;
         let result_state = {
             let ctx: revm_context::Context<
                 BlockEnv,

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -340,13 +340,19 @@ fn get_call_service_argument<Ctx: ContextTr>(context: &mut Ctx, inputs: &CallInp
     Ok(argument)
 }
 
-fn get_call_contract_argument<Ctx: ContextTr>(context: &mut Ctx, inputs: &CallInputs) -> Result<Vec<u8>, ExecutionError> {
+fn get_call_contract_argument<Ctx: ContextTr>(context: &mut Ctx, inputs: &CallInputs) -> Result<(Vec<u8>, usize), ExecutionError> {
     let mut final_argument = INTERPRETER_RESULT_SELECTOR.to_vec();
+    tracing::info!("get_call_contract_argument, inputs.value={:?}", inputs.value);
     let value = get_value(&inputs.value)?;
+    tracing::info!("get_call_contract_argument, value={}", value);
+    tracing::info!("get_call_contract_argument, inputs.input={:?}", inputs.input);
     let argument = get_argument(context, &inputs.input);
+    let n_input = argument.len();
+    tracing::info!("get_call_contract_argument, argument={:?} n_input={n_input}", argument);
     let argument = get_internal_mutation(value, argument)?;
+    tracing::info!("get_call_contract_argument, argument={:?}", argument);
     final_argument.extend(&argument);
-    Ok(final_argument)
+    Ok((final_argument, n_input))
 }
 
 fn base_runtime_call<Runtime: BaseRuntime>(
@@ -716,16 +722,28 @@ impl<Runtime: ContractRuntime> CallInterceptorContract<Runtime> {
                 tracing::info!("call_or_fail, runtime.transfer, after");
             }
         }
+        tracing::info!("CallInterceptorContract :: target_address={}", inputs.target_address);
         // Other smart contracts calls are handled by the runtime
         let target = address_to_user_application_id(inputs.target_address);
-        let argument = get_call_contract_argument(context, inputs)?;
-        let authenticated = true;
-        let result = {
-            let mut runtime = self.db.runtime.lock().expect("The lock should be possible");
-            runtime.try_call_application(authenticated, target, argument)?
+        let (argument, n_input) = get_call_contract_argument(context, inputs)?;
+        tracing::info!("CallInterceptorContract :: argument={argument:?}, n_input={n_input}");
+        let result = if n_input > 0 {
+            // The input is non-trivial, we are calling a real contract
+            let authenticated = true;
+            let result = {
+                let mut runtime = self.db.runtime.lock().expect("The lock should be possible");
+                runtime.try_call_application(authenticated, target, argument)?
+            };
+            get_interpreter_result(&result, inputs)?
+        } else {
+            InterpreterResult {
+                result: InstructionResult::Stop,
+                output: Bytes::default(),
+                gas: Gas::new(inputs.gas_limit),
+            }
         };
         let call_outcome = CallOutcome {
-            result: get_interpreter_result(&result, inputs)?,
+            result,
             memory_offset: inputs.return_memory_offset.clone(),
         };
         Ok(Some(call_outcome))
@@ -886,6 +904,7 @@ where
 
     fn execute_operation(&mut self, operation: Vec<u8>) -> Result<Vec<u8>, ExecutionError> {
         self.db.set_contract_address()?;
+        tracing::info!("execute_operation, operation = {operation:?}");
         ensure_message_length(operation.len(), 4)?;
         let caller = self.get_msg_address()?;
         let (gas_final, output, logs) = if &operation[..4] == INTERPRETER_RESULT_SELECTOR {
@@ -933,6 +952,7 @@ where
     }
 
     fn finalize(&mut self) -> Result<(), ExecutionError> {
+        tracing::info!("-------------------------------------------------");
         Ok(())
     }
 }
@@ -1176,6 +1196,7 @@ where
     Runtime: ServiceRuntime,
 {
     fn handle_query(&mut self, argument: Vec<u8>) -> Result<Vec<u8>, ExecutionError> {
+        tracing::info!("RevmServiceInstance :: handle_query");
         self.db.set_contract_address()?;
         let evm_query = serde_json::from_slice(&argument)?;
         let query = match evm_query {

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -158,6 +158,7 @@ where
                 amount,
                 signer,
                 application_id,
+                chain_id,
                 callback,
             } => callback.respond(
                 self.system
@@ -167,6 +168,7 @@ where
                         source,
                         Recipient::Account(destination),
                         amount,
+                        chain_id,
                     )
                     .await?,
             ),
@@ -613,6 +615,7 @@ pub enum ExecutionRequest {
         #[debug(skip_if = Option::is_none)]
         signer: Option<AccountOwner>,
         application_id: ApplicationId,
+        chain_id: ChainId,
         #[debug(skip)]
         callback: Sender<Option<OutgoingMessage>>,
     },

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1274,6 +1274,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
                 amount,
                 signer,
                 application_id,
+                chain_id: this.chain_id,
                 callback,
             })?
             .recv_response()?;

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -396,7 +396,7 @@ where
                 recipient,
             } => {
                 let maybe_message = self
-                    .transfer(context.authenticated_signer, None, owner, recipient, amount)
+                    .transfer(context.authenticated_signer, None, owner, recipient, amount, context.chain_id)
                     .await?;
                 txn_tracker.add_outgoing_messages(maybe_message)?;
             }
@@ -608,6 +608,7 @@ where
         source: AccountOwner,
         recipient: Recipient,
         amount: Amount,
+        chain_id: ChainId,
     ) -> Result<Option<OutgoingMessage>, ExecutionError> {
         if source == AccountOwner::CHAIN {
             ensure!(
@@ -632,14 +633,31 @@ where
         self.debit(&source, amount).await?;
         match recipient {
             Recipient::Account(account) => {
-                let message = SystemMessage::Credit {
-                    amount,
-                    source,
-                    target: account.owner,
-                };
-                Ok(Some(
-                    OutgoingMessage::new(account.chain_id, message).with_kind(MessageKind::Tracked),
-                ))
+                // Check if destination is on the same chain
+                if account.chain_id == chain_id {
+                    // Handle same-chain transfer locally
+                    let target = account.owner;
+                    if target == AccountOwner::CHAIN {
+                        let new_balance = self.balance.get().saturating_add(amount);
+                        self.balance.set(new_balance);
+                    } else {
+                        let balance = self.balances.get_mut_or_default(&target).await?;
+                        *balance = balance.saturating_add(amount);
+                    }
+                    // No outgoing message for same-chain transfers
+                    Ok(None)
+                } else {
+                    // Handle cross-chain transfer with message
+                    let message = SystemMessage::Credit {
+                        amount,
+                        source,
+                        target: account.owner,
+                    };
+                    Ok(Some(
+                        OutgoingMessage::new(account.chain_id, message)
+                            .with_kind(MessageKind::Tracked),
+                    ))
+                }
             }
             Recipient::Burn => Ok(None),
         }

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -284,7 +284,7 @@ impl Validator {
 #[cfg(with_testing)]
 impl LocalNetConfig {
     pub fn new_test(database: Database, network: Network) -> Self {
-        let num_shards = 4;
+        let num_shards = 1;
         let num_proxies = 1;
         let storage_config_builder = InnerStorageConfigBuilder::TestConfig;
         let path_provider = PathProvider::create_temporary_directory().unwrap();
@@ -301,7 +301,7 @@ impl LocalNetConfig {
             cross_chain_config,
             testing_prng_seed: Some(37),
             namespace: linera_views::random::generate_test_namespace(),
-            num_initial_validators: 4,
+            num_initial_validators: 1,
             num_shards,
             num_proxies,
             storage_config_builder,

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -284,7 +284,7 @@ impl Validator {
 #[cfg(with_testing)]
 impl LocalNetConfig {
     pub fn new_test(database: Database, network: Network) -> Self {
-        let num_shards = 1;
+        let num_shards = 4;
         let num_proxies = 1;
         let storage_config_builder = InnerStorageConfigBuilder::TestConfig;
         let path_provider = PathProvider::create_temporary_directory().unwrap();
@@ -301,7 +301,7 @@ impl LocalNetConfig {
             cross_chain_config,
             testing_prng_seed: Some(37),
             namespace: linera_views::random::generate_test_namespace(),
-            num_initial_validators: 1,
+            num_initial_validators: 4,
             num_shards,
             num_proxies,
             storage_config_builder,

--- a/linera-service/tests/fixtures/evm_balance_and_transfer.sol
+++ b/linera-service/tests/fixtures/evm_balance_and_transfer.sol
@@ -1,0 +1,20 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+contract InnerContractCheck {
+    constructor() payable {
+    }
+
+    function send_cash(uint256 amount) external returns (uint64) {
+        address recipient = msg.sender;
+        (bool success, ) = recipient.call{value: amount}("");
+        require(success, "Ether transfer failed");
+        return 1;
+    }
+
+    function get_balance(address account) external returns (uint256) {
+        uint256 balance = account.balance;
+        return balance;
+    }
+}

--- a/linera-service/tests/fixtures/evm_balance_and_transfer.sol
+++ b/linera-service/tests/fixtures/evm_balance_and_transfer.sol
@@ -6,8 +6,7 @@ contract InnerContractCheck {
     constructor() payable {
     }
 
-    function send_cash(uint256 amount) external returns (uint64) {
-        address recipient = msg.sender;
+    function send_cash(address recipient, uint256 amount) external returns (uint64) {
         (bool success, ) = recipient.call{value: amount}("");
         require(success, "Ether transfer failed");
         return 1;

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -550,8 +550,8 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     tracing::info!("address2 = {address2}");
     let account1 = Account { chain_id: chain, owner: account_owner1 };
     let account2 = Account { chain_id: chain, owner: account_owner2 };
-    client.transfer_with_accounts(Amount::from_tokens(5), account_chain, account1).await?;
-    client.transfer_with_accounts(Amount::from_tokens(5), account_chain, account2).await?;
+    client.transfer_with_accounts(Amount::from_tokens(50), account_chain, account1).await?;
+    client.transfer_with_accounts(Amount::from_tokens(50), account_chain, account2).await?;
     tracing::info!("test_evm_end_to_end_balance_and_transfer, step 4");
 
     sol! {

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -522,11 +522,11 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) -> Result<()> {
-    use alloy_sol_types::{sol, SolCall, SolValue};
+    use alloy_sol_types::{sol, SolCall};
     use linera_base::vm::EvmQuery;
     use linera_execution::{
         evm::inputs::{get_mutation, EvmInstantiation},
-        test_utils::solidity::{get_evm_contract_path, read_evm_u64_entry},
+        test_utils::solidity::{get_evm_contract_path, read_evm_u256_entry},
     };
     use linera_sdk::abis::evm::EvmAbi;
 
@@ -534,21 +534,31 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client) = config.instantiate().await?;
-    let account_owner = client.get_owner();
+    let chain = client.load_wallet()?.default_chain().unwrap();
+    let account_chain = Account::chain(chain);
+
+    let account_owner1 = client.get_owner().unwrap();
+    let address1 = account_owner1.to_evm_address().unwrap();
+    let account_owner2 = client.keygen().await?;
+    let address2 = account_owner2.to_evm_address().unwrap();
+    let account1 = Account { chain_id: chain, owner: account_owner1 };
+    let account2 = Account { chain_id: chain, owner: account_owner2 };
+    client.transfer_with_accounts(Amount::from_tokens(5), account_chain, account1).await?;
+    client.transfer_with_accounts(Amount::from_tokens(5), account_chain, account2).await?;
 
     sol! {
-        function send_cash();
+        function send_cash(address recipient, uint256 amount);
+        function get_balance(address account);
     }
 
     let constructor_argument = Vec::new();
 
-    let chain = client.load_wallet()?.default_chain().unwrap();
-    let account_chain = Account::chain(chain);
 
     let (evm_contract, _dir) =
         get_evm_contract_path("tests/fixtures/evm_balance_and_transfer.sol")?;
 
-    let instantiation_argument = EvmInstantiation { value, argument };
+    let start_value = Amount::ZERO;
+    let instantiation_argument = EvmInstantiation { value: start_value, argument: vec![] };
     let application_id = client
         .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
             evm_contract.clone(),
@@ -565,30 +575,52 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     let mut node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
 
 
-    let balance1 = node_service.balance(&account_chain).await?;
+    let balance_chain = node_service.balance(&account_chain).await?;
+    let balance1 = node_service.balance(&account1).await?;
+    let balance2 = node_service.balance(&account2).await?;
+    tracing::info!("balance_chain={balance_chain}");
+    tracing::info!("balance1={balance1}");
+    tracing::info!("balance2={balance2}");
 
-    
     let application = node_service
         .make_application(&chain, &application_id)
         .await?;
 
+    // Checking the balances on input
+
+    let query1 = get_balanceCall { account: address1 };
+    let query1 = EvmQuery::Query(query1.abi_encode());
+    let result = application.run_json_query(query1.clone()).await?;
+    assert_eq!(read_evm_u256_entry(result), balance1.into());
+
+    let query2 = get_balanceCall { account: address2 };
+    let query2 = EvmQuery::Query(query2.abi_encode());
+    let result = application.run_json_query(query2.clone()).await?;
+    assert_eq!(read_evm_u256_entry(result), balance2.into());
+
+    // Transfering amount
+
     let amount = Amount::from_tokens(1);
-    let query = get_balanceCall { address: };
-    let query = query.abi_encode();
-    let query = EvmQuery::Query(query);
-    let result = application.run_json_query(query.clone()).await?;
 
-    let counter_value = read_evm_u64_entry(result);
-    assert_eq!(counter_value, original_counter_value);
-
-    let mutation = incrementCall { input: increment };
+    let mutation = send_cashCall { recipient: address2, amount: amount.into() };
     let mutation = get_mutation(Amount::ZERO, mutation)?;
     let mutation = EvmQuery::Mutation(mutation);
     application.run_json_query(mutation).await?;
 
-    let result = application.run_json_query(query).await?;
-    let counter_value = read_evm_u64_entry(result);
-    assert_eq!(counter_value, original_counter_value + increment);
+    // Checking the balances
+
+    let balance1_after = node_service.balance(&account1).await?;
+    let balance2_after = node_service.balance(&account2).await?;
+    assert_eq!(balance1_after, balance1 - amount);
+    assert_eq!(balance2_after, balance2 + amount);
+
+    let result = application.run_json_query(query1).await?;
+    assert_eq!(read_evm_u256_entry(result), balance1_after.into());
+
+    let result = application.run_json_query(query2.clone()).await?;
+    assert_eq!(read_evm_u256_entry(result), balance2.into());
+
+    // Winding down
 
     node_service.ensure_is_running()?;
 
@@ -1378,9 +1410,8 @@ async fn test_evm_process_streams_end_to_end_counters(config: impl LineraNetConf
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_evm_msg_sender(config: impl LineraNetConfig) -> Result<()> {
-    use alloy_primitives::Address;
     use alloy_sol_types::sol;
-    use linera_base::{identifiers::AccountOwner, vm::EvmQuery};
+    use linera_base::vm::EvmQuery;
     use linera_execution::{
         evm::inputs::{get_mutation, EvmInstantiation},
         test_utils::solidity::get_evm_contract_path,
@@ -1391,11 +1422,8 @@ async fn test_evm_msg_sender(config: impl LineraNetConfig) -> Result<()> {
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client) = config.instantiate().await?;
-    let account_owner = client.get_owner();
-    let Some(AccountOwner::Address20(address)) = account_owner else {
-        panic!("The owner should be of the form Some(Address20(...))");
-    };
-    let owner = Address::from(address);
+    let account_owner = client.get_owner().unwrap();
+    let owner = account_owner.to_evm_address().unwrap();
     let chain = client.load_wallet()?.default_chain().unwrap();
 
     sol! {

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -577,7 +577,6 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     let mut node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
 
 
-    let balance_chain = node_service.balance(&account_chain).await?;
     let balance1 = node_service.balance(&account1).await?;
     let balance2 = node_service.balance(&account2).await?;
     let balance_app = node_service.balance(&account_app).await?;
@@ -1665,7 +1664,10 @@ async fn test_evm_erc20_shared(config: impl LineraNetConfig) -> Result<()> {
     use alloy_primitives::{B256, U256};
     use alloy_sol_types::{sol, SolCall, SolValue};
     use linera_base::vm::EvmQuery;
-    use linera_execution::test_utils::solidity::{get_evm_contract_path, read_evm_u256_entry};
+    use linera_execution::{
+        evm::inputs::{get_mutation, EvmInstantiation},
+        test_utils::solidity::{get_evm_contract_path, read_evm_u256_entry},
+    };
     use linera_sdk::abis::evm::EvmAbi;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
@@ -1697,12 +1699,12 @@ async fn test_evm_erc20_shared(config: impl LineraNetConfig) -> Result<()> {
     let constructor_argument = ConstructorArgs { the_supply };
     let constructor_argument = constructor_argument.abi_encode();
 
-    let instantiation_argument = U256::abi_encode(&the_supply);
+    let instantiation_argument = EvmInstantiation { value: Amount::ZERO, argument: U256::abi_encode(&the_supply) };
 
     let (evm_contract, _dir) = get_evm_contract_path("tests/fixtures/erc20_shared.sol")?;
 
     let application_id = client1
-        .publish_and_create::<EvmAbi, Vec<u8>, Vec<u8>>(
+        .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
             evm_contract.clone(),
             evm_contract,
             VmRuntime::Evm,
@@ -1740,7 +1742,8 @@ async fn test_evm_erc20_shared(config: impl LineraNetConfig) -> Result<()> {
         to: address2,
         value: transfer1,
     };
-    let mutation = EvmQuery::Mutation(mutation.abi_encode());
+    let mutation = get_mutation(Amount::ZERO, mutation)?;
+    let mutation = EvmQuery::Mutation(mutation);
     application1.run_json_query(mutation).await?;
 
     let query = balanceOfCall { account: address1 };
@@ -1763,7 +1766,8 @@ async fn test_evm_erc20_shared(config: impl LineraNetConfig) -> Result<()> {
         destination: address2,
         value: transfer2,
     };
-    let mutation = EvmQuery::Mutation(mutation.abi_encode());
+    let mutation = get_mutation(Amount::ZERO, mutation)?;
+    let mutation = EvmQuery::Mutation(mutation);
     application1.run_json_query(mutation).await?;
 
     node_service2.process_inbox(&chain2).await?;

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -579,6 +579,7 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
             None,
         )
         .await?;
+    tracing::info!("application_id = {application_id:?}");
     let account_owner_app: AccountOwner = application_id.into();
     tracing::info!("test_evm_end_to_end_balance_and_transfer, step 6, account_owner_app = {account_owner_app}");
     let account_app = Account { chain_id: chain, owner: account_owner_app };
@@ -591,6 +592,9 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     let balance1 = node_service.balance(&account1).await?;
     let balance2 = node_service.balance(&account2).await?;
     let balance_app = node_service.balance(&account_app).await?;
+    assert_eq!(balance1, Amount::from_tokens(46));
+    assert_eq!(balance2, Amount::from_tokens(50));
+    assert_eq!(balance_app, Amount::from_tokens(4));
     tracing::info!("balance_chain = {balance_chain}");
     tracing::info!("balance1 = {balance1}");
     tracing::info!("balance2 = {balance2}");
@@ -602,6 +606,7 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     tracing::info!("test_evm_end_to_end_balance_and_transfer, step 7");
 
     // Checking the balances on input
+
 
     let query1 = get_balanceCall { account: address1 };
     let query1 = EvmQuery::Query(query1.abi_encode());
@@ -617,7 +622,6 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
 
     // Transfering amount
 
-    /*
     let amount = Amount::from_tokens(1);
 
     let mutation = send_cashCall { recipient: address2, amount: amount.into() };
@@ -625,16 +629,19 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     let mutation = EvmQuery::Mutation(mutation);
     application.run_json_query(mutation).await?;
     tracing::info!("test_evm_end_to_end_balance_and_transfer, step 10");
-*/
 
-    
     // Checking the balances
 
-    /*
     let balance1_after = node_service.balance(&account1).await?;
     let balance2_after = node_service.balance(&account2).await?;
-    assert_eq!(balance1_after, balance1 - amount);
+    let balance_app_after = node_service.balance(&account_app).await?;
+    tracing::info!("amount = {amount}");
+    tracing::info!("balance1_after = {balance1_after}");
+    tracing::info!("balance2_after = {balance2_after}");
+    tracing::info!("balance_app_after = {balance_app_after}");
+    assert_eq!(balance1_after, balance1);
     assert_eq!(balance2_after, balance2 + amount);
+    assert_eq!(balance_app_after, balance_app - amount);
     tracing::info!("test_evm_end_to_end_balance_and_transfer, step 11");
 
     let result = application.run_json_query(query1).await?;
@@ -642,9 +649,8 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     tracing::info!("test_evm_end_to_end_balance_and_transfer, step 12");
 
     let result = application.run_json_query(query2.clone()).await?;
-    assert_eq!(read_evm_u256_entry(result), balance2.into());
+    assert_eq!(read_evm_u256_entry(result), balance2_after.into());
     tracing::info!("test_evm_end_to_end_balance_and_transfer, step 13");
-    */
 
     // Winding down
 
@@ -653,7 +659,6 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     net.ensure_is_running().await?;
     net.terminate().await?;
 
-    assert!(false);
     Ok(())
 }
 

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -530,29 +530,21 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     };
     use linera_sdk::abis::evm::EvmAbi;
 
-    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 1");
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
-    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 2");
     let (mut net, client) = config.instantiate().await?;
     let chain = client.load_wallet()?.default_chain().unwrap();
     let account_chain = Account::chain(chain);
-    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 3");
 
     let account_owner1 = client.get_owner().unwrap();
     let account_owner2 = client.keygen().await?;
-    tracing::info!("account_owner1 = {account_owner1}");
-    tracing::info!("account_owner2 = {account_owner2}");
     let address1 = account_owner1.to_evm_address().unwrap();
     let address2 = account_owner2.to_evm_address().unwrap();
-    tracing::info!("address1 = {address1}");
-    tracing::info!("address2 = {address2}");
     let account1 = Account { chain_id: chain, owner: account_owner1 };
     let account2 = Account { chain_id: chain, owner: account_owner2 };
     client.transfer_with_accounts(Amount::from_tokens(50), account_chain, account1).await?;
     client.transfer_with_accounts(Amount::from_tokens(50), account_chain, account2).await?;
-    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 4");
 
     sol! {
         function send_cash(address recipient, uint256 amount);
@@ -564,7 +556,6 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
 
     let (evm_contract, _dir) =
         get_evm_contract_path("tests/fixtures/evm_balance_and_transfer.sol")?;
-    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 5");
 
     let start_value = Amount::from_tokens(4);
     let instantiation_argument = EvmInstantiation { value: start_value, argument: vec![] };
@@ -579,9 +570,7 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
             None,
         )
         .await?;
-    tracing::info!("application_id = {application_id:?}");
     let account_owner_app: AccountOwner = application_id.into();
-    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 6, account_owner_app = {account_owner_app}");
     let account_app = Account { chain_id: chain, owner: account_owner_app };
 
     let port = get_node_port().await;
@@ -595,15 +584,10 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     assert_eq!(balance1, Amount::from_tokens(46));
     assert_eq!(balance2, Amount::from_tokens(50));
     assert_eq!(balance_app, Amount::from_tokens(4));
-    tracing::info!("balance_chain = {balance_chain}");
-    tracing::info!("balance1 = {balance1}");
-    tracing::info!("balance2 = {balance2}");
-    tracing::info!("balance_app = {balance_app}");
 
     let application = node_service
         .make_application(&chain, &application_id)
         .await?;
-    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 7");
 
     // Checking the balances on input
 
@@ -612,13 +596,11 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     let query1 = EvmQuery::Query(query1.abi_encode());
     let result = application.run_json_query(query1.clone()).await?;
     assert_eq!(read_evm_u256_entry(result), balance1.into());
-    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 8");
 
     let query2 = get_balanceCall { account: address2 };
     let query2 = EvmQuery::Query(query2.abi_encode());
     let result = application.run_json_query(query2.clone()).await?;
     assert_eq!(read_evm_u256_entry(result), balance2.into());
-    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 9");
 
     // Transfering amount
 
@@ -628,29 +610,21 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     let mutation = get_mutation(Amount::ZERO, mutation)?;
     let mutation = EvmQuery::Mutation(mutation);
     application.run_json_query(mutation).await?;
-    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 10");
 
     // Checking the balances
 
     let balance1_after = node_service.balance(&account1).await?;
     let balance2_after = node_service.balance(&account2).await?;
     let balance_app_after = node_service.balance(&account_app).await?;
-    tracing::info!("amount = {amount}");
-    tracing::info!("balance1_after = {balance1_after}");
-    tracing::info!("balance2_after = {balance2_after}");
-    tracing::info!("balance_app_after = {balance_app_after}");
     assert_eq!(balance1_after, balance1);
     assert_eq!(balance2_after, balance2 + amount);
     assert_eq!(balance_app_after, balance_app - amount);
-    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 11");
 
     let result = application.run_json_query(query1).await?;
     assert_eq!(read_evm_u256_entry(result), balance1_after.into());
-    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 12");
 
     let result = application.run_json_query(query2.clone()).await?;
     assert_eq!(read_evm_u256_entry(result), balance2_after.into());
-    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 13");
 
     // Winding down
 

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -438,7 +438,10 @@ impl AmmApp {
 async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()> {
     use alloy_sol_types::{sol, SolCall, SolValue};
     use linera_base::vm::EvmQuery;
-    use linera_execution::test_utils::solidity::{get_evm_contract_path, read_evm_u64_entry};
+    use linera_execution::{
+        evm::inputs::{get_mutation, EvmInstantiation},
+        test_utils::solidity::{get_evm_contract_path, read_evm_u64_entry},
+    };
     use linera_sdk::abis::evm::EvmAbi;
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -466,9 +469,9 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
 
     let (evm_contract, _dir) = get_evm_contract_path("tests/fixtures/evm_example_counter.sol")?;
 
-    let instantiation_argument = Vec::new();
+    let instantiation_argument = EvmInstantiation::default();
     let application_id = client
-        .publish_and_create::<EvmAbi, Vec<u8>, Vec<u8>>(
+        .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
             evm_contract.clone(),
             evm_contract,
             VmRuntime::Evm,
@@ -495,7 +498,91 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
     assert_eq!(counter_value, original_counter_value);
 
     let mutation = incrementCall { input: increment };
-    let mutation = mutation.abi_encode();
+    let mutation = get_mutation(Amount::ZERO, mutation)?;
+    let mutation = EvmQuery::Mutation(mutation);
+    application.run_json_query(mutation).await?;
+
+    let result = application.run_json_query(query).await?;
+    let counter_value = read_evm_u64_entry(result);
+    assert_eq!(counter_value, original_counter_value + increment);
+
+    node_service.ensure_is_running()?;
+
+    net.ensure_is_running().await?;
+    net.terminate().await?;
+
+    Ok(())
+}
+
+#[cfg(with_revm)]
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
+#[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) -> Result<()> {
+    use alloy_sol_types::{sol, SolCall, SolValue};
+    use linera_base::vm::EvmQuery;
+    use linera_execution::{
+        evm::inputs::{get_mutation, EvmInstantiation},
+        test_utils::solidity::{get_evm_contract_path, read_evm_u64_entry},
+    };
+    use linera_sdk::abis::evm::EvmAbi;
+
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let (mut net, client) = config.instantiate().await?;
+    let account_owner = client.get_owner();
+
+    sol! {
+        function send_cash();
+    }
+
+    let constructor_argument = Vec::new();
+
+    let chain = client.load_wallet()?.default_chain().unwrap();
+    let account_chain = Account::chain(chain);
+
+    let (evm_contract, _dir) =
+        get_evm_contract_path("tests/fixtures/evm_balance_and_transfer.sol")?;
+
+    let instantiation_argument = EvmInstantiation { value, argument };
+    let application_id = client
+        .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
+            evm_contract.clone(),
+            evm_contract,
+            VmRuntime::Evm,
+            &constructor_argument,
+            &instantiation_argument,
+            &[],
+            None,
+        )
+        .await?;
+
+    let port = get_node_port().await;
+    let mut node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
+
+
+    let balance1 = node_service.balance(&account_chain).await?;
+
+    
+    let application = node_service
+        .make_application(&chain, &application_id)
+        .await?;
+
+    let amount = Amount::from_tokens(1);
+    let query = get_balanceCall { address: };
+    let query = query.abi_encode();
+    let query = EvmQuery::Query(query);
+    let result = application.run_json_query(query.clone()).await?;
+
+    let counter_value = read_evm_u64_entry(result);
+    assert_eq!(counter_value, original_counter_value);
+
+    let mutation = incrementCall { input: increment };
+    let mutation = get_mutation(Amount::ZERO, mutation)?;
     let mutation = EvmQuery::Mutation(mutation);
     application.run_json_query(mutation).await?;
 
@@ -520,12 +607,15 @@ async fn test_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()>
 #[test_log::test(tokio::test)]
 async fn test_evm_event(config: impl LineraNetConfig) -> Result<()> {
     use alloy_primitives::{Bytes, Log, U256};
-    use alloy_sol_types::{sol, SolCall, SolValue};
+    use alloy_sol_types::{sol, SolValue};
     use linera_base::{
         identifiers::{GenericApplicationId, StreamId, StreamName},
         vm::EvmQuery,
     };
-    use linera_execution::test_utils::solidity::get_evm_contract_path;
+    use linera_execution::{
+        evm::inputs::{get_mutation, EvmInstantiation},
+        test_utils::solidity::get_evm_contract_path,
+    };
     use linera_sdk::abis::evm::EvmAbi;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
@@ -549,9 +639,9 @@ async fn test_evm_event(config: impl LineraNetConfig) -> Result<()> {
 
     let (evm_contract, _dir) = get_evm_contract_path("tests/fixtures/evm_example_log.sol")?;
 
-    let instantiation_argument = Vec::new();
+    let instantiation_argument = EvmInstantiation::default();
     let application_id = client
-        .publish_and_create::<EvmAbi, Vec<u8>, Vec<u8>>(
+        .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
             evm_contract.clone(),
             evm_contract,
             VmRuntime::Evm,
@@ -595,7 +685,7 @@ async fn test_evm_event(config: impl LineraNetConfig) -> Result<()> {
     assert_eq!(start_index, 1);
 
     let mutation = incrementCall { input: increment };
-    let mutation = mutation.abi_encode();
+    let mutation = get_mutation(Amount::ZERO, mutation)?;
     let mutation = EvmQuery::Mutation(mutation);
     application.run_json_query(mutation).await?;
 
@@ -636,7 +726,10 @@ async fn test_evm_event(config: impl LineraNetConfig) -> Result<()> {
 async fn test_wasm_call_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()> {
     use alloy_sol_types::{sol, SolValue};
     use call_evm_counter::{CallCounterAbi, CallCounterRequest};
-    use linera_execution::test_utils::solidity::get_evm_contract_path;
+    use linera_execution::{
+        evm::inputs::EvmInstantiation,
+        test_utils::solidity::get_evm_contract_path,
+    };
     use linera_sdk::abis::evm::EvmAbi;
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -661,9 +754,9 @@ async fn test_wasm_call_evm_end_to_end_counter(config: impl LineraNetConfig) -> 
 
     let (evm_contract, _dir) = get_evm_contract_path("tests/fixtures/evm_example_counter.sol")?;
 
-    let instantiation_argument = Vec::new();
+    let instantiation_argument = EvmInstantiation::default();
     let evm_application_id = client
-        .publish_and_create::<EvmAbi, Vec<u8>, Vec<u8>>(
+        .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
             evm_contract.clone(),
             evm_contract,
             VmRuntime::Evm,
@@ -737,7 +830,10 @@ async fn test_wasm_call_evm_end_to_end_counter(config: impl LineraNetConfig) -> 
 async fn test_evm_call_evm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()> {
     use alloy_sol_types::{sol, SolCall, SolValue};
     use linera_base::vm::EvmQuery;
-    use linera_execution::test_utils::solidity::{get_evm_contract_path, read_evm_u64_entry};
+    use linera_execution::{
+        evm::inputs::{get_mutation, EvmInstantiation},
+        test_utils::solidity::{get_evm_contract_path, read_evm_u64_entry},
+    };
     use linera_sdk::abis::evm::EvmAbi;
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -765,9 +861,9 @@ async fn test_evm_call_evm_end_to_end_counter(config: impl LineraNetConfig) -> R
         constructor_argument.abi_encode()
     };
 
-    let instantiation_argument = Vec::new();
+    let instantiation_argument = EvmInstantiation::default();
     let evm_application_id = client
-        .publish_and_create::<EvmAbi, Vec<u8>, Vec<u8>>(
+        .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
             evm_contract.clone(),
             evm_contract,
             VmRuntime::Evm,
@@ -796,7 +892,7 @@ async fn test_evm_call_evm_end_to_end_counter(config: impl LineraNetConfig) -> R
         get_evm_contract_path("tests/fixtures/evm_call_evm_example_counter.sol")?;
 
     let nest_application_id = client
-        .publish_and_create::<EvmAbi, Vec<u8>, Vec<u8>>(
+        .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
             nest_contract.clone(),
             nest_contract,
             VmRuntime::Evm,
@@ -822,7 +918,7 @@ async fn test_evm_call_evm_end_to_end_counter(config: impl LineraNetConfig) -> R
     assert_eq!(counter_value, original_counter_value);
 
     let mutation = nest_incrementCall { input: increment };
-    let mutation = mutation.abi_encode();
+    let mutation = get_mutation(Amount::ZERO, mutation)?;
     let mutation = EvmQuery::Mutation(mutation);
     nest_application.run_json_query(mutation).await?;
 
@@ -849,7 +945,10 @@ async fn test_evm_call_wasm_end_to_end_counter(config: impl LineraNetConfig) -> 
     use alloy_sol_types::{sol, SolCall, SolValue};
     use counter_no_graphql::CounterNoGraphQlAbi;
     use linera_base::vm::EvmQuery;
-    use linera_execution::test_utils::solidity::{get_evm_contract_path, read_evm_u64_entry};
+    use linera_execution::{
+        evm::inputs::{get_mutation, EvmInstantiation},
+        test_utils::solidity::{get_evm_contract_path, read_evm_u64_entry},
+    };
     use linera_sdk::abis::evm::EvmAbi;
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -894,9 +993,9 @@ async fn test_evm_call_wasm_end_to_end_counter(config: impl LineraNetConfig) -> 
     let (nest_contract, _dir) =
         get_evm_contract_path("tests/fixtures/evm_call_wasm_example_counter.sol")?;
 
-    let instantiation_argument = Vec::new();
+    let instantiation_argument = EvmInstantiation::default();
     let nest_application_id = client
-        .publish_and_create::<EvmAbi, Vec<u8>, Vec<u8>>(
+        .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
             nest_contract.clone(),
             nest_contract,
             VmRuntime::Evm,
@@ -919,7 +1018,7 @@ async fn test_evm_call_wasm_end_to_end_counter(config: impl LineraNetConfig) -> 
     assert_eq!(counter_value, original_counter_value);
 
     let mutation = nest_incrementCall { input: increment };
-    let mutation = mutation.abi_encode();
+    let mutation = get_mutation(Amount::ZERO, mutation)?;
     let mutation = EvmQuery::Mutation(mutation);
     nest_application.run_json_query(mutation).await?;
 
@@ -946,7 +1045,10 @@ async fn test_evm_execute_message_end_to_end_counter(config: impl LineraNetConfi
     use alloy_primitives::B256;
     use alloy_sol_types::{sol, SolCall, SolValue};
     use linera_base::vm::EvmQuery;
-    use linera_execution::test_utils::solidity::{get_evm_contract_path, read_evm_u64_entry};
+    use linera_execution::{
+        evm::inputs::{get_mutation, EvmInstantiation},
+        test_utils::solidity::{get_evm_contract_path, read_evm_u64_entry},
+    };
     use linera_sdk::abis::evm::EvmAbi;
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -979,13 +1081,13 @@ async fn test_evm_execute_message_end_to_end_counter(config: impl LineraNetConfi
     let constructor_argument = ConstructorArgs { test_value: 42 };
     let constructor_argument = constructor_argument.abi_encode();
 
-    let instantiation_argument = u64::abi_encode(&original_value);
+    let instantiation_argument = EvmInstantiation { value: Amount::ZERO, argument: u64::abi_encode(&original_value) };
 
     let (evm_contract, _dir) =
         get_evm_contract_path("tests/fixtures/evm_example_execute_message.sol")?;
 
     let application_id = client1
-        .publish_and_create::<EvmAbi, Vec<u8>, Vec<u8>>(
+        .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
             evm_contract.clone(),
             evm_contract,
             VmRuntime::Evm,
@@ -1031,7 +1133,7 @@ async fn test_evm_execute_message_end_to_end_counter(config: impl LineraNetConfi
         chain_id,
         moved_value,
     };
-    let mutation = mutation.abi_encode();
+    let mutation = get_mutation(Amount::ZERO, mutation)?;
     let mutation = EvmQuery::Mutation(mutation);
     application1.run_json_query(mutation).await?;
 
@@ -1066,7 +1168,10 @@ async fn test_evm_execute_message_end_to_end_counter(config: impl LineraNetConfi
 async fn test_evm_empty_instantiate(config: impl LineraNetConfig) -> Result<()> {
     use alloy_sol_types::{sol, SolCall};
     use linera_base::vm::EvmQuery;
-    use linera_execution::test_utils::solidity::{get_evm_contract_path, read_evm_u64_entry};
+    use linera_execution::{
+        evm::inputs::EvmInstantiation,
+        test_utils::solidity::{get_evm_contract_path, read_evm_u64_entry},
+    };
     use linera_sdk::abis::evm::EvmAbi;
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -1088,13 +1193,13 @@ async fn test_evm_empty_instantiate(config: impl LineraNetConfig) -> Result<()> 
     let query = EvmQuery::Query(query);
 
     let constructor_argument = Vec::new();
-    let instantiation_argument = Vec::new();
+    let instantiation_argument = EvmInstantiation::default();
 
     let (evm_contract, _dir) =
         get_evm_contract_path("tests/fixtures/evm_example_empty_instantiate.sol")?;
 
     let application_id = client1
-        .publish_and_create::<EvmAbi, Vec<u8>, Vec<u8>>(
+        .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
             evm_contract.clone(),
             evm_contract,
             VmRuntime::Evm,
@@ -1147,7 +1252,10 @@ async fn test_evm_process_streams_end_to_end_counters(config: impl LineraNetConf
     use alloy_primitives::B256;
     use alloy_sol_types::{sol, SolCall};
     use linera_base::vm::EvmQuery;
-    use linera_execution::test_utils::solidity::{get_evm_contract_path, read_evm_u64_entry};
+    use linera_execution::{
+        evm::inputs::{get_mutation, EvmInstantiation},
+        test_utils::solidity::{get_evm_contract_path, read_evm_u64_entry},
+    };
     use linera_sdk::abis::evm::EvmAbi;
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -1180,13 +1288,13 @@ async fn test_evm_process_streams_end_to_end_counters(config: impl LineraNetConf
     let query = EvmQuery::Query(query);
 
     let constructor_argument = Vec::new();
-    let instantiation_argument = Vec::new();
+    let instantiation_argument = EvmInstantiation::default();
 
     let (evm_contract, _dir) =
         get_evm_contract_path("tests/fixtures/evm_example_process_streams.sol")?;
 
     let evm_application_id = client1
-        .publish_and_create::<EvmAbi, Vec<u8>, Vec<u8>>(
+        .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
             evm_contract.clone(),
             evm_contract,
             VmRuntime::Evm,
@@ -1226,7 +1334,7 @@ async fn test_evm_process_streams_end_to_end_counters(config: impl LineraNetConf
         chain_id: chain_id1,
         application_id,
     };
-    let mutation = mutation.abi_encode();
+    let mutation = get_mutation(Amount::ZERO, mutation)?;
     let mutation = EvmQuery::Mutation(mutation);
     application2.run_json_query(mutation).await?;
 
@@ -1237,7 +1345,7 @@ async fn test_evm_process_streams_end_to_end_counters(config: impl LineraNetConf
     // Second: increment the values
 
     let mutation = increment_valueCall { increment };
-    let mutation = mutation.abi_encode();
+    let mutation = get_mutation(Amount::ZERO, mutation)?;
     let mutation = EvmQuery::Mutation(mutation);
     application1.run_json_query(mutation).await?;
 
@@ -1271,9 +1379,12 @@ async fn test_evm_process_streams_end_to_end_counters(config: impl LineraNetConf
 #[test_log::test(tokio::test)]
 async fn test_evm_msg_sender(config: impl LineraNetConfig) -> Result<()> {
     use alloy_primitives::Address;
-    use alloy_sol_types::{sol, SolCall};
+    use alloy_sol_types::sol;
     use linera_base::{identifiers::AccountOwner, vm::EvmQuery};
-    use linera_execution::test_utils::solidity::get_evm_contract_path;
+    use linera_execution::{
+        evm::inputs::{get_mutation, EvmInstantiation},
+        test_utils::solidity::get_evm_contract_path,
+    };
     use linera_sdk::abis::evm::EvmAbi;
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -1292,14 +1403,14 @@ async fn test_evm_msg_sender(config: impl LineraNetConfig) -> Result<()> {
         function remote_check(address remote_address);
     }
 
-    let instantiation_argument = Vec::new();
+    let instantiation_argument = EvmInstantiation::default();
     let constructor_argument = Vec::new();
 
     // Creating the inner EVM contract
 
     let (inner_contract, _dir) = get_evm_contract_path("tests/fixtures/evm_msg_sender_inner.sol")?;
     let application_id_inner = client
-        .publish_and_create::<EvmAbi, Vec<u8>, Vec<u8>>(
+        .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
             inner_contract.clone(),
             inner_contract,
             VmRuntime::Evm,
@@ -1315,7 +1426,7 @@ async fn test_evm_msg_sender(config: impl LineraNetConfig) -> Result<()> {
 
     let (outer_contract, _dir) = get_evm_contract_path("tests/fixtures/evm_msg_sender_outer.sol")?;
     let application_id_outer = client
-        .publish_and_create::<EvmAbi, Vec<u8>, Vec<u8>>(
+        .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
             outer_contract.clone(),
             outer_contract,
             VmRuntime::Evm,
@@ -1341,14 +1452,14 @@ async fn test_evm_msg_sender(config: impl LineraNetConfig) -> Result<()> {
     let mutation = check_msg_senderCall {
         remote_address: owner,
     };
-    let mutation = mutation.abi_encode();
+    let mutation = get_mutation(Amount::ZERO, mutation)?;
     let mutation = EvmQuery::Mutation(mutation);
     application_inner.run_json_query(mutation).await?;
 
     let mutation = remote_checkCall {
         remote_address: evm_contract_inner,
     };
-    let mutation = mutation.abi_encode();
+    let mutation = get_mutation(Amount::ZERO, mutation)?;
     let mutation = EvmQuery::Mutation(mutation);
     application_outer.run_json_query(mutation).await?;
 
@@ -1371,7 +1482,10 @@ async fn test_evm_linera_features(config: impl LineraNetConfig) -> Result<()> {
     use alloy_primitives::B256;
     use alloy_sol_types::{sol, SolCall};
     use linera_base::vm::EvmQuery;
-    use linera_execution::test_utils::solidity::get_evm_contract_path;
+    use linera_execution::{
+        evm::inputs::EvmInstantiation,
+        test_utils::solidity::get_evm_contract_path,
+    };
     use linera_sdk::abis::evm::EvmAbi;
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -1392,9 +1506,9 @@ async fn test_evm_linera_features(config: impl LineraNetConfig) -> Result<()> {
     let (contract, _dir) = get_evm_contract_path("tests/fixtures/evm_test_linera_features.sol")?;
 
     let constructor_argument = Vec::new();
-    let instantiation_argument = Vec::new();
+    let instantiation_argument = EvmInstantiation::default();
     let application_id = client
-        .publish_and_create::<EvmAbi, Vec<u8>, Vec<u8>>(
+        .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
             contract.clone(),
             contract,
             VmRuntime::Evm,

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -530,21 +530,29 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     };
     use linera_sdk::abis::evm::EvmAbi;
 
+    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 1");
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
+    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 2");
     let (mut net, client) = config.instantiate().await?;
     let chain = client.load_wallet()?.default_chain().unwrap();
     let account_chain = Account::chain(chain);
+    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 3");
 
     let account_owner1 = client.get_owner().unwrap();
-    let address1 = account_owner1.to_evm_address().unwrap();
     let account_owner2 = client.keygen().await?;
+    tracing::info!("account_owner1 = {account_owner1}");
+    tracing::info!("account_owner2 = {account_owner2}");
+    let address1 = account_owner1.to_evm_address().unwrap();
     let address2 = account_owner2.to_evm_address().unwrap();
+    tracing::info!("address1 = {address1}");
+    tracing::info!("address2 = {address2}");
     let account1 = Account { chain_id: chain, owner: account_owner1 };
     let account2 = Account { chain_id: chain, owner: account_owner2 };
     client.transfer_with_accounts(Amount::from_tokens(5), account_chain, account1).await?;
     client.transfer_with_accounts(Amount::from_tokens(5), account_chain, account2).await?;
+    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 4");
 
     sol! {
         function send_cash(address recipient, uint256 amount);
@@ -556,8 +564,9 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
 
     let (evm_contract, _dir) =
         get_evm_contract_path("tests/fixtures/evm_balance_and_transfer.sol")?;
+    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 5");
 
-    let start_value = Amount::ZERO;
+    let start_value = Amount::from_tokens(4);
     let instantiation_argument = EvmInstantiation { value: start_value, argument: vec![] };
     let application_id = client
         .publish_and_create::<EvmAbi, Vec<u8>, EvmInstantiation>(
@@ -570,6 +579,9 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
             None,
         )
         .await?;
+    let account_owner_app: AccountOwner = application_id.into();
+    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 6, account_owner_app = {account_owner_app}");
+    let account_app = Account { chain_id: chain, owner: account_owner_app };
 
     let port = get_node_port().await;
     let mut node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
@@ -578,13 +590,16 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     let balance_chain = node_service.balance(&account_chain).await?;
     let balance1 = node_service.balance(&account1).await?;
     let balance2 = node_service.balance(&account2).await?;
-    tracing::info!("balance_chain={balance_chain}");
-    tracing::info!("balance1={balance1}");
-    tracing::info!("balance2={balance2}");
+    let balance_app = node_service.balance(&account_app).await?;
+    tracing::info!("balance_chain = {balance_chain}");
+    tracing::info!("balance1 = {balance1}");
+    tracing::info!("balance2 = {balance2}");
+    tracing::info!("balance_app = {balance_app}");
 
     let application = node_service
         .make_application(&chain, &application_id)
         .await?;
+    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 7");
 
     // Checking the balances on input
 
@@ -592,33 +607,44 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     let query1 = EvmQuery::Query(query1.abi_encode());
     let result = application.run_json_query(query1.clone()).await?;
     assert_eq!(read_evm_u256_entry(result), balance1.into());
+    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 8");
 
     let query2 = get_balanceCall { account: address2 };
     let query2 = EvmQuery::Query(query2.abi_encode());
     let result = application.run_json_query(query2.clone()).await?;
     assert_eq!(read_evm_u256_entry(result), balance2.into());
+    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 9");
 
     // Transfering amount
 
+    /*
     let amount = Amount::from_tokens(1);
 
     let mutation = send_cashCall { recipient: address2, amount: amount.into() };
     let mutation = get_mutation(Amount::ZERO, mutation)?;
     let mutation = EvmQuery::Mutation(mutation);
     application.run_json_query(mutation).await?;
+    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 10");
+*/
 
+    
     // Checking the balances
 
+    /*
     let balance1_after = node_service.balance(&account1).await?;
     let balance2_after = node_service.balance(&account2).await?;
     assert_eq!(balance1_after, balance1 - amount);
     assert_eq!(balance2_after, balance2 + amount);
+    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 11");
 
     let result = application.run_json_query(query1).await?;
     assert_eq!(read_evm_u256_entry(result), balance1_after.into());
+    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 12");
 
     let result = application.run_json_query(query2.clone()).await?;
     assert_eq!(read_evm_u256_entry(result), balance2.into());
+    tracing::info!("test_evm_end_to_end_balance_and_transfer, step 13");
+    */
 
     // Winding down
 
@@ -627,6 +653,7 @@ async fn test_evm_end_to_end_balance_and_transfer(config: impl LineraNetConfig) 
     net.ensure_is_running().await?;
     net.terminate().await?;
 
+    assert!(false);
     Ok(())
 }
 


### PR DESCRIPTION
## Motivation

Linera has its native-token (do we call it lineras?), and we need to have synchronicity between it and the balance
of the EVM. This is harder to achieve

Fixes #3756 

## Proposal

In the EVM world, there is complete identity between transferring ethers and calling a function. This is not so in Linera.

Therefore, some changes have to be made for it to work:
* Linera amounts are on 128 bits while EVM ethers are on 256 bits. But that is not a problem since, in effect, only 85 bits are ever used. But this introduces a conversion function.
* Now the `transact_commit` takes an amount being transmitted and the function call. Just like in the EVM world.
* We introduce a `get_mutation` function that takes an amount, an operation, and encapsulates it into a single `Vec<u8>`.
* This is followed when operations are transmitted to another function.
* Currently, the `fn transfer` function works in the sense that the beneficiary receives the ethers on the next block. Since the beneficiaries of transfers are on the same chain as the source, we can make it sync.
* When instantiating a new contract, we can start with some value. But this is only for the creator chain. For other chains, nothing is received.

Other changes being made:
* Better tracking of occurring errors.
* Move some code into `inputs.rs`.

Further needed work:
* Make the example `test_wasm_call_evm_end_to_end_counter` work. This requires exposing the `get_mutation` function in the SDK.
* In `commit_changes`, check that the written balance matches what is on the Linera chain.
* A type `EvmInstantiation` is introduced that contains the native token at instantiation and the command for instantiating.
* When converting `ApplicationId` of EVM app, convert them to `AccountOwner::Address20`.
* Resolve the error in the tests of PR #4268.
* The beneficiary of a transfer operation can be an Externally Owned Account or a Smart Contract. The problem is in distinguishing between the two. In this PR we use it by the size of the operation; if null, then it is an EOA. But this is not strictly exact. What matters in the end is whether the corresponding blob exists, since if we call an application that does not yet exist but has a blob, then it is instantiated and executed.
* Allow transfer of native tokens in `execute_message`. Again, in Linera the `transfer` and `try_call_application` are different things. But this is not the case in the EVM, so even if `execute_message` is not an EVM concept, it would be good if it fits their mental model.

## Test Plan

The CI. The test that demonstrates the functionality is `test_evm_end_to_end_balance_and_transfer`.

## Release Plan

<!--
If this PR targets the `main` branch, **keep the applicable lines** to indicate if you
recommend the changes to be picked in release branches, SDKs, and hotfixes.

This generally concerns only bug fixes.

Note that altering the public protocol (e.g. transaction format, WASM syscalls) or storage
formats requires a new deployment.
-->
- Nothing to do / These changes follow the usual release cycle.
- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- Backporting is not possible but we may want to deploy a new `devnet` and release a new
      SDK soon.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
