### PR TITLE
Always import `Instant` from `linera_base`.

### DIFF
--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -6,7 +6,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     thread,
-    time::{Duration, Instant},
 };
 
 use assert_matches::assert_matches;
@@ -20,6 +19,7 @@ use linera_base::{
     http,
     identifiers::{Account, AccountOwner, ApplicationId, ChainId, ModuleId},
     ownership::ChainOwnership,
+    time::{Duration, Instant},
     vm::VmRuntime,
 };
 use linera_execution::{

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -6,7 +6,6 @@ use std::{
     mem,
     ops::{Deref, DerefMut},
     sync::{Arc, Mutex},
-    time::Instant,
 };
 
 use custom_debug_derive::Debug;
@@ -22,6 +21,7 @@ use linera_base::{
         StreamName,
     },
     ownership::ChainOwnership,
+    time::Instant,
     vm::VmRuntime,
 };
 use linera_views::batch::Batch;

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -5,11 +5,14 @@ use std::{
     net::{IpAddr, SocketAddr},
     str::FromStr,
     task::{Context, Poll},
-    time::{Duration, Instant},
 };
 
 use futures::{channel::mpsc, future::BoxFuture, FutureExt as _};
-use linera_base::{data_types::Blob, identifiers::ChainId};
+use linera_base::{
+    data_types::Blob,
+    identifiers::ChainId,
+    time::{Duration, Instant},
+};
 use linera_core::{
     join_set_ext::JoinSet,
     node::NodeError,

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -10,7 +10,7 @@ use linera_base::{
     async_graphql::InputType,
     data_types::Amount,
     identifiers::{Account, AccountOwner, ApplicationId, ChainId},
-    time::timer::Instant,
+    time::Instant,
     vm::VmRuntime,
 };
 use linera_sdk::abis::fungible::{self, FungibleTokenAbi, InitialState, Parameters};

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -11,7 +11,6 @@ use std::{
     path::PathBuf,
     process,
     sync::Arc,
-    time::Instant,
 };
 
 use anyhow::{anyhow, bail, ensure, Context, Error};
@@ -25,7 +24,7 @@ use linera_base::{
     identifiers::{AccountOwner, ChainId},
     listen_for_shutdown_signals,
     ownership::ChainOwnership,
-    time::Duration,
+    time::{Duration, Instant},
 };
 use linera_client::{
     benchmark::BenchmarkConfig,

--- a/linera-service/src/exporter/runloops/indexer/client.rs
+++ b/linera-service/src/exporter/runloops/indexer/client.rs
@@ -5,7 +5,6 @@
 use std::{
     collections::VecDeque,
     sync::{Arc, Mutex},
-    time::Instant,
 };
 
 use futures::StreamExt;
@@ -32,7 +31,7 @@ pub(super) struct IndexerClient {
     client: IndexerClientInner<Channel>,
     #[cfg(with_metrics)]
     // Tracks timestamps of when we start exporting a Block to an indexer.
-    sent_latency: Arc<Mutex<VecDeque<Instant>>>,
+    sent_latency: Arc<Mutex<VecDeque<linera_base::time::Instant>>>,
     #[cfg(with_metrics)]
     address: String,
 }

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -12,10 +12,7 @@
 
 mod guard;
 
-use std::{
-    env,
-    time::{Duration, Instant},
-};
+use std::env;
 
 use anyhow::Result;
 use async_graphql::InputType;
@@ -29,6 +26,7 @@ use linera_base::{
     crypto::{CryptoHash, Secp256k1SecretKey},
     data_types::Amount,
     identifiers::{Account, AccountOwner, ApplicationId, ChainId},
+    time::{Duration, Instant},
     vm::VmRuntime,
 };
 use linera_core::worker::{Notification, Reason};


### PR DESCRIPTION
## Motivation

We import `Instant` directly from `std` in some places. We should always import them from `linera_base`, since the `std` versions don't work in Wasm.

## Proposal

Fix imports.

## Test Plan

CI

(I'm not sure whether these cases specifically caused any issues; we should just be consistent.)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
