### PR TITLE
Resolve the blob persistence problem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5721,6 +5721,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "prost",
+ "publish-read-data-blob",
  "quick_cache",
  "rand 0.8.5",
  "reqwest 0.11.27",
@@ -7513,6 +7514,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "publish-read-data-blob"
+version = "0.1.0"
+dependencies = [
+ "linera-sdk",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,6 +313,7 @@ matching-engine = { path = "./examples/matching-engine" }
 meta-counter = { path = "./examples/meta-counter" }
 native-fungible = { path = "./examples/native-fungible" }
 non-fungible = { path = "./examples/non-fungible" }
+publish-read-data-blob = { path = "./examples/publish-read-data-blob" }
 social = { path = "./examples/social" }
 
 [workspace.dependencies.aws-config]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -5014,6 +5014,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "publish-read-data-blob"
+version = "0.1.0"
+dependencies = [
+ "assert_matches",
+ "linera-sdk",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "pulp"
 version = "0.18.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "meta-counter",
     "native-fungible",
     "non-fungible",
+    "publish-read-data-blob",
     "rfq",
     "social",
 ]

--- a/examples/publish-read-data-blob/Cargo.toml
+++ b/examples/publish-read-data-blob/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "publish-read-data-blob"
+version = "0.1.0"
+authors = ["Linera <contact@linera.io>"]
+edition = "2021"
+
+[dependencies]
+linera-sdk.workspace = true
+serde.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+linera-sdk = { workspace = true, features = ["test", "wasmer"] }
+tokio = { workspace = true, features = ["rt", "sync"] }
+
+[dev-dependencies]
+assert_matches.workspace = true
+linera-sdk = { workspace = true, features = ["test"] }
+
+[[bin]]
+name = "publish_read_data_blob_contract"
+path = "src/contract.rs"
+
+[[bin]]
+name = "publish_read_data_blob_service"
+path = "src/service.rs"

--- a/examples/publish-read-data-blob/README.md
+++ b/examples/publish-read-data-blob/README.md
@@ -1,0 +1,11 @@
+# Publish and read a data blob
+
+This example shows how to create a blob and how to read it.
+This example should be read in conjunction with the end-to-end
+test `test_wasm_end_to_end_publish_read_data_blob`.
+
+It shows 3 scenarios:
+* Publishing and reading blobs with the publishing and reading in different
+blocks.
+* Publishing and reading blobs in the same transaction.
+* Publishing and reqding blobs in the same block but not the same transaction

--- a/examples/publish-read-data-blob/src/contract.rs
+++ b/examples/publish-read-data-blob/src/contract.rs
@@ -6,9 +6,9 @@
 mod state;
 
 use linera_sdk::{
-    linera_base_types::WithContractAbi,
+    linera_base_types::{DataBlobHash, WithContractAbi},
     views::{RootView, View},
-    Contract, ContractRuntime, DataBlobHash,
+    Contract, ContractRuntime,
 };
 use publish_read_data_blob::{Operation, PublishReadDataBlobAbi};
 

--- a/examples/publish-read-data-blob/src/contract.rs
+++ b/examples/publish-read-data-blob/src/contract.rs
@@ -1,0 +1,75 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+mod state;
+
+use linera_sdk::{
+    linera_base_types::WithContractAbi,
+    views::{RootView, View},
+    Contract, ContractRuntime, DataBlobHash,
+};
+use publish_read_data_blob::{Operation, PublishReadDataBlobAbi};
+
+use self::state::PublishReadDataBlobState;
+
+pub struct PublishReadDataBlobContract {
+    state: PublishReadDataBlobState,
+    runtime: ContractRuntime<Self>,
+}
+
+linera_sdk::contract!(PublishReadDataBlobContract);
+
+impl WithContractAbi for PublishReadDataBlobContract {
+    type Abi = PublishReadDataBlobAbi;
+}
+
+impl Contract for PublishReadDataBlobContract {
+    type Message = ();
+    type InstantiationArgument = ();
+    type Parameters = ();
+    type EventValue = ();
+
+    async fn load(runtime: ContractRuntime<Self>) -> Self {
+        let state = PublishReadDataBlobState::load(runtime.root_view_storage_context())
+            .await
+            .expect("Failed to load state");
+        PublishReadDataBlobContract { state, runtime }
+    }
+
+    async fn instantiate(&mut self, _argument: ()) {
+        // Validate that the application parameters were configured correctly.
+        self.runtime.application_parameters();
+    }
+
+    async fn execute_operation(&mut self, operation: Operation) {
+        match operation {
+            Operation::CreateDataBlob(data) => {
+                let hash: DataBlobHash = self.runtime.create_data_blob(data);
+                self.state.hash.set(Some(hash));
+            }
+            Operation::ReadDataBlob(hash, expected_data) => {
+                let data = self.runtime.read_data_blob(hash);
+                assert_eq!(
+                    data, expected_data,
+                    "Read data does not match expected data"
+                );
+            }
+            Operation::CreateAndReadDataBlob(data) => {
+                let hash: DataBlobHash = self.runtime.create_data_blob(data.clone());
+                self.state.hash.set(Some(hash));
+                let data_read = self.runtime.read_data_blob(hash);
+                assert_eq!(data_read, data);
+            }
+        }
+    }
+
+    async fn execute_message(&mut self, _message: ()) {
+        panic!("Publish-Read Data Blob application doesn't support any cross-chain messages");
+    }
+
+    async fn store(mut self) {
+        self.state.save().await.expect("Failed to save state");
+    }
+}

--- a/examples/publish-read-data-blob/src/contract.rs
+++ b/examples/publish-read-data-blob/src/contract.rs
@@ -60,6 +60,5 @@ impl Contract for PublishReadDataBlobContract {
         panic!("Publish-Read Data Blob application doesn't support any cross-chain messages");
     }
 
-    async fn store(self) {
-    }
+    async fn store(self) {}
 }

