### PR TITLE
Two-phase chain listener

### DIFF
--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -130,14 +130,10 @@ impl<Env: Environment> Benchmark<Env> {
         let notifier = Arc::new(Notify::new());
         let barrier = Arc::new(Barrier::new(num_chains + 1));
 
-        let chain_listener_handle = tokio::spawn(
-            async move {
-                if let Err(e) = chain_listener.run().await {
-                    warn!("Chain listener error: {}", e);
-                }
-            }
-            .instrument(tracing::info_span!("chain_listener")),
-        );
+        let chain_listener_result = chain_listener.run().await;
+
+        let chain_listener_handle =
+            tokio::spawn(async move { chain_listener_result?.await }.in_current_span());
 
         let bps_control_task = Self::bps_control_task(
             &barrier,
@@ -216,7 +212,10 @@ impl<Env: Environment> Benchmark<Env> {
         if let Some(runtime_control_task) = runtime_control_task {
             runtime_control_task.await?;
         }
-        chain_listener_handle.await?;
+
+        if let Err(e) = chain_listener_handle.await? {
+            tracing::error!("chain listener error: {e}");
+        }
 
         Ok(())
     }

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -682,7 +682,8 @@ where
             self.storage,
             cancellation_token.clone(),
         )
-        .run();
+        .run()
+        .await?;
         let batch_processor_task = batch_processor.run(cancellation_token.clone());
         let tcp_listener =
             tokio::net::TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], port))).await?;

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -895,7 +895,9 @@ where
         let storage = self.context.lock().await.storage().clone();
 
         let chain_listener =
-            ChainListener::new(self.config, self.context, storage, cancellation_token).run();
+            ChainListener::new(self.config, self.context, storage, cancellation_token)
+                .run()
+                .await?;
         let mut chain_listener = Box::pin(chain_listener).fuse();
         let tcp_listener =
             tokio::net::TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], port))).await?;

--- a/linera-web/src/lib.rs
+++ b/linera-web/src/lib.rs
@@ -211,17 +211,16 @@ impl Client {
             signer,
         )));
         let client_context_clone = client_context.clone();
+        let chain_listener = ChainListener::new(
+            ChainListenerConfig::default(),
+            client_context_clone,
+            storage,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .run()
+        .await?;
         wasm_bindgen_futures::spawn_local(async move {
-            if let Err(error) = ChainListener::new(
-                ChainListenerConfig::default(),
-                client_context_clone,
-                storage,
-                tokio_util::sync::CancellationToken::new(),
-            )
-            .run()
-            .boxed_local()
-            .await
-            {
+            if let Err(error) = chain_listener.boxed_local().await {
                 tracing::error!("ChainListener error: {error:?}");
             }
         });

--- a/linera-web/src/lib.rs
+++ b/linera-web/src/lib.rs
@@ -8,6 +8,7 @@ This module defines the client API for the Web extension.
 // We sometimes need functions in this module to be async in order to
 // ensure the generated code will return a `Promise`.
 #![allow(clippy::unused_async)]
+#![recursion_limit = "256"]
 
 pub mod signer;
 
@@ -218,12 +219,17 @@ impl Client {
             tokio_util::sync::CancellationToken::new(),
         )
         .run()
-        .await?;
-        wasm_bindgen_futures::spawn_local(async move {
-            if let Err(error) = chain_listener.boxed_local().await {
-                tracing::error!("ChainListener error: {error:?}");
+        .boxed_local()
+        .await?
+        .boxed_local();
+        wasm_bindgen_futures::spawn_local(
+            async move {
+                if let Err(error) = chain_listener.await {
+                    tracing::error!("ChainListener error: {error:?}");
+                }
             }
-        });
+            .boxed_local(),
+        );
         log::info!("Linera Web client successfully initialized");
         Ok(Self { client_context })
     }


### PR DESCRIPTION
## Motivation

Currently we don't synchronize the chains when starting up the client.  Now that we also don't pessimistically synchronize chains before performing operations, we sometimes run into the situation where we want to do something with a chain whose blocks haven't been seen yet (e.g. because it came from the faucet), which leads to an error.

## Proposal

Ideally when we find a block from the future we should synchronize the offending chain.  But for now it should be sufficient to make sure to synchronize the initial chains at startup.

Split `ChainListener::run` into two futures: the latter is the full chain listener loop, as before, but first there's an initialization step that synchronizes all the initial chains, and the caller can wait on this in serial to ensure the chains are synchronized before performing operations on the client.

## Test Plan

CI should check for regressions; it would be nice to add a test for this case, perhaps after testnet release.

## Release Plan

- These changes should be backported to the latest `devnet` branch
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
