### PR TITLE
Eliminate the `Recipient` type.

### DIFF
--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, HashMap};
 use fungible::{self, NativeFungibleTokenAbi};
 use linera_sdk::{
     linera_base_types::{Account, AccountOwner, Amount, CryptoHash},
-    test::{ActiveChain, Recipient, TestValidator},
+    test::{ActiveChain, TestValidator},
 };
 
 /// Tests if tokens from the shared chain balance can be sent to a different chain.
@@ -29,7 +29,7 @@ async fn chain_balance_transfers() {
 
     let transfer_amount = Amount::ONE;
     let funding_chain = validator.get_chain(&validator.admin_chain_id());
-    let recipient = Recipient::chain(recipient_chain.id());
+    let recipient = Account::chain(recipient_chain.id());
 
     let transfer_certificate = funding_chain
         .add_block(|block| {
@@ -68,7 +68,7 @@ async fn transfer_to_owner() {
     let funding_chain = validator.get_chain(&validator.admin_chain_id());
     let owner = AccountOwner::from(CryptoHash::test_hash("owner"));
     let account = Account::new(recipient_chain.id(), owner);
-    let recipient = Recipient::Account(account);
+    let recipient = account;
 
     let transfer_certificate = funding_chain
         .add_block(|block| {
@@ -111,7 +111,7 @@ async fn transfer_to_multiple_owners() {
         .iter()
         .copied()
         .map(|account_owner| Account::new(recipient_chain.id(), account_owner))
-        .map(Recipient::Account);
+;
 
     let transfer_certificate = funding_chain
         .add_block(|block| {
@@ -152,7 +152,7 @@ async fn emptied_account_disappears_from_queries() {
     let funding_chain = validator.get_chain(&validator.admin_chain_id());
 
     let owner = AccountOwner::from(recipient_chain.public_key());
-    let recipient = Recipient::Account(Account::new(recipient_chain.id(), owner));
+    let recipient = Account::new(recipient_chain.id(), owner);
 
     let transfer_certificate = funding_chain
         .add_block(|block| {
@@ -168,7 +168,7 @@ async fn emptied_account_disappears_from_queries() {
 
     recipient_chain
         .add_block(|block| {
-            block.with_native_token_transfer(owner, Recipient::Account(Account::chain(recipient_chain.id())), transfer_amount);
+            block.with_native_token_transfer(owner, Account::chain(recipient_chain.id()), transfer_amount);
         })
         .await;
 

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -168,7 +168,7 @@ async fn emptied_account_disappears_from_queries() {
 
     recipient_chain
         .add_block(|block| {
-            block.with_native_token_transfer(owner, Recipient::Burn, transfer_amount);
+            block.with_native_token_transfer(owner, Recipient::Account(Account::chain(recipient_chain.id())), transfer_amount);
         })
         .await;
 

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -67,8 +67,7 @@ async fn transfer_to_owner() {
     let transfer_amount = Amount::from_tokens(2);
     let funding_chain = validator.get_chain(&validator.admin_chain_id());
     let owner = AccountOwner::from(CryptoHash::test_hash("owner"));
-    let account = Account::new(recipient_chain.id(), owner);
-    let recipient = account;
+    let recipient = Account::new(recipient_chain.id(), owner);
 
     let transfer_certificate = funding_chain
         .add_block(|block| {

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -110,8 +110,7 @@ async fn transfer_to_multiple_owners() {
     let recipients = account_owners
         .iter()
         .copied()
-        .map(|account_owner| Account::new(recipient_chain.id(), account_owner))
-;
+        .map(|account_owner| Account::new(recipient_chain.id(), account_owner));
 
     let transfer_certificate = funding_chain
         .add_block(|block| {
@@ -168,7 +167,11 @@ async fn emptied_account_disappears_from_queries() {
 
     recipient_chain
         .add_block(|block| {
-            block.with_native_token_transfer(owner, Account::chain(recipient_chain.id()), transfer_amount);
+            block.with_native_token_transfer(
+                owner,
+                Account::chain(recipient_chain.id()),
+                transfer_amount,
+            );
         })
         .await;
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -101,6 +101,16 @@ impl Account {
             owner: AccountOwner::CHAIN,
         }
     }
+
+    /// An address used exclusively for tests
+    #[cfg(with_testing)]
+    pub fn burn_address(chain_id: ChainId) -> Self {
+        let hash = CryptoHash::test_hash("burn");
+        Account {
+            chain_id,
+            owner: hash.into(),
+        }
+    }
 }
 
 impl fmt::Display for Account {

--- a/linera-chain/src/test/mod.rs
+++ b/linera-chain/src/test/mod.rs
@@ -8,11 +8,10 @@ mod http_server;
 use linera_base::{
     crypto::{AccountPublicKey, Signer, ValidatorPublicKey},
     data_types::{Amount, BlockHeight, Epoch, Round, Timestamp},
-    identifiers::{AccountOwner, ChainId},
+    identifiers::{Account, AccountOwner, ChainId},
 };
 use linera_execution::{
     committee::{Committee, ValidatorState},
-    system::Recipient,
     Message, MessageKind, Operation, ResourceControlPolicy, SystemOperation,
 };
 
@@ -63,7 +62,7 @@ pub trait BlockTestExt: Sized {
     fn with_operation(self, operation: impl Into<Operation>) -> Self;
 
     /// Returns the block with a transfer operation appended at the end.
-    fn with_transfer(self, owner: AccountOwner, recipient: Recipient, amount: Amount) -> Self;
+    fn with_transfer(self, owner: AccountOwner, recipient: Account, amount: Amount) -> Self;
 
     /// Returns the block with a simple transfer operation appended at the end.
     fn with_simple_transfer(self, chain_id: ChainId, amount: Amount) -> Self;
@@ -110,7 +109,7 @@ impl BlockTestExt for ProposedBlock {
         self
     }
 
-    fn with_transfer(self, owner: AccountOwner, recipient: Recipient, amount: Amount) -> Self {
+    fn with_transfer(self, owner: AccountOwner, recipient: Account, amount: Amount) -> Self {
         self.with_operation(SystemOperation::Transfer {
             owner,
             recipient,
@@ -119,7 +118,7 @@ impl BlockTestExt for ProposedBlock {
     }
 
     fn with_simple_transfer(self, chain_id: ChainId, amount: Amount) -> Self {
-        self.with_transfer(AccountOwner::CHAIN, Recipient::chain(chain_id), amount)
+        self.with_transfer(AccountOwner::CHAIN, Account::chain(chain_id), amount)
     }
 
 

--- a/linera-chain/src/test/mod.rs
+++ b/linera-chain/src/test/mod.rs
@@ -77,8 +77,6 @@ pub trait BlockTestExt: Sized {
     /// Returns the block with the specified epoch.
     fn with_epoch(self, epoch: impl Into<Epoch>) -> Self;
 
-    /// Returns the block with the burn operation appended at the end.
-    fn with_burn(self, amount: Amount) -> Self;
 
     /// Returns a block proposal in the first round in a default ownership configuration
     /// (`Round::MultiLeader(0)`) without any hashed certificate values or validated block.
@@ -124,13 +122,6 @@ impl BlockTestExt for ProposedBlock {
         self.with_transfer(AccountOwner::CHAIN, Recipient::chain(chain_id), amount)
     }
 
-    fn with_burn(self, amount: Amount) -> Self {
-        self.with_operation(SystemOperation::Transfer {
-            owner: AccountOwner::CHAIN,
-            recipient: Recipient::Burn,
-            amount,
-        })
-    }
 
     fn with_incoming_bundle(mut self, incoming_bundle: IncomingBundle) -> Self {
         self.transactions

--- a/linera-chain/src/test/mod.rs
+++ b/linera-chain/src/test/mod.rs
@@ -76,7 +76,6 @@ pub trait BlockTestExt: Sized {
     /// Returns the block with the specified epoch.
     fn with_epoch(self, epoch: impl Into<Epoch>) -> Self;
 
-
     /// Returns a block proposal in the first round in a default ownership configuration
     /// (`Round::MultiLeader(0)`) without any hashed certificate values or validated block.
     async fn into_first_proposal<S: Signer + ?Sized>(
@@ -120,7 +119,6 @@ impl BlockTestExt for ProposedBlock {
     fn with_simple_transfer(self, chain_id: ChainId, amount: Amount) -> Self {
         self.with_transfer(AccountOwner::CHAIN, Account::chain(chain_id), amount)
     }
-
 
     fn with_incoming_bundle(mut self, incoming_bundle: IncomingBundle) -> Self {
         self.transactions

--- a/linera-chain/src/test/mod.rs
+++ b/linera-chain/src/test/mod.rs
@@ -76,6 +76,9 @@ pub trait BlockTestExt: Sized {
     /// Returns the block with the specified epoch.
     fn with_epoch(self, epoch: impl Into<Epoch>) -> Self;
 
+    /// Returns the block with the burn operation (transfer to a special address) appended at the end.
+    fn with_burn(self, amount: Amount) -> Self;
+
     /// Returns a block proposal in the first round in a default ownership configuration
     /// (`Round::MultiLeader(0)`) without any hashed certificate values or validated block.
     async fn into_first_proposal<S: Signer + ?Sized>(
@@ -118,6 +121,15 @@ impl BlockTestExt for ProposedBlock {
 
     fn with_simple_transfer(self, chain_id: ChainId, amount: Amount) -> Self {
         self.with_transfer(AccountOwner::CHAIN, Account::chain(chain_id), amount)
+    }
+
+    fn with_burn(self, amount: Amount) -> Self {
+        let recipient = Account::burn_address(self.chain_id);
+        self.with_operation(SystemOperation::Transfer {
+            owner: AccountOwner::CHAIN,
+            recipient,
+            amount,
+        })
     }
 
     fn with_incoming_bundle(mut self, incoming_bundle: IncomingBundle) -> Self {

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -160,7 +160,7 @@ async fn test_block_size_limit() -> anyhow::Result<()> {
     let time = Timestamp::from(0);
 
     // The size of the executed valid block below.
-    let maximum_block_size = 261;
+    let maximum_block_size = 260;
 
     let config = env.make_open_chain_config();
 

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -18,13 +18,12 @@ use linera_base::{
         ChainDescription, ChainOrigin, Epoch, InitialChainConfig, Timestamp,
     },
     http,
-    identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId},
+    identifiers::{Account, AccountOwner, ApplicationId, ChainId, ModuleId},
     ownership::ChainOwnership,
     vm::VmRuntime,
 };
 use linera_execution::{
     committee::{Committee, ValidatorState},
-    system::Recipient,
     test_utils::{ExpectedCall, MockApplication},
     BaseRuntime, ContractRuntime, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext,
     Operation, ResourceControlPolicy, ServiceRuntime, SystemOperation, TestExecutionRuntimeContext,
@@ -199,7 +198,7 @@ async fn test_block_size_limit() -> anyhow::Result<()> {
         .with_authenticated_signer(Some(owner))
         .with_operation(SystemOperation::Transfer {
             owner: AccountOwner::CHAIN,
-            recipient: Recipient::chain(env.admin_id()),
+            recipient: Account::chain(env.admin_id()),
             amount: Amount::ONE,
         });
 
@@ -208,7 +207,7 @@ async fn test_block_size_limit() -> anyhow::Result<()> {
         .clone()
         .with_operation(SystemOperation::Transfer {
             owner: AccountOwner::CHAIN,
-            recipient: Recipient::chain(env.admin_id()),
+            recipient: Account::chain(env.admin_id()),
             amount: Amount::ONE,
         });
 

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -12,7 +12,7 @@ use std::{
 
 use linera_base::{
     data_types::Amount,
-    identifiers::{AccountOwner, ApplicationId, ChainId},
+    identifiers::{Account, AccountOwner, ApplicationId, ChainId},
     time::Instant,
 };
 use linera_core::{
@@ -20,7 +20,7 @@ use linera_core::{
     Environment,
 };
 use linera_execution::{
-    system::{Recipient, SystemOperation},
+    system::SystemOperation,
     Operation,
 };
 use linera_sdk::abis::fungible::{self, FungibleOperation};
@@ -696,7 +696,7 @@ impl<Env: Environment> Benchmark<Env> {
                     ),
                     None => Operation::system(SystemOperation::Transfer {
                         owner: AccountOwner::CHAIN,
-                        recipient: Recipient::chain(recipient_chain_id),
+                        recipient: Account::chain(recipient_chain_id),
                         amount,
                     }),
                 };

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -19,10 +19,7 @@ use linera_core::{
     client::{ChainClient, ChainClientError},
     Environment,
 };
-use linera_execution::{
-    system::SystemOperation,
-    Operation,
-};
+use linera_execution::{system::SystemOperation, Operation};
 use linera_sdk::abis::fungible::{self, FungibleOperation};
 use num_format::{Locale, ToFormattedString};
 use prometheus_parse::{HistogramCount, Scrape, Value};

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -9,7 +9,7 @@ use futures::{lock::Mutex, FutureExt as _};
 use linera_base::{
     crypto::{AccountPublicKey, InMemorySigner},
     data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
-    identifiers::{AccountOwner, ChainId},
+    identifiers::{Account, AccountOwner, ChainId},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_core::{
@@ -219,9 +219,9 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
                 .unwrap()
         }
     });
-    // Burn one token.
+    // Transfer one token.
     let certificate = client0
-        .burn(AccountOwner::CHAIN, Amount::ONE)
+        .transfer_to_account(AccountOwner::CHAIN, Amount::ONE, Account::chain(client0.chain_id()))
         .await?
         .unwrap();
     for i in 0.. {

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -17,7 +17,6 @@ use linera_core::{
     environment,
     test_utils::{MemoryStorageBuilder, StorageBuilder as _, TestBuilder},
 };
-use linera_execution::system::Recipient;
 use linera_storage::Storage;
 use tokio_util::sync::CancellationToken;
 
@@ -157,7 +156,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     });
     // Transfer one token to chain 0. The listener should eventually become leader and receive
     // the message.
-    let recipient0 = Recipient::chain(chain_id0);
+    let recipient0 = Account::chain(chain_id0);
     client1
         .transfer(AccountOwner::CHAIN, Amount::ONE, recipient0)
         .await?;

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -218,13 +218,9 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
                 .unwrap()
         }
     });
-    // Transfer one token.
+    // Burn one token.
     let certificate = client0
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::ONE,
-            Account::chain(client0.chain_id()),
-        )
+        .burn(AccountOwner::CHAIN, Amount::ONE)
         .await?
         .unwrap();
     for i in 0.. {

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -220,7 +220,11 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
     });
     // Transfer one token.
     let certificate = client0
-        .transfer_to_account(AccountOwner::CHAIN, Amount::ONE, Account::chain(client0.chain_id()))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(client0.chain_id()),
+        )
         .await?
         .unwrap();
     for i in 0.. {

--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -9,7 +9,6 @@ use linera_base::{
     time::Duration,
 };
 use linera_core::test_utils::{ChainClient, MemoryStorageBuilder, StorageBuilder, TestBuilder};
-use linera_execution::system::Recipient;
 use linera_storage::metrics::{
     READ_CERTIFICATE_COUNTER, READ_CONFIRMED_BLOCK_COUNTER, WRITE_CERTIFICATE_COUNTER,
 };
@@ -71,7 +70,7 @@ pub async fn run_claim_bench<B>(
         Amount::from_tokens(9)
     );
 
-    let account = Recipient::chain(chain1.chain_id());
+    let account = Account::chain(chain1.chain_id());
     let cert = chain1
         .claim(owner1, chain2.chain_id(), account, amt)
         .await

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2745,10 +2745,8 @@ impl<Env: Environment> ChainClient<Env> {
         amount: Amount,
         account: Account,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
-        self.transfer(from, amount, account)
-            .await
+        self.transfer(from, amount, account).await
     }
-
 
     /// Attempts to synchronize chains that have sent us messages and populate our local
     /// inbox.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2749,15 +2749,6 @@ impl<Env: Environment> ChainClient<Env> {
             .await
     }
 
-    /// Burns tokens.
-    #[instrument(level = "trace")]
-    pub async fn burn(
-        &self,
-        owner: AccountOwner,
-        amount: Amount,
-    ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
-        self.transfer(owner, amount, Recipient::Burn).await
-    }
 
     /// Attempts to synchronize chains that have sent us messages and populate our local
     /// inbox.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2748,6 +2748,18 @@ impl<Env: Environment> ChainClient<Env> {
         self.transfer(from, amount, account).await
     }
 
+    /// Burns tokens (transfer to a special address).
+    #[cfg(with_testing)]
+    #[instrument(level = "trace")]
+    pub async fn burn(
+        &self,
+        owner: AccountOwner,
+        amount: Amount,
+    ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
+        let recipient = Account::burn_address(self.chain_id);
+        self.transfer(owner, amount, recipient).await
+    }
+
     /// Attempts to synchronize chains that have sent us messages and populate our local
     /// inbox.
     ///
@@ -3507,11 +3519,11 @@ impl<Env: Environment> ChainClient<Env> {
         &self,
         owner: AccountOwner,
         amount: Amount,
-        account: Account,
+        recipient: Account,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
         self.execute_operation(SystemOperation::Transfer {
             owner,
-            recipient: account,
+            recipient,
             amount,
         })
         .await

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -54,7 +54,7 @@ use linera_chain::{
 use linera_execution::{
     committee::Committee,
     system::{
-        AdminOperation, OpenChainConfig, Recipient, SystemOperation, EPOCH_STREAM_NAME,
+        AdminOperation, OpenChainConfig, SystemOperation, EPOCH_STREAM_NAME,
         REMOVED_EPOCH_STREAM_NAME,
     },
     ExecutionError, Operation, Query, QueryOutcome, QueryResponse, SystemQuery, SystemResponse,
@@ -2238,7 +2238,7 @@ impl<Env: Environment> ChainClient<Env> {
         &self,
         owner: AccountOwner,
         amount: Amount,
-        recipient: Recipient,
+        recipient: Account,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
         // TODO(#467): check the balance of `owner` before signing any block proposal.
         self.execute_operation(SystemOperation::Transfer {
@@ -2270,7 +2270,7 @@ impl<Env: Environment> ChainClient<Env> {
         &self,
         owner: AccountOwner,
         target_id: ChainId,
-        recipient: Recipient,
+        recipient: Account,
         amount: Amount,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
         self.execute_operation(SystemOperation::Claim {
@@ -2745,7 +2745,7 @@ impl<Env: Environment> ChainClient<Env> {
         amount: Amount,
         account: Account,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
-        self.transfer(from, amount, Recipient::Account(account))
+        self.transfer(from, amount, account)
             .await
     }
 
@@ -3513,7 +3513,7 @@ impl<Env: Environment> ChainClient<Env> {
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
         self.execute_operation(SystemOperation::Transfer {
             owner,
-            recipient: Recipient::Account(account),
+            recipient: account,
             amount,
         })
         .await

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1500,12 +1500,9 @@ where
         LockingBlock::Regular(validated),
         *info2_b.manager.requested_locking.unwrap()
     );
+    let recipient = Account::burn_address(client_2b.chain_id());
     let bt_certificate = client_2b
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(1),
-            Account::chain(client_2b.chain_id()),
-        )
+        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(1), recipient)
         .await
         .unwrap_ok_committed();
 
@@ -1518,7 +1515,7 @@ where
     assert!(certificate_values[0].block().body.operations().any(|op| *op
         == Operation::system(SystemOperation::Transfer {
             owner: AccountOwner::CHAIN,
-            recipient: Account::chain(client_2b.chain_id()),
+            recipient,
             amount: Amount::from_tokens(1),
         })));
 
@@ -1637,12 +1634,9 @@ where
     builder.set_fault_type([0, 1, 3], FaultType::Honest).await;
 
     client2_b.prepare_chain().await.unwrap();
+    let recipient = Account::burn_address(client2_b.chain_id());
     let bt_certificate = client2_b
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(1),
-            Account::chain(client2_b.chain_id()),
-        )
+        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(1), recipient)
         .await
         .unwrap_ok_committed();
 
@@ -1655,7 +1649,7 @@ where
     assert!(certificate_values[0].block().body.operations().any(|op| *op
         == Operation::system(SystemOperation::Transfer {
             owner: AccountOwner::CHAIN,
-            recipient: Account::chain(client2_b.chain_id()),
+            recipient,
             amount: Amount::from_tokens(1),
         })));
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -23,10 +23,8 @@ use linera_chain::{
     ChainError, ChainExecutionContext,
 };
 use linera_execution::{
-    committee::Committee,
-    system::SystemOperation,
-    ExecutionError, Message, MessageKind, Operation, QueryOutcome, ResourceControlPolicy,
-    SystemMessage, SystemQuery, SystemResponse,
+    committee::Committee, system::SystemOperation, ExecutionError, Message, MessageKind, Operation,
+    QueryOutcome, ResourceControlPolicy, SystemMessage, SystemQuery, SystemResponse,
 };
 use linera_storage::Storage;
 use rand::Rng;
@@ -300,7 +298,11 @@ where
     sender.synchronize_from_validators().await.unwrap();
     // Can still use the chain.
     sender
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(3), Account::chain(sender.chain_id))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(3),
+            Account::chain(sender.chain_id),
+        )
         .await
         .unwrap();
     Ok(())
@@ -348,7 +350,11 @@ where
     // Cannot use the chain any more.
     assert_matches!(
         sender
-            .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(3), Account::chain(sender.chain_id))
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_tokens(3),
+                Account::chain(sender.chain_id)
+            )
             .await,
         Err(ChainClientError::NotAnOwner(_))
     );
@@ -394,7 +400,11 @@ where
     sender.synchronize_from_validators().await.unwrap();
     // Can still use the chain with the old client.
     sender
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(2), Account::chain(receiver.chain_id))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(2),
+            Account::chain(receiver.chain_id),
+        )
         .await
         .unwrap();
     let sender_info = sender.chain_info().await?;
@@ -422,7 +432,13 @@ where
 
     // We need at least three validators for making an operation.
     builder.set_fault_type([0, 1], FaultType::Offline).await;
-    let result = client.transfer_to_account(AccountOwner::CHAIN, Amount::ONE, Account::chain(sender.chain_id)).await;
+    let result = client
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(sender.chain_id),
+        )
+        .await;
     assert_matches!(
         result,
         Err(ChainClientError::CommunicationError(
@@ -432,7 +448,13 @@ where
     builder.set_fault_type([0, 1], FaultType::Honest).await;
     builder.set_fault_type([2, 3], FaultType::Offline).await;
     assert_matches!(
-        sender.transfer_to_account(AccountOwner::CHAIN, Amount::ONE, Account::chain(sender.chain_id)).await,
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::ONE,
+                Account::chain(sender.chain_id)
+            )
+            .await,
         Err(ChainClientError::CommunicationError(
             CommunicationError::Trusted(ClientIoError { .. })
         ))
@@ -451,7 +473,11 @@ where
     );
     client.clear_pending_proposal();
     client
-        .transfer_to_account(AccountOwner::CHAIN, Amount::ONE, Account::chain(receiver.chain_id))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(receiver.chain_id),
+        )
         .await
         .unwrap_ok_committed();
     assert_eq!(client.local_balance().await.unwrap(), Amount::ONE);
@@ -463,7 +489,11 @@ where
     assert_eq!(sender.local_balance().await.unwrap(), Amount::ONE);
     sender.clear_pending_proposal();
     sender
-        .transfer_to_account(AccountOwner::CHAIN, Amount::ONE, Account::chain(receiver.chain_id))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(receiver.chain_id),
+        )
         .await
         .unwrap_ok_committed();
 
@@ -625,7 +655,11 @@ where
         Amount::from_tokens(3)
     );
     client
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(3), Account::chain(sender.chain_id))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(3),
+            Account::chain(sender.chain_id),
+        )
         .await
         .unwrap();
     Ok(())
@@ -688,7 +722,11 @@ where
         Amount::from_tokens(3)
     );
     client
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(3), Account::chain(sender.chain_id))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(3),
+            Account::chain(sender.chain_id),
+        )
         .await
         .unwrap();
     assert_eq!(client.local_balance().await.unwrap(), Amount::ZERO);
@@ -738,7 +776,11 @@ where
     );
     // Cannot use the chain for operations any more.
     let result = client1
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(3), Account::chain(client2.chain_id()))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(3),
+            Account::chain(client2.chain_id()),
+        )
         .await;
     assert!(
         matches!(
@@ -1256,12 +1298,20 @@ where
     let receiver = builder.add_root_chain(2, Amount::ZERO).await?;
 
     let obtained_error = sender
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(4), Account::chain(receiver.chain_id))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(4),
+            Account::chain(receiver.chain_id),
+        )
         .await;
     assert_insufficient_balance_during_operation(obtained_error, 0);
 
     let obtained_error = sender
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(3), Account::chain(receiver.chain_id))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(3),
+            Account::chain(receiver.chain_id),
+        )
         .await;
     // We have balance=3, we try to transfer 3 tokens but the operation itself
     // costs 1 microtoken so we don't have enough balance to pay for it.
@@ -1291,7 +1341,11 @@ where
         .await
         .unwrap_ok_committed();
     let cert1 = sender
-        .transfer_to_account(AccountOwner::CHAIN, Amount::ONE, Account::chain(sender.chain_id))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(sender.chain_id),
+        )
         .await
         .unwrap_ok_committed();
     let cert2 = sender
@@ -1505,7 +1559,11 @@ where
         *info2_b.manager.requested_locking.unwrap()
     );
     let bt_certificate = client_2b
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(1), Account::chain(client_2b.chain_id()))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(1),
+            Account::chain(client_2b.chain_id()),
+        )
         .await
         .unwrap_ok_committed();
 
@@ -1638,7 +1696,11 @@ where
 
     client2_b.prepare_chain().await.unwrap();
     let bt_certificate = client2_b
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(1), Account::chain(client2_b.chain_id()))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(1),
+            Account::chain(client2_b.chain_id()),
+        )
         .await
         .unwrap_ok_committed();
 
@@ -1706,7 +1768,11 @@ where
         .set_fault_type([2, 3], FaultType::OfflineWithInfo)
         .await;
     assert!(client1
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_millis(1), Account::chain(client1.chain_id()))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_millis(1),
+            Account::chain(client1.chain_id())
+        )
         .await
         .is_err());
 
@@ -1716,7 +1782,11 @@ where
         .await;
     builder.set_fault_type([2, 3], FaultType::Honest).await;
     assert!(client2
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_millis(2), Account::chain(client2.chain_id()))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_millis(2),
+            Account::chain(client2.chain_id())
+        )
         .await
         .is_err());
 
@@ -2177,7 +2247,11 @@ where
         .set_fault_type([2], FaultType::OfflineWithInfo)
         .await;
     let result = client0
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(3), Account::chain(client0.chain_id()))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(3),
+            Account::chain(client0.chain_id()),
+        )
         .await;
     assert!(result.is_err());
 
@@ -2220,7 +2294,11 @@ where
     // Client 0 now only tries to transfer 1 token. Before that, they automatically finalize the
     // pending block, which publishes the blob, leaving 10 - 1 = 9.
     client0
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(1), Account::chain(client0.chain_id()))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(1),
+            Account::chain(client0.chain_id()),
+        )
         .await
         .unwrap();
     client0.synchronize_from_validators().await.unwrap();
@@ -2234,7 +2312,11 @@ where
     // Transfer another token so Client 1 sees that the blob is already published
     client1.prepare_chain().await.unwrap();
     client1
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(1), Account::chain(client1.chain_id()))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(1),
+            Account::chain(client1.chain_id()),
+        )
         .await
         .unwrap();
     client1.synchronize_from_validators().await.unwrap();
