### PR TITLE
Attempt at resolving the error in end-to-end test running on the Devnet.

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -1970,6 +1970,11 @@ async fn test_wasm_end_to_end_allowances_fungible(config: impl LineraNetConfig) 
             .await?,
     );
 
+    // Synchronization is needed since below, when asserting balances, the client need
+    // to access to the latest block that contains the balances.
+    node_service2.process_inbox(&chain2).await?;
+    node_service3.process_inbox(&chain2).await?;
+
     let expected_balances = [
         (owner1, Amount::from_tokens(9)),
         (owner2, Amount::from_tokens(19)),


### PR DESCRIPTION
## Motivation

The test `test_wasm_end_to_end_allowances_fungible` is about a multi-owner chain and can fail in some situations.

## Proposal

The failure scenario is the following (per @afck):
* client1 is creating the bytecode blobs in block 0.
* client1 is creating the application in block 1.
* client2 has not synchronized yet and we query the state of the application.
* client2 requests the application description blob, together with block 1 which certifies it.
* It only pre-process block1, because it doesn't have block0 yet.
* Now it realizes it also needs the bytecode blobs, so it requests those, together with block 0.
* It processes and executes block 0, but not block 1.
* So the application state is still empty and reading the balance returns 0.

The use of the `process_inbox` forces the client to update and so get the correct balance.

## Test Plan

The CI should be the first part even though that test has not failed there before.

## Release Plan

If ok, then devnet publication should follow.

## Links

None.