### PR TITLE
Make sure all fields in the GraphQL schema are documented

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -942,11 +942,11 @@ pub struct ApplicationPermissions {
     #[graphql(default)]
     #[debug(skip_if = Vec::is_empty)]
     pub mandatory_applications: Vec<ApplicationId>,
-    /// These applications are allowed to close the current chain using the system API.
+    /// These applications are allowed to close the current chain.
     #[graphql(default)]
     #[debug(skip_if = Vec::is_empty)]
     pub close_chain: Vec<ApplicationId>,
-    /// These applications are allowed to change the application permissions using the system API.
+    /// These applications are allowed to change the application permissions.
     #[graphql(default)]
     #[debug(skip_if = Vec::is_empty)]
     pub change_application_permissions: Vec<ApplicationId>,
@@ -1161,7 +1161,7 @@ pub enum DecompressionError {
     InvalidCompressedBytecode(#[from] io::Error),
 }
 
-/// A compressed WebAssembly module's bytecode.
+/// A compressed module bytecode (WebAssembly or EVM).
 #[derive(Clone, Debug, Deserialize, Hash, Serialize, WitType, WitStore)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 pub struct CompressedBytecode {
@@ -1529,7 +1529,7 @@ impl StreamUpdate {
 
 impl BcsHashable<'_> for Event {}
 
-doc_scalar!(Bytecode, "A WebAssembly module's bytecode");
+doc_scalar!(Bytecode, "A module bytecode (WebAssembly or EVM)");
 doc_scalar!(Amount, "A non-negative amount of tokens.");
 doc_scalar!(
     Epoch,

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -97,7 +97,7 @@ impl From<CryptoHash> for AccountOwner {
 pub struct Account {
     /// The chain of the account.
     pub chain_id: ChainId,
-    /// The owner of the account, or `None` for the chain balance.
+    /// The owner of the account.
     pub owner: AccountOwner,
 }
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -7,7 +7,7 @@ input Account {
 	"""
 	chainId: ChainId!
 	"""
-	The owner of the account, or `None` for the chain balance.
+	The owner of the account.
 	"""
 	owner: AccountOwner!
 }
@@ -21,7 +21,7 @@ type AccountOutput {
 	"""
 	chainId: ChainId!
 	"""
-	The owner of the account, or `None` for the chain balance.
+	The owner of the account.
 	"""
 	owner: AccountOwner!
 }
@@ -68,11 +68,11 @@ input ApplicationPermissions {
 	"""
 	mandatoryApplications: [ApplicationId!]! = []
 	"""
-	These applications are allowed to close the current chain using the system API.
+	These applications are allowed to close the current chain.
 	"""
 	closeChain: [ApplicationId!]! = []
 	"""
-	These applications are allowed to change the application permissions using the system API.
+	These applications are allowed to change the application permissions.
 	"""
 	changeApplicationPermissions: [ApplicationId!]! = []
 	"""
@@ -251,7 +251,7 @@ type BundleInInbox {
 }
 
 """
-A WebAssembly module's bytecode
+A module bytecode (WebAssembly or EVM)
 """
 scalar Bytecode
 
@@ -778,36 +778,119 @@ type MutationRoot {
 	"""
 	Processes the inbox and returns the lists of certificate hashes that were created, if any.
 	"""
-	processInbox(chainId: ChainId!): [CryptoHash!]!
+	processInbox(
+		"""
+		The chain whose inbox is being processed.
+		"""
+		chainId: ChainId!
+	): [CryptoHash!]!
 	"""
 	Retries the pending block that was unsuccessfully proposed earlier.
 	"""
-	retryPendingBlock(chainId: ChainId!): CryptoHash
+	retryPendingBlock(
+		"""
+		The chain on whose block is being retried.
+		"""
+		chainId: ChainId!
+	): CryptoHash
 	"""
 	Transfers `amount` units of value from the given owner's account to the recipient.
 	If no owner is given, try to take the units out of the chain account.
 	"""
-	transfer(chainId: ChainId!, owner: AccountOwner!, recipient: Account!, amount: Amount!): CryptoHash!
+	transfer(
+		"""
+		The chain which native tokens are being transferred from.
+		"""
+		chainId: ChainId!,
+		"""
+		The account being debited on the chain.
+		"""
+		owner: AccountOwner!,
+		"""
+		The recipient of the transfer.
+		"""
+		recipient: Account!,
+		"""
+		The amount being transferred.
+		"""
+		amount: Amount!
+	): CryptoHash!
 	"""
 	Claims `amount` units of value from the given owner's account in the remote
 	`target` chain. Depending on its configuration, the `target` chain may refuse to
 	process the message.
 	"""
-	claim(chainId: ChainId!, owner: AccountOwner!, targetId: ChainId!, recipient: Account!, amount: Amount!): CryptoHash!
+	claim(
+		"""
+		The chain for whom owner is one of the owner.
+		"""
+		chainId: ChainId!,
+		"""
+		The owner of chain targetId being debited.
+		"""
+		owner: AccountOwner!,
+		"""
+		The chain whose owner is being debited.
+		"""
+		targetId: ChainId!,
+		"""
+		The recipient of the transfer.
+		"""
+		recipient: Account!,
+		"""
+		The amount being transferred.
+		"""
+		amount: Amount!
+	): CryptoHash!
 	"""
 	Test if a data blob is readable from a transaction in the current chain.
 	"""
 	readDataBlob(chainId: ChainId!, hash: CryptoHash!): CryptoHash!
 	"""
-	Creates (or activates) a new chain with the given owner.
-	This will automatically subscribe to the future committees created by `admin_id`.
+	Creates a new single-owner chain.
 	"""
-	openChain(chainId: ChainId!, owner: AccountOwner!, balance: Amount): ChainId!
+	openChain(
+		"""
+		The chain paying for the creation of the new chain.
+		"""
+		chainId: ChainId!,
+		"""
+		The owner of the new chain.
+		"""
+		owner: AccountOwner!,
+		"""
+		The balance of the chain being created. Zero if `None`.
+		"""
+		balance: Amount
+	): ChainId!
 	"""
-	Creates (or activates) a new chain by installing the given authentication keys.
-	This will automatically subscribe to the future committees created by `admin_id`.
+	Creates a new multi-owner chain.
 	"""
-	openMultiOwnerChain(		chainId: ChainId!,		applicationPermissions: ApplicationPermissions,		owners: [AccountOwner!]!,		weights: [Int!],		multiLeaderRounds: Int,		balance: Amount,
+	openMultiOwnerChain(
+		"""
+		The chain paying for the creation of the new chain.
+		"""
+		chainId: ChainId!,
+		"""
+		Permissions for applications on the new chain
+		"""
+		applicationPermissions: ApplicationPermissions,
+		"""
+		The owners of the chain
+		"""
+		owners: [AccountOwner!]!,
+		"""
+		The weights of the owners
+		"""
+		weights: [Int!],
+		"""
+		The number of multi-leader rounds
+		"""
+		multiLeaderRounds: Int,
+		"""
+		The balance of the chain. Zero if `None`
+		"""
+		balance: Amount,
 		"""
 		The duration of the fast round, in milliseconds; default: no timeout
 		"""
@@ -826,17 +909,51 @@ type MutationRoot {
 		fallbackDurationMs: Int! = 86400000
 	): ChainId!
 	"""
-	Closes the chain. Returns `None` if it was already closed.
+	Closes the chain. Returns the new block hash if successful or `None` if it was already closed.
 	"""
-	closeChain(chainId: ChainId!): CryptoHash
+	closeChain(
+		"""
+		The chain being closed.
+		"""
+		chainId: ChainId!
+	): CryptoHash
 	"""
-	Changes the authentication key of the chain.
+	Changes the chain to a single-owner chain
 	"""
-	changeOwner(chainId: ChainId!, newOwner: AccountOwner!): CryptoHash!
+	changeOwner(
+		"""
+		The chain whose ownership changes
+		"""
+		chainId: ChainId!,
+		"""
+		The new single owner of the chain
+		"""
+		newOwner: AccountOwner!
+	): CryptoHash!
 	"""
-	Changes the authentication key of the chain.
+	Changes the ownership of the chain
 	"""
-	changeMultipleOwners(		chainId: ChainId!,		newOwners: [AccountOwner!]!,		newWeights: [Int!]!,		multiLeaderRounds: Int!,		openMultiLeaderRounds: Boolean!,
+	changeMultipleOwners(
+		"""
+		The chain whose ownership changes
+		"""
+		chainId: ChainId!,
+		"""
+		The new list of owners of the chain
+		"""
+		newOwners: [AccountOwner!]!,
+		"""
+		The new list of weights of the owners
+		"""
+		newWeights: [Int!]!,
+		"""
+		The multi-leader round of the chain
+		"""
+		multiLeaderRounds: Int!,
+		"""
+		Whether multi-leader rounds are unrestricted, that is not limited to chain owners.
+		"""
+		openMultiLeaderRounds: Boolean!,
 		"""
 		The duration of the fast round, in milliseconds; default: no timeout
 		"""
@@ -857,7 +974,38 @@ type MutationRoot {
 	"""
 	Changes the application permissions configuration on this chain.
 	"""
-	changeApplicationPermissions(chainId: ChainId!, closeChain: [ApplicationId!]!, executeOperations: [ApplicationId!], mandatoryApplications: [ApplicationId!]!, changeApplicationPermissions: [ApplicationId!]!, callServiceAsOracle: [ApplicationId!], makeHttpRequests: [ApplicationId!]): CryptoHash!
+	changeApplicationPermissions(
+		"""
+		The chain whose permissions are being changed
+		"""
+		chainId: ChainId!,
+		"""
+		These applications are allowed to close the current chain.
+		"""
+		closeChain: [ApplicationId!]!,
+		"""
+		If this is `None`, all system operations and application operations are allowed.
+		If it is `Some`, only operations from the specified applications are allowed,
+		and no system operations.
+		"""
+		executeOperations: [ApplicationId!],
+		"""
+		At least one operation or incoming message from each of these applications must occur in every block.
+		"""
+		mandatoryApplications: [ApplicationId!]!,
+		"""
+		These applications are allowed to change the application permissions.
+		"""
+		changeApplicationPermissions: [ApplicationId!]!,
+		"""
+		These applications are allowed to perform calls to services as oracles.
+		"""
+		callServiceAsOracle: [ApplicationId!],
+		"""
+		These applications are allowed to perform HTTP requests.
+		"""
+		makeHttpRequests: [ApplicationId!]
+	): CryptoHash!
 	"""
 	(admin chain only) Registers a new committee. This will notify the subscribers of
 	the admin chain so that they can migrate to the new epoch (by accepting the
@@ -873,15 +1021,62 @@ type MutationRoot {
 	"""
 	Publishes a new application module.
 	"""
-	publishModule(chainId: ChainId!, contract: Bytecode!, service: Bytecode!, vmRuntime: VmRuntime!): ModuleId!
+	publishModule(
+		"""
+		The chain publishing the module
+		"""
+		chainId: ChainId!,
+		"""
+		The bytecode of the contract code
+		"""
+		contract: Bytecode!,
+		"""
+		The bytecode of the service code (only relevant for WebAssembly)
+		"""
+		service: Bytecode!,
+		"""
+		The virtual machine being used (either Wasm or Evm)
+		"""
+		vmRuntime: VmRuntime!
+	): ModuleId!
 	"""
 	Publishes a new data blob.
 	"""
-	publishDataBlob(chainId: ChainId!, bytes: [Int!]!): CryptoHash!
+	publishDataBlob(
+		"""
+		The chain paying for the blob publication
+		"""
+		chainId: ChainId!,
+		"""
+		The content of the data blob being created
+		"""
+		bytes: [Int!]!
+	): CryptoHash!
 	"""
 	Creates a new application.
 	"""
-	createApplication(chainId: ChainId!, moduleId: ModuleId!, parameters: String!, instantiationArgument: String!, requiredApplicationIds: [ApplicationId!]!): ApplicationId!
+	createApplication(
+		"""
+		The chain paying for the creation of the application
+		"""
+		chainId: ChainId!,
+		"""
+		The module ID of the application being created
+		"""
+		moduleId: ModuleId!,
+		"""
+		The JSON serialization of the parameters of the application
+		"""
+		parameters: String!,
+		"""
+		The JSON serialization of the instantiation argument of the application
+		"""
+		instantiationArgument: String!,
+		"""
+		The dependencies of the application being created
+		"""
+		requiredApplicationIds: [ApplicationId!]!
+	): ApplicationId!
 }
 
 """

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -174,7 +174,10 @@ where
     C: ClientContext + 'static,
 {
     /// Processes the inbox and returns the lists of certificate hashes that were created, if any.
-    async fn process_inbox(&self, chain_id: ChainId) -> Result<Vec<CryptoHash>, Error> {
+    async fn process_inbox(
+        &self,
+        #[graphql(desc = "The chain whose inbox is being processed.")] chain_id: ChainId,
+    ) -> Result<Vec<CryptoHash>, Error> {
         let mut hashes = Vec::new();
         loop {
             let client = self.context.lock().await.make_chain_client(chain_id);
@@ -195,7 +198,10 @@ where
     }
 
     /// Retries the pending block that was unsuccessfully proposed earlier.
-    async fn retry_pending_block(&self, chain_id: ChainId) -> Result<Option<CryptoHash>, Error> {
+    async fn retry_pending_block(
+        &self,
+        #[graphql(desc = "The chain on whose block is being retried.")] chain_id: ChainId,
+    ) -> Result<Option<CryptoHash>, Error> {
         let client = self.context.lock().await.make_chain_client(chain_id);
         let outcome = client.process_pending_block().await?;
         self.context.lock().await.update_wallet(&client).await?;
@@ -213,10 +219,11 @@ where
     /// If no owner is given, try to take the units out of the chain account.
     async fn transfer(
         &self,
+        #[graphql(desc = "The chain which native tokens are being transferred from.")]
         chain_id: ChainId,
-        owner: AccountOwner,
-        recipient: Account,
-        amount: Amount,
+        #[graphql(desc = "The account being debited on the chain.")] owner: AccountOwner,
+        #[graphql(desc = "The recipient of the transfer.")] recipient: Account,
+        #[graphql(desc = "The amount being transferred.")] amount: Amount,
     ) -> Result<CryptoHash, Error> {
         self.apply_client_command(&chain_id, move |client| async move {
             let result = client
@@ -234,11 +241,11 @@ where
     /// process the message.
     async fn claim(
         &self,
-        chain_id: ChainId,
-        owner: AccountOwner,
-        target_id: ChainId,
-        recipient: Account,
-        amount: Amount,
+        #[graphql(desc = "The chain for whom owner is one of the owner.")] chain_id: ChainId,
+        #[graphql(desc = "The owner of chain targetId being debited.")] owner: AccountOwner,
+        #[graphql(desc = "The chain whose owner is being debited.")] target_id: ChainId,
+        #[graphql(desc = "The recipient of the transfer.")] recipient: Account,
+        #[graphql(desc = "The amount being transferred.")] amount: Amount,
     ) -> Result<CryptoHash, Error> {
         self.apply_client_command(&chain_id, move |client| async move {
             let result = client
@@ -269,12 +276,12 @@ where
         .await
     }
 
-    /// Creates (or activates) a new chain with the given owner.
-    /// This will automatically subscribe to the future committees created by `admin_id`.
+    /// Creates a new single-owner chain.
     async fn open_chain(
         &self,
-        chain_id: ChainId,
-        owner: AccountOwner,
+        #[graphql(desc = "The chain paying for the creation of the new chain.")] chain_id: ChainId,
+        #[graphql(desc = "The owner of the new chain.")] owner: AccountOwner,
+        #[graphql(desc = "The balance of the chain being created. Zero if `None`.")]
         balance: Option<Amount>,
     ) -> Result<ChainId, Error> {
         let ownership = ChainOwnership::single(owner);
@@ -295,17 +302,17 @@ where
         Ok(description.id())
     }
 
-    /// Creates (or activates) a new chain by installing the given authentication keys.
-    /// This will automatically subscribe to the future committees created by `admin_id`.
+    /// Creates a new multi-owner chain.
     #[expect(clippy::too_many_arguments)]
     async fn open_multi_owner_chain(
         &self,
-        chain_id: ChainId,
+        #[graphql(desc = "The chain paying for the creation of the new chain.")] chain_id: ChainId,
+        #[graphql(desc = "Permissions for applications on the new chain")]
         application_permissions: Option<ApplicationPermissions>,
-        owners: Vec<AccountOwner>,
-        weights: Option<Vec<u64>>,
-        multi_leader_rounds: Option<u32>,
-        balance: Option<Amount>,
+        #[graphql(desc = "The owners of the chain")] owners: Vec<AccountOwner>,
+        #[graphql(desc = "The weights of the owners")] weights: Option<Vec<u64>>,
+        #[graphql(desc = "The number of multi-leader rounds")] multi_leader_rounds: Option<u32>,
+        #[graphql(desc = "The balance of the chain. Zero if `None`")] balance: Option<Amount>,
         #[graphql(desc = "The duration of the fast round, in milliseconds; default: no timeout")]
         fast_round_ms: Option<u64>,
         #[graphql(
@@ -367,8 +374,11 @@ where
         Ok(description.id())
     }
 
-    /// Closes the chain. Returns `None` if it was already closed.
-    async fn close_chain(&self, chain_id: ChainId) -> Result<Option<CryptoHash>, Error> {
+    /// Closes the chain. Returns the new block hash if successful or `None` if it was already closed.
+    async fn close_chain(
+        &self,
+        #[graphql(desc = "The chain being closed.")] chain_id: ChainId,
+    ) -> Result<Option<CryptoHash>, Error> {
         let maybe_cert = self
             .apply_client_command(&chain_id, |client| async move {
                 let result = client.close_chain().await.map_err(Error::from);
@@ -378,11 +388,11 @@ where
         Ok(maybe_cert.as_ref().map(GenericCertificate::hash))
     }
 
-    /// Changes the authentication key of the chain.
+    /// Changes the chain to a single-owner chain
     async fn change_owner(
         &self,
-        chain_id: ChainId,
-        new_owner: AccountOwner,
+        #[graphql(desc = "The chain whose ownership changes")] chain_id: ChainId,
+        #[graphql(desc = "The new single owner of the chain")] new_owner: AccountOwner,
     ) -> Result<CryptoHash, Error> {
         let operation = SystemOperation::ChangeOwnership {
             super_owners: vec![new_owner],
@@ -394,14 +404,17 @@ where
         self.execute_system_operation(operation, chain_id).await
     }
 
-    /// Changes the authentication key of the chain.
+    /// Changes the ownership of the chain
     #[expect(clippy::too_many_arguments)]
     async fn change_multiple_owners(
         &self,
-        chain_id: ChainId,
-        new_owners: Vec<AccountOwner>,
-        new_weights: Vec<u64>,
-        multi_leader_rounds: u32,
+        #[graphql(desc = "The chain whose ownership changes")] chain_id: ChainId,
+        #[graphql(desc = "The new list of owners of the chain")] new_owners: Vec<AccountOwner>,
+        #[graphql(desc = "The new list of weights of the owners")] new_weights: Vec<u64>,
+        #[graphql(desc = "The multi-leader round of the chain")] multi_leader_rounds: u32,
+        #[graphql(
+            desc = "Whether multi-leader rounds are unrestricted, that is not limited to chain owners."
+        )]
         open_multi_leader_rounds: bool,
         #[graphql(desc = "The duration of the fast round, in milliseconds; default: no timeout")]
         fast_round_ms: Option<u64>,
@@ -442,12 +455,26 @@ where
     #[expect(clippy::too_many_arguments)]
     async fn change_application_permissions(
         &self,
-        chain_id: ChainId,
+        #[graphql(desc = "The chain whose permissions are being changed")] chain_id: ChainId,
+        #[graphql(desc = "These applications are allowed to close the current chain.")]
         close_chain: Vec<ApplicationId>,
+        #[graphql(
+            desc = "If this is `None`, all system operations and application operations are allowed.
+If it is `Some`, only operations from the specified applications are allowed,
+and no system operations."
+        )]
         execute_operations: Option<Vec<ApplicationId>>,
+        #[graphql(
+            desc = "At least one operation or incoming message from each of these applications must occur in every block."
+        )]
         mandatory_applications: Vec<ApplicationId>,
+        #[graphql(desc = "These applications are allowed to change the application permissions.")]
         change_application_permissions: Vec<ApplicationId>,
+        #[graphql(
+            desc = "These applications are allowed to perform calls to services as oracles."
+        )]
         call_service_as_oracle: Option<Vec<ApplicationId>>,
+        #[graphql(desc = "These applications are allowed to perform HTTP requests.")]
         make_http_requests: Option<Vec<ApplicationId>>,
     ) -> Result<CryptoHash, Error> {
         let operation = SystemOperation::ChangeApplicationPermissions(ApplicationPermissions {
@@ -495,9 +522,11 @@ where
     /// Publishes a new application module.
     async fn publish_module(
         &self,
-        chain_id: ChainId,
-        contract: Bytecode,
+        #[graphql(desc = "The chain publishing the module")] chain_id: ChainId,
+        #[graphql(desc = "The bytecode of the contract code")] contract: Bytecode,
+        #[graphql(desc = "The bytecode of the service code (only relevant for WebAssembly)")]
         service: Bytecode,
+        #[graphql(desc = "The virtual machine being used (either Wasm or Evm)")]
         vm_runtime: VmRuntime,
     ) -> Result<ModuleId, Error> {
         self.apply_client_command(&chain_id, move |client| {
@@ -518,8 +547,8 @@ where
     /// Publishes a new data blob.
     async fn publish_data_blob(
         &self,
-        chain_id: ChainId,
-        bytes: Vec<u8>,
+        #[graphql(desc = "The chain paying for the blob publication")] chain_id: ChainId,
+        #[graphql(desc = "The content of the data blob being created")] bytes: Vec<u8>,
     ) -> Result<CryptoHash, Error> {
         self.apply_client_command(&chain_id, |client| {
             let bytes = bytes.clone();
@@ -535,10 +564,15 @@ where
     /// Creates a new application.
     async fn create_application(
         &self,
-        chain_id: ChainId,
-        module_id: ModuleId,
+        #[graphql(desc = "The chain paying for the creation of the application")] chain_id: ChainId,
+        #[graphql(desc = "The module ID of the application being created")] module_id: ModuleId,
+        #[graphql(desc = "The JSON serialization of the parameters of the application")]
         parameters: String,
+        #[graphql(
+            desc = "The JSON serialization of the instantiation argument of the application"
+        )]
         instantiation_argument: String,
+        #[graphql(desc = "The dependencies of the application being created")]
         required_application_ids: Vec<ApplicationId>,
     ) -> Result<ApplicationId, Error> {
         self.apply_client_command(&chain_id, move |client| {


### PR DESCRIPTION
## Motivation

The GraphQL definitions are a little bit inconsistent. Here we correct them.

Fixes #1308 

## Proposal

The following changes are made:
* Precising the role of the `ChainId`. For example, for `openChain`, a naive user may think that the input `chainId` is going to be the chain ID.
* Removing the fact that chains are subscribed to epoch changes from the admin chain. I think this is not useful as it is an implementation detail.
* Removing notes like "system API", which are not useful.
* Remove "(or activates)" which is unclear to me and probably obsolete.
* I added the EVM-relevant notes that occurred in a few places.

## Test Plan

The CI should take care of the schema update.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None