### PR TITLE
Fix spurious error logs in `is_retryable`.

### DIFF
--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -78,7 +78,7 @@ impl GrpcClient {
                 info!("Unexpected gRPC status: {}; retrying", status);
                 true
             }
-            Code::NotFound => false,
+            Code::NotFound => false, // This code is used if e.g. the validator is missing blobs.
             Code::InvalidArgument
             | Code::AlreadyExists
             | Code::PermissionDenied

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -25,7 +25,7 @@ use linera_core::{
 };
 use linera_version::VersionInfo;
 use tonic::{Code, IntoRequest, Request, Status};
-use tracing::{debug, error, info, instrument, warn, Level};
+use tracing::{debug, info, instrument, warn, Level};
 
 use super::{
     api::{self, validator_node_client::ValidatorNodeClient, SubscriptionRequest},
@@ -75,11 +75,11 @@ impl GrpcClient {
                 true
             }
             Code::Ok | Code::Cancelled | Code::ResourceExhausted => {
-                error!("Unexpected gRPC status: {}; retrying", status);
+                info!("Unexpected gRPC status: {}; retrying", status);
                 true
             }
+            Code::NotFound => false,
             Code::InvalidArgument
-            | Code::NotFound
             | Code::AlreadyExists
             | Code::PermissionDenied
             | Code::FailedPrecondition
@@ -88,7 +88,7 @@ impl GrpcClient {
             | Code::Internal
             | Code::DataLoss
             | Code::Unauthenticated => {
-                error!("Unexpected gRPC status: {}", status);
+                info!("Unexpected gRPC status: {}", status);
                 false
             }
         }


### PR DESCRIPTION
## Motivation

`is_retryable` was originally used only for gRPC _streams_, but is now used in other requests, too. The error-level logs in it are not appropriate anymore.

In particular, `NotFound` is expected in some cases. And in general, the logs should never be error-level, because they can be caused by a single faulty validator.

## Proposal

Fix logs and log levels.

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
