### PR TITLE
Add information about published events to the NewBlock notification

### DIFF
--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -458,9 +458,22 @@ where
         let mut actions = self.state.create_network_actions().await?;
         trace!("Processed confirmed block {height} on chain {chain_id:.8}");
         let hash = certificate.hash();
+        let event_streams = certificate
+            .value()
+            .block()
+            .body
+            .events
+            .iter()
+            .flatten()
+            .map(|event| event.stream_id.clone())
+            .collect();
         actions.notifications.push(Notification {
             chain_id,
-            reason: Reason::NewBlock { height, hash },
+            reason: Reason::NewBlock {
+                height,
+                hash,
+                event_streams,
+            },
         });
         // Persist chain.
         self.save().await?;

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -1093,6 +1093,7 @@ where
                 reason: NewBlock {
                     height: BlockHeight(0),
                     hash: certificate0.hash(),
+                    event_streams: BTreeSet::new(),
                 }
             },
             Notification {
@@ -1107,6 +1108,7 @@ where
                 reason: NewBlock {
                     height: BlockHeight(1),
                     hash: certificate1.hash(),
+                    event_streams: BTreeSet::new(),
                 }
             },
             Notification {

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
@@ -14,7 +14,7 @@ use linera_base::{
     data_types::{ApplicationDescription, ArithmeticError, Blob, BlockHeight, Epoch, Round},
     doc_scalar,
     hashed::Hashed,
-    identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, EventId},
+    identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, EventId, StreamId},
     time::timer::{sleep, timeout},
 };
 #[cfg(with_testing)]
@@ -124,6 +124,7 @@ pub enum Reason {
     NewBlock {
         height: BlockHeight,
         hash: CryptoHash,
+        event_streams: BTreeSet<StreamId>,
     },
     NewIncomingBundle {
         origin: ChainId,

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -1273,6 +1273,7 @@ pub mod tests {
             reason: linera_core::worker::Reason::NewBlock {
                 height: BlockHeight(0),
                 hash: CryptoHash::new(&Foo("".into())),
+                event_streams: Default::default(),
             },
         };
         let message = api::Notification::try_from(notification.clone()).unwrap();

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -321,7 +321,12 @@ where
                 )
             }
 
-            if let Reason::NewBlock { height: _, hash: _ } = reason {
+            if let Reason::NewBlock {
+                height: _,
+                hash: _,
+                event_streams: _,
+            } = reason
+            {
                 for exporter_client in &mut exporter_clients {
                     let request = tonic::Request::new(notification.clone());
                     if let Err(error) = exporter_client.notify(request).await {

--- a/linera-service/src/exporter/exporter_service.rs
+++ b/linera-service/src/exporter/exporter_service.rs
@@ -87,7 +87,12 @@ fn parse_notification(notification: Notification) -> core::result::Result<BlockI
     let reason = bincode::deserialize::<Reason>(&notification.reason)
         .map_err(|err| BadNotificationKind::InvalidReason { inner: Some(err) })?;
 
-    if let Reason::NewBlock { height, hash } = reason {
+    if let Reason::NewBlock {
+        height,
+        hash,
+        event_streams: _,
+    } = reason
+    {
         return Ok(BlockId::new(chain_id, hash, height));
     }
 

--- a/linera-service/src/exporter/exporter_service.rs
+++ b/linera-service/src/exporter/exporter_service.rs
@@ -123,6 +123,7 @@ mod test {
         let reason = Reason::NewBlock {
             height: 4.into(),
             hash: CryptoHash::test_hash("s"),
+            event_streams: Default::default(),
         };
         let request = Notification {
             chain_id: ChainId::default(),

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -4529,8 +4529,13 @@ async fn test_end_to_end_repeated_transfers(config: impl LineraNetConfig) -> Res
                         message_duration += start_time.elapsed();
                     }
                 }
-                Reason::NewBlock { height, hash } => {
+                Reason::NewBlock {
+                    height,
+                    hash,
+                    event_streams,
+                } => {
                     assert_eq!(height, next_height2);
+                    assert!(event_streams.is_empty());
                     assert!(
                         got_message,
                         "Missing message notification about transfer #{i}"


### PR DESCRIPTION
## Motivation

We want to include the information about published events in the notifications so that clients can choose whether they are interested in the particular blocks or not.

## Proposal

Add an `event_streams` field to the `NewBlock` notification, containing the stream IDs of streams to which the block published any events.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- #4261 (this is just the validator-side part, the client-side part of actually using the event information in the notifications will be done in a follow-up PR)
