### PR TITLE
Ignore dangling symlinks for gcloud

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -4,6 +4,9 @@
 # ---------------------------------------------------------------------------------*
 node_modules
 npm-debug.log
+# Ignore dangling symlinks to node_modules in web examples
+examples/*/public/js/@linera/client
+examples/*/*/public/js/@linera/client
 # ignore .git and .cache folders
 .git
 .cache


### PR DESCRIPTION
## Motivation

After #4383, we now have a dangling symlink in the repository, that points to the compiled `linera-web` once built. However, `gcloud builds` (which is what we use in `lineractl` to build our Docker Images) doesn't like dangling symlinks.

## Proposal

Add the dangling symlinks to `.gcloudignore` to make sure `gcloud` commands ignore it, and the builds succeed.

## Test Plan

Did a build with `gcloud builds` and now it works again

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
