### PR TITLE
Fix authenticated signer syscall and remove the offending field

### DIFF
--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -180,7 +180,6 @@ where
         BlockHeight(0),
         Some(0),
         None,
-        None,
         execution_state_sender,
         None,
         None,


### PR DESCRIPTION
## Motivation

Fix authenticated signer.

## Proposal

As pointed out in #4374, we were using the transaction instead of the last application on the calling stack, effectively ignoring whether calls were "authenticated" or not.

* Fix the bug
* Remove the field that caused the confusion in the first place

## Test Plan

CI + new unit test

I verified that the new unit test fails before the fix.

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
