### PR TITLE
One central benchmark command

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -25,7 +25,8 @@ This document contains the help content for the `linera` command-line program.
 * [`linera revoke-epochs`↴](#linera-revoke-epochs)
 * [`linera resource-control-policy`↴](#linera-resource-control-policy)
 * [`linera benchmark`↴](#linera-benchmark)
-* [`linera multi-benchmark`↴](#linera-multi-benchmark)
+* [`linera benchmark single`↴](#linera-benchmark-single)
+* [`linera benchmark multi`↴](#linera-benchmark-multi)
 * [`linera create-genesis-config`↴](#linera-create-genesis-config)
 * [`linera watch`↴](#linera-watch)
 * [`linera service`↴](#linera-service)
@@ -90,8 +91,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `remove-validator` — Remove a validator (admin only)
 * `revoke-epochs` — Deprecates all committees up to and including the specified one
 * `resource-control-policy` — View or update the resource control policy
-* `benchmark` — Start a benchmark, maintaining a given TPS or just sending one transfer per chain in bulk mode
-* `multi-benchmark` — Runs multiple `linera benchmark` processes in parallel
+* `benchmark` — Run benchmarks to test network performance
 * `create-genesis-config` — Create genesis configuration for a Linera deployment. Create initial user chains and print information to be used for initialization of validator setup. This will also create an initial wallet for the owner of the initial "root" chains
 * `watch` — Watch the network for notifications
 * `service` — Run a GraphQL service to explore and extend the chains of the wallet
@@ -527,9 +527,22 @@ View or update the resource control policy
 
 ## `linera benchmark`
 
-Start a benchmark, maintaining a given TPS or just sending one transfer per chain in bulk mode
+Run benchmarks to test network performance
 
-**Usage:** `linera benchmark [OPTIONS]`
+**Usage:** `linera benchmark <COMMAND>`
+
+###### **Subcommands:**
+
+* `single` — Start a single benchmark process, maintaining a given TPS
+* `multi` — Run multiple benchmark processes in parallel
+
+
+
+## `linera benchmark single`
+
+Start a single benchmark process, maintaining a given TPS
+
+**Usage:** `linera benchmark single [OPTIONS]`
 
 ###### **Options:**
 
@@ -558,41 +571,41 @@ Start a benchmark, maintaining a given TPS or just sending one transfer per chai
 
 
 
-## `linera multi-benchmark`
+## `linera benchmark multi`
 
-Runs multiple `linera benchmark` processes in parallel
+Run multiple benchmark processes in parallel
 
-**Usage:** `linera multi-benchmark [OPTIONS] --faucet <FAUCET>`
+**Usage:** `linera benchmark multi [OPTIONS] --faucet <FAUCET>`
 
 ###### **Options:**
 
-* `--processes <PROCESSES>` — The number of `linera benchmark` processes to run in parallel
+* `--num-chains <NUM_CHAINS>` — How many chains to use
+
+  Default value: `10`
+* `--tokens-per-chain <TOKENS_PER_CHAIN>` — How many tokens to assign to each newly created chain. These need to cover the transaction fees per chain for the benchmark
+
+  Default value: `0.1`
+* `--transactions-per-block <TRANSACTIONS_PER_BLOCK>` — How many transactions to put in each block
+
+  Default value: `1`
+* `--fungible-application-id <FUNGIBLE_APPLICATION_ID>` — The application ID of a fungible token on the wallet's default chain. If none is specified, the benchmark uses the native token
+* `--bps <BPS>` — The fixed BPS (Blocks Per Second) rate that block proposals will be sent at
+
+  Default value: `10`
+* `--close-chains` — If provided, will close the chains after the benchmark is finished. Keep in mind that closing the chains might take a while, and will increase the validator latency while they're being closed
+* `--health-check-endpoints <HEALTH_CHECK_ENDPOINTS>` — A comma-separated list of host:port pairs to query for health metrics. If provided, the benchmark will check these endpoints for validator health and terminate if any validator is unhealthy. Example: "127.0.0.1:21100,validator-1.some-network.linera.net:21100"
+* `--wrap-up-max-in-flight <WRAP_UP_MAX_IN_FLIGHT>` — The maximum number of in-flight requests to validators when wrapping up the benchmark. While wrapping up, this controls the concurrency level when processing inboxes and closing chains
+
+  Default value: `5`
+* `--confirm-before-start` — Confirm before starting the benchmark
+* `--runtime-in-seconds <RUNTIME_IN_SECONDS>` — How long to run the benchmark for. If not provided, the benchmark will run until it is interrupted
+* `--delay-between-chains-ms <DELAY_BETWEEN_CHAINS_MS>` — The delay between chains, in milliseconds. For example, if set to 200ms, the first chain will start, then the second will start 200 ms after the first one, the third 200 ms after the second one, and so on. This is used for slowly ramping up the TPS, so we don't pound the validators with the full TPS all at once
+* `--config-path <CONFIG_PATH>` — Path to YAML file containing chain IDs to send transfers to. If not provided, only transfers between chains in the same wallet
+* `--processes <PROCESSES>` — The number of benchmark processes to run in parallel
 
   Default value: `1`
 * `--faucet <FAUCET>` — The faucet (which implicitly defines the network)
 * `--client-state-dir <CLIENT_STATE_DIR>` — If specified, a directory with a random name will be created in this directory, and the client state will be stored there. If not specified, a temporary directory will be used for each client
-* `--num-chains <NUM_CHAINS>` — How many chains to use
-
-  Default value: `10`
-* `--tokens-per-chain <TOKENS_PER_CHAIN>` — How many tokens to assign to each newly created chain. These need to cover the transaction fees per chain for the benchmark
-
-  Default value: `0.1`
-* `--transactions-per-block <TRANSACTIONS_PER_BLOCK>` — How many transactions to put in each block
-
-  Default value: `1`
-* `--fungible-application-id <FUNGIBLE_APPLICATION_ID>` — The application ID of a fungible token on the wallet's default chain. If none is specified, the benchmark uses the native token
-* `--bps <BPS>` — The fixed BPS (Blocks Per Second) rate that block proposals will be sent at
-
-  Default value: `10`
-* `--close-chains` — If provided, will close the chains after the benchmark is finished. Keep in mind that closing the chains might take a while, and will increase the validator latency while they're being closed
-* `--health-check-endpoints <HEALTH_CHECK_ENDPOINTS>` — A comma-separated list of host:port pairs to query for health metrics. If provided, the benchmark will check these endpoints for validator health and terminate if any validator is unhealthy. Example: "127.0.0.1:21100,validator-1.some-network.linera.net:21100"
-* `--wrap-up-max-in-flight <WRAP_UP_MAX_IN_FLIGHT>` — The maximum number of in-flight requests to validators when wrapping up the benchmark. While wrapping up, this controls the concurrency level when processing inboxes and closing chains
-
-  Default value: `5`
-* `--confirm-before-start` — Confirm before starting the benchmark
-* `--runtime-in-seconds <RUNTIME_IN_SECONDS>` — How long to run the benchmark for. If not provided, the benchmark will run until it is interrupted
-* `--delay-between-chains-ms <DELAY_BETWEEN_CHAINS_MS>` — The delay between chains, in milliseconds. For example, if set to 200ms, the first chain will start, then the second will start 200 ms after the first one, the third 200 ms after the second one, and so on. This is used for slowly ramping up the TPS, so we don't pound the validators with the full TPS all at once
-* `--config-path <CONFIG_PATH>` — Path to YAML file containing chain IDs to send transfers to. If not provided, only transfers between chains in the same wallet
 * `--delay-between-processes <DELAY_BETWEEN_PROCESSES>` — The delay between starting the benchmark processes, in seconds. If --cross-wallet-transfers is true, this will be ignored
 
   Default value: `10`

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -26,7 +26,10 @@ use thiserror_context::Context;
 use tracing::{debug, info};
 #[cfg(not(web))]
 use {
-    crate::benchmark::{Benchmark, BenchmarkError},
+    crate::{
+        benchmark::{Benchmark, BenchmarkError},
+        client_metrics::ClientMetrics,
+    },
     futures::{stream, StreamExt, TryStreamExt},
     linera_base::{
         crypto::AccountPublicKey,
@@ -39,10 +42,8 @@ use {
         Operation,
     },
     std::{collections::HashSet, iter, path::Path},
-    tokio::task,
+    tokio::{sync::mpsc, task},
 };
-#[cfg(not(web))]
-use {crate::client_metrics::ClientMetrics, tokio::sync::mpsc};
 #[cfg(feature = "fs")]
 use {
     linera_base::{

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -42,14 +42,13 @@ use linera_execution::{
     committee::{Committee, ValidatorState},
     WasmRuntime, WithWasmDefault as _,
 };
-use linera_faucet_client::Faucet;
 use linera_faucet_server::{FaucetConfig, FaucetService};
 use linera_persistent::{self as persistent, Persist, PersistExt as _};
 use linera_service::{
     cli::{
         command::{
-            BenchmarkCommand, ClientCommand, DatabaseToolCommand, NetCommand, ProjectCommand,
-            WalletCommand,
+            BenchmarkCommand, BenchmarkOptions, ClientCommand, DatabaseToolCommand, NetCommand,
+            ProjectCommand, WalletCommand,
         },
         net_up_utils,
     },
@@ -796,107 +795,389 @@ impl Runnable for Job {
                 );
             }
 
-            Benchmark(benchmark_config) => {
-                let BenchmarkCommand {
-                    num_chains,
-                    tokens_per_chain,
-                    transactions_per_block,
-                    fungible_application_id,
-                    bps,
-                    close_chains,
-                    health_check_endpoints,
-                    wrap_up_max_in_flight,
-                    confirm_before_start,
-                    runtime_in_seconds,
-                    delay_between_chains_ms,
-                    config_path,
-                } = benchmark_config;
-                assert!(
-                    options.context_options.max_pending_message_bundles >= transactions_per_block,
-                    "max_pending_message_bundles must be set to at least the same as the \
+            Benchmark(benchmark_command) => match benchmark_command {
+                BenchmarkCommand::Single {
+                    options: benchmark_options,
+                } => {
+                    let BenchmarkOptions {
+                        num_chains,
+                        tokens_per_chain,
+                        transactions_per_block,
+                        fungible_application_id,
+                        bps,
+                        close_chains,
+                        health_check_endpoints,
+                        wrap_up_max_in_flight,
+                        confirm_before_start,
+                        runtime_in_seconds,
+                        delay_between_chains_ms,
+                        config_path,
+                    } = benchmark_options;
+                    assert!(
+                        options.context_options.max_pending_message_bundles
+                            >= transactions_per_block,
+                        "max_pending_message_bundles must be set to at least the same as the \
                      number of transactions per block ({transactions_per_block}) for benchmarking",
-                );
-                assert!(num_chains > 0, "Number of chains must be greater than 0");
-                assert!(
-                    transactions_per_block > 0,
-                    "Number of transactions per block must be greater than 0"
-                );
-                assert!(bps > 0, "BPS must be greater than 0");
+                    );
+                    assert!(num_chains > 0, "Number of chains must be greater than 0");
+                    assert!(
+                        transactions_per_block > 0,
+                        "Number of transactions per block must be greater than 0"
+                    );
+                    assert!(bps > 0, "BPS must be greater than 0");
 
-                let listener_config = ChainListenerConfig {
-                    skip_process_inbox: true,
-                    ..Default::default()
-                };
+                    let listener_config = ChainListenerConfig {
+                        skip_process_inbox: true,
+                        ..Default::default()
+                    };
 
-                let pub_keys: Vec<_> = std::iter::repeat_with(|| signer.generate_new())
-                    .take(num_chains)
-                    .collect();
-                signer.persist().await?;
+                    let pub_keys: Vec<_> = std::iter::repeat_with(|| signer.generate_new())
+                        .take(num_chains)
+                        .collect();
+                    signer.persist().await?;
 
-                let mut context = ClientContext::new(
-                    storage.clone(),
-                    options.context_options.clone(),
-                    wallet,
-                    signer.into_value(),
-                );
-                let (chain_clients, blocks_infos) = context
-                    .prepare_for_benchmark(
+                    let mut context = ClientContext::new(
+                        storage.clone(),
+                        options.context_options.clone(),
+                        wallet,
+                        signer.into_value(),
+                    );
+                    let (chain_clients, blocks_infos) = context
+                        .prepare_for_benchmark(
+                            num_chains,
+                            transactions_per_block,
+                            tokens_per_chain,
+                            fungible_application_id,
+                            pub_keys,
+                            config_path.as_deref(),
+                        )
+                        .await?;
+
+                    if confirm_before_start {
+                        info!("Ready to start benchmark. Say 'yes' when you want to proceed. Only 'yes' will be accepted");
+                        if !std::io::stdin()
+                            .lines()
+                            .next()
+                            .unwrap()?
+                            .eq_ignore_ascii_case("yes")
+                        {
+                            info!("Benchmark cancelled by user");
+                            context
+                                .wrap_up_benchmark(
+                                    chain_clients,
+                                    close_chains,
+                                    wrap_up_max_in_flight,
+                                )
+                                .await?;
+                            return Ok(());
+                        }
+                    }
+
+                    let shutdown_notifier = CancellationToken::new();
+                    tokio::spawn(listen_for_shutdown_signals(shutdown_notifier.clone()));
+
+                    let shared_context = std::sync::Arc::new(futures::lock::Mutex::new(context));
+                    let chain_listener = ChainListener::new(
+                        listener_config,
+                        shared_context.clone(),
+                        storage.clone(),
+                        shutdown_notifier.clone(),
+                    );
+                    linera_client::benchmark::Benchmark::run_benchmark(
                         num_chains,
                         transactions_per_block,
-                        tokens_per_chain,
-                        fungible_application_id,
-                        pub_keys,
-                        config_path.as_deref(),
+                        bps,
+                        chain_clients.clone(),
+                        blocks_infos,
+                        health_check_endpoints.clone(),
+                        runtime_in_seconds,
+                        delay_between_chains_ms,
+                        chain_listener,
+                        &shutdown_notifier,
                     )
                     .await?;
 
-                if confirm_before_start {
-                    info!("Ready to start benchmark. Say 'yes' when you want to proceed. Only 'yes' will be accepted");
-                    if !std::io::stdin()
-                        .lines()
-                        .next()
-                        .unwrap()?
-                        .eq_ignore_ascii_case("yes")
-                    {
-                        info!("Benchmark cancelled by user");
-                        context
-                            .wrap_up_benchmark(chain_clients, close_chains, wrap_up_max_in_flight)
-                            .await?;
-                        return Ok(());
-                    }
+                    let mut context = std::sync::Arc::try_unwrap(shared_context)
+                        .map_err(|_| anyhow::anyhow!("Failed to unwrap shared context"))?
+                        .into_inner();
+                    context
+                        .wrap_up_benchmark(chain_clients, close_chains, wrap_up_max_in_flight)
+                        .await?;
                 }
 
-                let shutdown_notifier = CancellationToken::new();
-                tokio::spawn(listen_for_shutdown_signals(shutdown_notifier.clone()));
+                BenchmarkCommand::Multi {
+                    options: benchmark_options,
+                    processes,
+                    faucet,
+                    client_state_dir,
+                    delay_between_processes,
+                    cross_wallet_transfers,
+                } => {
+                    let mut command = BenchmarkCommand::Single {
+                        options: benchmark_options.clone(),
+                    };
+                    let faucet_client = cli_wrappers::Faucet::new(faucet.clone());
+                    let on_drop = if benchmark_options.close_chains {
+                        OnClientDrop::CloseChains
+                    } else {
+                        OnClientDrop::LeakChains
+                    };
 
-                let shared_context = std::sync::Arc::new(futures::lock::Mutex::new(context));
-                let chain_listener = ChainListener::new(
-                    listener_config,
-                    shared_context.clone(),
-                    storage.clone(),
-                    shutdown_notifier.clone(),
-                );
-                linera_client::benchmark::Benchmark::run_benchmark(
-                    num_chains,
-                    transactions_per_block,
-                    bps,
-                    chain_clients.clone(),
-                    blocks_infos,
-                    health_check_endpoints,
-                    runtime_in_seconds,
-                    delay_between_chains_ms,
-                    chain_listener,
-                    &shutdown_notifier,
-                )
-                .await?;
+                    let clients = (0..processes)
+                        .map(|n| {
+                            let path_provider = if let Some(client_state_dir) = &client_state_dir {
+                                PathProvider::from_path_option(&Some(
+                                    tempfile::tempdir_in(client_state_dir)?
+                                        .keep()
+                                        .display()
+                                        .to_string(),
+                                ))?
+                            } else {
+                                PathProvider::from_path_option(&client_state_dir)?
+                            };
+                            Ok(Arc::new(ClientWrapper::new_with_extra_args(
+                                path_provider,
+                                Network::Grpc,
+                                None,
+                                n,
+                                on_drop,
+                                vec![
+                                    "--storage-max-stream-queries".to_string(),
+                                    "50".to_string(),
+                                    "--timings".to_string(),
+                                ],
+                            )))
+                        })
+                        .collect::<Result<Vec<_>, anyhow::Error>>()?;
 
-                let mut context = std::sync::Arc::try_unwrap(shared_context)
-                    .map_err(|_| anyhow::anyhow!("Failed to unwrap shared context"))?
-                    .into_inner();
-                context
-                    .wrap_up_benchmark(chain_clients, close_chains, wrap_up_max_in_flight)
-                    .await?;
-            }
+                    info!("Initializing wallets...");
+                    let mut join_set = JoinSet::new();
+
+                    if cross_wallet_transfers {
+                        for client in &clients {
+                            let client = client.clone();
+                            let faucet_client = faucet_client.clone();
+                            join_set.spawn(async move {
+                                client.wallet_init(Some(&faucet_client)).await?;
+                                client.request_chain(&faucet_client, true).await?;
+                                Ok::<_, anyhow::Error>(())
+                            });
+                        }
+
+                        join_set
+                            .join_all()
+                            .await
+                            .into_iter()
+                            .collect::<Result<Vec<_>, _>>()?;
+
+                        let chains_per_wallet = benchmark_options.num_chains;
+                        info!(
+                            "Creating {} chains per wallet ({} total chains)...",
+                            chains_per_wallet,
+                            chains_per_wallet * processes
+                        );
+
+                        let mut join_set = JoinSet::new();
+                        for client in &clients {
+                            let default_chain_id = client.default_chain().ok_or_else(|| {
+                                anyhow::anyhow!("No default chain found for client")
+                            })?;
+                            let client = client.clone();
+                            join_set.spawn(async move {
+                                let mut chain_ids = Vec::new();
+                                for _ in 0..chains_per_wallet {
+                                    let (chain_id, _owner) = client
+                                        .open_chain_super_owner(
+                                            default_chain_id,
+                                            None,
+                                            benchmark_options.tokens_per_chain,
+                                        )
+                                        .await?;
+                                    chain_ids.push(chain_id);
+                                }
+                                Ok::<Vec<ChainId>, anyhow::Error>(chain_ids)
+                            });
+                        }
+
+                        let all_chain_ids = join_set
+                            .join_all()
+                            .await
+                            .into_iter()
+                            .collect::<Result<Vec<_>, _>>()?
+                            .into_iter()
+                            .flatten()
+                            .collect::<Vec<_>>();
+
+                        let config = BenchmarkConfig {
+                            chain_ids: all_chain_ids,
+                        };
+
+                        let (_, path) = NamedTempFile::new()?.keep()?;
+                        config.save_to_file(&path)?;
+                        info!("Saved chains configuration to {}", path.display());
+                        if let BenchmarkCommand::Single { options } = &mut command {
+                            options.config_path = Some(path);
+                        }
+                    } else {
+                        for client in clients.clone() {
+                            let faucet_client = faucet_client.clone();
+                            join_set.spawn(async move {
+                                client.wallet_init(Some(&faucet_client)).await?;
+                                client.request_chain(&faucet_client, true).await?;
+                                Ok::<_, anyhow::Error>(())
+                            });
+                        }
+
+                        join_set
+                            .join_all()
+                            .await
+                            .into_iter()
+                            .collect::<Result<Vec<_>, _>>()?;
+                    }
+
+                    info!("Starting benchmark processes...");
+                    let mut join_set = JoinSet::new();
+                    for client in clients.clone() {
+                        let command = command.clone();
+                        let (tx, rx) = oneshot::channel();
+                        join_set.spawn(async move {
+                            let result = client.benchmark_detached(command, tx).await?;
+                            Ok::<_, anyhow::Error>((result, rx))
+                        });
+                    }
+
+                    let results = join_set
+                        .join_all()
+                        .await
+                        .into_iter()
+                        .collect::<Result<Vec<_>, _>>()?;
+
+                    let mut children = Vec::new();
+                    let mut stdout_handles = Vec::new();
+                    let mut stderr_handles = Vec::new();
+                    let mut rx_handles = Vec::new();
+                    for ((child, stdout_handle, stderr_handle), rx) in results {
+                        children.push(child);
+                        stdout_handles.push(stdout_handle);
+                        stderr_handles.push(stderr_handle);
+                        rx_handles.push(rx);
+                    }
+
+                    if benchmark_options.confirm_before_start {
+                        info!("Waiting until all child processes are ready...");
+                        let mut ready_count = 0;
+                        for rx in rx_handles {
+                            rx.await?;
+                            ready_count += 1;
+                            info!("{}/{} child processes are ready", ready_count, processes);
+                        }
+
+                        info!("Ready to start benchmark. Say 'yes' when you want to proceed. Only 'yes' will be accepted");
+                        if !std::io::stdin()
+                            .lines()
+                            .next()
+                            .unwrap()?
+                            .eq_ignore_ascii_case("yes")
+                        {
+                            info!("Benchmark cancelled by user");
+                            let mut join_set = JoinSet::new();
+                            for mut child in children {
+                                let mut stdin: ChildStdin = child.stdin.take().unwrap();
+                                stdin.write_all(b"no\n").await?;
+                                stdin.flush().await?;
+                                join_set.spawn(async move {
+                                    child.wait().await?;
+                                    Ok::<_, anyhow::Error>(())
+                                });
+                            }
+                            join_set
+                                .join_all()
+                                .await
+                                .into_iter()
+                                .collect::<Result<Vec<_>, _>>()?;
+                            return Ok(());
+                        }
+
+                        let mut previous = time::Instant::now();
+                        let mut first = true;
+                        let mut started_count = 0;
+                        for child in &mut children {
+                            if first {
+                                first = false;
+                            } else if !cross_wallet_transfers {
+                                let time_elapsed = previous.elapsed();
+                                if time_elapsed < Duration::from_secs(delay_between_processes) {
+                                    time::sleep(
+                                        Duration::from_secs(delay_between_processes) - time_elapsed,
+                                    )
+                                    .await;
+                                }
+                            }
+
+                            let mut stdin: ChildStdin = child.stdin.take().unwrap();
+                            stdin.write_all(b"yes\n").await?;
+                            stdin.flush().await?;
+                            started_count += 1;
+                            info!("{}/{} benchmarks started", started_count, processes);
+
+                            previous = time::Instant::now();
+                        }
+                    }
+
+                    let shutdown_notifier = CancellationToken::new();
+                    tokio::spawn(listen_for_shutdown_signals(shutdown_notifier.clone()));
+
+                    let mut join_set = JoinSet::new();
+                    let children_pids: Vec<u32> = children.iter().flat_map(|c| c.id()).collect();
+
+                    for ((mut child, stdout_handle), stderr_handle) in
+                        children.into_iter().zip(stdout_handles).zip(stderr_handles)
+                    {
+                        join_set.spawn(async move {
+                            let pid = child.id();
+                            let status = child.wait().await?;
+                            stdout_handle.await?;
+                            stderr_handle.await?;
+                            Ok::<_, anyhow::Error>((pid, status))
+                        });
+                    }
+
+                    loop {
+                        tokio::select! {
+                            result = join_set.join_next() => {
+                                match result {
+                                    Some(Ok(Ok((pid, status)))) => {
+                                        if !status.success() {
+                                            error!("Benchmark process (pid {:?}) failed with status: {:?}", pid, status);
+                                            kill_all_processes(&children_pids).await;
+                                            return Err(anyhow::anyhow!("Benchmark process (pid {:?}) failed", pid));
+                                        }
+                                    }
+                                    Some(Ok(Err(e))) => {
+                                        error!("Benchmark process failed: {}", e);
+                                        kill_all_processes(&children_pids).await;
+                                        return Err(e);
+                                    }
+                                    Some(Err(e)) => {
+                                        error!("Benchmark process panicked: {}", e);
+                                        kill_all_processes(&children_pids).await;
+                                        return Err(e.into());
+                                    }
+                                    None => {
+                                        info!("All benchmark processes have finished");
+                                        break;
+                                    }
+                                }
+                            }
+                            _ = shutdown_notifier.cancelled() => {
+                                info!("Shutdown signal received, waiting for all benchmark processes to finish");
+                                join_set.join_all().await.into_iter().collect::<Result<Vec<_>, _>>()?;
+                                break;
+                            }
+                        }
+                    }
+                }
+            },
 
             Watch { chain_id, raw } => {
                 let mut context = ClientContext::new(
@@ -1349,9 +1630,6 @@ impl Runnable for Job {
                 );
             }
 
-            MultiBenchmark { .. } => {
-                unreachable!()
-            }
             CreateGenesisConfig { .. }
             | Keygen
             | Net(_)
@@ -2158,277 +2436,6 @@ Make sure to use a Linera client compatible with this network.
                 Ok(0)
             }
         },
-
-        ClientCommand::MultiBenchmark {
-            processes,
-            faucet,
-            client_state_dir,
-            command,
-            delay_between_processes,
-            cross_wallet_transfers,
-        } => {
-            let mut command = command.clone();
-            let faucet = Faucet::new(faucet.clone());
-            let on_drop = if command.close_chains {
-                OnClientDrop::CloseChains
-            } else {
-                OnClientDrop::LeakChains
-            };
-
-            let clients = (0..*processes)
-                .map(|n| {
-                    let path_provider = if let Some(client_state_dir) = client_state_dir {
-                        PathProvider::from_path_option(&Some(
-                            tempfile::tempdir_in(client_state_dir)?
-                                .keep()
-                                .display()
-                                .to_string(),
-                        ))?
-                    } else {
-                        PathProvider::from_path_option(client_state_dir)?
-                    };
-                    Ok(Arc::new(ClientWrapper::new_with_extra_args(
-                        path_provider,
-                        Network::Grpc,
-                        None,
-                        n,
-                        on_drop,
-                        vec![
-                            "--storage-max-stream-queries".to_string(),
-                            "50".to_string(),
-                            "--timings".to_string(),
-                        ],
-                    )))
-                })
-                .collect::<Result<Vec<_>, anyhow::Error>>()?;
-
-            info!("Initializing wallets...");
-            let mut join_set = JoinSet::new();
-
-            if *cross_wallet_transfers {
-                for client in &clients {
-                    let client = client.clone();
-                    let faucet = faucet.clone();
-                    join_set.spawn(async move {
-                        client.wallet_init(Some(&faucet)).await?;
-                        client.request_chain(&faucet, true).await?;
-                        Ok::<_, anyhow::Error>(())
-                    });
-                }
-
-                join_set
-                    .join_all()
-                    .await
-                    .into_iter()
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                let chains_per_wallet = command.num_chains;
-                info!(
-                    "Creating {} chains per wallet ({} total chains)...",
-                    chains_per_wallet,
-                    chains_per_wallet * processes
-                );
-
-                let mut join_set = JoinSet::new();
-                for client in &clients {
-                    let default_chain_id = client
-                        .default_chain()
-                        .ok_or_else(|| anyhow::anyhow!("No default chain found for client"))?;
-                    let client = client.clone();
-                    join_set.spawn(async move {
-                        let mut chain_ids = Vec::new();
-                        for _ in 0..chains_per_wallet {
-                            let (chain_id, _owner) = client
-                                .open_chain_super_owner(
-                                    default_chain_id,
-                                    None,
-                                    command.tokens_per_chain,
-                                )
-                                .await?;
-                            chain_ids.push(chain_id);
-                        }
-                        Ok::<Vec<ChainId>, anyhow::Error>(chain_ids)
-                    });
-                }
-
-                let all_chain_ids = join_set
-                    .join_all()
-                    .await
-                    .into_iter()
-                    .collect::<Result<Vec<_>, _>>()?
-                    .into_iter()
-                    .flatten()
-                    .collect::<Vec<_>>();
-
-                let config = BenchmarkConfig {
-                    chain_ids: all_chain_ids,
-                };
-
-                let (_, path) = NamedTempFile::new()?.keep()?;
-                config.save_to_file(&path)?;
-                info!("Saved chains configuration to {}", path.display());
-                command.config_path = Some(path);
-            } else {
-                for client in clients.clone() {
-                    let faucet = faucet.clone();
-                    join_set.spawn(async move {
-                        client.wallet_init(Some(&faucet)).await?;
-                        client.request_chain(&faucet, true).await?;
-                        Ok::<_, anyhow::Error>(())
-                    });
-                }
-
-                join_set
-                    .join_all()
-                    .await
-                    .into_iter()
-                    .collect::<Result<Vec<_>, _>>()?;
-            }
-
-            info!("Starting benchmark processes...");
-            let confirm_before_start = command.confirm_before_start;
-            let mut join_set = JoinSet::new();
-            for client in clients.clone() {
-                let command = command.clone();
-                let (tx, rx) = oneshot::channel();
-                join_set.spawn(async move {
-                    let result = client.benchmark_detached(command, tx).await?;
-                    Ok::<_, anyhow::Error>((result, rx))
-                });
-            }
-
-            let results = join_set
-                .join_all()
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()?;
-
-            let mut children = Vec::new();
-            let mut stdout_handles = Vec::new();
-            let mut stderr_handles = Vec::new();
-            let mut rx_handles = Vec::new();
-            for ((child, stdout_handle, stderr_handle), rx) in results {
-                children.push(child);
-                stdout_handles.push(stdout_handle);
-                stderr_handles.push(stderr_handle);
-                rx_handles.push(rx);
-            }
-
-            if confirm_before_start {
-                info!("Waiting until all child processes are ready...");
-                let mut ready_count = 0;
-                for rx in rx_handles {
-                    rx.await?;
-                    ready_count += 1;
-                    info!("{}/{} child processes are ready", ready_count, processes);
-                }
-
-                info!("Ready to start benchmark. Say 'yes' when you want to proceed. Only 'yes' will be accepted");
-                if !std::io::stdin()
-                    .lines()
-                    .next()
-                    .unwrap()?
-                    .eq_ignore_ascii_case("yes")
-                {
-                    info!("Benchmark cancelled by user");
-                    let mut join_set = JoinSet::new();
-                    for mut child in children {
-                        let mut stdin: ChildStdin = child.stdin.take().unwrap();
-                        stdin.write_all(b"no\n").await?;
-                        stdin.flush().await?;
-                        join_set.spawn(async move {
-                            child.wait().await?;
-                            Ok::<_, anyhow::Error>(())
-                        });
-                    }
-                    join_set
-                        .join_all()
-                        .await
-                        .into_iter()
-                        .collect::<Result<Vec<_>, _>>()?;
-                    return Ok(1);
-                }
-
-                let mut previous = time::Instant::now();
-                let mut first = true;
-                let mut started_count = 0;
-                for child in &mut children {
-                    if first {
-                        first = false;
-                    } else if !*cross_wallet_transfers {
-                        let time_elapsed = previous.elapsed();
-                        if time_elapsed < Duration::from_secs(*delay_between_processes) {
-                            time::sleep(
-                                Duration::from_secs(*delay_between_processes) - time_elapsed,
-                            )
-                            .await;
-                        }
-                    }
-
-                    let mut stdin: ChildStdin = child.stdin.take().unwrap();
-                    stdin.write_all(b"yes\n").await?;
-                    stdin.flush().await?;
-                    started_count += 1;
-                    info!("{}/{} benchmarks started", started_count, processes);
-
-                    previous = time::Instant::now();
-                }
-            }
-
-            let shutdown_notifier = CancellationToken::new();
-            tokio::spawn(listen_for_shutdown_signals(shutdown_notifier.clone()));
-
-            let mut join_set = JoinSet::new();
-            let children_pids: Vec<u32> = children.iter().flat_map(|c| c.id()).collect();
-
-            for ((mut child, stdout_handle), stderr_handle) in
-                children.into_iter().zip(stdout_handles).zip(stderr_handles)
-            {
-                join_set.spawn(async move {
-                    let pid = child.id();
-                    let status = child.wait().await?;
-                    stdout_handle.await?;
-                    stderr_handle.await?;
-                    Ok::<_, anyhow::Error>((pid, status))
-                });
-            }
-
-            loop {
-                tokio::select! {
-                    result = join_set.join_next() => {
-                        match result {
-                            Some(Ok(Ok((pid, status)))) => {
-                                if !status.success() {
-                                    error!("Benchmark process (pid {:?}) failed with status: {:?}", pid, status);
-                                    kill_all_processes(&children_pids).await;
-                                    return Err(anyhow::anyhow!("Benchmark process (pid {:?}) failed", pid));
-                                }
-                            }
-                            Some(Ok(Err(e))) => {
-                                error!("Benchmark process failed: {}", e);
-                                kill_all_processes(&children_pids).await;
-                                return Err(e);
-                            }
-                            Some(Err(e)) => {
-                                error!("Benchmark process panicked: {}", e);
-                                kill_all_processes(&children_pids).await;
-                                return Err(e.into());
-                            }
-                            None => {
-                                info!("All benchmark processes have finished");
-                                break;
-                            }
-                        }
-                    }
-                    _ = shutdown_notifier.cancelled() => {
-                        info!("Shutdown signal received, waiting for all benchmark processes to finish");
-                        join_set.join_all().await.into_iter().collect::<Result<Vec<_>, _>>()?;
-                        break;
-                    }
-                }
-            }
-            Ok(0)
-        }
 
         _ => {
             options.run_with_storage(Job(options.clone())).await??;

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -784,7 +784,7 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
     use std::collections::BTreeMap;
 
     use fungible::{FungibleTokenAbi, InitialState, Parameters};
-    use linera_service::cli::command::BenchmarkCommand;
+    use linera_service::cli::command::{BenchmarkCommand, BenchmarkOptions};
 
     config.num_other_initial_chains = 2;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -795,13 +795,15 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
     assert_eq!(client.load_wallet()?.num_chains(), 3);
     // Launch local benchmark using some additional chains.
     client
-        .benchmark(BenchmarkCommand {
-            num_chains: 2,
-            transactions_per_block: 10,
-            bps: 2,
-            runtime_in_seconds: Some(5),
-            close_chains: true,
-            ..Default::default()
+        .benchmark(BenchmarkCommand::Single {
+            options: BenchmarkOptions {
+                num_chains: 2,
+                transactions_per_block: 10,
+                bps: 2,
+                runtime_in_seconds: Some(5),
+                close_chains: true,
+                ..Default::default()
+            },
         })
         .await?;
     assert_eq!(client.load_wallet()?.num_chains(), 3);
@@ -825,14 +827,16 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
         )
         .await?;
     client
-        .benchmark(BenchmarkCommand {
-            num_chains: 2,
-            transactions_per_block: 10,
-            bps: 2,
-            runtime_in_seconds: Some(5),
-            fungible_application_id: Some(application_id.forget_abi()),
-            close_chains: true,
-            ..Default::default()
+        .benchmark(BenchmarkCommand::Single {
+            options: BenchmarkOptions {
+                num_chains: 2,
+                transactions_per_block: 10,
+                bps: 2,
+                runtime_in_seconds: Some(5),
+                fungible_application_id: Some(application_id.forget_abi()),
+                close_chains: true,
+                ..Default::default()
+            },
         })
         .await?;
 


### PR DESCRIPTION
## Motivation

Right now we have `linera benchmark` and `linera multi-benchmark`. It would be nice if all the benchmark stuff was centralized in one command, with sub commands.

## Proposal

Modify things so that we have one single `linera benchmark` command, but with subcommands:
* `linera benchmark single`
* `linera benchmark multi`

## Test Plan

CI should cover it, but will test it against a local network as well

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
