### PR TITLE
Remove public key from `Vote`.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -338,7 +338,6 @@ struct VoteValue(CryptoHash, Round, CertificateKind);
 pub struct Vote<T> {
     pub value: T,
     pub round: Round,
-    pub public_key: ValidatorPublicKey,
     pub signature: ValidatorSignature,
 }
 
@@ -353,7 +352,6 @@ impl<T> Vote<T> {
         Self {
             value,
             round,
-            public_key: key_pair.public(),
             signature,
         }
     }
@@ -366,7 +364,6 @@ impl<T> Vote<T> {
         LiteVote {
             value: LiteValue::new(&self.value),
             round: self.round,
-            public_key: self.public_key,
             signature: self.signature,
         }
     }
@@ -383,7 +380,6 @@ impl<T> Vote<T> {
 pub struct LiteVote {
     pub value: LiteValue,
     pub round: Round,
-    pub public_key: ValidatorPublicKey,
     pub signature: ValidatorSignature,
 }
 
@@ -397,7 +393,6 @@ impl LiteVote {
         Some(Vote {
             value,
             round: self.round,
-            public_key: self.public_key,
             signature: self.signature,
         })
     }
@@ -631,15 +626,14 @@ impl LiteVote {
         Self {
             value,
             round,
-            public_key: secret_key.public(),
             signature,
         }
     }
 
     /// Verifies the signature in the vote.
-    pub fn check(&self) -> Result<(), ChainError> {
+    pub fn check(&self, public_key: ValidatorPublicKey) -> Result<(), ChainError> {
         let hash_and_round = VoteValue(self.value.value_hash, self.round, self.value.kind);
-        Ok(self.signature.check(&hash_and_round, self.public_key)?)
+        Ok(self.signature.check(&hash_and_round, public_key)?)
     }
 }
 

--- a/linera-chain/src/test/mod.rs
+++ b/linera-chain/src/test/mod.rs
@@ -6,7 +6,7 @@
 mod http_server;
 
 use linera_base::{
-    crypto::{AccountPublicKey, Signer},
+    crypto::{AccountPublicKey, Signer, ValidatorPublicKey},
     data_types::{Amount, BlockHeight, Epoch, Round, Timestamp},
     identifiers::{AccountOwner, ChainId},
 };
@@ -159,22 +159,22 @@ impl BlockTestExt for ProposedBlock {
 
 pub trait VoteTestExt<T: CertificateValue>: Sized {
     /// Returns a certificate for a committee consisting only of this validator.
-    fn into_certificate(self) -> GenericCertificate<T>;
+    fn into_certificate(self, public_key: ValidatorPublicKey) -> GenericCertificate<T>;
 }
 
 impl<T: CertificateValue> VoteTestExt<T> for Vote<T> {
-    fn into_certificate(self) -> GenericCertificate<T> {
+    fn into_certificate(self, public_key: ValidatorPublicKey) -> GenericCertificate<T> {
         let state = ValidatorState {
             network_address: "".to_string(),
             votes: 100,
             account_public_key: AccountPublicKey::test_key(1),
         };
         let committee = Committee::new(
-            vec![(self.public_key, state)].into_iter().collect(),
+            vec![(public_key, state)].into_iter().collect(),
             ResourceControlPolicy::only_fuel(),
         );
         SignatureAggregator::new(self.value, self.round, &committee)
-            .append(self.public_key, self.signature)
+            .append(public_key, self.signature)
             .unwrap()
             .unwrap()
     }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2199,7 +2199,10 @@ impl<Env: Environment> ChainClient<Env> {
         )
         .await;
         let received_certificate_batches = match result {
-            Ok(((), received_certificate_batches)) => received_certificate_batches,
+            Ok(((), received_certificate_batches)) => received_certificate_batches
+                .into_iter()
+                .map(|(_, batch)| batch)
+                .collect(),
             Err(CommunicationError::Trusted(NodeError::InactiveChain(id))) if id == chain_id => {
                 // The chain is visibly not active (yet or any more) so there is no need
                 // to synchronize received certificates.

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -263,7 +263,7 @@ where
         );
         let mut builder = SignatureAggregator::new(value, round, &self.committee);
         builder
-            .append(vote.public_key, vote.signature)
+            .append(self.worker.public_key(), vote.signature)
             .unwrap()
             .unwrap()
     }
@@ -3329,7 +3329,7 @@ where
     let certificate_timeout = vote
         .with_value(value_timeout.clone())
         .unwrap()
-        .into_certificate();
+        .into_certificate(env.worker().public_key());
     let (response, _) = env
         .worker()
         .handle_timeout_certificate(certificate_timeout)
@@ -3364,7 +3364,10 @@ where
 
     // If we send the validated block certificate to the worker, it votes to confirm.
     let vote = response.info.manager.pending.clone().unwrap();
-    let certificate1 = vote.with_value(value1.clone()).unwrap().into_certificate();
+    let certificate1 = vote
+        .with_value(value1.clone())
+        .unwrap()
+        .into_certificate(env.worker().public_key());
     let (response, _) = env
         .worker()
         .handle_validated_certificate(certificate1.clone())
@@ -3570,7 +3573,7 @@ where
     let certificate_timeout = vote
         .with_value(value_timeout.clone())
         .unwrap()
-        .into_certificate();
+        .into_certificate(env.worker().public_key());
     let (response, _) = env
         .worker()
         .handle_timeout_certificate(certificate_timeout)
@@ -3893,7 +3896,7 @@ where
         .get(&response.info.epoch)
         .unwrap()
         .validators
-        .get(&vote.public_key)
+        .get(&env.worker().public_key())
         .unwrap()
         .account_public_key;
     assert_eq!(manager.current_round, Round::Validator(0));

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -597,8 +597,6 @@ LiteVote:
         TYPENAME: LiteValue
     - round:
         TYPENAME: Round
-    - public_key:
-        TYPENAME: Secp256k1PublicKey
     - signature:
         TYPENAME: Secp256k1Signature
 LockingBlock:

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -225,9 +225,10 @@ impl BlockBuilder {
             self.validator.key_pair(),
         );
         let committee = self.validator.committee().await;
+        let public_key = self.validator.key_pair().public();
         let mut builder = SignatureAggregator::new(value, Round::Fast, &committee);
         let certificate = builder
-            .append(vote.public_key, vote.signature)
+            .append(public_key, vote.signature)
             .expect("Failed to sign block")
             .expect("Committee has more than one test validator");
 


### PR DESCRIPTION
## Motivation

The public key is known from the context everywhere, and having it explicitly in `Vote` and `LiteVote` just duplicates data and creates more error cases.

## Proposal

Remove the redundant field (with Claude).

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
