### PR TITLE
Rename a few structures in storage service

### DIFF
--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -30,7 +30,7 @@ use linera_chain::{
 use linera_execution::{committee::Committee, ResourceControlPolicy, WasmRuntime};
 use linera_storage::{DbStorage, ResultReadCertificates, Storage, TestClock};
 #[cfg(all(not(target_arch = "wasm32"), feature = "storage-service"))]
-use linera_storage_service::client::ServiceStoreClient;
+use linera_storage_service::client::ServiceStore;
 use linera_version::VersionInfo;
 #[cfg(feature = "dynamodb")]
 use linera_views::dynamo_db::DynamoDbStore;
@@ -1215,11 +1215,11 @@ impl ServiceStorageBuilder {
 #[cfg(all(not(target_arch = "wasm32"), feature = "storage-service"))]
 #[async_trait]
 impl StorageBuilder for ServiceStorageBuilder {
-    type Storage = DbStorage<ServiceStoreClient, TestClock>;
+    type Storage = DbStorage<ServiceStore, TestClock>;
 
     async fn build(&mut self) -> anyhow::Result<Self::Storage> {
         self.instance_counter += 1;
-        let config = ServiceStoreClient::new_test_config().await?;
+        let config = ServiceStore::new_test_config().await?;
         if self.namespace.is_empty() {
             self.namespace = generate_test_namespace();
         }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -30,7 +30,7 @@ use linera_chain::{
 use linera_execution::{committee::Committee, ResourceControlPolicy, WasmRuntime};
 use linera_storage::{DbStorage, ResultReadCertificates, Storage, TestClock};
 #[cfg(all(not(target_arch = "wasm32"), feature = "storage-service"))]
-use linera_storage_service::client::ServiceStore;
+use linera_storage_service::client::StorageServiceStore;
 use linera_version::VersionInfo;
 #[cfg(feature = "dynamodb")]
 use linera_views::dynamo_db::DynamoDbStore;
@@ -1215,11 +1215,11 @@ impl ServiceStorageBuilder {
 #[cfg(all(not(target_arch = "wasm32"), feature = "storage-service"))]
 #[async_trait]
 impl StorageBuilder for ServiceStorageBuilder {
-    type Storage = DbStorage<ServiceStore, TestClock>;
+    type Storage = DbStorage<StorageServiceStore, TestClock>;
 
     async fn build(&mut self) -> anyhow::Result<Self::Storage> {
         self.instance_counter += 1;
-        let config = ServiceStore::new_test_config().await?;
+        let config = StorageServiceStore::new_test_config().await?;
         if self.namespace.is_empty() {
             self.namespace = generate_test_namespace();
         }

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -10,7 +10,7 @@ use linera_execution::WasmRuntime;
 use linera_storage::{DbStorage, Storage, DEFAULT_NAMESPACE};
 #[cfg(feature = "storage-service")]
 use linera_storage_service::{
-    client::ServiceStoreClient,
+    client::ServiceStore,
     common::{ServiceStoreConfig, ServiceStoreInternalConfig},
 };
 #[cfg(feature = "dynamodb")]
@@ -626,7 +626,7 @@ impl StoreConfig {
             #[cfg(feature = "storage-service")]
             StoreConfig::Service { config, namespace } => {
                 let storage =
-                    DbStorage::<ServiceStoreClient, _>::connect(&config, &namespace, wasm_runtime)
+                    DbStorage::<ServiceStore, _>::connect(&config, &namespace, wasm_runtime)
                         .await?;
                 Ok(job.run(storage).await)
             }
@@ -674,7 +674,7 @@ impl StoreConfig {
             }
             #[cfg(feature = "storage-service")]
             StoreConfig::Service { config, namespace } => {
-                Ok(job.run::<ServiceStoreClient>(config, namespace).await?)
+                Ok(job.run::<ServiceStore>(config, namespace).await?)
             }
             #[cfg(feature = "rocksdb")]
             StoreConfig::RocksDb { config, namespace } => {

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -87,7 +87,7 @@ pub enum StoreConfig {
     },
     /// The storage service key-value store
     #[cfg(feature = "storage-service")]
-    Service {
+    StorageService {
         config: StorageServiceStoreConfig,
         namespace: String,
     },
@@ -450,7 +450,7 @@ impl StorageConfig {
                     inner_config,
                     storage_cache_config: options.storage_cache_config(),
                 };
-                Ok(StoreConfig::Service { config, namespace })
+                Ok(StoreConfig::StorageService { config, namespace })
             }
             #[cfg(feature = "rocksdb")]
             InnerStorageConfig::RocksDb { path, spawn_mode } => {
@@ -624,7 +624,7 @@ impl StoreConfig {
                 Ok(job.run(storage).await)
             }
             #[cfg(feature = "storage-service")]
-            StoreConfig::Service { config, namespace } => {
+            StoreConfig::StorageService { config, namespace } => {
                 let storage =
                     DbStorage::<StorageServiceStore, _>::connect(&config, &namespace, wasm_runtime)
                         .await?;
@@ -673,7 +673,7 @@ impl StoreConfig {
                 Err(anyhow!("Cannot run admin operations on the memory store"))
             }
             #[cfg(feature = "storage-service")]
-            StoreConfig::Service { config, namespace } => {
+            StoreConfig::StorageService { config, namespace } => {
                 Ok(job.run::<StorageServiceStore>(config, namespace).await?)
             }
             #[cfg(feature = "rocksdb")]

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -10,8 +10,8 @@ use linera_execution::WasmRuntime;
 use linera_storage::{DbStorage, Storage, DEFAULT_NAMESPACE};
 #[cfg(feature = "storage-service")]
 use linera_storage_service::{
-    client::ServiceStore,
-    common::{ServiceStoreConfig, ServiceStoreInternalConfig},
+    client::StorageServiceStore,
+    common::{StorageServiceStoreConfig, StorageServiceStoreInternalConfig},
 };
 #[cfg(feature = "dynamodb")]
 use linera_views::dynamo_db::{DynamoDbStore, DynamoDbStoreConfig, DynamoDbStoreInternalConfig};
@@ -88,7 +88,7 @@ pub enum StoreConfig {
     /// The storage service key-value store
     #[cfg(feature = "storage-service")]
     Service {
-        config: ServiceStoreConfig,
+        config: StorageServiceStoreConfig,
         namespace: String,
     },
     /// The RocksDB key value store
@@ -441,12 +441,12 @@ impl StorageConfig {
             }
             #[cfg(feature = "storage-service")]
             InnerStorageConfig::Service { endpoint } => {
-                let inner_config = ServiceStoreInternalConfig {
+                let inner_config = StorageServiceStoreInternalConfig {
                     endpoint: endpoint.clone(),
                     max_concurrent_queries: options.storage_max_concurrent_queries,
                     max_stream_queries: options.storage_max_stream_queries,
                 };
-                let config = ServiceStoreConfig {
+                let config = StorageServiceStoreConfig {
                     inner_config,
                     storage_cache_config: options.storage_cache_config(),
                 };
@@ -626,7 +626,7 @@ impl StoreConfig {
             #[cfg(feature = "storage-service")]
             StoreConfig::Service { config, namespace } => {
                 let storage =
-                    DbStorage::<ServiceStore, _>::connect(&config, &namespace, wasm_runtime)
+                    DbStorage::<StorageServiceStore, _>::connect(&config, &namespace, wasm_runtime)
                         .await?;
                 Ok(job.run(storage).await)
             }
@@ -674,7 +674,7 @@ impl StoreConfig {
             }
             #[cfg(feature = "storage-service")]
             StoreConfig::Service { config, namespace } => {
-                Ok(job.run::<ServiceStore>(config, namespace).await?)
+                Ok(job.run::<StorageServiceStore>(config, namespace).await?)
             }
             #[cfg(feature = "rocksdb")]
             StoreConfig::RocksDb { config, namespace } => {

--- a/linera-storage-service/benches/store.rs
+++ b/linera-storage-service/benches/store.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use linera_storage_service::client::ServiceStoreClient;
+use linera_storage_service::client::ServiceStore;
 use linera_views::test_utils::performance;
 use tokio::runtime::Runtime;
 
@@ -11,7 +11,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::contains_key::<ServiceStoreClient, _>(iterations, black_box).await
+                performance::contains_key::<ServiceStore, _>(iterations, black_box).await
             })
     });
 
@@ -19,7 +19,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::contains_keys::<ServiceStoreClient, _>(iterations, black_box).await
+                performance::contains_keys::<ServiceStore, _>(iterations, black_box).await
             })
     });
 
@@ -27,7 +27,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::find_keys_by_prefix::<ServiceStoreClient, _>(iterations, black_box)
+                performance::find_keys_by_prefix::<ServiceStore, _>(iterations, black_box)
                     .await
             })
     });
@@ -38,7 +38,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
             bencher
                 .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
                 .iter_custom(|iterations| async move {
-                    performance::find_key_values_by_prefix::<ServiceStoreClient, _>(
+                    performance::find_key_values_by_prefix::<ServiceStore, _>(
                         iterations, black_box,
                     )
                     .await
@@ -50,7 +50,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::read_value_bytes::<ServiceStoreClient, _>(iterations, black_box).await
+                performance::read_value_bytes::<ServiceStore, _>(iterations, black_box).await
             })
     });
 
@@ -58,7 +58,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::read_multi_values_bytes::<ServiceStoreClient, _>(iterations, black_box)
+                performance::read_multi_values_bytes::<ServiceStore, _>(iterations, black_box)
                     .await
             })
     });
@@ -67,7 +67,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::write_batch::<ServiceStoreClient>(iterations).await
+                performance::write_batch::<ServiceStore>(iterations).await
             })
     });
 }

