### PR TITLE
Fix `Address20` debug format.

### DIFF
--- a/linera-base/src/crypto/hash.rs
+++ b/linera-base/src/crypto/hash.rs
@@ -168,7 +168,7 @@ impl fmt::Display for CryptoHash {
 
 impl fmt::Debug for CryptoHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self, f)
+        write!(f, "{}", hex::encode(&self.0[..8]))
     }
 }
 

--- a/linera-base/src/crypto/hash.rs
+++ b/linera-base/src/crypto/hash.rs
@@ -168,7 +168,7 @@ impl fmt::Display for CryptoHash {
 
 impl fmt::Debug for CryptoHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(&self.0[..8]))
+        fmt::Display::fmt(self, f)
     }
 }
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 
 /// An account owner.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, WitLoad, WitStore, WitType)]
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd, WitLoad, WitStore, WitType)]
 #[cfg_attr(with_testing, derive(test_strategy::Arbitrary))]
 pub enum AccountOwner {
     /// Short addresses reserved for the protocol.
@@ -38,7 +38,17 @@ pub enum AccountOwner {
     /// 32-byte account address.
     Address32(CryptoHash),
     /// 20-byte account EVM-compatible address.
-    Address20(#[debug(with = "hex_debug")] [u8; 20]),
+    Address20([u8; 20]),
+}
+
+impl fmt::Debug for AccountOwner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Reserved(byte) => f.debug_tuple("Reserved").field(byte).finish(),
+            Self::Address32(hash) => write!(f, "Address32({:?}..)", hash),
+            Self::Address20(bytes) => write!(f, "Address20({}..)", hex::encode(&bytes[..8])),
+        }
+    }
 }
 
 impl AccountOwner {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -38,8 +38,7 @@ pub enum AccountOwner {
     /// 32-byte account address.
     Address32(CryptoHash),
     /// 20-byte account EVM-compatible address.
-    #[debug(with = "hex_debug")]
-    Address20([u8; 20]),
+    Address20(#[debug(with = "hex_debug")] [u8; 20]),
 }
 
 impl AccountOwner {

--- a/linera-base/src/unit_tests.rs
+++ b/linera-base/src/unit_tests.rs
@@ -155,3 +155,14 @@ fn chain_ownership_test_case() -> ChainOwnership {
         },
     }
 }
+
+#[test]
+fn account_owner_debug_format() {
+    assert_eq!(&format!("{:?}", AccountOwner::Reserved(10)), "Reserved(10)");
+    let addr32 = AccountOwner::Address32(CryptoHash::from([10u8; 32]));
+    let debug32 = "Address32(0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a)";
+    assert_eq!(&format!("{addr32:?}"), debug32);
+    let addr20 = AccountOwner::Address20([10u8; 20]);
+    let debug20 = "Address20(0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a)";
+    assert_eq!(&format!("{addr20:?}"), debug20);
+}

--- a/linera-base/src/unit_tests.rs
+++ b/linera-base/src/unit_tests.rs
@@ -160,9 +160,9 @@ fn chain_ownership_test_case() -> ChainOwnership {
 fn account_owner_debug_format() {
     assert_eq!(&format!("{:?}", AccountOwner::Reserved(10)), "Reserved(10)");
     let addr32 = AccountOwner::Address32(CryptoHash::from([10u8; 32]));
-    let debug32 = "Address32(0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a)";
+    let debug32 = "Address32(0a0a0a0a0a0a0a0a..)";
     assert_eq!(&format!("{addr32:?}"), debug32);
     let addr20 = AccountOwner::Address20([10u8; 20]);
-    let debug20 = "Address20(0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a)";
+    let debug20 = "Address20(0a0a0a0a0a0a0a0a..)";
     assert_eq!(&format!("{addr20:?}"), debug20);
 }


### PR DESCRIPTION
## Motivation

`AccountOwner::Address20`'s `Debug` impl prints something like:

```
Address20([10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10])
```

because the `hex_debug` attribute is in the wrong place.

## Proposal

Put the attribute directly on the field, not the enum variant. The `Debug` impl now says:

```
Address20(0a0a0a0a0a0a0a0a..)
```

## Test Plan

Tried it locally.

## Release Plan

- Should be backported to testnet and devnet.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
