### PR TITLE
Run benchmark e2e tests for a bit longer

### DIFF
--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -801,8 +801,8 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
         .benchmark(BenchmarkCommand {
             num_chains: 2,
             transactions_per_block: 10,
-            bps: 1,
-            runtime_in_seconds: Some(1),
+            bps: 2,
+            runtime_in_seconds: Some(5),
             close_chains: true,
             ..Default::default()
         })
@@ -831,8 +831,8 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
         .benchmark(BenchmarkCommand {
             num_chains: 2,
             transactions_per_block: 10,
-            bps: 1,
-            runtime_in_seconds: Some(1),
+            bps: 2,
+            runtime_in_seconds: Some(5),
             fungible_application_id: Some(application_id.forget_abi()),
             close_chains: true,
             ..Default::default()


### PR DESCRIPTION
## Motivation

Right now the tests start and run just for one second, which since we're doing a bunch of extra stuff now, it's not enough time. From the logs it seems like we're trying to kill things before some messages sent with `wait_for_outgoing_messages` (not coming from the benchmark specific code) actually get delivered. So it seems like we just wait forever in that case.

## Proposal

Run the tests for slightly longer (5 seconds instead of 1), and that seems to prevent us from killing things too early. Might be a good follow up to see if blocking cross chain messages should timeout?

## Test Plan

CI should pass now

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