--- a/examples/publish-read-data-blob/src/lib.rs
+++ b/examples/publish-read-data-blob/src/lib.rs
@@ -4,8 +4,7 @@
 /*! ABI of the Publish-Read Data Blob Example Application */
 
 use linera_sdk::{
-    linera_base_types::{ContractAbi, ServiceAbi},
-    DataBlobHash,
+    linera_base_types::{ContractAbi, DataBlobHash, ServiceAbi},
 };
 use serde::{Deserialize, Serialize};
 

--- a/examples/publish-read-data-blob/src/lib.rs
+++ b/examples/publish-read-data-blob/src/lib.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*! ABI of the Publish-Read Data Blob Example Application */
+
+use linera_sdk::{
+    linera_base_types::{ContractAbi, ServiceAbi},
+    DataBlobHash,
+};
+use serde::{Deserialize, Serialize};
+
+pub struct PublishReadDataBlobAbi;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum Operation {
+    CreateDataBlob(Vec<u8>),
+    ReadDataBlob(DataBlobHash, Vec<u8>),
+    CreateAndReadDataBlob(Vec<u8>),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum ServiceQuery {
+    GetHash,
+    PublishDataBlob(Vec<u8>),
+    ReadDataBlob(DataBlobHash, Vec<u8>),
+    PublishAndCreateOneOperation(Vec<u8>),
+    PublishAndCreateTwoOperations(Vec<u8>),
+}
+
+impl ContractAbi for PublishReadDataBlobAbi {
+    type Operation = Operation;
+    type Response = ();
+}
+
+impl ServiceAbi for PublishReadDataBlobAbi {
+    type Query = ServiceQuery;
+    type QueryResponse = Vec<u8>;
+}

--- a/examples/publish-read-data-blob/src/lib.rs
+++ b/examples/publish-read-data-blob/src/lib.rs
@@ -19,7 +19,6 @@ pub enum Operation {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum ServiceQuery {
-    GetHash,
     PublishDataBlob(Vec<u8>),
     ReadDataBlob(DataBlobHash, Vec<u8>),
     PublishAndCreateOneOperation(Vec<u8>),

--- a/examples/publish-read-data-blob/src/lib.rs
+++ b/examples/publish-read-data-blob/src/lib.rs
@@ -3,9 +3,7 @@
 
 /*! ABI of the Publish-Read Data Blob Example Application */
 
-use linera_sdk::{
-    linera_base_types::{ContractAbi, DataBlobHash, ServiceAbi},
-};
+use linera_sdk::linera_base_types::{ContractAbi, DataBlobHash, ServiceAbi};
 use serde::{Deserialize, Serialize};
 
 pub struct PublishReadDataBlobAbi;

--- a/examples/publish-read-data-blob/src/service.rs
+++ b/examples/publish-read-data-blob/src/service.rs
@@ -8,17 +8,12 @@ mod state;
 use std::sync::Arc;
 
 use linera_sdk::{
-    bcs,
     linera_base_types::{BlobContent, CryptoHash, DataBlobHash, WithServiceAbi},
-    views::View,
     Service, ServiceRuntime,
 };
 use publish_read_data_blob::{Operation, PublishReadDataBlobAbi, ServiceQuery};
 
-use self::state::PublishReadDataBlobState;
-
 pub struct PublishReadDataBlobService {
-    state: Arc<PublishReadDataBlobState>,
     runtime: Arc<ServiceRuntime<Self>>,
 }
 
@@ -32,21 +27,13 @@ impl Service for PublishReadDataBlobService {
     type Parameters = ();
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {
-        let state = PublishReadDataBlobState::load(runtime.root_view_storage_context())
-            .await
-            .expect("Failed to load state");
         PublishReadDataBlobService {
-            state: Arc::new(state),
             runtime: Arc::new(runtime),
         }
     }
 
     async fn handle_query(&self, query: ServiceQuery) -> Vec<u8> {
         match query {
-            ServiceQuery::GetHash => match self.state.hash.get() {
-                Some(hash) => bcs::to_bytes(&hash).unwrap(),
-                None => panic!("No Hash stored"),
-            },
             ServiceQuery::PublishDataBlob(data) => {
                 self.runtime
                     .schedule_operation(&Operation::CreateDataBlob(data));

--- a/examples/publish-read-data-blob/src/service.rs
+++ b/examples/publish-read-data-blob/src/service.rs
@@ -9,9 +9,9 @@ use std::sync::Arc;
 
 use linera_sdk::{
     bcs,
-    linera_base_types::{BlobContent, CryptoHash, WithServiceAbi},
+    linera_base_types::{BlobContent, CryptoHash, DataBlobHash, WithServiceAbi},
     views::View,
-    DataBlobHash, Service, ServiceRuntime,
+    Service, ServiceRuntime,
 };
 use publish_read_data_blob::{Operation, PublishReadDataBlobAbi, ServiceQuery};
 

--- a/examples/publish-read-data-blob/src/service.rs
+++ b/examples/publish-read-data-blob/src/service.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+mod state;
+
+use std::sync::Arc;
+
+use linera_sdk::{
+    bcs,
+    linera_base_types::{BlobContent, CryptoHash, WithServiceAbi},
+    views::View,
+    DataBlobHash, Service, ServiceRuntime,
+};
+use publish_read_data_blob::{Operation, PublishReadDataBlobAbi, ServiceQuery};
+
+use self::state::PublishReadDataBlobState;
+
+pub struct PublishReadDataBlobService {
+    state: Arc<PublishReadDataBlobState>,
+    runtime: Arc<ServiceRuntime<Self>>,
+}
+
+linera_sdk::service!(PublishReadDataBlobService);
+
+impl WithServiceAbi for PublishReadDataBlobService {
+    type Abi = PublishReadDataBlobAbi;
+}
+
+impl Service for PublishReadDataBlobService {
+    type Parameters = ();
+
+    async fn new(runtime: ServiceRuntime<Self>) -> Self {
+        let state = PublishReadDataBlobState::load(runtime.root_view_storage_context())
+            .await
+            .expect("Failed to load state");
+        PublishReadDataBlobService {
+            state: Arc::new(state),
+            runtime: Arc::new(runtime),
+        }
+    }
+
+    async fn handle_query(&self, query: ServiceQuery) -> Vec<u8> {
+        match query {
+            ServiceQuery::GetHash => match self.state.hash.get() {
+                Some(hash) => bcs::to_bytes(&hash).unwrap(),
+                None => panic!("No Hash stored"),
+            },
+            ServiceQuery::PublishDataBlob(data) => {
+                self.runtime
+                    .schedule_operation(&Operation::CreateDataBlob(data));
+                Vec::new()
+            }
+            ServiceQuery::ReadDataBlob(hash, expected_data) => {
+                self.runtime
+                    .schedule_operation(&Operation::ReadDataBlob(hash, expected_data));
+                Vec::new()
+            }
+            ServiceQuery::PublishAndCreateOneOperation(data) => {
+                self.runtime
+                    .schedule_operation(&Operation::CreateAndReadDataBlob(data));
+                Vec::new()
+            }
+            ServiceQuery::PublishAndCreateTwoOperations(data) => {
+                // First operation: create the blob
+                self.runtime
+                    .schedule_operation(&Operation::CreateDataBlob(data.clone()));
+
+                // Compute the blob_id from the data
+                let content = BlobContent::new_data(data.clone());
+                let hash = DataBlobHash(CryptoHash::new(&content));
+
+                // Second operation: read the blob with verification
+                self.runtime
+                    .schedule_operation(&Operation::ReadDataBlob(hash, data));
+                Vec::new()
+            }
+        }
+    }
+}

--- a/examples/publish-read-data-blob/src/state.rs
+++ b/examples/publish-read-data-blob/src/state.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use linera_sdk::{
+    views::{linera_views, RegisterView, RootView, ViewStorageContext},
+    DataBlobHash,
+};
+
+#[derive(RootView)]
+#[view(context = ViewStorageContext)]
+pub struct PublishReadDataBlobState {
+    pub hash: RegisterView<Option<DataBlobHash>>,
+}

--- a/examples/publish-read-data-blob/src/state.rs
+++ b/examples/publish-read-data-blob/src/state.rs
@@ -3,7 +3,7 @@
 
 use linera_sdk::{
     views::{linera_views, RegisterView, RootView, ViewStorageContext},
-    DataBlobHash,
+    linera_base_types::DataBlobHash,
 };
 
 #[derive(RootView)]

--- a/examples/publish-read-data-blob/src/state.rs
+++ b/examples/publish-read-data-blob/src/state.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_sdk::{
-    views::{linera_views, RegisterView, RootView, ViewStorageContext},
     linera_base_types::DataBlobHash,
+    views::{linera_views, RegisterView, RootView, ViewStorageContext},
 };
 
 #[derive(RootView)]

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1353,6 +1353,14 @@ impl Blob {
         Blob { hash, content }
     }
 
+    /// Creates a blob from ud and content without checks
+    pub fn new_with_hash_unchecked(blob_id: BlobId, content: BlobContent) -> Self {
+        Blob {
+            hash: blob_id.hash,
+            content,
+        }
+    }
+
     /// Creates a blob without checking that the hash actually matches the content.
     pub fn new_with_id_unchecked(blob_id: BlobId, bytes: impl Into<Box<[u8]>>) -> Self {
         Blob {

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -176,6 +176,7 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
             self.next_application_index,
             self.next_chain_index,
             self.oracle_responses()?,
+            &self.blobs,
         ))
     }
 

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -280,6 +280,7 @@ where
                 0,
                 0,
                 Some(vec![OracleResponse::Blob(application_description_blob_id)]),
+                &[],
             ),
             &mut controller,
         )

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -131,6 +131,7 @@ where
             next_application_index,
             next_chain_index,
             None,
+            &[],
         );
         txn_tracker.add_created_blob(blob);
         self.run_user_action(

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -368,13 +368,13 @@ pub trait ExecutionRuntimeContext {
     async fn get_user_contract(
         &self,
         description: &ApplicationDescription,
-        created_blobs: &BTreeMap<BlobId, Blob>,
+        txn_tracker: &TransactionTracker,
     ) -> Result<UserContractCode, ExecutionError>;
 
     async fn get_user_service(
         &self,
         description: &ApplicationDescription,
-        created_blobs: &BTreeMap<BlobId, Blob>,
+        txn_tracker: &TransactionTracker,
     ) -> Result<UserServiceCode, ExecutionError>;
 
     async fn get_blob(&self, blob_id: BlobId) -> Result<Option<Blob>, ViewError>;
@@ -1042,7 +1042,7 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
     async fn get_user_contract(
         &self,
         description: &ApplicationDescription,
-        _created_blobs: &BTreeMap<BlobId, Blob>,
+        _txn_tracker: &TransactionTracker,
     ) -> Result<UserContractCode, ExecutionError> {
         let application_id = description.into();
         Ok(self
@@ -1057,7 +1057,7 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
     async fn get_user_service(
         &self,
         description: &ApplicationDescription,
-        _created_blobs: &BTreeMap<BlobId, Blob>,
+        _txn_tracker: &TransactionTracker,
     ) -> Result<UserServiceCode, ExecutionError> {
         let application_id = description.into();
         Ok(self

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -941,7 +941,7 @@ where
         let mut this = self.inner();
         let blob_id = hash.into();
         if let Some(content) = this.transaction_tracker.get_blob_content(&blob_id) {
-            return Ok(content.into_bytes().into_vec());
+            return Ok(content.bytes().to_vec());
         };
         let (content, is_new) = this
             .execution_state_sender

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -940,7 +940,6 @@ where
     fn read_data_blob(&mut self, hash: DataBlobHash) -> Result<Vec<u8>, ExecutionError> {
         let mut this = self.inner();
         let blob_id = hash.into();
-        let (blob_content, is_new) = this
         if let Some(content) = this.transaction_tracker.get_blob_content(&blob_id) {
             return Ok(content.into_bytes().into_vec());
         };

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -941,6 +941,10 @@ where
         let mut this = self.inner();
         let blob_id = hash.into();
         let (blob_content, is_new) = this
+        if let Some(content) = this.transaction_tracker.get_blob_content(&blob_id) {
+            return Ok(content.into_bytes().into_vec());
+        };
+        let (content, is_new) = this
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::ReadBlobContent { blob_id, callback })?
             .recv_response()?;
@@ -948,7 +952,7 @@ where
             this.transaction_tracker
                 .replay_oracle_response(OracleResponse::Blob(blob_id))?;
         }
-        Ok(blob_content.into_bytes().into_vec())
+        Ok(content.into_bytes().into_vec())
     }
 
     fn assert_data_blob_exists(&mut self, hash: DataBlobHash) -> Result<(), ExecutionError> {

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -937,12 +937,12 @@ where
         txn_tracker: &mut TransactionTracker,
     ) -> Result<ApplicationDescription, ExecutionError> {
         let blob_id = id.description_blob_id();
-        let blob_content = match txn_tracker.created_blobs().get(&blob_id) {
-            Some(blob) => blob.content().clone(),
+        let content = match txn_tracker.created_blobs().get(&blob_id) {
+            Some(content) => content.clone(),
             None => self.read_blob_content(blob_id).await?,
         };
         self.blob_used(txn_tracker, blob_id).await?;
-        let description: ApplicationDescription = bcs::from_bytes(blob_content.bytes())?;
+        let description: ApplicationDescription = bcs::from_bytes(content.bytes())?;
 
         let blob_ids = self
             .check_bytecode_blobs(&description.module_id, txn_tracker)

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -8,7 +8,7 @@ use std::{
 
 use custom_debug_derive::Debug;
 use linera_base::{
-    data_types::{Blob, Event, OracleResponse, StreamUpdate, Timestamp},
+    data_types::{Blob, BlobContent, Event, OracleResponse, StreamUpdate, Timestamp},
     ensure,
     identifiers::{ApplicationId, BlobId, ChainId, StreamId},
 };
@@ -44,7 +44,9 @@ pub struct TransactionTracker {
     /// - [`EvmBytecode`]
     /// - [`ApplicationDescription`]
     /// - [`ChainDescription`]
-    blobs: BTreeMap<BlobId, Blob>,
+    blobs: BTreeMap<BlobId, BlobContent>,
+    /// The blobs created in the previous transactions.
+    previously_created_blobs: BTreeMap<BlobId, BlobContent>,
     /// Operation result.
     operation_result: Option<Vec<u8>>,
     /// Streams that have been updated but not yet processed during this transaction.
@@ -79,18 +81,26 @@ impl TransactionTracker {
         next_application_index: u32,
         next_chain_index: u32,
         oracle_responses: Option<Vec<OracleResponse>>,
+        blobs: &[Vec<Blob>],
     ) -> Self {
+        let mut previously_created_blobs = BTreeMap::new();
+        for tx_blobs in blobs {
+            for blob in tx_blobs {
+                previously_created_blobs.insert(blob.id(), blob.content().clone());
+            }
+        }
         TransactionTracker {
             local_time,
             transaction_index,
             next_application_index,
             next_chain_index,
             replaying_oracle_responses: oracle_responses.map(Vec::into_iter),
+            previously_created_blobs,
             ..Self::default()
         }
     }
 
-    pub fn with_blobs(mut self, blobs: BTreeMap<BlobId, Blob>) -> Self {
+    pub fn with_blobs(mut self, blobs: BTreeMap<BlobId, BlobContent>) -> Self {
         self.blobs = blobs;
         self
     }
@@ -137,15 +147,22 @@ impl TransactionTracker {
         });
     }
 
+    pub fn get_blob_content(&self, blob_id: &BlobId) -> Option<BlobContent> {
+        if let Some(content) = self.blobs.get(blob_id) {
+            return Some(content.clone());
+        }
+        self.previously_created_blobs.get(blob_id).cloned()
+    }
+
     pub fn add_created_blob(&mut self, blob: Blob) {
-        self.blobs.insert(blob.id(), blob);
+        self.blobs.insert(blob.id(), blob.into_content());
     }
 
     pub fn add_published_blob(&mut self, blob_id: BlobId) {
         self.blobs_published.insert(blob_id);
     }
 
-    pub fn created_blobs(&self) -> &BTreeMap<BlobId, Blob> {
+    pub fn created_blobs(&self) -> &BTreeMap<BlobId, BlobContent> {
         &self.blobs
     }
 
@@ -262,6 +279,7 @@ impl TransactionTracker {
             next_chain_index,
             events,
             blobs,
+            previously_created_blobs: _,
             operation_result,
             streams_to_process,
             blobs_published,
@@ -276,13 +294,17 @@ impl TransactionTracker {
                 ExecutionError::UnexpectedOracleResponse
             );
         }
+        let blobs = blobs
+            .into_iter()
+            .map(|(blob_id, content)| Blob::new_with_hash_unchecked(blob_id, content))
+            .collect::<Vec<_>>();
         Ok(TransactionOutcome {
             outgoing_messages,
             oracle_responses,
             next_application_index,
             next_chain_index,
             events,
-            blobs: blobs.into_values().collect(),
+            blobs,
             operation_result: operation_result.unwrap_or_default(),
             blobs_published,
         })
@@ -294,7 +316,7 @@ impl TransactionTracker {
     /// Creates a new [`TransactionTracker`] for testing, with default values and the given
     /// oracle responses.
     pub fn new_replaying(oracle_responses: Vec<OracleResponse>) -> Self {
-        TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(oracle_responses))
+        TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(oracle_responses), &[])
     }
 
     /// Creates a new [`TransactionTracker`] for testing, with default values and oracle responses

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -147,11 +147,11 @@ impl TransactionTracker {
         });
     }
 
-    pub fn get_blob_content(&self, blob_id: &BlobId) -> Option<BlobContent> {
+    pub fn get_blob_content(&self, blob_id: &BlobId) -> Option<&BlobContent> {
         if let Some(content) = self.blobs.get(blob_id) {
-            return Some(content.clone());
+            return Some(content);
         }
-        self.previously_created_blobs.get(blob_id).cloned()
+        self.previously_created_blobs.get(blob_id)
     }
 
     pub fn add_created_blob(&mut self, blob: Blob) {

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1227,6 +1227,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
         first_message_index,
         0,
         Some(blob_oracle_responses(blobs.iter())),
+        &[],
     );
     view.execute_operation(context, operation, &mut txn_tracker, &mut controller)
         .await?;

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -155,6 +155,7 @@ native-fungible.workspace = true
 non-fungible.workspace = true
 prometheus.workspace = true
 proptest.workspace = true
+publish-read-data-blob.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 social.workspace = true
 test-case.workspace = true

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -4731,3 +4731,80 @@ async fn test_end_to_end_repeated_transfers(config: impl LineraNetConfig) -> Res
 
     Ok(())
 }
+
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
+#[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_wasm_end_to_end_publish_read_data_blob(config: impl LineraNetConfig) -> Result<()> {
+    use publish_read_data_blob::{PublishReadDataBlobAbi, ServiceQuery};
+
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let (mut net, client) = config.instantiate().await?;
+
+    let chain = client.load_wallet()?.default_chain().unwrap();
+    let (contract, service) = client.build_example("publish-read-data-blob").await?;
+
+    let application_id = client
+        .publish_and_create::<PublishReadDataBlobAbi, (), ()>(
+            contract,
+            service,
+            VmRuntime::Wasm,
+            &(),
+            &(),
+            &[],
+            None,
+        )
+        .await?;
+
+    let port = get_node_port().await;
+    let mut node_service = client.run_node_service(port, ProcessInbox::Skip).await?;
+
+    let application = node_service
+        .make_application(&chain, &application_id)
+        .await?;
+
+    // Method 1: Publishing and reading in different blocks.
+
+    let test_data = b"This is test data for method 1.".to_vec();
+
+    // publishing the data.
+    let mutation = ServiceQuery::PublishDataBlob(test_data.clone());
+    application.run_json_query(&mutation).await?;
+
+    // getting the blob_id.
+    let query = ServiceQuery::GetHash;
+    let result = application.run_json_query(&query).await?;
+    let result: Vec<u8> = serde_json::from_value(result)?;
+    let hash: DataBlobHash = bcs::from_bytes(&result)?;
+
+    // reading and checking
+    let mutation = ServiceQuery::ReadDataBlob(hash, test_data);
+    application.run_json_query(&mutation).await?;
+
+    // Method 2: Publishing and reading in the same transaction
+
+    let test_data = b"This is test data for method 2.".to_vec();
+
+    let mutation = ServiceQuery::PublishAndCreateOneOperation(test_data);
+    application.run_json_query(&mutation).await?;
+
+    // Method 3: Publishing and reading in the same block but different transactions
+
+    let test_data = b"This is test data for method 3.".to_vec();
+
+    let mutation = ServiceQuery::PublishAndCreateTwoOperations(test_data);
+    application.run_json_query(&mutation).await?;
+
+    // Winding down
+
+    node_service.ensure_is_running()?;
+    net.ensure_is_running().await?;
+    net.terminate().await?;
+
+    Ok(())
+}

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -4776,11 +4776,9 @@ async fn test_wasm_end_to_end_publish_read_data_blob(config: impl LineraNetConfi
     let mutation = ServiceQuery::PublishDataBlob(test_data.clone());
     application.run_json_query(&mutation).await?;
 
-    // getting the blob_id.
-    let query = ServiceQuery::GetHash;
-    let result = application.run_json_query(&query).await?;
-    let result: Vec<u8> = serde_json::from_value(result)?;
-    let hash: DataBlobHash = bcs::from_bytes(&result)?;
+    // getting the hash
+    let content = BlobContent::new_data(test_data.clone());
+    let hash = DataBlobHash(CryptoHash::new(&content));
 
     // reading and checking
     let mutation = ServiceQuery::ReadDataBlob(hash, test_data);

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -27,8 +27,8 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::Committee, system::EPOCH_STREAM_NAME, BlobState, ExecutionError,
-    ExecutionRuntimeConfig, ExecutionRuntimeContext, UserContractCode, UserServiceCode,
-    WasmRuntime,
+    ExecutionRuntimeConfig, ExecutionRuntimeContext, TransactionTracker, UserContractCode,
+    UserServiceCode, WasmRuntime,
 };
 #[cfg(with_revm)]
 use linera_execution::{
@@ -262,17 +262,21 @@ pub trait Storage: Sized {
     async fn load_contract(
         &self,
         application_description: &ApplicationDescription,
-        created_blobs: &BTreeMap<BlobId, Blob>,
+        txn_tracker: &TransactionTracker,
     ) -> Result<UserContractCode, ExecutionError> {
         let contract_bytecode_blob_id = application_description.contract_bytecode_blob_id();
-        let contract_blob = match created_blobs.get(&contract_bytecode_blob_id) {
-            Some(blob) => blob.clone(),
-            None => self.read_blob(contract_bytecode_blob_id).await?.ok_or(
-                ExecutionError::BlobsNotFound(vec![contract_bytecode_blob_id]),
-            )?,
+        let content = match txn_tracker.get_blob_content(&contract_bytecode_blob_id) {
+            Some(content) => content,
+            None => self
+                .read_blob(contract_bytecode_blob_id)
+                .await?
+                .ok_or(ExecutionError::BlobsNotFound(vec![
+                    contract_bytecode_blob_id,
+                ]))?
+                .into_content(),
         };
         let compressed_contract_bytecode = CompressedBytecode {
-            compressed_bytes: contract_blob.into_bytes().to_vec(),
+            compressed_bytes: content.into_bytes().to_vec(),
         };
         #[cfg_attr(not(any(with_wasm_runtime, with_revm)), allow(unused_variables))]
         let contract_bytecode =
@@ -325,17 +329,21 @@ pub trait Storage: Sized {
     async fn load_service(
         &self,
         application_description: &ApplicationDescription,
-        created_blobs: &BTreeMap<BlobId, Blob>,
+        txn_tracker: &TransactionTracker,
     ) -> Result<UserServiceCode, ExecutionError> {
         let service_bytecode_blob_id = application_description.service_bytecode_blob_id();
-        let service_blob = match created_blobs.get(&service_bytecode_blob_id) {
-            Some(blob) => blob.clone(),
-            None => self.read_blob(service_bytecode_blob_id).await?.ok_or(
-                ExecutionError::BlobsNotFound(vec![service_bytecode_blob_id]),
-            )?,
+        let content = match txn_tracker.get_blob_content(&service_bytecode_blob_id) {
+            Some(content) => content,
+            None => self
+                .read_blob(service_bytecode_blob_id)
+                .await?
+                .ok_or(ExecutionError::BlobsNotFound(vec![
+                    service_bytecode_blob_id,
+                ]))?
+                .into_content(),
         };
         let compressed_service_bytecode = CompressedBytecode {
-            compressed_bytes: service_blob.into_bytes().to_vec(),
+            compressed_bytes: content.into_bytes().to_vec(),
         };
         #[cfg_attr(not(any(with_wasm_runtime, with_revm)), allow(unused_variables))]
         let service_bytecode = linera_base::task::Blocking::<linera_base::task::NoInput, _>::spawn(
@@ -450,16 +458,13 @@ where
     async fn get_user_contract(
         &self,
         description: &ApplicationDescription,
-        created_blobs: &BTreeMap<BlobId, Blob>,
+        txn_tracker: &TransactionTracker,
     ) -> Result<UserContractCode, ExecutionError> {
         let application_id = description.into();
         if let Some(contract) = self.user_contracts.get(&application_id) {
             return Ok(contract.clone());
         }
-        let contract = self
-            .storage
-            .load_contract(description, created_blobs)
-            .await?;
+        let contract = self.storage.load_contract(description, txn_tracker).await?;
         self.user_contracts.insert(application_id, contract.clone());
         Ok(contract)
     }
@@ -467,16 +472,13 @@ where
     async fn get_user_service(
         &self,
         description: &ApplicationDescription,
-        created_blobs: &BTreeMap<BlobId, Blob>,
+        txn_tracker: &TransactionTracker,
     ) -> Result<UserServiceCode, ExecutionError> {
         let application_id = description.into();
         if let Some(service) = self.user_services.get(&application_id) {
             return Ok(service.clone());
         }
-        let service = self
-            .storage
-            .load_service(description, created_blobs)
-            .await?;
+        let service = self.storage.load_service(description, txn_tracker).await?;
         self.user_services.insert(application_id, service.clone());
         Ok(service)
     }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -266,7 +266,7 @@ pub trait Storage: Sized {
     ) -> Result<UserContractCode, ExecutionError> {
         let contract_bytecode_blob_id = application_description.contract_bytecode_blob_id();
         let content = match txn_tracker.get_blob_content(&contract_bytecode_blob_id) {
-            Some(content) => content,
+            Some(content) => content.clone(),
             None => self
                 .read_blob(contract_bytecode_blob_id)
                 .await?
@@ -276,7 +276,7 @@ pub trait Storage: Sized {
                 .into_content(),
         };
         let compressed_contract_bytecode = CompressedBytecode {
-            compressed_bytes: content.into_bytes().to_vec(),
+            compressed_bytes: content.into_bytes().into_vec(),
         };
         #[cfg_attr(not(any(with_wasm_runtime, with_revm)), allow(unused_variables))]
         let contract_bytecode =
@@ -333,7 +333,7 @@ pub trait Storage: Sized {
     ) -> Result<UserServiceCode, ExecutionError> {
         let service_bytecode_blob_id = application_description.service_bytecode_blob_id();
         let content = match txn_tracker.get_blob_content(&service_bytecode_blob_id) {
-            Some(content) => content,
+            Some(content) => content.clone(),
             None => self
                 .read_blob(service_bytecode_blob_id)
                 .await?
@@ -343,7 +343,7 @@ pub trait Storage: Sized {
                 .into_content(),
         };
         let compressed_service_bytecode = CompressedBytecode {
-            compressed_bytes: content.into_bytes().to_vec(),
+            compressed_bytes: content.into_bytes().into_vec(),
         };
         #[cfg_attr(not(any(with_wasm_runtime, with_revm)), allow(unused_variables))]
         let service_bytecode = linera_base::task::Blocking::<linera_base::task::NoInput, _>::spawn(


### PR DESCRIPTION
## Motivation

Following PR #4247, PR #4278, and PR #3382, we face the scenario where a contract can create a blob
but not have it available right away. This concerns the access to Blob Bytecode, Blob ApplicationDescription, and
Blob Data.

This PR addresses those problems.

Fixes #4287 
Fixes #4279 

## Proposal

This PR addresses the problem with the data blob. But it also addresses the issues for the ApplicationDescription blob
and the contract blobs.

There are three scenarios to cover:
* The blob is created in one block and read in another block.
* The blob is created in one operation and read in the same operation.
* The blob is created in two different operations of the same block.

The first scenario is already working correctly.

The second scenario is addressed with the addition of the test of `created_blobs` in `ReadBlobContent`. This is done
in the same way as for access to the ApplicationDescription and the Contract/Service.

The third scenario is addressed by the change in how the TransactionTracker is built in `block_tracker`.

## Test Plan

The CI and the test in `test_wasm_end_to_end_publish_read_data_blob`, which considers all 3 scenarios.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None