### PR TITLE
Make the `clone_unchecked` a function that does not return errors.

### DIFF
--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -222,7 +222,7 @@ where
         &mut self,
     ) -> Result<OwnedRwLockReadGuard<ChainStateView<StorageClient::Context>>, WorkerError> {
         if self.shared_chain_view.is_none() {
-            self.shared_chain_view = Some(Arc::new(RwLock::new(self.chain.clone_unchecked()?)));
+            self.shared_chain_view = Some(Arc::new(RwLock::new(self.chain.clone_unchecked())));
         }
 
         Ok(self

--- a/linera-service/src/exporter/state.rs
+++ b/linera-service/src/exporter/state.rs
@@ -69,7 +69,7 @@ where
         );
 
         let states = view.destination_states.get().clone();
-        let canonical_state = view.canonical_state.clone_unchecked()?;
+        let canonical_state = view.canonical_state.clone_unchecked();
 
         Ok((view, canonical_state, states))
     }

--- a/linera-service/src/exporter/storage.rs
+++ b/linera-service/src/exporter/storage.rs
@@ -431,7 +431,7 @@ where
             count: self.count,
             state_cache: self.state_cache.clone(),
             state_updates_buffer: self.state_updates_buffer.clone(),
-            state_context: self.state_context.clone_unchecked()?,
+            state_context: self.state_context.clone_unchecked(),
         })
     }
 

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -345,7 +345,7 @@ fn generate_clonable_view_code(input: ItemStruct) -> TokenStream2 {
         let name = &field.ident;
         let ty = &field.ty;
         clone_constraints.push(quote! { #ty: ClonableView });
-        clone_fields.push(quote! { #name: self.#name.clone_unchecked()? });
+        clone_fields.push(quote! { #name: self.#name.clone_unchecked() });
     }
 
     quote! {
@@ -355,10 +355,10 @@ fn generate_clonable_view_code(input: ItemStruct) -> TokenStream2 {
             #(#clone_constraints,)*
             Self: linera_views::views::View,
         {
-            fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
-                Ok(Self {
+            fn clone_unchecked(&mut self) -> Self {
+                Self {
                     #(#clone_fields,)*
-                })
+                }
             }
         }
     }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-2.snap
@@ -9,10 +9,10 @@ where
     CollectionView<C, usize, RegisterView<C, usize>>: ClonableView,
     Self: linera_views::views::View,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
-        Ok(Self {
-            register: self.register.clone_unchecked()?,
-            collection: self.collection.clone_unchecked()?,
-        })
+    fn clone_unchecked(&mut self) -> Self {
+        Self {
+            register: self.register.clone_unchecked(),
+            collection: self.collection.clone_unchecked(),
+        }
     }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-3.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-3.snap
@@ -12,10 +12,10 @@ where
     >: ClonableView,
     Self: linera_views::views::View,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
-        Ok(Self {
-            register: self.register.clone_unchecked()?,
-            collection: self.collection.clone_unchecked()?,
-        })
+    fn clone_unchecked(&mut self) -> Self {
+        Self {
+            register: self.register.clone_unchecked(),
+            collection: self.collection.clone_unchecked(),
+        }
     }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-4.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-4.snap
@@ -13,10 +13,10 @@ where
     >: ClonableView,
     Self: linera_views::views::View,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
-        Ok(Self {
-            register: self.register.clone_unchecked()?,
-            collection: self.collection.clone_unchecked()?,
-        })
+    fn clone_unchecked(&mut self) -> Self {
+        Self {
+            register: self.register.clone_unchecked(),
+            collection: self.collection.clone_unchecked(),
+        }
     }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-5.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-5.snap
@@ -12,10 +12,10 @@ where
     >: ClonableView,
     Self: linera_views::views::View,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
-        Ok(Self {
-            register: self.register.clone_unchecked()?,
-            collection: self.collection.clone_unchecked()?,
-        })
+    fn clone_unchecked(&mut self) -> Self {
+        Self {
+            register: self.register.clone_unchecked(),
+            collection: self.collection.clone_unchecked(),
+        }
     }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-6.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-6.snap
@@ -13,10 +13,10 @@ where
     >: ClonableView,
     Self: linera_views::views::View,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
-        Ok(Self {
-            register: self.register.clone_unchecked()?,
-            collection: self.collection.clone_unchecked()?,
-        })
+    fn clone_unchecked(&mut self) -> Self {
+        Self {
+            register: self.register.clone_unchecked(),
+            collection: self.collection.clone_unchecked(),
+        }
     }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-7.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-7.snap
@@ -12,10 +12,10 @@ where
     >: ClonableView,
     Self: linera_views::views::View,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
-        Ok(Self {
-            register: self.register.clone_unchecked()?,
-            collection: self.collection.clone_unchecked()?,
-        })
+    fn clone_unchecked(&mut self) -> Self {
+        Self {
+            register: self.register.clone_unchecked(),
+            collection: self.collection.clone_unchecked(),
+        }
     }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-8.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-8.snap
@@ -13,10 +13,10 @@ where
     >: ClonableView,
     Self: linera_views::views::View,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
-        Ok(Self {
-            register: self.register.clone_unchecked()?,
-            collection: self.collection.clone_unchecked()?,
-        })
+    fn clone_unchecked(&mut self) -> Self {
+        Self {
+            register: self.register.clone_unchecked(),
+            collection: self.collection.clone_unchecked(),
+        }
     }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code.snap
@@ -8,10 +8,10 @@ where
     CollectionView<C, usize, RegisterView<C, usize>>: ClonableView,
     Self: linera_views::views::View,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, linera_views::ViewError> {
-        Ok(Self {
-            register: self.register.clone_unchecked()?,
-            collection: self.collection.clone_unchecked()?,
-        })
+    fn clone_unchecked(&mut self) -> Self {
+        Self {
+            register: self.register.clone_unchecked(),
+            collection: self.collection.clone_unchecked(),
+        }
     }
 }

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -298,15 +298,15 @@ impl<C: Clone, T: Clone, const N: usize> ClonableView for BucketQueueView<C, T, 
 where
     Self: View,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
-        Ok(BucketQueueView {
+    fn clone_unchecked(&mut self) -> Self {
+        BucketQueueView {
             context: self.context.clone(),
             stored_data: self.stored_data.clone(),
             new_back_values: self.new_back_values.clone(),
             stored_position: self.stored_position,
             cursor: self.cursor.clone(),
             delete_storage_first: self.delete_storage_first,
-        })
+        }
     }
 }
 

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -159,7 +159,7 @@ impl<W: View> View for ByteCollectionView<W::Context, W> {
 }
 
 impl<W: ClonableView> ClonableView for ByteCollectionView<W::Context, W> {
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
+    fn clone_unchecked(&mut self) -> Self {
         let cloned_updates = self
             .updates
             .get_mut()
@@ -167,17 +167,17 @@ impl<W: ClonableView> ClonableView for ByteCollectionView<W::Context, W> {
             .map(|(key, value)| {
                 let cloned_value = match value {
                     Update::Removed => Update::Removed,
-                    Update::Set(view) => Update::Set(view.clone_unchecked()?),
+                    Update::Set(view) => Update::Set(view.clone_unchecked()),
                 };
-                Ok((key.clone(), cloned_value))
+                (key.clone(), cloned_value)
             })
-            .collect::<Result<_, ViewError>>()?;
+            .collect();
 
-        Ok(ByteCollectionView {
+        ByteCollectionView {
             context: self.context.clone(),
             delete_storage_first: self.delete_storage_first,
             updates: RwLock::new(cloned_updates),
-        })
+        }
     }
 }
 
@@ -734,11 +734,11 @@ impl<I, W: ClonableView> ClonableView for CollectionView<W::Context, I, W>
 where
     I: Send + Sync + Serialize + DeserializeOwned,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
-        Ok(CollectionView {
-            collection: self.collection.clone_unchecked()?,
+    fn clone_unchecked(&mut self) -> Self {
+        CollectionView {
+            collection: self.collection.clone_unchecked(),
             _phantom: PhantomData,
-        })
+        }
     }
 }
 
@@ -1084,11 +1084,11 @@ impl<I: Send + Sync, W: View> View for CustomCollectionView<W::Context, I, W> {
 }
 
 impl<I: Send + Sync, W: ClonableView> ClonableView for CustomCollectionView<W::Context, I, W> {
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
-        Ok(CustomCollectionView {
-            collection: self.collection.clone_unchecked()?,
+    fn clone_unchecked(&mut self) -> Self {
+        CustomCollectionView {
+            collection: self.collection.clone_unchecked(),
             _phantom: PhantomData,
-        })
+        }
     }
 }
 

--- a/linera-views/src/views/hashable_wrapper.rs
+++ b/linera-views/src/views/hashable_wrapper.rs
@@ -149,13 +149,13 @@ where
     O: Serialize + DeserializeOwned + Send + Sync + Copy + PartialEq,
     W::Hasher: Hasher<Output = O>,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
-        Ok(WrappedHashableContainerView {
+    fn clone_unchecked(&mut self) -> Self {
+        WrappedHashableContainerView {
             _phantom: PhantomData,
             stored_hash: self.stored_hash,
             hash: Mutex::new(*self.hash.get_mut().unwrap()),
-            inner: self.inner.clone_unchecked()?,
-        })
+            inner: self.inner.clone_unchecked(),
+        }
     }
 }
 

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -368,17 +368,17 @@ impl<C: Context> View for KeyValueStoreView<C> {
 }
 
 impl<C: Context> ClonableView for KeyValueStoreView<C> {
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
-        Ok(KeyValueStoreView {
+    fn clone_unchecked(&mut self) -> Self {
+        KeyValueStoreView {
             context: self.context.clone(),
             deletion_set: self.deletion_set.clone(),
             updates: self.updates.clone(),
             stored_total_size: self.stored_total_size,
             total_size: self.total_size,
-            sizes: self.sizes.clone_unchecked()?,
+            sizes: self.sizes.clone_unchecked(),
             stored_hash: self.stored_hash,
             hash: Mutex::new(*self.hash.get_mut().unwrap()),
-        })
+        }
     }
 }
 

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -134,13 +134,13 @@ where
     C: Context,
     T: Clone + Send + Sync + Serialize,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
-        Ok(LogView {
+    fn clone_unchecked(&mut self) -> Self {
+        LogView {
             context: self.context.clone(),
             delete_storage_first: self.delete_storage_first,
             stored_count: self.stored_count,
             new_values: self.new_values.clone(),
-        })
+        }
     }
 }
 

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -195,12 +195,12 @@ impl<C: Clone, V: Clone> ClonableView for ByteMapView<C, V>
 where
     Self: View,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
-        Ok(ByteMapView {
+    fn clone_unchecked(&mut self) -> Self {
+        ByteMapView {
             context: self.context.clone(),
             updates: self.updates.clone(),
             deletion_set: self.deletion_set.clone(),
-        })
+        }
     }
 }
 
@@ -1036,11 +1036,11 @@ where
     Self: View,
     ByteMapView<C, V>: ClonableView,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
-        Ok(MapView {
-            map: self.map.clone_unchecked()?,
+    fn clone_unchecked(&mut self) -> Self {
+        MapView {
+            map: self.map.clone_unchecked(),
             _phantom: PhantomData,
-        })
+        }
     }
 }
 
@@ -1521,11 +1521,11 @@ where
     Self: View,
     ByteMapView<C, V>: ClonableView,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
-        Ok(CustomMapView {
-            map: self.map.clone_unchecked()?,
+    fn clone_unchecked(&mut self) -> Self {
+        CustomMapView {
+            map: self.map.clone_unchecked(),
             _phantom: PhantomData,
-        })
+        }
     }
 }
 

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -187,5 +187,5 @@ pub trait CryptoHashRootView: RootView + CryptoHashView {}
 pub trait ClonableView: View {
     /// Creates a clone of this view, sharing the underlying storage context but prone to
     /// data races which can corrupt the view state.
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError>;
+    fn clone_unchecked(&mut self) -> Self;
 }

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -160,14 +160,14 @@ where
     C: Context,
     T: Clone + Send + Sync + Serialize,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
-        Ok(QueueView {
+    fn clone_unchecked(&mut self) -> Self {
+        QueueView {
             context: self.context.clone(),
             stored_indices: self.stored_indices.clone(),
             front_delete_count: self.front_delete_count,
             delete_storage_first: self.delete_storage_first,
             new_back_values: self.new_back_values.clone(),
-        })
+        }
     }
 }
 

