### PR TITLE
Make `ChainClient::subscribe` synchronous.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1705,16 +1705,13 @@ impl<Env: Environment> ChainClient<Env> {
 
     /// Subscribes to notifications from this client's chain.
     #[instrument(level = "trace")]
-    pub async fn subscribe(&self) -> Result<NotificationStream, LocalNodeError> {
-        self.subscribe_to(self.chain_id).await
+    pub fn subscribe(&self) -> Result<NotificationStream, LocalNodeError> {
+        self.subscribe_to(self.chain_id)
     }
 
     /// Subscribes to notifications from the specified chain.
     #[instrument(level = "trace")]
-    pub async fn subscribe_to(
-        &self,
-        chain_id: ChainId,
-    ) -> Result<NotificationStream, LocalNodeError> {
+    pub fn subscribe_to(&self, chain_id: ChainId) -> Result<NotificationStream, LocalNodeError> {
         Ok(Box::pin(UnboundedReceiverStream::new(
             self.client.notifier.subscribe(vec![chain_id]),
         )))
@@ -3708,8 +3705,8 @@ impl<Env: Environment> ChainClient<Env> {
         }
 
         let mut senders = HashMap::new(); // Senders to cancel notification streams.
-        let notifications = self.subscribe().await?;
-        let (abortable_notifications, abort) = stream::abortable(self.subscribe().await?);
+        let notifications = self.subscribe()?;
+        let (abortable_notifications, abort) = stream::abortable(self.subscribe()?);
         let sync_result = if self.is_tracked() {
             self.synchronize_from_validators().await
         } else {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -100,7 +100,7 @@ where
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let chain_2 = builder.add_root_chain(2, Amount::ZERO).await?;
     // Listen to the notifications on the sender chain.
-    let mut notifications = sender.subscribe().await?;
+    let mut notifications = sender.subscribe()?;
     let (listener, _listen_handle, _) = sender.listen().await?;
     tokio::spawn(listener);
     {

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -113,7 +113,7 @@ where
         chain_id: ChainId,
     ) -> Result<impl Stream<Item = Notification>, Error> {
         let client = self.context.lock().await.make_chain_client(chain_id);
-        Ok(client.subscribe().await?)
+        Ok(client.subscribe()?)
     }
 }
 
@@ -155,7 +155,7 @@ where
     {
         loop {
             let client = self.context.lock().await.make_chain_client(*chain_id);
-            let mut stream = client.subscribe().await?;
+            let mut stream = client.subscribe()?;
             let (result, client) = f(client).await;
             self.context.lock().await.update_wallet(&client).await?;
             let timeout = match result? {
@@ -186,7 +186,7 @@ where
             match maybe_timeout {
                 None => return Ok(hashes),
                 Some(timestamp) => {
-                    let mut stream = client.subscribe().await?;
+                    let mut stream = client.subscribe()?;
                     drop(client);
                     util::wait_for_next_round(&mut stream, timestamp).await;
                 }
@@ -901,7 +901,7 @@ where
                 ClientOutcome::Committed(certificate) => break certificate.hash(),
                 ClientOutcome::WaitForTimeout(timeout) => timeout,
             };
-            let mut stream = client.subscribe().await.map_err(|_| {
+            let mut stream = client.subscribe().map_err(|_| {
                 ChainClientError::InternalError("Could not subscribe to the local node.")
             })?;
             util::wait_for_next_round(&mut stream, timeout).await;

--- a/linera-web/src/lib.rs
+++ b/linera-web/src/lib.rs
@@ -244,7 +244,6 @@ impl Client {
                 .await
                 .unwrap()
                 .subscribe()
-                .await
                 .unwrap();
             while let Some(notification) = notifications.next().await {
                 tracing::debug!("received notification: {notification:?}");
@@ -282,7 +281,7 @@ impl Client {
                 Ok(WaitForTimeout(timeout)) => timeout,
                 Err(e) => break Ok(Err(e)),
             };
-            let mut stream = chain_client.subscribe().await?;
+            let mut stream = chain_client.subscribe()?;
             linera_client::util::wait_for_next_round(&mut stream, timeout).await;
         };
 


### PR DESCRIPTION
## Motivation

This channel only adds a sender entry into a map. It doesn't need to be `async`.

## Proposal

Make it synchronous.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
