### PR TITLE
`linera-core`: make sure to use Web-compatible time primitives

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -8,7 +8,6 @@ use std::{
     iter,
     ops::{Deref, DerefMut},
     sync::{Arc, RwLock},
-    time::{Duration, Instant},
 };
 
 use chain_client_state::ChainClientState;
@@ -36,6 +35,7 @@ use linera_base::{
         ModuleId, StreamId,
     },
     ownership::{ChainOwnership, TimeoutConfig},
+    time::{Duration, Instant},
 };
 #[cfg(not(target_arch = "wasm32"))]
 use linera_base::{data_types::Bytecode, vm::VmRuntime};


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/4265 moved some uses of `std::time` primitives out of benchmarking-specific code and into the main codepath of `linera-core`.  Unfortunately, `std::time` primitives panic on Wasm, so we must always remember to use `linera_base::time` for anything that may be compiled for the Web (or, as a rule of thumb, anywhere in the codebase: I don't think there's any harm to it).

## Proposal

Make sure to use the Web-compatible time shim in `linera-base`.

## Test Plan

Test in Web demos.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

Thankfully we haven't released a devnet with this bug yet.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
