### PR TITLE
Remove unnecessary `prepare_chain` call.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -422,7 +422,6 @@ impl<Env: Environment, W: Persist<Target = Wallet>> ClientContext<Env, W> {
 
         loop {
             // Try applying f. Return if committed.
-            client.prepare_chain().await?;
             let result = f(client).await;
             self.update_wallet_from_client(client).await?;
             let timeout = match result? {


### PR DESCRIPTION
## Motivation

In https://github.com/linera-io/linera-protocol/pull/3099 I added a `prepare_chain` call that shouldn't be necessary, because `test_end_to_end_listen_for_new_rounds::storage_test_service_grpc` was flaky for me locally.

I believe the underlying issue may have been fixed in https://github.com/linera-io/linera-protocol/pull/4361.

## Proposal

Remove the unnecessary call again.

## Test Plan

It now passed for me locally 10 times in debug and 10 times in release mode.
(I believe we didn't see the failure in CI.)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Fixes https://github.com/linera-io/linera-protocol/issues/3100.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
