### PR TITLE
Make execution state actor borrow txn tracker & resource controller.

### DIFF
--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -12,9 +12,9 @@ use linera_base::{
     identifiers::{AccountOwner, BlobId, ChainId, StreamId},
 };
 use linera_execution::{
-    ExecutionRuntimeContext, ExecutionStateView, MessageContext, OperationContext, OutgoingMessage,
-    ResourceController, ResourceTracker, SystemExecutionStateView, TransactionOutcome,
-    TransactionTracker,
+    execution_state_actor::ExecutionStateActor, ExecutionRuntimeContext, ExecutionStateView,
+    MessageContext, OperationContext, OutgoingMessage, ResourceController, ResourceTracker,
+    SystemExecutionStateView, TransactionOutcome, TransactionTracker,
 };
 use linera_views::context::Context;
 
@@ -144,14 +144,11 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                     authenticated_signer: self.authenticated_signer,
                     timestamp: self.timestamp,
                 };
-                Box::pin(chain.execute_operation(
-                    context,
-                    operation.clone(),
-                    &mut txn_tracker,
-                    self.resource_controller_mut(),
-                ))
-                .await
-                .with_execution_context(chain_execution_context)?;
+                let mut actor =
+                    ExecutionStateActor::new(chain, &mut txn_tracker, self.resource_controller);
+                Box::pin(actor.execute_operation(context, operation.clone()))
+                    .await
+                    .with_execution_context(chain_execution_context)?;
                 self.resource_controller_mut()
                     .with_state(&mut chain.system)
                     .await?
@@ -213,17 +210,17 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                 // Once a chain is closed, accepting incoming messages is not allowed.
                 ensure!(!chain.system.closed.get(), ChainError::ClosedChain);
 
-                Box::pin(chain.execute_message(
+                let mut actor =
+                    ExecutionStateActor::new(chain, txn_tracker, self.resource_controller);
+                Box::pin(actor.execute_message(
                     context,
                     posted_message.message.clone(),
                     (grant > Amount::ZERO).then_some(&mut grant),
-                    txn_tracker,
-                    self.resource_controller_mut(),
                 ))
                 .await
                 .with_execution_context(chain_execution_context)?;
-                chain
-                    .send_refund(context, grant, txn_tracker)
+                actor
+                    .send_refund(context, grant)
                     .await
                     .with_execution_context(chain_execution_context)?;
             }
@@ -238,16 +235,18 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                         posted_message: Box::new(posted_message.clone()),
                     }
                 );
+                let mut actor =
+                    ExecutionStateActor::new(chain, txn_tracker, self.resource_controller);
                 if posted_message.is_tracked() {
                     // Bounce the message.
-                    chain
-                        .bounce_message(context, grant, posted_message.message.clone(), txn_tracker)
+                    actor
+                        .bounce_message(context, grant, posted_message.message.clone())
                         .await
                         .with_execution_context(ChainExecutionContext::Block)?;
                 } else {
                     // Nothing to do except maybe refund the grant.
-                    chain
-                        .send_refund(context, grant, txn_tracker)
+                    actor
+                        .send_refund(context, grant)
                         .await
                         .with_execution_context(ChainExecutionContext::Block)?;
                 }

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -27,8 +27,9 @@ use linera_chain::{
     types::ConfirmedBlock,
 };
 use linera_execution::{
-    system::SystemOperation, test_utils::SystemExecutionState, ExecutionRuntimeContext, Operation,
-    OperationContext, ResourceController, TransactionTracker, WasmContractModule, WasmRuntime,
+    system::SystemOperation, test_utils::SystemExecutionState, ExecutionRuntimeContext,
+    ExecutionStateActor, Operation, OperationContext, ResourceController, TransactionTracker,
+    WasmContractModule, WasmRuntime,
 };
 use linera_storage::{DbStorage, Storage};
 #[cfg(feature = "dynamodb")]
@@ -268,22 +269,21 @@ where
         timestamp: Timestamp::from(3),
     };
     let mut controller = ResourceController::default();
-    creator_state
+    let mut txn_tracker = TransactionTracker::new(
+        Timestamp::from(3),
+        0,
+        0,
+        0,
+        Some(vec![OracleResponse::Blob(application_description_blob_id)]),
+        &[],
+    );
+    ExecutionStateActor::new(&mut creator_state, &mut txn_tracker, &mut controller)
         .execute_operation(
             operation_context,
             Operation::User {
                 application_id,
                 bytes: user_operation,
             },
-            &mut TransactionTracker::new(
-                Timestamp::from(3),
-                0,
-                0,
-                0,
-                Some(vec![OracleResponse::Blob(application_description_blob_id)]),
-                &[],
-            ),
-            &mut controller,
         )
         .await?;
     creator_state.system.timestamp.set(Timestamp::from(3));

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -1,15 +1,12 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    vec,
-};
+use std::vec;
 
 use futures::{FutureExt, StreamExt};
 use linera_base::{
-    data_types::{Amount, BlockHeight, StreamUpdate},
-    identifiers::{Account, AccountOwner, StreamId},
+    data_types::{BlockHeight, StreamUpdate},
+    identifiers::{AccountOwner, StreamId},
 };
 use linera_views::{
     context::Context,
@@ -32,10 +29,10 @@ use {
 use super::{execution_state_actor::ExecutionRequest, runtime::ServiceRuntimeRequest};
 use crate::{
     execution_state_actor::ExecutionStateActor, resources::ResourceController,
-    system::SystemExecutionStateView, ApplicationDescription, ApplicationId, ContractSyncRuntime,
-    ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message, MessageContext,
-    MessageKind, Operation, OperationContext, OutgoingMessage, ProcessStreamsContext, Query,
-    QueryContext, QueryOutcome, ServiceSyncRuntime, SystemMessage, Timestamp, TransactionTracker,
+    system::SystemExecutionStateView, ApplicationDescription, ApplicationId, ExecutionError,
+    ExecutionRuntimeConfig, ExecutionRuntimeContext, MessageContext, OperationContext,
+    ProcessStreamsContext, Query, QueryContext, QueryOutcome, ServiceSyncRuntime, Timestamp,
+    TransactionTracker,
 };
 
 /// A view accessing the execution state of a chain.
@@ -134,15 +131,9 @@ where
             &[],
         );
         txn_tracker.add_created_blob(blob);
-        self.run_user_action(
-            application_id,
-            action,
-            context.refund_grant_to(),
-            None,
-            &mut txn_tracker,
-            &mut resource_controller,
-        )
-        .await?;
+        ExecutionStateActor::new(self, &mut txn_tracker, &mut resource_controller)
+            .run_user_action(application_id, action, context.refund_grant_to(), None)
+            .await?;
 
         Ok(())
     }
