### PR TITLE
`linera-web`: add a log output at the start of application queries

### DIFF
--- a/linera-web/src/lib.rs
+++ b/linera-web/src/lib.rs
@@ -441,6 +441,7 @@ impl Application {
     // TODO(#14) allow passing bytes here rather than just strings
     // TODO(#15) a lot of this logic is shared with `linera_service::node_service`
     pub async fn query(&self, query: &str) -> JsResult<String> {
+        tracing::debug!("querying application: {query}");
         let chain_client = self.client.default_chain_client().await?;
 
         let linera_execution::QueryOutcome {


### PR DESCRIPTION
## Motivation

Help measure timings for benchmarking.

## Proposal

Add a log line when we start an application query.

## Test Plan

Tested manually.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- These changes should be backported to the latest `devnet` branch, then
    - be released in a demo hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a demo hotfix.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