--- a/linera-storage-service/benches/store.rs
+++ b/linera-storage-service/benches/store.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use linera_storage_service::client::ServiceStore;
+use linera_storage_service::client::StorageServiceStore;
 use linera_views::test_utils::performance;
 use tokio::runtime::Runtime;
 
@@ -11,7 +11,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::contains_key::<ServiceStore, _>(iterations, black_box).await
+                performance::contains_key::<StorageServiceStore, _>(iterations, black_box).await
             })
     });
 
@@ -19,7 +19,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::contains_keys::<ServiceStore, _>(iterations, black_box).await
+                performance::contains_keys::<StorageServiceStore, _>(iterations, black_box).await
             })
     });
 
@@ -27,7 +27,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::find_keys_by_prefix::<ServiceStore, _>(iterations, black_box)
+                performance::find_keys_by_prefix::<StorageServiceStore, _>(iterations, black_box)
                     .await
             })
     });
@@ -38,7 +38,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
             bencher
                 .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
                 .iter_custom(|iterations| async move {
-                    performance::find_key_values_by_prefix::<ServiceStore, _>(
+                    performance::find_key_values_by_prefix::<StorageServiceStore, _>(
                         iterations, black_box,
                     )
                     .await
@@ -50,7 +50,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::read_value_bytes::<ServiceStore, _>(iterations, black_box).await
+                performance::read_value_bytes::<StorageServiceStore, _>(iterations, black_box).await
             })
     });
 
