### PR TITLE
Display more details.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -181,7 +181,7 @@ jobs:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
 
     steps:
     - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5412,6 +5412,7 @@ dependencies = [
  "linera-base",
  "linera-chain",
  "linera-core",
+ "linera-execution",
  "linera-service-graphql-client",
  "linera-version",
  "linera-views",

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -945,6 +945,17 @@ pub enum MessageKind {
     Bouncing,
 }
 
+impl Display for MessageKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MessageKind::Simple => write!(f, "Simple"),
+            MessageKind::Protected => write!(f, "Protected"),
+            MessageKind::Tracked => write!(f, "Tracked"),
+            MessageKind::Bouncing => write!(f, "Bouncing"),
+        }
+    }
+}
+
 /// A posted message together with routing information.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
 pub struct OutgoingMessage {

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -8,6 +8,7 @@ mod tests;
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
+    fmt::{Display, Formatter},
     mem,
 };
 
@@ -269,11 +270,11 @@ impl Recipient {
     }
 }
 
-impl ToString for Recipient {
-    fn to_string(&self) -> String {
+impl Display for Recipient {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            Recipient::Burn => "burn".to_string(),
-            Recipient::Account(account) => account.to_string(),
+            Recipient::Burn => write!(f, "burn"),
+            Recipient::Account(account) => write!(f, "{}", account),
         }
     }
 }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -269,6 +269,15 @@ impl Recipient {
     }
 }
 
