### PR TITLE
Improve log messages in `synchronize_chain_state_from`.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -975,6 +975,10 @@ impl<Env: Environment> Client<Env> {
 
         // If we are at the same height as the remote node, we also update our chain manager.
         if local_info.next_block_height != remote_info.next_block_height {
+            debug!(
+                "Synced from validator {}; but remote height is {} and local height is {}",
+                remote_node.public_key, remote_info.next_block_height, local_info.next_block_height
+            );
             return Ok(());
         };
 
@@ -997,7 +1001,7 @@ impl<Env: Environment> Client<Env> {
                     let hash = cert.hash();
                     if let Err(err) = self.try_process_locking_block_from(remote_node, cert).await {
                         debug!(
-                            "Skipping certificate {hash} from validator {} at height {}: {err}",
+                            "Skipping locked block {hash} from validator {} at height {}: {err}",
                             remote_node.public_key, local_info.next_block_height,
                         );
                     }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -997,8 +997,8 @@ impl<Env: Environment> Client<Env> {
                     let hash = cert.hash();
                     if let Err(err) = self.try_process_locking_block_from(remote_node, cert).await {
                         debug!(
-                            "Skipping certificate {hash} from validator {}: {err}",
-                            remote_node.public_key
+                            "Skipping certificate {hash} from validator {} at height {}: {err}",
+                            remote_node.public_key, local_info.next_block_height,
                         );
                     }
                 }
@@ -1023,8 +1023,11 @@ impl<Env: Environment> Client<Env> {
                             {
                                 Ok(content) => content,
                                 Err(err) => {
-                                    let public_key = &remote_node.public_key;
-                                    warn!("Skipping proposal from {owner} and validator {public_key}: {err}");
+                                    warn!(
+                                        "Skipping proposal from {owner} and validator {} at \
+                                        height {}; failed to download {blob_id}: {err}",
+                                        remote_node.public_key, local_info.next_block_height
+                                    );
                                     continue;
                                 }
                             };
@@ -1063,8 +1066,10 @@ impl<Env: Environment> Client<Env> {
                     }
                 }
 
-                let public_key = &remote_node.public_key;
-                debug!("Skipping proposal from {owner} and validator {public_key}: {err}");
+                debug!(
+                    "Skipping proposal from {owner} and validator {} at height {}: {err}",
+                    remote_node.public_key, local_info.next_block_height
+                );
             }
         }
         Ok(())

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1004,7 +1004,7 @@ impl<Env: Environment> Client<Env> {
                 }
             }
         }
-        for proposal in proposals {
+        'proposal_loop: for proposal in proposals {
             let owner: AccountOwner = proposal.owner();
             if let Err(mut err) = self
                 .local_node
@@ -1028,7 +1028,7 @@ impl<Env: Environment> Client<Env> {
                                         height {}; failed to download {blob_id}: {err}",
                                         remote_node.public_key, local_info.next_block_height
                                     );
-                                    continue;
+                                    continue 'proposal_loop;
                                 }
                             };
                             blobs.push(Blob::new(blob_content));

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -988,7 +988,7 @@ where
         .set_fault_type([0, 1, 2, 3], FaultType::Honest)
         .await;
 
-    // Now player A claim victory since B has timed out. This works because it sees the existing
+    // Now player A claims victory since B has timed out. This works because it sees the existing
     // block proposal and makes a new proposal in the next round instead.
     let claim_victory_operation = HexOperation::ClaimVictory;
     client_a.synchronize_from_validators().await?;


### PR DESCRIPTION
## Motivation

I can't reproduce https://github.com/linera-io/linera-protocol/issues/4422 locally, so we have to try to get more helpful logs in CI if it happens again.

## Proposal

Improve log messages.

Also fix one `continue` in `synchronize_chain_state_from`: If we can't download any of the required blobs we can skip this proposal immediately, not just this blob.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Related to https://github.com/linera-io/linera-protocol/issues/4422.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
