### PR TITLE
Stop returning an Option from validate_proposal_content

### DIFF
--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -206,7 +206,7 @@ where
         &mut self,
         content: &ProposalContent,
         published_blobs: &[Blob],
-    ) -> Result<Option<(BlockExecutionOutcome, Timestamp)>, WorkerError> {
+    ) -> Result<(BlockExecutionOutcome, Timestamp), WorkerError> {
         let ProposalContent {
             block,
             round,
@@ -245,7 +245,7 @@ where
         )?;
         // Verify that the resulting chain would have no unconfirmed incoming messages.
         chain.validate_incoming_bundles().await?;
-        Ok(Some((outcome, local_time)))
+        Ok((outcome, local_time))
     }
 
     /// Prepares a [`ChainInfoResponse`] for a [`ChainInfoQuery`].


### PR DESCRIPTION
## Motivation

We don't evern return `None`.

## Proposal

Clean up the code to not return an `Option` anymore

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
