### PR TITLE
Switch the `Blob` from `Box<[u8]>` to `Arc<Box<[u8]>>`.

### DIFF
--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -52,7 +52,7 @@ prometheus = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true, features = ["alloc"] }
 rand.workspace = true
 reqwest = { workspace = true, optional = true }
-serde.workspace = true
+serde = { workspace = true, features = ["rc"] }
 serde-name.workspace = true
 serde_bytes.workspace = true
 serde_json.workspace = true

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1265,7 +1265,10 @@ impl BlobContent {
     /// Creates a new [`BlobContent`] from the provided bytes and [`BlobId`].
     pub fn new(blob_type: BlobType, bytes: impl Into<Box<[u8]>>) -> Self {
         let bytes = bytes.into();
-        BlobContent { blob_type, bytes: Arc::new(bytes) }
+        BlobContent {
+            blob_type,
+            bytes: Arc::new(bytes),
+        }
     }
 
     /// Creates a new data [`BlobContent`] from the provided bytes.

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -946,7 +946,7 @@ where
             this.transaction_tracker
                 .replay_oracle_response(OracleResponse::Blob(blob_id))?;
         }
-        Ok(content.into_bytes().to_vec())
+        Ok(content.into_vec_or_clone())
     }
 
     fn assert_data_blob_exists(&mut self, hash: DataBlobHash) -> Result<(), ExecutionError> {

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -946,7 +946,7 @@ where
             this.transaction_tracker
                 .replay_oracle_response(OracleResponse::Blob(blob_id))?;
         }
-        Ok(content.into_bytes().into_vec())
+        Ok(content.into_bytes().to_vec())
     }
 
     fn assert_data_blob_exists(&mut self, hash: DataBlobHash) -> Result<(), ExecutionError> {

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1237,8 +1237,8 @@ async fn test_open_chain() -> anyhow::Result<()> {
     let new_blob = &txn_outcome.blobs[0];
     assert_eq!(new_blob.id().hash, child_id.0);
     assert_eq!(new_blob.id().blob_type, BlobType::ChainDescription);
-    let created_description: ChainDescription = bcs::from_bytes(&new_blob.clone().into_bytes())
-        .expect("should deserialize a chain description");
+    let created_description: ChainDescription =
+        bcs::from_bytes(new_blob.bytes()).expect("should deserialize a chain description");
     assert_eq!(created_description.config().balance, Amount::ONE);
     assert_eq!(created_description.config().ownership, child_ownership);
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -276,7 +276,7 @@ pub trait Storage: Sized {
                 .into_content(),
         };
         let compressed_contract_bytecode = CompressedBytecode {
-            compressed_bytes: content.into_bytes().into_vec(),
+            compressed_bytes: content.into_bytes().to_vec(),
         };
         #[cfg_attr(not(any(with_wasm_runtime, with_revm)), allow(unused_variables))]
         let contract_bytecode =
@@ -343,7 +343,7 @@ pub trait Storage: Sized {
                 .into_content(),
         };
         let compressed_service_bytecode = CompressedBytecode {
-            compressed_bytes: content.into_bytes().into_vec(),
+            compressed_bytes: content.into_bytes().to_vec(),
         };
         #[cfg_attr(not(any(with_wasm_runtime, with_revm)), allow(unused_variables))]
         let service_bytecode = linera_base::task::Blocking::<linera_base::task::NoInput, _>::spawn(

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -276,7 +276,7 @@ pub trait Storage: Sized {
                 .into_content(),
         };
         let compressed_contract_bytecode = CompressedBytecode {
-            compressed_bytes: content.into_bytes().to_vec(),
+            compressed_bytes: content.into_vec_or_clone(),
         };
         #[cfg_attr(not(any(with_wasm_runtime, with_revm)), allow(unused_variables))]
         let contract_bytecode =
@@ -343,7 +343,7 @@ pub trait Storage: Sized {
                 .into_content(),
         };
         let compressed_service_bytecode = CompressedBytecode {
-            compressed_bytes: content.into_bytes().to_vec(),
+            compressed_bytes: content.into_vec_or_clone(),
         };
         #[cfg_attr(not(any(with_wasm_runtime, with_revm)), allow(unused_variables))]
         let service_bytecode = linera_base::task::Blocking::<linera_base::task::NoInput, _>::spawn(


### PR DESCRIPTION
## Motivation

We are doing some cloning operations for blobs. This occurs in the `TransactionTracker` with the `previously_created_blobs`.

Fixes #2389

## Proposal

The implementation is done with the `serde_with` for the serialization.

## Test Plan

The CI.
A test has been introduced for this serialization and hash.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None