### PR TITLE
Move to the use of DataBlobHash.

### DIFF
--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -9,9 +9,9 @@ use std::collections::BTreeSet;
 
 use fungible::Account;
 use linera_sdk::{
-    linera_base_types::{AccountOwner, WithContractAbi},
+    linera_base_types::{AccountOwner, DataBlobHash, WithContractAbi},
     views::{RootView, View},
-    Contract, ContractRuntime, DataBlobHash,
+    Contract, ContractRuntime,
 };
 use non_fungible::{Message, Nft, NonFungibleTokenAbi, Operation, TokenId};
 

--- a/examples/non-fungible/src/lib.rs
+++ b/examples/non-fungible/src/lib.rs
@@ -9,8 +9,8 @@ use async_graphql::{InputObject, Request, Response, SimpleObject};
 use fungible::Account;
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, ApplicationId, ChainId, ContractAbi, ServiceAbi},
-    DataBlobHash, ToBcsBytes,
+    linera_base_types::{AccountOwner, ApplicationId, ChainId, ContractAbi, DataBlobHash, ServiceAbi},
+    ToBcsBytes,
 };
 use serde::{Deserialize, Serialize};
 

--- a/examples/non-fungible/src/lib.rs
+++ b/examples/non-fungible/src/lib.rs
@@ -9,7 +9,9 @@ use async_graphql::{InputObject, Request, Response, SimpleObject};
 use fungible::Account;
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, ApplicationId, ChainId, ContractAbi, DataBlobHash, ServiceAbi},
+    linera_base_types::{
+        AccountOwner, ApplicationId, ChainId, ContractAbi, DataBlobHash, ServiceAbi,
+    },
     ToBcsBytes,
 };
 use serde::{Deserialize, Serialize};

--- a/examples/non-fungible/src/service.rs
+++ b/examples/non-fungible/src/service.rs
@@ -14,9 +14,9 @@ use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
 use base64::engine::{general_purpose::STANDARD_NO_PAD, Engine as _};
 use fungible::Account;
 use linera_sdk::{
-    linera_base_types::{AccountOwner, WithServiceAbi},
+    linera_base_types::{AccountOwner, DataBlobHash, WithServiceAbi},
     views::View,
-    DataBlobHash, Service, ServiceRuntime,
+    Service, ServiceRuntime,
 };
 use non_fungible::{NftOutput, Operation, TokenId};
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -314,6 +314,12 @@ impl<'a> Deserialize<'a> for BlobId {
 )]
 pub struct DataBlobHash(pub CryptoHash);
 
+impl From<DataBlobHash> for BlobId {
+    fn from(hash: DataBlobHash) -> BlobId {
+        BlobId::new(hash.0, BlobType::Data)
+    }
+}
+
 /// A unique identifier for a user application from a blob.
 #[derive(Debug, WitLoad, WitStore, WitType)]
 #[cfg_attr(with_testing, derive(Default, test_strategy::Arbitrary))]

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -309,7 +309,9 @@ impl<'a> Deserialize<'a> for BlobId {
 }
 
 /// Hash of a data blob.
-#[derive(Eq, Hash, PartialEq, Debug, Serialize, Deserialize, Clone, Copy, WitType, WitLoad, WitStore)]
+#[derive(
+    Eq, Hash, PartialEq, Debug, Serialize, Deserialize, Clone, Copy, WitType, WitLoad, WitStore,
+)]
 pub struct DataBlobHash(pub CryptoHash);
 
 /// A unique identifier for a user application from a blob.

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -308,6 +308,10 @@ impl<'a> Deserialize<'a> for BlobId {
     }
 }
 
+/// Hash of a data blob.
+#[derive(Eq, Hash, PartialEq, Debug, Serialize, Deserialize, Clone, Copy, WitType, WitLoad, WitStore)]
+pub struct DataBlobHash(pub CryptoHash);
+
 /// A unique identifier for a user application from a blob.
 #[derive(Debug, WitLoad, WitStore, WitType)]
 #[cfg_attr(with_testing, derive(Default, test_strategy::Arbitrary))]
@@ -1079,6 +1083,7 @@ impl From<ChainDescription> for ChainId {
 }
 
 bcs_scalar!(ApplicationId, "A unique identifier for a user application");
