### PR TITLE
Remove unnecessary `dead_code` attributes.

### DIFF
--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -775,7 +775,6 @@ where
 // * When using `LocalValidatorClient`, clients communicate with an exact quorum then stop.
 // * Most tests have 1 faulty validator out 4 so that there is exactly only 1 quorum to
 // communicate with.
-#[allow(dead_code)]
 pub struct TestBuilder<B: StorageBuilder> {
     storage_builder: B,
     pub initial_committee: Committee,
@@ -1201,7 +1200,6 @@ impl StorageBuilder for MemoryStorageBuilder {
 impl MemoryStorageBuilder {
     /// Creates a [`MemoryStorageBuilder`] that uses the specified [`WasmRuntime`] to run Wasm
     /// applications.
-    #[allow(dead_code)]
     pub fn with_wasm_runtime(wasm_runtime: impl Into<Option<WasmRuntime>>) -> Self {
         MemoryStorageBuilder {
             wasm_runtime: wasm_runtime.into(),
@@ -1326,7 +1324,6 @@ pub struct DynamoDbStorageBuilder {
 impl DynamoDbStorageBuilder {
     /// Creates a [`DynamoDbStorageBuilder`] that uses the specified [`WasmRuntime`] to run Wasm
     /// applications.
-    #[allow(dead_code)]
     pub fn with_wasm_runtime(wasm_runtime: impl Into<Option<WasmRuntime>>) -> Self {
         DynamoDbStorageBuilder {
             wasm_runtime: wasm_runtime.into(),
@@ -1371,7 +1368,6 @@ pub struct ScyllaDbStorageBuilder {
 impl ScyllaDbStorageBuilder {
     /// Creates a [`ScyllaDbStorageBuilder`] that uses the specified [`WasmRuntime`] to run Wasm
     /// applications.
-    #[allow(dead_code)]
     pub fn with_wasm_runtime(wasm_runtime: impl Into<Option<WasmRuntime>>) -> Self {
         ScyllaDbStorageBuilder {
             wasm_runtime: wasm_runtime.into(),

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -3,8 +3,6 @@
 
 //! Mocking of user applications to help with execution scenario tests.
 
-#![allow(dead_code)]
-
 use std::{
     collections::VecDeque,
     fmt::{self, Debug, Display, Formatter},


### PR DESCRIPTION
## Motivation

There are several `#[allow(dead_code)]` annotations without an explaining comment or link to an issue. Some of them seem to be unnecessary.

## Proposal

Remove them.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