--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -137,13 +137,13 @@ where
     C: Context,
     T: Clone + Default + Send + Sync + Serialize + DeserializeOwned,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
-        Ok(RegisterView {
+    fn clone_unchecked(&mut self) -> Self {
+        RegisterView {
             delete_storage_first: self.delete_storage_first,
             context: self.context.clone(),
             stored_value: self.stored_value.clone(),
             update: self.update.clone(),
-        })
+        }
     }
 }
 

--- a/linera-views/src/views/set_view.rs
+++ b/linera-views/src/views/set_view.rs
@@ -126,12 +126,12 @@ impl<C: Context> View for ByteSetView<C> {
 }
 
 impl<C: Context> ClonableView for ByteSetView<C> {
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
-        Ok(ByteSetView {
+    fn clone_unchecked(&mut self) -> Self {
+        ByteSetView {
             context: self.context.clone(),
             delete_storage_first: self.delete_storage_first,
             updates: self.updates.clone(),
-        })
+        }
     }
 }
 
@@ -440,11 +440,11 @@ where
     C: Context,
     I: Send + Sync + Serialize,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
-        Ok(SetView {
-            set: self.set.clone_unchecked()?,
+    fn clone_unchecked(&mut self) -> Self {
+        SetView {
+            set: self.set.clone_unchecked(),
             _phantom: PhantomData,
-        })
+        }
     }
 }
 
