### PR TITLE
Add the `application-creator-chain-id` to the ServiceRuntime.

### DIFF
--- a/examples/counter-no-graphql/src/service.rs
+++ b/examples/counter-no-graphql/src/service.rs
@@ -63,7 +63,12 @@ mod tests {
     use std::sync::Arc;
 
     use futures::FutureExt as _;
-    use linera_sdk::{util::BlockingWait, views::View, Service, ServiceRuntime};
+    use linera_sdk::{
+        linera_base_types::{ChainId, CryptoHash},
+        util::BlockingWait,
+        views::View,
+        Service, ServiceRuntime,
+    };
 
     use super::{CounterRequest, CounterService, CounterState};
 
@@ -71,6 +76,9 @@ mod tests {
     fn query() {
         let value = 61_098_721_u64;
         let runtime = Arc::new(ServiceRuntime::<CounterService>::new());
+        let hash = ChainId(CryptoHash::test_hash("test"));
+        runtime.set_chain_id(hash);
+        runtime.set_application_creator_chain_id(hash);
         let mut state = CounterState::load(runtime.root_view_storage_context())
             .blocking_wait()
             .expect("Failed to read from mock key value store");

--- a/examples/counter-no-graphql/src/service.rs
+++ b/examples/counter-no-graphql/src/service.rs
@@ -37,6 +37,16 @@ impl Service for CounterService {
     }
 
     async fn handle_query(&self, request: CounterRequest) -> u64 {
+        // Load chain_id and application_creator_chain_id for comparison
+        let chain_id = self.runtime.chain_id();
+        let application_creator_chain_id = self.runtime.application_creator_chain_id();
+
+        // Check that they are equal (for demonstration purposes)
+        assert_eq!(
+            chain_id, application_creator_chain_id,
+            "Chain ID and Application Creator Chain ID should be equal"
+        );
+
         match request {
             CounterRequest::Query => *self.state.value.get(),
             CounterRequest::Increment(value) => {

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -23,6 +23,7 @@ where
 {
     application_parameters: Mutex<Option<Application::Parameters>>,
     application_id: Mutex<Option<ApplicationId<Application::Abi>>>,
+    application_creator_chain_id: Mutex<Option<ChainId>>,
     chain_id: Mutex<Option<ChainId>>,
     next_block_height: Mutex<Option<BlockHeight>>,
     timestamp: Mutex<Option<Timestamp>>,
@@ -40,6 +41,7 @@ where
         ServiceRuntime {
             application_parameters: Mutex::new(None),
             application_id: Mutex::new(None),
+            application_creator_chain_id: Mutex::new(None),
             chain_id: Mutex::new(None),
             next_block_height: Mutex::new(None),
             timestamp: Mutex::new(None),
@@ -76,6 +78,13 @@ where
     pub fn application_id(&self) -> ApplicationId<Application::Abi> {
         Self::fetch_value_through_cache(&self.application_id, || {
             ApplicationId::from(base_wit::get_application_id()).with_abi()
+        })
+    }
+
+    /// Returns the chain ID of the current application creator.
+    pub fn application_creator_chain_id(&self) -> ChainId {
+        Self::fetch_value_through_cache(&self.application_creator_chain_id, || {
+            base_wit::get_application_creator_chain_id().into()
         })
     }
 

--- a/linera-sdk/src/service/test_runtime.rs
+++ b/linera-sdk/src/service/test_runtime.rs
@@ -26,6 +26,7 @@ where
 {
     application_parameters: Mutex<Option<Application::Parameters>>,
     application_id: Mutex<Option<ApplicationId<Application::Abi>>>,
+    application_creator_chain_id: Mutex<Option<ChainId>>,
     chain_id: Mutex<Option<ChainId>>,
     next_block_height: Mutex<Option<BlockHeight>>,
     timestamp: Mutex<Option<Timestamp>>,
@@ -56,6 +57,7 @@ where
         MockServiceRuntime {
             application_parameters: Mutex::new(None),
             application_id: Mutex::new(None),
+            application_creator_chain_id: Mutex::new(None),
             chain_id: Mutex::new(None),
             next_block_height: Mutex::new(None),
             timestamp: Mutex::new(None),
@@ -124,6 +126,27 @@ where
             &self.application_id,
             "Application ID has not been mocked, \
             please call `MockServiceRuntime::set_application_id` first",
+        )
+    }
+
+    /// Configures the application creator chain ID to return during the test.
+    pub fn with_application_creator_chain_id(self, application_creator_chain_id: ChainId) -> Self {
+        *self.application_creator_chain_id.lock().unwrap() = Some(application_creator_chain_id);
+        self
+    }
+
+    /// Configures the application creator chain ID to return during the test.
+    pub fn set_application_creator_chain_id(&self, application_creator_chain_id: ChainId) -> &Self {
+        *self.application_creator_chain_id.lock().unwrap() = Some(application_creator_chain_id);
+        self
+    }
+
+    /// Returns the chain ID of the current application creator.
+    pub fn application_creator_chain_id(&self) -> ChainId {
+        Self::fetch_mocked_value(
+            &self.application_creator_chain_id,
+            "Application creator chain ID has not been mocked, \
+            please call `MockServiceRuntime::set_application_creator_chain_id` first",
         )
     }
 

--- a/linera-sdk/src/test/mock_stubs.rs
+++ b/linera-sdk/src/test/mock_stubs.rs
@@ -34,6 +34,13 @@ pub fn mock_application_id(_application_id: impl Into<Option<ApplicationId>>) {
     unreachable!("{ERROR_MESSAGE}");
 }
 
+/// Sets the mocked application creator chain ID.
+pub fn mock_application_creator_chain_id(
+    _application_creator_chain_id: impl Into<Option<ChainId>>,
+) {
+    unreachable!("{ERROR_MESSAGE}");
+}
+
 /// Sets the mocked application parameters.
 pub fn mock_application_parameters(_application_parameters: &impl Serialize) {
     unreachable!("{ERROR_MESSAGE}");


### PR DESCRIPTION
## Motivation

The `application-creator-chain-id` was not in `ServiceRuntime` which was an oversight.

Fixes #3606 

## Proposal

The implementation is straightforward.

## Test Plan

The CI.
The test has been added to the `counter-no-graphql`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None