### PR TITLE
Fix and re-enable `test_finalize_validated`.

### DIFF
--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1271,7 +1271,7 @@ where
     B: StorageBuilder,
 {
     let signer = InMemorySigner::new(None);
-    let mut builder = TestBuilder::new(storage_builder, 4, 1, signer).await?;
+    let mut builder = TestBuilder::new(storage_builder, 2, 0, signer).await?;
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let receiver = builder.add_root_chain(2, Amount::ZERO).await?;
     let receiver_id = receiver.chain_id();

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2115,9 +2115,6 @@ where
     Ok(())
 }
 
-// TODO(#3860): this test is currently intermittently failing if the faulty validators respond to
-// client0 before the correct ones. Un-ignore when this issue is fixed.
-#[ignore]
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
@@ -2158,6 +2155,10 @@ where
         .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await;
     assert!(result.is_err());
+    // Make sure at least one validator has added the proposal to its state.
+    let info = client0.chain_info_with_manager_values().await?;
+    let proposal = info.manager.requested_proposed.unwrap();
+    builder.node(1).handle_block_proposal(*proposal).await?;
 
     // Client 1 thinks it is madness to burn 3 tokens! They want to publish a blob instead.
     // The validators are still faulty: They validate blocks but don't confirm them.
@@ -2179,8 +2180,8 @@ where
         .blobs
         .is_empty());
 
-    // Finally, the validators are online and honest again.
-    builder.set_fault_type([1, 2], FaultType::Honest);
+    // Finally, enough validators are online and honest again.
+    builder.set_fault_type([2], FaultType::Honest);
     client0.synchronize_from_validators().await.unwrap();
     let manager = client0
         .chain_info_with_manager_values()


### PR DESCRIPTION
## Motivation

This test is `#[ignore]`d because it's flaky: If the faulty validators respond before the other ones start processing the proposal, neither of them will have the proposal in their chain manager.

Also, `test_sparse_sender_chain` is flaky: If the randomly chosen validator (the first in the committee, i.e. by public key) is faulty, processing the notification will fail.

## Proposal

Explicitly handle the proposal in one of the validators to make sure the test is set up for the intended scenario.

In `test_sparse_sender_chain`, use two validators with no faulty one, so the selected validator is guaranteed to have the block.

## Test Plan

I ran it 20 times locally and it always passed.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- (Backporting would be no problem.)

## Links

- Closes #3860.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
