### PR TITLE
Update the way that keys are build in views obtained by `linera-views-derive`.

### DIFF
--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -95,10 +95,10 @@ fn generate_view_code(input: ItemStruct, root: bool) -> TokenStream2 {
         num_init_keys_quotes.push(quote! { #g :: NUM_INIT_KEYS });
 
         let derive_key_logic = if num_fields < 256 {
-            let idx_byte = idx as u8;
+            let idx_u8 = idx as u8;
             quote! {
-                let __linera_reserved_index_byte = #idx_byte;
-                let __linera_reserved_base_key = context.base_key().derive_tag_key(linera_views::views::MIN_VIEW_TAG, &__linera_reserved_index_byte)?;
+                let __linera_reserved_index = #idx_u8;
+                let __linera_reserved_base_key = context.base_key().derive_tag_key(linera_views::views::MIN_VIEW_TAG, &__linera_reserved_index)?;
             }
         } else {
             assert!(num_fields < 65536);

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
@@ -28,12 +28,12 @@ where
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -41,12 +41,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -63,15 +63,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<C, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<C, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             C,
             usize,
@@ -80,15 +80,15 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
         let collection = CollectionView::<
             C,
             usize,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
@@ -28,12 +28,12 @@ where
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -41,12 +41,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -63,12 +63,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<C, usize>::NUM_INIT_KEYS;
@@ -80,12 +80,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
@@ -29,12 +29,12 @@ where
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -42,12 +42,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -64,12 +64,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<C, usize>::NUM_INIT_KEYS;
@@ -81,12 +81,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
@@ -29,12 +29,12 @@ where
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -42,12 +42,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -64,15 +64,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<C, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<C, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             C,
             usize,
@@ -81,15 +81,15 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
         let collection = CollectionView::<
             C,
             usize,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
@@ -33,12 +33,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -46,12 +46,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -68,12 +68,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
@@ -85,12 +85,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
@@ -33,12 +33,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -46,12 +46,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -68,15 +68,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             CustomContext,
             usize,
@@ -85,19 +85,19 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_base_key = context
+            .base_key()
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index_byte,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 CustomContext,
                 usize,
                 RegisterView<CustomContext, usize>,
             >::NUM_INIT_KEYS;
-        let __linera_reserved_base_key = context
-            .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
         let collection = CollectionView::<
             CustomContext,
             usize,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
@@ -34,12 +34,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -47,12 +47,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -69,15 +69,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             CustomContext,
             usize,
@@ -86,19 +86,19 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_base_key = context
+            .base_key()
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index_byte,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 CustomContext,
                 usize,
                 RegisterView<CustomContext, usize>,
             >::NUM_INIT_KEYS;
-        let __linera_reserved_base_key = context
-            .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
         let collection = CollectionView::<
             CustomContext,
             usize,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
@@ -34,12 +34,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -47,12 +47,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -69,12 +69,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
@@ -86,12 +86,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
@@ -33,12 +33,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -46,12 +46,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -68,12 +68,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
@@ -85,12 +85,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
@@ -33,12 +33,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -46,12 +46,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -68,15 +68,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             custom::GenericContext<T>,
             usize,
@@ -85,19 +85,19 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_base_key = context
+            .base_key()
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index_byte,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::GenericContext<T>,
                 usize,
                 RegisterView<custom::GenericContext<T>, usize>,
             >::NUM_INIT_KEYS;
-        let __linera_reserved_base_key = context
-            .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
         let collection = CollectionView::<
             custom::GenericContext<T>,
             usize,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
@@ -34,12 +34,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -47,12 +47,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -69,15 +69,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             custom::GenericContext<T>,
             usize,
@@ -86,19 +86,19 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_base_key = context
+            .base_key()
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index_byte,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::GenericContext<T>,
                 usize,
                 RegisterView<custom::GenericContext<T>, usize>,
             >::NUM_INIT_KEYS;
-        let __linera_reserved_base_key = context
-            .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
         let collection = CollectionView::<
             custom::GenericContext<T>,
             usize,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
@@ -34,12 +34,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -47,12 +47,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -69,12 +69,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
@@ -86,12 +86,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
@@ -33,12 +33,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -46,12 +46,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -68,15 +68,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             custom::path::to::ContextType,
             usize,
@@ -85,19 +85,19 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_base_key = context
+            .base_key()
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index_byte,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::path::to::ContextType,
                 usize,
                 RegisterView<custom::path::to::ContextType, usize>,
             >::NUM_INIT_KEYS;
-        let __linera_reserved_base_key = context
-            .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
         let collection = CollectionView::<
             custom::path::to::ContextType,
             usize,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
@@ -33,12 +33,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -46,12 +46,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -68,12 +68,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
@@ -85,12 +85,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
@@ -34,12 +34,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -47,12 +47,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -69,12 +69,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
@@ -86,12 +86,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
@@ -34,12 +34,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -47,12 +47,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -69,15 +69,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             custom::path::to::ContextType,
             usize,
@@ -86,19 +86,19 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_base_key = context
+            .base_key()
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index_byte,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::path::to::ContextType,
                 usize,
                 RegisterView<custom::path::to::ContextType, usize>,
             >::NUM_INIT_KEYS;
-        let __linera_reserved_base_key = context
-            .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
         let collection = CollectionView::<
             custom::path::to::ContextType,
             usize,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
@@ -28,12 +28,12 @@ where
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -41,12 +41,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -63,15 +63,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<C, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<C, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             C,
             usize,
@@ -80,15 +80,15 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
         let collection = CollectionView::<
             C,
             usize,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
@@ -28,12 +28,12 @@ where
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -41,12 +41,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -63,12 +63,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<C, usize>::NUM_INIT_KEYS;
@@ -80,12 +80,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
@@ -29,12 +29,12 @@ where
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -42,12 +42,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -64,12 +64,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<C, usize>::NUM_INIT_KEYS;
@@ -81,12 +81,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
@@ -29,12 +29,12 @@ where
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -42,12 +42,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -64,15 +64,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<C, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<C, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             C,
             usize,
@@ -81,15 +81,15 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
         let collection = CollectionView::<
             C,
             usize,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
@@ -33,12 +33,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -46,12 +46,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -68,12 +68,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
@@ -85,12 +85,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
@@ -33,12 +33,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -46,12 +46,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -68,15 +68,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             CustomContext,
             usize,
@@ -85,19 +85,19 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_base_key = context
+            .base_key()
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index_byte,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 CustomContext,
                 usize,
                 RegisterView<CustomContext, usize>,
             >::NUM_INIT_KEYS;
-        let __linera_reserved_base_key = context
-            .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
         let collection = CollectionView::<
             CustomContext,
             usize,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
@@ -34,12 +34,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -47,12 +47,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -69,15 +69,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             CustomContext,
             usize,
@@ -86,19 +86,19 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_base_key = context
+            .base_key()
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index_byte,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 CustomContext,
                 usize,
                 RegisterView<CustomContext, usize>,
             >::NUM_INIT_KEYS;
-        let __linera_reserved_base_key = context
-            .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
         let collection = CollectionView::<
             CustomContext,
             usize,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
@@ -34,12 +34,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -47,12 +47,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -69,12 +69,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
@@ -86,12 +86,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
@@ -33,12 +33,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -46,12 +46,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -68,12 +68,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
@@ -85,12 +85,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
@@ -33,12 +33,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -46,12 +46,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -68,15 +68,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             custom::GenericContext<T>,
             usize,
@@ -85,19 +85,19 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_base_key = context
+            .base_key()
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index_byte,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::GenericContext<T>,
                 usize,
                 RegisterView<custom::GenericContext<T>, usize>,
             >::NUM_INIT_KEYS;
-        let __linera_reserved_base_key = context
-            .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
         let collection = CollectionView::<
             custom::GenericContext<T>,
             usize,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
@@ -34,12 +34,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -47,12 +47,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -69,15 +69,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             custom::GenericContext<T>,
             usize,
@@ -86,19 +86,19 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_base_key = context
+            .base_key()
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index_byte,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::GenericContext<T>,
                 usize,
                 RegisterView<custom::GenericContext<T>, usize>,
             >::NUM_INIT_KEYS;
-        let __linera_reserved_base_key = context
-            .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
         let collection = CollectionView::<
             custom::GenericContext<T>,
             usize,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
@@ -34,12 +34,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -47,12 +47,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -69,12 +69,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
@@ -86,12 +86,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
@@ -33,12 +33,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -46,12 +46,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -68,15 +68,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             custom::path::to::ContextType,
             usize,
@@ -85,19 +85,19 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_base_key = context
+            .base_key()
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index_byte,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::path::to::ContextType,
                 usize,
                 RegisterView<custom::path::to::ContextType, usize>,
             >::NUM_INIT_KEYS;
-        let __linera_reserved_base_key = context
-            .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
         let collection = CollectionView::<
             custom::path::to::ContextType,
             usize,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
@@ -33,12 +33,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -46,12 +46,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -68,12 +68,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
@@ -85,12 +85,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
@@ -34,12 +34,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             RegisterView::<
@@ -47,12 +47,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         keys.extend(
             CollectionView::<
@@ -69,12 +69,12 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index_byte = 0u8;
+        let __linera_reserved_index = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
@@ -86,12 +86,12 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_index = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index_byte,
+                &__linera_reserved_index,
             )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
@@ -34,12 +34,12 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             RegisterView::<
@@ -47,12 +47,12 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
         keys.extend(
             CollectionView::<
@@ -69,15 +69,15 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0;
-        let __linera_reserved_pos_next = __linera_reserved_pos
-            + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
+        let __linera_reserved_index_byte = 0u8;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
                 linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
+                &__linera_reserved_index_byte,
             )?;
+        let __linera_reserved_pos_next = __linera_reserved_pos
+            + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
             custom::path::to::ContextType,
             usize,
@@ -86,19 +86,19 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1;
+        let __linera_reserved_index_byte = 1u8;
+        let __linera_reserved_base_key = context
+            .base_key()
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index_byte,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::path::to::ContextType,
                 usize,
                 RegisterView<custom::path::to::ContextType, usize>,
             >::NUM_INIT_KEYS;
-        let __linera_reserved_base_key = context
-            .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
         let collection = CollectionView::<
             custom::path::to::ContextType,
             usize,


### PR DESCRIPTION
## Motivation

It has recently been indicated in PR #4347 that the use `ChainId` in a message would be a waste of space.
But there are other wastage of key space that can be reduced.

Fixes #2391

## Proposal

We check for the number of entries in views obtained by `linera-views-derive`. If lower than 256, we convert to `u8`.
It is likely that we need to remove as well the `linera_views::views::MIN_VIEW_TAG`.

## Test Plan

CI.

## Release Plan

It is definitely breaking the testnet.

## Links

None