### PR TITLE
Replace fault type `Malicious` with `NoChains`.

### DIFF
--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -803,7 +803,7 @@ where
 {
     let signer = InMemorySigner::new(None);
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
-    builder.set_fault_type([0, 1], FaultType::Malicious);
+    builder.set_fault_type([0, 1], FaultType::NoChains);
     let chain_1 = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let chain_2 = builder.add_root_chain(2, Amount::from_tokens(4)).await?;
     let result = chain_1
@@ -817,7 +817,7 @@ where
     assert_matches!(
         result,
         Err(ChainClientError::CommunicationError(
-            CommunicationError::Trusted(NodeError::ArithmeticError { .. })
+            CommunicationError::Trusted(NodeError::InactiveChain(_))
         )),
         "unexpected result"
     );

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -63,7 +63,7 @@ pub enum FaultType {
     Honest,
     Offline,
     OfflineWithInfo,
-    Malicious,
+    NoChains,
     DontSendConfirmVote,
     DontProcessValidated,
     DontSendValidateVote,
@@ -298,10 +298,6 @@ where
         self.fault_type = fault_type;
     }
 
-    async fn fault_type(&self) -> FaultType {
-        self.fault_type
-    }
-
     /// Obtains the basic `ChainInfo` data for the local validator chain, with chain manager values.
     pub async fn chain_info_with_manager_values(
         &mut self,
@@ -339,7 +335,7 @@ where
             FaultType::Offline | FaultType::OfflineWithInfo => Err(NodeError::ClientIoError {
                 error: "offline".to_string(),
             }),
-            FaultType::Malicious => Err(ArithmeticError::Overflow.into()),
+            FaultType::NoChains => Err(NodeError::InactiveChain(proposal.content.block.chain_id)),
             FaultType::DontSendValidateVote
             | FaultType::Honest
             | FaultType::DontSendConfirmVote
@@ -399,9 +395,9 @@ where
                     error: "refusing to process validated block".to_string(),
                 })
             }
+            FaultType::NoChains => Err(NodeError::InactiveChain(certificate.value().chain_id())),
             FaultType::Honest
             | FaultType::DontSendConfirmVote
-            | FaultType::Malicious
             | FaultType::DontProcessValidated
             | FaultType::DontSendValidateVote => {
                 let result = validator
@@ -443,16 +439,20 @@ where
         sender: oneshot::Sender<Result<ChainInfoResponse, NodeError>>,
     ) -> Result<(), Result<ChainInfoResponse, NodeError>> {
         let validator = self.client.lock().await;
-        let result = if self.fault_type == FaultType::Offline {
-            Err(NodeError::ClientIoError {
+        let result = match self.fault_type {
+            FaultType::Offline => Err(NodeError::ClientIoError {
                 error: "offline".to_string(),
-            })
-        } else {
-            validator
+            }),
+            FaultType::NoChains => Err(NodeError::InactiveChain(query.chain_id)),
+            FaultType::Honest
+            | FaultType::DontSendConfirmVote
+            | FaultType::DontProcessValidated
+            | FaultType::DontSendValidateVote
+            | FaultType::OfflineWithInfo => validator
                 .state
                 .handle_chain_info_query(query)
                 .await
-                .map_err(Into::into)
+                .map_err(Into::into),
         };
         // In a local node cross-chain messages can't get lost, so we can ignore the actions here.
         sender.send(result.map(|(info, _actions)| info))
@@ -867,7 +867,7 @@ where
             let mut validator = LocalValidatorClient::new(validator_public_key, state);
             if i < with_faulty_validators {
                 faulty_validators.insert(validator_public_key);
-                validator.set_fault_type(FaultType::Malicious);
+                validator.set_fault_type(FaultType::NoChains);
             }
             validator_clients.push(validator);
             validator_storages.insert(validator_public_key, storage);
@@ -966,19 +966,7 @@ where
                 .write_blob(&committee_blob)
                 .await
                 .expect("writing a blob should succeed");
-            if validator.fault_type().await == FaultType::Malicious {
-                let origin = description.origin();
-                let config = InitialChainConfig {
-                    balance: Amount::ZERO,
-                    ..description.config().clone()
-                };
-                storage
-                    .create_chain(ChainDescription::new(origin, config, Timestamp::from(0)))
-                    .await
-                    .unwrap();
-            } else {
-                storage.create_chain(description.clone()).await.unwrap();
-            }
+            storage.create_chain(description.clone()).await.unwrap();
         }
         for storage in self.chain_client_storages.iter_mut() {
             storage.create_chain(description.clone()).await.unwrap();


### PR DESCRIPTION
## Motivation

We simulate a range of validator faults in the `linera-core` tests. One of them is called `Malicious`, but it really just initializes the storage with wrong chains and returns `ArithmeticError`s in some cases. After https://github.com/linera-io/linera-protocol/pull/3787#discussion_r2065778559, the wrong initialization even causes the chains to have different chain ID, not just a wrong balance, so they will often return `InactiveChain` errors.

Even before that chain, the storage initialization fault didn't play well with `set_fault_type`: Even if we switch them to `Honest`, they will still be faulty due to their storage contents.

## Proposal

Replace `Malicious` with `NoChains`: Storage _does_ get initialized, but these validators return `InactiveChain` anyway, when handling block proposals, certificates or chain info queries.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- (But might as well be backported: It's test only and not problematic.)

## Links

- Closes #3858.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