@@ -705,11 +705,11 @@ where
     C: Context,
     I: Send + Sync + CustomSerialize,
 {
-    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
-        Ok(CustomSetView {
-            set: self.set.clone_unchecked()?,
+    fn clone_unchecked(&mut self) -> Self {
+        CustomSetView {
+            set: self.set.clone_unchecked(),
             _phantom: PhantomData,
-        })
+        }
     }
 }
 

--- a/linera-views/src/views/unit_tests/views.rs
+++ b/linera-views/src/views/unit_tests/views.rs
@@ -270,7 +270,7 @@ where
     let mut original = V::load(context).await?;
     let original_state = original.stage_initial_changes().await?;
 
-    let clone = original.clone_unchecked()?;
+    let clone = original.clone_unchecked();
     let clone_state = clone.read().await?;
 
     assert_eq!(original_state, clone_state);
@@ -297,8 +297,8 @@ where
     let mut original = V::load(context).await?;
     original.stage_initial_changes().await?;
 
-    let mut first_clone = original.clone_unchecked()?;
-    let second_clone = original.clone_unchecked()?;
+    let mut first_clone = original.clone_unchecked();
+    let second_clone = original.clone_unchecked();
 
     let original_state = original.stage_changes_to_be_discarded().await?;
     let first_clone_state = first_clone.stage_changes_to_be_persisted().await?;


### PR DESCRIPTION
## Motivation

An examination of the source code reveals that `clone_unchecked` never returns an error.
The case of `?` are due to the calls to `clone_unchecked`.

## Proposal

Remove the error case.

Note that there are second order effects. For example `fn chain_state_view` no longer needs to return an error.
But this is for subsequent works.

## Test Plan

CI,.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None