@@ -2268,7 +2350,11 @@ where
         .set_fault_type([2], FaultType::OfflineWithInfo)
         .await;
     let result = client1
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(3), Account::chain(client2.chain_id()))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(3),
+            Account::chain(client2.chain_id()),
+        )
         .await;
     assert!(result.is_err());
 
@@ -2277,7 +2363,14 @@ where
 
     // The client1 tries to transfer another token. Before that, they automatically finalize the
     // pending block, which transfers 3 tokens, leaving 10 - 3 - 1 = 6.
-    client1.transfer_to_account(AccountOwner::CHAIN, Amount::ONE, Account::chain(client2.chain_id())).await.unwrap();
+    client1
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(client2.chain_id()),
+        )
+        .await
+        .unwrap();
     client1.synchronize_from_validators().await.unwrap();
     client1.process_inbox().await.unwrap();
     assert_eq!(
@@ -2330,7 +2423,11 @@ where
     builder.set_fault_type([3], FaultType::Offline).await;
 
     let result = client0
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(3), Account::chain(client2.chain_id()))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(3),
+            Account::chain(client2.chain_id()),
+        )
         .await;
     assert!(result.is_err());
     let manager = client0
@@ -2368,7 +2465,11 @@ where
     assert!(manager.requested_locking.is_none());
     assert_eq!(manager.current_round, Round::MultiLeader(0));
     let result = client1
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(2), Account::chain(client2.chain_id()))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(2),
+            Account::chain(client2.chain_id()),
+        )
         .await;
     assert!(result.is_err());
 
