### PR TITLE
Replace std::time imports with linera_base::time

### DIFF
--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -3,9 +3,6 @@
 
 //! Handle requests from the synchronous execution thread of user applications.
 
-#[cfg(not(web))]
-use std::time::Duration;
-
 use custom_debug_derive::Debug;
 use futures::{channel::mpsc, StreamExt as _};
 #[cfg(with_metrics)]
@@ -381,7 +378,7 @@ where
                     .headers(headers);
                 #[cfg(not(web))]
                 {
-                    request = request.timeout(Duration::from_millis(
+                    request = request.timeout(linera_base::time::Duration::from_millis(
                         committee.policy().http_request_timeout_ms,
                     ));
                 }

--- a/linera-service/src/exporter/runloops/block_processor/mod.rs
+++ b/linera-service/src/exporter/runloops/block_processor/mod.rs
@@ -145,12 +145,11 @@ where
 
 #[cfg(test)]
 mod test {
-    use std::time::Duration;
-
     use linera_base::{
         crypto::CryptoHash,
         data_types::{Round, Timestamp},
         identifiers::ChainId,
+        time::Duration,
     };
     use linera_chain::{
         data_types::{BlockExecutionOutcome, IncomingBundle, MessageBundle},

--- a/linera-service/src/exporter/runloops/indexer/client.rs
+++ b/linera-service/src/exporter/runloops/indexer/client.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
 #[cfg(with_metrics)]
 use std::{
     collections::VecDeque,
@@ -10,6 +9,7 @@ use std::{
 };
 
 use futures::StreamExt;
+use linera_base::time::Duration;
 use linera_rpc::{
     grpc::{transport::Options, GrpcError, GRPC_MAX_MESSAGE_SIZE},
     NodeOptions,
@@ -67,7 +67,7 @@ impl IndexerClient {
             let request = {
                 let stream = ReceiverStream::new(receiver).map(|element: Element| {
                     if let Some(Payload::Block(_)) = &element.payload {
-                        use std::time::Instant;
+                        use linera_base::time::Instant;
                         self.sent_latency.lock().unwrap().push_back(Instant::now());
                     }
                     element

--- a/linera-service/src/exporter/tests.rs
+++ b/linera-service/src/exporter/tests.rs
@@ -6,9 +6,8 @@
     feature = "scylladb",
     feature = "storage-service",
 ))]
-use std::time::Duration;
-
 use anyhow::Result;
+use linera_base::time::Duration;
 use linera_core::{data_types::ChainInfoQuery, node::ValidatorNode};
 use linera_rpc::config::ExporterServiceConfig;
 use linera_service::{

--- a/linera-views/benches/queue_view.rs
+++ b/linera-views/benches/queue_view.rs
@@ -1,9 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::{Duration, Instant};
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use linera_base::time::{Duration, Instant};
 #[cfg(with_dynamodb)]
 use linera_views::dynamo_db::DynamoDbDatabase;
 #[cfg(with_rocksdb)]

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -485,7 +485,7 @@ where
 /// selection, Scylla is forced to introduce around 100000 tombstones
 /// which triggers the crash with the default settings.
 pub async fn tombstone_triggering_test<C: KeyValueStore>(key_value_store: C) {
-    use std::time::Instant;
+    use linera_base::time::Instant;
     let t1 = Instant::now();
     let mut rng = make_deterministic_rng();
     let value_size = 100;

--- a/linera-views/src/test_utils/performance.rs
+++ b/linera-views/src/test_utils/performance.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::{Duration, Instant};
+use linera_base::time::{Duration, Instant};
 
 use crate::{
     batch::Batch,


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/4265 moved some uses of std::time primitives out of benchmarking-specific code and into the main codepath of linera-core. Unfortunately, std::time primitives panic on Wasm, so we must always remember to use linera_base::time for anything that may be compiled for the Web (or, as a rule of thumb, anywhere in the codebase: I don't think there's any harm to it).

## Proposal

Replace all usages of std::time with linera_base::time

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
