### PR TITLE
Change the result being transmitted by the calls to the `execution_state_actor`.

### DIFF
--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -454,9 +454,10 @@ where
                                 .body(request.body)
                                 .headers(headers);
                             #[cfg(not(web))]
-                            let request = request.timeout(linera_base::time::Duration::from_millis(
-                                committee.policy().http_request_timeout_ms,
-                            ));
+                            let request =
+                                request.timeout(linera_base::time::Duration::from_millis(
+                                    committee.policy().http_request_timeout_ms,
+                                ));
 
                             let response = request.send().await?;
 

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -128,7 +128,7 @@ async fn test_write_batch() {
         assert_eq!(batch, expected_batch);
 
         callback
-            .send(())
+            .send(Ok(()))
             .expect("Failed to notify that writing the batch finished");
     });
 


### PR DESCRIPTION
## Motivation

The `execution_state_actor` is working in an inconsistent way. Sometimes, it returns `Result<T,ExecutionError>` and
sometimes it returns `T`. This needs to be homogenized.

## Proposal

I argue that the right way to handle this is to return a `Result<T, ExecutionError>`. The wrong way to handle it
is by doing a call to `?` in the code. An example of problematic code is
```rust
            WriteBatch { id, batch, callback } => {
                let mut view = self.state.users.try_load_entry_mut(&id).await?;
                view.write_batch(batch).await?;
                callback.respond(());
            }
```

That is, if we have an error in the storage code, then the callback is not being called. This means that the error
being returned is `ExecutionError::MissingRuntimeResponse`. This is not great as it hides the real error.

Other changes being made is simplifying the "index_values.into_iter().collect()` since it is already of the right type.

## Test Plan

The CI.

## Release Plan

The correction could be cherry-picked into TestNet as it only changes the error handling, but not the code overall.

## Links

None.