### PR TITLE
Make transaction tracker oracle methods harder to misuse.

### DIFF
--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -27,7 +27,7 @@ use crate::{
     execution::UserAction,
     runtime::ContractSyncRuntime,
     system::{CreateApplicationResult, OpenChainConfig},
-    util::RespondExt,
+    util::{OracleResponseExt as _, RespondExt as _},
     ApplicationDescription, ApplicationId, ExecutionError, ExecutionRuntimeConfig,
     ExecutionRuntimeContext, ExecutionStateView, Message, MessageContext, MessageKind, ModuleId,
     Operation, OperationContext, OutgoingMessage, ProcessStreamsContext, QueryContext,
@@ -387,66 +387,60 @@ where
                 http_responses_are_oracle_responses,
                 callback,
             } => {
-                let response = if let Some(response) =
-                    self.txn_tracker.next_replayed_oracle_response()?
-                {
-                    match response {
-                        OracleResponse::Http(response) => response,
-                        _ => return Err(ExecutionError::OracleResponseMismatch),
-                    }
-                } else {
-                    let headers = request
-                        .headers
-                        .into_iter()
-                        .map(|http::Header { name, value }| Ok((name.parse()?, value.try_into()?)))
-                        .collect::<Result<HeaderMap, ExecutionError>>()?;
+                let system = &mut self.state.system;
+                let response = self
+                    .txn_tracker
+                    .oracle(|| async {
+                        let headers = request
+                            .headers
+                            .into_iter()
+                            .map(|http::Header { name, value }| {
+                                Ok((name.parse()?, value.try_into()?))
+                            })
+                            .collect::<Result<HeaderMap, ExecutionError>>()?;
 
-                    let url = Url::parse(&request.url)?;
-                    let host = url
-                        .host_str()
-                        .ok_or_else(|| ExecutionError::UnauthorizedHttpRequest(url.clone()))?;
+                        let url = Url::parse(&request.url)?;
+                        let host = url
+                            .host_str()
+                            .ok_or_else(|| ExecutionError::UnauthorizedHttpRequest(url.clone()))?;
 
-                    let (_epoch, committee) = self
-                        .state
-                        .system
-                        .current_committee()
-                        .ok_or_else(|| ExecutionError::UnauthorizedHttpRequest(url.clone()))?;
-                    let allowed_hosts = &committee.policy().http_request_allow_list;
+                        let (_epoch, committee) = system
+                            .current_committee()
+                            .ok_or_else(|| ExecutionError::UnauthorizedHttpRequest(url.clone()))?;
+                        let allowed_hosts = &committee.policy().http_request_allow_list;
 
-                    ensure!(
-                        allowed_hosts.contains(host),
-                        ExecutionError::UnauthorizedHttpRequest(url)
-                    );
+                        ensure!(
+                            allowed_hosts.contains(host),
+                            ExecutionError::UnauthorizedHttpRequest(url)
+                        );
 
-                    #[cfg_attr(web, allow(unused_mut))]
-                    let mut request = Client::new()
-                        .request(request.method.into(), url)
-                        .body(request.body)
-                        .headers(headers);
-                    #[cfg(not(web))]
-                    {
-                        request = request.timeout(linera_base::time::Duration::from_millis(
-                            committee.policy().http_request_timeout_ms,
-                        ));
-                    }
+                        #[cfg_attr(web, allow(unused_mut))]
+                        let mut request = Client::new()
+                            .request(request.method.into(), url)
+                            .body(request.body)
+                            .headers(headers);
+                        #[cfg(not(web))]
+                        {
+                            request = request.timeout(linera_base::time::Duration::from_millis(
+                                committee.policy().http_request_timeout_ms,
+                            ));
+                        }
 
-                    let response = request.send().await?;
+                        let response = request.send().await?;
 
-                    let mut response_size_limit = committee.policy().maximum_http_response_bytes;
+                        let mut response_size_limit =
+                            committee.policy().maximum_http_response_bytes;
 
-                    if http_responses_are_oracle_responses {
-                        response_size_limit = response_size_limit
-                            .min(committee.policy().maximum_oracle_response_bytes);
-                    }
-
-                    self.receive_http_response(response, response_size_limit)
-                        .await?
-                };
-
-                // Record the oracle response
-                self.txn_tracker
-                    .add_oracle_response(OracleResponse::Http(response.clone()));
-
+                        if http_responses_are_oracle_responses {
+                            response_size_limit = response_size_limit
+                                .min(committee.policy().maximum_oracle_response_bytes);
+                        }
+                        Ok(OracleResponse::Http(
+                            Self::receive_http_response(response, response_size_limit).await?,
+                        ))
+                    })
+                    .await?
+                    .to_http_response()?;
                 callback.respond(response);
             }
 