@@ -198,215 +189,6 @@ where
     C: Context + Clone + Send + Sync + 'static,
     C::Extra: ExecutionRuntimeContext,
 {
-    async fn run_user_action(
-        &mut self,
-        application_id: ApplicationId,
-        action: UserAction,
-        refund_grant_to: Option<Account>,
-        grant: Option<&mut Amount>,
-        txn_tracker: &mut TransactionTracker,
-        resource_controller: &mut ResourceController<Option<AccountOwner>>,
-    ) -> Result<(), ExecutionError> {
-        let ExecutionRuntimeConfig {} = self.context().extra().execution_runtime_config();
-        self.run_user_action_with_runtime(
-            application_id,
-            action,
-            refund_grant_to,
-            grant,
-            txn_tracker,
-            resource_controller,
-        )
-        .await
-    }
-
-    async fn run_user_action_with_runtime(
-        &mut self,
-        application_id: ApplicationId,
-        action: UserAction,
-        refund_grant_to: Option<Account>,
-        grant: Option<&mut Amount>,
-        txn_tracker: &mut TransactionTracker,
-        resource_controller: &mut ResourceController<Option<AccountOwner>>,
-    ) -> Result<(), ExecutionError> {
-        let chain_id = self.context().extra().chain_id();
-        let mut cloned_grant = grant.as_ref().map(|x| **x);
-        let initial_balance = resource_controller
-            .with_state_and_grant(&mut self.system, cloned_grant.as_mut())
-            .await?
-            .balance()?;
-        let controller = ResourceController::new(
-            resource_controller.policy().clone(),
-            resource_controller.tracker,
-            initial_balance,
-        );
-        let (execution_state_sender, mut execution_state_receiver) =
-            futures::channel::mpsc::unbounded();
-
-        let mut actor = ExecutionStateActor::new(self, txn_tracker, resource_controller);
-        let (code, description) = actor.load_contract(application_id).await?;
-
-        let contract_runtime_task = linera_base::task::Blocking::spawn(move |mut codes| {
-            let runtime = ContractSyncRuntime::new(
-                execution_state_sender,
-                chain_id,
-                refund_grant_to,
-                controller,
-                &action,
-            );
-
-            async move {
-                let code = codes.next().await.expect("we send this immediately below");
-                runtime.preload_contract(application_id, code, description)?;
-                runtime.run_action(application_id, chain_id, action)
-            }
-        })
-        .await;
-
-        contract_runtime_task.send(code)?;
-
-        while let Some(request) = execution_state_receiver.next().await {
-            actor.handle_request(request).await?;
-        }
-
-        let (result, controller) = contract_runtime_task.join().await?;
-
-        txn_tracker.add_operation_result(result);
-
-        resource_controller
-            .with_state_and_grant(&mut self.system, grant)
-            .await?
-            .merge_balance(initial_balance, controller.balance()?)?;
-        resource_controller.tracker = controller.tracker;
-
-        Ok(())
-    }
-
-    pub async fn execute_operation(
-        &mut self,
-        context: OperationContext,
-        operation: Operation,
-        txn_tracker: &mut TransactionTracker,
-        resource_controller: &mut ResourceController<Option<AccountOwner>>,
-    ) -> Result<(), ExecutionError> {
-        assert_eq!(context.chain_id, self.context().extra().chain_id());
-        match operation {
-            Operation::System(op) => {
-                let new_application = self
-                    .system
-                    .execute_operation(context, *op, txn_tracker, resource_controller)
-                    .await?;
-                if let Some((application_id, argument)) = new_application {
-                    let user_action = UserAction::Instantiate(context, argument);
-                    self.run_user_action(
-                        application_id,
-                        user_action,
-                        context.refund_grant_to(),
-                        None,
-                        txn_tracker,
-                        resource_controller,
-                    )
-                    .await?;
-                }
-            }
-            Operation::User {
-                application_id,
-                bytes,
-            } => {
-                self.run_user_action(
-                    application_id,
-                    UserAction::Operation(context, bytes),
-                    context.refund_grant_to(),
-                    None,
-                    txn_tracker,
-                    resource_controller,
-                )
-                .await?;
-            }
-        }
-        self.process_subscriptions(txn_tracker, resource_controller, context.into())
-            .await?;
-        Ok(())
-    }
-
-    pub async fn execute_message(
-        &mut self,
-        context: MessageContext,
-        message: Message,
-        grant: Option<&mut Amount>,
-        txn_tracker: &mut TransactionTracker,
-        resource_controller: &mut ResourceController<Option<AccountOwner>>,
-    ) -> Result<(), ExecutionError> {
-        assert_eq!(context.chain_id, self.context().extra().chain_id());
-        match message {
-            Message::System(message) => {
-                let outcome = self.system.execute_message(context, message).await?;
-                txn_tracker.add_outgoing_messages(outcome);
-            }
-            Message::User {
-                application_id,
-                bytes,
-            } => {
-                self.run_user_action(
-                    application_id,
-                    UserAction::Message(context, bytes),
-                    context.refund_grant_to,
-                    grant,
-                    txn_tracker,
-                    resource_controller,
-                )
-                .await?;
-            }
-        }
-        self.process_subscriptions(txn_tracker, resource_controller, context.into())
-            .await?;
-        Ok(())
-    }
-
-    pub async fn bounce_message(
-        &self,
-        context: MessageContext,
-        grant: Amount,
-        message: Message,
-        txn_tracker: &mut TransactionTracker,
-    ) -> Result<(), ExecutionError> {
-        assert_eq!(context.chain_id, self.context().extra().chain_id());
-        txn_tracker.add_outgoing_message(OutgoingMessage {
-            destination: context.origin,
-            authenticated_signer: context.authenticated_signer,
-            refund_grant_to: context.refund_grant_to.filter(|_| !grant.is_zero()),
-            grant,
-            kind: MessageKind::Bouncing,
-            message,
-        });
-        Ok(())
-    }
-
-    pub async fn send_refund(
-        &self,
-        context: MessageContext,
-        amount: Amount,
-        txn_tracker: &mut TransactionTracker,
-    ) -> Result<(), ExecutionError> {
-        assert_eq!(context.chain_id, self.context().extra().chain_id());
-        if amount.is_zero() {
-            return Ok(());
-        }
-        let Some(account) = context.refund_grant_to else {
-            return Err(ExecutionError::InternalError(
-                "Messages with grants should have a non-empty `refund_grant_to`",
-            ));
-        };
-        let message = SystemMessage::Credit {
-            amount,
-            source: context.authenticated_signer.unwrap_or(AccountOwner::CHAIN),
-            target: account.owner,
-        };
-        txn_tracker.add_outgoing_message(
-            OutgoingMessage::new(account.chain_id, message).with_kind(MessageKind::Tracked),
-        );
-        Ok(())
-    }
-
     pub async fn query_application(
         &mut self,
         context: QueryContext,
@@ -529,57 +311,5 @@ where
             applications.push((app_id, application_description));
         }
         Ok(applications)
-    }
-
-    /// Calls `process_streams` for all applications that are subscribed to streams with new
-    /// events or that have new subscriptions.
-    async fn process_subscriptions(
-        &mut self,
-        txn_tracker: &mut TransactionTracker,
-        resource_controller: &mut ResourceController<Option<AccountOwner>>,
-        context: ProcessStreamsContext,
-    ) -> Result<(), ExecutionError> {
-        // Keep track of which streams we have already processed. This is to guard against
-        // applications unsubscribing and subscribing in the process_streams call itself.
-        let mut processed = BTreeSet::new();
-        loop {
-            let to_process = txn_tracker
-                .take_streams_to_process()
-                .into_iter()
-                .filter_map(|(app_id, updates)| {
-                    let updates = updates
-                        .into_iter()
-                        .filter_map(|update| {
-                            if !processed.insert((
-                                app_id,
-                                update.chain_id,
-                                update.stream_id.clone(),
-                            )) {
-                                return None;
-                            }
-                            Some(update)
-                        })
-                        .collect::<Vec<_>>();
-                    if updates.is_empty() {
-                        return None;
-                    }
-                    Some((app_id, updates))
-                })
-                .collect::<BTreeMap<_, _>>();
-            if to_process.is_empty() {
-                return Ok(());
-            }
-            for (app_id, updates) in to_process {
-                self.run_user_action(
-                    app_id,
-                    UserAction::ProcessStreams(context, updates),
-                    None,
-                    None,
-                    txn_tracker,
-                    resource_controller,
-                )
-                .await?;
-            }
-        }
     }
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -9,7 +9,7 @@
 pub mod committee;
 pub mod evm;
 mod execution;
