### PR TITLE
Use of the `Arc<Box<[u8]>>` for the `CompressedBytecode`.

### DIFF
--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -90,10 +90,10 @@ pub fn create_dummy_user_application_description(
     contract_bytes.push(index as u8);
     service_bytes.push(index as u8);
     let contract_blob = Blob::new_contract_bytecode(CompressedBytecode {
-        compressed_bytes: contract_bytes,
+        compressed_bytes: Arc::new(contract_bytes.into_boxed_slice()),
     });
     let service_blob = Blob::new_service_bytecode(CompressedBytecode {
-        compressed_bytes: service_bytes,
+        compressed_bytes: Arc::new(service_bytes.into_boxed_slice()),
     });
 
     let vm_runtime = VmRuntime::Wasm;

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -5,6 +5,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    sync::Arc,
     vec,
 };
 
@@ -672,7 +673,7 @@ impl TransferTestEndpoint {
     /// sender as an application.
     fn sender_application_contract_blob() -> Blob {
         Blob::new_contract_bytecode(CompressedBytecode {
-            compressed_bytes: b"sender contract".to_vec(),
+            compressed_bytes: Arc::new(b"sender contract".to_vec().into_boxed_slice()),
         })
     }
 
@@ -680,7 +681,7 @@ impl TransferTestEndpoint {
     /// as an application.
     fn sender_application_service_blob() -> Blob {
         Blob::new_service_bytecode(CompressedBytecode {
-            compressed_bytes: b"sender service".to_vec(),
+            compressed_bytes: Arc::new(b"sender service".to_vec().into_boxed_slice()),
         })
     }
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -276,7 +276,7 @@ pub trait Storage: Sized {
                 .into_content(),
         };
         let compressed_contract_bytecode = CompressedBytecode {
-            compressed_bytes: content.into_vec_or_clone(),
+            compressed_bytes: content.into_arc_bytes(),
         };
         #[cfg_attr(not(any(with_wasm_runtime, with_revm)), allow(unused_variables))]
         let contract_bytecode =
@@ -343,7 +343,7 @@ pub trait Storage: Sized {
                 .into_content(),
         };
         let compressed_service_bytecode = CompressedBytecode {
-            compressed_bytes: content.into_vec_or_clone(),
+            compressed_bytes: content.into_arc_bytes(),
         };
         #[cfg_attr(not(any(with_wasm_runtime, with_revm)), allow(unused_variables))]
         let service_bytecode = linera_base::task::Blocking::<linera_base::task::NoInput, _>::spawn(


### PR DESCRIPTION
## Motivation

We are using the `Vec<u8>` in the `CompressedBytecode`. But the vector is never modified so this makes
a copy that is not needed.

## Proposal

The compressed bytecode is now a `Arc<Box<[u8]>>`. An alternative could have been to use `BlobContent`.
However, we would need to track the `BlobType`, which would be hard.

## Test Plan

The CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.