### PR TITLE
Upgrade out of deprecated startup-script version

### DIFF
--- a/kubernetes/linera-validator/scylla-setup/gke-daemonset-raid-disks.yaml
+++ b/kubernetes/linera-validator/scylla-setup/gke-daemonset-raid-disks.yaml
@@ -19,7 +19,7 @@ spec:
       hostPID: true
       containers:
         - name: startup-script
-          image: registry.k8s.io/startup-script:v1
+          image: registry.k8s.io/startup-script:v2
           securityContext:
             privileged: true
           env:


### PR DESCRIPTION
## Motivation

`v1` just got deprecated, so anyone using `v1` got their stuff broken. So need to update to `v2`. Deployments do not work with `v1` anymore

## Proposal

Update to `v2`

## Test Plan

The latest `devnet` was deployed with `v2`, as it didn't work with `v1`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
