### PR TITLE
Remove the `ApplicationCreated` that is no longer useful.

### DIFF
--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -263,8 +263,6 @@ pub enum SystemMessage {
         amount: Amount,
         recipient: Recipient,
     },
-    /// Notifies that a new application was created.
-    ApplicationCreated,
 }
 
 /// A query to the system state.
@@ -796,8 +794,6 @@ where
                     Recipient::Burn => (),
                 }
             }
-            // This message is only a placeholder: Its ID is part of the application ID.
-            ApplicationCreated => {}
         }
         Ok(outcome)
     }

--- a/linera-indexer/lib/src/db/sqlite/mod.rs
+++ b/linera-indexer/lib/src/db/sqlite/mod.rs
@@ -1051,9 +1051,6 @@ impl SqliteDatabase {
                         Some(owner.to_string()),
                         Some(recipient.to_string()),
                     ),
-                    SystemMessage::ApplicationCreated => {
-                        ("ApplicationCreated", None, None, None, None, None)
-                    }
                 };
 
                 MessageClassification {

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -1153,8 +1153,6 @@ SystemMessage:
               TYPENAME: Amount
           - recipient:
               TYPENAME: Recipient
-    2:
-      ApplicationCreated: UNIT
 SystemOperation:
   ENUM:
     0:


### PR DESCRIPTION
## Motivation

This was a leftover from previous works.

## Proposal

Simple removal.

## Test Plan

The CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.