@@ -2389,7 +2490,11 @@ where
     assert_eq!(manager.current_round, Round::MultiLeader(1));
     assert!(client1.pending_proposal().is_some());
     client1
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(4), Account::chain(client2.chain_id()))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(4),
+            Account::chain(client2.chain_id()),
+        )
         .await
         .unwrap();
 
@@ -2457,7 +2562,13 @@ where
         .set_fault_type([1, 2, 3], FaultType::OfflineWithInfo)
         .await;
 
-    let result = client0.transfer_to_account(owner0, Amount::from_tokens(3), Account::chain(client2.chain_id)).await;
+    let result = client0
+        .transfer_to_account(
+            owner0,
+            Amount::from_tokens(3),
+            Account::chain(client2.chain_id),
+        )
+        .await;
     assert!(result.is_err());
     let manager = client0
         .chain_info_with_manager_values()
@@ -2488,7 +2599,11 @@ where
     // about the proposed fast block and make their own instead.
     builder.set_fault_type([3], FaultType::Offline).await;
     let result = client1
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(2), Account::chain(client2.chain_id()))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(2),
+            Account::chain(client2.chain_id()),
+        )
         .await;
     assert!(result.is_err());
 
@@ -2498,7 +2613,11 @@ where
     client1.synchronize_from_validators().await.unwrap();
     assert!(client1.pending_proposal().is_some());
     client1
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(4), Account::chain(client2.chain_id()))
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(4),
+            Account::chain(client2.chain_id()),
+        )
         .await
         .unwrap();
     // Round 0 needs to time out again, so client 1 is actually allowed to propose.

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -298,11 +298,7 @@ where
     sender.synchronize_from_validators().await.unwrap();
     // Can still use the chain.
     sender
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(3),
-            Account::chain(sender.chain_id),
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await
         .unwrap();
     Ok(())