+doc_scalar!(DataBlobHash, "Hash of a Data Blob");
 doc_scalar!(
     GenericApplicationId,
     "A unique identifier for a user application or for the system application"

--- a/linera-execution/solidity/Linera.sol
+++ b/linera-execution/solidity/Linera.sol
@@ -383,7 +383,8 @@ library Linera {
     function read_data_blob(bytes32 hash) internal returns (bytes memory) {
         address precompile = address(0x0b);
         LineraTypes.CryptoHash memory hash2 = LineraTypes.CryptoHash(hash);
-        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_read_data_blob(hash2);
+        LineraTypes.DataBlobHash memory hash3 = LineraTypes.DataBlobHash(hash2);
+        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_read_data_blob(hash3);
         LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_base(base);
         bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
         (bool success, bytes memory output) = precompile.call(input2);
@@ -394,7 +395,8 @@ library Linera {
     function assert_data_blob_exists(bytes32 hash) internal {
         address precompile = address(0x0b);
         LineraTypes.CryptoHash memory hash2 = LineraTypes.CryptoHash(hash);
-        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_assert_data_blob_exists(hash2);
+        LineraTypes.DataBlobHash memory hash3 = LineraTypes.DataBlobHash(hash2);
+        LineraTypes.BaseRuntimePrecompile memory base = LineraTypes.BaseRuntimePrecompile_case_assert_data_blob_exists(hash3);
         LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_base(base);
         bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
         (bool success, bytes memory output) = precompile.call(input2);

--- a/linera-execution/solidity/LineraTypes.sol
+++ b/linera-execution/solidity/LineraTypes.sol
@@ -266,9 +266,9 @@ library LineraTypes {
         // choice=7 corresponds to ReadBalanceOwners
         // choice=8 corresponds to ChainOwnership
         // choice=9 corresponds to ReadDataBlob
-        CryptoHash read_data_blob;
+        DataBlobHash read_data_blob;
         // choice=10 corresponds to AssertDataBlobExists
-        CryptoHash assert_data_blob_exists;
+        DataBlobHash assert_data_blob_exists;
     }
 
     function BaseRuntimePrecompile_case_chain_id()
@@ -277,8 +277,8 @@ library LineraTypes {
         returns (BaseRuntimePrecompile memory)
     {
         AccountOwner memory read_owner_balance;
-        CryptoHash memory read_data_blob;
-        CryptoHash memory assert_data_blob_exists;
+        DataBlobHash memory read_data_blob;
+        DataBlobHash memory assert_data_blob_exists;
         return BaseRuntimePrecompile(uint8(0), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
@@ -288,8 +288,8 @@ library LineraTypes {
         returns (BaseRuntimePrecompile memory)
     {
         AccountOwner memory read_owner_balance;
-        CryptoHash memory read_data_blob;
-        CryptoHash memory assert_data_blob_exists;
+        DataBlobHash memory read_data_blob;
+        DataBlobHash memory assert_data_blob_exists;
         return BaseRuntimePrecompile(uint8(1), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
@@ -299,8 +299,8 @@ library LineraTypes {
         returns (BaseRuntimePrecompile memory)
     {
         AccountOwner memory read_owner_balance;
-        CryptoHash memory read_data_blob;
-        CryptoHash memory assert_data_blob_exists;
+        DataBlobHash memory read_data_blob;
+        DataBlobHash memory assert_data_blob_exists;
         return BaseRuntimePrecompile(uint8(2), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
@@ -310,8 +310,8 @@ library LineraTypes {
         returns (BaseRuntimePrecompile memory)
     {
         AccountOwner memory read_owner_balance;
-        CryptoHash memory read_data_blob;
-        CryptoHash memory assert_data_blob_exists;
+        DataBlobHash memory read_data_blob;
+        DataBlobHash memory assert_data_blob_exists;
         return BaseRuntimePrecompile(uint8(3), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
@@ -321,8 +321,8 @@ library LineraTypes {
         returns (BaseRuntimePrecompile memory)
     {
         AccountOwner memory read_owner_balance;
-        CryptoHash memory read_data_blob;
-        CryptoHash memory assert_data_blob_exists;
+        DataBlobHash memory read_data_blob;
+        DataBlobHash memory assert_data_blob_exists;
         return BaseRuntimePrecompile(uint8(4), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
@@ -331,8 +331,8 @@ library LineraTypes {
         pure
         returns (BaseRuntimePrecompile memory)
     {
-        CryptoHash memory read_data_blob;
-        CryptoHash memory assert_data_blob_exists;
+        DataBlobHash memory read_data_blob;
+        DataBlobHash memory assert_data_blob_exists;
         return BaseRuntimePrecompile(uint8(5), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
@@ -342,8 +342,8 @@ library LineraTypes {
         returns (BaseRuntimePrecompile memory)
     {
         AccountOwner memory read_owner_balance;
-        CryptoHash memory read_data_blob;
-        CryptoHash memory assert_data_blob_exists;
+        DataBlobHash memory read_data_blob;
+        DataBlobHash memory assert_data_blob_exists;
         return BaseRuntimePrecompile(uint8(6), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
@@ -353,8 +353,8 @@ library LineraTypes {
         returns (BaseRuntimePrecompile memory)
     {
         AccountOwner memory read_owner_balance;
-        CryptoHash memory read_data_blob;
-        CryptoHash memory assert_data_blob_exists;
+        DataBlobHash memory read_data_blob;
+        DataBlobHash memory assert_data_blob_exists;
         return BaseRuntimePrecompile(uint8(7), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
@@ -364,28 +364,28 @@ library LineraTypes {
         returns (BaseRuntimePrecompile memory)
     {
         AccountOwner memory read_owner_balance;
-        CryptoHash memory read_data_blob;
-        CryptoHash memory assert_data_blob_exists;
+        DataBlobHash memory read_data_blob;
+        DataBlobHash memory assert_data_blob_exists;
         return BaseRuntimePrecompile(uint8(8), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
-    function BaseRuntimePrecompile_case_read_data_blob(CryptoHash memory read_data_blob)
+    function BaseRuntimePrecompile_case_read_data_blob(DataBlobHash memory read_data_blob)
         internal
         pure
         returns (BaseRuntimePrecompile memory)
     {
         AccountOwner memory read_owner_balance;
-        CryptoHash memory assert_data_blob_exists;
+        DataBlobHash memory assert_data_blob_exists;
         return BaseRuntimePrecompile(uint8(9), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
-    function BaseRuntimePrecompile_case_assert_data_blob_exists(CryptoHash memory assert_data_blob_exists)
+    function BaseRuntimePrecompile_case_assert_data_blob_exists(DataBlobHash memory assert_data_blob_exists)
         internal
         pure
         returns (BaseRuntimePrecompile memory)
     {
         AccountOwner memory read_owner_balance;
-        CryptoHash memory read_data_blob;
+        DataBlobHash memory read_data_blob;
         return BaseRuntimePrecompile(uint8(10), read_owner_balance, read_data_blob, assert_data_blob_exists);
     }
 
@@ -398,10 +398,10 @@ library LineraTypes {
             return abi.encodePacked(input.choice, bcs_serialize_AccountOwner(input.read_owner_balance));
         }
         if (input.choice == 9) {
-            return abi.encodePacked(input.choice, bcs_serialize_CryptoHash(input.read_data_blob));
+            return abi.encodePacked(input.choice, bcs_serialize_DataBlobHash(input.read_data_blob));
         }
         if (input.choice == 10) {
-            return abi.encodePacked(input.choice, bcs_serialize_CryptoHash(input.assert_data_blob_exists));
+            return abi.encodePacked(input.choice, bcs_serialize_DataBlobHash(input.assert_data_blob_exists));
         }
         return abi.encodePacked(input.choice);
     }
@@ -418,13 +418,13 @@ library LineraTypes {
         if (choice == 5) {
             (new_pos, read_owner_balance) = bcs_deserialize_offset_AccountOwner(new_pos, input);
         }
-        CryptoHash memory read_data_blob;
+        DataBlobHash memory read_data_blob;
         if (choice == 9) {
-            (new_pos, read_data_blob) = bcs_deserialize_offset_CryptoHash(new_pos, input);
+            (new_pos, read_data_blob) = bcs_deserialize_offset_DataBlobHash(new_pos, input);
         }
-        CryptoHash memory assert_data_blob_exists;
+        DataBlobHash memory assert_data_blob_exists;
         if (choice == 10) {
-            (new_pos, assert_data_blob_exists) = bcs_deserialize_offset_CryptoHash(new_pos, input);
+            (new_pos, assert_data_blob_exists) = bcs_deserialize_offset_DataBlobHash(new_pos, input);
         }
         require(choice < 11);
         return (new_pos, BaseRuntimePrecompile(choice, read_owner_balance, read_data_blob, assert_data_blob_exists));
@@ -1156,6 +1156,41 @@ library LineraTypes {
         uint256 new_pos;
         CryptoHash memory value;
         (new_pos, value) = bcs_deserialize_offset_CryptoHash(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    struct DataBlobHash {
+        CryptoHash value;
+    }
+
+    function bcs_serialize_DataBlobHash(DataBlobHash memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return bcs_serialize_CryptoHash(input.value);
+    }
+
+    function bcs_deserialize_offset_DataBlobHash(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, DataBlobHash memory)
+    {
+        uint256 new_pos;
+        CryptoHash memory value;
+        (new_pos, value) = bcs_deserialize_offset_CryptoHash(pos, input);
+        return (new_pos, DataBlobHash(value));
+    }
+
+    function bcs_deserialize_DataBlobHash(bytes memory input)
+        internal
+        pure
+        returns (DataBlobHash memory)
+    {
+        uint256 new_pos;
+        DataBlobHash memory value;
+        (new_pos, value) = bcs_deserialize_offset_DataBlobHash(0, input);
         require(new_pos == input.length, "incomplete deserialization");
         return value;
     }

--- a/linera-execution/solidity/LineraTypes.yaml
+++ b/linera-execution/solidity/LineraTypes.yaml
@@ -75,6 +75,9 @@ CryptoHash:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 32
+DataBlobHash:
+  NEWTYPESTRUCT:
+    TYPENAME: CryptoHash
 BlockHeight:
   NEWTYPESTRUCT: U64
 ChainId:
@@ -126,11 +129,11 @@ BaseRuntimePrecompile:
     9:
       ReadDataBlob:
         NEWTYPE:
-          TYPENAME: CryptoHash
+          TYPENAME: DataBlobHash
     10:
       AssertDataBlobExists:
         NEWTYPE:
-          TYPENAME: CryptoHash
+          TYPENAME: DataBlobHash
 ContractRuntimePrecompile:
   ENUM:
     0:

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -37,7 +37,7 @@ use crate::{
         data_types::AmountU256,
         database::{DatabaseRuntime, StorageStats, EVM_SERVICE_GAS_LIMIT},
     },
-    BaseRuntime, ContractRuntime, ContractSyncRuntimeHandle, EvmExecutionError, EvmRuntime,
+    BaseRuntime, ContractRuntime, ContractSyncRuntimeHandle, DataBlobHash, EvmExecutionError, EvmRuntime,
     ExecutionError, ServiceRuntime, ServiceSyncRuntimeHandle, UserContract, UserContractInstance,
     UserContractModule, UserService, UserServiceInstance, UserServiceModule,
 };
@@ -495,9 +495,9 @@ enum BaseRuntimePrecompile {
     /// Calling `chain_ownership` of `BaseRuntime`
     ChainOwnership,
     /// Calling `read_data_blob` of `BaseRuntime`
-    ReadDataBlob(CryptoHash),
+    ReadDataBlob(DataBlobHash),
     /// Calling `assert_data_blob_exists` of `BaseRuntime`
-    AssertDataBlobExists(CryptoHash),
+    AssertDataBlobExists(DataBlobHash),
 }
 
 /// Some functionalities from the ContractRuntime not in BaseRuntime
@@ -648,9 +648,9 @@ fn base_runtime_call<Runtime: BaseRuntime>(
             let chain_ownership = runtime.chain_ownership()?;
             Ok(bcs::to_bytes(&chain_ownership)?)
         }
-        BaseRuntimePrecompile::ReadDataBlob(hash) => runtime.read_data_blob(&hash),
+        BaseRuntimePrecompile::ReadDataBlob(hash) => runtime.read_data_blob(hash),
         BaseRuntimePrecompile::AssertDataBlobExists(hash) => {
-            runtime.assert_data_blob_exists(&hash)?;
+            runtime.assert_data_blob_exists(hash)?;
             Ok(Vec::new())
         }
     }

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -37,9 +37,9 @@ use crate::{
         data_types::AmountU256,
         database::{DatabaseRuntime, StorageStats, EVM_SERVICE_GAS_LIMIT},
     },
-    BaseRuntime, ContractRuntime, ContractSyncRuntimeHandle, DataBlobHash, EvmExecutionError, EvmRuntime,
-    ExecutionError, ServiceRuntime, ServiceSyncRuntimeHandle, UserContract, UserContractInstance,
-    UserContractModule, UserService, UserServiceInstance, UserServiceModule,
+    BaseRuntime, ContractRuntime, ContractSyncRuntimeHandle, DataBlobHash, EvmExecutionError,
+    EvmRuntime, ExecutionError, ServiceRuntime, ServiceSyncRuntimeHandle, UserContract,
+    UserContractInstance, UserContractModule, UserService, UserServiceInstance, UserServiceModule,
 };
 
 /// This is the selector of the `execute_message` that should be called

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -41,7 +41,7 @@ use linera_base::{
     },
     doc_scalar, hex_debug, http,
     identifiers::{
-        Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, EventId,
+        Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, DataBlobHash, EventId,
         GenericApplicationId, ModuleId, StreamName,
     },
     ownership::ChainOwnership,
@@ -668,10 +668,10 @@ pub trait BaseRuntime {
     fn assert_before(&mut self, timestamp: Timestamp) -> Result<(), ExecutionError>;
 
     /// Reads a data blob specified by a given hash.
-    fn read_data_blob(&mut self, hash: &CryptoHash) -> Result<Vec<u8>, ExecutionError>;
+    fn read_data_blob(&mut self, hash: DataBlobHash) -> Result<Vec<u8>, ExecutionError>;
 
     /// Asserts the existence of a data blob with the given hash.
-    fn assert_data_blob_exists(&mut self, hash: &CryptoHash) -> Result<(), ExecutionError>;
+    fn assert_data_blob_exists(&mut self, hash: DataBlobHash) -> Result<(), ExecutionError>;
 }
 
 pub trait ServiceRuntime: BaseRuntime {
@@ -803,8 +803,8 @@ pub trait ContractRuntime: BaseRuntime {
         required_application_ids: Vec<ApplicationId>,
     ) -> Result<ApplicationId, ExecutionError>;
 
-    /// Creates a new data blob and returns its ID.
-    fn create_data_blob(&mut self, bytes: Vec<u8>) -> Result<BlobId, ExecutionError>;
+    /// Creates a new data blob and returns its hash.
+    fn create_data_blob(&mut self, bytes: Vec<u8>) -> Result<DataBlobHash, ExecutionError>;
 
     /// Publishes a module with contract and service bytecode and returns the module ID.
     fn publish_module(

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -16,8 +16,7 @@ use linera_base::{
     },
     ensure, http,
     identifiers::{
-        Account, AccountOwner, BlobId, BlobType, ChainId, EventId, GenericApplicationId, StreamId,
-        StreamName,
+        Account, AccountOwner, ChainId, EventId, GenericApplicationId, StreamId, StreamName,
     },
     ownership::ChainOwnership,
     time::Instant,
@@ -940,7 +939,7 @@ where
 
     fn read_data_blob(&mut self, hash: DataBlobHash) -> Result<Vec<u8>, ExecutionError> {
         let mut this = self.inner();
-        let blob_id = BlobId::new(hash.0, BlobType::Data);
+        let blob_id = hash.into();
         let (blob_content, is_new) = this
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::ReadBlobContent { blob_id, callback })?
@@ -954,7 +953,7 @@ where
 
     fn assert_data_blob_exists(&mut self, hash: DataBlobHash) -> Result<(), ExecutionError> {
         let mut this = self.inner();
-        let blob_id = BlobId::new(hash.0, BlobType::Data);
+        let blob_id = hash.into();
         let is_new = this
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::AssertBlobExists { blob_id, callback })?

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -32,10 +32,11 @@ use crate::{
     resources::ResourceController,
     system::CreateApplicationResult,
     util::{ReceiverExt, UnboundedSenderExt},
-    ApplicationDescription, ApplicationId, BaseRuntime, ContractRuntime, DataBlobHash, ExecutionError,
-    FinalizeContext, Message, MessageContext, MessageKind, ModuleId, Operation, OutgoingMessage,
-    QueryContext, QueryOutcome, ServiceRuntime, TransactionTracker, UserContractCode,
-    UserContractInstance, UserServiceCode, UserServiceInstance, MAX_STREAM_NAME_LEN,
+    ApplicationDescription, ApplicationId, BaseRuntime, ContractRuntime, DataBlobHash,
+    ExecutionError, FinalizeContext, Message, MessageContext, MessageKind, ModuleId, Operation,
+    OutgoingMessage, QueryContext, QueryOutcome, ServiceRuntime, TransactionTracker,
+    UserContractCode, UserContractInstance, UserServiceCode, UserServiceInstance,
+    MAX_STREAM_NAME_LEN,
 };
 
 #[cfg(test)]

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -10,7 +10,6 @@ use std::{
 
 use custom_debug_derive::Debug;
 use linera_base::{
-    crypto::CryptoHash,
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Bytecode,
         OracleResponse, SendMessageRequest, Timestamp,
@@ -33,7 +32,7 @@ use crate::{
     resources::ResourceController,
     system::CreateApplicationResult,
     util::{ReceiverExt, UnboundedSenderExt},
-    ApplicationDescription, ApplicationId, BaseRuntime, ContractRuntime, ExecutionError,
+    ApplicationDescription, ApplicationId, BaseRuntime, ContractRuntime, DataBlobHash, ExecutionError,
     FinalizeContext, Message, MessageContext, MessageKind, ModuleId, Operation, OutgoingMessage,
     QueryContext, QueryOutcome, ServiceRuntime, TransactionTracker, UserContractCode,
     UserContractInstance, UserServiceCode, UserServiceInstance, MAX_STREAM_NAME_LEN,
@@ -938,9 +937,9 @@ where
         Ok(())
     }
 
-    fn read_data_blob(&mut self, hash: &CryptoHash) -> Result<Vec<u8>, ExecutionError> {
+    fn read_data_blob(&mut self, hash: DataBlobHash) -> Result<Vec<u8>, ExecutionError> {
         let mut this = self.inner();
-        let blob_id = BlobId::new(*hash, BlobType::Data);
+        let blob_id = BlobId::new(hash.0, BlobType::Data);
         let (blob_content, is_new) = this
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::ReadBlobContent { blob_id, callback })?
@@ -952,9 +951,9 @@ where
         Ok(blob_content.into_bytes().into_vec())
     }
 
-    fn assert_data_blob_exists(&mut self, hash: &CryptoHash) -> Result<(), ExecutionError> {
+    fn assert_data_blob_exists(&mut self, hash: DataBlobHash) -> Result<(), ExecutionError> {
         let mut this = self.inner();
-        let blob_id = BlobId::new(*hash, BlobType::Data);
+        let blob_id = BlobId::new(hash.0, BlobType::Data);
         let is_new = this
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::AssertBlobExists { blob_id, callback })?
@@ -1602,11 +1601,11 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         Ok(app_id)
     }
 
-    fn create_data_blob(&mut self, bytes: Vec<u8>) -> Result<BlobId, ExecutionError> {
+    fn create_data_blob(&mut self, bytes: Vec<u8>) -> Result<DataBlobHash, ExecutionError> {
         let blob = Blob::new_data(bytes);
         let blob_id = blob.id();
         self.inner().transaction_tracker.add_created_blob(blob);
-        Ok(blob_id)
+        Ok(DataBlobHash(blob_id.hash))
     }
 
     fn publish_module(

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -4,12 +4,11 @@
 use std::{any::Any, collections::HashMap, marker::PhantomData};
 
 use linera_base::{
-    crypto::CryptoHash,
     data_types::{
         Amount, ApplicationPermissions, BlockHeight, Bytecode, SendMessageRequest, Timestamp,
     },
     http,
-    identifiers::{Account, AccountOwner, ApplicationId, BlobId, ChainId, StreamName},
+    identifiers::{Account, AccountOwner, ApplicationId, ChainId, StreamName},
     ownership::{ChainOwnership, ChangeApplicationPermissionsError, CloseChainError},
     vm::VmRuntime,
 };
@@ -18,7 +17,7 @@ use linera_witty::{wit_export, Instance, RuntimeError};
 use tracing::log;
 
 use super::WasmExecutionError;
-use crate::{BaseRuntime, ContractRuntime, ExecutionError, ModuleId, ServiceRuntime};
+use crate::{BaseRuntime, ContractRuntime, DataBlobHash, ExecutionError, ModuleId, ServiceRuntime};
 
 /// Common host data used as the `UserData` of the system API implementations.
 pub struct RuntimeApiData<Runtime> {
@@ -212,20 +211,20 @@ where
     }
 
     /// Reads a data blob from storage.
-    fn read_data_blob(caller: &mut Caller, hash: CryptoHash) -> Result<Vec<u8>, RuntimeError> {
+    fn read_data_blob(caller: &mut Caller, hash: DataBlobHash) -> Result<Vec<u8>, RuntimeError> {
         caller
             .user_data_mut()
             .runtime
-            .read_data_blob(&hash)
+            .read_data_blob(hash)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
     /// Asserts the existence of a data blob with the given hash.
-    fn assert_data_blob_exists(caller: &mut Caller, hash: CryptoHash) -> Result<(), RuntimeError> {
+    fn assert_data_blob_exists(caller: &mut Caller, hash: DataBlobHash) -> Result<(), RuntimeError> {
         caller
             .user_data_mut()
             .runtime
-            .assert_data_blob_exists(&hash)
+            .assert_data_blob_exists(hash)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
@@ -533,8 +532,8 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
-    /// Creates a new data blob and returns its ID.
-    fn create_data_blob(caller: &mut Caller, bytes: Vec<u8>) -> Result<BlobId, RuntimeError> {
+    /// Creates a new data blob and returns its hash.
+    fn create_data_blob(caller: &mut Caller, bytes: Vec<u8>) -> Result<DataBlobHash, RuntimeError> {
         caller
             .user_data_mut()
             .runtime

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -220,7 +220,10 @@ where
     }
 
     /// Asserts the existence of a data blob with the given hash.
-    fn assert_data_blob_exists(caller: &mut Caller, hash: DataBlobHash) -> Result<(), RuntimeError> {
+    fn assert_data_blob_exists(
+        caller: &mut Caller,
+        hash: DataBlobHash,
+    ) -> Result<(), RuntimeError> {
         caller
             .user_data_mut()
             .runtime

--- a/linera-sdk/src/base/conversions_from_wit.rs
+++ b/linera-sdk/src/base/conversions_from_wit.rs
@@ -7,7 +7,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
     http,
-    identifiers::{AccountOwner, ApplicationId, ChainId},
+    identifiers::{AccountOwner, ApplicationId, ChainId, DataBlobHash},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 
@@ -26,6 +26,12 @@ macro_rules! impl_from_wit {
                     hash_value.part3,
                     hash_value.part4,
                 ])
+            }
+        }
+
+        impl From<$wit_base_api::DataBlobHash> for DataBlobHash {
+            fn from(hash_value: $wit_base_api::DataBlobHash) -> Self {
+                DataBlobHash(hash_value.inner0.into())
             }
         }
 

--- a/linera-sdk/src/base/conversions_to_wit.rs
+++ b/linera-sdk/src/base/conversions_to_wit.rs
@@ -7,7 +7,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{BlockHeight, Timestamp},
     http,
-    identifiers::{AccountOwner, ApplicationId, ChainId},
+    identifiers::{AccountOwner, ApplicationId, ChainId, DataBlobHash},
 };
 
 use crate::{
@@ -26,6 +26,14 @@ macro_rules! impl_to_wit {
                     part2: parts[1],
                     part3: parts[2],
                     part4: parts[3],
+                }
+            }
+        }
+
+        impl From<DataBlobHash> for $wit_base_api::DataBlobHash {
+            fn from(hash_value: DataBlobHash) -> Self {
+                $wit_base_api::DataBlobHash {
+                    inner0: hash_value.0.into(),
                 }
             }
         }

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -7,7 +7,8 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, StreamUpdate},
     identifiers::{
-        AccountOwner, ApplicationId, ChainId, GenericApplicationId, ModuleId, StreamId, StreamName,
+        AccountOwner, ApplicationId, ChainId, DataBlobHash, GenericApplicationId, ModuleId,
+        StreamId, StreamName,
     },
     ownership::{ChangeApplicationPermissionsError, CloseChainError},
     vm::VmRuntime,
@@ -26,6 +27,12 @@ impl From<wit_contract_api::CryptoHash> for CryptoHash {
             crypto_hash.part3,
             crypto_hash.part4,
         ])
+    }
+}
+
+impl From<wit_contract_api::DataBlobHash> for DataBlobHash {
+    fn from(hash_value: wit_contract_api::DataBlobHash) -> Self {
+        DataBlobHash(hash_value.inner0.into())
     }
 }
 

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -8,7 +8,9 @@ use linera_base::{
     data_types::{
         Amount, ApplicationPermissions, Bytecode, Resources, SendMessageRequest, TimeDelta,
     },
-    identifiers::{Account, AccountOwner, ApplicationId, ChainId, ModuleId, StreamName},
+    identifiers::{
+        Account, AccountOwner, ApplicationId, ChainId, DataBlobHash, ModuleId, StreamName,
+    },
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
 };
@@ -25,6 +27,14 @@ impl From<CryptoHash> for wit_contract_api::CryptoHash {
             part2: parts[1],
             part3: parts[2],
             part4: parts[3],
+        }
+    }
+}
+
+impl From<DataBlobHash> for wit_contract_api::DataBlobHash {
+    fn from(hash_value: DataBlobHash) -> Self {
+        wit_contract_api::DataBlobHash {
+            inner0: hash_value.0.into(),
         }
     }
 }

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -161,12 +161,12 @@ where
 
     /// Reads a data blob with the given hash from storage.
     pub fn read_data_blob(&mut self, hash: DataBlobHash) -> Vec<u8> {
-        base_wit::read_data_blob(hash.0.into())
+        base_wit::read_data_blob(hash.into())
     }
 
     /// Asserts that a data blob with the given hash exists in storage.
     pub fn assert_data_blob_exists(&mut self, hash: DataBlobHash) {
-        base_wit::assert_data_blob_exists(hash.0.into())
+        base_wit::assert_data_blob_exists(hash.into())
     }
 }
 
@@ -384,8 +384,8 @@ where
 
     /// Creates a new data blob and returns its hash.
     pub fn create_data_blob(&mut self, bytes: Vec<u8>) -> DataBlobHash {
-        let blob_id = contract_wit::create_data_blob(&bytes);
-        DataBlobHash(blob_id.hash.into())
+        let hash = contract_wit::create_data_blob(&bytes);
+        hash.into()
     }
 
     /// Publishes a module with contract and service bytecode and returns the module ID.

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -10,7 +10,9 @@ use linera_base::{
         Timestamp,
     },
     ensure, http,
-    identifiers::{Account, AccountOwner, ApplicationId, ChainId, DataBlobHash, ModuleId, StreamName},
+    identifiers::{
+        Account, AccountOwner, ApplicationId, ChainId, DataBlobHash, ModuleId, StreamName,
+    },
     ownership::{
         AccountPermissionError, ChainOwnership, ChangeApplicationPermissionsError, CloseChainError,
     },

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -10,7 +10,7 @@ use linera_base::{
         Timestamp,
     },
     ensure, http,
-    identifiers::{Account, AccountOwner, ApplicationId, ChainId, ModuleId, StreamName},
+    identifiers::{Account, AccountOwner, ApplicationId, ChainId, DataBlobHash, ModuleId, StreamName},
     ownership::{
         AccountPermissionError, ChainOwnership, ChangeApplicationPermissionsError, CloseChainError,
     },
@@ -19,7 +19,7 @@ use linera_base::{
 use serde::Serialize;
 
 use super::wit::{base_runtime_api as base_wit, contract_runtime_api as contract_wit};
-use crate::{Contract, DataBlobHash, KeyValueStore, ViewStorageContext};
+use crate::{Contract, KeyValueStore, ViewStorageContext};
 
 /// The common runtime to interface with the host executing the contract.
 ///

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -15,7 +15,7 @@ use linera_base::{
         Timestamp,
     },
     ensure, http,
-    identifiers::{Account, AccountOwner, ApplicationId, BlobId, ChainId, ModuleId, StreamName},
+    identifiers::{Account, AccountOwner, ApplicationId, BlobId, ChainId, DataBlobHash, ModuleId, StreamName},
     ownership::{
         AccountPermissionError, ChainOwnership, ChangeApplicationPermissionsError, CloseChainError,
     },
@@ -23,7 +23,7 @@ use linera_base::{
 };
 use serde::Serialize;
 
-use crate::{Contract, DataBlobHash, KeyValueStore, ViewStorageContext};
+use crate::{Contract, KeyValueStore, ViewStorageContext};
 
 struct ExpectedPublishModuleCall {
     contract: Bytecode,

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -15,7 +15,9 @@ use linera_base::{
         Timestamp,
     },
     ensure, http,
-    identifiers::{Account, AccountOwner, ApplicationId, BlobId, ChainId, DataBlobHash, ModuleId, StreamName},
+    identifiers::{
+        Account, AccountOwner, ApplicationId, BlobId, ChainId, DataBlobHash, ModuleId, StreamName,
+    },
     ownership::{
         AccountPermissionError, ChainOwnership, ChangeApplicationPermissionsError, CloseChainError,
     },

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -53,11 +53,9 @@ pub use linera_base::{
 };
 use linera_base::{
     abi::{ContractAbi, ServiceAbi, WithContractAbi, WithServiceAbi},
-    crypto::CryptoHash,
     data_types::StreamUpdate,
-    doc_scalar,
 };
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 pub use serde_json;
 
 #[doc(hidden)]
@@ -70,11 +68,6 @@ pub use self::{
     views::{KeyValueStore, ViewStorageContext},
 };
 
-/// Hash of a data blob.
-#[derive(Eq, Hash, PartialEq, Debug, Serialize, Deserialize, Clone, Copy)]
-pub struct DataBlobHash(pub CryptoHash);
-
-doc_scalar!(DataBlobHash, "Hash of a Data Blob");
 
 /// The contract interface of a Linera application.
 ///

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -68,7 +68,6 @@ pub use self::{
     views::{KeyValueStore, ViewStorageContext},
 };
 
-
 /// The contract interface of a Linera application.
 ///
 /// As opposed to the [`Service`] interface of an application, contract entry points

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -9,7 +9,7 @@ use linera_base::{
     abi::ServiceAbi,
     data_types::{Amount, BlockHeight, Timestamp},
     http,
-    identifiers::{AccountOwner, DataBlobHash, ApplicationId, ChainId},
+    identifiers::{AccountOwner, ApplicationId, ChainId, DataBlobHash},
 };
 use serde::Serialize;
 

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -9,12 +9,12 @@ use linera_base::{
     abi::ServiceAbi,
     data_types::{Amount, BlockHeight, Timestamp},
     http,
-    identifiers::{AccountOwner, ApplicationId, ChainId},
+    identifiers::{AccountOwner, DataBlobHash, ApplicationId, ChainId},
 };
 use serde::Serialize;
 
 use super::wit::{base_runtime_api as base_wit, service_runtime_api as service_wit};
-use crate::{DataBlobHash, KeyValueStore, Service, ViewStorageContext};
+use crate::{KeyValueStore, Service, ViewStorageContext};
 
 /// The runtime available during execution of a query.
 pub struct ServiceRuntime<Application>

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -152,12 +152,12 @@ where
 
     /// Reads a data blob with the given hash from storage.
     pub fn read_data_blob(&self, hash: DataBlobHash) -> Vec<u8> {
-        base_wit::read_data_blob(hash.0.into())
+        base_wit::read_data_blob(hash.into())
     }
 
     /// Asserts that a data blob with the given hash exists in storage.
     pub fn assert_data_blob_exists(&self, hash: DataBlobHash) {
-        base_wit::assert_data_blob_exists(hash.0.into())
+        base_wit::assert_data_blob_exists(hash.into())
     }
 }
 

--- a/linera-sdk/src/service/test_runtime.rs
+++ b/linera-sdk/src/service/test_runtime.rs
@@ -13,11 +13,11 @@ use linera_base::{
     abi::ServiceAbi,
     data_types::{Amount, BlockHeight, Timestamp},
     hex, http,
-    identifiers::{AccountOwner, ApplicationId, ChainId},
+    identifiers::{AccountOwner, ApplicationId, ChainId, DataBlobHash},
 };
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::{DataBlobHash, KeyValueStore, Service, ViewStorageContext};
+use crate::{KeyValueStore, Service, ViewStorageContext};
 
 /// The runtime available during execution of a query.
 pub struct MockServiceRuntime<Application>

--- a/linera-sdk/wit/base-runtime-api.wit
+++ b/linera-sdk/wit/base-runtime-api.wit
@@ -14,8 +14,8 @@ interface base-runtime-api {
     read-balance-owners: func() -> list<account-owner>;
     perform-http-request: func(request: http-request) -> http-response;
     assert-before: func(timestamp: timestamp);
-    read-data-blob: func(hash: crypto-hash) -> list<u8>;
-    assert-data-blob-exists: func(hash: crypto-hash);
+    read-data-blob: func(hash: data-blob-hash) -> list<u8>;
+    assert-data-blob-exists: func(hash: data-blob-hash);
     log: func(message: string, level: log-level);
     contains-key-new: func(key: list<u8>) -> u32;
     contains-key-wait: func(promise-id: u32) -> bool;
@@ -71,6 +71,10 @@ interface base-runtime-api {
         part2: u64,
         part3: u64,
         part4: u64,
+    }
+
+    record data-blob-hash {
+        inner0: crypto-hash,
     }
 
     record http-header {

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -12,7 +12,7 @@ interface contract-runtime-api {
     close-chain: func() -> result<tuple<>, close-chain-error>;
     change-application-permissions: func(application-permissions: application-permissions) -> result<tuple<>, change-application-permissions-error>;
     create-application: func(module-id: module-id, parameters: list<u8>, argument: list<u8>, required-application-ids: list<application-id>) -> application-id;
-    create-data-blob: func(bytes: list<u8>) -> blob-id;
+    create-data-blob: func(bytes: list<u8>) -> data-blob-hash;
     publish-module: func(contract: bytecode, service: bytecode, vm-runtime: vm-runtime) -> module-id;
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
     emit: func(name: stream-name, value: list<u8>) -> u32;
@@ -58,21 +58,6 @@ interface contract-runtime-api {
         part3: u64,
     }
 
-    record blob-id {
-        blob-type: blob-type,
-        hash: crypto-hash,
-    }
-
-    enum blob-type {
-        data,
-        contract-bytecode,
-        service-bytecode,
-        evm-bytecode,
-        application-description,
-        committee,
-        chain-description,
-    }
-
     record bytecode {
         bytes: list<u8>,
     }
@@ -102,6 +87,10 @@ interface contract-runtime-api {
         part2: u64,
         part3: u64,
         part4: u64,
+    }
+
+    record data-blob-hash {
+        inner0: crypto-hash,
     }
 
     record module-id {

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -32,8 +32,7 @@ use linera_base::{
 use linera_core::worker::{Notification, Reason};
 use linera_sdk::{
     abis::fungible::NativeFungibleTokenAbi,
-    linera_base_types::{AccountSecretKey, BlobContent, BlockHeight},
-    DataBlobHash,
+    linera_base_types::{AccountSecretKey, BlobContent, BlockHeight, DataBlobHash},
 };
 #[cfg(any(
     feature = "dynamodb",


### PR DESCRIPTION
## Motivation

The `BaseRuntime` and `ContractRuntime` are a little bit disorganised with their input and output:
* `read_data_blob` / `assert_data_blob_exists` are taking a `CryptoHash` as input.
* `create_data_blob` is returning a `BlobId`.

## Proposal

The natural type is the `DataBlobHash` that is the natural type for this.

Previous to this PR, it is in the `linera-sdk`. We are forced to move it to `linera-base`.

## Test Plan

The CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.