### PR TITLE
Simplify the `add_outgoing_message(s)` functions.

### DIFF
--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -325,7 +325,7 @@ where
         match message {
             Message::System(message) => {
                 let outcome = self.system.execute_message(context, message).await?;
-                txn_tracker.add_outgoing_messages(outcome)?;
+                txn_tracker.add_outgoing_messages(outcome);
             }
             Message::User {
                 application_id,
@@ -362,7 +362,7 @@ where
             grant,
             kind: MessageKind::Bouncing,
             message,
-        })?;
+        });
         Ok(())
     }
 
@@ -388,7 +388,7 @@ where
         };
         txn_tracker.add_outgoing_message(
             OutgoingMessage::new(account.chain_id, message).with_kind(MessageKind::Tracked),
-        )?;
+        );
         Ok(())
     }
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1250,7 +1250,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
                     application_id,
                     bytes: message.message,
                 },
-            })?;
+            });
 
         Ok(())
     }
@@ -1279,7 +1279,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             .recv_response()?;
 
         this.transaction_tracker
-            .add_outgoing_messages(maybe_message)?;
+            .add_outgoing_messages(maybe_message);
         Ok(())
     }
 
@@ -1305,7 +1305,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
                 callback,
             })?
             .recv_response()?;
-        this.transaction_tracker.add_outgoing_message(message)?;
+        this.transaction_tracker.add_outgoing_message(message);
         Ok(())
     }
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -408,7 +408,7 @@ where
                 let maybe_message = self
                     .transfer(context.authenticated_signer, None, owner, recipient, amount)
                     .await?;
-                txn_tracker.add_outgoing_messages(maybe_message)?;
+                txn_tracker.add_outgoing_messages(maybe_message);
             }
             Claim {
                 owner,
@@ -426,7 +426,7 @@ where
                         amount,
                     )
                     .await?;
-                txn_tracker.add_outgoing_message(message)?;
+                txn_tracker.add_outgoing_message(message);
             }
             Admin(admin_operation) => {
                 ensure!(

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -8,7 +8,7 @@ use std::{
 
 use custom_debug_derive::Debug;
 use linera_base::{
-    data_types::{ArithmeticError, Blob, Event, OracleResponse, StreamUpdate, Timestamp},
+    data_types::{Blob, Event, OracleResponse, StreamUpdate, Timestamp},
     ensure,
     identifiers::{ApplicationId, BlobId, ChainId, StreamId},
 };
@@ -115,22 +115,14 @@ impl TransactionTracker {
         index
     }
 
-    pub fn add_outgoing_message(
-        &mut self,
-        message: OutgoingMessage,
-    ) -> Result<(), ArithmeticError> {
+    pub fn add_outgoing_message(&mut self, message: OutgoingMessage) {
         self.outgoing_messages.push(message);
-        Ok(())
     }
 
-    pub fn add_outgoing_messages(
-        &mut self,
-        messages: impl IntoIterator<Item = OutgoingMessage>,
-    ) -> Result<(), ArithmeticError> {
+    pub fn add_outgoing_messages(&mut self, messages: impl IntoIterator<Item = OutgoingMessage>) {
         for message in messages {
-            self.add_outgoing_message(message)?;
+            self.add_outgoing_message(message);
         }
-        Ok(())
     }
 
     pub fn add_event(&mut self, stream_id: StreamId, index: u32, value: Vec<u8>) {

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -605,7 +605,7 @@ async fn test_sending_message_from_finalize() -> anyhow::Result<()> {
         expected_second_message,
         expected_third_message,
         expected_fourth_message,
-    ])?;
+    ]);
     assert_eq!(
         txn_outcome.outgoing_messages,
         expected.into_outcome().unwrap().outgoing_messages
@@ -859,7 +859,7 @@ async fn test_simple_message() -> anyhow::Result<()> {
 
     let txn_outcome = txn_tracker.into_outcome().unwrap();
     let mut expected = TransactionTracker::default();
-    expected.add_outgoing_message(expected_dummy_message)?;
+    expected.add_outgoing_message(expected_dummy_message);
     assert_eq!(
         txn_outcome.outgoing_messages,
         expected.into_outcome().unwrap().outgoing_messages
@@ -927,7 +927,7 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
 
     let txn_outcome = txn_tracker.into_outcome().unwrap();
     let mut expected = TransactionTracker::default();
-    expected.add_outgoing_message(expected_dummy_message)?;
+    expected.add_outgoing_message(expected_dummy_message);
     assert_eq!(
         txn_outcome.outgoing_messages,
         expected.into_outcome().unwrap().outgoing_messages
@@ -1009,7 +1009,7 @@ async fn test_message_from_deeper_call() -> anyhow::Result<()> {
 
     let txn_outcome = txn_tracker.into_outcome().unwrap();
     let mut expected = TransactionTracker::default();
-    expected.add_outgoing_message(expected_dummy_message)?;
+    expected.add_outgoing_message(expected_dummy_message);
     assert_eq!(
         txn_outcome.outgoing_messages,
         expected.into_outcome().unwrap().outgoing_messages
@@ -1143,7 +1143,7 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
                 bytes: b"second".to_vec(),
             },
         ),
-    ])?;
+    ]);
     assert_eq!(
         txn_outcome.outgoing_messages,
         expected.into_outcome().unwrap().outgoing_messages


### PR DESCRIPTION
## Motivation

Those functions were returning errors when no error could occur.

## Proposal

Simplify them.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None