### PR TITLE
Add tolerations for the new shards VM when starting the local-csi-driver

### DIFF
--- a/kubernetes/linera-validator/scylla-setup/gke-daemonset-raid-disks.yaml
+++ b/kubernetes/linera-validator/scylla-setup/gke-daemonset-raid-disks.yaml
@@ -16,6 +16,12 @@ spec:
     spec:
       nodeSelector:
         cloud.google.com/gke-local-nvme-ssd: "true"
+      # Add tolerations for all node types that might have local SSDs.
+      # Scylla nodes are managed by the Scylla NodeConfig, so no need to add tolerations for them.
+      tolerations:
+      - key: shards
+        value: "true"
+        effect: NoSchedule
       hostPID: true
       containers:
         - name: startup-script


### PR DESCRIPTION
## Motivation

Now that we have multiple VMs for different things, we need to adjust the tolerations in the local-csi-driver so it runs in the VMs that could have local SSDs.

## Proposal

Add shards tolerations to local-csi-driver config

## Test Plan

Deployed a dual store + local ssd network using this code, it works.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
