### PR TITLE
Fetch certificate last used the blob

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -155,6 +155,12 @@ pub trait ValidatorNode {
     /// Returns the hash of the `Certificate` that last used a blob.
     async fn blob_last_used_by(&self, blob_id: BlobId) -> Result<CryptoHash, NodeError>;
 
+    /// Returns the certificate that last used the blob.
+    async fn blob_last_used_by_certificate(
+        &self,
+        blob_id: BlobId,
+    ) -> Result<ConfirmedBlockCertificate, NodeError>;
+
     /// Returns the missing `Blob`s by their IDs.
     async fn missing_blob_ids(&self, blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError>;
 }

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -184,8 +184,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
         &self,
         blob_id: BlobId,
     ) -> Result<ConfirmedBlockCertificate, NodeError> {
-        let last_used_hash = self.node.blob_last_used_by(blob_id).await?;
-        let certificate = self.node.download_certificate(last_used_hash).await?;
+        let certificate = self.node.blob_last_used_by_certificate(blob_id).await?;
         if !certificate.block().requires_or_creates_blob(&blob_id) {
             warn!(
                 "Got invalid last used by certificate for blob {} from validator {}",

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -256,6 +256,16 @@ where
         .await
     }
 
+    async fn blob_last_used_by_certificate(
+        &self,
+        blob_id: BlobId,
+    ) -> Result<ConfirmedBlockCertificate, NodeError> {
+        self.spawn_and_receive(move |validator, sender| {
+            validator.do_blob_last_used_by_certificate(blob_id, sender)
+        })
+        .await
+    }
+
     async fn missing_blob_ids(&self, blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError> {
         self.spawn_and_receive(move |validator, sender| {
             validator.do_missing_blob_ids(blob_ids, sender)
@@ -675,6 +685,20 @@ where
         };
 
         sender.send(certificate_hash)
+    }
+
+    async fn do_blob_last_used_by_certificate(
+        self,
+        blob_id: BlobId,
+        sender: oneshot::Sender<Result<ConfirmedBlockCertificate, NodeError>>,
+    ) -> Result<(), Result<ConfirmedBlockCertificate, NodeError>> {
+        match self.blob_last_used_by(blob_id).await {
+            Ok(cert_hash) => {
+                let cert = self.download_certificate(cert_hash).await;
+                sender.send(cert)
+            }
+            Err(err) => sender.send(Err(err)),
+        }
     }
 
     async fn do_missing_blob_ids(

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -92,6 +92,10 @@ service ValidatorNode {
   // Return the hash of the `Certificate` that last used a blob.
   rpc BlobLastUsedBy(BlobId) returns (CryptoHash);
 
+  // Returns the certificate that last used the blob.
+  rpc BlobLastUsedByCertificate(BlobId) returns (Certificate);
+
+
   // Return the `BlobId`s that are not contained as `Blob`.
   rpc MissingBlobIds(BlobIds) returns (BlobIds);
 }

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -276,6 +276,20 @@ impl ValidatorNode for Client {
         })
     }
 
+    async fn blob_last_used_by_certificate(
+        &self,
+        blob_id: BlobId,
+    ) -> Result<ConfirmedBlockCertificate, NodeError> {
+        Ok(match self {
+            Client::Grpc(grpc_client) => grpc_client.blob_last_used_by_certificate(blob_id).await?,
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => {
+                simple_client.blob_last_used_by_certificate(blob_id).await?
+            }
+        })
+    }
+
     async fn missing_blob_ids(&self, blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => grpc_client.missing_blob_ids(blob_ids).await?,

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -475,6 +475,14 @@ impl ValidatorNode for GrpcClient {
     }
 
     #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
+    async fn blob_last_used_by_certificate(
+        &self,
+        blob_id: BlobId,
+    ) -> Result<ConfirmedBlockCertificate, NodeError> {
+        Ok(client_delegate!(self, blob_last_used_by_certificate, blob_id)?.try_into()?)
+    }
+
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
     async fn missing_blob_ids(&self, blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError> {
         Ok(client_delegate!(self, missing_blob_ids, blob_ids)?.try_into()?)
     }

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -62,6 +62,9 @@ pub enum RpcMessage {
 
     // Internal to a validator
     CrossChainRequest(Box<CrossChainRequest>),
+
+    BlobLastUsedByCertificate(Box<BlobId>),
+    BlobLastUsedByCertificateResponse(Box<ConfirmedBlockCertificate>),
 }
 
 impl RpcMessage {
@@ -100,6 +103,8 @@ impl RpcMessage {
             | DownloadCertificates(_)
             | BlobLastUsedBy(_)
             | BlobLastUsedByResponse(_)
+            | BlobLastUsedByCertificate(_)
+            | BlobLastUsedByCertificateResponse(_)
             | MissingBlobIds(_)
             | MissingBlobIdsResponse(_)
             | DownloadCertificatesResponse(_) => {
@@ -122,6 +127,7 @@ impl RpcMessage {
             | DownloadBlob(_)
             | DownloadConfirmedBlock(_)
             | BlobLastUsedBy(_)
+            | BlobLastUsedByCertificate(_)
             | MissingBlobIds(_)
             | DownloadCertificates(_)
             | DownloadCertificatesByHeights(_, _) => true,
@@ -144,6 +150,7 @@ impl RpcMessage {
             | DownloadBlobResponse(_)
             | DownloadConfirmedBlockResponse(_)
             | BlobLastUsedByResponse(_)
+            | BlobLastUsedByCertificateResponse(_)
             | MissingBlobIdsResponse(_)
             | DownloadCertificatesResponse(_)
             | DownloadCertificatesByHeightsResponse(_) => false,
@@ -190,6 +197,17 @@ impl TryFrom<RpcMessage> for ConfirmedBlock {
     fn try_from(message: RpcMessage) -> Result<Self, Self::Error> {
         match message {
             RpcMessage::DownloadConfirmedBlockResponse(certificate) => Ok(*certificate),
+            RpcMessage::Error(error) => Err(*error),
+            _ => Err(NodeError::UnexpectedMessage),
+        }
+    }
+}
+
+impl TryFrom<RpcMessage> for ConfirmedBlockCertificate {
+    type Error = NodeError;
+    fn try_from(message: RpcMessage) -> Result<Self, Self::Error> {
+        match message {
+            RpcMessage::BlobLastUsedByCertificateResponse(certificate) => Ok(*certificate),
             RpcMessage::Error(error) => Err(*error),
             _ => Err(NodeError::UnexpectedMessage),
         }

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -246,6 +246,16 @@ impl ValidatorNode for SimpleClient {
             .await
     }
 
+    async fn blob_last_used_by_certificate(
+        &self,
+        blob_id: BlobId,
+    ) -> Result<ConfirmedBlockCertificate, NodeError> {
+        self.query::<ConfirmedBlockCertificate>(RpcMessage::BlobLastUsedByCertificate(Box::new(
+            blob_id,
+        )))
+        .await
+    }
+
     async fn missing_blob_ids(&self, blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError> {
         self.query(RpcMessage::MissingBlobIds(blob_ids)).await
     }

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -379,6 +379,8 @@ where
             | RpcMessage::DownloadConfirmedBlockResponse(_)
             | RpcMessage::BlobLastUsedBy(_)
             | RpcMessage::BlobLastUsedByResponse(_)
+            | RpcMessage::BlobLastUsedByCertificate(_)
+            | RpcMessage::BlobLastUsedByCertificateResponse(_)
             | RpcMessage::MissingBlobIds(_)
             | RpcMessage::MissingBlobIdsResponse(_)
             | RpcMessage::DownloadCertificates(_)

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -1133,6 +1133,14 @@ RpcMessage:
       CrossChainRequest:
         NEWTYPE:
           TYPENAME: CrossChainRequest
+    31:
+      BlobLastUsedByCertificate:
+        NEWTYPE:
+          TYPENAME: BlobId
+    32:
+      BlobLastUsedByCertificateResponse:
+        NEWTYPE:
+          TYPENAME: ConfirmedBlockCertificate
 Secp256k1PublicKey:
   NEWTYPESTRUCT:
     TUPLEARRAY:

--- a/linera-service/src/exporter/test_utils.rs
+++ b/linera-service/src/exporter/test_utils.rs
@@ -360,6 +360,13 @@ impl ValidatorNode for DummyValidator {
         unimplemented!()
     }
 
+    async fn blob_last_used_by_certificate(
+        &self,
+        _request: Request<linera_rpc::grpc::api::BlobId>,
+    ) -> Result<Response<linera_rpc::grpc::api::Certificate>, Status> {
+        unimplemented!()
+    }
+
     async fn missing_blob_ids(
         &self,
         _request: Request<BlobIds>,

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -696,6 +696,16 @@ where
     }
 
     #[instrument(skip_all, err(level = Level::WARN))]
+    async fn blob_last_used_by_certificate(
+        &self,
+        request: Request<BlobId>,
+    ) -> Result<Response<Certificate>, Status> {
+        let cert_hash = self.blob_last_used_by(request).await?;
+        let request = Request::new(cert_hash.into_inner());
+        self.download_certificate(request).await
+    }
+
+    #[instrument(skip_all, err(level = Level::WARN))]
     async fn missing_blob_ids(
         &self,
         request: Request<BlobIds>,

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -143,6 +143,13 @@ impl ValidatorNode for DummyValidatorNode {
         Err(NodeError::UnexpectedMessage)
     }
 
+    async fn blob_last_used_by_certificate(
+        &self,
+        _blob_id: BlobId,
+    ) -> Result<ConfirmedBlockCertificate, NodeError> {
+        Err(NodeError::UnexpectedMessage)
+    }
+
     async fn missing_blob_ids(&self, _: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }


### PR DESCRIPTION
## Motivation

Continuation of the work on improving performance of clients. Trying to decrease # of roundtrips between clients and validators.

## Proposal

It was noted that we often make two requests to download a certificate for blob:
1. `BlobLastUsedBy` – returning a certificate hash
2. `DownloadCertificate` – returning the certificate.

Here we introduce a new endpoint – `BlobLastUsedByCertificate(blob_id) -> ConfirmedCertifiate` – which does both things in one query.

Note that the new endpoint is introduced in proxy only.

This decreases number of necessary network roundtrips from 9 to 6:

<img width="314" height="264" alt="Screenshot 2025-08-27 at 12 07 08" src="https://github.com/user-attachments/assets/1e6bc42c-276b-45a1-bf77-b6a304c57b17" />


## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle. **OR**
- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
