### PR TITLE
Fix discrepancy with `read_data_blob` between the test runtime and the wasm runtime

### DIFF
--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -979,10 +979,10 @@ where
     }
 
     /// Reads a data blob with the given hash from storage.
-    pub fn read_data_blob(&mut self, hash: &DataBlobHash) -> Vec<u8> {
+    pub fn read_data_blob(&mut self, hash: DataBlobHash) -> Vec<u8> {
         let maybe_request = self.expected_read_data_blob_requests.pop_front();
         let (expected_hash, response) = maybe_request.expect("Unexpected read_data_blob request");
-        assert_eq!(*hash, expected_hash);
+        assert_eq!(hash, expected_hash);
         response
     }
 


### PR DESCRIPTION
## Motivation

Fix the API `read_data_blob`

## Proposal

Make sure `read_data_blob` has the same API in `linera-sdk/src/contract/runtime.rs` and `linera-sdk/src/contract/test_runtime.rs`

We should generally stop passing hashes by references (since they are `Copy`).

## Test Plan

* `git grep 'fn read_data_blob'`
* CI
* used in my next PR

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