@@ -350,11 +346,7 @@ where
     // Cannot use the chain any more.
     assert_matches!(
         sender
-            .transfer_to_account(
-                AccountOwner::CHAIN,
-                Amount::from_tokens(3),
-                Account::chain(sender.chain_id)
-            )
+            .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
             .await,
         Err(ChainClientError::NotAnOwner(_))
     );
@@ -375,7 +367,6 @@ where
     let new_owner = signer.generate_new().into();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
-    let receiver = builder.add_root_chain(2, Amount::ZERO).await?;
     let certificate = sender
         .share_ownership(new_owner, 100)
         .await
@@ -400,11 +391,7 @@ where
     sender.synchronize_from_validators().await.unwrap();
     // Can still use the chain with the old client.
     sender
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(2),
-            Account::chain(receiver.chain_id),
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(2))
         .await
         .unwrap();
     let sender_info = sender.chain_info().await?;
@@ -432,13 +419,7 @@ where
 
     // We need at least three validators for making an operation.
     builder.set_fault_type([0, 1], FaultType::Offline).await;
-    let result = client
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::ONE,
-            Account::chain(sender.chain_id),
-        )
-        .await;
+    let result = client.burn(AccountOwner::CHAIN, Amount::ONE).await;
     assert_matches!(
         result,
         Err(ChainClientError::CommunicationError(
@@ -448,13 +429,7 @@ where
     builder.set_fault_type([0, 1], FaultType::Honest).await;
     builder.set_fault_type([2, 3], FaultType::Offline).await;
     assert_matches!(
-        sender
-            .transfer_to_account(
-                AccountOwner::CHAIN,
-                Amount::ONE,
-                Account::chain(sender.chain_id)
-            )
-            .await,
+        sender.burn(AccountOwner::CHAIN, Amount::ONE).await,
         Err(ChainClientError::CommunicationError(
             CommunicationError::Trusted(ClientIoError { .. })
         ))
@@ -473,11 +448,7 @@ where
     );
     client.clear_pending_proposal();
     client
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::ONE,
-            Account::chain(receiver.chain_id),
-        )
+        .burn(AccountOwner::CHAIN, Amount::ONE)
         .await
         .unwrap_ok_committed();
     assert_eq!(client.local_balance().await.unwrap(), Amount::ONE);
@@ -489,11 +460,7 @@ where
     assert_eq!(sender.local_balance().await.unwrap(), Amount::ONE);
     sender.clear_pending_proposal();
     sender
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::ONE,
-            Account::chain(receiver.chain_id),
-        )
+        .burn(AccountOwner::CHAIN, Amount::ONE)
         .await
         .unwrap_ok_committed();
 
@@ -655,11 +622,7 @@ where
         Amount::from_tokens(3)
     );
     client
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(3),
-            Account::chain(sender.chain_id),
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await
         .unwrap();
     Ok(())
