### PR TITLE
Downgrade log levels when skipping proposals or certificates from valdators.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1035,7 +1035,7 @@ impl<Env: Environment> Client<Env> {
                 LockingBlock::Regular(cert) => {
                     let hash = cert.hash();
                     if let Err(err) = self.try_process_locking_block_from(remote_node, cert).await {
-                        warn!(
+                        debug!(
                             "Skipping certificate {hash} from validator {}: {err}",
                             remote_node.public_key
                         );
@@ -1103,7 +1103,7 @@ impl<Env: Environment> Client<Env> {
                 }
 
                 let public_key = &remote_node.public_key;
-                warn!("Skipping proposal from {owner} and validator {public_key}: {err}");
+                debug!("Skipping proposal from {owner} and validator {public_key}: {err}");
             }
         }
         Ok(())


### PR DESCRIPTION
## Motivation

Proposals or certificates we learn about when syncing from validators aren't expected to always still be relevant for us, or even to successfully execute (for the proposals).

## Proposal

Downgrade the log level to debug when logging such failures.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #3001.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
