### PR TITLE
Extend the support of GraphQLMutationRoot to structs

### DIFF
--- a/examples/counter-no-graphql/src/contract.rs
+++ b/examples/counter-no-graphql/src/contract.rs
@@ -47,8 +47,7 @@ impl Contract for CounterContract {
 
     async fn execute_operation(&mut self, operation: CounterOperation) -> u64 {
         let previous_value = self.state.value.get();
-        let CounterOperation::Increment(value) = operation;
-        let new_value = previous_value + value;
+        let new_value = previous_value + operation.increment;
         self.state.value.set(new_value);
         new_value
     }
@@ -75,7 +74,7 @@ mod tests {
         let mut counter = create_and_instantiate_counter(initial_value);
 
         let increment = 42_308_u64;
-        let operation = CounterOperation::Increment(increment);
+        let operation = CounterOperation { increment };
 
         let response = counter
             .execute_operation(operation)
@@ -106,7 +105,7 @@ mod tests {
         let mut counter = create_and_instantiate_counter(initial_value);
 
         let increment = 8_u64;
-        let operation = CounterOperation::Increment(increment);
+        let operation = CounterOperation { increment };
 
         let response = counter
             .execute_operation(operation)

--- a/examples/counter-no-graphql/src/lib.rs
+++ b/examples/counter-no-graphql/src/lib.rs
@@ -25,6 +25,6 @@ pub enum CounterRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum CounterOperation {
-    Increment(u64),
+pub struct CounterOperation {
+    pub increment: u64,
 }

--- a/examples/counter-no-graphql/src/service.rs
+++ b/examples/counter-no-graphql/src/service.rs
@@ -49,8 +49,8 @@ impl Service for CounterService {
 
         match request {
             CounterRequest::Query => *self.state.value.get(),
-            CounterRequest::Increment(value) => {
-                let operation = CounterOperation::Increment(value);
+            CounterRequest::Increment(increment) => {
+                let operation = CounterOperation { increment };
                 self.runtime.schedule_operation(&operation);
                 0
             }

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -87,9 +87,7 @@ query {
 ```
 - To increase the value of the counter by 3, perform the `increment` operation.
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APPLICATION_ID
-mutation Increment {
-  increment(field0: 3)
-}
+mutation { counterOperation(increment: 3) }
 ```
 - Running the query again would yield `4`.
 

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -46,8 +46,7 @@ impl Contract for CounterContract {
     }
 
     async fn execute_operation(&mut self, operation: CounterOperation) -> u64 {
-        let CounterOperation::Increment(operation) = operation;
-        let new_value = self.state.value.get() + operation;
+        let new_value = self.state.value.get() + operation.increment;
         self.state.value.set(new_value);
         new_value
     }
@@ -75,7 +74,7 @@ mod tests {
         let mut counter = create_and_instantiate_counter(initial_value);
 
         let increment = 42_308_u64;
-        let operation = CounterOperation::Increment(increment);
+        let operation = CounterOperation { increment };
 
         let response = counter
             .execute_operation(operation)
@@ -106,7 +105,7 @@ mod tests {
         let mut counter = create_and_instantiate_counter(initial_value);
 
         let increment = 8_u64;
-        let operation = CounterOperation::Increment(increment);
+        let operation = CounterOperation { increment };
 
         let response = counter
             .execute_operation(operation)

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -13,9 +13,9 @@ use serde::{Deserialize, Serialize};
 pub struct CounterAbi;
 
 #[derive(Debug, Deserialize, Serialize, GraphQLMutationRoot)]
-pub enum CounterOperation {
-    /// Increment the counter by the given value
-    Increment(u64),
+pub struct CounterOperation {
+    /// The value to increment the counter by
+    pub increment: u64,
 }
 
 impl ContractAbi for CounterAbi {

--- a/examples/counter/tests/single_chain.rs
+++ b/examples/counter/tests/single_chain.rs
@@ -24,7 +24,7 @@ async fn single_chain_test() {
         .await;
 
     let increment = 15u64;
-    let operation = CounterOperation::Increment(increment);
+    let operation = CounterOperation { increment };
     chain
         .add_block(|block| {
             block.with_operation(application_id, operation);

--- a/examples/create-and-call/src/contract.rs
+++ b/examples/create-and-call/src/contract.rs
@@ -72,7 +72,9 @@ impl Contract for CreateAndCallContract {
         assert_eq!(value, 0);
 
         // Step 4: Call the contract with counter increment operation
-        let counter_operation = CounterOperation { increment: operation.increment };
+        let counter_operation = CounterOperation {
+            increment: operation.increment,
+        };
         self.runtime
             .call_application(true, application_id, &counter_operation)
     }

--- a/examples/create-and-call/src/lib.rs
+++ b/examples/create-and-call/src/lib.rs
@@ -25,6 +25,9 @@ pub enum CreateAndCallRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum CreateAndCallOperation {
-    CreateAndCall(Vec<u8>, Vec<u8>, u64, u64),
+pub struct CreateAndCallOperation {
+    pub contract_bytes: Vec<u8>,
+    pub service_bytes: Vec<u8>,
+    pub initial_value: u64,
+    pub increment: u64,
 }

--- a/examples/create-and-call/src/service.rs
+++ b/examples/create-and-call/src/service.rs
@@ -45,13 +45,13 @@ impl Service for CreateAndCallService {
                 self.runtime
                     .query_application(application_id, &counter_request)
             }
-            CreateAndCallRequest::CreateAndCall(bytecode, calldata, initial_value, increment) => {
-                let operation = CreateAndCallOperation::CreateAndCall(
-                    bytecode,
-                    calldata,
+            CreateAndCallRequest::CreateAndCall(contract_bytes, service_bytes, initial_value, increment) => {
+                let operation = CreateAndCallOperation {
+                    contract_bytes,
+                    service_bytes,
                     initial_value,
                     increment,
-                );
+                };
                 self.runtime.schedule_operation(&operation);
                 0
             }

--- a/examples/create-and-call/src/service.rs
+++ b/examples/create-and-call/src/service.rs
@@ -45,7 +45,12 @@ impl Service for CreateAndCallService {
                 self.runtime
                     .query_application(application_id, &counter_request)
             }
-            CreateAndCallRequest::CreateAndCall(contract_bytes, service_bytes, initial_value, increment) => {
+            CreateAndCallRequest::CreateAndCall(
+                contract_bytes,
+                service_bytes,
+                initial_value,
+                increment,
+            ) => {
                 let operation = CreateAndCallOperation {
                     contract_bytes,
                     service_bytes,

--- a/examples/create-and-call/tests/test_create_and_call.rs
+++ b/examples/create-and-call/tests/test_create_and_call.rs
@@ -39,14 +39,14 @@ async fn test_create_and_call() {
 
     // Step 3: Call the CreateAndCall operation with the counter bytecode,
     // initialization value of 43, and increment of 5
-    let initialization_value = 43;
-    let increment_value = 5;
-    let create_and_call_operation = create_and_call::CreateAndCallOperation::CreateAndCall(
-        counter_contract_bytes,
-        counter_service_bytes,
-        initialization_value,
-        increment_value,
-    );
+    let initial_value = 43;
+    let increment = 5;
+    let create_and_call_operation = create_and_call::CreateAndCallOperation {
+        contract_bytes: counter_contract_bytes,
+        service_bytes: counter_service_bytes,
+        initial_value,
+        increment,
+    };
 
     chain
         .add_block(|block| {

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -92,10 +92,10 @@ impl Contract for MetaCounterContract {
             Message::Fail => {
                 panic!("Message failed intentionally");
             }
-            Message::Increment(value) => {
+            Message::Increment(increment) => {
                 let counter_id = self.counter_id();
-                log::trace!("executing {} via {:?}", value, counter_id);
-                let operation = counter::CounterOperation::Increment(value);
+                log::trace!("executing {} via {:?}", increment, counter_id);
+                let operation = counter::CounterOperation { increment };
                 self.runtime.call_application(true, counter_id, &operation);
             }
         }

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -165,7 +165,7 @@ where
         .unwrap_ok_committed();
 
     let increment = 5_u64;
-    let counter_operation = counter::CounterOperation::Increment(increment);
+    let counter_operation = counter::CounterOperation { increment };
     creator
         .execute_operation(Operation::user(application_id, &counter_operation)?)
         .await
@@ -884,7 +884,7 @@ async fn test_memory_fuel_limit(wasm_runtime: WasmRuntime) -> anyhow::Result<()>
         .unwrap_ok_committed();
 
     let increment = 5_u64;
-    let operation = counter::CounterOperation::Increment(increment);
+    let operation = counter::CounterOperation { increment };
     publisher
         .execute_operation(Operation::user(application_id, &operation)?)
         .await

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -252,7 +252,7 @@ where
 
     // Execute an application operation
     let increment = 5_u64;
-    let counter_operation = counter::CounterOperation::Increment(increment);
+    let counter_operation = counter::CounterOperation { increment };
     let user_operation = bcs::to_bytes(&counter_operation)?;
     let run_block = make_child_block(&create_certificate.into_value())
         .with_timestamp(3)

--- a/linera-sdk-derive/src/lib.rs
+++ b/linera-sdk-derive/src/lib.rs
@@ -8,7 +8,7 @@ mod utils;
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
 use syn::{
-    parse_macro_input, Fields, ItemEnum,
+    parse_macro_input, Fields, ItemEnum, ItemStruct, Data, DeriveInput,
     __private::{quote::quote, TokenStream2},
 };
 
@@ -16,17 +16,49 @@ use crate::utils::{concat, snakify};
 
 #[proc_macro_derive(GraphQLMutationRoot)]
 pub fn derive_mutation_root(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as ItemEnum);
-    generate_mutation_root_code(input, "linera_sdk").into()
+    let input = parse_macro_input!(input as DeriveInput);
+    generate_mutation_root_code_dispatch(input, "linera_sdk").into()
 }
 
 #[proc_macro_derive(GraphQLMutationRootInCrate)]
 pub fn derive_mutation_root_in_crate(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as ItemEnum);
-    generate_mutation_root_code(input, "crate").into()
+    let input = parse_macro_input!(input as DeriveInput);
+    generate_mutation_root_code_dispatch(input, "crate").into()
 }
 
-fn generate_mutation_root_code(input: ItemEnum, crate_root: &str) -> TokenStream2 {
+fn generate_mutation_root_code_dispatch(input: DeriveInput, crate_root: &str) -> TokenStream2 {
+    match input.data {
+        Data::Enum(data_enum) => {
+            let item_enum = ItemEnum {
+                attrs: input.attrs,
+                vis: input.vis,
+                enum_token: data_enum.enum_token,
+                ident: input.ident,
+                generics: input.generics,
+                brace_token: data_enum.brace_token,
+                variants: data_enum.variants,
+            };
+            generate_mutation_root_code_for_enum(item_enum, crate_root)
+        }
+        Data::Struct(data_struct) => {
+            let item_struct = ItemStruct {
+                attrs: input.attrs,
+                vis: input.vis,
+                struct_token: data_struct.struct_token,
+                ident: input.ident,
+                generics: input.generics,
+                fields: data_struct.fields,
+                semi_token: data_struct.semi_token,
+            };
+            generate_mutation_root_code_for_struct(item_struct, crate_root)
+        }
+        Data::Union(_) => {
+            panic!("GraphQLMutationRoot can only be derived for enums and structs, not unions")
+        }
+    }
+}
+
+fn generate_mutation_root_code_for_enum(input: ItemEnum, crate_root: &str) -> TokenStream2 {
     let crate_root = Ident::new(crate_root, Span::call_site());
     let enum_name = input.ident;
     let mutation_root_name = concat(&enum_name, "MutationRoot");
@@ -127,11 +159,110 @@ fn generate_mutation_root_code(input: ItemEnum, crate_root: &str) -> TokenStream
     }
 }
 
+fn generate_mutation_root_code_for_struct(input: ItemStruct, crate_root: &str) -> TokenStream2 {
+    let crate_root = Ident::new(crate_root, Span::call_site());
+    let struct_name = &input.ident;
+    let mutation_root_name = concat(struct_name, "MutationRoot");
+    
+    // Convert struct name to snake_case for the method name
+    let method_name = snakify(struct_name);
+    
+    let method = match input.fields {
+        Fields::Named(named) => {
+            let mut fields = vec![];
+            let mut field_names = vec![];
+            for field in named.named {
+                let name = field.ident.expect("named fields always have names");
+                let ty = field.ty;
+                fields.push(quote! {#name: #ty});
+                field_names.push(name);
+            }
+            quote! {
+                async fn #method_name(&self, #(#fields,)*) -> [u8; 0] {
+                    let operation = #struct_name {
+                        #(#field_names,)*
+                    };
+
+                    self.runtime.schedule_operation(&operation);
+
+                    []
+                }
+            }
+        }
+        Fields::Unnamed(unnamed) => {
+            let mut fields = vec![];
+            let mut field_names = vec![];
+            for (i, field) in unnamed.unnamed.iter().enumerate() {
+                let name = concat(&syn::parse_str::<Ident>("field").unwrap(), &i.to_string());
+                let ty = &field.ty;
+                fields.push(quote! {#name: #ty});
+                field_names.push(name);
+            }
+            quote! {
+                async fn #method_name(&self, #(#fields,)*) -> [u8; 0] {
+                    let operation = #struct_name(
+                        #(#field_names,)*
+                    );
+
+                    self.runtime.schedule_operation(&operation);
+
+                    []
+                }
+            }
+        }
+        Fields::Unit => {
+            quote! {
+                async fn #method_name(&self) -> [u8; 0] {
+                    let operation = #struct_name;
+
+                    self.runtime.schedule_operation(&operation);
+
+                    []
+                }
+            }
+        }
+    };
+
+    quote! {
+        /// Mutation root
+        pub struct #mutation_root_name<Application>
+        where
+            Application: #crate_root::Service,
+            #crate_root::ServiceRuntime<Application>: Send + Sync,
+        {
+            runtime: ::std::sync::Arc<#crate_root::ServiceRuntime<Application>>,
+        }
+
+        #[async_graphql::Object]
+        impl<Application> #mutation_root_name<Application>
+        where
+            Application: #crate_root::Service,
+            #crate_root::ServiceRuntime<Application>: Send + Sync,
+        {
+            #method
+        }
+
+        impl<Application> #crate_root::graphql::GraphQLMutationRoot<Application> for #struct_name
+        where
+            Application: #crate_root::Service,
+            #crate_root::ServiceRuntime<Application>: Send + Sync,
+        {
+            type MutationRoot = #mutation_root_name<Application>;
+
+            fn mutation_root(
+                runtime: ::std::sync::Arc<#crate_root::ServiceRuntime<Application>>,
+            ) -> Self::MutationRoot {
+                #mutation_root_name { runtime }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
-    use syn::{parse_quote, ItemEnum, __private::quote::quote};
+    use syn::{parse_quote, ItemEnum, ItemStruct, __private::quote::quote};
 
-    use crate::generate_mutation_root_code;
+    use crate::{generate_mutation_root_code_for_enum, generate_mutation_root_code_for_struct};
 
     fn assert_eq_no_whitespace(mut actual: String, mut expected: String) {
         // Intentionally left here for debugging purposes
@@ -156,7 +287,7 @@ pub mod tests {
             }
         };
 
-        let output = generate_mutation_root_code(operation, "linera_sdk");
+        let output = generate_mutation_root_code_for_enum(operation, "linera_sdk");
 
         let expected = quote! {
             /// Mutation root
@@ -188,6 +319,109 @@ pub mod tests {
 
                 async fn empty_variant(&self) -> [u8; 0] {
                     let operation = SomeOperation::EmptyVariant;
+                    self.runtime.schedule_operation(&operation);
+                    []
+                }
+            }
+
+            impl<Application> linera_sdk::graphql::GraphQLMutationRoot<Application>
+                for SomeOperation
+            where
+                Application: linera_sdk::Service,
+                linera_sdk::ServiceRuntime<Application>: Send + Sync,
+            {
+                type MutationRoot = SomeOperationMutationRoot<Application>;
+
+                fn mutation_root(
+                    runtime: ::std::sync::Arc<linera_sdk::ServiceRuntime<Application>>,
+                ) -> Self::MutationRoot {
+                    SomeOperationMutationRoot { runtime }
+                }
+            }
+        };
+
+        assert_eq_no_whitespace(output.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn test_derive_mutation_root_struct() {
+        let operation: ItemStruct = parse_quote! {
+            struct SomeOperation {
+                a: u32,
+                b: String,
+            }
+        };
+
+        let output = generate_mutation_root_code_for_struct(operation, "linera_sdk");
+
+        let expected = quote! {
+            /// Mutation root
+            pub struct SomeOperationMutationRoot<Application>
+            where
+                Application: linera_sdk::Service,
+                linera_sdk::ServiceRuntime<Application>: Send + Sync,
+            {
+                runtime: ::std::sync::Arc<linera_sdk::ServiceRuntime<Application>>,
+            }
+
+            #[async_graphql::Object]
+            impl<Application> SomeOperationMutationRoot<Application>
+            where
+                Application: linera_sdk::Service,
+                linera_sdk::ServiceRuntime<Application>: Send + Sync,
+            {
+                async fn some_operation(&self, a: u32, b: String,) -> [u8; 0] {
+                    let operation = SomeOperation { a, b, };
+                    self.runtime.schedule_operation(&operation);
+                    []
+                }
+            }
+
+            impl<Application> linera_sdk::graphql::GraphQLMutationRoot<Application>
+                for SomeOperation
+            where
+                Application: linera_sdk::Service,
+                linera_sdk::ServiceRuntime<Application>: Send + Sync,
+            {
+                type MutationRoot = SomeOperationMutationRoot<Application>;
+
+                fn mutation_root(
+                    runtime: ::std::sync::Arc<linera_sdk::ServiceRuntime<Application>>,
+                ) -> Self::MutationRoot {
+                    SomeOperationMutationRoot { runtime }
+                }
+            }
+        };
+
+        assert_eq_no_whitespace(output.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn test_derive_mutation_root_unit_struct() {
+        let operation: ItemStruct = parse_quote! {
+            struct SomeOperation;
+        };
+
+        let output = generate_mutation_root_code_for_struct(operation, "linera_sdk");
+
+        let expected = quote! {
+            /// Mutation root
+            pub struct SomeOperationMutationRoot<Application>
+            where
+                Application: linera_sdk::Service,
+                linera_sdk::ServiceRuntime<Application>: Send + Sync,
+            {
+                runtime: ::std::sync::Arc<linera_sdk::ServiceRuntime<Application>>,
+            }
+
+            #[async_graphql::Object]
+            impl<Application> SomeOperationMutationRoot<Application>
+            where
+                Application: linera_sdk::Service,
+                linera_sdk::ServiceRuntime<Application>: Send + Sync,
+            {
+                async fn some_operation(&self) -> [u8; 0] {
+                    let operation = SomeOperation;
                     self.runtime.schedule_operation(&operation);
                     []
                 }

--- a/linera-sdk-derive/src/lib.rs
+++ b/linera-sdk-derive/src/lib.rs
@@ -8,7 +8,7 @@ mod utils;
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
 use syn::{
-    parse_macro_input, Fields, ItemEnum, ItemStruct, Data, DeriveInput,
+    parse_macro_input, Data, DeriveInput, Fields, ItemEnum, ItemStruct,
     __private::{quote::quote, TokenStream2},
 };
 
@@ -163,10 +163,10 @@ fn generate_mutation_root_code_for_struct(input: ItemStruct, crate_root: &str) -
     let crate_root = Ident::new(crate_root, Span::call_site());
     let struct_name = &input.ident;
     let mutation_root_name = concat(struct_name, "MutationRoot");
-    
+
     // Convert struct name to snake_case for the method name
     let method_name = snakify(struct_name);
-    
+
     let method = match input.fields {
         Fields::Named(named) => {
             let mut fields = vec![];

--- a/linera-service/tests/fixtures/evm_call_wasm_example_counter.sol
+++ b/linera-service/tests/fixtures/evm_call_wasm_example_counter.sol
@@ -19,17 +19,11 @@ contract ExampleCallWasmCounter {
     }
 
     struct CounterOperation {
-        uint8 choice;
-        // choice=0 corresponds to Increment
         uint64 increment;
     }
 
     function bcs_serialize_CounterOperation(CounterOperation memory input) internal pure returns (bytes memory) {
-        bytes memory result = abi.encodePacked(input.choice);
-        if (input.choice == 0) {
-            return abi.encodePacked(result, bcs_serialize_uint64(input.increment));
-        }
-        return result;
+        return bcs_serialize_uint64(input.increment);
     }
 
     struct CounterRequest {
@@ -129,7 +123,7 @@ contract ExampleCallWasmCounter {
 
     function nest_increment(uint64 input1) external returns (uint64) {
         address precompile = address(0x0b);
-        CounterOperation memory input2 = CounterOperation({choice: 0, increment: input1});
+        CounterOperation memory input2 = CounterOperation({increment: input1});
         bytes memory input3 = bcs_serialize_CounterOperation(input2);
         bytes memory return1 = Linera.try_call_application(universal_address, input3);
         uint64 return2 = bcs_deserialize_uint64(return1);

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -1521,7 +1521,7 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()
     let balance2 = node_service.balance(&account_chain).await?;
     assert_eq!(balance1, balance2);
 
-    let mutation = format!("increment(field0: {increment})");
+    let mutation = format!("counterOperation(increment: {increment})");
     application.mutate(mutation).await?;
     let balance3 = node_service.balance(&account_chain).await?;
     assert!(balance3 < balance2);
@@ -1778,7 +1778,7 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
     let counter_value: u64 = application.query_json("value").await?;
     assert_eq!(counter_value, original_counter_value);
 
-    let mutation = format!("increment(field0: {increment})");
+    let mutation = format!("counterOperation(increment: {increment})");
     application.mutate(mutation).await?;
 
     let counter_value: u64 = application.query_json("value").await?;


### PR DESCRIPTION
## Motivation

The `GraphQLMutationRoot` works only for enums. There are other inputs where it uses a struct.

Fixes #2534 

## Proposal

The code is coded via Claude.

## Test Plan

The CI.
The `Operation` input type is corrected for `counter`, `counter-no-graphql`, and `create-and-call`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None