### PR TITLE
Remove unused error variants; make some modules private.

### DIFF
--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -26,7 +26,7 @@ pub use chain::ChainStateView;
 use data_types::{MessageBundle, PostedMessage};
 use linera_base::{
     bcs,
-    crypto::{CryptoError, CryptoHash},
+    crypto::CryptoError,
     data_types::{ArithmeticError, BlockHeight, Round, Timestamp},
     identifiers::{ApplicationId, ChainId},
 };
@@ -123,8 +123,7 @@ pub enum ChainError {
         "Block timestamp {new} must not be earlier than the parent block's timestamp {parent}"
     )]
     InvalidBlockTimestamp { parent: Timestamp, new: Timestamp },
-    #[error("Cannot initiate a new block while the previous one is still pending confirmation")]
-    PreviousBlockMustBeConfirmedFirst,
+
     #[error("Round number should be at least {0:?}")]
     InsufficientRound(Round),
     #[error("Round number should be greater than {0:?}")]
@@ -141,16 +140,14 @@ pub enum ChainError {
     CertificateValidatorReuse,
     #[error("Signatures in a certificate must form a quorum")]
     CertificateRequiresQuorum,
-    #[error("Certificate signature verification failed: {error}")]
-    CertificateSignatureVerificationFailed { error: String },
+
     #[error("Internal error {0}")]
     InternalError(String),
     #[error("Block proposal has size {0} which is too large")]
     BlockProposalTooLarge(usize),
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
-    #[error("Insufficient balance to pay the fees")]
-    InsufficientBalance,
+
     #[error("Invalid owner weights: {0}")]
     OwnerWeightError(#[from] WeightedError),
     #[error("Closed chains cannot have operations, accepted messages or empty blocks")]
@@ -161,15 +158,9 @@ pub enum ChainError {
     AuthorizedApplications(Vec<ApplicationId>),
     #[error("Missing operations or messages from mandatory applications: {0:?}")]
     MissingMandatoryApplications(Vec<ApplicationId>),
-    #[error("Can't use grant across different broadcast messages")]
-    GrantUseOnBroadcast,
+
     #[error("Executed block contains fewer oracle responses than requests")]
     MissingOracleResponseList,
-    #[error("Unexpected hash for CertificateValue! Expected: {expected:?}, Actual: {actual:?}")]
-    CertificateValueHashMismatch {
-        expected: CryptoHash,
-        actual: CryptoHash,
-    },
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -123,7 +123,6 @@ pub enum ChainError {
         "Block timestamp {new} must not be earlier than the parent block's timestamp {parent}"
     )]
     InvalidBlockTimestamp { parent: Timestamp, new: Timestamp },
-
     #[error("Round number should be at least {0:?}")]
     InsufficientRound(Round),
     #[error("Round number should be greater than {0:?}")]
@@ -140,14 +139,12 @@ pub enum ChainError {
     CertificateValidatorReuse,
     #[error("Signatures in a certificate must form a quorum")]
     CertificateRequiresQuorum,
-
     #[error("Internal error {0}")]
     InternalError(String),
     #[error("Block proposal has size {0} which is too large")]
     BlockProposalTooLarge(usize),
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
-
     #[error("Invalid owner weights: {0}")]
     OwnerWeightError(#[from] WeightedError),
     #[error("Closed chains cannot have operations, accepted messages or empty blocks")]
@@ -158,7 +155,6 @@ pub enum ChainError {
     AuthorizedApplications(Vec<ApplicationId>),
     #[error("Missing operations or messages from mandatory applications: {0:?}")]
     MissingMandatoryApplications(Vec<ApplicationId>),
-
     #[error("Executed block contains fewer oracle responses than requests")]
     MissingOracleResponseList,
 }

--- a/linera-client/src/error.rs
+++ b/linera-client/src/error.rs
@@ -33,7 +33,7 @@ pub(crate) enum Inner {
     #[error("no keypair found for chain: {0:?}")]
     NonexistentKeypair(linera_base::identifiers::ChainId),
     #[error("error on the local node: {0}")]
-    LocalNode(#[from] linera_core::local_node::LocalNodeError),
+    LocalNode(#[from] linera_core::LocalNodeError),
     #[error("remote node operation failed: {0}")]
     RemoteNode(#[from] linera_core::node::NodeError),
     #[error("arithmetic error: {0}")]

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -205,12 +205,6 @@ impl<Env: Environment> Client<Env> {
         self.environment.network()
     }
 
-    /// Returns a reference to the [`LocalNodeClient`] of the client.
-    #[instrument(level = "trace", skip(self))]
-    pub(crate) fn local_node(&self) -> &LocalNodeClient<Env::Storage> {
-        &self.local_node
-    }
-
     /// Returns a reference to the [`Signer`] of the client.
     #[instrument(level = "trace", skip(self))]
     pub fn signer(&self) -> &impl Signer {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -207,7 +207,7 @@ impl<Env: Environment> Client<Env> {
 
     /// Returns a reference to the [`LocalNodeClient`] of the client.
     #[instrument(level = "trace", skip(self))]
-    pub fn local_node(&self) -> &LocalNodeClient<Env::Storage> {
+    pub(crate) fn local_node(&self) -> &LocalNodeClient<Env::Storage> {
         &self.local_node
     }
 

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -7,14 +7,14 @@
 #![recursion_limit = "256"]
 #![deny(clippy::large_futures)]
 
-pub mod chain_worker;
+mod chain_worker;
 pub mod client;
 pub mod data_types;
 pub mod join_set_ext;
-pub mod local_node;
+mod local_node;
 pub mod node;
 pub mod notifier;
-pub mod remote_node;
+mod remote_node;
 #[cfg(with_testing)]
 #[path = "unit_tests/test_utils.rs"]
 pub mod test_utils;
@@ -23,6 +23,7 @@ pub mod worker;
 pub(crate) mod updater;
 mod value_cache;
 
+pub use local_node::LocalNodeError;
 pub use updater::DEFAULT_GRACE_PERIOD;
 
 pub use crate::join_set_ext::{JoinSetExt, TaskHandle};

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -10,8 +10,8 @@ use std::{
 use futures::{stream::FuturesUnordered, TryStreamExt as _};
 use linera_base::{
     crypto::ValidatorPublicKey,
-    data_types::{ApplicationDescription, ArithmeticError, Blob, BlockHeight, Epoch},
-    identifiers::{ApplicationId, BlobId, ChainId},
+    data_types::{ArithmeticError, Blob, BlockHeight, Epoch},
+    identifiers::{BlobId, ChainId},
 };
 use linera_chain::{
     data_types::{BlockProposal, ProposedBlock},
@@ -246,20 +246,6 @@ where
     ) -> Result<QueryOutcome, LocalNodeError> {
         let outcome = self.node.state.query_application(chain_id, query).await?;
         Ok(outcome)
-    }
-
-    #[instrument(level = "trace", skip(self))]
-    pub async fn describe_application(
-        &self,
-        chain_id: ChainId,
-        application_id: ApplicationId,
-    ) -> Result<ApplicationDescription, LocalNodeError> {
-        let response = self
-            .node
-            .state
-            .describe_application(chain_id, application_id)
-            .await?;
-        Ok(response)
     }
 
     /// Handles any pending local cross-chain requests.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -221,8 +221,6 @@ pub enum ExecutionError {
         caller_id: Box<ApplicationId>,
         callee_id: Box<ApplicationId>,
     },
-    #[error("Attempt to write to storage from a contract")]
-    ServiceWriteAttempt,
     #[error("Failed to load bytecode from storage {0:?}")]
     ApplicationBytecodeNotFound(Box<ApplicationDescription>),
     // TODO(#2927): support dynamic loading of modules on the Web
@@ -245,8 +243,6 @@ pub enum ExecutionError {
     HttpResponseSizeLimitExceeded { limit: u64, size: u64 },
     #[error("Runtime failed to respond to application")]
     MissingRuntimeResponse,
-    #[error("Module ID {0:?} is invalid")]
-    InvalidModuleId(ModuleId),
     #[error("Application is not authorized to perform system operations on this chain: {0:}")]
     UnauthorizedApplication(ApplicationId),
     #[error("Failed to make network reqwest: {0}")]
@@ -295,8 +291,6 @@ pub enum ExecutionError {
 
     #[error("No NetworkDescription found in storage")]
     NoNetworkDescriptionFound,
-    #[error("Invalid committees")]
-    InvalidCommittees,
     #[error("{epoch:?} is not recognized by chain {chain_id:}")]
     InvalidEpoch { chain_id: ChainId, epoch: Epoch },
     #[error("Transfer must have positive amount")]
@@ -320,16 +314,6 @@ pub enum ExecutionError {
     InvalidCommitteeEpoch { expected: Epoch, provided: Epoch },
     #[error("Failed to remove committee")]
     InvalidCommitteeRemoval,
-    #[error("Amount overflow")]
-    AmountOverflow,
-    #[error("Amount underflow")]
-    AmountUnderflow,
-    #[error("Chain balance overflow")]
-    BalanceOverflow,
-    #[error("Chain balance underflow")]
-    BalanceUnderflow,
-    #[error("Application {0:?} is not registered by the chain")]
-    UnknownApplicationId(Box<ApplicationId>),
     #[error("No recorded response for oracle query")]
     MissingOracleResponse,
     #[error("process_streams was not called for all stream updates")]


### PR DESCRIPTION
## Motivation

Public items make it hard to detect unused code.

## Proposal

I let Claude find and remove unused error variants. I also made some modules in `linera-core` private.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
