### PR TITLE
Fix local chain info error handling.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -3521,14 +3521,16 @@ impl<Env: Environment> ChainClient<Env> {
         &self,
         chain_id: ChainId,
         local_node: &mut LocalNodeClient<Env::Storage>,
-    ) -> Option<Box<ChainInfo>> {
-        let Ok(info) = local_node.chain_info(chain_id).await else {
-            error!("Fail to read local chain info for {chain_id}");
-            return None;
-        };
-        // Useful in case `chain_id` is the same as the local chain.
-        self.client.update_from_info(&info);
-        Some(info)
+    ) -> Result<Option<Box<ChainInfo>>, ChainClientError> {
+        match local_node.chain_info(chain_id).await {
+            Ok(info) => {
+                // Useful in case `chain_id` is the same as a local chain.
+                self.client.update_from_info(&info);
+                Ok(Some(info))
+            }
+            Err(LocalNodeError::BlobsNotFound(_) | LocalNodeError::InactiveChain(_)) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
     }
 
     #[instrument(level = "trace", skip(chain_id, local_node))]
@@ -3536,9 +3538,11 @@ impl<Env: Environment> ChainClient<Env> {
         &self,
         chain_id: ChainId,
         local_node: &mut LocalNodeClient<Env::Storage>,
-    ) -> BlockHeight {
-        let maybe_info = self.local_chain_info(chain_id, local_node).await;
-        maybe_info.map_or(BlockHeight::ZERO, |info| info.next_block_height)
+    ) -> Result<BlockHeight, ChainClientError> {
+        Ok(self
+            .local_chain_info(chain_id, local_node)
+            .await?
+            .map_or(BlockHeight::ZERO, |info| info.next_block_height))
     }
 
     /// Returns the next height we expect to receive from the given sender chain, according to the
@@ -3584,7 +3588,7 @@ impl<Env: Environment> ChainClient<Env> {
                 let chain_id = notification.chain_id;
                 if self
                     .local_next_block_height(chain_id, &mut local_node)
-                    .await
+                    .await?
                     > height
                 {
                     debug!(
@@ -3596,16 +3600,17 @@ impl<Env: Environment> ChainClient<Env> {
                 self.client
                     .synchronize_chain_state_from(&remote_node, chain_id)
                     .await?;
-                let local_height = self
+                if self
                     .local_next_block_height(chain_id, &mut local_node)
-                    .await;
-                if local_height <= height {
+                    .await?
+                    <= height
+                {
                     error!("NewBlock: Fail to synchronize new block after notification");
                 }
             }
             Reason::NewRound { height, round } => {
                 let chain_id = notification.chain_id;
-                if let Some(info) = self.local_chain_info(chain_id, &mut local_node).await {
+                if let Some(info) = self.local_chain_info(chain_id, &mut local_node).await? {
                     if (info.next_block_height, info.manager.current_round) >= (height, round) {
                         debug!(
                             chain_id = %self.chain_id,
@@ -3617,7 +3622,7 @@ impl<Env: Environment> ChainClient<Env> {
                 self.client
                     .synchronize_chain_state_from(&remote_node, chain_id)
                     .await?;
-                let Some(info) = self.local_chain_info(chain_id, &mut local_node).await else {
+                let Some(info) = self.local_chain_info(chain_id, &mut local_node).await? else {
                     error!(
                         chain_id = %self.chain_id,
                         "NewRound: Fail to read local chain info for {chain_id}"


### PR DESCRIPTION
## Motivation

`ChainClient::local_chain_info` and `local_next_block_height` ignore some errors in case a chain is not active. However, only the error variants specific to that case should be ignored.

## Proposal

Return other error variants.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
