### PR TITLE
Changes to support separate VMs

### DIFF
--- a/kubernetes/linera-validator/templates/monitoring-namespace.yaml
+++ b/kubernetes/linera-validator/templates/monitoring-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring

--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -50,6 +50,12 @@ spec:
       labels:
         app: proxy
     spec:
+      nodeSelector:
+        workload: proxies
+      tolerations:
+      - key: proxies
+        value: "true"
+        effect: NoSchedule
       terminationGracePeriodSeconds: 10
       initContainers:
         - name: linera-proxy-initializer

--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -30,6 +30,12 @@ spec:
       labels:
         app: shards
     spec:
+      nodeSelector:
+        workload: shards
+      tolerations:
+      - key: shards
+        value: "true"
+        effect: NoSchedule
       terminationGracePeriodSeconds: 10
       initContainers:
         - name: linera-server-initializer


### PR DESCRIPTION
## Motivation

We're splitting our deployment to have a VM for monitoring, one for proxies and one for shards.

## Proposal

These are the `linera-protocol` side changes needed to support those changes.

## Test Plan

Deployed networks with the `linera-infra` changes and validated these are ok

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
