### PR TITLE
Update more occurences of std::time to use linera_base::time

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2312,10 +2312,10 @@ impl<Env: Environment> ChainClient<Env> {
         operations: Vec<Operation>,
         blobs: Vec<Blob>,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
-        let timing_start = std::time::Instant::now();
+        let timing_start = linera_base::time::Instant::now();
 
         let result = loop {
-            let execute_block_start = std::time::Instant::now();
+            let execute_block_start = linera_base::time::Instant::now();
             // TODO(#2066): Remove boxing once the call-stack is shallower
             match Box::pin(self.execute_block(operations.clone(), blobs.clone())).await {
                 Ok(ExecuteBlockOutcome::Executed(certificate)) => {
@@ -2872,7 +2872,7 @@ impl<Env: Environment> ChainClient<Env> {
         let committee = self.local_committee().await?;
         let block = Block::new(proposed_block, outcome);
         // Send the query to validators.
-        let submit_block_proposal_start = std::time::Instant::now();
+        let submit_block_proposal_start = linera_base::time::Instant::now();
         let certificate = if round.is_fast() {
             let hashed_value = ConfirmedBlock::new(block);
             let certificate = self
@@ -2897,7 +2897,7 @@ impl<Env: Environment> ChainClient<Env> {
         }
 
         debug!(round = %certificate.round, "Sending confirmed block to validators");
-        let update_validators_start = std::time::Instant::now();
+        let update_validators_start = linera_base::time::Instant::now();
         self.update_validators(Some(&committee)).await?;
         if let Some(sender) = &self.timing_sender {
             let _ = sender.send((

--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -53,7 +53,7 @@ impl Faucet {
         let builder = reqwest::ClientBuilder::new();
 
         #[cfg(not(target_arch = "wasm32"))]
-        let builder = builder.timeout(std::time::Duration::from_secs(30));
+        let builder = builder.timeout(linera_base::time::Duration::from_secs(30));
 
         let response: GraphQlResponse<Response> = builder
             .build()

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -62,6 +62,7 @@ use tracing::{debug, error, info, warn, Instrument as _};
 #[cfg(feature = "benchmark")]
 use {
     linera_base::identifiers::ChainId,
+    linera_base::time::Duration,
     linera_client::{
         benchmark::BenchmarkConfig,
         chain_listener::{ChainListener, ChainListenerConfig},
@@ -71,7 +72,6 @@ use {
         cli::command::BenchmarkCommand,
         cli_wrappers::{local_net::PathProvider, ClientWrapper, Network, OnClientDrop},
     },
-    std::time::Duration,
     tempfile::NamedTempFile,
     tokio::{
         io::AsyncWriteExt,

--- a/linera-service/src/exporter/runloops/validator_exporter.rs
+++ b/linera-service/src/exporter/runloops/validator_exporter.rs
@@ -156,7 +156,7 @@ where
                         blob.id()
                     );
                     #[cfg(with_metrics)]
-                    let start = std::time::Instant::now();
+                    let start = linera_base::time::Instant::now();
                     let result = self
                         .node
                         .upload_blob((*blob).clone().into())
@@ -185,7 +185,7 @@ where
         let block_id = BlockId::from_confirmed_block(certificate.value());
         tracing::info!(?block_id, "dispatching block");
         #[cfg(with_metrics)]
-        let start = std::time::Instant::now();
+        let start = linera_base::time::Instant::now();
         match self
             .node
             .handle_confirmed_certificate(certificate, delivery)

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -173,7 +173,7 @@ where
     F: std::future::Future<Output = bool>,
 {
     for i in 0..5 {
-        linera_base::time::timer::sleep(std::time::Duration::from_secs(i)).await;
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_secs(i)).await;
         if condition().await {
             return true;
         }

--- a/linera-web/src/lib.rs
+++ b/linera-web/src/lib.rs
@@ -65,16 +65,16 @@ type ChainClient = linera_core::client::ChainClient<WebEnvironment>;
 
 // TODO(#13): get from user
 pub const OPTIONS: ClientContextOptions = ClientContextOptions {
-    send_timeout: std::time::Duration::from_millis(4000),
-    recv_timeout: std::time::Duration::from_millis(4000),
+    send_timeout: linera_base::time::Duration::from_millis(4000),
+    recv_timeout: linera_base::time::Duration::from_millis(4000),
     max_pending_message_bundles: 10,
-    retry_delay: std::time::Duration::from_millis(1000),
+    retry_delay: linera_base::time::Duration::from_millis(1000),
     max_retries: 10,
     wait_for_outgoing_messages: false,
     blanket_message_policy: linera_core::client::BlanketMessagePolicy::Accept,
     restrict_chain_ids_to: None,
     long_lived_services: false,
-    blob_download_timeout: std::time::Duration::from_millis(1000),
+    blob_download_timeout: linera_base::time::Duration::from_millis(1000),
     chain_worker_ttl: Duration::from_secs(30),
     grace_period: linera_core::DEFAULT_GRACE_PERIOD,
 


### PR DESCRIPTION
## Motivation

Web client keeps failing on block proposal due to the usage of std::time when constructing a proposal.

## Proposal

Fix all occurences of std::time to linera_base::time

## Test Plan

CI and manual

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
