### PR TITLE
Check transaction number on total chains

### DIFF
--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -829,22 +829,12 @@ impl Runnable for Job {
                     "max_pending_message_bundles must be set to at least the same as the \
                      number of transactions per block ({transactions_per_block}) for benchmarking",
                 );
-                assert!(
-                    num_chains > 0,
-                    "Number of chain groups must be greater than 0"
-                );
+                assert!(num_chains > 0, "Number of chains must be greater than 0");
                 assert!(
                     transactions_per_block > 0,
                     "Number of transactions per block must be greater than 0"
                 );
                 assert!(bps > 0, "BPS must be greater than 0");
-                if num_chains > 1 {
-                    assert!(
-                        transactions_per_block % (num_chains - 1) == 0,
-                        "Number of transactions per block must be a multiple of the number of \
-                         chains minus 1, to make sure transactions always cancel each other out"
-                    );
-                }
 
                 let listener_config = ChainListenerConfig {
                     skip_process_inbox: true,


### PR DESCRIPTION
## Motivation

Right now we're checking just the number of chains in a wallet, but if we're using cross wallet transfers, we need to take all chains from all wallets into consideration.

## Proposal

Take all chains from all wallets used in the benchmark into consideration

## Test Plan

Ran this against a deployed network

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