@@ -513,25 +507,18 @@ where
             }
 
             ReadEvent { event_id, callback } => {
-                let event = match self.txn_tracker.next_replayed_oracle_response()? {
-                    None => {
-                        let event = self
-                            .state
-                            .context()
-                            .extra()
+                let extra = self.state.context().extra();
+                let event = self
+                    .txn_tracker
+                    .oracle(|| async {
+                        let event = extra
                             .get_event(event_id.clone())
-                            .await?;
-                        event.ok_or(ExecutionError::EventsNotFound(vec![event_id.clone()]))?
-                    }
-                    Some(OracleResponse::Event(recorded_event_id, event))
-                        if recorded_event_id == event_id =>
-                    {
-                        event
-                    }
-                    Some(_) => return Err(ExecutionError::OracleResponseMismatch),
-                };
-                self.txn_tracker
-                    .add_oracle_response(OracleResponse::Event(event_id, event.clone()));
+                            .await?
+                            .ok_or(ExecutionError::EventsNotFound(vec![event_id.clone()]))?;
+                        Ok(OracleResponse::Event(event_id.clone(), event))
+                    })
+                    .await?
+                    .to_event(&event_id)?;
                 callback.respond(event);
             }
 
@@ -598,36 +585,37 @@ where
                 query,
                 callback,
             } => {
-                let response = match self.txn_tracker.next_replayed_oracle_response()? {
-                    Some(OracleResponse::Service(bytes)) => bytes,
-                    Some(_) => return Err(ExecutionError::OracleResponseMismatch),
-                    None => {
+                let state = &mut self.state;
+                let local_time = self.txn_tracker.local_time();
+                let created_blobs = self.txn_tracker.created_blobs().clone();
+                let bytes = self
+                    .txn_tracker
+                    .oracle(|| async {
                         let context = QueryContext {
-                            chain_id: self.state.context().extra().chain_id(),
+                            chain_id: state.context().extra().chain_id(),
                             next_block_height,
-                            local_time: self.txn_tracker.local_time(),
+                            local_time,
                         };
                         let QueryOutcome {
                             response,
                             operations,
-                        } = Box::pin(self.state.query_user_application_with_deadline(
+                        } = Box::pin(state.query_user_application_with_deadline(
                             application_id,
                             context,
                             query,
                             deadline,
-                            self.txn_tracker.created_blobs().clone(),
+                            created_blobs,
                         ))
                         .await?;
                         ensure!(
                             operations.is_empty(),
                             ExecutionError::ServiceOracleQueryOperations(operations)
                         );
-                        response
-                    }
-                };
-                self.txn_tracker
-                    .add_oracle_response(OracleResponse::Service(response.clone()));
-                callback.respond(response);
+                        Ok(OracleResponse::Service(response))
+                    })
+                    .await?
+                    .to_service_response()?;
+                callback.respond(bytes);
             }
 
             AddOutgoingMessage { message, callback } => {
@@ -673,18 +661,12 @@ where
             }
 
             ValidationRound { round, callback } => {
-                let result_round =
-                    if let Some(response) = self.txn_tracker.next_replayed_oracle_response()? {
-                        match response {
-                            OracleResponse::Round(round) => round,
-                            _ => return Err(ExecutionError::OracleResponseMismatch),
-                        }
-                    } else {
-                        round
-                    };
-                self.txn_tracker
-                    .add_oracle_response(OracleResponse::Round(result_round));
-                callback.respond(result_round);
+                let validation_round = self
+                    .txn_tracker
+                    .oracle(|| async { Ok(OracleResponse::Round(round)) })
+                    .await?
+                    .to_round()?;
+                callback.respond(validation_round);
             }
         }
 
@@ -929,7 +911,6 @@ where
     ///
     /// Ensures that the response does not exceed the provided `size_limit`.
     async fn receive_http_response(
-        &mut self,
         response: reqwest::Response,
         size_limit: u64,
     ) -> Result<http::Response, ExecutionError> {

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -3,6 +3,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    future::Future,
     mem, vec,
 };
 
@@ -166,12 +167,24 @@ impl TransactionTracker {
         &self.blobs
     }
 
