### PR TITLE
Update validators less eagerly - fewer queries when proposing a block

### DIFF
--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -5,8 +5,8 @@
 
 use prometheus::{
     exponential_buckets, histogram_opts, linear_buckets, register_histogram,
-    register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, Histogram,
-    HistogramVec, IntCounterVec, IntGaugeVec, Opts,
+    register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge_vec,
+    Histogram, HistogramVec, IntCounter, IntCounterVec, IntGaugeVec, Opts,
 };
 
 use crate::time::Instant;
@@ -21,6 +21,12 @@ pub fn register_int_counter_vec(
 ) -> IntCounterVec {
     let counter_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     register_int_counter_vec!(counter_opts, label_names).expect("IntCounter can be created")
+}
+
+/// Wrapper around Prometheus register_int_counter_vec! macro which also sets the `linera` namespace
+pub fn register_int_counter(name: &str, description: &str) -> IntCounter {
+    let counter_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
+    register_int_counter!(counter_opts).expect("IntCounter can be created")
 }
 
 /// Wrapper around Prometheus `register_histogram_vec!` macro which also sets the `linera` namespace

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -13,7 +13,7 @@ use crate::time::Instant;
 
 const LINERA_NAMESPACE: &str = "linera";
 
-/// Wrapper around Prometheus register_int_counter_vec! macro which also sets the `linera` namespace
+/// Wrapper around Prometheus `register_int_counter_vec!` macro which also sets the `linera` namespace
 pub fn register_int_counter_vec(
     name: &str,
     description: &str,
@@ -23,7 +23,7 @@ pub fn register_int_counter_vec(
     register_int_counter_vec!(counter_opts, label_names).expect("IntCounter can be created")
 }
 
-/// Wrapper around Prometheus register_int_counter_vec! macro which also sets the `linera` namespace
+/// Wrapper around Prometheus `register_int_counter!` macro which also sets the `linera` namespace
 pub fn register_int_counter(name: &str, description: &str) -> IntCounter {
     let counter_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     register_int_counter!(counter_opts).expect("IntCounter can be created")

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -118,7 +118,7 @@ pub enum ChainError {
     #[error("The previous block hash of a new block should match the last block of the chain")]
     UnexpectedPreviousBlockHash,
     #[error("Sequence numbers above the maximal value are not usable for blocks")]
-    InvalidBlockHeight,
+    BlockHeightOverflow,
     #[error(
         "Block timestamp {new} must not be earlier than the parent block's timestamp {parent}"
     )]

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -298,7 +298,7 @@ where
         // When a block is certified, incrementing its height must succeed.
         ensure!(
             new_block.height < BlockHeight::MAX,
-            ChainError::InvalidBlockHeight
+            ChainError::BlockHeightOverflow
         );
         let current_round = self.current_round();
         match new_round {

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -218,7 +218,6 @@ impl<C: ClientContext> ChainListener<C> {
             }
             Reason::NewRound { .. } => self.update_validators(&notification).await?,
             Reason::NewBlock { hash, .. } => {
-                // self.update_validators(&notification).await?;
                 self.update_wallet(notification.chain_id).await?;
                 self.add_new_chains(*hash).await?;
                 let publishers = self

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -218,7 +218,7 @@ impl<C: ClientContext> ChainListener<C> {
             }
             Reason::NewRound { .. } => self.update_validators(&notification).await?,
             Reason::NewBlock { hash, .. } => {
-                self.update_validators(&notification).await?;
+                // self.update_validators(&notification).await?;
                 self.update_wallet(notification.chain_id).await?;
                 self.add_new_chains(*hash).await?;
                 let publishers = self

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2826,9 +2826,12 @@ impl<Env: Environment> ChainClient<Env> {
         // Send the query to validators.
         let certificate = if round.is_fast() {
             let hashed_value = ConfirmedBlock::new(block);
-            self.client
+            let certificate = self
+                .client
                 .submit_block_proposal(&committee, proposal, hashed_value)
-                .await?
+                .await?;
+            self.update_validators(Some(&committee)).await?;
+            certificate
         } else {
             let hashed_value = ValidatedBlock::new(block);
             let certificate = self
@@ -2841,7 +2844,6 @@ impl<Env: Environment> ChainClient<Env> {
             round = %certificate.round,
             "Sending confirmed block to validators",
         );
-        self.update_validators(Some(&committee)).await?;
         Ok(ClientOutcome::Committed(Some(certificate)))
     }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2837,7 +2837,7 @@ impl<Env: Environment> ChainClient<Env> {
             self.client.finalize_block(&committee, certificate).await?
         };
         debug!(round = %certificate.round, "Sending confirmed block to validators");
-        self.update_validators(Some(&committee)).await?;
+        // self.update_validators(Some(&committee)).await?;
         Ok(ClientOutcome::Committed(Some(certificate)))
     }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2255,11 +2255,7 @@ impl<Env: Environment> ChainClient<Env> {
         let committee = info.current_committee()?;
         let height = info.next_block_height;
         let round = info.manager.current_round;
-        let action = CommunicateAction::RequestTimeout {
-            height,
-            round,
-            chain_id,
-        };
+        let action = CommunicateAction::RequestTimeout { round, chain_id };
         let value = Timeout::new(chain_id, height, info.epoch);
         let certificate = Box::new(
             self.client

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2337,6 +2337,7 @@ impl<Env: Environment> ChainClient<Env> {
 
         let mutex = self.state().client_mutex();
         let _guard = mutex.lock_owned().await;
+        // TOOD: We shouldn't need to call this explicitly.
         match self.process_pending_block_without_prepare().await? {
             ClientOutcome::Committed(Some(certificate)) => {
                 return Ok(ExecuteBlockOutcome::Conflict(certificate))
@@ -2836,8 +2837,11 @@ impl<Env: Environment> ChainClient<Env> {
                 .await?;
             self.client.finalize_block(&committee, certificate).await?
         };
-        debug!(round = %certificate.round, "Sending confirmed block to validators");
-        // self.update_validators(Some(&committee)).await?;
+        debug!(
+            round = %certificate.round,
+            "Sending confirmed block to validators",
+        );
+        self.update_validators(Some(&committee)).await?;
         Ok(ClientOutcome::Committed(Some(certificate)))
     }
 

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -285,7 +285,8 @@ impl NodeError {
         // It is unclear why `ChainError { error: "Round number should be Fast" }` is returned in some cases.
         matches!(
             self,
-            NodeError::ChainError { .. } | NodeError::MissingCrossChainUpdate { .. }
+            NodeError::ChainError { .. }
+                | NodeError::MissingCrossChainUpdate { .. }
                 | NodeError::MissingCertificateValue
                 | NodeError::BlobsNotFound(_)
                 | NodeError::EventsNotFound(_)

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -279,6 +279,20 @@ pub enum NodeError {
     ResponseHandlingError { error: String },
 }
 
+impl NodeError {
+    pub fn is_missing_data(&self) -> bool {
+        // TODO: Should we include other errors here?
+        // It is unclear why `ChainError { error: "Round number should be Fast" }` is returned in some cases.
+        matches!(
+            self,
+            NodeError::ChainError { .. } | NodeError::MissingCrossChainUpdate { .. }
+                | NodeError::MissingCertificateValue
+                | NodeError::BlobsNotFound(_)
+                | NodeError::EventsNotFound(_)
+        )
+    }
+}
+
 impl From<tonic::Status> for NodeError {
     fn from(status: tonic::Status) -> Self {
         Self::GrpcError {

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -9,7 +9,7 @@ use futures::stream::LocalBoxStream as BoxStream;
 use futures::stream::Stream;
 use linera_base::{
     crypto::{CryptoError, CryptoHash, ValidatorPublicKey},
-    data_types::{ArithmeticError, Blob, BlobContent, BlockHeight, NetworkDescription},
+    data_types::{ArithmeticError, Blob, BlobContent, BlockHeight, NetworkDescription, Round},
     identifiers::{BlobId, ChainId, EventId},
 };
 use linera_chain::{
@@ -213,6 +213,17 @@ pub enum NodeError {
     #[error("The chain {0} is not active in validator")]
     InactiveChain(ChainId),
 
+    #[error("Round number should be {0:?}")]
+    WrongRound(Round),
+
+    #[error(
+        "Was expecting block height {expected_block_height} but found {found_block_height} instead"
+    )]
+    UnexpectedBlockHeight {
+        expected_block_height: BlockHeight,
+        found_block_height: BlockHeight,
+    },
+
     // This error must be normalized during conversions.
     #[error(
         "Cannot vote for block proposal of chain {chain_id:?} because a message \
@@ -277,20 +288,6 @@ pub enum NodeError {
     EmptyBlobsNotFound,
     #[error("Local error handling validator response: {error}")]
     ResponseHandlingError { error: String },
-}
-
-impl NodeError {
-    pub fn is_missing_data(&self) -> bool {
-        // TODO: Should we include other errors here?
-        // It is unclear why `ChainError { error: "Round number should be Fast" }` is returned in some cases.
-        matches!(
-            self,
-            NodeError::ChainError { .. } | NodeError::InactiveChain(_) // | NodeError::MissingCrossChainUpdate { .. }
-                                                                       // | NodeError::MissingCertificateValue
-                                                                       // | NodeError::BlobsNotFound(_)
-                                                                       // | NodeError::EventsNotFound(_)
-        )
-    }
 }
 
 impl From<tonic::Status> for NodeError {
@@ -362,6 +359,14 @@ impl From<ChainError> for NodeError {
                     error: ChainError::ExecutionError(execution_error, context).to_string(),
                 },
             },
+            ChainError::UnexpectedBlockHeight {
+                expected_block_height,
+                found_block_height,
+            } => Self::UnexpectedBlockHeight {
+                expected_block_height,
+                found_block_height,
+            },
+            ChainError::WrongRound(round) => Self::WrongRound(round),
             error => Self::ChainError {
                 error: error.to_string(),
             },

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -285,11 +285,10 @@ impl NodeError {
         // It is unclear why `ChainError { error: "Round number should be Fast" }` is returned in some cases.
         matches!(
             self,
-            NodeError::ChainError { .. }
-                | NodeError::MissingCrossChainUpdate { .. }
-                | NodeError::MissingCertificateValue
-                | NodeError::BlobsNotFound(_)
-                | NodeError::EventsNotFound(_)
+            NodeError::ChainError { .. } | NodeError::InactiveChain(_) // | NodeError::MissingCrossChainUpdate { .. }
+                                                                       // | NodeError::MissingCertificateValue
+                                                                       // | NodeError::BlobsNotFound(_)
+                                                                       // | NodeError::EventsNotFound(_)
         )
     }
 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2608,6 +2608,7 @@ where
         .execute_operation(SystemOperation::VerifyBlob { blob_id })
         .await
         .unwrap_ok_committed();
+
     // This read a new blob, so it cannot be a fast block.
     assert_eq!(certificate.round, Round::MultiLeader(0));
     let block = certificate.block();

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2588,23 +2588,6 @@ where
         .unwrap_ok_committed();
     assert_eq!(certificate.round, Round::Fast);
 
-    let nodes = client1.client.validator_nodes().await.unwrap();
-    let _ = client1
-        .client
-        .update_local_node_with_blobs_from(vec![blob_id], &nodes)
-        .await
-        .unwrap();
-    let _ = client2
-        .client
-        .update_local_node_with_blobs_from(vec![blob_id], &nodes)
-        .await
-        .unwrap();
-    let _ = client3
-        .client
-        .update_local_node_with_blobs_from(vec![blob_id], &nodes)
-        .await
-        .unwrap();
-
     // Send a message from chain 2 to chain 3.
     let certificate = client2
         .transfer(

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -287,6 +287,30 @@ where
                 .await
             {
                 Ok(info) => return Ok(info),
+                Err(NodeError::WrongRound(_round)) => {
+                    // The proposal is for a different round, so we need to update the validator.
+                    // TODO: this should probably be more specific as to which rounds are retried.
+                    self.send_chain_information(
+                        chain_id,
+                        proposal.content.block.height,
+                        CrossChainMessageDelivery::NonBlocking,
+                    )
+                    .await?;
+                }
+                Err(NodeError::UnexpectedBlockHeight {
+                    expected_block_height,
+                    found_block_height,
+                }) => {
+                    if expected_block_height < found_block_height {
+                        // The proposal is for a a later block height, so we need to update the validator.
+                        self.send_chain_information(
+                            chain_id,
+                            found_block_height,
+                            CrossChainMessageDelivery::NonBlocking,
+                        )
+                        .await?;
+                    }
+                }
                 Err(NodeError::MissingCrossChainUpdate { .. }) if !sent_cross_chain_updates => {
                     sent_cross_chain_updates = true;
                     // Some received certificates may be missing for this validator
@@ -482,7 +506,7 @@ where
         &mut self,
         action: CommunicateAction,
     ) -> Result<LiteVote, ChainClientError> {
-        let (target_block_height, chain_id) = match &action {
+        let (_target_block_height, chain_id) = match &action {
             CommunicateAction::SubmitBlock { proposal, .. } => {
                 let block = &proposal.content.block;
                 (block.height, block.chain_id)
@@ -498,52 +522,17 @@ where
         // Send the block proposal, certificate or timeout request and return a vote.
         let vote = match action {
             CommunicateAction::SubmitBlock { proposal, blob_ids } => {
-                match self
-                    .send_block_proposal(proposal.clone(), blob_ids.clone())
-                    .await
-                {
-                    Ok(info) => info.manager.pending,
-                    Err(ChainClientError::RemoteNodeError(err)) if err.is_missing_data() => {
-                        // Update the validator with missing information, if needed.
-                        self.send_chain_information(
-                            chain_id,
-                            target_block_height,
-                            CrossChainMessageDelivery::NonBlocking,
-                        )
-                        .await?;
-                        // Retry sending the block proposal.
-                        self.send_block_proposal(proposal, blob_ids)
-                            .await?
-                            .manager
-                            .pending
-                    }
-                    Err(err) => return Err(err),
-                }
+                let info = self.send_block_proposal(proposal, blob_ids).await?;
+                info.manager.pending
             }
             CommunicateAction::FinalizeBlock {
                 certificate,
                 delivery,
             } => {
-                match self
-                    .send_validated_certificate(*certificate.clone(), delivery)
-                    .await
-                {
-                    Ok(info) => info.manager.pending,
-                    Err(ChainClientError::RemoteNodeError(err)) if err.is_missing_data() => {
-                        // Update the validator with missing information, if needed.
-                        self.send_chain_information(
-                            chain_id,
-                            target_block_height,
-                            CrossChainMessageDelivery::NonBlocking,
-                        )
-                        .await?;
-                        // Retry sending the certificate.
-                        self.send_validated_certificate(*certificate, delivery)
-                            .await
-                            .map(|info| info.manager.pending)?
-                    }
-                    Err(err) => return Err(err),
-                }
+                let info = self
+                    .send_validated_certificate(*certificate, delivery)
+                    .await?;
+                info.manager.pending
             }
             CommunicateAction::RequestTimeout { .. } => {
                 let query = ChainInfoQuery::new(chain_id).with_timeout();

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -498,13 +498,24 @@ where
         // Send the block proposal, certificate or timeout request and return a vote.
         let vote = match action {
             CommunicateAction::SubmitBlock { proposal, blob_ids } => {
-                match self.send_block_proposal(proposal.clone(), blob_ids.clone()).await {
+                match self
+                    .send_block_proposal(proposal.clone(), blob_ids.clone())
+                    .await
+                {
                     Ok(info) => info.manager.pending,
                     Err(ChainClientError::RemoteNodeError(err)) if err.is_missing_data() => {
                         // Update the validator with missing information, if needed.
-                        self.send_chain_information(chain_id, target_block_height, CrossChainMessageDelivery::NonBlocking).await?;
+                        self.send_chain_information(
+                            chain_id,
+                            target_block_height,
+                            CrossChainMessageDelivery::NonBlocking,
+                        )
+                        .await?;
                         // Retry sending the block proposal.
-                        self.send_block_proposal(proposal, blob_ids).await?.manager.pending
+                        self.send_block_proposal(proposal, blob_ids)
+                            .await?
+                            .manager
+                            .pending
                     }
                     Err(err) => return Err(err),
                 }
@@ -520,10 +531,16 @@ where
                     Ok(info) => info.manager.pending,
                     Err(ChainClientError::RemoteNodeError(err)) if err.is_missing_data() => {
                         // Update the validator with missing information, if needed.
-                        self.send_chain_information(chain_id, target_block_height, CrossChainMessageDelivery::NonBlocking ).await?;
+                        self.send_chain_information(
+                            chain_id,
+                            target_block_height,
+                            CrossChainMessageDelivery::NonBlocking,
+                        )
+                        .await?;
                         // Retry sending the certificate.
                         self.send_validated_certificate(*certificate, delivery)
-                            .await.map(|info| info.manager.pending)?
+                            .await
+                            .map(|info| info.manager.pending)?
                     }
                     Err(err) => return Err(err),
                 }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -482,7 +482,7 @@ where
         &mut self,
         action: CommunicateAction,
     ) -> Result<LiteVote, ChainClientError> {
-        let (target_block_height, chain_id) = match &action {
+        let (_target_block_height, chain_id) = match &action {
             CommunicateAction::SubmitBlock { proposal, .. } => {
                 let block = &proposal.content.block;
                 (block.height, block.chain_id)
@@ -495,10 +495,10 @@ where
                 height, chain_id, ..
             } => (*height, *chain_id),
         };
-        // Update the validator with missing information, if needed.
-        let delivery = CrossChainMessageDelivery::NonBlocking;
-        self.send_chain_information(chain_id, target_block_height, delivery)
-            .await?;
+        // // Update the validator with missing information, if needed.
+        // let delivery = CrossChainMessageDelivery::NonBlocking;
+        // self.send_chain_information(chain_id, target_block_height, delivery)
+        //     .await?;
         // Send the block proposal, certificate or timeout request and return a vote.
         let vote = match action {
             CommunicateAction::SubmitBlock { proposal, blob_ids } => {

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -54,7 +54,6 @@ pub enum CommunicateAction {
     },
     RequestTimeout {
         chain_id: ChainId,
-        height: BlockHeight,
         round: Round,
     },
 }
@@ -506,18 +505,12 @@ where
         &mut self,
         action: CommunicateAction,
     ) -> Result<LiteVote, ChainClientError> {
-        let (_target_block_height, chain_id) = match &action {
-            CommunicateAction::SubmitBlock { proposal, .. } => {
-                let block = &proposal.content.block;
-                (block.height, block.chain_id)
+        let chain_id = match &action {
+            CommunicateAction::SubmitBlock { proposal, .. } => proposal.content.block.chain_id,
+            CommunicateAction::FinalizeBlock { certificate, .. } => {
+                certificate.inner().block().header.chain_id
             }
-            CommunicateAction::FinalizeBlock { certificate, .. } => (
-                certificate.inner().block().header.height,
-                certificate.inner().block().header.chain_id,
-            ),
-            CommunicateAction::RequestTimeout {
-                height, chain_id, ..
-            } => (*height, *chain_id),
+            CommunicateAction::RequestTimeout { chain_id, .. } => *chain_id,
         };
         // Send the block proposal, certificate or timeout request and return a vote.
         let vote = match action {

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -52,9 +52,10 @@ mod metrics {
     use std::sync::LazyLock;
 
     use linera_base::prometheus_util::{
-        exponential_bucket_interval, register_histogram_vec, register_int_counter_vec,
+        exponential_bucket_interval, register_histogram_vec, register_int_counter,
+        register_int_counter_vec,
     };
-    use prometheus::{HistogramVec, IntCounterVec};
+    use prometheus::{HistogramVec, IntCounter, IntCounterVec};
 
     pub static NUM_ROUNDS_IN_CERTIFICATE: LazyLock<HistogramVec> = LazyLock::new(|| {
         register_histogram_vec(
@@ -89,11 +90,10 @@ mod metrics {
         )
     });
 
-    pub static CHAIN_INFO_QUERIES: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
+    pub static CHAIN_INFO_QUERIES: LazyLock<IntCounter> = LazyLock::new(|| {
+        register_int_counter(
             "chain_info_queries",
             "Number of chain info queries processed",
-            &[],
         )
     });
 }
@@ -926,7 +926,7 @@ where
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname, query);
         #[cfg(with_metrics)]
-        metrics::CHAIN_INFO_QUERIES.with_label_values(&[]).inc();
+        metrics::CHAIN_INFO_QUERIES.inc();
         let result = self
             .query_chain_worker(query.chain_id, move |callback| {
                 ChainWorkerRequest::HandleChainInfoQuery { query, callback }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -697,6 +697,17 @@ NodeError:
         NEWTYPE:
           TYPENAME: ChainId
     6:
+      WrongRound:
+        NEWTYPE:
+          TYPENAME: Round
+    7:
+      UnexpectedBlockHeight:
+        STRUCT:
+          - expected_block_height:
+              TYPENAME: BlockHeight
+          - found_block_height:
+              TYPENAME: BlockHeight
+    8:
       MissingCrossChainUpdate:
         STRUCT:
           - chain_id:
@@ -705,62 +716,62 @@ NodeError:
               TYPENAME: ChainId
           - height:
               TYPENAME: BlockHeight
-    7:
+    9:
       BlobsNotFound:
         NEWTYPE:
           SEQ:
             TYPENAME: BlobId
-    8:
+    10:
       EventsNotFound:
         NEWTYPE:
           SEQ:
             TYPENAME: EventId
-    9:
+    11:
       MissingCertificateValue: UNIT
-    10:
+    12:
       MissingCertificates:
         NEWTYPE:
           SEQ:
             TYPENAME: CryptoHash
-    11:
-      MissingVoteInValidatorResponse: UNIT
-    12:
-      InvalidChainInfoResponse: UNIT
     13:
-      UnexpectedCertificateValue: UNIT
+      MissingVoteInValidatorResponse: UNIT
     14:
-      InvalidDecoding: UNIT
+      InvalidChainInfoResponse: UNIT
     15:
-      UnexpectedMessage: UNIT
+      UnexpectedCertificateValue: UNIT
     16:
+      InvalidDecoding: UNIT
+    17:
+      UnexpectedMessage: UNIT
+    18:
       GrpcError:
         STRUCT:
           - error: STR
-    17:
+    19:
       ClientIoError:
         STRUCT:
           - error: STR
-    18:
+    20:
       CannotResolveValidatorAddress:
         STRUCT:
           - address: STR
-    19:
+    21:
       SubscriptionError:
         STRUCT:
           - transport: STR
-    20:
+    22:
       SubscriptionFailed:
         STRUCT:
           - status: STR
-    21:
+    23:
       InvalidCertificateForBlob:
         NEWTYPE:
           TYPENAME: BlobId
-    22:
-      DuplicatesInBlobsNotFound: UNIT
-    23:
-      UnexpectedEntriesInBlobsNotFound: UNIT
     24:
+      DuplicatesInBlobsNotFound: UNIT
+    25:
+      UnexpectedEntriesInBlobsNotFound: UNIT
+    26:
       UnexpectedCertificates:
         STRUCT:
           - returned:
@@ -769,9 +780,9 @@ NodeError:
           - requested:
               SEQ:
                 TYPENAME: CryptoHash
-    25:
+    27:
       EmptyBlobsNotFound: UNIT
-    26:
+    28:
       ResponseHandlingError:
         STRUCT:
           - error: STR


### PR DESCRIPTION
## Motivation

We've noticed that in our app demos we make more than optimal # of requests when proposing a block. Obviously we should try to do as little work as possible.

## Proposal


## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
