### PR TITLE
Remove some unused code, annotations.

### DIFF
--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -414,17 +414,14 @@ where
                             ExecutionError::UnauthorizedHttpRequest(url)
                         );
 
-                        #[cfg_attr(web, allow(unused_mut))]
-                        let mut request = Client::new()
+                        let request = Client::new()
                             .request(request.method.into(), url)
                             .body(request.body)
                             .headers(headers);
                         #[cfg(not(web))]
-                        {
-                            request = request.timeout(linera_base::time::Duration::from_millis(
-                                committee.policy().http_request_timeout_ms,
-                            ));
-                        }
+                        let request = request.timeout(linera_base::time::Duration::from_millis(
+                            committee.policy().http_request_timeout_ms,
+                        ));
 
                         let response = request.send().await?;
 

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -6,7 +6,6 @@
 use std::{
     collections::VecDeque,
     fmt::{self, Debug, Display, Formatter},
-    mem,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, Mutex,
@@ -15,10 +14,7 @@ use std::{
 
 #[cfg(web)]
 use js_sys::wasm_bindgen;
-use linera_base::{
-    data_types::StreamUpdate,
-    identifiers::{ChainId, StreamId},
-};
+use linera_base::data_types::StreamUpdate;
 
 use crate::{
     ContractSyncRuntimeHandle, ExecutionError, ServiceSyncRuntimeHandle, UserContract,

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -1,10 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Some of these items are only used by some tests, but Rust will complain about unused
-// items for the tests where they aren't used
-#![allow(unused_imports)]
-
 mod mock_application;
 #[cfg(with_revm)]
 pub mod solidity;
@@ -13,28 +9,26 @@ mod system_execution_state;
 use std::{collections::BTreeMap, sync::Arc, thread, vec};
 
 use linera_base::{
-    crypto::{AccountPublicKey, BcsSignable, CryptoHash, ValidatorPublicKey},
+    crypto::{AccountPublicKey, ValidatorPublicKey},
     data_types::{
         Amount, Blob, BlockHeight, ChainDescription, ChainOrigin, CompressedBytecode, Epoch,
         InitialChainConfig, OracleResponse, Timestamp,
     },
-    identifiers::{AccountOwner, ApplicationId, BlobId, BlobType, ChainId, ModuleId},
+    identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, ModuleId},
     ownership::ChainOwnership,
     vm::VmRuntime,
 };
-use linera_views::{context::Context, views::View, ViewError};
+use linera_views::{context::Context, views::View};
 use proptest::{prelude::any, strategy::Strategy};
-use serde::{Deserialize, Serialize};
 
 pub use self::{
     mock_application::{ExpectedCall, MockApplication, MockApplicationInstance},
     system_execution_state::SystemExecutionState,
 };
 use crate::{
-    committee::Committee, execution_state_actor::ExecutionRequest, ApplicationDescription,
-    ExecutionRuntimeContext, ExecutionStateView, MessageContext, OperationContext, QueryContext,
-    ServiceRuntimeEndpoint, ServiceRuntimeRequest, ServiceSyncRuntime, SystemExecutionStateView,
-    TestExecutionRuntimeContext,
+    committee::Committee, ApplicationDescription, ExecutionRuntimeContext, ExecutionStateView,
+    MessageContext, OperationContext, QueryContext, ServiceRuntimeEndpoint, ServiceSyncRuntime,
+    SystemExecutionStateView,
 };
 
 pub fn dummy_committee() -> Committee {

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -4,7 +4,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     ops::Not,
-    sync::Arc,
 };
 
 use custom_debug_derive::Debug;
@@ -15,21 +14,14 @@ use linera_base::{
     ownership::ChainOwnership,
 };
 use linera_views::{
-    context::{Context, MemoryContext},
-    random::generate_test_namespace,
+    context::MemoryContext,
     views::{CryptoHashView, View},
-    ViewError,
 };
 
-use super::{
-    dummy_chain_description, dummy_committees, AccountPublicKey, MockApplication,
-    RegisterMockApplication, ValidatorPublicKey,
-};
+use super::{dummy_chain_description, dummy_committees, MockApplication, RegisterMockApplication};
 use crate::{
-    committee::Committee, execution::UserAction, ApplicationDescription, ExecutionError,
-    ExecutionRuntimeConfig, ExecutionRuntimeContext, ExecutionStateView, OperationContext,
-    ResourceControlPolicy, ResourceController, ResourceTracker, TestExecutionRuntimeContext,
-    UserContractCode,
+    committee::Committee, ApplicationDescription, ExecutionRuntimeConfig, ExecutionRuntimeContext,
+    ExecutionStateView, TestExecutionRuntimeContext,
 };
 
 /// A system execution state, not represented as a view but as a simple struct.

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -412,7 +412,7 @@ where
     }
 
     fn log_request_outcome_and_latency(start: Instant, success: bool, method_name: &str) {
-        #![allow(unused_variables)]
+        #![cfg_attr(not(with_metrics), allow(unused_variables))]
         #[cfg(with_metrics)]
         {
             metrics::SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE


### PR DESCRIPTION
## Motivation

In `test_utils` we `#![allow(unused_imports)]` because "items are only used by some tests" and "Rust will complain". That doesn't seem to be true, and if it were I don't see why the affected test shouldn't just import the items in question directly.

## Proposal

Remove the attribute and the unused imports.

Also, remove or restrict some similar attributes in other places.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
