### PR TITLE
Add new DownloadRawCertificatesByHeight endpoint and use it.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5577,6 +5577,7 @@ version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bcs",
  "bincode",
  "bytes",
  "cfg-if",

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -44,6 +44,7 @@ web-default = ["web"]
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+bcs.workspace = true
 bincode.workspace = true
 bytes.workspace = true
 cfg-if.workspace = true

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -86,8 +86,11 @@ service ValidatorNode {
   // Download a batch of certificates.
   rpc DownloadCertificates(CertificatesBatchRequest) returns (CertificatesBatchResponse);
 
-  /// Download a batch of certificates by height range.
+  /// Download a batch of certificates by heights.
   rpc DownloadCertificatesByHeights(DownloadCertificatesByHeightsRequest) returns (CertificatesBatchResponse);
+
+  // Download a batch of certificates, in serialized form, by their heights.
+  rpc DownloadRawCertificatesByHeights(DownloadCertificatesByHeightsRequest) returns (RawCertificatesBatch);
 
   // Return the hash of the `Certificate` that last used a blob.
   rpc BlobLastUsedBy(BlobId) returns (CryptoHash);
@@ -98,6 +101,19 @@ service ValidatorNode {
 
   // Return the `BlobId`s that are not contained as `Blob`.
   rpc MissingBlobIds(BlobIds) returns (BlobIds);
+}
+
+// Batch of raw certificates.
+message RawCertificatesBatch {
+  repeated RawCertificate certificates = 1;
+}
+
+// A confirmed block certificate in a serialized form.
+message RawCertificate {
+  // BCS-serialized bytes of lite certificate part.
+  bytes lite_certificate = 1;
+  // BCS-serialized bytes of confirmed block part.
+  bytes confirmed_block = 2;
 }
 
 // A request for downloading certificates by block heights.

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -14,8 +14,8 @@ use linera_base::{
 use linera_chain::{
     data_types::{self},
     types::{
-        self, Certificate, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate, Timeout,
-        ValidatedBlock,
+        self, Certificate, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate,
+        LiteCertificate, Timeout, ValidatedBlock,
     },
 };
 use linera_core::{
@@ -32,8 +32,8 @@ use super::{
     transport, GRPC_MAX_MESSAGE_SIZE,
 };
 use crate::{
-    HandleConfirmedCertificateRequest, HandleLiteCertRequest, HandleTimeoutCertificateRequest,
-    HandleValidatedCertificateRequest,
+    grpc::api::RawCertificate, HandleConfirmedCertificateRequest, HandleLiteCertRequest,
+    HandleTimeoutCertificateRequest, HandleValidatedCertificateRequest,
 };
 
 #[derive(Clone)]
@@ -447,15 +447,26 @@ impl ValidatorNode for GrpcClient {
                 chain_id,
                 heights: missing.clone(),
             };
-            let mut received: Vec<ConfirmedBlockCertificate> = Vec::<Certificate>::try_from(
-                client_delegate!(self, download_certificates_by_heights, request)?,
-            )?
-            .into_iter()
-            .map(|cert| {
-                ConfirmedBlockCertificate::try_from(cert)
-                    .map_err(|_| NodeError::UnexpectedCertificateValue)
-            })
-            .collect::<Result<_, _>>()?;
+            let mut received: Vec<ConfirmedBlockCertificate> =
+                client_delegate!(self, download_raw_certificates_by_heights, request)?
+                    .certificates
+                    .into_iter()
+                    .map(
+                        |RawCertificate {
+                             lite_certificate,
+                             confirmed_block,
+                         }| {
+                            let cert = bcs::from_bytes::<LiteCertificate>(&lite_certificate)
+                                .map_err(|_| NodeError::UnexpectedCertificateValue)?;
+
+                            let block = bcs::from_bytes::<ConfirmedBlock>(&confirmed_block)
+                                .map_err(|_| NodeError::UnexpectedCertificateValue)?;
+
+                            cert.with_value(block)
+                                .ok_or(NodeError::UnexpectedCertificateValue)
+                        },
+                    )
+                    .collect::<Result<_, _>>()?;
 
             if received.is_empty() {
                 break;

--- a/linera-service/src/exporter/test_utils.rs
+++ b/linera-service/src/exporter/test_utils.rs
@@ -353,6 +353,13 @@ impl ValidatorNode for DummyValidator {
         unimplemented!()
     }
 
+    async fn download_raw_certificates_by_heights(
+        &self,
+        _request: Request<linera_rpc::grpc::api::DownloadCertificatesByHeightsRequest>,
+    ) -> Result<Response<linera_rpc::grpc::api::RawCertificatesBatch>, Status> {
+        unimplemented!()
+    }
+
     async fn blob_last_used_by(
         &self,
         _request: Request<linera_rpc::grpc::api::BlobId>,

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -140,6 +140,17 @@ pub trait Storage: Sized {
         hashes: I,
     ) -> Result<Vec<Option<ConfirmedBlockCertificate>>, ViewError>;
 
+    /// Reads certificates by hashes.
+    ///
+    /// Returns a vector of tuples where the first element is a lite certificate
+    /// and the second element is confirmed block.
+    ///
+    /// It does not check if all hashes all returned.
+    async fn read_certificates_raw<I: IntoIterator<Item = CryptoHash> + Send>(
+        &self,
+        hashes: I,
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ViewError>;
+
     /// Reads the event with the given ID.
     async fn read_event(&self, id: EventId) -> Result<Option<Vec<u8>>, ViewError>;
 


### PR DESCRIPTION
## Motivation

During our performance tests it was found that proxies' bottleneck is (de)serialization of certificates when responding to `DownloadCertificatesByHeights` request.

## Proposal

It is a waste of CPU cycles to deserialize data (after loading from the DB) only to serialize it for transporting over gRPC protocol.

This PR:
- adds a new method on the storage `read_certificates_raw` which returns raw bytes of the requested certificates
- adds a new endpoint to `rpc.proto/ValidatorNode` – `DownloadRawCertificatesByHeight` that responds with (bcs) bytes of the requested certificates
- updates proxy code to serve the new endpoint
- the gRPC _client_  does NOT get a new method, instead the old `download_certificates_by_height` is modified to use the new endpoint. **This is safe:** b/c we will release this as a new SDK version meaning old clients still use old code paths while next version uses new.

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
