### PR TITLE
Add single destination per block option to benchmark client

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -568,6 +568,7 @@ Start a single benchmark process, maintaining a given TPS
 * `--runtime-in-seconds <RUNTIME_IN_SECONDS>` — How long to run the benchmark for. If not provided, the benchmark will run until it is interrupted
 * `--delay-between-chains-ms <DELAY_BETWEEN_CHAINS_MS>` — The delay between chains, in milliseconds. For example, if set to 200ms, the first chain will start, then the second will start 200 ms after the first one, the third 200 ms after the second one, and so on. This is used for slowly ramping up the TPS, so we don't pound the validators with the full TPS all at once
 * `--config-path <CONFIG_PATH>` — Path to YAML file containing chain IDs to send transfers to. If not provided, only transfers between chains in the same wallet
+* `--single-destination-per-block` — Transaction distribution mode. If false (default), distributes transactions evenly across chains within each block. If true, sends all transactions in each block to a single chain, rotating through chains for subsequent blocks
 
 
 
@@ -601,6 +602,7 @@ Run multiple benchmark processes in parallel
 * `--runtime-in-seconds <RUNTIME_IN_SECONDS>` — How long to run the benchmark for. If not provided, the benchmark will run until it is interrupted
 * `--delay-between-chains-ms <DELAY_BETWEEN_CHAINS_MS>` — The delay between chains, in milliseconds. For example, if set to 200ms, the first chain will start, then the second will start 200 ms after the first one, the third 200 ms after the second one, and so on. This is used for slowly ramping up the TPS, so we don't pound the validators with the full TPS all at once
 * `--config-path <CONFIG_PATH>` — Path to YAML file containing chain IDs to send transfers to. If not provided, only transfers between chains in the same wallet
+* `--single-destination-per-block` — Transaction distribution mode. If false (default), distributes transactions evenly across chains within each block. If true, sends all transactions in each block to a single chain, rotating through chains for subsequent blocks
 * `--processes <PROCESSES>` — The number of benchmark processes to run in parallel
 
   Default value: `1`

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -121,6 +121,7 @@ impl<Env: Environment> Benchmark<Env> {
         delay_between_chains_ms: Option<u64>,
         chain_listener: ChainListener<C>,
         shutdown_notifier: &CancellationToken,
+        single_destination_per_block: bool,
     ) -> Result<(), BenchmarkError> {
         let num_chains = chain_clients.len();
         let bps_counts = (0..num_chains)
@@ -183,6 +184,7 @@ impl<Env: Environment> Benchmark<Env> {
                         notifier_clone,
                         runtime_control_sender_clone,
                         delay_between_chains_ms,
+                        single_destination_per_block,
                     ))
                     .await?;
 
@@ -566,6 +568,7 @@ impl<Env: Environment> Benchmark<Env> {
         notifier: Arc<Notify>,
         runtime_control_sender: Option<mpsc::Sender<()>>,
         delay_between_chains_ms: Option<u64>,
+        single_destination_per_block: bool,
     ) -> Result<(), BenchmarkError> {
         barrier.wait().await;
         if let Some(delay_between_chains_ms) = delay_between_chains_ms {
@@ -600,6 +603,7 @@ impl<Env: Environment> Benchmark<Env> {
                         transactions_per_block,
                         fungible_application_id,
                         &mut destination_manager,
+                        single_destination_per_block,
                     ),
                     vec![]
                 ) => {
@@ -643,21 +647,37 @@ impl<Env: Environment> Benchmark<Env> {
         transactions_per_block: usize,
         fungible_application_id: Option<ApplicationId>,
         destination_manager: &mut ChainDestinationManager,
+        single_destination_per_block: bool,
     ) -> Vec<Operation> {
-        let mut operations = Vec::with_capacity(transactions_per_block);
         let amount = Amount::from_attos(1);
 
-        for _ in 0..transactions_per_block {
+        if single_destination_per_block {
             let recipient_chain_id = destination_manager.get_next_destination();
-            operations.push(Self::create_operation(
-                fungible_application_id,
-                recipient_chain_id,
-                owner,
-                amount,
-            ));
-        }
 
-        operations
+            (0..transactions_per_block)
+                .map(|_| {
+                    Self::create_operation(
+                        fungible_application_id,
+                        recipient_chain_id,
+                        owner,
+                        amount,
+                    )
+                })
+                .collect()
+        } else {
+            let mut operations = Vec::with_capacity(transactions_per_block);
+            for _ in 0..transactions_per_block {
+                let recipient_chain_id = destination_manager.get_next_destination();
+
+                operations.push(Self::create_operation(
+                    fungible_application_id,
+                    recipient_chain_id,
+                    owner,
+                    amount,
+                ));
+            }
+            operations
+        }
     }
 
     /// Closes the chain that was created for the benchmark.

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -91,6 +91,12 @@ pub struct BenchmarkOptions {
     /// If not provided, only transfers between chains in the same wallet.
     #[arg(long)]
     pub config_path: Option<PathBuf>,
+
+    /// Transaction distribution mode. If false (default), distributes transactions evenly
+    /// across chains within each block. If true, sends all transactions in each block
+    /// to a single chain, rotating through chains for subsequent blocks.
+    #[arg(long)]
+    pub single_destination_per_block: bool,
 }
 
 impl Default for BenchmarkOptions {
@@ -108,6 +114,7 @@ impl Default for BenchmarkOptions {
             runtime_in_seconds: None,
             delay_between_chains_ms: None,
             config_path: None,
+            single_destination_per_block: false,
         }
     }
 }

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -811,6 +811,7 @@ impl Runnable for Job {
                         runtime_in_seconds,
                         delay_between_chains_ms,
                         config_path,
+                        single_destination_per_block,
                     } = benchmark_options;
                     assert!(
                         options.context_options.max_pending_message_bundles
@@ -892,6 +893,7 @@ impl Runnable for Job {
                         delay_between_chains_ms,
                         chain_listener,
                         &shutdown_notifier,
+                        single_destination_per_block,
                     )
                     .await?;
 


### PR DESCRIPTION
## Motivation

Right now the default is for every chain to always send transfers to every other chain, in a way that in each block we cycle through the chains.

## Proposal

Add an option so that we continue sending chains to every other chain, but every block contains transactions to just one of the other chains, and we cycle through chains per block instead of per transfer.

## Test Plan

Deploy a network and test this mode against it.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.