### PR TITLE
Clean the execution code.

### DIFF
--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -199,7 +199,7 @@ where
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         match query {
             Query::System(query) => {
-                let outcome = self.system.handle_query(context, query).await?;
+                let outcome = self.system.handle_query(context, query);
                 Ok(outcome.into())
             }
             Query::User {

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -337,7 +337,7 @@ where
                 if !app_permissions.can_close_chain(&application_id) {
                     callback.respond(Err(ExecutionError::UnauthorizedApplication(application_id)));
                 } else {
-                    self.system.close_chain();
+                    self.state.system.close_chain();
                     callback.respond(Ok(()));
                 }
             }

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -337,7 +337,7 @@ where
                 if !app_permissions.can_close_chain(&application_id) {
                     callback.respond(Err(ExecutionError::UnauthorizedApplication(application_id)));
                 } else {
-                    self.state.system.close_chain().await?;
+                    self.system.close_chain();
                     callback.respond(Ok(()));
                 }
             }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -458,9 +458,8 @@ impl SyncRuntimeInternal<UserContractInstance> {
     }
 
     /// Cleans up the runtime after the execution of a call to a different contract.
-    fn finish_call(&mut self) -> Result<(), ExecutionError> {
+    fn finish_call(&mut self)  {
         self.pop_application();
-        Ok(())
     }
 
     /// Runs the service in a separate thread as an oracle.
@@ -1255,7 +1254,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             .expect("Applications should not have reentrant calls")
             .execute_operation(argument)?;
 
-        self.inner().finish_call()?;
+        self.inner().finish_call();
 
         Ok(value)
     }
@@ -1477,7 +1476,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             .expect("Applications should not have reentrant calls")
             .instantiate(argument)?;
 
-        self.inner().finish_call()?;
+        self.inner().finish_call();
 
         Ok(app_id)
     }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -458,7 +458,7 @@ impl SyncRuntimeInternal<UserContractInstance> {
     }
 
     /// Cleans up the runtime after the execution of a call to a different contract.
-    fn finish_call(&mut self)  {
+    fn finish_call(&mut self) {
         self.pop_application();
     }
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -379,7 +379,7 @@ where
             ChangeApplicationPermissions(application_permissions) => {
                 self.application_permissions.set(application_permissions);
             }
-            CloseChain => self.close_chain().await?,
+            CloseChain => self.close_chain(),
             Transfer {
                 owner,
                 amount,
@@ -811,19 +811,19 @@ where
         Ok(false)
     }
 
-    pub async fn handle_query(
+    pub fn handle_query(
         &mut self,
         context: QueryContext,
         _query: SystemQuery,
-    ) -> Result<QueryOutcome<SystemResponse>, ExecutionError> {
+    ) -> QueryOutcome<SystemResponse> {
         let response = SystemResponse {
             chain_id: context.chain_id,
             balance: *self.balance.get(),
         };
-        Ok(QueryOutcome {
+        QueryOutcome {
             response,
             operations: vec![],
-        })
+        }
     }
 
     /// Returns the messages to open a new chain, and subtracts the new chain's balance
@@ -865,9 +865,8 @@ where
         Ok(child_id)
     }
 
-    pub async fn close_chain(&mut self) -> Result<(), ExecutionError> {
+    pub fn close_chain(&mut self) {
         self.closed.set(true);
-        Ok(())
     }
 
     pub async fn create_application(


### PR DESCRIPTION
## Motivation

The `linera-execution` code has several possible cleanups.

## Proposal

The following operations are done:
* Make `fn close_chain` no longer async and no longer returning error.
* Make `fn handle_query` no longer async and no longer returning error.
* Make `fn finish_call` no longer returning error.

## Test Plan

The CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.