### PR TITLE
Fix sanity check for incoming bundle notifications.

### DIFF
--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1302,7 +1302,22 @@ where
         .await
         .unwrap_ok_committed();
 
-    receiver.synchronize_from_validators().await?;
+    // Process the notification about the incoming message.
+    let notification = Notification {
+        chain_id: receiver_id,
+        reason: Reason::NewIncomingBundle {
+            origin: cert2.block().header.chain_id,
+            height: cert2.block().header.height,
+        },
+    };
+    let validator = builder
+        .initial_committee
+        .validator_addresses()
+        .next()
+        .unwrap();
+    receiver
+        .process_notification_from(notification, validator)
+        .await;
     receiver.process_inbox().await?;
 
     // The first and last blocks sent something to the receiver. The middle one didn't.


### PR DESCRIPTION
## Motivation

The sanity check was still assuming we would be _executing_ the sender chain.

## Proposal

Check the inboxes instead.

## Test Plan

The client test with sparse sender chains was modified to use the notification logic instead: With the fix, this doesn't print the spurious error anymore.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
