### PR TITLE
Make the handling of GraphQL in the counter example in line with other contracts.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,6 +2460,7 @@ dependencies = [
  "async-graphql",
  "futures",
  "linera-sdk",
+ "serde",
  "serde_json",
 ]
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1669,6 +1669,7 @@ dependencies = [
  "async-graphql",
  "futures",
  "linera-sdk",
+ "serde",
  "serde_json",
  "tokio",
 ]

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 async-graphql.workspace = true
 futures.workspace = true
 linera-sdk.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -88,7 +88,7 @@ query {
 - To increase the value of the counter by 3, perform the `increment` operation.
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APPLICATION_ID
 mutation Increment {
-  increment(value: 3)
+  increment(field0: 3)
 }
 ```
 - Running the query again would yield `4`.

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -5,7 +5,7 @@
 
 mod state;
 
-use counter::CounterAbi;
+use counter::{CounterAbi, CounterOperation};
 use linera_sdk::{
     linera_base_types::WithContractAbi,
     views::{RootView, View},
@@ -45,7 +45,8 @@ impl Contract for CounterContract {
         self.state.value.set(value);
     }
 
-    async fn execute_operation(&mut self, operation: u64) -> u64 {
+    async fn execute_operation(&mut self, operation: CounterOperation) -> u64 {
+        let CounterOperation::Increment(operation) = operation;
         let new_value = self.state.value.get() + operation;
         self.state.value.set(new_value);
         new_value
@@ -66,6 +67,7 @@ mod tests {
     use linera_sdk::{util::BlockingWait, views::View, Contract, ContractRuntime};
 
     use super::{CounterContract, CounterState};
+    use counter::CounterOperation;
 
     #[test]
     fn operation() {
@@ -73,9 +75,10 @@ mod tests {
         let mut counter = create_and_instantiate_counter(initial_value);
 
         let increment = 42_308_u64;
+        let operation = CounterOperation::Increment(increment);
 
         let response = counter
-            .execute_operation(increment)
+            .execute_operation(operation)
             .now_or_never()
             .expect("Execution of counter operation should not await anything");
 
@@ -103,9 +106,10 @@ mod tests {
         let mut counter = create_and_instantiate_counter(initial_value);
 
         let increment = 8_u64;
+        let operation = CounterOperation::Increment(increment);
 
         let response = counter
-            .execute_operation(increment)
+            .execute_operation(operation)
             .now_or_never()
             .expect("Execution of counter operation should not await anything");
 

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -63,11 +63,11 @@ impl Contract for CounterContract {
 
 #[cfg(test)]
 mod tests {
+    use counter::CounterOperation;
     use futures::FutureExt as _;
     use linera_sdk::{util::BlockingWait, views::View, Contract, ContractRuntime};
 
     use super::{CounterContract, CounterState};
-    use counter::CounterOperation;
 
     #[test]
     fn operation() {

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -4,12 +4,19 @@
 /*! ABI of the Counter Example Application */
 
 use async_graphql::{Request, Response};
-use linera_sdk::linera_base_types::{ContractAbi, ServiceAbi};
+use linera_sdk::{graphql::GraphQLMutationRoot, linera_base_types::{ContractAbi, ServiceAbi}};
+use serde::{Deserialize, Serialize};
 
 pub struct CounterAbi;
 
+#[derive(Debug, Deserialize, Serialize, GraphQLMutationRoot)]
+pub enum CounterOperation {
+    /// Increment the counter by the given value
+    Increment(u64),
+}
+
 impl ContractAbi for CounterAbi {
-    type Operation = u64;
+    type Operation = CounterOperation;
     type Response = u64;
 }
 

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -4,7 +4,10 @@
 /*! ABI of the Counter Example Application */
 
 use async_graphql::{Request, Response};
-use linera_sdk::{graphql::GraphQLMutationRoot, linera_base_types::{ContractAbi, ServiceAbi}};
+use linera_sdk::{
+    graphql::GraphQLMutationRoot,
+    linera_base_types::{ContractAbi, ServiceAbi},
+};
 use serde::{Deserialize, Serialize};
 
 pub struct CounterAbi;

--- a/examples/counter/src/state.rs
+++ b/examples/counter/src/state.rs
@@ -4,7 +4,7 @@
 use linera_sdk::views::{linera_views, RegisterView, RootView, ViewStorageContext};
 
 /// The application state.
-#[derive(RootView)]
+#[derive(RootView, async_graphql::SimpleObject)]
 #[view(context = ViewStorageContext)]
 pub struct CounterState {
     pub value: RegisterView<u64>,

--- a/examples/counter/tests/single_chain.rs
+++ b/examples/counter/tests/single_chain.rs
@@ -6,6 +6,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use linera_sdk::test::{QueryOutcome, TestValidator};
+use counter::CounterOperation;
 
 /// Test setting a counter and testing its coherency across microchains.
 ///
@@ -23,9 +24,10 @@ async fn single_chain_test() {
         .await;
 
     let increment = 15u64;
+    let operation = CounterOperation::Increment(increment);
     chain
         .add_block(|block| {
-            block.with_operation(application_id, increment);
+            block.with_operation(application_id, operation);
         })
         .await;
 

--- a/examples/counter/tests/single_chain.rs
+++ b/examples/counter/tests/single_chain.rs
@@ -5,8 +5,8 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
-use linera_sdk::test::{QueryOutcome, TestValidator};
 use counter::CounterOperation;
+use linera_sdk::test::{QueryOutcome, TestValidator};
 
 /// Test setting a counter and testing its coherency across microchains.
 ///

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -95,7 +95,8 @@ impl Contract for MetaCounterContract {
             Message::Increment(value) => {
                 let counter_id = self.counter_id();
                 log::trace!("executing {} via {:?}", value, counter_id);
-                self.runtime.call_application(true, counter_id, &value);
+                let operation = counter::CounterOperation::Increment(value);
+                self.runtime.call_application(true, counter_id, &operation);
             }
         }
     }

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -161,8 +161,9 @@ where
         .unwrap_ok_committed();
 
     let increment = 5_u64;
+    let counter_operation = counter::CounterOperation::Increment(increment);
     creator
-        .execute_operation(Operation::user(application_id, &increment)?)
+        .execute_operation(Operation::user(application_id, &counter_operation)?)
         .await
         .unwrap();
 
@@ -879,14 +880,15 @@ async fn test_memory_fuel_limit(wasm_runtime: WasmRuntime) -> anyhow::Result<()>
         .unwrap_ok_committed();
 
     let increment = 5_u64;
+    let operation = counter::CounterOperation::Increment(increment);
     publisher
-        .execute_operation(Operation::user(application_id, &increment)?)
+        .execute_operation(Operation::user(application_id, &operation)?)
         .await
         .unwrap_ok_committed();
 
     assert!(publisher
         .execute_operations(
-            vec![Operation::user(application_id, &increment)?; 10],
+            vec![Operation::user(application_id, &operation)?; 10],
             vec![]
         )
         .await

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -252,7 +252,8 @@ where
 
     // Execute an application operation
     let increment = 5_u64;
-    let user_operation = bcs::to_bytes(&increment)?;
+    let counter_operation = counter::CounterOperation::Increment(increment);
+    let user_operation = bcs::to_bytes(&counter_operation)?;
     let run_block = make_child_block(&create_certificate.into_value())
         .with_timestamp(3)
         .with_operation(Operation::User {

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -1521,7 +1521,7 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()
     let balance2 = node_service.balance(&account_chain).await?;
     assert_eq!(balance1, balance2);
 
-    let mutation = format!("increment(value: {increment})");
+    let mutation = format!("increment(field0: {increment})");
     application.mutate(mutation).await?;
     let balance3 = node_service.balance(&account_chain).await?;
     assert!(balance3 < balance2);
@@ -1778,7 +1778,7 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
     let counter_value: u64 = application.query_json("value").await?;
     assert_eq!(counter_value, original_counter_value);
 
-    let mutation = format!("increment(value: {increment})");
+    let mutation = format!("increment(field0: {increment})");
     application.mutate(mutation).await?;
 
     let counter_value: u64 = application.query_json("value").await?;


### PR DESCRIPTION
## Motivation

The `counter` example was processing GraphQL queries quite differently from other examples.
We put it in line with other examples.

Fixes #2854 

## Proposal

The work is fairly standard, but forces the introduction of a `CounterOperation` since the input
must satisfy the `GraphQLMutationRoot` trait.

## Test Plan

The CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.