### PR TITLE
Add metrics to the block exporter

### DIFF
--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -4,8 +4,9 @@
 //! This module defines utility functions for interacting with Prometheus (logging metrics, etc)
 
 use prometheus::{
-    exponential_buckets, histogram_opts, linear_buckets, register_histogram_vec,
-    register_int_counter_vec, HistogramVec, IntCounterVec, Opts,
+    exponential_buckets, histogram_opts, linear_buckets, register_histogram,
+    register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, Histogram,
+    HistogramVec, IntCounterVec, IntGaugeVec, Opts,
 };
 
 use crate::time::Instant;
@@ -36,6 +37,23 @@ pub fn register_histogram_vec(
     };
 
     register_histogram_vec!(histogram_opts, label_names).expect("Histogram can be created")
+}
+
+/// Wrapper around Prometheus `register_histogram!` macro which also sets the `linera` namespace
+pub fn register_histogram(name: &str, description: &str, buckets: Option<Vec<f64>>) -> Histogram {
+    let histogram_opts = if let Some(buckets) = buckets {
+        histogram_opts!(name, description, buckets).namespace(LINERA_NAMESPACE)
+    } else {
+        histogram_opts!(name, description).namespace(LINERA_NAMESPACE)
+    };
+
+    register_histogram!(histogram_opts).expect("Histogram can be created")
+}
+
+/// Wrapper around Prometheus `register_int_gauge_vec!` macro which also sets the `linera` namespace
+pub fn register_int_gauge_vec(name: &str, description: &str, label_names: &[&str]) -> IntGaugeVec {
+    let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
+    register_int_gauge_vec!(gauge_opts, label_names).expect("IntGauge can be created")
 }
 
 /// Construct the bucket interval exponentially starting from a value and an ending value.
@@ -142,6 +160,19 @@ impl MeasureLatency for HistogramVec {
 
     fn finish_measurement(&self, milliseconds: f64) {
         self.with_label_values(&[]).observe(milliseconds);
+    }
+}
+
+impl MeasureLatency for Histogram {
+    fn measure_latency(&self) -> ActiveMeasurementGuard<'_, Self> {
+        ActiveMeasurementGuard {
+            start: Instant::now(),
+            metric: Some(self),
+        }
+    }
+
+    fn finish_measurement(&self, milliseconds: f64) {
+        self.observe(milliseconds);
     }
 }
 

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -4,6 +4,7 @@
 
 use std::{
     iter::IntoIterator,
+    net::SocketAddr,
     ops::{Deref, DerefMut},
 };
 
@@ -264,6 +265,16 @@ pub struct BlockExporterConfig {
     /// on the resources used by the linera-exporter.
     #[serde(default)]
     pub limits: LimitsConfig,
+
+    /// The address to expose the `/metrics` endpoint on.
+    pub metrics_port: u16,
+}
+
+impl BlockExporterConfig {
+    /// Returns the address to expose the `/metrics` endpoint on.
+    pub fn metrics_address(&self) -> SocketAddr {
+        SocketAddr::from(([0, 0, 0, 0], self.metrics_port))
+    }
 }
 
 /// Configuration file for the exports.

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -62,6 +62,11 @@ impl GrpcClient {
         }
     }
 
