### PR TITLE
Don't log errors returned from gRPC client methods.

### DIFF
--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -25,7 +25,7 @@ use linera_core::{
 };
 use linera_version::VersionInfo;
 use tonic::{Code, IntoRequest, Request, Status};
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn, Level};
 
 use super::{
     api::{self, validator_node_client::ValidatorNodeClient, SubscriptionRequest},
@@ -188,7 +188,7 @@ macro_rules! client_delegate {
 impl ValidatorNode for GrpcClient {
     type NotificationStream = NotificationStream;
 
-    #[instrument(target = "grpc_client", skip_all, fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
     async fn handle_block_proposal(
         &self,
         proposal: data_types::BlockProposal,
@@ -210,7 +210,7 @@ impl ValidatorNode for GrpcClient {
         GrpcClient::try_into_chain_info(client_delegate!(self, handle_lite_certificate, request)?)
     }
 
-    #[instrument(target = "grpc_client", skip_all, fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
     async fn handle_confirmed_certificate(
         &self,
         certificate: GenericCertificate<ConfirmedBlock>,
@@ -228,7 +228,7 @@ impl ValidatorNode for GrpcClient {
         )?)
     }
 
-    #[instrument(target = "grpc_client", skip_all, fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
     async fn handle_validated_certificate(
         &self,
         certificate: GenericCertificate<ValidatedBlock>,
@@ -241,7 +241,7 @@ impl ValidatorNode for GrpcClient {
         )?)
     }
 
-    #[instrument(target = "grpc_client", skip_all, fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
     async fn handle_timeout_certificate(
         &self,
         certificate: GenericCertificate<Timeout>,
@@ -254,7 +254,7 @@ impl ValidatorNode for GrpcClient {
         )?)
     }
 
-    #[instrument(target = "grpc_client", skip_all, fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
     async fn handle_chain_info_query(
         &self,
         query: linera_core::data_types::ChainInfoQuery,
@@ -262,7 +262,7 @@ impl ValidatorNode for GrpcClient {
         GrpcClient::try_into_chain_info(client_delegate!(self, handle_chain_info_query, query)?)
     }
 
-    #[instrument(target = "grpc_client", skip_all, fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
     async fn subscribe(&self, chains: Vec<ChainId>) -> Result<Self::NotificationStream, NodeError> {
         let retry_delay = self.retry_delay;
         let max_retries = self.max_retries;
@@ -343,29 +343,29 @@ impl ValidatorNode for GrpcClient {
         Ok(Box::pin(notification_stream))
     }
 
-    #[instrument(target = "grpc_client", skip_all, fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
     async fn get_version_info(&self) -> Result<VersionInfo, NodeError> {
         let req = ();
         Ok(client_delegate!(self, get_version_info, req)?.into())
     }
 
-    #[instrument(target = "grpc_client", skip_all, fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
     async fn get_network_description(&self) -> Result<NetworkDescription, NodeError> {
         let req = ();
         Ok(client_delegate!(self, get_network_description, req)?.try_into()?)
     }
 
-    #[instrument(target = "grpc_client", skip(self), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
     async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError> {
         Ok(client_delegate!(self, upload_blob, content)?.try_into()?)
     }
 
-    #[instrument(target = "grpc_client", skip(self), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
     async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
         Ok(client_delegate!(self, download_blob, blob_id)?.try_into()?)
     }
 
-    #[instrument(target = "grpc_client", skip(self), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
     async fn download_pending_blob(
         &self,
         chain_id: ChainId,
@@ -375,7 +375,7 @@ impl ValidatorNode for GrpcClient {
         client_delegate!(self, download_pending_blob, req)?.try_into()
     }
 
-    #[instrument(target = "grpc_client", skip(self), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
     async fn handle_pending_blob(
         &self,
         chain_id: ChainId,
@@ -385,7 +385,7 @@ impl ValidatorNode for GrpcClient {
         GrpcClient::try_into_chain_info(client_delegate!(self, handle_pending_blob, req)?)
     }
 
-    #[instrument(target = "grpc_client", skip_all, fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
     async fn download_certificate(
         &self,
         hash: CryptoHash,
@@ -398,7 +398,7 @@ impl ValidatorNode for GrpcClient {
         .map_err(|_| NodeError::UnexpectedCertificateValue)
     }
 
-    #[instrument(target = "grpc_client", skip_all, fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
     async fn download_certificates(
         &self,
         hashes: Vec<CryptoHash>,
@@ -434,12 +434,12 @@ impl ValidatorNode for GrpcClient {
         Ok(certs_collected)
     }
 
-    #[instrument(target = "grpc_client", skip(self), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
     async fn blob_last_used_by(&self, blob_id: BlobId) -> Result<CryptoHash, NodeError> {
         Ok(client_delegate!(self, blob_last_used_by, blob_id)?.try_into()?)
     }
 
-    #[instrument(target = "grpc_client", skip(self), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
     async fn missing_blob_ids(&self, blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError> {
         Ok(client_delegate!(self, missing_blob_ids, blob_ids)?.try_into()?)
     }


### PR DESCRIPTION
## Motivation

An error in the gRPC client can usually be caused by just one faulty validator, which is not considered to be an error for the overall BFT system.

## Proposal

Reduce the log level. (Thanks for the proper fix, @ndr-ds!)

## Test Plan

CI

And we will need to see in the logs if there are any other unwanted error-level logs.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #3391.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
