### PR TITLE
Make transaction tracker oracle methods harder to misuse.

### DIFF
--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -265,12 +265,11 @@ impl TransactionTracker {
                 recorded_response == oracle_response,
                 ExecutionError::OracleResponseMismatch
             );
-            self.oracle_responses.push(recorded_response);
             true
         } else {
-            self.oracle_responses.push(oracle_response);
             false
         };
+        self.oracle_responses.push(oracle_response);
         Ok(replaying)
     }
 


### PR DESCRIPTION
## Motivation

In the execution code, oracles must always be used as follows:
* In replay mode, we consume an oracle response from the recorded ones.
* If _not_ in replay mode, we query the actual oracle to obtain the value.
* In both cases, we have to add it to the oracle responses in the execution outcome.

It's currently easy to forget one of those steps.

## Proposal

Refactor the transaction tracker's methods to make it a bit harder to use them the wrong way.

Also remove a few unused execution requests. (We could make these crate-private, but in a separate PR.)

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- (But could easily be backported.)

## Links

- Closes #3519.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
