### PR TITLE
Add `currentCommittee` to the faucet; use it in `wallet init`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5396,6 +5396,7 @@ version = "0.16.0"
 dependencies = [
  "linera-base",
  "linera-client",
+ "linera-execution",
  "linera-version",
  "reqwest 0.11.27",
  "serde",

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -4,7 +4,6 @@
 
 use std::{borrow::Cow, collections::BTreeMap, str::FromStr};
 
-use async_graphql::InputObject;
 use linera_base::crypto::{AccountPublicKey, CryptoError, ValidatorPublicKey};
 use serde::{Deserialize, Serialize};
 
@@ -59,7 +58,8 @@ pub struct ValidatorState {
 }
 
 /// A set of validators (identified by their public keys) and their voting rights.
-#[derive(Eq, PartialEq, Hash, Clone, Debug, Default, InputObject)]
+#[derive(Eq, PartialEq, Hash, Clone, Debug, Default)]
+#[cfg_attr(with_graphql, derive(async_graphql::InputObject))]
 pub struct Committee {
     /// The validators in the committee.
     pub validators: BTreeMap<ValidatorPublicKey, ValidatorState>,

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -21,6 +21,12 @@ use crate::{
 
 doc_scalar!(UserData, "Optional user message attached to a transfer");
 
+async_graphql::scalar!(
+    ResourceControlPolicy,
+    "ResourceControlPolicyScalar",
+    "A collection of prices and limits associated with block execution"
+);
+
 #[async_graphql::Object(cache_control(no_cache))]
 impl Committee {
     #[graphql(derived(name = "validators"))]

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -14,6 +14,7 @@ use linera_views::{context::Context, map_view::MapView};
 
 use crate::{
     committee::{Committee, ValidatorState},
+    policy::ResourceControlPolicy,
     system::UserData,
     ExecutionStateView, SystemExecutionStateView,
 };
@@ -40,6 +41,11 @@ impl Committee {
     #[graphql(derived(name = "validity_threshold"))]
     async fn _validity_threshold(&self) -> u64 {
         self.validity_threshold()
+    }
+
+    #[graphql(derived(name = "policy"))]
+    async fn _policy(&self) -> &ResourceControlPolicy {
+        self.policy()
     }
 }
 

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -11,7 +11,6 @@
 
 use std::{collections::BTreeSet, fmt};
 
-use async_graphql::{InputObject, SimpleObject};
 use linera_base::{
     data_types::{Amount, ArithmeticError, BlobContent, CompressedBytecode, Resources},
     ensure,
@@ -23,8 +22,7 @@ use serde::{Deserialize, Serialize};
 use crate::ExecutionError;
 
 /// A collection of prices and limits associated with block execution.
-#[derive(Eq, PartialEq, Hash, Clone, Debug, Serialize, Deserialize, InputObject, SimpleObject)]
-#[graphql(name = "ResourceControlPolicyOutput")]
+#[derive(Eq, PartialEq, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct ResourceControlPolicy {
     /// The price per unit of fuel (aka gas) for Wasm execution.
     pub wasm_fuel_unit: Amount,

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -11,7 +11,7 @@
 
 use std::{collections::BTreeSet, fmt};
 
-use async_graphql::InputObject;
+use async_graphql::{InputObject, SimpleObject};
 use linera_base::{
     data_types::{Amount, ArithmeticError, BlobContent, CompressedBytecode, Resources},
     ensure,
@@ -23,7 +23,8 @@ use serde::{Deserialize, Serialize};
 use crate::ExecutionError;
 
 /// A collection of prices and limits associated with block execution.
-#[derive(Eq, PartialEq, Hash, Clone, Debug, Serialize, Deserialize, InputObject)]
+#[derive(Eq, PartialEq, Hash, Clone, Debug, Serialize, Deserialize, InputObject, SimpleObject)]
+#[graphql(name = "ResourceControlPolicyOutput")]
 pub struct ResourceControlPolicy {
     /// The price per unit of fuel (aka gas) for Wasm execution.
     pub wasm_fuel_unit: Amount,

--- a/linera-faucet/client/Cargo.toml
+++ b/linera-faucet/client/Cargo.toml
@@ -14,6 +14,7 @@ edition.workspace = true
 [dependencies]
 linera-base.workspace = true
 linera-client.workspace = true
+linera-execution.workspace = true
 linera-version.workspace = true
 reqwest.workspace = true
 serde.workspace = true

--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -5,8 +5,14 @@
 
 // TODO(#3362): generate this code
 
-use linera_base::{crypto::ValidatorPublicKey, data_types::ChainDescription};
+use std::collections::{BTreeMap, BTreeSet};
+
+use linera_base::{
+    crypto::ValidatorPublicKey,
+    data_types::{Amount, ChainDescription},
+};
 use linera_client::config::GenesisConfig;
+use linera_execution::{committee::ValidatorState, Committee, ResourceControlPolicy};
 use linera_version::VersionInfo;
 use thiserror_context::Context;
 
@@ -136,5 +142,141 @@ impl Faucet {
             .into_iter()
             .map(|validator| (validator.public_key, validator.network_address))
             .collect())
+    }
+
+    pub async fn current_committee(&self) -> Result<Committee, Error> {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct PolicyResponse {
+            wasm_fuel_unit: Amount,
+            evm_fuel_unit: Amount,
+            read_operation: Amount,
+            write_operation: Amount,
+            byte_runtime: Amount,
+            byte_read: Amount,
+            byte_written: Amount,
+            blob_read: Amount,
+            blob_published: Amount,
+            blob_byte_read: Amount,
+            blob_byte_published: Amount,
+            byte_stored: Amount,
+            operation: Amount,
+            operation_byte: Amount,
+            message: Amount,
+            message_byte: Amount,
+            service_as_oracle_query: Amount,
+            http_request: Amount,
+            maximum_wasm_fuel_per_block: u64,
+            maximum_evm_fuel_per_block: u64,
+            maximum_service_oracle_execution_ms: u64,
+            maximum_block_size: u64,
+            maximum_bytecode_size: u64,
+            maximum_blob_size: u64,
+            maximum_published_blobs: u64,
+            maximum_block_proposal_size: u64,
+            maximum_bytes_read_per_block: u64,
+            maximum_bytes_written_per_block: u64,
+            maximum_oracle_response_bytes: u64,
+            maximum_http_response_bytes: u64,
+            http_request_timeout_ms: u64,
+            http_request_allow_list: BTreeSet<String>,
+        }
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct CommitteeResponse {
+            validators: BTreeMap<ValidatorPublicKey, ValidatorState>,
+            policy: PolicyResponse,
+        }
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Response {
+            current_committee: CommitteeResponse,
+        }
+
+        let response = self
+            .query::<Response>(
+                "query { currentCommittee { \
+                    validators \
+                    policy { \
+                        wasmFuelUnit \
+                        evmFuelUnit \
+                        readOperation \
+                        writeOperation \
+                        byteRuntime \
+                        byteRead \
+                        byteWritten \
+                        blobRead \
+                        blobPublished \
+                        blobByteRead \
+                        blobBytePublished \
+                        byteStored \
+                        operation \
+                        operationByte \
+                        message \
+                        messageByte \
+                        serviceAsOracleQuery \
+                        httpRequest \
+                        maximumWasmFuelPerBlock \
+                        maximumEvmFuelPerBlock \
+                        maximumServiceOracleExecutionMs \
+                        maximumBlockSize \
+                        maximumBytecodeSize \
+                        maximumBlobSize \
+                        maximumPublishedBlobs \
+                        maximumBlockProposalSize \
+                        maximumBytesReadPerBlock \
+                        maximumBytesWrittenPerBlock \
+                        maximumOracleResponseBytes \
+                        maximumHttpResponseBytes \
+                        httpRequestTimeoutMs \
+                        httpRequestAllowList \
+                    } \
+                } }",
+            )
+            .await?;
+
+        let committee_response = response.current_committee;
+        let policy = ResourceControlPolicy {
+            wasm_fuel_unit: committee_response.policy.wasm_fuel_unit,
+            evm_fuel_unit: committee_response.policy.evm_fuel_unit,
+            read_operation: committee_response.policy.read_operation,
+            write_operation: committee_response.policy.write_operation,
+            byte_runtime: committee_response.policy.byte_runtime,
+            byte_read: committee_response.policy.byte_read,
+            byte_written: committee_response.policy.byte_written,
+            blob_read: committee_response.policy.blob_read,
+            blob_published: committee_response.policy.blob_published,
+            blob_byte_read: committee_response.policy.blob_byte_read,
+            blob_byte_published: committee_response.policy.blob_byte_published,
+            byte_stored: committee_response.policy.byte_stored,
+            operation: committee_response.policy.operation,
+            operation_byte: committee_response.policy.operation_byte,
+            message: committee_response.policy.message,
+            message_byte: committee_response.policy.message_byte,
+            service_as_oracle_query: committee_response.policy.service_as_oracle_query,
+            http_request: committee_response.policy.http_request,
+            maximum_wasm_fuel_per_block: committee_response.policy.maximum_wasm_fuel_per_block,
+            maximum_evm_fuel_per_block: committee_response.policy.maximum_evm_fuel_per_block,
+            maximum_service_oracle_execution_ms: committee_response
+                .policy
+                .maximum_service_oracle_execution_ms,
+            maximum_block_size: committee_response.policy.maximum_block_size,
+            maximum_bytecode_size: committee_response.policy.maximum_bytecode_size,
+            maximum_blob_size: committee_response.policy.maximum_blob_size,
+            maximum_published_blobs: committee_response.policy.maximum_published_blobs,
+            maximum_block_proposal_size: committee_response.policy.maximum_block_proposal_size,
+            maximum_bytes_read_per_block: committee_response.policy.maximum_bytes_read_per_block,
+            maximum_bytes_written_per_block: committee_response
+                .policy
+                .maximum_bytes_written_per_block,
+            maximum_oracle_response_bytes: committee_response.policy.maximum_oracle_response_bytes,
+            maximum_http_response_bytes: committee_response.policy.maximum_http_response_bytes,
+            http_request_timeout_ms: committee_response.policy.http_request_timeout_ms,
+            http_request_allow_list: committee_response.policy.http_request_allow_list,
+        };
+
+        Ok(Committee::new(committee_response.validators, policy))
     }
 }

--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -5,12 +5,9 @@
 
 // TODO(#3362): generate this code
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
-use linera_base::{
-    crypto::ValidatorPublicKey,
-    data_types::{Amount, ChainDescription},
-};
+use linera_base::{crypto::ValidatorPublicKey, data_types::ChainDescription};
 use linera_client::config::GenesisConfig;
 use linera_execution::{committee::ValidatorState, Committee, ResourceControlPolicy};
 use linera_version::VersionInfo;
@@ -146,47 +143,9 @@ impl Faucet {
 
     pub async fn current_committee(&self) -> Result<Committee, Error> {
         #[derive(serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct PolicyResponse {
-            wasm_fuel_unit: Amount,
-            evm_fuel_unit: Amount,
-            read_operation: Amount,
-            write_operation: Amount,
-            byte_runtime: Amount,
-            byte_read: Amount,
-            byte_written: Amount,
-            blob_read: Amount,
-            blob_published: Amount,
-            blob_byte_read: Amount,
-            blob_byte_published: Amount,
-            byte_stored: Amount,
-            operation: Amount,
-            operation_byte: Amount,
-            message: Amount,
-            message_byte: Amount,
-            service_as_oracle_query: Amount,
-            http_request: Amount,
-            maximum_wasm_fuel_per_block: u64,
-            maximum_evm_fuel_per_block: u64,
-            maximum_service_oracle_execution_ms: u64,
-            maximum_block_size: u64,
-            maximum_bytecode_size: u64,
-            maximum_blob_size: u64,
-            maximum_published_blobs: u64,
-            maximum_block_proposal_size: u64,
-            maximum_bytes_read_per_block: u64,
-            maximum_bytes_written_per_block: u64,
-            maximum_oracle_response_bytes: u64,
-            maximum_http_response_bytes: u64,
-            http_request_timeout_ms: u64,
-            http_request_allow_list: BTreeSet<String>,
-        }
-
-        #[derive(serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
         struct CommitteeResponse {
             validators: BTreeMap<ValidatorPublicKey, ValidatorState>,
-            policy: PolicyResponse,
+            policy: ResourceControlPolicy,
         }
 
         #[derive(serde::Deserialize)]
@@ -199,84 +158,16 @@ impl Faucet {
             .query::<Response>(
                 "query { currentCommittee { \
                     validators \
-                    policy { \
-                        wasmFuelUnit \
-                        evmFuelUnit \
-                        readOperation \
-                        writeOperation \
-                        byteRuntime \
-                        byteRead \
-                        byteWritten \
-                        blobRead \
-                        blobPublished \
-                        blobByteRead \
-                        blobBytePublished \
-                        byteStored \
-                        operation \
-                        operationByte \
-                        message \
-                        messageByte \
-                        serviceAsOracleQuery \
-                        httpRequest \
-                        maximumWasmFuelPerBlock \
-                        maximumEvmFuelPerBlock \
-                        maximumServiceOracleExecutionMs \
-                        maximumBlockSize \
-                        maximumBytecodeSize \
-                        maximumBlobSize \
-                        maximumPublishedBlobs \
-                        maximumBlockProposalSize \
-                        maximumBytesReadPerBlock \
-                        maximumBytesWrittenPerBlock \
-                        maximumOracleResponseBytes \
-                        maximumHttpResponseBytes \
-                        httpRequestTimeoutMs \
-                        httpRequestAllowList \
-                    } \
+                    policy \
                 } }",
             )
             .await?;
 
         let committee_response = response.current_committee;
-        let policy = ResourceControlPolicy {
-            wasm_fuel_unit: committee_response.policy.wasm_fuel_unit,
-            evm_fuel_unit: committee_response.policy.evm_fuel_unit,
-            read_operation: committee_response.policy.read_operation,
-            write_operation: committee_response.policy.write_operation,
-            byte_runtime: committee_response.policy.byte_runtime,
-            byte_read: committee_response.policy.byte_read,
-            byte_written: committee_response.policy.byte_written,
-            blob_read: committee_response.policy.blob_read,
-            blob_published: committee_response.policy.blob_published,
-            blob_byte_read: committee_response.policy.blob_byte_read,
-            blob_byte_published: committee_response.policy.blob_byte_published,
-            byte_stored: committee_response.policy.byte_stored,
-            operation: committee_response.policy.operation,
-            operation_byte: committee_response.policy.operation_byte,
-            message: committee_response.policy.message,
-            message_byte: committee_response.policy.message_byte,
-            service_as_oracle_query: committee_response.policy.service_as_oracle_query,
-            http_request: committee_response.policy.http_request,
-            maximum_wasm_fuel_per_block: committee_response.policy.maximum_wasm_fuel_per_block,
-            maximum_evm_fuel_per_block: committee_response.policy.maximum_evm_fuel_per_block,
-            maximum_service_oracle_execution_ms: committee_response
-                .policy
-                .maximum_service_oracle_execution_ms,
-            maximum_block_size: committee_response.policy.maximum_block_size,
-            maximum_bytecode_size: committee_response.policy.maximum_bytecode_size,
-            maximum_blob_size: committee_response.policy.maximum_blob_size,
-            maximum_published_blobs: committee_response.policy.maximum_published_blobs,
-            maximum_block_proposal_size: committee_response.policy.maximum_block_proposal_size,
-            maximum_bytes_read_per_block: committee_response.policy.maximum_bytes_read_per_block,
-            maximum_bytes_written_per_block: committee_response
-                .policy
-                .maximum_bytes_written_per_block,
-            maximum_oracle_response_bytes: committee_response.policy.maximum_oracle_response_bytes,
-            maximum_http_response_bytes: committee_response.policy.maximum_http_response_bytes,
-            http_request_timeout_ms: committee_response.policy.http_request_timeout_ms,
-            http_request_allow_list: committee_response.policy.http_request_allow_list,
-        };
 
-        Ok(Committee::new(committee_response.validators, policy))
+        Ok(Committee::new(
+            committee_response.validators,
+            committee_response.policy,
+        ))
     }
 }

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -39,7 +39,7 @@ use linera_core::{
 };
 use linera_execution::{
     system::{OpenChainConfig, SystemOperation},
-    ExecutionError, Operation,
+    Committee, ExecutionError, Operation,
 };
 #[cfg(feature = "metrics")]
 use linera_metrics::prometheus_server;
@@ -194,6 +194,11 @@ where
                 network_address: validator.network_address.clone(),
             })
             .collect())
+    }
+
+    /// Returns the current committee, including weights and resource policy.
+    async fn current_committee(&self) -> Result<Committee, Error> {
+        Ok(self.client.local_committee().await?)
     }
 }
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -450,7 +450,7 @@ input Committee {
 	"""
 	The policy agreed on for this epoch.
 	"""
-	policy: ResourceControlPolicy!
+	policy: ResourceControlPolicyOutput!
 }
 
 type ConfirmedBlock {
@@ -1254,7 +1254,7 @@ type ReentrantCollectionView_ChainId_OutboxStateView_06c2376d {
 """
 A collection of prices and limits associated with block execution.
 """
-input ResourceControlPolicy {
+input ResourceControlPolicyOutput {
 	"""
 	The price per unit of fuel (aka gas) for Wasm execution.
 	"""

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -450,7 +450,7 @@ input Committee {
 	"""
 	The policy agreed on for this epoch.
 	"""
-	policy: ResourceControlPolicyOutput!
+	policy: ResourceControlPolicyScalar!
 }
 
 type ConfirmedBlock {
@@ -1252,139 +1252,9 @@ type ReentrantCollectionView_ChainId_OutboxStateView_06c2376d {
 }
 
 """
-A collection of prices and limits associated with block execution.
+A collection of prices and limits associated with block execution
 """
-input ResourceControlPolicyOutput {
-	"""
-	The price per unit of fuel (aka gas) for Wasm execution.
-	"""
-	wasmFuelUnit: Amount!
-	"""
-	The price per unit of fuel (aka gas) for EVM execution.
-	"""
-	evmFuelUnit: Amount!
-	"""
-	The price of one read operation.
-	"""
-	readOperation: Amount!
-	"""
-	The price of one write operation.
-	"""
-	writeOperation: Amount!
-	"""
-	The price of accessing one byte from the runtime.
-	"""
-	byteRuntime: Amount!
-	"""
-	The price of reading a byte.
-	"""
-	byteRead: Amount!
-	"""
-	The price of writing a byte
-	"""
-	byteWritten: Amount!
-	"""
-	The base price to read a blob.
-	"""
-	blobRead: Amount!
-	"""
-	The base price to publish a blob.
-	"""
-	blobPublished: Amount!
-	"""
-	The price to read a blob, per byte.
-	"""
-	blobByteRead: Amount!
-	"""
-	The price to publish a blob, per byte.
-	"""
-	blobBytePublished: Amount!
-	"""
-	The price of increasing storage by a byte.
-	"""
-	byteStored: Amount!
-	"""
-	The base price of adding an operation to a block.
-	"""
-	operation: Amount!
-	"""
-	The additional price for each byte in the argument of a user operation.
-	"""
-	operationByte: Amount!
-	"""
-	The base price of sending a message from a block.
-	"""
-	message: Amount!
-	"""
-	The additional price for each byte in the argument of a user message.
-	"""
-	messageByte: Amount!
-	"""
-	The price per query to a service as an oracle.
-	"""
-	serviceAsOracleQuery: Amount!
-	"""
-	The price for a performing an HTTP request.
-	"""
-	httpRequest: Amount!
-	"""
-	The maximum amount of Wasm fuel a block can consume.
-	"""
-	maximumWasmFuelPerBlock: Int!
-	"""
-	The maximum amount of EVM fuel a block can consume.
-	"""
-	maximumEvmFuelPerBlock: Int!
-	"""
-	The maximum time in milliseconds that a block can spend executing services as oracles.
-	"""
-	maximumServiceOracleExecutionMs: Int!
-	"""
-	The maximum size of a block. This includes the block proposal itself as well as
-	the execution outcome.
-	"""
-	maximumBlockSize: Int!
-	"""
-	The maximum size of decompressed contract or service bytecode, in bytes.
-	"""
-	maximumBytecodeSize: Int!
-	"""
-	The maximum size of a blob.
-	"""
-	maximumBlobSize: Int!
-	"""
-	The maximum number of published blobs per block.
-	"""
-	maximumPublishedBlobs: Int!
-	"""
-	The maximum size of a block proposal.
-	"""
-	maximumBlockProposalSize: Int!
-	"""
-	The maximum data to read per block
-	"""
-	maximumBytesReadPerBlock: Int!
-	"""
-	The maximum data to write per block
-	"""
-	maximumBytesWrittenPerBlock: Int!
-	"""
-	The maximum size in bytes of an oracle response.
-	"""
-	maximumOracleResponseBytes: Int!
-	"""
-	The maximum size in bytes of a received HTTP response.
-	"""
-	maximumHttpResponseBytes: Int!
-	"""
-	The maximum amount of time allowed to wait for an HTTP response.
-	"""
-	httpRequestTimeoutMs: Int!
-	"""
-	The list of hosts that contracts and services can send HTTP requests to.
-	"""
-	httpRequestAllowList: [String!]!
-}
+scalar ResourceControlPolicyScalar
 
 """
 A number to identify successive attempts to decide a value in a consensus protocol.

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -19,7 +19,7 @@ use chrono::Utc;
 use colored::Colorize;
 use futures::{lock::Mutex, FutureExt as _, StreamExt};
 use linera_base::{
-    crypto::{AccountPublicKey, InMemorySigner, Signer},
+    crypto::{InMemorySigner, Signer},
     data_types::{ApplicationPermissions, Timestamp},
     identifiers::{AccountOwner, ChainId},
     listen_for_shutdown_signals,
@@ -1624,24 +1624,8 @@ impl Runnable for Job {
                     signer.into_value(),
                 );
                 let faucet = cli_wrappers::Faucet::new(faucet_url);
-                let validators = faucet.current_validators().await?;
+                let committee = faucet.current_committee().await?;
                 let chain_client = context.make_chain_client(network_description.admin_chain_id);
-                // TODO(#4434): This is a quick workaround with an equal-weight committee. Instead,
-                // the faucet should provide the full committee including weights.
-                let committee = Committee::new(
-                    validators
-                        .into_iter()
-                        .map(|(pub_key, network_address)| {
-                            let state = ValidatorState {
-                                network_address,
-                                votes: 100,
-                                account_public_key: AccountPublicKey::from_slice(&[0; 33]).unwrap(),
-                            };
-                            (pub_key, state)
-                        })
-                        .collect(),
-                    Default::default(), // unused
-                );
                 chain_client
                     .synchronize_chain_state_from_committee(committee)
                     .await?;


### PR DESCRIPTION
## Motivation

In https://github.com/linera-io/linera-protocol/pull/4437 I used the existing `currentValidators` faucet query in `wallet init` and then made the client synchronize the initial admin chain from a committee where all these validators have the same weight.

## Proposal

Add a `currentCommittee` query that returns the actual current committee, and use that to synchronize.

## Test Plan

The reconfiguration test exercises this.

## Release Plan

- These changes should be backported to devnet and testnet, published in an SDK and deployed in the faucet.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/4434.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
