### PR TITLE
Make faucet claims idempotent.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -640,6 +640,9 @@ Run a GraphQL service that exposes a faucet where users can claim tokens. This g
 * `--listener-delay-after-ms <DELAY_AFTER_MS>` — Wait after processing any notification (useful for rate limiting)
 
   Default value: `0`
+* `--storage-path <STORAGE_PATH>` — Path to the persistent storage file for faucet mappings
+
+  Default value: `faucet_storage.json`
 
 
 

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -730,6 +730,10 @@ pub enum ClientCommand {
         /// Configuration for the faucet chain listener.
         #[command(flatten)]
         config: ChainListenerConfig,
+
+        /// Path to the persistent storage file for faucet mappings.
+        #[arg(long, default_value = "faucet_storage.json")]
+        storage_path: PathBuf,
     },
 
     /// Publish module.

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -951,6 +951,7 @@ impl Runnable for Job {
                 amount,
                 limit_rate_until,
                 config,
+                storage_path,
             } => {
                 let context = ClientContext::new(
                     storage.clone(),
@@ -978,6 +979,7 @@ impl Runnable for Job {
                     end_timestamp,
                     genesis_config,
                     chain_listener_config: config,
+                    storage_path,
                 };
                 let faucet = FaucetService::new(config, context, storage).await?;
                 let cancellation_token = CancellationToken::new();


### PR DESCRIPTION
## Motivation

In the future we plan to add a map of default user chains to the system itself (https://github.com/linera-io/linera-protocol/issues/4154), but this will involve deeper changes.

## Proposal

For now, make the faucet remember which chains it has created so far. If the same user (i.e. same public key) requests a chain twice, it now returns the same chain ID again.

Written mostly by Claude.

## Test Plan

`test_faucet_persistence` was added.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Quick temporary solution for https://github.com/linera-io/linera-protocol/issues/4154.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
