### PR TITLE
Add tolerations for shards and proxy pods

### DIFF
--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -50,6 +50,14 @@ spec:
       labels:
         app: proxy
     spec:
+      {{- if eq .Values.environment "GCP" }}
+      nodeSelector:
+        workload: proxies
+      tolerations:
+      - key: proxies
+        value: "true"
+        effect: NoSchedule
+      {{- end }}
       terminationGracePeriodSeconds: 10
       initContainers:
         - name: linera-proxy-initializer

--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -30,6 +30,14 @@ spec:
       labels:
         app: shards
     spec:
+      {{- if eq .Values.environment "GCP" }}
+      nodeSelector:
+        workload: shards
+      tolerations:
+      - key: shards
+        value: "true"
+        effect: NoSchedule
+      {{- end }}
       terminationGracePeriodSeconds: 10
       initContainers:
         - name: linera-server-initializer

--- a/linera-service/src/cli_wrappers/helmfile.rs
+++ b/linera-service/src/cli_wrappers/helmfile.rs
@@ -42,9 +42,12 @@ impl HelmFile {
             )
             .env("LINERA_HELMFILE_SET_NUM_SHARDS", num_shards.to_string())
             .env("LINERA_HELMFILE_LINERA_IMAGE", docker_image_name)
+            .env(
+                "LINERA_HELMFILE_SET_KUBE_CONTEXT",
+                format!("kind-{}", cluster_id),
+            )
             .arg("sync")
             .arg("--wait")
-            .args(["--kube-context", &format!("kind-{}", cluster_id)])
             .spawn_and_wait()
             .await
     }


### PR DESCRIPTION
## Motivation

We're splitting the proxies, shards, monitoring, etc into separate VMs for better resource management and isolation.

## Proposal

We need to add these tolerations to ensure that the proxies and shards will only get scheduled in the appropriate VMs

## Test Plan

Deployed a network with these changes plus XXX, saw the pods were deployed into separate VMs, as expected

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