-mod execution_state_actor;
+pub mod execution_state_actor;
 #[cfg(with_graphql)]
 mod graphql;
 mod policy;
@@ -55,7 +55,6 @@ use thiserror::Error;
 
 #[cfg(with_revm)]
 use crate::evm::EvmExecutionError;
-use crate::runtime::ContractSyncRuntime;
 #[cfg(with_testing)]
 use crate::test_utils::dummy_chain_description;
 #[cfg(all(with_testing, with_wasm_runtime))]
@@ -68,7 +67,7 @@ pub use crate::wasm::{
 pub use crate::{
     committee::Committee,
     execution::{ExecutionStateView, ServiceRuntimeEndpoint},
-    execution_state_actor::ExecutionRequest,
+    execution_state_actor::{ExecutionRequest, ExecutionStateActor},
     policy::ResourceControlPolicy,
     resources::{BalanceHolder, ResourceController, ResourceTracker},
     runtime::{

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -256,6 +256,8 @@ pub enum ExecutionError {
     BcsError(#[from] bcs::Error),
     #[error("Recorded response for oracle query has the wrong type")]
     OracleResponseMismatch,
+    #[error("Service oracle query tried to create operations: {0:?}")]
+    ServiceOracleQueryOperations(Vec<Operation>),
     #[error("Assertion failed: local time {local_time} is not earlier than {timestamp}")]
     AssertBefore {
         timestamp: Timestamp,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -12,7 +12,7 @@ use custom_debug_derive::Debug;
 use linera_base::{
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Bytecode,
-        OracleResponse, SendMessageRequest, Timestamp,
+        SendMessageRequest, Timestamp,
     },
     ensure, http,
     identifiers::{
@@ -33,9 +33,8 @@ use crate::{
     util::{ReceiverExt, UnboundedSenderExt},
     ApplicationDescription, ApplicationId, BaseRuntime, ContractRuntime, DataBlobHash,
     ExecutionError, FinalizeContext, Message, MessageContext, MessageKind, ModuleId, Operation,
-    OutgoingMessage, QueryContext, QueryOutcome, ServiceRuntime, TransactionTracker,
-    UserContractCode, UserContractInstance, UserServiceCode, UserServiceInstance,
-    MAX_STREAM_NAME_LEN,
+    OutgoingMessage, QueryContext, QueryOutcome, ServiceRuntime, UserContractCode,
+    UserContractInstance, UserServiceCode, UserServiceInstance, MAX_STREAM_NAME_LEN,
 };
 
 #[cfg(test)]
@@ -107,8 +106,6 @@ pub struct SyncRuntimeInternal<UserInstance: WithContext> {
     call_stack: Vec<ApplicationStatus>,
     /// The set of the IDs of the applications that are in the `call_stack`.
     active_applications: HashSet<ApplicationId>,
-    /// The tracking information for this transaction.
-    transaction_tracker: TransactionTracker,
     /// The operations scheduled during this query.
     scheduled_operations: Vec<Operation>,
 
@@ -313,7 +310,6 @@ impl<UserInstance: WithContext> SyncRuntimeInternal<UserInstance> {
         deadline: Option<Instant>,
         refund_grant_to: Option<Account>,
         resource_controller: ResourceController,
-        transaction_tracker: TransactionTracker,
         user_context: UserInstance::UserContext,
     ) -> Self {
         Self {
@@ -331,7 +327,6 @@ impl<UserInstance: WithContext> SyncRuntimeInternal<UserInstance> {
             deadline,
             refund_grant_to,
             resource_controller,
-            transaction_tracker,
             scheduled_operations: Vec::new(),
             user_context,
         }
@@ -407,16 +402,10 @@ impl SyncRuntimeInternal<UserContractInstance> {
             }
             #[cfg(not(web))]
             hash_map::Entry::Vacant(entry) => {
-                let txn_tracker_moved = mem::take(&mut self.transaction_tracker);
-                let (code, description, txn_tracker_moved) = self
+                let (code, description) = self
                     .execution_state_sender
-                    .send_request(move |callback| ExecutionRequest::LoadContract {
-                        id,
-                        callback,
-                        txn_tracker: txn_tracker_moved,
-                    })?
+                    .send_request(move |callback| ExecutionRequest::LoadContract { id, callback })?
                     .recv_response()?;
-                self.transaction_tracker = txn_tracker_moved;
 
                 let instance = code.instantiate(this)?;
 
@@ -480,15 +469,17 @@ impl SyncRuntimeInternal<UserContractInstance> {
         application_id: ApplicationId,
         query: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
+        let local_time = self
+            .execution_state_sender
+            .send_request(|callback| ExecutionRequest::GetLocalTime { callback })?
+            .recv_response()?;
+
         let context = QueryContext {
             chain_id: self.chain_id,
             next_block_height: self.height,
-            local_time: self.transaction_tracker.local_time(),
+            local_time,
         };
         let sender = self.execution_state_sender.clone();
-
-        let txn_tracker = TransactionTracker::default()
-            .with_blobs(self.transaction_tracker.created_blobs().clone());
 
         let timeout = self
             .resource_controller
@@ -496,8 +487,7 @@ impl SyncRuntimeInternal<UserContractInstance> {
         let execution_start = Instant::now();
         let deadline = Some(execution_start + timeout);
 
-        let mut service_runtime =
-            ServiceSyncRuntime::new_with_txn_tracker(sender, context, deadline, txn_tracker);
+        let mut service_runtime = ServiceSyncRuntime::new_with_deadline(sender, context, deadline);
 
         let result = service_runtime.run_query(application_id, query);
 
@@ -537,16 +527,10 @@ impl SyncRuntimeInternal<UserServiceInstance> {
             }
             #[cfg(not(web))]
             hash_map::Entry::Vacant(entry) => {
-                let txn_tracker_moved = mem::take(&mut self.transaction_tracker);
-                let (code, description, txn_tracker_moved) = self
+                let (code, description) = self
                     .execution_state_sender
-                    .send_request(move |callback| ExecutionRequest::LoadService {
-                        id,
-                        callback,
-                        txn_tracker: txn_tracker_moved,
-                    })?
+                    .send_request(move |callback| ExecutionRequest::LoadService { id, callback })?
                     .recv_response()?;
-                self.transaction_tracker = txn_tracker_moved;
 
                 let instance = code.instantiate(this)?;
                 Ok(entry
@@ -892,74 +876,44 @@ where
 
         this.resource_controller.track_http_request()?;
 
-        let response =
-            if let Some(response) = this.transaction_tracker.next_replayed_oracle_response()? {
-                match response {
-                    OracleResponse::Http(response) => response,
-                    _ => return Err(ExecutionError::OracleResponseMismatch),
-                }
-            } else {
-                this.execution_state_sender
-                    .send_request(|callback| ExecutionRequest::PerformHttpRequest {
-                        request,
-                        http_responses_are_oracle_responses:
-                            Self::LIMIT_HTTP_RESPONSE_SIZE_TO_ORACLE_RESPONSE_SIZE,
-                        callback,
-                    })?
-                    .recv_response()?
-            };
-        this.transaction_tracker
-            .add_oracle_response(OracleResponse::Http(response.clone()));
+        let response = this
+            .execution_state_sender
+            .send_request(|callback| ExecutionRequest::PerformHttpRequest {
+                request,
+                http_responses_are_oracle_responses:
+                    Self::LIMIT_HTTP_RESPONSE_SIZE_TO_ORACLE_RESPONSE_SIZE,
+                callback,
+            })?
+            .recv_response()?;
         Ok(response)
     }
 
     fn assert_before(&mut self, timestamp: Timestamp) -> Result<(), ExecutionError> {
-        let mut this = self.inner();
-        if !this
-            .transaction_tracker
-            .replay_oracle_response(OracleResponse::Assert)?
-        {
-            // There are no recorded oracle responses, so we check the local time.
-            let local_time = this.transaction_tracker.local_time();
-            ensure!(
-                local_time < timestamp,
-                ExecutionError::AssertBefore {
-                    timestamp,
-                    local_time,
-                }
-            );
-        }
-        Ok(())
+        let this = self.inner();
+        this.execution_state_sender
+            .send_request(|callback| ExecutionRequest::AssertBefore {
+                timestamp,
+                callback,
+            })?
+            .recv_response()?
     }
 
     fn read_data_blob(&mut self, hash: DataBlobHash) -> Result<Vec<u8>, ExecutionError> {
-        let mut this = self.inner();
+        let this = self.inner();
         let blob_id = hash.into();
-        if let Some(content) = this.transaction_tracker.get_blob_content(&blob_id) {
-            return Ok(content.bytes().to_vec());
-        };
-        let (content, is_new) = this
+        let content = this
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::ReadBlobContent { blob_id, callback })?
             .recv_response()?;
-        if is_new {
-            this.transaction_tracker
-                .replay_oracle_response(OracleResponse::Blob(blob_id))?;
-        }
         Ok(content.into_vec_or_clone())
     }
 
     fn assert_data_blob_exists(&mut self, hash: DataBlobHash) -> Result<(), ExecutionError> {
-        let mut this = self.inner();
+        let this = self.inner();
         let blob_id = hash.into();
-        let is_new = this
-            .execution_state_sender
+        this.execution_state_sender
             .send_request(|callback| ExecutionRequest::AssertBlobExists { blob_id, callback })?
             .recv_response()?;
-        if is_new {
-            this.transaction_tracker
-                .replay_oracle_response(OracleResponse::Blob(blob_id))?;
-        }
         Ok(())
     }
 }
@@ -996,7 +950,6 @@ impl ContractSyncRuntime {
         refund_grant_to: Option<Account>,
         resource_controller: ResourceController,
         action: &UserAction,
-        txn_tracker: TransactionTracker,
     ) -> Self {
         SyncRuntime(Some(ContractSyncRuntimeHandle::from(
             SyncRuntimeInternal::new(
@@ -1012,7 +965,6 @@ impl ContractSyncRuntime {
                 None,
                 refund_grant_to,
                 resource_controller,
-                txn_tracker,
                 action.timestamp(),
             ),
         )))
@@ -1048,18 +1000,15 @@ impl ContractSyncRuntime {
         application_id: ApplicationId,
         chain_id: ChainId,
         action: UserAction,
-    ) -> Result<(Option<Vec<u8>>, ResourceController, TransactionTracker), ExecutionError> {
+    ) -> Result<(Option<Vec<u8>>, ResourceController), ExecutionError> {
         let result = self
             .deref_mut()
             .run_action(application_id, chain_id, action)?;
         let runtime = self
             .into_inner()
             .expect("Runtime clones should have been freed by now");
-        Ok((
-            result,
-            runtime.resource_controller,
-            runtime.transaction_tracker,
-        ))
+
+        Ok((result, runtime.resource_controller))
     }
 }
 
@@ -1238,18 +1187,22 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             MessageKind::Simple
         };
 
-        this.transaction_tracker
-            .add_outgoing_message(OutgoingMessage {
-                destination: message.destination,
-                authenticated_signer,
-                refund_grant_to,
-                grant,
-                kind,
-                message: Message::User {
-                    application_id,
-                    bytes: message.message,
+        this.execution_state_sender
+            .send_request(|callback| ExecutionRequest::AddOutgoingMessage {
+                message: OutgoingMessage {
+                    destination: message.destination,
+                    authenticated_signer,
+                    refund_grant_to,
+                    grant,
+                    kind,
+                    message: Message::User {
+                        application_id,
+                        bytes: message.message,
+                    },
                 },
-            });
+                callback,
+            })?
+            .recv_response()?;
 
         Ok(())
     }
@@ -1260,13 +1213,12 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         destination: Account,
         amount: Amount,
     ) -> Result<(), ExecutionError> {
-        let mut this = self.inner();
+        let this = self.inner();
         let current_application = this.current_application();
         let application_id = current_application.id;
         let signer = current_application.signer;
 
-        let maybe_message = this
-            .execution_state_sender
+        this.execution_state_sender
             .send_request(|callback| ExecutionRequest::Transfer {
                 source,
                 destination,
@@ -1276,9 +1228,6 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
                 callback,
             })?
             .recv_response()?;
-
-        this.transaction_tracker
-            .add_outgoing_messages(maybe_message);
         Ok(())
     }
 
@@ -1288,13 +1237,12 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         destination: Account,
         amount: Amount,
     ) -> Result<(), ExecutionError> {
-        let mut this = self.inner();
+        let this = self.inner();
         let current_application = this.current_application();
         let application_id = current_application.id;
         let signer = current_application.signer;
 
-        let maybe_message = this
-            .execution_state_sender
+        this.execution_state_sender
             .send_request(|callback| ExecutionRequest::Claim {
                 source,
                 destination,
@@ -1304,8 +1252,6 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
                 callback,
             })?
             .recv_response()?;
-        this.transaction_tracker
-            .add_outgoing_messages(maybe_message);
         Ok(())
     }
 
@@ -1340,17 +1286,17 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             stream_name,
             application_id,
         };
+        let value_len = value.len() as u64;
         let index = this
             .execution_state_sender
-            .send_request(|callback| ExecutionRequest::NextEventIndex {
-                stream_id: stream_id.clone(),
+            .send_request(|callback| ExecutionRequest::Emit {
+                stream_id,
+                value,
                 callback,
             })?
             .recv_response()?;
         // TODO(#365): Consider separate event fee categories.
-        this.resource_controller
-            .track_bytes_written(value.len() as u64)?;
-        this.transaction_tracker.add_event(stream_id, index, value);
+        this.resource_controller.track_bytes_written(value_len)?;
         Ok(index)
     }
 
@@ -1375,23 +1321,10 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             index,
             chain_id,
         };
-        let event = match this.transaction_tracker.next_replayed_oracle_response()? {
-            None => this
-                .execution_state_sender
-                .send_request(|callback| ExecutionRequest::ReadEvent {
-                    event_id: event_id.clone(),
-                    callback,
-                })?
-                .recv_response()?,
-            Some(OracleResponse::Event(recorded_event_id, event))
-                if recorded_event_id == event_id =>
-            {
-                event
-            }
-            Some(_) => return Err(ExecutionError::OracleResponseMismatch),
-        };
-        this.transaction_tracker
-            .add_oracle_response(OracleResponse::Event(event_id, event.clone()));
+        let event = this
+            .execution_state_sender
+            .send_request(|callback| ExecutionRequest::ReadEvent { event_id, callback })?
+            .recv_response()?;
         // TODO(#365): Consider separate event fee categories.
         this.resource_controller
             .track_bytes_read(event.len() as u64)?;
@@ -1404,7 +1337,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         application_id: ApplicationId,
         stream_name: StreamName,
     ) -> Result<(), ExecutionError> {
-        let mut this = self.inner();
+        let this = self.inner();
         ensure!(
             stream_name.0.len() <= MAX_STREAM_NAME_LEN,
             ExecutionError::StreamNameTooLong
@@ -1414,22 +1347,14 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             application_id: application_id.into(),
         };
         let subscriber_app_id = this.current_application().id;
-        let next_index = this
-            .execution_state_sender
+        this.execution_state_sender
             .send_request(|callback| ExecutionRequest::SubscribeToEvents {
                 chain_id,
-                stream_id: stream_id.clone(),
+                stream_id,
                 subscriber_app_id,
                 callback,
             })?
             .recv_response()?;
-        this.transaction_tracker.add_stream_to_process(
-            subscriber_app_id,
-            chain_id,
-            stream_id,
-            0,
-            next_index,
-        );
         Ok(())
     }
 
@@ -1439,7 +1364,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         application_id: ApplicationId,
         stream_name: StreamName,
     ) -> Result<(), ExecutionError> {
-        let mut this = self.inner();
+        let this = self.inner();
         ensure!(
             stream_name.0.len() <= MAX_STREAM_NAME_LEN,
             ExecutionError::StreamNameTooLong
@@ -1452,13 +1377,11 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         this.execution_state_sender
             .send_request(|callback| ExecutionRequest::UnsubscribeFromEvents {
                 chain_id,
-                stream_id: stream_id.clone(),
+                stream_id,
                 subscriber_app_id,
                 callback,
             })?
             .recv_response()?;
-        this.transaction_tracker
-            .remove_stream_to_process(application_id, chain_id, stream_id);
         Ok(())
     }
 
@@ -1481,19 +1404,21 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         );
 
         this.resource_controller.track_service_oracle_call()?;
-        let response =
-            if let Some(response) = this.transaction_tracker.next_replayed_oracle_response()? {
-                match response {
-                    OracleResponse::Service(bytes) => bytes,
-                    _ => return Err(ExecutionError::OracleResponseMismatch),
-                }
-            } else {
-                this.run_service_oracle_query(application_id, query)?
-            };
 
-        this.transaction_tracker
-            .add_oracle_response(OracleResponse::Service(response.clone()));
-
+        let response = match this
+            .execution_state_sender
+            .send_request(|callback| ExecutionRequest::QueryServiceOracle { callback })?
+            .recv_response()?
+        {
+            Some(bytes) => bytes,
+            None => this.run_service_oracle_query(application_id, query)?,
+        };
+        this.execution_state_sender
+            .send_request(|callback| ExecutionRequest::QueryService {
+                response: response.clone(),
+                callback,
+            })?
+            .recv_response()?;
         Ok(response)
     }
 
@@ -1506,10 +1431,9 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         let parent_id = self.inner().chain_id;
         let block_height = self.block_height()?;
 
-        let txn_tracker_moved = mem::take(&mut self.inner().transaction_tracker);
         let timestamp = self.inner().user_context;
 
-        let (chain_id, txn_tracker_moved) = self
+        let chain_id = self
             .inner()
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::OpenChain {
@@ -1520,11 +1444,8 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
                 timestamp,
                 application_permissions,
                 callback,
-                txn_tracker: txn_tracker_moved,
             })?
             .recv_response()?;
-
-        self.inner().transaction_tracker = txn_tracker_moved;
 
         Ok(chain_id)
     }
@@ -1565,12 +1486,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         let chain_id = self.inner().chain_id;
         let block_height = self.block_height()?;
 
-        let txn_tracker_moved = mem::take(&mut self.inner().transaction_tracker);
-
-        let CreateApplicationResult {
-            app_id,
-            txn_tracker: txn_tracker_moved,
-        } = self
+        let CreateApplicationResult { app_id } = self
             .inner()
             .execution_state_sender
             .send_request(move |callback| ExecutionRequest::CreateApplication {
@@ -1580,11 +1496,8 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
                 parameters,
                 required_application_ids,
                 callback,
-                txn_tracker: txn_tracker_moved,
             })?
             .recv_response()??;
-
-        self.inner().transaction_tracker = txn_tracker_moved;
 
         let contract = self.inner().prepare_for_call(self.clone(), true, app_id)?;
 
@@ -1601,7 +1514,10 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
     fn create_data_blob(&mut self, bytes: Vec<u8>) -> Result<DataBlobHash, ExecutionError> {
         let blob = Blob::new_data(bytes);
         let blob_id = blob.id();
-        self.inner().transaction_tracker.add_created_blob(blob);
+        let this = self.inner();
+        this.execution_state_sender
+            .send_request(|callback| ExecutionRequest::AddCreatedBlob { blob, callback })?
+            .recv_response()?;
         Ok(DataBlobHash(blob_id.hash))
     }
 
@@ -1613,26 +1529,21 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
     ) -> Result<ModuleId, ExecutionError> {
         let (blobs, module_id) =
             crate::runtime::create_bytecode_blobs_sync(contract, service, vm_runtime);
+        let this = self.inner();
         for blob in blobs {
-            self.inner().transaction_tracker.add_created_blob(blob);
+            this.execution_state_sender
+                .send_request(|callback| ExecutionRequest::AddCreatedBlob { blob, callback })?
+                .recv_response()?;
         }
         Ok(module_id)
     }
 
     fn validation_round(&mut self) -> Result<Option<u32>, ExecutionError> {
-        let mut this = self.inner();
-        let round =
-            if let Some(response) = this.transaction_tracker.next_replayed_oracle_response()? {
-                match response {
-                    OracleResponse::Round(round) => round,
-                    _ => return Err(ExecutionError::OracleResponseMismatch),
-                }
-            } else {
-                this.round
-            };
-        this.transaction_tracker
-            .add_oracle_response(OracleResponse::Round(round));
-        Ok(round)
+        let this = self.inner();
+        let round = this.round;
+        this.execution_state_sender
+            .send_request(|callback| ExecutionRequest::ValidationRound { round, callback })?
+            .recv_response()
     }
 
     fn write_batch(&mut self, batch: Batch) -> Result<(), ExecutionError> {
@@ -1662,17 +1573,14 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
 impl ServiceSyncRuntime {
     /// Creates a new [`ServiceSyncRuntime`] ready to execute using a provided [`QueryContext`].
     pub fn new(execution_state_sender: ExecutionStateSender, context: QueryContext) -> Self {
-        let mut txn_tracker = TransactionTracker::default();
-        txn_tracker.set_local_time(context.local_time);
-        Self::new_with_txn_tracker(execution_state_sender, context, None, txn_tracker)
+        Self::new_with_deadline(execution_state_sender, context, None)
     }
 
     /// Creates a new [`ServiceSyncRuntime`] ready to execute using a provided [`QueryContext`].
-    pub fn new_with_txn_tracker(
+    pub fn new_with_deadline(
         execution_state_sender: ExecutionStateSender,
         context: QueryContext,
         deadline: Option<Instant>,
-        txn_tracker: TransactionTracker,
     ) -> Self {
         let runtime = SyncRuntime(Some(
             SyncRuntimeInternal::new(
@@ -1684,7 +1592,6 @@ impl ServiceSyncRuntime {
                 deadline,
                 None,
                 ResourceController::default(),
-                txn_tracker,
                 (),
             )
             .into(),
@@ -1732,14 +1639,20 @@ impl ServiceSyncRuntime {
                 callback,
             } = request;
 
-            self.prepare_for_query(context);
+            if let Err(error) = self.prepare_for_query(context) {
+                let _ = callback.send(Err(error));
+                return;
+            }
 
             let _ = callback.send(self.run_query(application_id, query));
         }
     }
 
     /// Prepares the runtime to query an application.
-    pub(crate) fn prepare_for_query(&mut self, new_context: QueryContext) {
+    pub(crate) fn prepare_for_query(
+        &mut self,
+        new_context: QueryContext,
+    ) -> Result<(), ExecutionError> {
         let expected_context = QueryContext {
             local_time: new_context.local_time,
             ..self.current_context
@@ -1751,9 +1664,14 @@ impl ServiceSyncRuntime {
         } else {
             self.handle_mut()
                 .inner()
-                .transaction_tracker
-                .set_local_time(new_context.local_time);
+                .execution_state_sender
+                .send_request(|callback| ExecutionRequest::SetLocalTime {
+                    local_time: new_context.local_time,
+                    callback,
+                })?
+                .recv_response()?;
         }
+        Ok(())
     }
 
     /// Queries an application specified by its [`ApplicationId`].

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -6,10 +6,7 @@
 #[path = "./unit_tests/system_tests.rs"]
 mod tests;
 
-use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
-    mem,
-};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use custom_debug_derive::Debug;
 use linera_base::{
@@ -310,7 +307,6 @@ impl UserData {
 #[derive(Debug)]
 pub struct CreateApplicationResult {
     pub app_id: ApplicationId,
-    pub txn_tracker: TransactionTracker,
 }
 
 impl<C> SystemExecutionStateView<C>
@@ -462,21 +458,16 @@ where
                 instantiation_argument,
                 required_application_ids,
             } => {
-                let txn_tracker_moved = mem::take(txn_tracker);
-                let CreateApplicationResult {
-                    app_id,
-                    txn_tracker: txn_tracker_moved,
-                } = self
+                let CreateApplicationResult { app_id } = self
                     .create_application(
                         context.chain_id,
                         context.height,
                         module_id,
                         parameters,
                         required_application_ids,
-                        txn_tracker_moved,
+                        txn_tracker,
                     )
                     .await?;
-                *txn_tracker = txn_tracker_moved;
                 new_application = Some((app_id, instantiation_argument));
             }
             PublishDataBlob { blob_hash } => {
@@ -886,15 +877,15 @@ where
         module_id: ModuleId,
         parameters: Vec<u8>,
         required_application_ids: Vec<ApplicationId>,
-        mut txn_tracker: TransactionTracker,
+        txn_tracker: &mut TransactionTracker,
     ) -> Result<CreateApplicationResult, ExecutionError> {
         let application_index = txn_tracker.next_application_index();
 
-        let blob_ids = self.check_bytecode_blobs(&module_id, &txn_tracker).await?;
+        let blob_ids = self.check_bytecode_blobs(&module_id, txn_tracker).await?;
         // We only remember to register the blobs that aren't recorded in `used_blobs`
         // already.
         for blob_id in blob_ids {
-            self.blob_used(&mut txn_tracker, blob_id).await?;
+            self.blob_used(txn_tracker, blob_id).await?;
         }
 
         let application_description = ApplicationDescription {
@@ -905,7 +896,7 @@ where
             parameters,
             required_application_ids,
         };
-        self.check_required_applications(&application_description, &mut txn_tracker)
+        self.check_required_applications(&application_description, txn_tracker)
             .await?;
 
         let blob = Blob::new_application_description(&application_description);
@@ -914,7 +905,6 @@ where
 
         Ok(CreateApplicationResult {
             app_id: ApplicationId::from(&application_description),
-            txn_tracker,
         })
     }
 

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -31,9 +31,9 @@ pub use self::{
     system_execution_state::SystemExecutionState,
 };
 use crate::{
-    committee::Committee, ApplicationDescription, ExecutionRequest, ExecutionRuntimeContext,
-    ExecutionStateView, MessageContext, OperationContext, QueryContext, ServiceRuntimeEndpoint,
-    ServiceRuntimeRequest, ServiceSyncRuntime, SystemExecutionStateView,
+    committee::Committee, execution_state_actor::ExecutionRequest, ApplicationDescription,
+    ExecutionRuntimeContext, ExecutionStateView, MessageContext, OperationContext, QueryContext,
+    ServiceRuntimeEndpoint, ServiceRuntimeRequest, ServiceSyncRuntime, SystemExecutionStateView,
     TestExecutionRuntimeContext,
 };
 

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -19,7 +19,7 @@ use crate::{
     execution_state_actor::ExecutionRequest,
     runtime::{LoadedApplication, ResourceController, SyncRuntime},
     test_utils::{create_dummy_user_application_description, dummy_chain_description},
-    ContractRuntime, TransactionTracker, UserContractInstance,
+    ContractRuntime, UserContractInstance,
 };
 
 /// Test if dropping [`SyncRuntime`] does not leak memory.
@@ -184,7 +184,6 @@ where
         None,
         None,
         resource_controller,
-        TransactionTracker::new_replaying(Vec::new()),
         Default::default(),
     );
 

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -73,14 +73,10 @@ async fn application_message_index() -> anyhow::Result<()> {
         .extra()
         .add_blobs([contract_blob, service_blob])
         .await?;
+    let mut controller = ResourceController::default();
     let new_application = view
         .system
-        .execute_operation(
-            context,
-            operation,
-            &mut txn_tracker,
-            &mut ResourceController::default(),
-        )
+        .execute_operation(context, operation, &mut txn_tracker, &mut controller)
         .await?;
     let id = expected_application_id(&context, &module_id, vec![], vec![], 0);
     assert_eq!(new_application, Some((id, vec![])));
@@ -100,14 +96,10 @@ async fn open_chain_message_index() {
     };
     let mut txn_tracker = TransactionTracker::default();
     let operation = SystemOperation::OpenChain(config.clone());
+    let mut controller = ResourceController::default();
     let new_application = view
         .system
-        .execute_operation(
-            context,
-            operation,
-            &mut txn_tracker,
-            &mut ResourceController::default(),
-        )
+        .execute_operation(context, operation, &mut txn_tracker, &mut controller)
         .await
         .unwrap();
     assert_eq!(new_application, None);

--- a/linera-execution/tests/revm.rs
+++ b/linera-execution/tests/revm.rs
@@ -17,9 +17,9 @@ use linera_execution::{
         solidity::{load_solidity_example, read_evm_u64_entry},
         SystemExecutionState,
     },
-    ExecutionRuntimeConfig, ExecutionRuntimeContext, Operation, OperationContext, Query,
-    QueryContext, QueryResponse, ResourceControlPolicy, ResourceController, ResourceTracker,
-    TransactionTracker,
+    ExecutionRuntimeConfig, ExecutionRuntimeContext, ExecutionStateActor, Operation,
+    OperationContext, Query, QueryContext, QueryResponse, ResourceControlPolicy,
+    ResourceController, ResourceTracker, TransactionTracker,
 };
 use linera_views::{context::Context as _, views::View};
 
@@ -117,13 +117,9 @@ async fn test_fuel_for_counter_revm_application() -> anyhow::Result<()> {
             application_id: app_id,
             bytes,
         };
-        view.execute_operation(
-            operation_context,
-            operation,
-            &mut txn_tracker,
-            &mut controller,
-        )
-        .await?;
+        ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+            .execute_operation(operation_context, operation)
+            .await?;
 
         let query = get_valueCall {};
         let query = query.abi_encode();
@@ -235,13 +231,8 @@ async fn test_terminate_execute_operation_by_lack_of_fuel() -> anyhow::Result<()
         application_id: app_id,
         bytes,
     };
-    let result = view
-        .execute_operation(
-            operation_context,
-            operation,
-            &mut txn_tracker,
-            &mut controller,
-        )
+    let result = ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(operation_context, operation)
         .await;
 
     assert!(result.is_err());
@@ -413,13 +404,8 @@ async fn test_basic_evm_features() -> anyhow::Result<()> {
         application_id: app_id,
         bytes,
     };
-    let result = view
-        .execute_operation(
-            operation_context,
-            operation,
-            &mut txn_tracker,
-            &mut controller,
-        )
+    let result = ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(operation_context, operation)
         .await;
     assert!(result.is_err());
 

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -14,9 +14,9 @@ use linera_execution::{
         dummy_chain_description, dummy_chain_description_with_ownership_and_balance,
         SystemExecutionState,
     },
-    Message, MessageContext, Operation, OperationContext, Query, QueryContext, QueryOutcome,
-    QueryResponse, ResourceController, SystemMessage, SystemOperation, SystemQuery, SystemResponse,
-    TransactionTracker,
+    ExecutionStateActor, Message, MessageContext, Operation, OperationContext, Query, QueryContext,
+    QueryOutcome, QueryResponse, ResourceController, SystemMessage, SystemOperation, SystemQuery,
+    SystemResponse, TransactionTracker,
 };
 
 #[tokio::test]
@@ -53,14 +53,9 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
     };
     let mut controller = ResourceController::default();
     let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
-    view.execute_operation(
-        context,
-        Operation::system(operation),
-        &mut txn_tracker,
-        &mut controller,
-    )
-    .await
-    .unwrap();
+    ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(context, Operation::system(operation))
+        .await?;
     assert_eq!(view.system.balance.get(), &Amount::ZERO);
     let txn_outcome = txn_tracker.into_outcome().unwrap();
     assert!(txn_outcome.outgoing_messages.is_empty());
@@ -91,15 +86,9 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
     };
     let mut controller = ResourceController::default();
     let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
-    view.execute_message(
-        context,
-        Message::System(message),
-        None,
-        &mut txn_tracker,
-        &mut controller,
-    )
-    .await
-    .unwrap();
+    ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_message(context, Message::System(message), None)
+        .await?;
     assert_eq!(view.system.balance.get(), &Amount::from_tokens(4));
     let txn_outcome = txn_tracker.into_outcome().unwrap();
     assert!(txn_outcome.outgoing_messages.is_empty());

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -10,9 +10,10 @@ use linera_execution::{
     test_utils::{
         create_dummy_user_application_description, dummy_chain_description, SystemExecutionState,
     },
-    ExecutionRuntimeConfig, ExecutionRuntimeContext, Operation, OperationContext, Query,
-    QueryContext, QueryOutcome, QueryResponse, ResourceControlPolicy, ResourceController,
-    ResourceTracker, TransactionTracker, WasmContractModule, WasmRuntime, WasmServiceModule,
+    ExecutionRuntimeConfig, ExecutionRuntimeContext, ExecutionStateActor, Operation,
+    OperationContext, Query, QueryContext, QueryOutcome, QueryResponse, ResourceControlPolicy,
+    ResourceController, ResourceTracker, TransactionTracker, WasmContractModule, WasmRuntime,
+    WasmServiceModule,
 };
 use linera_views::{context::Context as _, views::View};
 use serde_json::json;
@@ -90,13 +91,12 @@ async fn test_fuel_for_counter_wasm_application(
         } else {
             vec![]
         });
-        view.execute_operation(
-            context,
-            Operation::user_without_abi(app_id, increment).unwrap(),
-            &mut txn_tracker,
-            &mut controller,
-        )
-        .await?;
+        ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+            .execute_operation(
+                context,
+                Operation::user_without_abi(app_id, increment).unwrap(),
+            )
+            .await?;
         let txn_outcome = txn_tracker.into_outcome().unwrap();
         assert!(txn_outcome.outgoing_messages.is_empty());
     }


### PR DESCRIPTION
## Motivation

The transaction tracker is a field in the runtime but also passed into some execution state methods. In some cases, we take the tracker from the runtime, send it to the execution state actor, send it back and put it back into the runtime field. This is confusing and error-prone.

## Proposal

Make the `ExecutionStateActor` a struct that borrows the state, tracker and resource controller.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
