### PR TITLE
Eliminate `authenticated_caller_id` from the `OperationContext`

### DIFF
--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -142,7 +142,6 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                     height: self.block_height,
                     round,
                     authenticated_signer: self.authenticated_signer,
-                    authenticated_caller_id: None,
                     timestamp: self.timestamp,
                 };
                 Box::pin(chain.execute_operation(

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -262,7 +262,6 @@ where
     let operation_context = OperationContext {
         chain_id: creator_chain.id(),
         authenticated_signer: None,
-        authenticated_caller_id: None,
         height: run_block.height,
         round: Some(0),
         timestamp: Timestamp::from(3),

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -92,7 +92,6 @@ where
         let context = OperationContext {
             chain_id,
             authenticated_signer: None,
-            authenticated_caller_id: None,
             height: application_description.block_height,
             round: None,
             timestamp: local_time,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -412,10 +412,6 @@ pub struct OperationContext {
     /// The authenticated signer of the operation, if any.
     #[debug(skip_if = Option::is_none)]
     pub authenticated_signer: Option<AccountOwner>,
-    /// `None` if this is the transaction entrypoint or the caller doesn't want this particular
-    /// call to be authenticated (e.g. for safety reasons).
-    #[debug(skip_if = Option::is_none)]
-    pub authenticated_caller_id: Option<ApplicationId>,
     /// The current block height.
     pub height: BlockHeight,
     /// The consensus round number, if this is a block that gets validated in a multi-leader round.

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -118,7 +118,6 @@ pub fn create_dummy_operation_context(chain_id: ChainId) -> OperationContext {
         height: BlockHeight(0),
         round: Some(0),
         authenticated_signer: None,
-        authenticated_caller_id: None,
         timestamp: Default::default(),
     }
 }

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -19,7 +19,6 @@ async fn new_view_and_context() -> (
     let context = OperationContext {
         chain_id: ChainId::from(&description),
         authenticated_signer: None,
-        authenticated_caller_id: None,
         height: BlockHeight::from(7),
         round: Some(0),
         timestamp: Default::default(),

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -86,7 +86,6 @@ async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
         height: BlockHeight(0),
         round: Some(0),
         authenticated_signer: None,
-        authenticated_caller_id: None,
         timestamp: Default::default(),
     };
 
@@ -210,7 +209,6 @@ async fn test_terminate_execute_operation_by_lack_of_fuel() -> anyhow::Result<()
         height: BlockHeight(0),
         round: Some(0),
         authenticated_signer: None,
-        authenticated_caller_id: None,
         timestamp: Default::default(),
     };
 
@@ -387,7 +385,6 @@ async fn test_basic_evm_features() -> anyhow::Result<()> {
         height: BlockHeight(0),
         round: Some(0),
         authenticated_signer: None,
-        authenticated_caller_id: None,
         timestamp: Default::default(),
     };
 

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -49,7 +49,6 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         height: BlockHeight(0),
         round: Some(0),
         authenticated_signer: Some(owner),
-        authenticated_caller_id: None,
         timestamp: Default::default(),
     };
     let mut controller = ResourceController::default();

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -72,7 +72,6 @@ async fn test_fuel_for_counter_wasm_application(
         height: BlockHeight(0),
         round: Some(0),
         authenticated_signer: None,
-        authenticated_caller_id: None,
         timestamp: Default::default(),
     };
     let increments = [2_u64, 9, 7, 1000];


### PR DESCRIPTION
## Motivation

It is not used and not set to any other value than `None`.

## Proposal

Straight removal.
I am not 100% sure, but I think that it is not an error that it is not used.
The `authenticated_caller_id` is instead available via the call_stack.

## Test Plan

The CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.