@@ -722,11 +685,7 @@ where
         Amount::from_tokens(3)
     );
     client
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(3),
-            Account::chain(sender.chain_id),
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await
         .unwrap();
     assert_eq!(client.local_balance().await.unwrap(), Amount::ZERO);
@@ -776,11 +735,7 @@ where
     );
     // Cannot use the chain for operations any more.
     let result = client1
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(3),
-            Account::chain(client2.chain_id()),
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await;
     assert!(
         matches!(
@@ -1295,25 +1250,16 @@ where
         .await?
         .with_policy(policy);
     let sender = builder.add_root_chain(1, Amount::from_tokens(3)).await?;
-    let receiver = builder.add_root_chain(2, Amount::ZERO).await?;
 
     let obtained_error = sender
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(4),
-            Account::chain(receiver.chain_id),
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(4))
         .await;
     assert_insufficient_balance_during_operation(obtained_error, 0);
 
     let obtained_error = sender
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(3),
-            Account::chain(receiver.chain_id),
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await;
-    // We have balance=3, we try to transfer 3 tokens but the operation itself
+    // We have balance=3, we try to burn 3 tokens but the operation itself
     // costs 1 microtoken so we don't have enough balance to pay for it.
     assert_fees_exceed_funding(obtained_error);
     Ok(())
@@ -1341,11 +1287,7 @@ where
         .await
         .unwrap_ok_committed();
     let cert1 = sender
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::ONE,
-            Account::chain(sender.chain_id),
-        )
+        .burn(AccountOwner::CHAIN, Amount::ONE)
         .await
         .unwrap_ok_committed();
     let cert2 = sender
@@ -1576,7 +1518,7 @@ where
     assert!(certificate_values[0].block().body.operations().any(|op| *op
         == Operation::system(SystemOperation::Transfer {
             owner: AccountOwner::CHAIN,
-            recipient: (Account::chain(client_2b.chain_id())),
+            recipient: Account::chain(client_2b.chain_id()),
             amount: Amount::from_tokens(1),
         })));
 
@@ -1713,7 +1655,7 @@ where
     assert!(certificate_values[0].block().body.operations().any(|op| *op
         == Operation::system(SystemOperation::Transfer {
             owner: AccountOwner::CHAIN,
-            recipient: (Account::chain(client2_b.chain_id())),
+            recipient: Account::chain(client2_b.chain_id()),
             amount: Amount::from_tokens(1),
         })));
 
@@ -1768,11 +1710,7 @@ where
         .set_fault_type([2, 3], FaultType::OfflineWithInfo)
         .await;
     assert!(client1
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_millis(1),
-            Account::chain(client1.chain_id())
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_millis(1))
         .await
         .is_err());
 
@@ -1782,11 +1720,7 @@ where
         .await;
     builder.set_fault_type([2, 3], FaultType::Honest).await;
     assert!(client2
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_millis(2),
-            Account::chain(client2.chain_id())
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_millis(2))
         .await
         .is_err());
 
@@ -2241,21 +2175,17 @@ where
     client1.set_preferred_owner(owner1);
     assert!(owner0 != owner1);
 
-    // Client 0 tries to transfer 3 tokens. Two validators are offline, so nothing will get
+    // Client 0 tries to burn 3 tokens. Two validators are offline, so nothing will get
     // validated or confirmed. However, client 0 now has a pending block.
     builder
         .set_fault_type([2], FaultType::OfflineWithInfo)
         .await;
     let result = client0
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(3),
-            Account::chain(client0.chain_id()),
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await;
     assert!(result.is_err());
 
-    // Client 1 thinks it is madness to transfer 3 tokens! They want to publish a blob instead.
+    // Client 1 thinks it is madness to burn 3 tokens! They want to publish a blob instead.
     // The validators are still faulty: They validate blocks but don't confirm them.
     builder
         .set_fault_type([2], FaultType::DontSendConfirmVote)
@@ -2294,11 +2224,7 @@ where
     // Client 0 now only tries to transfer 1 token. Before that, they automatically finalize the
     // pending block, which publishes the blob, leaving 10 - 1 = 9.
     client0
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(1),
-            Account::chain(client0.chain_id()),
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(1))
         .await
         .unwrap();
     client0.synchronize_from_validators().await.unwrap();
@@ -2312,11 +2238,7 @@ where
     // Transfer another token so Client 1 sees that the blob is already published
     client1.prepare_chain().await.unwrap();
     client1
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(1),
-            Account::chain(client1.chain_id()),
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(1))
         .await
         .unwrap();
     client1.synchronize_from_validators().await.unwrap();
@@ -2341,40 +2263,28 @@ where
 {
     let signer = InMemorySigner::new(None);
     let mut builder = TestBuilder::new(storage_builder, 4, 1, signer).await?;
-    let client1 = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
-    let client2 = builder.add_root_chain(2, Amount::ZERO).await?;
+    let client = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
 
-    // The client1 tries to transfer 3 tokens. Two validators are offline, so nothing will get
-    // validated or confirmed. However, the client1 now has a pending block.
+    // The client tries to burn 3 tokens. Two validators are offline, so nothing will get
+    // validated or confirmed. However, the client now has a pending block.
     builder
         .set_fault_type([2], FaultType::OfflineWithInfo)
         .await;
-    let result = client1
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(3),
-            Account::chain(client2.chain_id()),
-        )
+    let result = client
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await;
     assert!(result.is_err());
 
     // Now three validators are online again.
     builder.set_fault_type([2], FaultType::Honest).await;
 
-    // The client1 tries to transfer another token. Before that, they automatically finalize the
+    // The client tries to burn another token. Before that, they automatically finalize the
     // pending block, which transfers 3 tokens, leaving 10 - 3 - 1 = 6.
-    client1
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::ONE,
-            Account::chain(client2.chain_id()),
-        )
-        .await
-        .unwrap();
-    client1.synchronize_from_validators().await.unwrap();
-    client1.process_inbox().await.unwrap();
+    client.burn(AccountOwner::CHAIN, Amount::ONE).await.unwrap();
+    client.synchronize_from_validators().await.unwrap();
+    client.process_inbox().await.unwrap();
     assert_eq!(
-        client1.local_balance().await.unwrap(),
+        client.local_balance().await.unwrap(),
         Amount::from_tokens(6)
     );
     Ok(())
@@ -2394,7 +2304,6 @@ where
     let signer = InMemorySigner::new(None);
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
     let client0 = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
-    let client2 = builder.add_root_chain(2, Amount::ZERO).await?;
     let chain_id = client0.chain_id();
     let owner0 = client0.identity().await.unwrap();
     let owner1 = builder.signer.generate_new().into();
@@ -2415,7 +2324,7 @@ where
         .await?;
     client1.set_preferred_owner(owner1);
 
-    // Client 0 tries to transfer 3 tokens. Three validators are faulty: 1 and 2 will validate the
+    // Client 0 tries to burn 3 tokens. Three validators are faulty: 1 and 2 will validate the
     // block but not receive it for confirmation. Validator 3 is offline.
     builder
         .set_fault_type([1, 2], FaultType::DontProcessValidated)
@@ -2423,11 +2332,7 @@ where
     builder.set_fault_type([3], FaultType::Offline).await;
 
     let result = client0
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(3),
-            Account::chain(client2.chain_id()),
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await;
     assert!(result.is_err());
     let manager = client0
@@ -2448,7 +2353,7 @@ where
         .await
         .unwrap();
 
-    // Client 1 wants to transfer 2 tokens. They learn about the proposal in round 0, but now the
+    // Client 1 wants to burn 2 tokens. They learn about the proposal in round 0, but now the
     // validator 0 is offline, so they don't learn about the validated block and make their own
     // proposal in round 1.
     builder.set_fault_type([0], FaultType::Offline).await;
@@ -2465,16 +2370,12 @@ where
     assert!(manager.requested_locking.is_none());
     assert_eq!(manager.current_round, Round::MultiLeader(0));
     let result = client1
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(2),
-            Account::chain(client2.chain_id()),
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(2))
         .await;
     assert!(result.is_err());
 
     // Finally, three validators are online and honest again. Client 1 realizes there has been a
