### PR TITLE
Send `NewRound` notifications after proposals.

### DIFF
--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3623,7 +3623,8 @@ where
         .into_proposal_with_round(owner1, &signer, Round::MultiLeader(1))
         .await
         .unwrap();
-    let _ = env.worker().handle_block_proposal(proposal1).await?;
+    let (_, actions) = env.worker().handle_block_proposal(proposal1).await?;
+    assert_matches!(actions.notifications[0].reason, Reason::NewRound { .. });
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
     let (response, _) = env.worker().handle_chain_info_query(query_values).await?;
     assert_eq!(response.info.manager.current_round, Round::MultiLeader(1));


### PR DESCRIPTION
## Motivation

`NewRound` notifications are mainly needed for single-leader mode, where they are triggered by timeout certificates.

However, in multi-leader mode, in case of failed proposals, they are also useful, so that the other owners can avoid making a conflicting proposal in the same round.

## Proposal

Send `NewRound` notifications in `handle_block_proposal`, too.

## Test Plan

An assertion was added to a worker test.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #4472.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