+    /// Returns the address of the gRPC server.
+    pub fn address(&self) -> &str {
+        &self.address
+    }
+
     /// Returns whether this gRPC status means the server stream should be reconnected to, or not.
     /// Logs a warning on unexpected status codes.
     fn is_retryable(status: &Status) -> bool {

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -444,6 +444,10 @@ impl LocalNet {
         12000 + validator * 100 + exporter_id + 1
     }
 
+    fn block_exporter_metrics_port(exporter_id: usize) -> usize {
+        13000 + exporter_id + 1
+    }
+
     fn configuration_string(&self, server_number: usize) -> Result<String> {
         let n = server_number;
         let path = self
@@ -519,9 +523,12 @@ impl LocalNet {
         let n = validator;
         let host = Network::Grpc.localhost();
         let port = Self::block_exporter_port(n, exporter_id as usize);
+        let metrics_port = Self::block_exporter_metrics_port(exporter_id as usize);
         let mut config = format!(
             r#"
             id = {exporter_id}
+
+            metrics_port = {metrics_port}
 
             [service_config]
             host = "{host}"

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -647,7 +647,7 @@ impl LocalNet {
         let child = self
             .command_for_binary("linera-exporter")
             .await?
-            .args(["--config_path", &config_path])
+            .args(["--config-path", &config_path])
             .args(["--storage", &storage])
             .args(["--genesis", "genesis.json"])
             .spawn_into()?;

--- a/linera-service/src/exporter/main.rs
+++ b/linera-service/src/exporter/main.rs
@@ -11,6 +11,8 @@ use futures::FutureExt;
 use linera_base::listen_for_shutdown_signals;
 use linera_client::config::{BlockExporterConfig, GenesisConfig};
 use linera_rpc::NodeOptions;
+#[cfg(with_metrics)]
+use linera_service::prometheus_server;
 use linera_service::{
     storage::{Runnable, StorageConfigNamespace},
     util,
@@ -22,12 +24,19 @@ use tokio_util::sync::CancellationToken;
 
 mod common;
 mod exporter_service;
+#[cfg(with_metrics)]
+mod metrics;
 mod runloops;
 mod state;
 mod storage;
 
 #[cfg(test)]
 mod test_utils;
+
+#[cfg(not(feature = "metrics"))]
+const IS_WITH_METRICS: bool = false;
+#[cfg(feature = "metrics")]
+const IS_WITH_METRICS: bool = true;
 
 /// Options for running the linera block exporter.
 #[derive(clap::Parser, Debug, Clone)]
@@ -67,6 +76,10 @@ struct ExporterOptions {
     /// Number of times to retry connecting to a destination.
     #[arg(long, default_value = "10")]
     pub max_retries: u32,
+
+    /// Port for the metrics server.
+    #[arg(long)]
+    pub metrics_port: Option<u16>,
 
     /// The maximal number of simultaneous queries to the database
     #[arg(long)]
@@ -109,6 +122,9 @@ impl Runnable for ExporterContext {
         let shutdown_notifier = CancellationToken::new();
         tokio::spawn(listen_for_shutdown_signals(shutdown_notifier.clone()));
 
+        #[cfg(with_metrics)]
+        prometheus_server::start_metrics(self.config.metrics_address(), shutdown_notifier.clone());
+
         let (sender, handle) = start_block_processor_task(
             storage,
             ExporterCancellationSignal::new(shutdown_notifier.clone()),
@@ -145,7 +161,7 @@ impl ExporterOptions {
     fn run(&self) -> anyhow::Result<()> {
         let config_string = fs_err::read_to_string(&self.config_path)
             .expect("Unable to read the configuration file");
-        let config: BlockExporterConfig =
+        let mut config: BlockExporterConfig =
             toml::from_str(&config_string).expect("Invalid configuration file format");
 
         let node_options = NodeOptions {
@@ -154,6 +170,17 @@ impl ExporterOptions {
             retry_delay: self.retry_delay,
             max_retries: self.max_retries,
         };
+
+        if let Some(port) = self.metrics_port {
+            if IS_WITH_METRICS {
+                tracing::info!("overriding metrics port to {}", port);
+                config.metrics_port = port;
+            } else {
+                tracing::warn!(
+                    "Metrics are not enabled in this build, ignoring metrics port configuration."
+                );
+            }
+        }
 
         let context = ExporterContext::new(node_options, config);
 

--- a/linera-service/src/exporter/main.rs
+++ b/linera-service/src/exporter/main.rs
@@ -46,7 +46,7 @@ const IS_WITH_METRICS: bool = true;
 )]
 struct ExporterOptions {
     /// Path to the TOML file describing the configuration for the block exporter.
-    #[arg(long = "config_path")]
+    #[arg(long)]
     config_path: PathBuf,
 
     /// Storage configuration for the blockchain history, chain states and binary blobs.

--- a/linera-service/src/exporter/metrics.rs
+++ b/linera-service/src/exporter/metrics.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::LazyLock;
+
+use linera_base::prometheus_util::{self};
+use prometheus::{Histogram, HistogramVec, IntCounterVec, IntGaugeVec};
+
+pub(crate) static GET_BLOB_HISTOGRAM: LazyLock<Histogram> = LazyLock::new(|| {
+    prometheus_util::register_histogram(
+        "get_blob_histogram_ms",
+        "Time it took to read a blob from the storage",
+        None,
+    )
+});
+
+pub(crate) static GET_CERTIFICATE_HISTOGRAM: LazyLock<Histogram> = LazyLock::new(|| {
+    prometheus_util::register_histogram(
+        "get_certificate_histogram",
+        "Time it took to read a certificate from the storage",
+        None,
+    )
+});
+
+pub(crate) static GET_CANONICAL_BLOCK_HISTOGRAM: LazyLock<Histogram> = LazyLock::new(|| {
+    prometheus_util::register_histogram(
+        "get_canonical_block_histogram_ms",
+        "Time it took to read a canonical block from the storage",
+        None,
+    )
+});
+
+pub(crate) static SAVE_HISTOGRAM: LazyLock<Histogram> = LazyLock::new(|| {
+    prometheus_util::register_histogram(
+        "block_processor_state_save_histogram_ms",
+        "Time it took to save the exporter state to the storage",
+        None,
+    )
+});
+
+pub(crate) static DISPATCH_BLOCK_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(|| {
+    prometheus_util::register_histogram_vec(
+        "dispatch_block_histogram_ms",
+        "Time it took to dispatch a block to a destination",
+        &["destination"],
+        None,
+    )
+});
+
+pub(crate) static DISPATCH_BLOB_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(|| {
+    prometheus_util::register_histogram_vec(
+        "dispatch_blob_histogram_ms",
+        "Time it took to dispatch a blob to a validator destination",
+        &["destination"],
+        None,
+    )
+});
+
+pub(crate) static DESTINATION_STATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    prometheus_util::register_int_counter_vec(
+        "destination_state_counter",
+        "Current state (height) of the destination as seen by the exporter",
+        &["destination"],
+    )
+});
+
+pub(crate) static VALIDATOR_EXPORTER_QUEUE_LENGTH: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    prometheus_util::register_int_gauge_vec(
+        "validator_exporter_queue_length",
+        "Length of the block queue for validator exporters",
+        &["destination"],
+    )
+});

--- a/linera-service/src/exporter/runloops/indexer/client.rs
+++ b/linera-service/src/exporter/runloops/indexer/client.rs
@@ -2,7 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Duration;
+#[cfg(with_metrics)]
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
 
+use futures::StreamExt;
 use linera_rpc::{
     grpc::{transport::Options, GrpcError, GRPC_MAX_MESSAGE_SIZE},
     NodeOptions,
@@ -14,6 +21,8 @@ use tonic::{
     Request, Streaming,
 };
 
+#[cfg(with_metrics)]
+use super::indexer_api::element::Payload;
 use super::indexer_api::{indexer_client::IndexerClient as IndexerClientInner, Element};
 use crate::ExporterError;
 
@@ -21,6 +30,11 @@ pub(super) struct IndexerClient {
     max_retries: u32,
     retry_delay: Duration,
     client: IndexerClientInner<Channel>,
+    #[cfg(with_metrics)]
+    // Tracks timestamps of when we start exporting a Block to an indexer.
+    sent_latency: Arc<Mutex<VecDeque<Instant>>>,
+    #[cfg(with_metrics)]
+    address: String,
 }
 
 impl IndexerClient {
@@ -34,6 +48,10 @@ impl IndexerClient {
             client,
             retry_delay: options.retry_delay,
             max_retries: options.max_retries,
+            #[cfg(with_metrics)]
+            sent_latency: Arc::from(Mutex::new(VecDeque::new())),
+            #[cfg(with_metrics)]
+            address: address.to_string(),
         })
     }
 
@@ -45,9 +63,40 @@ impl IndexerClient {
         let mut retry_count = 0;
         loop {
             let (sender, receiver) = tokio::sync::mpsc::channel(queue_size);
+            #[cfg(with_metrics)]
+            let request = {
+                let stream = ReceiverStream::new(receiver).map(|element: Element| {
+                    if let Some(Payload::Block(_)) = &element.payload {
+                        use std::time::Instant;
+                        self.sent_latency.lock().unwrap().push_back(Instant::now());
+                    }
+                    element
+                });
+                Request::new(stream.into_inner())
+            };
+            #[cfg(not(with_metrics))]
             let request = Request::new(ReceiverStream::new(receiver));
             match self.client.index_batch(request).await {
-                Ok(res) => return Ok((sender, res.into_inner())),
+                Ok(res) => {
+                    let ack_stream = res.into_inner().map(|response: Result<(), tonic::Status>| {
+                        #[cfg(with_metrics)]
+                        {
+                            // We assume that indexer responds with ACKs only after storing a block
+                            // and that it doesn't ACK blocks out of order.
+                            let start_time = self
+                                .sent_latency
+                                .lock()
+                                .unwrap()
+                                .pop_front()
+                                .expect("have timer waiting");
+                            crate::metrics::DISPATCH_BLOCK_HISTOGRAM
+                                .with_label_values(&[&self.address])
+                                .observe(start_time.elapsed().as_secs_f64() * 1000.0);
+                        }
+                        response
+                    });
+                    return Ok((sender, ack_stream.into_inner()));
+                }
                 Err(e) => {
                     if retry_count > self.max_retries {
                         return Err(ExporterError::SynchronizationFailed(e.into()));

--- a/linera-service/src/exporter/runloops/validator_exporter.rs
+++ b/linera-service/src/exporter/runloops/validator_exporter.rs
@@ -118,6 +118,10 @@ where
         mut receiver: Receiver<(Arc<ConfirmedBlockCertificate>, Vec<BlobId>)>,
     ) -> anyhow::Result<()> {
         while let Some((block, blobs_ids)) = receiver.recv().await {
+            #[cfg(with_metrics)]
+            crate::metrics::VALIDATOR_EXPORTER_QUEUE_LENGTH
+                .with_label_values(&[self.node.address()])
+                .set(receiver.len() as i64);
             match self.dispatch_block((*block).clone()).await {
                 Ok(_) => {}
 
@@ -141,6 +145,10 @@ where
 
     fn increment_destination_state(&self) {
         let _ = self.destination_state.fetch_add(1, Ordering::Release);
+        #[cfg(with_metrics)]
+        crate::metrics::DESTINATION_STATE_COUNTER
+            .with_label_values(&[self.node.address()])
+            .inc();
     }
 
     async fn upload_blobs(&self, blobs: Vec<BlobId>) -> anyhow::Result<()> {
@@ -152,11 +160,20 @@ where
                         "dispatching blob with id: {:#?} from linera exporter",
                         blob.id()
                     );
-                    self.node
+                    #[cfg(with_metrics)]
+                    let start = std::time::Instant::now();
+                    let result = self
+                        .node
                         .upload_blob((*blob).clone().into())
                         .await
                         .map_err(|e| ExporterError::GenericError(e.into()))
                         .map(|_| ())
+                        .map_err(|e| ExporterError::GenericError(e.into()));
+                    #[cfg(with_metrics)]
+                    crate::metrics::DISPATCH_BLOB_HISTOGRAM
+                        .with_label_values(&[self.node.address()])
+                        .observe(start.elapsed().as_secs_f64() * 1000.0);
+                    result
                 }
             }
         });
@@ -173,14 +190,25 @@ where
         let delivery = CrossChainMessageDelivery::NonBlocking;
         let block_id = BlockId::from_confirmed_block(certificate.value());
         tracing::info!(?block_id, "dispatching block");
+        #[cfg(with_metrics)]
+        let start = std::time::Instant::now();
         match self
             .node
             .handle_confirmed_certificate(certificate, delivery)
             .await
         {
-            Ok(_) => {}
+            Ok(_) => {
+                #[cfg(with_metrics)]
+                crate::metrics::DISPATCH_BLOCK_HISTOGRAM
+                    .with_label_values(&[self.node.address()])
+                    .observe(start.elapsed().as_secs_f64() * 1000.0);
+            }
             Err(e) => {
                 tracing::error!(error=%e, ?block_id, "error when dispatching block");
+                #[cfg(with_metrics)]
+                crate::metrics::DISPATCH_BLOCK_HISTOGRAM
+                    .with_label_values(&[self.node.address()])
+                    .observe(start.elapsed().as_secs_f64() * 1000.0);
                 Err(e)?
             }
         }

--- a/linera-service/src/exporter/storage.rs
+++ b/linera-service/src/exporter/storage.rs
@@ -9,6 +9,8 @@ use std::{
 
 use dashmap::DashMap;
 use futures::future::try_join_all;
+#[cfg(with_metrics)]
+use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Blob, BlockHeight},
@@ -25,6 +27,8 @@ use linera_views::{batch::Batch, context::Context, log_view::LogView, views::Clo
 use mini_moka::unsync::Cache as LfuCache;
 use quick_cache::{sync::Cache as FifoCache, Weighter};
 
+#[cfg(with_metrics)]
+use crate::metrics;
 use crate::{
     common::{BlockId, CanonicalBlock, ExporterError, LiteBlockId},
     state::{BlockExporterStateView, DestinationStates},
@@ -39,6 +43,9 @@ where
     shared_storage: SharedStorage<S::BlockExporterContext, S>,
 }
 
+type BlobCache = FifoCache<BlobId, Arc<Blob>, BlobCacheWeighter>;
+type BlockCache = FifoCache<CryptoHash, Arc<ConfirmedBlockCertificate>, BlockCacheWeighter>;
+
 struct SharedStorage<C, S>
 where
     S: Storage + Clone + Send + Sync + 'static,
@@ -46,8 +53,8 @@ where
     storage: S,
     destination_states: DestinationStates,
     shared_canonical_state: CanonicalState<C>,
-    blobs_cache: Arc<FifoCache<BlobId, Arc<Blob>, BlobCacheWeighter>>,
-    blocks_cache: Arc<FifoCache<CryptoHash, Arc<ConfirmedBlockCertificate>, BlockCacheWeighter>>,
+    blobs_cache: Arc<BlobCache>,
+    blocks_cache: Arc<BlockCache>,
 }
 
 pub(super) struct BlockProcessorStorage<S>
@@ -57,6 +64,7 @@ where
     blob_state_cache: LfuCache<BlobId, ()>,
     chain_states_cache: LfuCache<ChainId, LiteBlockId>,
     shared_storage: SharedStorage<S::BlockExporterContext, S>,
+    // Handle on the persistent storage where the exporter state is pushed to periodically.
     exporter_state_view: BlockExporterStateView<<S as Storage>::BlockExporterContext>,
 }
 
@@ -100,6 +108,8 @@ where
         match self.blocks_cache.get_value_or_guard_async(&hash).await {
             Ok(value) => Ok(value),
             Err(guard) => {
+                #[cfg(with_metrics)]
+                metrics::GET_CERTIFICATE_HISTOGRAM.measure_latency();
                 let block = self.storage.read_certificate(hash).await?;
                 let heaped_block = Arc::new(block);
                 let _ = guard.insert(heaped_block.clone());
@@ -112,6 +122,8 @@ where
         match self.blobs_cache.get_value_or_guard_async(&blob_id).await {
             Ok(blob) => Ok(blob),
             Err(guard) => {
+                #[cfg(with_metrics)]
+                metrics::GET_BLOB_HISTOGRAM.measure_latency();
                 let blob = self.storage.read_blob(blob_id).await?;
                 let heaped_blob = Arc::new(blob);
                 let _ = guard.insert(heaped_blob.clone());
@@ -318,6 +330,12 @@ where
             let state = match self.shared_storage.destination_states.get(&id) {
                 None => {
                     tracing::trace!(id=?id, "adding new committee member");
+                    #[cfg(with_metrics)]
+                    {
+                        metrics::DESTINATION_STATE_COUNTER
+                            .with_label_values(&[id.address()])
+                            .reset();
+                    }
                     Arc::new(AtomicU64::new(0))
                 }
                 Some(state) => state.clone(),
@@ -338,6 +356,8 @@ where
 
         self.exporter_state_view.flush(&mut batch)?;
         self.exporter_state_view.rollback();
+        #[cfg(with_metrics)]
+        metrics::SAVE_HISTOGRAM.measure_latency();
         if let Err(e) = self.exporter_state_view.context().write_batch(batch).await {
             Err(ExporterError::ViewError(e.into()))?;
         };
@@ -350,11 +370,23 @@ where
     }
 }
 
+/// A view of the canonical state that is used to store blocks in the exporter.
 struct CanonicalState<C> {
+    /// The number of blocks in the canonical state.
     count: usize,
+    /// The (persistent) storage view that is used to access the canonical state.
     state_context: LogView<C, CanonicalBlock>,
-    state_updates_buffer: Arc<DashMap<usize, CanonicalBlock>>,
+    /// A cache that stores the canonical blocks.
+    /// This cache is used to speed up access to the canonical state.
+    /// It uses a FIFO eviction policy and is limited by the size of the cache.
+    /// The cache is used to avoid reading the canonical state from the persistent storage
+    /// for every request.
     state_cache: Arc<FifoCache<usize, CanonicalBlock, CanonicalStateCacheWeighter>>,
+    /// A buffer that stores the updates to the canonical state.
+    ///
+    /// This buffer is used to temporarily hold updates to the canonical state before they are
+    /// flushed to the persistent storage.
+    state_updates_buffer: Arc<DashMap<usize, CanonicalBlock>>,
 }
 
 impl<C> CanonicalState<C>
@@ -400,6 +432,8 @@ where
                 {
                     entry
                 } else {
+                    #[cfg(with_metrics)]
+                    metrics::GET_CANONICAL_BLOCK_HISTOGRAM.measure_latency();
                     self.state_context
                         .get(index)
                         .await?

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -1004,6 +1004,7 @@ async fn test_linera_exporter(database: Database, network: Network) -> Result<()
             port: 0,
         },
         limits: LimitsConfig::default(),
+        metrics_port: 1234,
     };
 
     let config = LocalNetConfig {


### PR DESCRIPTION
## Motivation

A slightly adjusted backport of #4244

## Proposal

I also backported the PR that removes the necessity to provide a path to genesis config. This simplifies the command to run the exporter.

## Test Plan

CI and manually.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
