### PR TITLE
Fix "skipped proposal" scenario; take note of proposals even if they fail.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4214,6 +4214,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-game"
+version = "0.1.0"
+dependencies = [
+ "async-graphql",
+ "bcs",
+ "linera-sdk",
+ "log",
+ "serde",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5252,6 +5263,7 @@ dependencies = [
  "dashmap 5.5.3",
  "fungible",
  "futures",
+ "hex-game",
  "linera-base",
  "linera-chain",
  "linera-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,6 +309,7 @@ create-and-call = { path = "./examples/create-and-call" }
 crowd-funding = { path = "./examples/crowd-funding" }
 ethereum-tracker = { path = "./examples/ethereum-tracker" }
 fungible = { path = "./examples/fungible" }
+hex-game = { path = "./examples/hex-game" }
 matching-engine = { path = "./examples/matching-engine" }
 meta-counter = { path = "./examples/meta-counter" }
 native-fungible = { path = "./examples/native-fungible" }

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -154,10 +154,10 @@ where
     /// The probability distribution for choosing a fallback round leader.
     #[cfg_attr(with_graphql, graphql(skip))] // Derived from validator weights.
     pub fallback_distribution: RegisterView<C, Option<WeightedAliasIndex<u64>>>,
-    /// Highest-round authenticated block that we have received, but not necessarily check yet.
-    /// If there are multiple proposals in the same round, this contains only the first one.
-    /// This can even contain proposals that did not execute successfully, to determine which round
-    /// to propose in.
+    /// Highest-round authenticated block that we have received, but not necessarily
+    /// checked yet. If there are multiple proposals in the same round, this contains only the
+    /// first one. This can even contain proposals that did not execute successfully, to determine
+    /// which round to propose in.
     #[cfg_attr(with_graphql, graphql(skip))]
     pub signed_proposal: RegisterView<C, Option<BlockProposal>>,
     /// Highest-round authenticated block that we have received and checked. If there are multiple

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -93,6 +93,7 @@ assert_matches.workspace = true
 counter.workspace = true
 criterion.workspace = true
 fungible.workspace = true
+hex-game.workspace = true
 linera-core = { path = ".", default-features = false, features = ["test"] }
 linera-views.workspace = true
 meta-counter.workspace = true

--- a/linera-core/src/chain_worker/state/guard.rs
+++ b/linera-core/src/chain_worker/state/guard.rs
@@ -794,6 +794,12 @@ where
             return Ok((self.chain_info_response(), NetworkActions::default()));
         }
 
+        // Make sure we remember that a proposal was signed, to determine the correct round to
+        // propose in.
+        if self.0.chain.manager.update_signed_proposal(&proposal) {
+            self.save().await?;
+        }
+
         let published_blobs = self.load_proposal_blobs(&proposal).await?;
         let ProposalContent {
             block,

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -980,16 +980,12 @@ where
     // Set the validators back to Honest.
     builder.set_fault_type([0, 1], FaultType::Honest).await;
 
-    // Now player A tries to claim victory since B has timed out.
+    // Now player A claim victory since B has timed out. This works because it sees the existing
+    // block proposal and makes a new proposal in the next round instead.
     let claim_victory_operation = HexOperation::ClaimVictory;
     client_a.synchronize_from_validators().await?;
-    let result = client_a
+    client_a
         .execute_operation(Operation::user(app_id, &claim_victory_operation)?)
-        .await;
-
-    // This fails due to the expected bug: game_client_a proposed in multi-leader round 0 again.
-    // TODO(#2971): Fix this and assert that it passes.
-    assert_matches!(result, Err(ChainClientError::CommunicationError(_)));
-
+        .await?;
     Ok(())
 }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -373,6 +373,9 @@ ChainManagerInfo:
   STRUCT:
     - ownership:
         TYPENAME: ChainOwnership
+    - requested_signed_proposal:
+        OPTION:
+          TYPENAME: BlockProposal
     - requested_proposed:
         OPTION:
           TYPENAME: BlockProposal

--- a/linera-service/src/exporter/test_utils.rs
+++ b/linera-service/src/exporter/test_utils.rs
@@ -199,26 +199,11 @@ impl ValidatorNode for DummyValidator {
             }
         }
 
-        let manager = ChainManagerInfo {
-            ownership: Default::default(),
-            requested_proposed: None,
-            requested_locking: None,
-            timeout: None,
-            pending: None,
-            timeout_vote: None,
-            fallback_vote: None,
-            requested_confirmed: None,
-            requested_validated: None,
-            current_round: Default::default(),
-            leader: None,
-            round_timeout: None,
-        };
-
         let chain_info = ChainInfo {
             chain_id: ChainId(CryptoHash::test_hash("test")),
             epoch: Epoch::ZERO,
             description: None,
-            manager: manager.into(),
+            manager: ChainManagerInfo::default().into(),
             chain_balance: Amount::ONE,
             block_hash: None,
             timestamp: Timestamp::now(),


### PR DESCRIPTION
## Motivation

Proposals by other chain owners that the client learns about from validators can fail to execute locally, e.g. due to different oracle values. But in multi-leader rounds, clients need to take not of such failed proposals anyway, so they know that they shouldn't also make a conflicting proposal in the same round.

## Proposal

Add another `signed_proposed_block` field to the chain manager to keep track of this.

## Test Plan

A regression test was added; and it failed without this fix.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #2971.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