-    // validated block in round 0, and re-proposes it when it tries to transfer 4 tokens.
+    // validated block in round 0, and re-proposes it when it tries to burn 4 tokens.
     builder.set_fault_type([0, 1, 2], FaultType::Honest).await;
     builder.set_fault_type([3], FaultType::Offline).await;
     client1.synchronize_from_validators().await.unwrap();
@@ -2490,15 +2391,11 @@ where
     assert_eq!(manager.current_round, Round::MultiLeader(1));
     assert!(client1.pending_proposal().is_some());
     client1
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(4),
-            Account::chain(client2.chain_id()),
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(4))
         .await
         .unwrap();
 
-    // Transferring 3 and 4 tokens got finalized; the pending 2 tokens got skipped.
+    // Burning 3 and 4 tokens got finalized; the pending 2 tokens got skipped.
     client0.synchronize_from_validators().await.unwrap();
     assert_eq!(
         client0.local_balance().await.unwrap(),
@@ -2522,7 +2419,6 @@ where
     let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
     let client0 = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
-    let client2 = builder.add_root_chain(2, Amount::ZERO).await?;
     let chain_id = client0.chain_id();
     let owner0 = client0.identity().await.unwrap();
     let owner1 = builder.signer.generate_new().into();
@@ -2557,18 +2453,12 @@ where
         )
         .await?;
 
-    // Client 0 tries to transfer 3 of their own tokens, but three validators are faulty.
+    // Client 0 tries to burn 3 of their own tokens, but three validators are faulty.
     builder
         .set_fault_type([1, 2, 3], FaultType::OfflineWithInfo)
         .await;
 
-    let result = client0
-        .transfer_to_account(
-            owner0,
-            Amount::from_tokens(3),
-            Account::chain(client2.chain_id),
-        )
-        .await;
+    let result = client0.burn(owner0, Amount::from_tokens(3)).await;
     assert!(result.is_err());
     let manager = client0
         .chain_info_with_manager_values()
@@ -2595,36 +2485,28 @@ where
     client1.synchronize_from_validators().await.unwrap();
     client1.request_leader_timeout().await.unwrap();
 
-    // Client 1 wants to transfer 2 tokens. But now validators 0 and 3 is offline, so they don't learn
+    // Client 1 wants to burn 2 tokens. But now validators 0 and 3 is offline, so they don't learn
     // about the proposed fast block and make their own instead.
     builder.set_fault_type([3], FaultType::Offline).await;
     let result = client1
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(2),
-            Account::chain(client2.chain_id()),
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(2))
         .await;
     assert!(result.is_err());
 
     // Finally, three validators are online and honest again. Client 1 realizes there has been a
-    // validated block in round 0, and re-proposes it when it tries to transfer 4 tokens.
+    // validated block in round 0, and re-proposes it when it tries to burn 4 tokens.
     builder.set_fault_type([0, 1, 2], FaultType::Honest).await;
     client1.synchronize_from_validators().await.unwrap();
     assert!(client1.pending_proposal().is_some());
     client1
-        .transfer_to_account(
-            AccountOwner::CHAIN,
-            Amount::from_tokens(4),
-            Account::chain(client2.chain_id()),
-        )
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(4))
         .await
         .unwrap();
     // Round 0 needs to time out again, so client 1 is actually allowed to propose.
     clock.add(TimeDelta::from_secs(5));
     client1.process_pending_block().await.unwrap();
 
-    // Transferring 3 and 4 tokens got finalized; the pending 2 tokens got skipped.
+    // Burning 3 and 4 tokens got finalized; the pending 2 tokens got skipped.
     client0.synchronize_from_validators().await.unwrap();
     assert_eq!(
         client0.local_balance().await.unwrap(),

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -24,7 +24,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::Committee,
-    system::{Recipient, SystemOperation},
+    system::SystemOperation,
     ExecutionError, Message, MessageKind, Operation, QueryOutcome, ResourceControlPolicy,
     SystemMessage, SystemQuery, SystemResponse,
 };
@@ -214,7 +214,7 @@ where
         .claim(
             owner,
             receiver_id,
-            Recipient::chain(sender.chain_id()),
+            Account::chain(sender.chain_id()),
             Amount::from_tokens(5),
         )
         .await
@@ -224,7 +224,7 @@ where
         .claim(
             owner,
             receiver_id,
-            Recipient::chain(sender.chain_id()),
+            Account::chain(sender.chain_id()),
             Amount::from_tokens(2),
         )
         .await
@@ -1518,7 +1518,7 @@ where
     assert!(certificate_values[0].block().body.operations().any(|op| *op
         == Operation::system(SystemOperation::Transfer {
             owner: AccountOwner::CHAIN,
-            recipient: Recipient::Account(Account::chain(client_2b.chain_id())),
+            recipient: (Account::chain(client_2b.chain_id())),
             amount: Amount::from_tokens(1),
         })));
 
@@ -1651,7 +1651,7 @@ where
     assert!(certificate_values[0].block().body.operations().any(|op| *op
         == Operation::system(SystemOperation::Transfer {
             owner: AccountOwner::CHAIN,
-            recipient: Recipient::Account(Account::chain(client2_b.chain_id())),
+            recipient: (Account::chain(client2_b.chain_id())),
             amount: Amount::from_tokens(1),
         })));
 
@@ -2087,7 +2087,7 @@ where
         .transfer(
             AccountOwner::CHAIN,
             Amount::ONE,
-            Recipient::chain(observer_id),
+            Account::chain(observer_id),
         )
         .await
         .unwrap();
@@ -2118,7 +2118,7 @@ where
         .transfer(
             AccountOwner::CHAIN,
             Amount::ONE,
-            Recipient::chain(observer_id),
+            Account::chain(observer_id),
         )
         .await
         .unwrap_ok_committed();
@@ -2531,7 +2531,7 @@ where
         .with_policy(ResourceControlPolicy::only_fuel());
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let mut receiver = builder.add_root_chain(2, Amount::ZERO).await?;
-    let recipient = Recipient::chain(receiver.chain_id());
+    let recipient = Account::chain(receiver.chain_id());
     let cert = sender
         .transfer(AccountOwner::CHAIN, Amount::ONE, recipient)
         .await
@@ -2620,7 +2620,7 @@ where
         .transfer(
             AccountOwner::CHAIN,
             Amount::from_millis(1),
-            Recipient::chain(chain_id3),
+            Account::chain(chain_id3),
         )
         .await
         .unwrap_ok_committed();

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -650,10 +650,13 @@ where
     let small_transfer = Amount::from_micros(1);
     let mut env = TestEnvironment::new(storage, false, false).await;
     let chain_1_desc = env.add_root_chain(1, owner, balance).await;