@@ -58,8 +58,10 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::read_multi_values_bytes::<ServiceStore, _>(iterations, black_box)
-                    .await
+                performance::read_multi_values_bytes::<StorageServiceStore, _>(
+                    iterations, black_box,
+                )
+                .await
             })
     });
 
@@ -67,7 +69,7 @@ fn bench_storage_service(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::write_batch::<ServiceStore>(iterations).await
+                performance::write_batch::<StorageServiceStore>(iterations).await
             })
     });
 }

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -28,7 +28,9 @@ use tonic::transport::{Channel, Endpoint};
 #[cfg(with_testing)]
 use crate::common::storage_service_test_endpoint;
 use crate::{
-    common::{KeyPrefix, ServiceStoreError, ServiceStoreInternalConfig, MAX_PAYLOAD_SIZE},
+    common::{
+        KeyPrefix, StorageServiceStoreError, StorageServiceStoreInternalConfig, MAX_PAYLOAD_SIZE,
+    },
     key_value_store::{
         statement::Operation, store_processor_client::StoreProcessorClient, KeyValue,
         KeyValueAppend, ReplyContainsKey, ReplyContainsKeys, ReplyExistsNamespace,
@@ -64,7 +66,7 @@ const MAX_KEY_SIZE: usize = 1000000;
 //   [`KeyPrefix::RootKey`] + namespace + root_key
 //   to indicate the existence of a root key.
 #[derive(Clone)]
-pub struct ServiceStoreInternal {
+pub struct StorageServiceStoreInternal {
     channel: Channel,
     semaphore: Option<Arc<Semaphore>>,
     max_stream_queries: usize,
@@ -73,19 +75,25 @@ pub struct ServiceStoreInternal {
     root_key_written: Arc<AtomicBool>,
 }
 
-impl WithError for ServiceStoreInternal {
-    type Error = ServiceStoreError;
+impl WithError for StorageServiceStoreInternal {
+    type Error = StorageServiceStoreError;
 }
 
-impl ReadableKeyValueStore for ServiceStoreInternal {
+impl ReadableKeyValueStore for StorageServiceStoreInternal {
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
 
     fn max_stream_queries(&self) -> usize {
         self.max_stream_queries
     }
 
-    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, ServiceStoreError> {
-        ensure!(key.len() <= MAX_KEY_SIZE, ServiceStoreError::KeyTooLong);
+    async fn read_value_bytes(
+        &self,
+        key: &[u8],
+    ) -> Result<Option<Vec<u8>>, StorageServiceStoreError> {
+        ensure!(
+            key.len() <= MAX_KEY_SIZE,
+            StorageServiceStoreError::KeyTooLong
+        );
         let mut full_key = self.start_key.clone();
         full_key.extend(key);
         let query = RequestReadValue { key: full_key };
@@ -107,8 +115,11 @@ impl ReadableKeyValueStore for ServiceStoreInternal {
         }
     }
 
-    async fn contains_key(&self, key: &[u8]) -> Result<bool, ServiceStoreError> {
-        ensure!(key.len() <= MAX_KEY_SIZE, ServiceStoreError::KeyTooLong);
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, StorageServiceStoreError> {
+        ensure!(
+            key.len() <= MAX_KEY_SIZE,
+            StorageServiceStoreError::KeyTooLong
+        );
         let mut full_key = self.start_key.clone();
         full_key.extend(key);
         let query = RequestContainsKey { key: full_key };
@@ -122,10 +133,16 @@ impl ReadableKeyValueStore for ServiceStoreInternal {
         Ok(test)
     }
 
-    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ServiceStoreError> {
+    async fn contains_keys(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<bool>, StorageServiceStoreError> {
         let mut full_keys = Vec::new();
         for key in keys {
-            ensure!(key.len() <= MAX_KEY_SIZE, ServiceStoreError::KeyTooLong);
+            ensure!(
+                key.len() <= MAX_KEY_SIZE,
+                StorageServiceStoreError::KeyTooLong
+            );
             let mut full_key = self.start_key.clone();
             full_key.extend(&key);
             full_keys.push(full_key);
@@ -144,10 +161,13 @@ impl ReadableKeyValueStore for ServiceStoreInternal {
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<Option<Vec<u8>>>, ServiceStoreError> {
+    ) -> Result<Vec<Option<Vec<u8>>>, StorageServiceStoreError> {
         let mut full_keys = Vec::new();
         for key in keys {
-            ensure!(key.len() <= MAX_KEY_SIZE, ServiceStoreError::KeyTooLong);
+            ensure!(
+                key.len() <= MAX_KEY_SIZE,
+                StorageServiceStoreError::KeyTooLong
+            );
             let mut full_key = self.start_key.clone();
             full_key.extend(&key);
             full_keys.push(full_key);
@@ -178,10 +198,10 @@ impl ReadableKeyValueStore for ServiceStoreInternal {
     async fn find_keys_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Vec<Vec<u8>>, ServiceStoreError> {
+    ) -> Result<Vec<Vec<u8>>, StorageServiceStoreError> {
         ensure!(
             key_prefix.len() <= MAX_KEY_SIZE,
-            ServiceStoreError::KeyTooLong
+            StorageServiceStoreError::KeyTooLong
         );
         let mut full_key_prefix = self.start_key.clone();
         full_key_prefix.extend(key_prefix);
@@ -212,10 +232,10 @@ impl ReadableKeyValueStore for ServiceStoreInternal {
     async fn find_key_values_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ServiceStoreError> {
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, StorageServiceStoreError> {
         ensure!(
             key_prefix.len() <= MAX_KEY_SIZE,
-            ServiceStoreError::KeyTooLong
+            StorageServiceStoreError::KeyTooLong
         );
         let mut full_key_prefix = self.start_key.clone();
         full_key_prefix.extend(key_prefix);
@@ -248,10 +268,10 @@ impl ReadableKeyValueStore for ServiceStoreInternal {
     }
 }
 
-impl WritableKeyValueStore for ServiceStoreInternal {
+impl WritableKeyValueStore for StorageServiceStoreInternal {
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
-    async fn write_batch(&self, batch: Batch) -> Result<(), ServiceStoreError> {
+    async fn write_batch(&self, batch: Batch) -> Result<(), StorageServiceStoreError> {
         if batch.operations.is_empty() {
             return Ok(());
         }
@@ -280,7 +300,10 @@ impl WritableKeyValueStore for ServiceStoreInternal {
                 WriteOperation::DeletePrefix { key_prefix } => (key_prefix.len(), 0),
             };
             let operation_size = key_len + value_len + root_key_len;
-            ensure!(key_len <= MAX_KEY_SIZE, ServiceStoreError::KeyTooLong);
+            ensure!(
+                key_len <= MAX_KEY_SIZE,
+                StorageServiceStoreError::KeyTooLong
+            );
             if operation_size + chunk_size < MAX_PAYLOAD_SIZE {
                 let statement = self.get_statement(operation);
                 statements.push(statement);
@@ -324,12 +347,12 @@ impl WritableKeyValueStore for ServiceStoreInternal {
         self.submit_statements(mem::take(&mut statements)).await
     }
 
-    async fn clear_journal(&self) -> Result<(), ServiceStoreError> {
+    async fn clear_journal(&self) -> Result<(), StorageServiceStoreError> {
         Ok(())
     }
 }
 
-impl ServiceStoreInternal {
+impl StorageServiceStoreInternal {
     /// Obtains the semaphore lock on the database if needed.
     async fn acquire(&self) -> Option<SemaphoreGuard<'_>> {
         match &self.semaphore {
@@ -338,7 +361,10 @@ impl ServiceStoreInternal {
         }
     }
 
-    async fn submit_statements(&self, statements: Vec<Statement>) -> Result<(), ServiceStoreError> {
+    async fn submit_statements(
+        &self,
+        statements: Vec<Statement>,
+    ) -> Result<(), StorageServiceStoreError> {
         if !statements.is_empty() {
             let query = RequestWriteBatchExtended { statements };
             let request = tonic::Request::new(query);
@@ -383,7 +409,7 @@ impl ServiceStoreInternal {
         &self,
         message_index: i64,
         index: i32,
-    ) -> Result<Vec<u8>, ServiceStoreError> {
+    ) -> Result<Vec<u8>, StorageServiceStoreError> {
         let channel = self.channel.clone();
         let query = RequestSpecificChunk {
             message_index,
@@ -401,7 +427,7 @@ impl ServiceStoreInternal {
         &self,
         message_index: i64,
         num_chunks: i32,
-    ) -> Result<S, ServiceStoreError> {
+    ) -> Result<S, StorageServiceStoreError> {
         let mut handles = Vec::new();
         for index in 0..num_chunks {
             let handle = self.read_single_entry(message_index, index);
@@ -416,14 +442,17 @@ impl ServiceStoreInternal {
     }
 }
 
-impl AdminKeyValueStore for ServiceStoreInternal {
-    type Config = ServiceStoreInternalConfig;
+impl AdminKeyValueStore for StorageServiceStoreInternal {
+    type Config = StorageServiceStoreInternalConfig;
 
     fn get_name() -> String {
         "service store".to_string()
     }
 
-    async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, ServiceStoreError> {
+    async fn connect(
+        config: &Self::Config,
+        namespace: &str,
+    ) -> Result<Self, StorageServiceStoreError> {
         let semaphore = config
             .max_concurrent_queries
             .map(|n| Arc::new(Semaphore::new(n)));
@@ -445,7 +474,7 @@ impl AdminKeyValueStore for ServiceStoreInternal {
         })
     }
 
-    fn open_exclusive(&self, root_key: &[u8]) -> Result<Self, ServiceStoreError> {
+    fn open_exclusive(&self, root_key: &[u8]) -> Result<Self, StorageServiceStoreError> {
         let channel = self.channel.clone();
         let prefix_len = self.prefix_len;
         let semaphore = self.semaphore.clone();
@@ -462,7 +491,7 @@ impl AdminKeyValueStore for ServiceStoreInternal {
         })
     }
 
-    async fn list_all(config: &Self::Config) -> Result<Vec<String>, ServiceStoreError> {
+    async fn list_all(config: &Self::Config) -> Result<Vec<String>, StorageServiceStoreError> {
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
         let mut client = StoreProcessorClient::connect(endpoint).make_sync().await?;
@@ -479,7 +508,7 @@ impl AdminKeyValueStore for ServiceStoreInternal {
     async fn list_root_keys(
         config: &Self::Config,
         namespace: &str,
-    ) -> Result<Vec<Vec<u8>>, ServiceStoreError> {
+    ) -> Result<Vec<Vec<u8>>, StorageServiceStoreError> {
         let namespace = bcs::to_bytes(namespace)?;
         let query = RequestListRootKeys { namespace };
         let request = tonic::Request::new(query);
@@ -492,7 +521,7 @@ impl AdminKeyValueStore for ServiceStoreInternal {
         Ok(root_keys)
     }
 
-    async fn delete_all(config: &Self::Config) -> Result<(), ServiceStoreError> {
+    async fn delete_all(config: &Self::Config) -> Result<(), StorageServiceStoreError> {
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
         let mut client = StoreProcessorClient::connect(endpoint).make_sync().await?;
@@ -500,7 +529,10 @@ impl AdminKeyValueStore for ServiceStoreInternal {
         Ok(())
     }
 
-    async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, ServiceStoreError> {
+    async fn exists(
+        config: &Self::Config,
+        namespace: &str,
+    ) -> Result<bool, StorageServiceStoreError> {
         let namespace = bcs::to_bytes(namespace)?;
         let query = RequestExistsNamespace { namespace };
         let request = tonic::Request::new(query);
@@ -513,9 +545,12 @@ impl AdminKeyValueStore for ServiceStoreInternal {
         Ok(exists)
     }
 
-    async fn create(config: &Self::Config, namespace: &str) -> Result<(), ServiceStoreError> {
-        if ServiceStoreInternal::exists(config, namespace).await? {
-            return Err(ServiceStoreError::StoreAlreadyExists);
+    async fn create(
+        config: &Self::Config,
+        namespace: &str,
+    ) -> Result<(), StorageServiceStoreError> {
+        if StorageServiceStoreInternal::exists(config, namespace).await? {
+            return Err(StorageServiceStoreError::StoreAlreadyExists);
         }
         let namespace = bcs::to_bytes(namespace)?;
         let query = RequestCreateNamespace { namespace };
@@ -527,7 +562,10 @@ impl AdminKeyValueStore for ServiceStoreInternal {
         Ok(())
     }
 
-    async fn delete(config: &Self::Config, namespace: &str) -> Result<(), ServiceStoreError> {
+    async fn delete(
+        config: &Self::Config,
+        namespace: &str,
+    ) -> Result<(), StorageServiceStoreError> {
         let namespace = bcs::to_bytes(namespace)?;
         let query = RequestDeleteNamespace { namespace };
         let request = tonic::Request::new(query);
@@ -540,18 +578,19 @@ impl AdminKeyValueStore for ServiceStoreInternal {
 }
 
 #[cfg(with_testing)]
-impl TestKeyValueStore for ServiceStoreInternal {
-    async fn new_test_config() -> Result<ServiceStoreInternalConfig, ServiceStoreError> {
+impl TestKeyValueStore for StorageServiceStoreInternal {
+    async fn new_test_config() -> Result<StorageServiceStoreInternalConfig, StorageServiceStoreError>
+    {
         let endpoint = storage_service_test_endpoint()?;
         service_config_from_endpoint(&endpoint)
     }
 }
 
-/// Creates a `ServiceStoreConfig` from an endpoint.
+/// Creates a `StorageServiceStoreConfig` from an endpoint.
 pub fn service_config_from_endpoint(
     endpoint: &str,
-) -> Result<ServiceStoreInternalConfig, ServiceStoreError> {
-    Ok(ServiceStoreInternalConfig {
+) -> Result<StorageServiceStoreInternalConfig, StorageServiceStoreError> {
+    Ok(StorageServiceStoreInternalConfig {
         endpoint: endpoint.to_string(),
         max_concurrent_queries: None,
         max_stream_queries: 100,
@@ -559,26 +598,30 @@ pub fn service_config_from_endpoint(
 }
 
 /// Checks that endpoint is truly absent.
-pub async fn storage_service_check_absence(endpoint: &str) -> Result<bool, ServiceStoreError> {
+pub async fn storage_service_check_absence(
+    endpoint: &str,
+) -> Result<bool, StorageServiceStoreError> {
     let endpoint = Endpoint::from_shared(endpoint.to_string())?;
     let result = StoreProcessorClient::connect(endpoint).await;
     Ok(result.is_err())
 }
 
 /// Checks whether an endpoint is valid or not.
-pub async fn storage_service_check_validity(endpoint: &str) -> Result<(), ServiceStoreError> {
+pub async fn storage_service_check_validity(
+    endpoint: &str,
+) -> Result<(), StorageServiceStoreError> {
     let config = service_config_from_endpoint(endpoint).unwrap();
     let namespace = "namespace";
-    let store = ServiceStoreInternal::connect(&config, namespace).await?;
+    let store = StorageServiceStoreInternal::connect(&config, namespace).await?;
     let _value = store.read_value_bytes(&[42]).await?;
     Ok(())
 }
 
 /// The service store client with metrics
 #[cfg(with_metrics)]
-pub type ServiceStore =
-    MeteredStore<LruCachingStore<MeteredStore<ServiceStoreInternal>>>;
+pub type StorageServiceStore =
+    MeteredStore<LruCachingStore<MeteredStore<StorageServiceStoreInternal>>>;
 
 /// The service store client without metrics
 #[cfg(not(with_metrics))]
-pub type ServiceStore = LruCachingStore<ServiceStoreInternal>;
+pub type StorageServiceStore = LruCachingStore<StorageServiceStoreInternal>;

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -30,7 +30,7 @@ pub enum KeyPrefix {
 }
 
 #[derive(Debug, Error)]
-pub enum ServiceStoreError {
+pub enum StorageServiceStoreError {
     /// Store already exists during a create operation
     #[error("Store already exists during a create operation")]
     StoreAlreadyExists,
@@ -64,22 +64,22 @@ pub enum ServiceStoreError {
     BcsError(#[from] bcs::Error),
 }
 
-impl From<Status> for ServiceStoreError {
+impl From<Status> for StorageServiceStoreError {
     fn from(error: Status) -> Self {
         Box::new(error).into()
     }
 }
 
-impl KeyValueStoreError for ServiceStoreError {
+impl KeyValueStoreError for StorageServiceStoreError {
     const BACKEND: &'static str = "service";
 }
 
-pub fn storage_service_test_endpoint() -> Result<String, ServiceStoreError> {
+pub fn storage_service_test_endpoint() -> Result<String, StorageServiceStoreError> {
     Ok(std::env::var("LINERA_STORAGE_SERVICE")?)
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ServiceStoreInternalConfig {
+pub struct StorageServiceStoreInternalConfig {
     /// The endpoint used by the shared store
     pub endpoint: String,
     /// Maximum number of concurrent database queries allowed for this client.
@@ -89,9 +89,9 @@ pub struct ServiceStoreInternalConfig {
 }
 
 /// The config type
-pub type ServiceStoreConfig = LruCachingConfig<ServiceStoreInternalConfig>;
+pub type StorageServiceStoreConfig = LruCachingConfig<StorageServiceStoreInternalConfig>;
 
-impl ServiceStoreInternalConfig {
+impl StorageServiceStoreInternalConfig {
     pub fn http_address(&self) -> String {
         format!("http://{}", self.endpoint)
     }
@@ -100,7 +100,7 @@ impl ServiceStoreInternalConfig {
 /// Obtains the binary of the executable.
 /// The path depends whether the test are run in the directory "linera-storage-service"
 /// or in the main directory
-pub async fn get_service_storage_binary() -> Result<PathBuf, ServiceStoreError> {
+pub async fn get_service_storage_binary() -> Result<PathBuf, StorageServiceStoreError> {
     let binary = resolve_binary("linera-storage-server", "linera-storage-service").await;
     if let Ok(binary) = binary {
         return Ok(binary);
@@ -109,5 +109,5 @@ pub async fn get_service_storage_binary() -> Result<PathBuf, ServiceStoreError> 
     if let Ok(binary) = binary {
         return Ok(binary);
     }
-    Err(ServiceStoreError::FailedToFindStorageServerBinary)
+    Err(StorageServiceStoreError::FailedToFindStorageServerBinary)
 }

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -4,7 +4,7 @@
 #![cfg(feature = "storage-service")]
 
 use anyhow::Result;
-use linera_storage_service::client::{ServiceStore, ServiceStoreInternal};
+use linera_storage_service::client::{StorageServiceStore, StorageServiceStoreInternal};
 use linera_views::{
     batch::Batch,
     store::TestKeyValueStore as _,
@@ -18,7 +18,7 @@ use linera_views::{
 #[tokio::test]
 async fn test_storage_service_reads() -> Result<()> {
     for scenario in get_random_test_scenarios() {
-        let store = ServiceStoreInternal::new_test_store().await?;
+        let store = StorageServiceStoreInternal::new_test_store().await?;
         run_reads(store, scenario).await;
     }
     Ok(())
@@ -26,31 +26,31 @@ async fn test_storage_service_reads() -> Result<()> {
 
 #[tokio::test]
 async fn test_storage_service_writes_from_blank() -> Result<()> {
-    let store = ServiceStoreInternal::new_test_store().await?;
+    let store = StorageServiceStoreInternal::new_test_store().await?;
     run_writes_from_blank(&store).await;
     Ok(())
 }
 
 #[tokio::test]
 async fn test_storage_service_writes_from_state() -> Result<()> {
-    let store = ServiceStoreInternal::new_test_store().await?;
+    let store = StorageServiceStoreInternal::new_test_store().await?;
     run_writes_from_state(&store).await;
     Ok(())
 }
 
 #[tokio::test]
 async fn test_storage_service_namespace_admin() {
-    namespace_admin_test::<ServiceStore>().await;
+    namespace_admin_test::<StorageServiceStore>().await;
 }
 
 #[tokio::test]
 async fn test_storage_service_root_key_admin() {
-    root_key_admin_test::<ServiceStore>().await;
+    root_key_admin_test::<StorageServiceStore>().await;
 }
 
 #[tokio::test]
 async fn test_storage_service_big_raw_write() -> Result<()> {
-    let store = ServiceStoreInternal::new_test_store().await?;
+    let store = StorageServiceStoreInternal::new_test_store().await?;
     let n = 5000000;
     let mut rng = linera_views::random::make_deterministic_rng();
     let vector = get_random_byte_vector(&mut rng, &[], n);

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -4,7 +4,7 @@
 #![cfg(feature = "storage-service")]
 
 use anyhow::Result;
-use linera_storage_service::client::{ServiceStoreClient, ServiceStoreClientInternal};
+use linera_storage_service::client::{ServiceStore, ServiceStoreInternal};
 use linera_views::{
     batch::Batch,
     store::TestKeyValueStore as _,
@@ -18,7 +18,7 @@ use linera_views::{
 #[tokio::test]
 async fn test_storage_service_reads() -> Result<()> {
     for scenario in get_random_test_scenarios() {
-        let store = ServiceStoreClientInternal::new_test_store().await?;
+        let store = ServiceStoreInternal::new_test_store().await?;
         run_reads(store, scenario).await;
     }
     Ok(())
@@ -26,31 +26,31 @@ async fn test_storage_service_reads() -> Result<()> {
 
 #[tokio::test]
 async fn test_storage_service_writes_from_blank() -> Result<()> {
-    let store = ServiceStoreClientInternal::new_test_store().await?;
+    let store = ServiceStoreInternal::new_test_store().await?;
     run_writes_from_blank(&store).await;
     Ok(())
 }
 
 #[tokio::test]
 async fn test_storage_service_writes_from_state() -> Result<()> {
-    let store = ServiceStoreClientInternal::new_test_store().await?;
+    let store = ServiceStoreInternal::new_test_store().await?;
     run_writes_from_state(&store).await;
     Ok(())
 }
 
 #[tokio::test]
 async fn test_storage_service_namespace_admin() {
-    namespace_admin_test::<ServiceStoreClient>().await;
+    namespace_admin_test::<ServiceStore>().await;
 }
 
 #[tokio::test]
 async fn test_storage_service_root_key_admin() {
-    root_key_admin_test::<ServiceStoreClient>().await;
+    root_key_admin_test::<ServiceStore>().await;
 }
 
 #[tokio::test]
 async fn test_storage_service_big_raw_write() -> Result<()> {
-    let store = ServiceStoreClientInternal::new_test_store().await?;
+    let store = ServiceStoreInternal::new_test_store().await?;
     let n = 5000000;
     let mut rng = linera_views::random::make_deterministic_rng();
     let vector = get_random_byte_vector(&mut rng, &[], n);

--- a/linera-views/README.md
+++ b/linera-views/README.md
@@ -19,7 +19,7 @@ We provide support for the following databases:
 * `RocksDbStore` is a disk-based key-value store
 * `DynamoDbStore` is the AWS-based DynamoDB service.
 * `ScyllaDbStore` is a cloud-based Cassandra-compatible database.
-* `ServiceStoreClient` is a gRPC-based storage that uses either memory or RocksDB. It is available in `linera-storage-service`.
+* `ServiceStore` is a gRPC-based storage that uses either memory or RocksDB. It is available in `linera-storage-service`.
 
 The corresponding trait in the code is the [`crate::store::KeyValueStore`](https://docs.rs/linera-views/latest/linera_views/store/trait.KeyValueStore.html).
 The trait decomposes into a [`store::ReadableKeyValueStore`](https://docs.rs/linera-views/latest/linera_views/store/trait.ReadableKeyValueStore.html)

--- a/linera-views/README.md
+++ b/linera-views/README.md
@@ -19,7 +19,7 @@ We provide support for the following databases:
 * `RocksDbStore` is a disk-based key-value store
 * `DynamoDbStore` is the AWS-based DynamoDB service.
 * `ScyllaDbStore` is a cloud-based Cassandra-compatible database.
-* `ServiceStore` is a gRPC-based storage that uses either memory or RocksDB. It is available in `linera-storage-service`.
+* `StorageServiceStore` is a gRPC-based storage that uses either memory or RocksDB. It is available in `linera-storage-service`.
 
 The corresponding trait in the code is the [`crate::store::KeyValueStore`](https://docs.rs/linera-views/latest/linera_views/store/trait.KeyValueStore.html).
 The trait decomposes into a [`store::ReadableKeyValueStore`](https://docs.rs/linera-views/latest/linera_views/store/trait.ReadableKeyValueStore.html)

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -21,7 +21,7 @@ We provide support for the following databases:
 * `RocksDbStore` is a disk-based key-value store
 * `DynamoDbStore` is the AWS-based DynamoDB service.
 * `ScyllaDbStore` is a cloud-based Cassandra-compatible database.
-* `ServiceStoreClient` is a gRPC-based storage that uses either memory or RocksDB. It is available in `linera-storage-service`.
+* `ServiceStore` is a gRPC-based storage that uses either memory or RocksDB. It is available in `linera-storage-service`.
 
 The corresponding trait in the code is the [`crate::store::KeyValueStore`](https://docs.rs/linera-views/latest/linera_views/store/trait.KeyValueStore.html).
 The trait decomposes into a [`store::ReadableKeyValueStore`](https://docs.rs/linera-views/latest/linera_views/store/trait.ReadableKeyValueStore.html)

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -21,7 +21,7 @@ We provide support for the following databases:
 * `RocksDbStore` is a disk-based key-value store
 * `DynamoDbStore` is the AWS-based DynamoDB service.
 * `ScyllaDbStore` is a cloud-based Cassandra-compatible database.
-* `ServiceStore` is a gRPC-based storage that uses either memory or RocksDB. It is available in `linera-storage-service`.
+* `StorageServiceStore` is a gRPC-based storage that uses either memory or RocksDB. It is available in `linera-storage-service`.
 
 The corresponding trait in the code is the [`crate::store::KeyValueStore`](https://docs.rs/linera-views/latest/linera_views/store/trait.KeyValueStore.html).
 The trait decomposes into a [`store::ReadableKeyValueStore`](https://docs.rs/linera-views/latest/linera_views/store/trait.ReadableKeyValueStore.html)


### PR DESCRIPTION
## Motivation

Facilitate the future refactoring to address https://github.com/linera-io/linera-protocol/issues/4275

## Proposal

* rename `ServiceStoreServerInternal` into `LocalStore` (implements the `KeyValueStore` trait)
* rename `ServiceStoreServer` into `StorageServer` (just a server state)
* rename `ServiceStoreClient` into `StorageServiceStore` (implements the `KeyValueStore` trait + "Service" is a bit vague)
* rename `StoreConfig::Service` into `StoreConfig::StorageService` (idem: "Service" is a bit vague)

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
