### PR TITLE
Don't save in `ensure_is_active`.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -484,7 +484,6 @@ where
             local_time,
             maybe_committee.flat_map(|(_, committee)| committee.account_keys_and_weights()),
         )?;
-        self.save().await?;
         Ok(())
     }
 

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -27,7 +27,7 @@ use linera_chain::{
 };
 use linera_execution::{ExecutionStateView, Query, QueryOutcome, ServiceRuntimeEndpoint};
 use linera_storage::{Clock as _, ResultReadCertificates, Storage};
-use linera_views::views::ClonableView;
+use linera_views::views::{ClonableView, RootView};
 use tokio::sync::{oneshot, OwnedRwLockReadGuard, RwLock, RwLockWriteGuard};
 use tracing::{instrument, warn};
 
@@ -437,6 +437,8 @@ where
         if !self.knows_chain_is_active {
             let local_time = self.storage.clock().current_time();
             self.chain.ensure_is_active(local_time).await?;
+            self.clear_shared_chain_view().await;
+            self.chain.save().await?;
             self.knows_chain_is_active = true;
         }
         Ok(())


### PR DESCRIPTION
## Motivation

We are currently debugging https://github.com/linera-io/linera-protocol/issues/4299. This could, among other things, be caused by calling `save()` on a chain state view while there are read-only clones of that view being used by other tasks.

## Proposal

Move the `save()` call to the relevant call site, and clear the shared chain views before saving.

## Test Plan

CI should catch regressions.

Unfortunately this change did not fully fix the cache issue, though.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Related to #4299
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
