### PR TITLE
Sync after publishing the app to make allowance test not flaky.

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -1922,10 +1922,6 @@ async fn test_wasm_end_to_end_allowances_fungible(config: impl LineraNetConfig) 
     client2.assign(owner2, chain2).await?;
     client3.assign(owner3, chain2).await?;
 
-    // Synchronizing the chains that need be.
-    client2.sync(chain2).await?;
-    client3.sync(chain2).await?;
-
     // The initial accounts on chain1
     let accounts = BTreeMap::from([
         (owner1, Amount::from_tokens(9)),
@@ -1946,6 +1942,10 @@ async fn test_wasm_end_to_end_allowances_fungible(config: impl LineraNetConfig) 
             Some(chain2),
         )
         .await?;
+
+    // Synchronize the chain in clients 2 and 3, so they see the initialized application state.
+    client2.sync(chain2).await?;
+    client3.sync(chain2).await?;
 
     let port1 = get_node_port().await;
     let port2 = get_node_port().await;


### PR DESCRIPTION
## Motivation

`test_wasm_end_to_end_allowances_fungible` is flaky: If client 2 hasn't finished syncing or processing notifications when `app2.assert_balances(expected_balances)` is called, the assertion can fail, because the block where the application was created isn't seen yet. Same for client 3.

## Proposal

Call `sync` _after_ creating the application.

## Test Plan

CI: The test should not be flaky anymore.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
