### PR TITLE
Add `epoch` to the `UserChain` and `linera wallet show`

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -14,7 +14,7 @@ use futures::{
 };
 use linera_base::{
     crypto::{CryptoHash, Signer},
-    data_types::{ChainDescription, Timestamp},
+    data_types::{ChainDescription, Epoch, Timestamp},
     identifiers::{AccountOwner, BlobType, ChainId},
     task::NonBlockingFuture,
 };
@@ -107,6 +107,7 @@ pub trait ClientContext {
         chain_id: ChainId,
         owner: Option<AccountOwner>,
         timestamp: Timestamp,
+        epoch: Epoch,
     ) -> Result<(), Error>;
 
     async fn update_wallet(&mut self, client: &ContextChainClient<Self>) -> Result<(), Error>;
@@ -339,6 +340,7 @@ impl<C: ClientContext> ChainListener<C> {
                             new_chain_id,
                             Some(chain_owner),
                             block.header.timestamp,
+                            block.header.epoch,
                         )
                         .await?;
                     new_ids.insert(new_chain_id, ListeningMode::FullChain);

--- a/linera-client/src/unit_tests/wallet.rs
+++ b/linera-client/src/unit_tests/wallet.rs
@@ -52,7 +52,6 @@ async fn test_save_wallet_with_pending_blobs() -> anyhow::Result<()> {
         new_pubkey.into(),
         builder.admin_description().unwrap().clone(),
         clock.current_time(),
-        Epoch::ZERO,
     ));
     wallet.chains_mut().next().unwrap().pending_proposal = Some(PendingProposal {
         block: ProposedBlock {

--- a/linera-client/src/unit_tests/wallet.rs
+++ b/linera-client/src/unit_tests/wallet.rs
@@ -52,6 +52,7 @@ async fn test_save_wallet_with_pending_blobs() -> anyhow::Result<()> {
         new_pubkey.into(),
         builder.admin_description().unwrap().clone(),
         clock.current_time(),
+        Epoch::ZERO,
     ));
     wallet.chains_mut().next().unwrap().pending_proposal = Some(PendingProposal {
         block: ProposedBlock {

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeMap, iter::IntoIterator};
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{BlockHeight, ChainDescription, Timestamp},
+    data_types::{BlockHeight, ChainDescription, Epoch, Timestamp},
     ensure,
     identifiers::{AccountOwner, ChainId},
 };
@@ -109,6 +109,7 @@ impl Wallet {
         owner: AccountOwner,
         chain_id: ChainId,
         timestamp: Timestamp,
+        epoch: Epoch,
     ) -> Result<(), Error> {
         let user_chain = UserChain {
             chain_id,
@@ -117,6 +118,7 @@ impl Wallet {
             timestamp,
             next_block_height: BlockHeight(0),
             pending_proposal: None,
+            epoch: Some(epoch),
         };
         self.insert(user_chain);
         Ok(())
@@ -144,6 +146,7 @@ impl Wallet {
             next_block_height: info.next_block_height,
             timestamp: info.timestamp,
             pending_proposal,
+            epoch: Some(info.epoch),
         });
     }
 
@@ -165,6 +168,7 @@ pub struct UserChain {
     pub timestamp: Timestamp,
     pub next_block_height: BlockHeight,
     pub pending_proposal: Option<PendingProposal>,
+    pub epoch: Option<Epoch>,
 }
 
 impl Clone for UserChain {
@@ -176,6 +180,7 @@ impl Clone for UserChain {
             timestamp: self.timestamp,
             next_block_height: self.next_block_height,
             pending_proposal: self.pending_proposal.clone(),
+            epoch: self.epoch,
         }
     }
 }
@@ -186,6 +191,7 @@ impl UserChain {
         owner: AccountOwner,
         description: ChainDescription,
         timestamp: Timestamp,
+        epoch: Epoch,
     ) -> Self {
         Self {
             chain_id: description.into(),
@@ -194,11 +200,12 @@ impl UserChain {
             timestamp,
             next_block_height: BlockHeight::ZERO,
             pending_proposal: None,
+            epoch: Some(epoch),
         }
     }
 
-    /// Creates an entry for a chain that we don't own. The timestamp must be the genesis
-    /// timestamp or earlier.
+    /// Creates an entry for a chain that we don't own. The timestamp is the genesis
+    /// timestamp or earlier. The Epoch is 0.
     pub fn make_other(chain_id: ChainId, timestamp: Timestamp) -> Self {
         Self {
             chain_id,
@@ -207,6 +214,7 @@ impl UserChain {
             timestamp,
             next_block_height: BlockHeight::ZERO,
             pending_proposal: None,
+            epoch: None,
         }
     }
 }

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -191,8 +191,8 @@ impl UserChain {
         owner: AccountOwner,
         description: ChainDescription,
         timestamp: Timestamp,
-        epoch: Epoch,
     ) -> Self {
+        let epoch = description.config().epoch;
         Self {
             chain_id: description.into(),
             owner: Some(owner),
@@ -205,7 +205,7 @@ impl UserChain {
     }
 
     /// Creates an entry for a chain that we don't own. The timestamp must be the genesis
-    /// timestamp or earlier. The Epoch is unknwon.
+    /// timestamp or earlier. The Epoch is `None`.
     pub fn make_other(chain_id: ChainId, timestamp: Timestamp) -> Self {
         Self {
             chain_id,

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -204,8 +204,8 @@ impl UserChain {
         }
     }
 
-    /// Creates an entry for a chain that we don't own. The timestamp is the genesis
-    /// timestamp or earlier. The Epoch is 0.
+    /// Creates an entry for a chain that we don't own. The timestamp must be the genesis
+    /// timestamp or earlier. The Epoch is unknwon.
     pub fn make_other(chain_id: ChainId, timestamp: Timestamp) -> Self {
         Self {
             chain_id,

--- a/linera-faucet/server/src/tests.rs
+++ b/linera-faucet/server/src/tests.rs
@@ -8,7 +8,7 @@ use std::{collections::VecDeque, path::PathBuf, sync::Arc};
 use futures::lock::Mutex;
 use linera_base::{
     crypto::{AccountPublicKey, CryptoHash, InMemorySigner, TestString},
-    data_types::{Amount, Timestamp},
+    data_types::{Amount, Epoch, Timestamp},
     identifiers::{AccountOwner, ChainId},
 };
 use linera_client::{chain_listener, wallet::Wallet};
@@ -58,6 +58,7 @@ impl chain_listener::ClientContext for ClientContext {
         _: ChainId,
         _: Option<AccountOwner>,
         _: Timestamp,
+        _: Epoch,
     ) -> Result<(), linera_client::Error> {
         self.update_calls += 1;
         Ok(())

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -19,7 +19,7 @@ use colored::Colorize;
 use futures::{lock::Mutex, FutureExt as _, StreamExt};
 use linera_base::{
     crypto::{InMemorySigner, Signer},
-    data_types::{ApplicationPermissions, Epoch, Timestamp},
+    data_types::{ApplicationPermissions, Timestamp},
     identifiers::{AccountOwner, ChainId},
     listen_for_shutdown_signals,
     ownership::ChainOwnership,
@@ -2149,19 +2149,16 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                 ),
             )?;
             let admin_chain_description = genesis_config.admin_chain_description();
-            let epoch = Epoch::ZERO; // By definition, genesis is the first.
             let mut chains = vec![UserChain::make_initial(
                 admin_public_key.into(),
                 admin_chain_description.clone(),
                 timestamp,
-                epoch,
             )];
             for _ in 0..*num_other_initial_chains {
                 // Create keys.
                 let public_key = signer.mutate(|s| s.generate_new()).await?;
                 let description = genesis_config.add_root_chain(public_key, *initial_funding);
-                let chain =
-                    UserChain::make_initial(public_key.into(), description, timestamp, epoch);
+                let chain = UserChain::make_initial(public_key.into(), description, timestamp);
                 chains.push(chain);
             }
             genesis_config.persist().await?;

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{BlobContent, BlockHeight, NetworkDescription, Timestamp},
+    data_types::{BlobContent, BlockHeight, Epoch, NetworkDescription, Timestamp},
     identifiers::{AccountOwner, BlobId, ChainId},
 };
 use linera_chain::{
@@ -212,6 +212,7 @@ impl ClientContext for DummyContext {
         _: ChainId,
         _: Option<AccountOwner>,
         _: Timestamp,
+        _: Epoch,
     ) -> Result<(), Error> {
         Ok(())
     }

--- a/linera-service/src/wallet.rs
+++ b/linera-service/src/wallet.rs
@@ -18,6 +18,7 @@ pub async fn pretty_print(wallet: &Wallet, chain_ids: impl IntoIterator<Item = C
             Cell::new("Chain ID").add_attribute(Attribute::Bold),
             Cell::new("Latest Block").add_attribute(Attribute::Bold),
         ]);
+
     for chain_id in chain_ids {
         let Some(user_chain) = wallet.chains.get(&chain_id) else {
             panic!("Chain {} not found.", chain_id);
@@ -39,10 +40,15 @@ async fn update_table_with_chain(
     user_chain: &UserChain,
     is_default_chain: bool,
 ) {
+    let epoch = user_chain.epoch;
     let chain_id_cell = if is_default_chain {
         Cell::new(format!("{}", chain_id)).fg(Color::Green)
     } else {
         Cell::new(format!("{}", chain_id))
+    };
+    let epoch_str = match epoch {
+        None => "-".to_string(),
+        Some(epoch) => format!("{}", epoch),
     };
     let account_owner = user_chain.owner;
     table.add_row(vec![
@@ -51,7 +57,8 @@ async fn update_table_with_chain(
             r#"AccountOwner:       {}
 Block Hash:         {}
 Timestamp:          {}
-Next Block Height:  {}"#,
+Next Block Height:  {}
+Epoch:              {}"#,
             account_owner
                 .as_ref()
                 .map(|o| o.to_string())
@@ -61,7 +68,8 @@ Next Block Height:  {}"#,
                 .map(|bh| bh.to_string())
                 .unwrap_or_else(|| "-".to_string()),
             user_chain.timestamp,
-            user_chain.next_block_height
+            user_chain.next_block_height,
+            epoch_str
         )),
     ]);
 }

--- a/linera-web/src/lib.rs
+++ b/linera-web/src/lib.rs
@@ -140,6 +140,7 @@ impl JsFaucet {
                     account_owner,
                     description.id(),
                     description.timestamp(),
+                    description.config().epoch,
                 )
             })
             .await??;


### PR DESCRIPTION
## Motivation

The `linera wallet show` presents the data on the chain being tracked. Other information can be added easily.

Fixes #2958 

## Proposal

The `epoch` is always present in the output of `chain_info_query`. So, it can be added to the `UserChain`
easily.

Possible extension:
* Adding if a chain is closed or not (it suffices to add a boolean to `ChainInfo`).

## Test Plan

The readme test case fungible which is the only one with `linera wallet show` has been 

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.