### PR TITLE
Implement composed operations

### DIFF
--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -45,11 +45,11 @@ impl Contract for CounterContract {
         self.state.value.set(value);
     }
 
-    async fn execute_operation(&mut self, operation: CounterOperation) -> u64 {
+    async fn execute_operation(&mut self, operation: CounterOperation) -> CounterOperation {
         let CounterOperation::Increment { value } = operation;
         let new_value = self.state.value.get() + value;
         self.state.value.set(new_value);
-        new_value
+        operation
     }
 
     async fn execute_message(&mut self, _message: ()) {
@@ -87,8 +87,8 @@ mod tests {
 
         let expected_value = initial_value + increment;
 
-        assert_eq!(response, expected_value);
-        assert_eq!(*counter.state.value.get(), initial_value + increment);
+        assert_eq!(response, CounterOperation::Increment { value: increment });
+        assert_eq!(*counter.state.value.get(), expected_value);
     }
 
     #[test]
@@ -118,7 +118,7 @@ mod tests {
 
         let expected_value = initial_value + increment;
 
-        assert_eq!(response, expected_value);
+        assert_eq!(response, CounterOperation::Increment { value: increment });
         assert_eq!(*counter.state.value.get(), expected_value);
     }
 

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 pub struct CounterAbi;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub enum CounterOperation {
     /// Increment the counter by the given value
     Increment { value: u64 },
@@ -17,7 +17,7 @@ pub enum CounterOperation {
 
 impl ContractAbi for CounterAbi {
     type Operation = CounterOperation;
-    type Response = u64;
+    type Response = CounterOperation;
 }
 
 impl ServiceAbi for CounterAbi {

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -29,7 +29,7 @@ use futures::StreamExt as _;
 use linera_base::identifiers::{AccountOwner, ApplicationId, ChainId};
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::{client::ChainClient, worker::Reason};
-use linera_execution::{Operation, WasmRuntime};
+use linera_execution::{Operation, OperationInput, WasmRuntime};
 use linera_storage::{DbStorage, Storage as _};
 use linera_views::{
     backends::{
@@ -520,7 +520,7 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
                                     .expect("failed to BCS-serialize BridgeOperation");
                                 Operation::User {
                                     application_id: bridge_app_id,
-                                    bytes: op_bytes,
+                                    input: OperationInput::Direct(op_bytes),
                                 }
                             }).collect();
 

--- a/linera-bridge/src/test_helpers.rs
+++ b/linera-bridge/src/test_helpers.rs
@@ -19,7 +19,7 @@ use linera_chain::{
 use linera_execution::{
     committee::ValidatorState, system::AdminOperation,
     test_utils::solidity::compile_solidity_contract_with_options, Message, MessageKind, Operation,
-    ResourceControlPolicy, SystemOperation,
+    OperationInput, ResourceControlPolicy, SystemOperation,
 };
 use revm::{
     database::{CacheDB, EmptyDB},
@@ -101,7 +101,7 @@ pub fn create_signed_certificate_for_chain(
 ) -> ConfirmedBlockCertificate {
     let transactions = vec![Transaction::ExecuteOperation(Operation::User {
         application_id: ApplicationId::new(CryptoHash::new(&TestString::new("test_app"))),
-        bytes: vec![0xDE, 0xAD, 0xBE, 0xEF],
+        input: OperationInput::Direct(vec![0xDE, 0xAD, 0xBE, 0xEF]),
     })];
     create_certificate_with_transactions(secret, public, chain_id, height, transactions)
 }

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -170,6 +170,12 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
 
     /// Returns a new TransactionTracker for the current transaction.
     fn new_transaction_tracker(&self) -> Result<TransactionTracker, ChainError> {
+        let previous_operation_results = self
+            .operation_results
+            .iter()
+            .map(|result| result.0.clone())
+            .collect();
+
         Ok(TransactionTracker::new(
             self.local_time,
             self.transaction_index,
@@ -177,6 +183,7 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
             self.next_chain_index,
             self.oracle_responses()?,
             &self.blobs,
+            previous_operation_results,
         ))
     }
 

--- a/linera-chain/src/data_types/mod.rs
+++ b/linera-chain/src/data_types/mod.rs
@@ -186,11 +186,14 @@ impl From<&Operation> for OperationMetadata {
             },
             Operation::User {
                 application_id,
-                bytes,
+                input,
             } => OperationMetadata {
                 operation_type: "User".to_string(),
                 application_id: Some(*application_id),
-                user_bytes_hex: Some(hex::encode(bytes)),
+                user_bytes_hex: Some(match input {
+                    linera_execution::OperationInput::Direct(bytes) => hex::encode(bytes),
+                    linera_execution::OperationInput::Composed => "composed".to_string(),
+                }),
                 system_operation: None,
             },
         }

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -26,8 +26,8 @@ use linera_execution::{
     committee::{Committee, ValidatorState},
     test_utils::{ExpectedCall, MockApplication},
     BaseRuntime, ContractRuntime, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext,
-    Message, MessageKind, Operation, ResourceControlPolicy, ResourceTracker, ServiceRuntime,
-    SystemOperation, TestExecutionRuntimeContext,
+    Message, MessageKind, Operation, OperationInput, ResourceControlPolicy, ResourceTracker,
+    ServiceRuntime, SystemOperation, TestExecutionRuntimeContext,
 };
 use linera_views::{
     context::{Context as _, MemoryContext, ViewContext},
@@ -342,11 +342,11 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     application.expect_call(ExpectedCall::default_finalize());
     let app_operation = Operation::User {
         application_id,
-        bytes: b"foo".to_vec(),
+        input: OperationInput::Direct(b"foo".to_vec()),
     };
     let another_app_operation = Operation::User {
         application_id: another_app_id,
-        bytes: b"bar".to_vec(),
+        input: OperationInput::Direct(b"bar".to_vec()),
     };
 
     let valid_block = make_first_block(chain_id)
@@ -879,7 +879,7 @@ async fn prepare_test_with_dummy_mock_application(
 
     let block = make_first_block(chain_id).with_operation(Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     });
 
     Ok((application, application_id, chain, block, time))

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -20,7 +20,7 @@ use linera_core::{
     data_types::ClientOutcome,
     Environment,
 };
-use linera_execution::{system::SystemOperation, Operation};
+use linera_execution::{system::SystemOperation, Operation, OperationInput};
 use linera_sdk::abis::fungible::FungibleOperation;
 use num_format::{Locale, ToFormattedString};
 use prometheus_parse::{HistogramCount, Scrape, Value};
@@ -860,6 +860,6 @@ pub fn fungible_transfer(
     .expect("should serialize fungible token operation");
     Operation::User {
         application_id,
-        bytes,
+        input: OperationInput::Direct(bytes),
     }
 }

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -36,7 +36,7 @@ use linera_base::{
 };
 use linera_chain::{data_types::MessageAction, ChainError, ChainExecutionContext};
 use linera_execution::{
-    wasm_test, ExecutionError, Message, MessageKind, Operation, QueryOutcome,
+    wasm_test, ExecutionError, Message, MessageKind, Operation, OperationInput, QueryOutcome,
     ResourceControlPolicy, SystemMessage, SystemOperation, WasmRuntime,
 };
 use linera_storage::Storage as _;
@@ -170,8 +170,10 @@ where
 
     let increment = 5_u64;
     let counter_operation = counter::CounterOperation::Increment { value: increment };
+    let operation1 = Operation::user(application_id, &counter_operation)?;
+    let operation2 = Operation::user_composed(application_id.forget_abi());
     creator
-        .execute_operation(Operation::user(application_id, &counter_operation)?)
+        .execute_operations(vec![operation1, operation2], vec![])
         .await
         .unwrap();
 
@@ -181,9 +183,10 @@ where
         .await
         .unwrap();
 
+    // We do an increment by 5 and then immediately reiterate it.
     let expected = QueryOutcome {
         response: async_graphql::Response::new(
-            async_graphql::Value::from_json(json!({"value": 15})).unwrap(),
+            async_graphql::Value::from_json(json!({"value": 20})).unwrap(),
         ),
         operations: vec![],
     };
@@ -1723,7 +1726,7 @@ where
     let operation = &operations[0];
     if let Operation::User {
         application_id,
-        bytes,
+        input: OperationInput::Direct(bytes),
     } = operation
     {
         assert_eq!(application_id, &app_id.forget_abi());

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -28,7 +28,7 @@ use linera_chain::{
     },
     test::{make_child_block, make_first_block, BlockTestExt},
 };
-use linera_execution::{system::SystemOperation, Operation, WasmRuntime};
+use linera_execution::{system::SystemOperation, Operation, OperationInput, WasmRuntime};
 use linera_storage::Storage;
 use test_case::test_case;
 
@@ -233,7 +233,7 @@ where
         .with_timestamp(3)
         .with_operation(Operation::User {
             application_id,
-            bytes: user_operation.clone(),
+            input: OperationInput::Direct(user_operation.clone()),
         });
     let run_certificate = env.execute_proposal(run_block.clone(), vec![]).await?;
 
@@ -408,7 +408,7 @@ where
         .with_timestamp(4)
         .with_operation(Operation::User {
             application_id: meta_app_id,
-            bytes: fail_op_bytes,
+            input: OperationInput::Direct(fail_op_bytes),
         });
     let send_fail_cert = env.execute_proposal(send_fail_block, vec![]).await?;
     env.worker()

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -238,6 +238,7 @@ where
     let run_certificate = env.execute_proposal(run_block.clone(), vec![]).await?;
 
     assert!(run_certificate.value().matches_proposed_block(&run_block));
+    let result = counter::CounterOperation::Increment { value: 5 };
     assert_outcome_matches!(
         run_certificate.block(),
         &[vec![]],
@@ -246,7 +247,7 @@ where
         &[vec![]],
         &[vec![]],
         &[vec![]],
-        &[OperationResult(bcs::to_bytes(&15u64)?)],
+        &[OperationResult(bcs::to_bytes(&result)?)],
     );
 
     let info = env

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -78,8 +78,9 @@ use crate::{
         },
     },
     BaseRuntime, ContractRuntime, ContractSyncRuntimeHandle, DataBlobHash, EvmExecutionError,
-    EvmRuntime, ExecutionError, ServiceRuntime, ServiceSyncRuntimeHandle, UserContract,
-    UserContractInstance, UserContractModule, UserService, UserServiceInstance, UserServiceModule,
+    EvmRuntime, ExecutionError, OperationInput, ServiceRuntime, ServiceSyncRuntimeHandle,
+    UserContract, UserContractInstance, UserContractModule, UserService, UserServiceInstance,
+    UserServiceModule,
 };
 
 /// Fictional selector for internal cross-contract calls to retrieve account information.
@@ -1572,13 +1573,13 @@ where
             EvmQuery::Query(vec) => vec,
             EvmQuery::Operation(operation) => {
                 let mut runtime = self.db.lock_runtime();
-                runtime.schedule_operation(operation)?;
+                runtime.schedule_operation(OperationInput::Direct(operation))?;
                 return Ok(Vec::new());
             }
             EvmQuery::Operations(operations) => {
                 let mut runtime = self.db.lock_runtime();
                 for operation in operations {
-                    runtime.schedule_operation(operation)?;
+                    runtime.schedule_operation(OperationInput::Direct(operation))?;
                 }
                 return Ok(Vec::new());
             }

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -190,6 +190,7 @@ where
             next_chain_index,
             None,
             &[],
+            vec![], // No previous operation results for testing
         );
         txn_tracker.add_created_blob(blob);
         Box::pin(

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -1080,8 +1080,18 @@ where
             }
             Operation::User {
                 application_id,
-                bytes,
+                input,
             } => {
+                let bytes = match input {
+                    crate::OperationInput::Direct(bytes) => bytes,
+                    crate::OperationInput::Composed => {
+                        let previous_results = self.txn_tracker.previous_operation_results();
+                        if previous_results.is_empty() {
+                            return Err(ExecutionError::ComposedOperationCannotBeFirst);
+                        }
+                        previous_results.last().unwrap().clone()
+                    }
+                };
                 self.run_user_action(
                     application_id,
                     UserAction::Operation(context, bytes),

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -46,6 +46,7 @@ use linera_base::{
     vm::VmRuntime,
 };
 use linera_views::{batch::Batch, ViewError};
+use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Serialize};
 use system::AdminOperation;
 use thiserror::Error;
@@ -247,7 +248,8 @@ pub enum ExecutionError {
     DecompressionError(#[from] DecompressionError),
     #[error("The given promise is invalid or was polled once already")]
     InvalidPromise,
-
+    #[error("Composed operation cannot be first")]
+    ComposedOperationCannotBeFirst,
     #[error("Attempted to perform a reentrant call to application {0}")]
     ReentrantCall(ApplicationId),
     #[error(
@@ -419,6 +421,7 @@ impl ExecutionError {
             | ExecutionError::MissingOracleResponse
             | ExecutionError::UnprocessedStreams
             | ExecutionError::OutdatedUpdateStreams
+            | ExecutionError::ComposedOperationCannotBeFirst
             | ExecutionError::ViewError(ViewError::NotFound(_)) => false,
             #[cfg(with_wasm_runtime)]
             ExecutionError::WasmError(_) => false,
@@ -929,7 +932,7 @@ pub trait ServiceRuntime: BaseRuntime {
     ) -> Result<Vec<u8>, ExecutionError>;
 
     /// Schedules an operation to be included in the block proposed after execution.
-    fn schedule_operation(&mut self, operation: Vec<u8>) -> Result<(), ExecutionError>;
+    fn schedule_operation(&mut self, input: OperationInput) -> Result<(), ExecutionError>;
 
     /// Checks if the service has exceeded its execution time limit.
     fn check_execution_time(&mut self) -> Result<(), ExecutionError>;
@@ -1091,6 +1094,32 @@ pub trait ContractRuntime: BaseRuntime {
     fn write_batch(&mut self, batch: Batch) -> Result<(), ExecutionError>;
 }
 
+/// Input for an operation, which can be either direct bytes or a composed operation.
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Clone,
+    Serialize,
+    Deserialize,
+    Allocative,
+    WitType,
+    WitLoad,
+    WitStore,
+)]
+pub enum OperationInput {
+    /// Direct input as bytes.
+    Direct(
+        #[serde(with = "serde_bytes")]
+        #[debug(with = "hex_debug")]
+        Vec<u8>,
+    ),
+    /// Composed input that uses the result from the previous operation in the block.
+    /// If operation_results is empty, an error should be raised during execution.
+    Composed,
+}
+
 /// An operation to be executed in a block.
 #[derive(
     Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Allocative, strum::AsRefStr,
@@ -1098,12 +1127,10 @@ pub trait ContractRuntime: BaseRuntime {
 pub enum Operation {
     /// A system operation.
     System(Box<SystemOperation>),
-    /// A user operation (in serialized form).
+    /// A user operation.
     User {
         application_id: ApplicationId,
-        #[serde(with = "serde_bytes")]
-        #[debug(with = "hex_debug")]
-        bytes: Vec<u8>,
+        input: OperationInput,
     },
 }
 
@@ -1458,8 +1485,18 @@ impl Operation {
     ) -> Result<Self, bcs::Error> {
         Ok(Operation::User {
             application_id,
-            bytes: bcs::to_bytes(&operation)?,
+            input: OperationInput::Direct(bcs::to_bytes(&operation)?),
         })
+    }
+
+    /// Creates a new composed user application operation that uses the result from the
+    /// previous operation as input.
+    #[cfg(with_testing)]
+    pub fn user_composed(application_id: ApplicationId) -> Self {
+        Operation::User {
+            application_id,
+            input: OperationInput::Composed,
+        }
     }
 
     /// Returns a reference to the [`SystemOperation`] in this [`Operation`], if this [`Operation`]

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -423,8 +423,16 @@ where
         self.update_balance(self.policy.operation)?;
         match operation {
             Operation::System(_) => Ok(()),
-            Operation::User { bytes, .. } => {
-                let size = bytes.len();
+            Operation::User { input, .. } => {
+                let size = match input {
+                    crate::OperationInput::Direct(bytes) => bytes.len(),
+                    crate::OperationInput::Composed => {
+                        // For composed operations, we don't know the size until execution time
+                        // Since the input comes from the previous operation result.
+                        // We'll use 0 for now but this might need to be revisited.
+                        0
+                    }
+                };
                 self.tracker.as_mut().operation_bytes = self
                     .tracker
                     .as_mut()

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -34,7 +34,7 @@ use crate::{
     util::{ReceiverExt, UnboundedSenderExt},
     ApplicationDescription, ApplicationId, BaseRuntime, ContractRuntime, DataBlobHash,
     ExecutionError, FinalizeContext, Message, MessageContext, MessageKind, ModuleId, Operation,
-    OutgoingMessage, QueryContext, QueryOutcome, ServiceRuntime, UserContractCode,
+    OperationInput, OutgoingMessage, QueryContext, QueryOutcome, ServiceRuntime, UserContractCode,
     UserContractInstance, UserServiceCode, UserServiceInstance, MAX_STREAM_NAME_LEN,
 };
 
@@ -1883,13 +1883,13 @@ impl ServiceRuntime for ServiceSyncRuntimeHandle {
         Ok(response)
     }
 
-    fn schedule_operation(&mut self, operation: Vec<u8>) -> Result<(), ExecutionError> {
+    fn schedule_operation(&mut self, input: OperationInput) -> Result<(), ExecutionError> {
         let mut this = self.inner();
         let application_id = this.current_application().id;
 
         this.scheduled_operations.push(Operation::User {
             application_id,
-            bytes: operation,
+            input,
         });
 
         Ok(())

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -50,6 +50,8 @@ pub struct TransactionTracker {
     previously_created_blobs: BTreeMap<BlobId, BlobContent>,
     /// Operation result.
     operation_result: Option<Vec<u8>>,
+    /// Results from previous operations in the current block.
+    previous_operation_results: Vec<Vec<u8>>,
     /// Streams that have been updated but not yet processed during this transaction.
     streams_to_process: BTreeMap<ApplicationId, AppStreamUpdates>,
     /// Published blobs this transaction refers to by [`BlobId`].
@@ -87,6 +89,7 @@ impl TransactionTracker {
         next_chain_index: u32,
         oracle_responses: Option<Vec<OracleResponse>>,
         blobs: &[Vec<Blob>],
+        previous_operation_results: Vec<Vec<u8>>,
     ) -> Self {
         let mut previously_created_blobs = BTreeMap::new();
         for tx_blobs in blobs {
@@ -101,6 +104,7 @@ impl TransactionTracker {
             next_chain_index,
             replaying_oracle_responses: oracle_responses.map(Vec::into_iter),
             previously_created_blobs,
+            previous_operation_results,
             ..Self::default()
         }
     }
@@ -198,6 +202,11 @@ impl TransactionTracker {
         };
         self.oracle_responses.push(response);
         Ok(self.oracle_responses.last().unwrap())
+    }
+
+    /// Returns the previous operation results in the current block.
+    pub fn previous_operation_results(&self) -> &[Vec<u8>] {
+        &self.previous_operation_results
     }
 
     pub fn add_stream_to_process(
@@ -305,6 +314,7 @@ impl TransactionTracker {
             blobs,
             previously_created_blobs: _,
             operation_result,
+            previous_operation_results: _,
             streams_to_process,
             blobs_published,
             free_blob_ids,
@@ -342,7 +352,15 @@ impl TransactionTracker {
     /// Creates a new [`TransactionTracker`] for testing, with default values and the given
     /// oracle responses.
     pub fn new_replaying(oracle_responses: Vec<OracleResponse>) -> Self {
-        TransactionTracker::new(Timestamp::from(0), 0, 0, 0, Some(oracle_responses), &[])
+        TransactionTracker::new(
+            Timestamp::from(0),
+            0,
+            0,
+            0,
+            Some(oracle_responses),
+            &[],
+            vec![],
+        )
     }
 
     /// Creates a new [`TransactionTracker`] for testing, with default values and oracle responses

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -18,7 +18,10 @@ use linera_witty::{wit_export, Instance, RuntimeError};
 use tracing::log;
 
 use super::WasmExecutionError;
-use crate::{BaseRuntime, ContractRuntime, DataBlobHash, ExecutionError, ModuleId, ServiceRuntime};
+use crate::{
+    BaseRuntime, ContractRuntime, DataBlobHash, ExecutionError, ModuleId, OperationInput,
+    ServiceRuntime,
+};
 
 /// Common host data used as the `UserData` of the system API implementations.
 pub struct RuntimeApiData<Runtime> {
@@ -820,7 +823,16 @@ where
         caller
             .user_data_mut()
             .runtime
-            .schedule_operation(operation)
+            .schedule_operation(OperationInput::Direct(operation))
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
+    /// Schedules a composed operation to be included in the block being built by this query.
+    fn schedule_composed_operation(caller: &mut Caller) -> Result<(), RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .schedule_operation(OperationInput::Composed)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -26,7 +26,7 @@ use linera_execution::{
         RegisterMockApplication, SystemExecutionState,
     },
     BaseRuntime, ContractRuntime, ExecutionError, ExecutionStateActor, Message, MessageContext,
-    Operation, OperationContext, ResourceController, SystemExecutionStateView,
+    Operation, OperationContext, OperationInput, ResourceController, SystemExecutionStateView,
     TestExecutionRuntimeContext, TransactionOutcome, TransactionTracker,
 };
 use linera_views::context::MemoryContext;
@@ -84,7 +84,7 @@ async fn test_transfer_system_api(
     let mut controller = ResourceController::default();
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
     let mut tracker = TransactionTracker::new_replaying_blobs([
         app_desc_blob_id,
@@ -169,7 +169,7 @@ async fn test_unauthorized_transfer_system_api(
     let mut controller = ResourceController::default();
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
     let mut txn_tracker = TransactionTracker::new_replaying_blobs([
         app_desc_blob_id,
@@ -254,7 +254,7 @@ async fn test_claim_system_api(
     let mut controller = ResourceController::default();
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
     let mut tracker = TransactionTracker::new_replaying_blobs([
         app_desc_blob_id,
@@ -382,7 +382,7 @@ async fn test_unauthorized_claims(
     let mut controller = ResourceController::default();
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
     let mut tracker = TransactionTracker::new_replaying_blobs([
         app_desc_blob_id,
@@ -436,7 +436,7 @@ async fn test_read_chain_balance_system_api(chain_balance: Amount) {
     let mut controller = ResourceController::default();
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
 
     let mut txn_tracker = TransactionTracker::new_replaying_blobs([
@@ -480,7 +480,7 @@ async fn test_read_owner_balance_system_api(
     let mut controller = ResourceController::default();
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
 
     let mut txn_tracker = TransactionTracker::new_replaying_blobs(blobs);
@@ -514,7 +514,7 @@ async fn test_read_owner_balance_returns_zero_for_missing_accounts(missing_accou
     let mut controller = ResourceController::default();
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
 
     let mut txn_tracker = TransactionTracker::new_replaying_blobs(blobs);
@@ -555,7 +555,7 @@ async fn test_read_owner_balances_system_api(
     let mut controller = ResourceController::default();
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
 
     let mut txn_tracker = TransactionTracker::new_replaying_blobs(blobs);
@@ -596,7 +596,7 @@ async fn test_read_balance_owners_system_api(
     let mut controller = ResourceController::default();
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
 
     let mut txn_tracker = TransactionTracker::new_replaying_blobs(blobs);
@@ -827,7 +827,7 @@ async fn test_query_service(authorized_apps: Option<Vec<()>>) -> Result<(), Exec
     let mut controller = ResourceController::default();
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
 
     let mut txn_tracker = TransactionTracker::new_replaying(vec![
@@ -896,7 +896,7 @@ async fn test_perform_http_request(authorized_apps: Option<Vec<()>>) -> Result<(
     let mut controller = ResourceController::default();
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
 
     let mut txn_tracker = TransactionTracker::new_replaying(vec![
@@ -945,7 +945,7 @@ async fn test_create_multiple_data_blobs() -> anyhow::Result<()> {
     let mut controller = ResourceController::default();
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
 
     let mut tracker = TransactionTracker::new_replaying_blobs(blobs);
@@ -1007,7 +1007,7 @@ async fn test_publish_module_different_bytecode() -> anyhow::Result<()> {
     let mut controller = ResourceController::default();
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
 
     let mut tracker = TransactionTracker::new_replaying_blobs(blobs);
@@ -1082,7 +1082,7 @@ async fn test_callee_api_calls() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id: caller_id,
-                bytes: dummy_operation.clone(),
+                input: OperationInput::Direct(dummy_operation.clone()),
             },
         )
         .await
@@ -1130,7 +1130,7 @@ async fn test_change_ownership_system_api() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await?;
@@ -1172,7 +1172,7 @@ async fn test_unauthorized_change_ownership_system_api() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await;

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -18,7 +18,7 @@ use linera_execution::{
         SystemExecutionState,
     },
     BaseRuntime, ContractRuntime, ExecutionError, ExecutionStateActor, Message, MessageContext,
-    ResourceControlPolicy, ResourceController, ResourceTracker, TransactionTracker,
+    OperationInput, ResourceControlPolicy, ResourceController, ResourceTracker, TransactionTracker,
 };
 use test_case::test_case;
 
@@ -554,7 +554,7 @@ async fn test_free_app_operation_still_charged() -> anyhow::Result<()> {
             context,
             linera_execution::Operation::User {
                 application_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await?;

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -18,7 +18,7 @@ use linera_execution::{
         SystemExecutionState,
     },
     ExecutionRuntimeConfig, ExecutionRuntimeContext, ExecutionStateActor, Operation,
-    OperationContext, Query, QueryContext, QueryResponse, ResourceControlPolicy,
+    OperationContext, OperationInput, Query, QueryContext, QueryResponse, ResourceControlPolicy,
     ResourceController, ResourceTracker, TransactionTracker,
 };
 use linera_views::{context::Context as _, views::View};
@@ -122,7 +122,7 @@ async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
         let bytes = operation_to_bytes(&operation)?;
         let operation = Operation::User {
             application_id: app_id,
-            bytes,
+            input: OperationInput::Direct(bytes),
         };
         ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
             .execute_operation(operation_context, operation)
@@ -238,7 +238,7 @@ async fn test_terminate_execute_operation_by_lack_of_fuel() -> anyhow::Result<()
     let bytes = operation_to_bytes(&operation)?;
     let operation = Operation::User {
         application_id: app_id,
-        bytes,
+        input: OperationInput::Direct(bytes),
     };
     let result = ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
         .execute_operation(operation_context, operation)
@@ -415,7 +415,7 @@ async fn test_basic_evm_features() -> anyhow::Result<()> {
     let bytes = operation_to_bytes(&operation)?;
     let operation = Operation::User {
         application_id: app_id,
-        bytes,
+        input: OperationInput::Direct(bytes),
     };
     let result = ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
         .execute_operation(operation_context, operation)

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -22,8 +22,8 @@ use linera_execution::{
         SystemExecutionState,
     },
     BaseRuntime, ContractRuntime, ExecutionError, ExecutionRuntimeContext, ExecutionStateActor,
-    Message, Operation, OperationContext, OutgoingMessage, Query, QueryContext, QueryOutcome,
-    QueryResponse, ResourceController, SystemOperation, TransactionTracker,
+    Message, Operation, OperationContext, OperationInput, OutgoingMessage, Query, QueryContext,
+    QueryOutcome, QueryResponse, ResourceController, SystemOperation, TransactionTracker,
 };
 use linera_views::{batch::Batch, context::Context, views::View};
 use test_case::test_case;
@@ -56,7 +56,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id: *app_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await;
@@ -143,7 +143,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id: caller_id,
-                bytes: dummy_operation.clone(),
+                input: OperationInput::Direct(dummy_operation.clone()),
             },
         )
         .await
@@ -175,7 +175,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
             context,
             Query::User {
                 application_id: caller_id,
-                bytes: vec![]
+                bytes: vec![],
             },
             Some(&mut service_runtime_endpoint),
         )
@@ -192,7 +192,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
             context,
             Query::User {
                 application_id: caller_id,
-                bytes: vec![]
+                bytes: vec![],
             },
             Some(&mut service_runtime_endpoint),
         )
@@ -285,7 +285,7 @@ async fn test_simulated_session() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id: caller_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await?;
@@ -352,7 +352,7 @@ async fn test_simulated_session_leak() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id: caller_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await;
@@ -387,7 +387,7 @@ async fn test_rejecting_block_from_finalize() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id: id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await;
@@ -454,7 +454,7 @@ async fn test_rejecting_block_from_called_applications_finalize() -> anyhow::Res
             context,
             Operation::User {
                 application_id: first_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await;
@@ -585,7 +585,7 @@ async fn test_sending_message_from_finalize() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id: first_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await?;
@@ -634,7 +634,7 @@ async fn test_cross_application_call_from_finalize() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id: caller_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await;
@@ -687,7 +687,7 @@ async fn test_cross_application_call_from_finalize_of_called_application() -> an
             context,
             Operation::User {
                 application_id: caller_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await;
@@ -739,7 +739,7 @@ async fn test_calling_application_again_from_finalize() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id: caller_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await;
@@ -789,7 +789,7 @@ async fn test_cross_application_error() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id: caller_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await;
@@ -840,7 +840,7 @@ async fn test_simple_message() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await?;
@@ -907,7 +907,7 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id: caller_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await?;
@@ -988,7 +988,7 @@ async fn test_message_from_deeper_call() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id: caller_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await?;
@@ -1098,7 +1098,7 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
             context,
             Operation::User {
                 application_id: caller_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await?;
@@ -1204,7 +1204,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
     let mut controller = ResourceController::default();
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
     let mut txn_tracker = TransactionTracker::new(
         Timestamp::from(0),
@@ -1213,6 +1213,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
         0,
         Some(blob_oracle_responses(blobs.iter())),
         &[],
+        vec![],
     );
     ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
         .execute_operation(context, operation)
@@ -1291,7 +1292,7 @@ async fn test_close_chain() -> anyhow::Result<()> {
     let mut controller = ResourceController::default();
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
     let mut txn_tracker = TransactionTracker::new_replaying_blobs(blobs);
     ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
@@ -1317,7 +1318,7 @@ async fn test_close_chain() -> anyhow::Result<()> {
 
     let operation = Operation::User {
         application_id,
-        bytes: vec![],
+        input: OperationInput::Direct(vec![]),
     };
     let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
     ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
@@ -1440,7 +1441,7 @@ async fn test_read_application_description() -> anyhow::Result<()> {
             context,
             Operation::User {
                 application_id: caller_id,
-                bytes: vec![],
+                input: OperationInput::Direct(vec![]),
             },
         )
         .await?;

--- a/linera-rpc/tests/format.rs
+++ b/linera-rpc/tests/format.rs
@@ -17,7 +17,7 @@ use linera_chain::{
 use linera_core::{data_types::CrossChainRequest, node::NodeError, worker::Reason};
 use linera_execution::{
     system::{AdminOperation, SystemMessage, SystemOperation},
-    Message, MessageKind, Operation,
+    Message, MessageKind, Operation, OperationInput,
 };
 use linera_rpc::RpcMessage;
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
@@ -62,6 +62,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<AdminOperation>(&samples)?;
     tracer.trace_type::<SystemMessage>(&samples)?;
     tracer.trace_type::<Operation>(&samples)?;
+    tracer.trace_type::<OperationInput>(&samples)?;
     tracer.trace_type::<Message>(&samples)?;
     tracer.trace_type::<Transaction>(&samples)?;
     tracer.trace_type::<OriginalProposal>(&samples)?;

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -847,7 +847,15 @@ Operation:
         STRUCT:
           - application_id:
               TYPENAME: ApplicationId
-          - bytes: BYTES
+          - input:
+              TYPENAME: OperationInput
+OperationInput:
+  ENUM:
+    0:
+      Direct:
+        NEWTYPE: BYTES
+    1:
+      Composed: UNIT
 OperationResult:
   NEWTYPESTRUCT: BYTES
 OracleResponse:

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -19,7 +19,7 @@ use linera_chain::{
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
 };
 use linera_core::worker::WorkerError;
-use linera_execution::{system::SystemOperation, Operation, ResourceTracker};
+use linera_execution::{system::SystemOperation, Operation, OperationInput, ResourceTracker};
 
 use super::TestValidator;
 
@@ -159,20 +159,38 @@ impl BlockBuilder {
     {
         let operation = <Abi as ContractAbi>::serialize_operation(&operation)
             .expect("Failed to serialize `Operation` in BlockBuilder");
+        let operation = OperationInput::Direct(operation);
         self.with_raw_operation(application_id.forget_abi(), operation)
+    }
+
+    /// Adds a user composed `operation` to this block.
+    ///
+    /// The composed operation is being inserted and added to the block, marked to be executed
+    /// by `application`.
+    pub fn with_composed_operation<Abi>(&mut self, application_id: ApplicationId<Abi>) -> &mut Self
+    where
+        Abi: ContractAbi,
+    {
+        self.block
+            .transactions
+            .push(Transaction::ExecuteOperation(Operation::User {
+                application_id: application_id.forget_abi(),
+                input: OperationInput::Composed,
+            }));
+        self
     }
 
     /// Adds an already serialized user `operation` to this block.
     pub fn with_raw_operation(
         &mut self,
         application_id: ApplicationId,
-        operation: impl Into<Vec<u8>>,
+        input: OperationInput,
     ) -> &mut Self {
         self.block
             .transactions
             .push(Transaction::ExecuteOperation(Operation::User {
                 application_id,
-                bytes: operation.into(),
+                input,
             }));
         self
     }

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -770,9 +770,9 @@ impl ActiveChain {
                 match operation {
                     Operation::User {
                         application_id,
-                        bytes,
+                        input,
                     } => {
-                        block.with_raw_operation(application_id, bytes);
+                        block.with_raw_operation(application_id, input);
                     }
                     Operation::System(system_operation) => {
                         block.with_system_operation(*system_operation);

--- a/linera-sdk/wit/service-runtime-api.wit
+++ b/linera-sdk/wit/service-runtime-api.wit
@@ -2,6 +2,7 @@ package linera:app;
 
 interface service-runtime-api {
     schedule-operation: func(operation: list<u8>);
+    schedule-composed-operation: func();
     try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
     check-execution-time: func(fuel-consumed: u64);
 

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -80,7 +80,7 @@ mod types {
         manager::ChainManager,
     };
     pub use linera_core::worker::{Notification, Reason};
-    pub use linera_execution::{Message, MessageKind, Operation, SystemOperation};
+    pub use linera_execution::{Message, MessageKind, Operation, OperationInput, SystemOperation};
 }
 
 pub use types::*;
@@ -569,20 +569,23 @@ mod from {
                             )
                         })?;
 
-                        // Convert hex string to bytes
-                        let bytes = hex::decode(bytes_hex).map_err(|_| {
-                            ConversionError::UnexpectedCertificateType(
-                                "Invalid hex in user_bytes_hex".to_string(),
-                            )
-                        })?;
-
                         Operation::User {
                             application_id: application_id.parse().map_err(|_| {
                                 ConversionError::UnexpectedCertificateType(
                                     "Invalid application_id format".to_string(),
                                 )
                             })?,
-                            bytes,
+                            input: if bytes_hex == "composed" {
+                                OperationInput::Composed
+                            } else {
+                                // Convert hex string to bytes
+                                let bytes = hex::decode(&bytes_hex).map_err(|_| {
+                                    ConversionError::UnexpectedCertificateType(
+                                        "Invalid hex in user_bytes_hex".to_string(),
+                                    )
+                                })?;
+                                OperationInput::Direct(bytes)
+                            },
                         }
                     }
                     _ => {

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -59,7 +59,7 @@ use linera_core::{
     worker::Reason,
     JoinSetExt as _, LocalNodeError,
 };
-use linera_execution::{committee::Committee, Operation};
+use linera_execution::{committee::Committee, Operation, OperationInput};
 use linera_faucet_server::{FaucetConfig, FaucetService};
 #[cfg(with_metrics)]
 use linera_metrics::monitoring_server;
@@ -1623,7 +1623,7 @@ impl Runnable for Job {
                     .context("invalid hex for operation bytes")?;
                 let user_operation = Operation::User {
                     application_id,
-                    bytes,
+                    input: OperationInput::Direct(bytes),
                 };
                 let mut context = options
                     .create_client_context(storage, wallet, keystore)

--- a/linera-service/src/controller.rs
+++ b/linera-service/src/controller.rs
@@ -161,7 +161,7 @@ where
                     .expect("bcs bytes");
                     let operation = linera_execution::Operation::User {
                         application_id: self.controller_id,
-                        bytes,
+                        input: linera_execution::OperationInput::Direct(bytes),
                     };
                     if let Err(e) = self
                         .chain_client
@@ -370,7 +370,7 @@ where
             bcs::to_bytes(&Operation::ExecuteWorkerCommand { owner, command }).expect("bcs bytes");
         let operation = linera_execution::Operation::User {
             application_id: self.controller_id,
-            bytes,
+            input: linera_execution::OperationInput::Direct(bytes),
         };
         if let Err(e) = self
             .chain_client


### PR DESCRIPTION
## Motivation

Due to the control of the order of the operations by the signer of the blocks, the signer can choose the return of one operation to be the input of the next one.

Fixes #2037 

## Proposal

The idea is simply to introduce a
```rust
enum OperationInput {
  Composed,
  Direct(Vec<u8>),
}
```

with `Direct` being the previous mechanism. Since the `BlockTracker` has all the needed data, this works fine.

Where some problems occur is with the typed operations of Wasm smart contracts. We could introduce an `OperationInput` taking a typed input. But this introduces a number of type complications, and the method instead is to have two functions:
```rust
schedule_operation(A::Oeration)
schedule_composed_operation()
```

And so we get a relatively simple 

## Test Plan

The CI.
One test uses the `Counter` example which was modified to return a `CounterOperation` and so to be composed.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.