+impl ToString for Recipient {
+    fn to_string(&self) -> String {
+        match self {
+            Recipient::Burn => "burn".to_string(),
+            Recipient::Account(account) => account.to_string(),
+        }
+    }
+}
+
 impl From<ChainId> for Recipient {
     fn from(chain_id: ChainId) -> Self {
         Recipient::chain(chain_id)

--- a/linera-explorer-new/server/database.js
+++ b/linera-explorer-new/server/database.js
@@ -123,7 +123,7 @@ export class BlockchainDatabase {
   // Get messages for a block
   getMessages(blockHash) {
     const stmt = this.db.prepare(`
-      SELECT * FROM outgoing_messages 
+      SELECT *, system_target, system_amount, system_source, system_owner, system_recipient FROM outgoing_messages 
       WHERE block_hash = ? 
       ORDER BY transaction_index ASC, message_index ASC
     `);

--- a/linera-explorer-new/server/database.js
+++ b/linera-explorer-new/server/database.js
@@ -104,6 +104,71 @@ export class BlockchainDatabase {
     return result.count;
   }
 
+  // Get operations for a block
+  getOperations(blockHash) {
+    const stmt = this.db.prepare(`
+      SELECT * FROM operations 
+      WHERE block_hash = ? 
+      ORDER BY operation_index ASC
+    `);
+    const operations = stmt.all(blockHash);
+    
+    // Convert binary data to base64 for JSON transport
+    return operations.map(op => ({
+      ...op,
+      data: op.data ? Buffer.from(op.data).toString('base64') : null
+    }));
+  }
+
+  // Get messages for a block
+  getMessages(blockHash) {
+    const stmt = this.db.prepare(`
+      SELECT * FROM outgoing_messages 
+      WHERE block_hash = ? 
+      ORDER BY transaction_index ASC, message_index ASC
+    `);
+    const messages = stmt.all(blockHash);
+    
+    // Convert binary data to base64 for JSON transport
+    return messages.map(msg => ({
+      ...msg,
+      data: msg.data ? Buffer.from(msg.data).toString('base64') : null
+    }));
+  }
+
+  // Get events for a block
+  getEvents(blockHash) {
+    const stmt = this.db.prepare(`
+      SELECT * FROM events 
+      WHERE block_hash = ? 
+      ORDER BY transaction_index ASC, event_index ASC
+    `);
+    const events = stmt.all(blockHash);
+    
+    // Convert binary data to base64 for JSON transport
+    return events.map(event => ({
+      ...event,
+      data: event.data ? Buffer.from(event.data).toString('base64') : null
+    }));
+  }
+
+  // Get oracle responses for a block
+  getOracleResponses(blockHash) {
+    const stmt = this.db.prepare(`
+      SELECT * FROM oracle_responses 
+      WHERE block_hash = ? 
+      ORDER BY transaction_index ASC, response_index ASC
+    `);
+    const responses = stmt.all(blockHash);
+    
+    // Convert binary data to base64 for JSON transport
+    return responses.map(resp => ({
+      ...resp,
+      data: resp.data ? Buffer.from(resp.data).toString('base64') : null
+    }));
+  }
+
+
   close() {
     this.db.close();
   }

--- a/linera-explorer-new/server/index.js
+++ b/linera-explorer-new/server/index.js
@@ -156,6 +156,51 @@ app.get('/api/stats', (req, res) => {
   }
 });
 
+// Get operations for a block
+app.get('/api/blocks/:hash/operations', (req, res) => {
+  try {
+    const { hash } = req.params;
+    const operations = db.getOperations(hash);
+    res.json(operations);
+  } catch (error) {
+    handleError(res, error, 'Failed to fetch operations');
+  }
+});
+
+// Get messages for a block
+app.get('/api/blocks/:hash/messages', (req, res) => {
+  try {
+    const { hash } = req.params;
+    const messages = db.getMessages(hash);
+    res.json(messages);
+  } catch (error) {
+    handleError(res, error, 'Failed to fetch messages');
+  }
+});
+
+// Get events for a block
+app.get('/api/blocks/:hash/events', (req, res) => {
+  try {
+    const { hash } = req.params;
+    const events = db.getEvents(hash);
+    res.json(events);
+  } catch (error) {
+    handleError(res, error, 'Failed to fetch events');
+  }
+});
+
+// Get oracle responses for a block
+app.get('/api/blocks/:hash/oracle-responses', (req, res) => {
+  try {
+    const { hash } = req.params;
+    const oracleResponses = db.getOracleResponses(hash);
+    res.json(oracleResponses);
+  } catch (error) {
+    handleError(res, error, 'Failed to fetch oracle responses');
+  }
+});
+
+
 // Health check
 app.get('/api/health', (req, res) => {
   res.json({ status: 'OK', timestamp: new Date().toISOString() });

--- a/linera-explorer-new/server/index.js
+++ b/linera-explorer-new/server/index.js
@@ -75,6 +75,30 @@ app.get('/api/blocks/:hash/bundles', (req, res) => {
   }
 });
 
+// Get bundles with messages - optimized single query
+app.get('/api/blocks/:hash/bundles-with-messages', (req, res) => {
+  try {
+    const { hash } = req.params;
+    const bundlesWithMessages = db.getBlockWithBundlesAndMessages(hash);
+    
+    // Convert binary data to base64 for JSON transport
+    bundlesWithMessages.forEach(bundle => {
+      bundle.messages.forEach(message => {
+        if (message.authenticated_signer) {
+          message.authenticated_signer = Buffer.from(message.authenticated_signer).toString('base64');
+        }
+        if (message.refund_grant_to) {
+          message.refund_grant_to = Buffer.from(message.refund_grant_to).toString('base64');
+        }
+      });
+    });
+    
+    res.json(bundlesWithMessages);
+  } catch (error) {
+    handleError(res, error, 'Failed to fetch bundles with messages');
+  }
+});
+
 // Get posted messages for a bundle
 app.get('/api/bundles/:id/messages', (req, res) => {
   try {

--- a/linera-explorer-new/src/components/BinaryDataSection.tsx
+++ b/linera-explorer-new/src/components/BinaryDataSection.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+
+interface BinaryDataSectionProps {
+  data: Uint8Array;
+  title: string;
+  maxDisplayBytes?: number;
+  className?: string;
+}
+
+export const BinaryDataSection: React.FC<BinaryDataSectionProps> = ({
+  data,
+  title,
+  maxDisplayBytes = 400,
+  className = ''
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  const formatBytes = (bytes: number) => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
+
+  const copyToClipboard = async () => {
+    try {
+      const hexString = Array.from(data).map(byte => byte.toString(16).padStart(2, '0')).join('');
+      await navigator.clipboard.writeText(hexString);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy binary data: ', err);
+    }
+  };
+
+  const displayData = data.slice(0, maxDisplayBytes);
+  const hexString = Array.from(displayData)
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join(' ')
+    .replace(/(.{48})/g, '$1\n'); // Add line breaks every 48 characters (16 bytes)
+
+  return (
+    <div className={`mt-3 pt-3 border-t border-linera-border/30 ${className}`}>
+      <span className="text-sm text-linera-gray-light block mb-2">{title}</span>
+      <div className="bg-linera-darker/50 rounded-lg border border-linera-border/50 p-4 font-mono text-xs overflow-x-auto">
+        <div className="text-linera-gray-light mb-4 flex items-center justify-between">
+          <div>
+            <span>Size: {formatBytes(data.length)}</span>
+            <span className="mx-2">•</span>
+            <span>Type: Binary Data</span>
+          </div>
+          <button
+            onClick={copyToClipboard}
+            className="text-linera-gray-medium hover:text-linera-red transition-colors"
+            title={copied ? 'Copied!' : 'Copy to clipboard'}
+          >
+            {copied ? (
+              <Check className="w-4 h-4 text-green-400" />
+            ) : (
+              <Copy className="w-4 h-4" />
+            )}
+          </button>
+        </div>
+        <div className="text-linera-gray-light leading-relaxed max-h-32 overflow-y-auto">
+          {hexString}
+          {data.length > maxDisplayBytes && (
+            <div className="text-linera-gray-medium mt-4">
+              ... and {data.length - maxDisplayBytes} more bytes
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/linera-explorer-new/src/components/BlockDetail.tsx
+++ b/linera-explorer-new/src/components/BlockDetail.tsx
@@ -502,7 +502,7 @@ export const BlockDetail: React.FC = () => {
                           )}
                           
                           {/* Grant Amount */}
-                          {msg.grant_amount > 0 && (
+                          {msg.grant_amount != '0' && (
                             <div className="mt-2 flex items-center justify-between">
                               <span className="text-linera-gray-light">Grant:</span>
                               <span className="text-white font-mono">{msg.grant_amount}</span>

--- a/linera-explorer-new/src/components/BlockDetail.tsx
+++ b/linera-explorer-new/src/components/BlockDetail.tsx
@@ -233,6 +233,36 @@ export const BlockDetail: React.FC = () => {
                           <span className="text-white font-mono text-xs">{message.system_message_type}</span>
                         </div>
                       )}
+                      {message.system_amount !== undefined && message.system_amount !== null && (
+                        <div className="flex items-center justify-between">
+                          <span className="text-sm text-linera-gray-light">Amount</span>
+                          <span className="text-white font-mono text-xs">{message.system_amount}</span>
+                        </div>
+                      )}
+                      {message.system_target && (
+                        <div className="space-y-1">
+                          <span className="text-sm text-linera-gray-light">Target</span>
+                          <CopyableHash value={message.system_target} format="short" className="text-xs" />
+                        </div>
+                      )}
+                      {message.system_source && (
+                        <div className="space-y-1">
+                          <span className="text-sm text-linera-gray-light">Source</span>
+                          <CopyableHash value={message.system_source} format="short" className="text-xs" />
+                        </div>
+                      )}
+                      {message.system_owner && (
+                        <div className="space-y-1">
+                          <span className="text-sm text-linera-gray-light">Owner</span>
+                          <CopyableHash value={message.system_owner} format="short" className="text-xs" />
+                        </div>
+                      )}
+                      {message.system_recipient && (
+                        <div className="space-y-1">
+                          <span className="text-sm text-linera-gray-light">Recipient</span>
+                          <CopyableHash value={message.system_recipient} format="short" className="text-xs" />
+                        </div>
+                      )}
                       {message.application_id && (
                         <div className="space-y-1">
                           <span className="text-sm text-linera-gray-light">Application</span>

--- a/linera-explorer-new/src/components/BlockDetail.tsx
+++ b/linera-explorer-new/src/components/BlockDetail.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Hash, Clock, Layers, HardDrive, Package, MessageSquare, Copy
 import { useBlock } from '../hooks/useDatabase';
 import { ExpandableSection } from './ExpandableSection';
 import { CopyableHash } from './CopyableHash';
+import { BinaryDataSection } from './BinaryDataSection';
 
 export const BlockDetail: React.FC = () => {
   const { hash } = useParams<{ hash: string }>();
@@ -184,13 +185,11 @@ export const BlockDetail: React.FC = () => {
                     </div>
                   </div>
                   {operation.data && (
-                    <div className="mt-3 pt-3 border-t border-linera-border/30">
-                      <span className="text-sm text-linera-gray-light block mb-2">Operation Data</span>
-                      <div className="font-mono text-xs bg-linera-darker/80 px-3 py-2 rounded border border-linera-border/50 text-linera-gray-light max-h-32 overflow-y-auto">
-                        {Array.from(operation.data.slice(0, 100)).map(byte => byte.toString(16).padStart(2, '0')).join(' ')}
-                        {operation.data.length > 100 && '...'}
-                      </div>
-                    </div>
+                    <BinaryDataSection 
+                      data={operation.data} 
+                      title="Operation Data"
+                      maxDisplayBytes={100}
+                    />
                   )}
                 </div>
               ))}
@@ -247,13 +246,11 @@ export const BlockDetail: React.FC = () => {
                     </div>
                   </div>
                   {message.data && (
-                    <div className="mt-3 pt-3 border-t border-linera-border/30">
-                      <span className="text-sm text-linera-gray-light block mb-2">Message Data</span>
-                      <div className="font-mono text-xs bg-linera-darker/80 px-3 py-2 rounded border border-linera-border/50 text-linera-gray-light max-h-32 overflow-y-auto">
-                        {Array.from(message.data.slice(0, 100)).map(byte => byte.toString(16).padStart(2, '0')).join(' ')}
-                        {message.data.length > 100 && '...'}
-                      </div>
-                    </div>
+                    <BinaryDataSection 
+                      data={message.data} 
+                      title="Message Data"
+                      maxDisplayBytes={100}
+                    />
                   )}
                 </div>
               ))}
@@ -291,13 +288,11 @@ export const BlockDetail: React.FC = () => {
                       </div>
                     </div>
                   </div>
-                  <div className="mt-3 pt-3 border-t border-linera-border/30">
-                    <span className="text-sm text-linera-gray-light block mb-2">Event Data</span>
-                    <div className="font-mono text-xs bg-linera-darker/80 px-3 py-2 rounded border border-linera-border/50 text-linera-gray-light max-h-32 overflow-y-auto">
-                      {Array.from(event.data.slice(0, 100)).map(byte => byte.toString(16).padStart(2, '0')).join(' ')}
-                      {event.data.length > 100 && '...'}
-                    </div>
-                  </div>
+                  <BinaryDataSection 
+                    data={event.data} 
+                    title="Event Data"
+                    maxDisplayBytes={100}
+                  />
                 </div>
               ))}
             </div>
@@ -331,13 +326,11 @@ export const BlockDetail: React.FC = () => {
                     </div>
                   </div>
                   {response.data && (
-                    <div className="mt-3 pt-3 border-t border-linera-border/30">
-                      <span className="text-sm text-linera-gray-light block mb-2">Response Data</span>
-                      <div className="font-mono text-xs bg-linera-darker/80 px-3 py-2 rounded border border-linera-border/50 text-linera-gray-light max-h-32 overflow-y-auto">
-                        {Array.from(response.data.slice(0, 100)).map(byte => byte.toString(16).padStart(2, '0')).join(' ')}
-                        {response.data.length > 100 && '...'}
-                      </div>
-                    </div>
+                    <BinaryDataSection 
+                      data={response.data} 
+                      title="Response Data"
+                      maxDisplayBytes={100}
+                    />
                   )}
                   {response.blob_hash && (
                     <div className="mt-3 pt-3 border-t border-linera-border/30">
@@ -445,32 +438,12 @@ export const BlockDetail: React.FC = () => {
             </div>
           </div>
           
-          <div className="bg-linera-darker/50 rounded-lg border border-linera-border/50 p-6 font-mono text-sm overflow-x-auto">
-            <div className="text-linera-gray-light mb-4 flex items-center justify-between">
-              <div>
-                <span>Size: {formatBytes(block.data.length)}</span>
-                <span className="mx-2">•</span>
-                <span>Type: Binary Data</span>
-              </div>
-              <button
-                onClick={() => copyToClipboard(Array.from(block.data).map(byte => byte.toString(16).padStart(2, '0')).join(''))}
-                className="text-linera-gray-medium hover:text-linera-red transition-colors"
-              >
-                <Copy className="w-4 h-4" />
-              </button>
-            </div>
-            <div className="text-linera-gray-light leading-relaxed">
-              {Array.from(block.data.slice(0, 400))
-                .map(byte => byte.toString(16).padStart(2, '0'))
-                .join(' ')
-                .replace(/(.{48})/g, '$1\n')}
-              {block.data.length > 400 && (
-                <div className="text-linera-gray-medium mt-4">
-                  ... and {block.data.length - 400} more bytes
-                </div>
-              )}
-            </div>
-          </div>
+          <BinaryDataSection 
+            data={block.data} 
+            title="Block Data"
+            maxDisplayBytes={400}
+            className="mt-0 pt-0 border-t-0"
+          />
         </div>
       )}
     </div>

--- a/linera-explorer-new/src/components/CopyableHash.tsx
+++ b/linera-explorer-new/src/components/CopyableHash.tsx
@@ -23,7 +23,8 @@ export const CopyableHash: React.FC<CopyableHashProps> = ({
     return hash;
   };
 
-  const copyToClipboard = async (text: string) => {
+  const copyToClipboard = async (text: string, event?: React.MouseEvent) => {
+    event?.stopPropagation();
     try {
       await navigator.clipboard.writeText(text);
       setCopied(true);
@@ -36,12 +37,12 @@ export const CopyableHash: React.FC<CopyableHashProps> = ({
   return (
     <div className={`relative group ${className}`}>
       <div className={`font-mono text-sm bg-linera-darker/80 px-3 py-2 rounded border border-linera-border/50 text-linera-gray-light group-hover:text-white transition-colors cursor-pointer ${showCopyIcon ? 'pr-12' : ''}`}
-           onClick={() => copyToClipboard(value)}>
+           onClick={(e) => copyToClipboard(value, e)}>
         {formatHash(value)}
       </div>
       {showCopyIcon && (
         <button
-          onClick={() => copyToClipboard(value)}
+          onClick={(e) => copyToClipboard(value, e)}
           className="absolute right-3 top-1/2 transform -translate-y-1/2 text-linera-gray-medium hover:text-linera-red transition-colors"
           title={copied ? 'Copied!' : 'Copy to clipboard'}
         >

--- a/linera-explorer-new/src/components/CopyableHash.tsx
+++ b/linera-explorer-new/src/components/CopyableHash.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+
+interface CopyableHashProps {
+  value: string;
+  format?: 'short' | 'full';
+  className?: string;
+  showCopyIcon?: boolean;
+}
+
+export const CopyableHash: React.FC<CopyableHashProps> = ({
+  value,
+  format = 'short',
+  className = '',
+  showCopyIcon = true
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  const formatHash = (hash: string) => {
+    if (format === 'short') {
+      return `${hash.slice(0, 12)}...${hash.slice(-12)}`;
+    }
+    return hash;
+  };
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  return (
+    <div className={`relative group ${className}`}>
+      <div className={`font-mono text-sm bg-linera-darker/80 px-3 py-2 rounded border border-linera-border/50 text-linera-gray-light group-hover:text-white transition-colors cursor-pointer ${showCopyIcon ? 'pr-12' : ''}`}
+           onClick={() => copyToClipboard(value)}>
+        {formatHash(value)}
+      </div>
+      {showCopyIcon && (
+        <button
+          onClick={() => copyToClipboard(value)}
+          className="absolute right-3 top-1/2 transform -translate-y-1/2 text-linera-gray-medium hover:text-linera-red transition-colors"
+          title={copied ? 'Copied!' : 'Copy to clipboard'}
+        >
+          {copied ? (
+            <Check className="w-4 h-4 text-green-400" />
+          ) : (
+            <Copy className="w-4 h-4" />
+          )}
+        </button>
+      )}
+    </div>
+  );
+};

--- a/linera-explorer-new/src/components/ExpandableSection.tsx
+++ b/linera-explorer-new/src/components/ExpandableSection.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+
+interface ExpandableSectionProps {
+  title: string;
+  count: number;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+  defaultExpanded?: boolean;
+  emptyMessage?: string;
+}
+
+export const ExpandableSection: React.FC<ExpandableSectionProps> = ({
+  title,
+  count,
+  icon,
+  children,
+  defaultExpanded = false,
+  emptyMessage = 'No data found'
+}) => {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  if (count === 0) {
+    return null;
+  }
+
+  return (
+    <div className="card">
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full flex items-center justify-between p-0 bg-transparent border-none cursor-pointer group"
+      >
+        <div className="flex items-center space-x-3">
+          <div className="p-2 bg-linera-red/20 rounded-lg border border-linera-red/30 group-hover:bg-linera-red/30 transition-colors">
+            {icon}
+          </div>
+          <div className="text-left">
+            <h2 className="text-xl font-epilogue font-semibold text-white group-hover:text-linera-red transition-colors">
+              {title}
+            </h2>
+            <p className="text-sm text-linera-gray-light">
+              {count} item{count !== 1 ? 's' : ''} found
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center space-x-2 text-linera-gray-medium group-hover:text-linera-red transition-colors">
+          <span className="text-sm">{isExpanded ? 'Hide' : 'Show'} Details</span>
+          {isExpanded ? (
+            <ChevronDown className="w-5 h-5" />
+          ) : (
+            <ChevronRight className="w-5 h-5" />
+          )}
+        </div>
+      </button>
+
+      {isExpanded && (
+        <div className="mt-6 border-t border-linera-border/30 pt-6 animate-slide-up">
+          {count > 0 ? children : (
+            <p className="text-linera-gray-light text-center py-8">{emptyMessage}</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/linera-explorer-new/src/hooks/useDatabase.ts
+++ b/linera-explorer-new/src/hooks/useDatabase.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { BlockchainAPI } from '../utils/database';
-import { BlockInfo, Block, IncomingBundle, ChainInfo, Operation, Message, Event, OracleResponse } from '../types/blockchain';
+import { BlockInfo, Block, IncomingBundleWithMessages, ChainInfo, Operation, Message, Event, OracleResponse } from '../types/blockchain';
 
 const api = new BlockchainAPI();
 
@@ -128,7 +128,7 @@ export const useBlocks = (limit: number = 50, refreshInterval: number = 5000) =>
 
 export const useBlock = (hash: string) => {
   const [block, setBlock] = useState<Block | null>(null);
-  const [bundles, setBundles] = useState<IncomingBundle[]>([]);
+  const [bundles, setBundles] = useState<IncomingBundleWithMessages[]>([]);
   const [operations, setOperations] = useState<Operation[]>([]);
   const [messages, setMessages] = useState<Message[]>([]);
   const [events, setEvents] = useState<Event[]>([]);
@@ -158,7 +158,7 @@ export const useBlock = (hash: string) => {
           oracleResponsesResult
         ] = await Promise.all([
           api.getBlockByHash(hash),
-          api.getIncomingBundles(hash),
+          api.getBundlesWithMessages(hash), // Use optimized query
           api.getOperations(hash),
           api.getMessages(hash),
           api.getEvents(hash),

--- a/linera-explorer-new/src/types/blockchain.ts
+++ b/linera-explorer-new/src/types/blockchain.ts
@@ -54,3 +54,54 @@ export interface ChainInfo {
   latest_height: number;
   latest_block_hash: string;
 }
+
+// Denormalized data structures
+export interface Operation {
+  id: number;
+  block_hash: string;
+  operation_index: number;
+  operation_type: 'System' | 'User';
+  application_id?: string;
+  system_operation_type?: string;
+  authenticated_signer?: string;
+  data: Uint8Array;
+  created_at: string;
+}
+
+export interface Message {
+  id: number;
+  block_hash: string;
+  transaction_index: number;
+  message_index: number;
+  destination_chain_id: string;
+  authenticated_signer?: string;
+  grant_amount: number;
+  message_kind: string; // 'Simple', 'Tracked', 'Bouncing', 'Protected'
+  message_type: 'System' | 'User';
+  application_id?: string;
+  system_message_type?: string;
+  data: Uint8Array;
+  created_at: string;
+}
+
+export interface Event {
+  id: number;
+  block_hash: string;
+  transaction_index: number;
+  event_index: number;
+  stream_id: string;
+  stream_index: number;
+  data: Uint8Array;
+  created_at: string;
+}
+
+export interface OracleResponse {
+  id: number;
+  block_hash: string;
+  transaction_index: number;
+  response_index: number;
+  response_type: string;
+  blob_hash?: string;
+  data?: Uint8Array;
+  created_at: string;
+}

--- a/linera-explorer-new/src/types/blockchain.ts
+++ b/linera-explorer-new/src/types/blockchain.ts
@@ -41,14 +41,14 @@ export interface PostedMessage {
   bundle_id: number;
   message_index: number;
   authenticated_signer: Uint8Array | null;
-  grant_amount: number;
+  grant_amount: string;
   refund_grant_to: Uint8Array | null;
   message_kind: string;
   message_type?: 'System' | 'User';
   application_id?: string;
   system_message_type?: string;
   system_target?: string;
-  system_amount?: number;
+  system_amount?: string;
   system_source?: string;
   system_owner?: string;
   system_recipient?: string;
@@ -87,13 +87,13 @@ export interface Message {
   message_index: number;
   destination_chain_id: string;
   authenticated_signer?: string;
-  grant_amount: number;
+  grant_amount: string;
   message_kind: string; // 'Simple', 'Tracked', 'Bouncing', 'Protected'
   message_type: 'System' | 'User';
   application_id?: string;
   system_message_type?: string;
   system_target?: string;
-  system_amount?: number;
+  system_amount?: string;
   system_source?: string;
   system_owner?: string;
   system_recipient?: string;

--- a/linera-explorer-new/src/types/blockchain.ts
+++ b/linera-explorer-new/src/types/blockchain.ts
@@ -44,8 +44,20 @@ export interface PostedMessage {
   grant_amount: number;
   refund_grant_to: Uint8Array | null;
   message_kind: string;
+  message_type?: 'System' | 'User';
+  application_id?: string;
+  system_message_type?: string;
+  system_target?: string;
+  system_amount?: number;
+  system_source?: string;
+  system_owner?: string;
+  system_recipient?: string;
   message_data: Uint8Array;
   created_at: string;
+}
+
+export interface IncomingBundleWithMessages extends IncomingBundle {
+  messages: PostedMessage[];
 }
 
 export interface ChainInfo {

--- a/linera-explorer-new/src/types/blockchain.ts
+++ b/linera-explorer-new/src/types/blockchain.ts
@@ -80,6 +80,11 @@ export interface Message {
   message_type: 'System' | 'User';
   application_id?: string;
   system_message_type?: string;
+  system_target?: string;
+  system_amount?: number;
+  system_source?: string;
+  system_owner?: string;
+  system_recipient?: string;
   data: Uint8Array;
   created_at: string;
 }

--- a/linera-explorer-new/src/utils/database.ts
+++ b/linera-explorer-new/src/utils/database.ts
@@ -1,4 +1,4 @@
-import { Block, BlockInfo, IncomingBundle, PostedMessage, ChainInfo } from '../types/blockchain';
+import { Block, BlockInfo, IncomingBundle, PostedMessage, ChainInfo, Operation, Message, Event, OracleResponse } from '../types/blockchain';
 
 const API_BASE_URL = 'http://localhost:3002/api';
 
@@ -120,4 +120,75 @@ export class BlockchainAPI {
     const stats = await response.json();
     return stats.totalBlocks;
   }
+
+  // Get operations for a block
+  async getOperations(blockHash: string): Promise<Operation[]> {
+    const response = await fetch(`${API_BASE_URL}/blocks/${blockHash}/operations`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch operations: ${response.statusText}`);
+    }
+    const operations = await response.json();
+    
+    // Convert binary data from base64
+    return operations.map((op: any) => ({
+      ...op,
+      data: op.data ? this.base64ToUint8Array(op.data) : new Uint8Array()
+    }));
+  }
+
+  // Get messages for a block
+  async getMessages(blockHash: string): Promise<Message[]> {
+    const response = await fetch(`${API_BASE_URL}/blocks/${blockHash}/messages`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch messages: ${response.statusText}`);
+    }
+    const messages = await response.json();
+    
+    // Convert binary data from base64
+    return messages.map((msg: any) => ({
+      ...msg,
+      data: msg.data ? this.base64ToUint8Array(msg.data) : new Uint8Array()
+    }));
+  }
+
+  // Get events for a block
+  async getEvents(blockHash: string): Promise<Event[]> {
+    const response = await fetch(`${API_BASE_URL}/blocks/${blockHash}/events`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch events: ${response.statusText}`);
+    }
+    const events = await response.json();
+    
+    // Convert binary data from base64
+    return events.map((event: any) => ({
+      ...event,
+      data: event.data ? this.base64ToUint8Array(event.data) : new Uint8Array()
+    }));
+  }
+
+  // Get oracle responses for a block
+  async getOracleResponses(blockHash: string): Promise<OracleResponse[]> {
+    const response = await fetch(`${API_BASE_URL}/blocks/${blockHash}/oracle-responses`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch oracle responses: ${response.statusText}`);
+    }
+    const responses = await response.json();
+    
+    // Convert binary data from base64
+    return responses.map((resp: any) => ({
+      ...resp,
+      data: resp.data ? this.base64ToUint8Array(resp.data) : undefined
+    }));
+  }
+
+  // Helper method to convert base64 to Uint8Array
+  private base64ToUint8Array(base64: string): Uint8Array {
+    const binaryString = atob(base64);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+    return bytes;
+  }
+
 }

--- a/linera-indexer/lib/Cargo.toml
+++ b/linera-indexer/lib/Cargo.toml
@@ -33,8 +33,8 @@ graphql-ws-client = { version = "0.5", features = ["client-graphql-client"] }
 graphql_client = { version = "0.13", features = ["reqwest-rustls"] }
 linera-base = { workspace = true, features = ["test"] }
 linera-chain.workspace = true
-linera-execution.workspace = true
 linera-core.workspace = true
+linera-execution.workspace = true
 linera-service-graphql-client.workspace = true
 linera-version.workspace = true
 linera-views.workspace = true

--- a/linera-indexer/lib/Cargo.toml
+++ b/linera-indexer/lib/Cargo.toml
@@ -33,6 +33,7 @@ graphql-ws-client = { version = "0.5", features = ["client-graphql-client"] }
 graphql_client = { version = "0.13", features = ["reqwest-rustls"] }
 linera-base = { workspace = true, features = ["test"] }
 linera-chain.workspace = true
+linera-execution.workspace = true
 linera-core.workspace = true
 linera-service-graphql-client.workspace = true
 linera-version.workspace = true

--- a/linera-indexer/lib/src/db/mod.rs
+++ b/linera-indexer/lib/src/db/mod.rs
@@ -156,7 +156,7 @@ pub struct IncomingBundleInfo {
 pub struct PostedMessageInfo {
     pub message_index: u32,
     pub authenticated_signer_data: Option<String>,
-    pub grant_amount: u64,
+    pub grant_amount: String,
     pub refund_grant_to_data: Option<String>,
     pub message_kind: String,
     pub message_data: Vec<u8>,

--- a/linera-indexer/lib/src/db/sqlite/consts.rs
+++ b/linera-indexer/lib/src/db/sqlite/consts.rs
@@ -73,7 +73,7 @@ CREATE TABLE IF NOT EXISTS outgoing_messages (
     application_id TEXT, -- For user messages
     system_message_type TEXT, -- For system messages (Credit, Withdraw, etc.)
     system_target TEXT, -- Credit target
-    system_amount INTEGER, -- Credit/Withdraw amount
+    system_amount TEXT, -- Credit/Withdraw amount
     system_source TEXT, -- Credit source
     system_owner TEXT, -- Withdraw owner
     system_recipient TEXT, -- Withdraw recipient
@@ -181,7 +181,7 @@ CREATE TABLE IF NOT EXISTS posted_messages (
     application_id TEXT, -- For user messages
     system_message_type TEXT, -- For system messages (Credit, Withdraw, etc.)
     system_target TEXT, -- Credit target
-    system_amount INTEGER, -- Credit/Withdraw amount
+    system_amount TEXT, -- Credit/Withdraw amount
     system_source TEXT, -- Credit source
     system_owner TEXT, -- Withdraw owner
     system_recipient TEXT, -- Withdraw recipient

--- a/linera-indexer/lib/src/db/sqlite/consts.rs
+++ b/linera-indexer/lib/src/db/sqlite/consts.rs
@@ -72,6 +72,11 @@ CREATE TABLE IF NOT EXISTS outgoing_messages (
     message_type TEXT NOT NULL, -- 'System' or 'User'
     application_id TEXT, -- For user messages
     system_message_type TEXT, -- For system messages (Credit, Withdraw, etc.)
+    system_target TEXT, -- Credit target
+    system_amount INTEGER, -- Credit/Withdraw amount
+    system_source TEXT, -- Credit source
+    system_owner TEXT, -- Withdraw owner
+    system_recipient TEXT, -- Withdraw recipient
     data BLOB NOT NULL, -- Serialized message content
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (block_hash) REFERENCES blocks(hash),
@@ -82,6 +87,7 @@ CREATE INDEX IF NOT EXISTS idx_outgoing_messages_block_hash ON outgoing_messages
 CREATE INDEX IF NOT EXISTS idx_outgoing_messages_destination ON outgoing_messages(destination_chain_id);
 CREATE INDEX IF NOT EXISTS idx_outgoing_messages_type ON outgoing_messages(message_type);
 CREATE INDEX IF NOT EXISTS idx_outgoing_messages_application_id ON outgoing_messages(application_id);
+CREATE INDEX IF NOT EXISTS idx_outgoing_messages_system_type ON outgoing_messages(system_message_type);
 "#;
 
 /// SQL schema for creating the events table
@@ -171,6 +177,14 @@ CREATE TABLE IF NOT EXISTS posted_messages (
     grant_amount INTEGER NOT NULL,
     refund_grant_to TEXT,
     message_kind TEXT NOT NULL,
+    message_type TEXT NOT NULL, -- 'System' or 'User'
+    application_id TEXT, -- For user messages
+    system_message_type TEXT, -- For system messages (Credit, Withdraw, etc.)
+    system_target TEXT, -- Credit target
+    system_amount INTEGER, -- Credit/Withdraw amount
+    system_source TEXT, -- Credit source
+    system_owner TEXT, -- Withdraw owner
+    system_recipient TEXT, -- Withdraw recipient
     message_data BLOB NOT NULL,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (bundle_id) REFERENCES incoming_bundles(id)
@@ -178,4 +192,6 @@ CREATE TABLE IF NOT EXISTS posted_messages (
 
 CREATE INDEX IF NOT EXISTS idx_posted_messages_bundle_id ON posted_messages(bundle_id);
 CREATE INDEX IF NOT EXISTS idx_posted_messages_kind ON posted_messages(message_kind);
+CREATE INDEX IF NOT EXISTS idx_posted_messages_type ON posted_messages(message_type);
+CREATE INDEX IF NOT EXISTS idx_posted_messages_system_type ON posted_messages(system_message_type);
 "#;

--- a/linera-indexer/lib/src/db/sqlite/consts.rs
+++ b/linera-indexer/lib/src/db/sqlite/consts.rs
@@ -3,29 +3,141 @@
 
 //! SQLite schema definitions and constants.
 
-/// SQL schema for creating the blocks table
+/// SQL schema for creating the blocks table with denormalized fields
 pub const CREATE_BLOCKS_TABLE: &str = r#"
 CREATE TABLE IF NOT EXISTS blocks (
     hash TEXT PRIMARY KEY NOT NULL,
     chain_id TEXT NOT NULL,
     height INTEGER NOT NULL,
     timestamp INTEGER NOT NULL,
+    
+    -- Denormalized fields from BlockHeader
+    epoch INTEGER NOT NULL,
+    state_hash TEXT NOT NULL,
+    previous_block_hash TEXT,
+    authenticated_signer TEXT,
+    
+    -- Aggregated counts for filtering and display
+    operation_count INTEGER NOT NULL DEFAULT 0,
+    incoming_bundle_count INTEGER NOT NULL DEFAULT 0,
+    message_count INTEGER NOT NULL DEFAULT 0,
+    event_count INTEGER NOT NULL DEFAULT 0,
+    blob_count INTEGER NOT NULL DEFAULT 0,
+    
+    -- Original serialized block data for backward compatibility
     data BLOB NOT NULL,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX IF NOT EXISTS idx_blocks_chain_height ON blocks(chain_id, height);
 CREATE INDEX IF NOT EXISTS idx_blocks_chain_id ON blocks(chain_id);
+CREATE INDEX IF NOT EXISTS idx_blocks_epoch ON blocks(epoch);
+CREATE INDEX IF NOT EXISTS idx_blocks_timestamp ON blocks(timestamp);
+CREATE INDEX IF NOT EXISTS idx_blocks_state_hash ON blocks(state_hash);
 "#;
 
-/// SQL schema for creating the blobs table
+/// SQL schema for creating the operations table
+pub const CREATE_OPERATIONS_TABLE: &str = r#"
+CREATE TABLE IF NOT EXISTS operations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    block_hash TEXT NOT NULL,
+    operation_index INTEGER NOT NULL,
+    operation_type TEXT NOT NULL, -- 'System' or 'User'
+    application_id TEXT, -- For user operations
+    system_operation_type TEXT, -- For system operations (Transfer, OpenChain, etc.)
+    authenticated_signer TEXT,
+    data BLOB NOT NULL, -- Serialized operation
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (block_hash) REFERENCES blocks(hash),
+    UNIQUE(block_hash, operation_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_operations_block_hash ON operations(block_hash);
+CREATE INDEX IF NOT EXISTS idx_operations_type ON operations(operation_type);
+CREATE INDEX IF NOT EXISTS idx_operations_application_id ON operations(application_id);
+CREATE INDEX IF NOT EXISTS idx_operations_system_type ON operations(system_operation_type);
+"#;
+
+/// SQL schema for creating the outgoing messages table
+pub const CREATE_OUTGOING_MESSAGES_TABLE: &str = r#"
+CREATE TABLE IF NOT EXISTS outgoing_messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    block_hash TEXT NOT NULL,
+    transaction_index INTEGER NOT NULL,
+    message_index INTEGER NOT NULL,
+    destination_chain_id TEXT NOT NULL,
+    authenticated_signer TEXT,
+    grant_amount INTEGER NOT NULL DEFAULT 0,
+    message_kind TEXT NOT NULL, -- 'Simple', 'Tracked', 'Bouncing', 'Protected'
+    message_type TEXT NOT NULL, -- 'System' or 'User'
+    application_id TEXT, -- For user messages
+    system_message_type TEXT, -- For system messages (Credit, Withdraw, etc.)
+    data BLOB NOT NULL, -- Serialized message content
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (block_hash) REFERENCES blocks(hash),
+    UNIQUE(block_hash, transaction_index, message_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_outgoing_messages_block_hash ON outgoing_messages(block_hash);
+CREATE INDEX IF NOT EXISTS idx_outgoing_messages_destination ON outgoing_messages(destination_chain_id);
+CREATE INDEX IF NOT EXISTS idx_outgoing_messages_type ON outgoing_messages(message_type);
+CREATE INDEX IF NOT EXISTS idx_outgoing_messages_application_id ON outgoing_messages(application_id);
+"#;
+
+/// SQL schema for creating the events table
+pub const CREATE_EVENTS_TABLE: &str = r#"
+CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    block_hash TEXT NOT NULL,
+    transaction_index INTEGER NOT NULL,
+    event_index INTEGER NOT NULL,
+    stream_id TEXT NOT NULL,
+    stream_index INTEGER NOT NULL,
+    data BLOB NOT NULL, -- Event payload
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (block_hash) REFERENCES blocks(hash),
+    UNIQUE(block_hash, transaction_index, event_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_block_hash ON events(block_hash);
+CREATE INDEX IF NOT EXISTS idx_events_stream_id ON events(stream_id);
+"#;
+
+/// SQL schema for creating the oracle responses table
+pub const CREATE_ORACLE_RESPONSES_TABLE: &str = r#"
+CREATE TABLE IF NOT EXISTS oracle_responses (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    block_hash TEXT NOT NULL,
+    transaction_index INTEGER NOT NULL,
+    response_index INTEGER NOT NULL,
+    response_type TEXT NOT NULL, -- 'Service' or 'Blob'
+    blob_hash TEXT, -- For blob responses
+    data BLOB, -- For service responses
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (block_hash) REFERENCES blocks(hash),
+    UNIQUE(block_hash, transaction_index, response_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_oracle_responses_block_hash ON oracle_responses(block_hash);
+CREATE INDEX IF NOT EXISTS idx_oracle_responses_type ON oracle_responses(response_type);
+"#;
+
+/// SQL schema for creating the blobs table with enhanced metadata
 pub const CREATE_BLOBS_TABLE: &str = r#"
 CREATE TABLE IF NOT EXISTS blobs (
     hash TEXT PRIMARY KEY NOT NULL,
-    type TEXT NOT NULL,
+    blob_type TEXT NOT NULL, -- 'Data', 'ContractBytecode', 'ServiceBytecode', etc.
+    application_id TEXT, -- If applicable
+    block_hash TEXT, -- Block that created this blob
+    transaction_index INTEGER, -- Transaction that created this blob
     data BLOB NOT NULL,
-    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (block_hash) REFERENCES blocks(hash)
 );
+
+CREATE INDEX IF NOT EXISTS idx_blobs_type ON blobs(blob_type);
+CREATE INDEX IF NOT EXISTS idx_blobs_block_hash ON blobs(block_hash);
+CREATE INDEX IF NOT EXISTS idx_blobs_application_id ON blobs(application_id);
 "#;
 
 /// SQL schema for creating the incoming_bundles table

--- a/linera-indexer/lib/src/db/sqlite/consts.rs
+++ b/linera-indexer/lib/src/db/sqlite/consts.rs
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS outgoing_messages (
     message_index INTEGER NOT NULL,
     destination_chain_id TEXT NOT NULL,
     authenticated_signer TEXT,
-    grant_amount INTEGER NOT NULL DEFAULT 0,
+    grant_amount TEXT,
     message_kind TEXT NOT NULL, -- 'Simple', 'Tracked', 'Bouncing', 'Protected'
     message_type TEXT NOT NULL, -- 'System' or 'User'
     application_id TEXT, -- For user messages
@@ -174,7 +174,7 @@ CREATE TABLE IF NOT EXISTS posted_messages (
     bundle_id INTEGER NOT NULL,
     message_index INTEGER NOT NULL,
     authenticated_signer TEXT,
-    grant_amount INTEGER NOT NULL,
+    grant_amount TEXT,
     refund_grant_to TEXT,
     message_kind TEXT NOT NULL,
     message_type TEXT NOT NULL, -- 'System' or 'User'

--- a/linera-indexer/lib/src/db/sqlite/mod.rs
+++ b/linera-indexer/lib/src/db/sqlite/mod.rs
@@ -65,25 +65,27 @@ struct MessageClassification {
 impl SqliteDatabase {
     /// Create a new SQLite database connection
     pub async fn new(database_url: &str) -> Result<Self, SqliteError> {
-        match std::fs::exists(database_url) {
-            Ok(true) => {
-                tracing::info!(?database_url, "opening existing SQLite database");
-            }
-            Ok(false) => {
-                tracing::info!(?database_url, "creating new SQLite database");
-                // Create the database file if it doesn't exist
-                std::fs::File::create(database_url).unwrap_or_else(|e| {
+        if !database_url.contains("memory") {
+            match std::fs::exists(database_url) {
+                Ok(true) => {
+                    tracing::info!(?database_url, "opening existing SQLite database");
+                }
+                Ok(false) => {
+                    tracing::info!(?database_url, "creating new SQLite database");
+                    // Create the database file if it doesn't exist
+                    std::fs::File::create(database_url).unwrap_or_else(|e| {
+                        panic!(
+                            "failed to create SQLite database file: {}, error: {}",
+                            database_url, e
+                        )
+                    });
+                }
+                Err(e) => {
                     panic!(
-                        "failed to create SQLite database file: {}, error: {}",
+                        "failed to check SQLite database existence. file: {}, error: {}",
                         database_url, e
                     )
-                });
-            }
-            Err(e) => {
-                panic!(
-                    "failed to check SQLite database existence. file: {}, error: {}",
-                    database_url, e
-                )
+                }
             }
         }
         let pool = SqlitePoolOptions::new()

--- a/linera-indexer/lib/src/db/sqlite/tests.rs
+++ b/linera-indexer/lib/src/db/sqlite/tests.rs
@@ -1,16 +1,18 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use assert_matches::assert_matches;
 use linera_base::{
     crypto::{CryptoHash, TestString},
-    data_types::{Blob, BlockHeight, Epoch, Timestamp},
-    identifiers::ChainId,
+    data_types::{Amount, Blob, BlockHeight, Epoch, Timestamp},
+    hashed::Hashed,
+    identifiers::{ApplicationId, ChainId},
 };
 use linera_chain::{
     block::{Block, BlockBody, BlockHeader},
-    data_types::MessageAction,
+    data_types::{IncomingBundle, MessageAction, PostedMessage},
 };
+use linera_execution::{Message, MessageKind};
+use linera_service_graphql_client::MessageBundle;
 
 use crate::db::{sqlite::SqliteDatabase, IndexerDatabase};
 
@@ -85,7 +87,7 @@ async fn test_high_level_atomic_api() {
     let height = BlockHeight(1);
     let timestamp = Timestamp::now();
     let test_block = create_test_block(chain_id, height);
-    let block_hash = CryptoHash::new(blob1.content());
+    let block_hash = Hashed::new(test_block.clone()).hash();
     let block_data = bincode::serialize(&test_block).unwrap();
 
     let blobs = vec![
@@ -141,93 +143,57 @@ async fn test_incoming_bundles_storage_and_query() {
         "posted_messages table should exist"
     );
 
-    // Test manual insertion to verify the schema works using string parsing
-    let block_hash = CryptoHash::new(&TestString::new("test_block_hash"));
-    let origin_chain = ChainId(CryptoHash::new(&TestString::new("origin_chain_id")));
+    // First insert a test block that the bundle can reference
+    let test_block = create_test_block(
+        ChainId(CryptoHash::new(&TestString::new("test_chain_id"))),
+        BlockHeight(100),
+    );
+    let origin_chain_id = ChainId(CryptoHash::new(&TestString::new("origin_chain")));
+    let block_hash = Hashed::new(test_block.clone()).hash();
+    let block_data = bincode::serialize(&test_block).unwrap();
+
     let source_cert_hash = CryptoHash::new(&TestString::new("source_cert_hash"));
 
     let mut tx = db.begin_transaction().await.unwrap();
 
-    // First insert a test block that the bundle can reference
-    let test_chain_id = ChainId(CryptoHash::new(&TestString::new("test_chain_id")));
-    let test_height = 100_i64;
-    let test_timestamp = Timestamp::now();
-    let test_block_data = b"test_block_data".to_vec();
-
-    // Insert with all required fields for the new schema
-    let test_epoch = 0i64;
-    let test_state_hash = CryptoHash::new(&TestString::new("test_state_hash"));
-    sqlx::query(
-        r#"INSERT INTO blocks 
-        (hash, chain_id, height, timestamp, epoch, state_hash, previous_block_hash, 
-         authenticated_signer, operation_count, incoming_bundle_count, message_count, 
-         event_count, blob_count, data) 
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)"#,
+    db.insert_block_tx(
+        &mut tx,
+        &block_hash,
+        &test_block.header.chain_id,
+        test_block.header.height,
+        test_block.header.timestamp,
+        &block_data,
     )
-    .bind(block_hash.to_string())
-    .bind(test_chain_id.to_string())
-    .bind(test_height)
-    .bind(test_timestamp.micros() as i64)
-    .bind(test_epoch)
-    .bind(test_state_hash.to_string())
-    .bind(None::<String>) // previous_block_hash
-    .bind(None::<String>) // authenticated_signer
-    .bind(0i64) // operation_count
-    .bind(0i64) // incoming_bundle_count
-    .bind(0i64) // message_count
-    .bind(0i64) // event_count
-    .bind(0i64) // blob_count
-    .bind(&test_block_data)
-    .execute(&mut *tx)
     .await
-    .expect("Should be able to insert test block");
+    .unwrap();
 
-    // Insert a test incoming bundle
-    let bundle_result = sqlx::query(
-            r#"
-            INSERT INTO incoming_bundles 
-            (block_hash, bundle_index, origin_chain_id, action, source_height, source_timestamp, source_cert_hash, transaction_index)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-            "#
-        )
-        .bind(block_hash.to_string())
-        .bind(0_i64)
-        .bind(origin_chain.to_string())
-        .bind("Accept")
-        .bind(10_i64)
-        .bind(1234567890_i64)
-        .bind(source_cert_hash.to_string())
-        .bind(2_i64)
-        .execute(&mut *tx)
-        .await;
+    let incoming_bundle_message = PostedMessage {
+        index: 0,
+        authenticated_signer: None,
+        grant: Amount::from_tokens(100),
+        refund_grant_to: None,
+        kind: MessageKind::Protected,
+        message: Message::User {
+            application_id: ApplicationId::new(CryptoHash::new(&TestString::new("test_app_id"))),
+            bytes: b"test_message_data".to_vec(),
+        },
+    };
 
-    let bundle_id = bundle_result
-        .expect("Should be able to insert into incoming_bundles")
-        .last_insert_rowid();
+    let incoming_bundle = IncomingBundle {
+        origin: origin_chain_id,
+        bundle: MessageBundle {
+            height: test_block.header.height,
+            timestamp: Timestamp::now(),
+            certificate_hash: source_cert_hash,
+            transaction_index: 2,
+            messages: vec![incoming_bundle_message.clone()],
+        },
+        action: MessageAction::Reject,
+    };
 
-    // Insert a test posted message
-    let message_result = sqlx::query(
-            r#"
-            INSERT INTO posted_messages 
-            (bundle_id, message_index, authenticated_signer, grant_amount, refund_grant_to, message_kind, message_data)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-            "#
-        )
-        .bind(bundle_id)
-        .bind(0_i64)
-        .bind(None::<Vec<u8>>)
-        .bind(1000_i64)
-        .bind(None::<Vec<u8>>)
-        .bind("Protected")
-        .bind(b"test_message_data".to_vec())
-        .execute(&mut *tx)
-        .await;
-
-    assert_matches!(
-        message_result,
-        Ok(_),
-        "Should be able to insert into posted_messages"
-    );
+    db.store_incoming_bundles_tx(&mut tx, &block_hash, vec![incoming_bundle.clone()])
+        .await
+        .unwrap();
 
     tx.commit().await.unwrap();
 
@@ -240,13 +206,13 @@ async fn test_incoming_bundles_storage_and_query() {
 
     let (queried_bundle_id, bundle_info) = &bundles[0];
     assert_eq!(bundle_info.bundle_index, 0);
-    assert_eq!(bundle_info.origin_chain_id, origin_chain);
-    assert_eq!(bundle_info.action, MessageAction::Accept);
+    assert_eq!(bundle_info.origin_chain_id, origin_chain_id);
+    assert_eq!(bundle_info.action, incoming_bundle.action);
+    assert_eq!(bundle_info.source_height, incoming_bundle.bundle.height);
     assert_eq!(
-        bundle_info.source_height,
-        linera_base::data_types::BlockHeight(10)
+        bundle_info.transaction_index,
+        incoming_bundle.bundle.transaction_index
     );
-    assert_eq!(bundle_info.transaction_index, 2);
 
     let messages = db
         .get_posted_messages_for_bundle(*queried_bundle_id)
@@ -256,15 +222,24 @@ async fn test_incoming_bundles_storage_and_query() {
 
     let message_info = &messages[0];
     assert_eq!(message_info.message_index, 0);
-    assert_eq!(message_info.grant_amount, 1000);
-    assert_eq!(message_info.message_kind, "Protected");
+    assert_eq!(
+        message_info.grant_amount,
+        Amount::from_tokens(100).to_string()
+    );
+    assert_eq!(
+        message_info.message_kind,
+        incoming_bundle_message.kind.to_string()
+    );
     assert!(message_info.authenticated_signer_data.is_none());
     assert!(message_info.refund_grant_to_data.is_none());
-    assert_eq!(message_info.message_data, b"test_message_data");
+    assert_eq!(
+        message_info.message_data,
+        bincode::serialize(&incoming_bundle_message.message).unwrap()
+    );
 
     // Test querying by origin chain
     let origin_bundles = db
-        .get_bundles_from_origin_chain(&origin_chain)
+        .get_bundles_from_origin_chain(&origin_chain_id)
         .await
         .unwrap();
     assert_eq!(origin_bundles.len(), 1);


### PR DESCRIPTION
## Motivation

Currently only a few fields (from the header, body or messages) are stored in a denormalized way in a database – ie they are stored in dedicated fields – while the whole block is stored as a blob data. We want to show more details to user, this could be done in one of the two ways:
1. load the blob, deserialize in frontend
2. store in denormalized way and load directly in frontend

## Proposal

Implement the approach `#2` – add more fields to database tables and store block's details directly there. Also, use the new data to show on the frontend of the explorer.


Some refactoring was done as part of the PR:
- add a dedicated type `ExpandableSection` that shows only the metadata of the section and expands on click to show more
- add `CopyableHash` to present a text that can be copied.

## Test Plan

Manual

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
