### PR TITLE
Remove test-only `WorkerState.with_key_pair`.

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -427,14 +427,6 @@ where
         &self.storage
     }
 
-    #[instrument(level = "trace", skip(self, key_pair))]
-    #[cfg(test)]
-    pub(crate) async fn with_key_pair(mut self, key_pair: Option<Arc<ValidatorSecretKey>>) -> Self {
-        self.chain_worker_config.key_pair = key_pair;
-        self.chain_workers.lock().unwrap().clear();
-        self
-    }
-
     #[instrument(level = "trace", skip(self, certificate))]
     pub(crate) async fn full_certificate(
         &self,


### PR DESCRIPTION
## Motivation

This test-only method risks dropping the handles of ongoing tasks with loaded chain state views, and then loading those chains again.

It's only used in one test, where we assert that the worker updates its locking block based on a validated block certificate even if it did not sign to confirm that block. Since this feature mainly matters on the client side, and we wanted to make sure it can't sign to confirm, we removed the worker's keys. However, the worker wouldn't sign it anyway, since it is not in the current round.

## Proposal

Remove the method; assert instead that the worker didn't sign to confirm.

## Test Plan

Only test code was changed.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