-    pub fn add_oracle_response(&mut self, oracle_response: OracleResponse) {
-        self.oracle_responses.push(oracle_response);
-    }
-
     pub fn add_operation_result(&mut self, result: Option<Vec<u8>>) {
         self.operation_result = result
+    }
+
+    /// In replay mode, returns the next recorded oracle response. Otherwise executes `f` and
+    /// records and returns the result. `f` is the implementation of the actual oracle and is
+    /// only called in validation mode, so it does not have to be fully deterministic.
+    pub async fn oracle<F, G>(&mut self, f: F) -> Result<&OracleResponse, ExecutionError>
+    where
+        F: FnOnce() -> G,
+        G: Future<Output = Result<OracleResponse, ExecutionError>>,
+    {
+        let response = match self.next_replayed_oracle_response()? {
+            Some(response) => response,
+            None => f().await?,
+        };
+        self.oracle_responses.push(response);
+        Ok(self.oracle_responses.last().unwrap())
     }
 
     pub fn add_stream_to_process(
@@ -245,7 +258,7 @@ impl TransactionTracker {
         } else {
             false
         };
-        self.add_oracle_response(oracle_response);
+        self.oracle_responses.push(oracle_response);
         Ok(replaying)
     }
 
@@ -256,9 +269,7 @@ impl TransactionTracker {
     ///
     /// In both cases, the value (returned or obtained from the oracle) must be recorded using
     /// `add_oracle_response`.
-    pub fn next_replayed_oracle_response(
-        &mut self,
-    ) -> Result<Option<OracleResponse>, ExecutionError> {
+    fn next_replayed_oracle_response(&mut self) -> Result<Option<OracleResponse>, ExecutionError> {
         let Some(responses) = &mut self.replaying_oracle_responses else {
             return Ok(None); // Not in replay mode.
         };

--- a/linera-execution/src/util/mod.rs
+++ b/linera-execution/src/util/mod.rs
@@ -6,6 +6,7 @@
 mod sync_response;
 
 use futures::channel::mpsc;
+use linera_base::{data_types::OracleResponse, http::Response, identifiers::EventId};
 
 pub use self::sync_response::SyncSender;
 use crate::ExecutionError;
@@ -122,6 +123,48 @@ impl<Response> RespondExt for SyncSender<Response> {
     fn respond(self, response: Self::Response) {
         if self.send(response).is_err() {
             tracing::debug!("Request sent to `RuntimeActor` was canceled");
+        }
+    }
+}
+
+pub(crate) trait OracleResponseExt {
+    fn to_round(&self) -> Result<Option<u32>, ExecutionError>;
+
+    fn to_service_response(&self) -> Result<Vec<u8>, ExecutionError>;
+
+    fn to_http_response(&self) -> Result<Response, ExecutionError>;
+
+    fn to_event(&self, event_id: &EventId) -> Result<Vec<u8>, ExecutionError>;
+}
+
+impl OracleResponseExt for OracleResponse {
+    fn to_round(&self) -> Result<Option<u32>, ExecutionError> {
+        match self {
+            OracleResponse::Round(round) => Ok(*round),
+            _ => Err(ExecutionError::OracleResponseMismatch),
+        }
+    }
+
+    fn to_service_response(&self) -> Result<Vec<u8>, ExecutionError> {
+        match self {
+            OracleResponse::Service(bytes) => Ok(bytes.clone()),
+            _ => Err(ExecutionError::OracleResponseMismatch),
+        }
+    }
+
+    fn to_http_response(&self) -> Result<Response, ExecutionError> {
+        match self {
+            OracleResponse::Http(response) => Ok(response.clone()),
+            _ => Err(ExecutionError::OracleResponseMismatch),
+        }
+    }
+
+    fn to_event(&self, event_id: &EventId) -> Result<Vec<u8>, ExecutionError> {
+        match self {
+            OracleResponse::Event(recorded_event_id, event) if recorded_event_id == event_id => {
+                Ok(event.clone())
+            }
+            _ => Err(ExecutionError::OracleResponseMismatch),
         }
     }
 }


### PR DESCRIPTION
## Motivation

In the execution code, oracles must always be used as follows:
* In replay mode, we consume an oracle response from the recorded ones.
* If _not_ in replay mode, we query the actual oracle to obtain the value.
* In both cases, we have to add it to the oracle responses in the execution outcome.

It's currently easy to forget one of those steps.

## Proposal

Refactor the transaction tracker's methods to make it a bit harder to use them the wrong way.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- (But could easily be backported.)

## Links

- Closes #3519.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