-    let chain_id = chain_1_desc.id();
+    let chain_2_desc = env.add_root_chain(2, owner, balance).await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = chain_2_desc.id();
+
     {
-        let block_proposal = make_first_block(chain_id)
-            .with_simple_transfer(chain_id, small_transfer)
+        let block_proposal = make_first_block(chain_1)
+            .with_simple_transfer(chain_2, small_transfer)
             .with_authenticated_signer(Some(owner))
             .with_timestamp(Timestamp::from(TEST_GRACE_PERIOD_MICROS + 1_000_000))
             .into_first_proposal(owner, &signer)
@@ -668,9 +671,9 @@ where
 
     let block_0_time = Timestamp::from(TEST_GRACE_PERIOD_MICROS);
     let certificate = {
-        let block = make_first_block(chain_id)
+        let block = make_first_block(chain_1)
             .with_timestamp(block_0_time)
-            .with_simple_transfer(chain_id, small_transfer)
+            .with_simple_transfer(chain_2, small_transfer)
             .with_authenticated_signer(Some(owner));
         let block_proposal = block
             .clone()
@@ -682,7 +685,7 @@ where
         future.await?;
 
         let system_state = SystemExecutionState {
-            balance,
+            balance: balance - small_transfer,
             timestamp: block_0_time,
             ..env.system_execution_state(&chain_1_desc.id())
         };

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3366,8 +3366,7 @@ where
     assert_eq!(response.info.manager.leader, Some(owner0));
 
     // Now owner 0 can propose a block, but owner 1 can't.
-    let proposed_block1 =
-        make_child_block(&value0).with_simple_transfer(chain_1, small_transfer);
+    let proposed_block1 = make_child_block(&value0).with_simple_transfer(chain_1, small_transfer);
     let (block1, _) = env
         .worker()
         .stage_block_execution(proposed_block1.clone(), None, vec![])
@@ -3669,11 +3668,7 @@ where
     // The first round is the multi-leader round 0. Anyone is allowed to propose.
     // But non-owners are not allowed to transfer the chain's funds.
     let proposal = make_child_block(&change_ownership_value)
-        .with_transfer(
-            AccountOwner::CHAIN,
-            Account::chain(chain_id),
-            Amount::from_tokens(1),
-        )
+        .with_burn(Amount::from_tokens(1))
         .into_proposal_with_round(owner, &signer, Round::MultiLeader(0))
         .await
         .unwrap();

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3666,7 +3666,11 @@ where
     // The first round is the multi-leader round 0. Anyone is allowed to propose.
     // But non-owners are not allowed to transfer the chain's funds.
     let proposal = make_child_block(&change_ownership_value)
-        .with_transfer(AccountOwner::CHAIN, Account::chain(chain_id), Amount::from_tokens(1))
+        .with_transfer(
+            AccountOwner::CHAIN,
+            Account::chain(chain_id),
+            Amount::from_tokens(1),
+        )
         .into_proposal_with_round(owner, &signer, Round::MultiLeader(0))
         .await
         .unwrap();

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -20,7 +20,7 @@ use oneshot::Sender;
 use reqwest::{header::HeaderMap, Client, Url};
 
 use crate::{
-    system::{CreateApplicationResult, OpenChainConfig, Recipient},
+    system::{CreateApplicationResult, OpenChainConfig},
     util::RespondExt,
     ApplicationDescription, ApplicationId, ExecutionError, ExecutionRuntimeContext,
     ExecutionStateView, ModuleId, OutgoingMessage, ResourceController, TransactionTracker,
@@ -162,7 +162,7 @@ where
                         signer,
                         Some(application_id),
                         source,
-                        Recipient::Account(destination),
+                        destination,
                         amount,
                     )
                     .await?,
@@ -182,7 +182,7 @@ where
                         Some(application_id),
                         source.owner,
                         source.chain_id,
-                        Recipient::Account(destination),
+                        destination,
                         amount,
                     )
                     .await?,

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -158,13 +158,7 @@ where
                 callback,
             } => callback.respond(
                 self.system
-                    .transfer(
-                        signer,
-                        Some(application_id),
-                        source,
-                        destination,
-                        amount,
-                    )
+                    .transfer(signer, Some(application_id), source, destination, amount)
                     .await?,
             ),
 

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -14,11 +14,10 @@ use linera_views::{context::Context, map_view::MapView};
 
 use crate::{
     committee::{Committee, ValidatorState},
-    system::{Recipient, UserData},
+    system::UserData,
     ExecutionStateView, SystemExecutionStateView,
 };
 
-doc_scalar!(Recipient, "The recipient of a transfer");
 doc_scalar!(UserData, "Optional user message attached to a transfer");
 
 #[async_graphql::Object(cache_control(no_cache))]

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -279,8 +279,6 @@ pub struct SystemResponse {
 /// The recipient of a transfer.
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize)]
 pub enum Recipient {
-    /// This is mainly a placeholder for future extensions.
-    Burn,
     /// Transfers to the balance of the given account.
     Account(Account),
 }
@@ -295,7 +293,6 @@ impl Recipient {
 impl Display for Recipient {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            Recipient::Burn => write!(f, "burn"),
             Recipient::Account(account) => write!(f, "{}", account),
         }
     }
@@ -686,7 +683,6 @@ where
                     ))
                 }
             }
-            Recipient::Burn => Ok(None),
         }
     }
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -275,7 +275,6 @@ pub struct SystemResponse {
     pub balance: Amount,
 }
 
-
 /// Optional user message attached to a transfer.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Default, Debug, Serialize, Deserialize)]
 pub struct UserData(pub Option<[u8; 32]>);
@@ -642,8 +641,7 @@ where
                 target: recipient.owner,
             };
             Ok(Some(
-                OutgoingMessage::new(recipient.chain_id, message)
-                    .with_kind(MessageKind::Tracked),
+                OutgoingMessage::new(recipient.chain_id, message).with_kind(MessageKind::Tracked),
             ))
         }
     }

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -42,7 +42,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
     let operation = SystemOperation::Transfer {
         owner: AccountOwner::CHAIN,
         amount: Amount::from_tokens(4),
-        recipient: Recipient::Burn,
+        recipient: Recipient::chain(chain_id),
     };
     let context = OperationContext {
         chain_id,
@@ -62,7 +62,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
     )
     .await
     .unwrap();
-    assert_eq!(view.system.balance.get(), &Amount::ZERO);
+    assert_eq!(view.system.balance.get(), &Amount::from_tokens(4));
     let txn_outcome = txn_tracker.into_outcome().unwrap();
     assert!(txn_outcome.outgoing_messages.is_empty());
     Ok(())

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -38,10 +38,11 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         ..SystemExecutionState::default()
     };
     let mut view = state.into_view().await;
+    let recipient = Account::burn_address(chain_id);
     let operation = SystemOperation::Transfer {
         owner: AccountOwner::CHAIN,
         amount: Amount::from_tokens(4),
-        recipient: Account::chain(chain_id),
+        recipient,
     };
     let context = OperationContext {
         chain_id,
@@ -61,7 +62,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
     )
     .await
     .unwrap();
-    assert_eq!(view.system.balance.get(), &Amount::from_tokens(4));
+    assert_eq!(view.system.balance.get(), &Amount::ZERO);
     let txn_outcome = txn_tracker.into_outcome().unwrap();
     assert!(txn_outcome.outgoing_messages.is_empty());
     Ok(())

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -6,11 +6,10 @@
 use linera_base::{
     crypto::AccountSecretKey,
     data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::AccountOwner,
+    identifiers::{Account, AccountOwner},
     ownership::ChainOwnership,
 };
 use linera_execution::{
-    system::Recipient,
     test_utils::{
         dummy_chain_description, dummy_chain_description_with_ownership_and_balance,
         SystemExecutionState,
@@ -42,7 +41,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
     let operation = SystemOperation::Transfer {
         owner: AccountOwner::CHAIN,
         amount: Amount::from_tokens(4),
-        recipient: Recipient::chain(chain_id),
+        recipient: Account::chain(chain_id),
     };
     let context = OperationContext {
         chain_id,

--- a/linera-rpc/tests/format.rs
+++ b/linera-rpc/tests/format.rs
@@ -5,7 +5,7 @@
 use linera_base::{
     crypto::{AccountPublicKey, AccountSignature, CryptoHash, TestString},
     data_types::{BlobContent, ChainDescription, ChainOrigin, OracleResponse, Round},
-    identifiers::{AccountOwner, BlobType, GenericApplicationId},
+    identifiers::{Account, AccountOwner, BlobType, GenericApplicationId},
     ownership::ChainOwnership,
     vm::VmRuntime,
 };
@@ -16,7 +16,7 @@ use linera_chain::{
 };
 use linera_core::{data_types::CrossChainRequest, node::NodeError};
 use linera_execution::{
-    system::{AdminOperation, Recipient, SystemMessage, SystemOperation},
+    system::{AdminOperation, SystemMessage, SystemOperation},
     Message, MessageKind, Operation,
 };
 use linera_rpc::RpcMessage;
@@ -57,7 +57,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<AccountSignature>(&samples)?;
     tracer.trace_type::<Round>(&samples)?;
     tracer.trace_type::<OracleResponse>(&samples)?;
-    tracer.trace_type::<Recipient>(&samples)?;
+    tracer.trace_type::<Account>(&samples)?;
     tracer.trace_type::<SystemOperation>(&samples)?;
     tracer.trace_type::<AdminOperation>(&samples)?;
     tracer.trace_type::<SystemMessage>(&samples)?;

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -906,12 +906,6 @@ ProposedBlock:
     - previous_block_hash:
         OPTION:
           TYPENAME: CryptoHash
-Recipient:
-  ENUM:
-    0:
-      Account:
-        NEWTYPE:
-          TYPENAME: Account
 ResourceControlPolicy:
   STRUCT:
     - wasm_fuel_unit:
@@ -1144,7 +1138,7 @@ SystemMessage:
           - amount:
               TYPENAME: Amount
           - recipient:
-              TYPENAME: Recipient
+              TYPENAME: Account
 SystemOperation:
   ENUM:
     0:
@@ -1153,7 +1147,7 @@ SystemOperation:
           - owner:
               TYPENAME: AccountOwner
           - recipient:
-              TYPENAME: Recipient
+              TYPENAME: Account
           - amount:
               TYPENAME: Amount
     1:
@@ -1164,7 +1158,7 @@ SystemOperation:
           - target_id:
               TYPENAME: ChainId
           - recipient:
-              TYPENAME: Recipient
+              TYPENAME: Account
           - amount:
               TYPENAME: Amount
     2:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -909,8 +909,6 @@ ProposedBlock:
 Recipient:
   ENUM:
     0:
-      Burn: UNIT
-    1:
       Account:
         NEWTYPE:
           TYPENAME: Account

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -8,7 +8,7 @@
 use linera_base::{
     abi::ContractAbi,
     data_types::{Amount, ApplicationPermissions, Blob, Epoch, Round, Timestamp},
-    identifiers::{AccountOwner, ApplicationId, ChainId},
+    identifiers::{Account, AccountOwner, ApplicationId, ChainId},
     ownership::TimeoutConfig,
 };
 use linera_chain::{
@@ -20,7 +20,7 @@ use linera_chain::{
 };
 use linera_core::worker::WorkerError;
 use linera_execution::{
-    system::{Recipient, SystemOperation},
+    system::SystemOperation,
     Operation,
 };
 
@@ -87,7 +87,7 @@ impl BlockBuilder {
     pub fn with_native_token_transfer(
         &mut self,
         sender: AccountOwner,
-        recipient: Recipient,
+        recipient: Account,
         amount: Amount,
     ) -> &mut Self {
         self.with_system_operation(SystemOperation::Transfer {

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -19,10 +19,7 @@ use linera_chain::{
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
 };
 use linera_core::worker::WorkerError;
-use linera_execution::{
-    system::SystemOperation,
-    Operation,
-};
+use linera_execution::{system::SystemOperation, Operation};
 
 use super::TestValidator;
 

--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -24,7 +24,7 @@ pub use {
         data_types::MessageAction, test::HttpServer, ChainError, ChainExecutionContext,
     },
     linera_core::worker::WorkerError,
-    linera_execution::{system::Recipient, ExecutionError, QueryOutcome, WasmExecutionError},
+    linera_execution::{ExecutionError, QueryOutcome, WasmExecutionError},
 };
 
 #[cfg(with_testing)]

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -365,5 +365,5 @@ subscription Notifications($chainId: ChainId!) {
 }
 
 mutation Transfer($chainId: ChainId!, $owner: AccountOwner!, $recipient_chain: ChainId!, $recipient_account: AccountOwner!, $amount: Amount!) {
-  transfer(chainId: $chainId, owner: $owner, recipient: { Account: { chain_id: $recipient_chain, owner: $recipient_account } }, amount: $amount)
+  transfer(chainId: $chainId, owner: $owner, recipient: { chain_id: $recipient_chain, owner: $recipient_account }, amount: $amount)
 }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -764,13 +764,13 @@ type MutationRoot {
 	Transfers `amount` units of value from the given owner's account to the recipient.
 	If no owner is given, try to take the units out of the chain account.
 	"""
-	transfer(chainId: ChainId!, owner: AccountOwner!, recipient: Recipient!, amount: Amount!): CryptoHash!
+	transfer(chainId: ChainId!, owner: AccountOwner!, recipient: Account!, amount: Amount!): CryptoHash!
 	"""
 	Claims `amount` units of value from the given owner's account in the remote
 	`target` chain. Depending on its configuration, the `target` chain may refuse to
 	process the message.
 	"""
-	claim(chainId: ChainId!, owner: AccountOwner!, targetId: ChainId!, recipient: Recipient!, amount: Amount!): CryptoHash!
+	claim(chainId: ChainId!, owner: AccountOwner!, targetId: ChainId!, recipient: Account!, amount: Amount!): CryptoHash!
 	"""
 	Test if a data blob is readable from a transaction in the current chain.
 	"""
@@ -1014,11 +1014,6 @@ type QueryRoot {
 type QueueView_MessageBundle_f4399f0b {
 	entries(count: Int): [MessageBundle!]!
 }
-
-"""
-The recipient of a transfer
-"""
-scalar Recipient
 
 type ReentrantCollectionView_AccountOwner_PendingBlobsView_d58d342d {
 	keys: [AccountOwner!]!

--- a/linera-service/benches/transfers.rs
+++ b/linera-service/benches/transfers.rs
@@ -12,7 +12,6 @@ use linera_base::{
     identifiers::{Account, AccountOwner},
     time::{Duration, Instant},
 };
-use linera_execution::system::Recipient;
 use linera_sdk::test::{ActiveChain, TestValidator};
 use tokio::runtime::Runtime;
 
@@ -78,10 +77,10 @@ async fn setup_native_token_balances(
     let admin_chain = validator.get_chain(&validator.admin_chain_id());
 
     for chain in &chains {
-        let recipient = Recipient::Account(Account {
+        let recipient = Account {
             chain_id: chain.id(),
             owner: AccountOwner::from(chain.public_key()),
-        });
+        };
 
         // TODO: Support benchmarking chains with multiple owner accounts
         assert_eq!(accounts_per_chain, 1);
@@ -128,7 +127,6 @@ fn prepare_transfers(
                 .cycle()
                 .skip(index)
                 .take(transfers_per_account)
-                .map(Recipient::Account)
                 .map(move |recipient| (sender, recipient))
                 .collect::<Vec<_>>();
 

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -15,7 +15,9 @@ use linera_base::{
     data_types::{
         Amount, ApplicationDescription, ApplicationPermissions, Bytecode, Epoch, TimeDelta,
     },
-    identifiers::{Account, AccountOwner, ApplicationId, ChainId, IndexAndEvent, ModuleId, StreamId},
+    identifiers::{
+        Account, AccountOwner, ApplicationId, ChainId, IndexAndEvent, ModuleId, StreamId,
+    },
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
     BcsHexParseError,
@@ -31,9 +33,8 @@ use linera_core::{
     worker::Notification,
 };
 use linera_execution::{
-    committee::Committee,
-    system::AdminOperation,
-    Operation, Query, QueryOutcome, QueryResponse, SystemOperation,
+    committee::Committee, system::AdminOperation, Operation, Query, QueryOutcome, QueryResponse,
+    SystemOperation,
 };
 use linera_sdk::linera_base_types::BlobContent;
 use serde::{Deserialize, Serialize};

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -15,7 +15,7 @@ use linera_base::{
     data_types::{
         Amount, ApplicationDescription, ApplicationPermissions, Bytecode, Epoch, TimeDelta,
     },
-    identifiers::{AccountOwner, ApplicationId, ChainId, IndexAndEvent, ModuleId, StreamId},
+    identifiers::{Account, AccountOwner, ApplicationId, ChainId, IndexAndEvent, ModuleId, StreamId},
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
     BcsHexParseError,
@@ -32,7 +32,7 @@ use linera_core::{
 };
 use linera_execution::{
     committee::Committee,
-    system::{AdminOperation, Recipient},
+    system::AdminOperation,
     Operation, Query, QueryOutcome, QueryResponse, SystemOperation,
 };
 use linera_sdk::linera_base_types::BlobContent;
@@ -214,7 +214,7 @@ where
         &self,
         chain_id: ChainId,
         owner: AccountOwner,
-        recipient: Recipient,
+        recipient: Account,
         amount: Amount,
     ) -> Result<CryptoHash, Error> {
         self.apply_client_command(&chain_id, move |client| async move {
@@ -236,7 +236,7 @@ where
         chain_id: ChainId,
         owner: AccountOwner,
         target_id: ChainId,
-        recipient: Recipient,
+        recipient: Account,
         amount: Amount,
     ) -> Result<CryptoHash, Error> {
         self.apply_client_command(&chain_id, move |client| async move {

--- a/linera-web/src/lib.rs
+++ b/linera-web/src/lib.rs
@@ -314,7 +314,7 @@ impl Client {
                 chain_client.transfer(
                     params.donor.unwrap_or(AccountOwner::CHAIN),
                     linera_base::data_types::Amount::from_tokens(params.amount.into()),
-                    linera_execution::system::Recipient::Account(params.recipient),
+                    params.recipient,
                 )
             })
             .await??;


### PR DESCRIPTION
## Motivation

The Recipient type variant `Burn` is used only for tests. So, we remove it. This let the `Recipient` having just a variant `Account`. And so the `Recipient` type is eliminated.

Fixes #3580 

## Proposal

Straightforward from the description.

## Test Plan

The CI.
The tests were restructured accordingly. For some tests the balance is now unchanged. For some tests we introduced another chain.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.