### PR TITLE
Revert "Move some `deny` attributes to Cargo.toml. (#4474)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -357,9 +357,3 @@ branch = "post-message"
 
 [workspace.metadata.spellcheck]
 config = "spellcheck-cfg.toml"
-
-[workspace.lints.rust]
-missing_docs = "deny"
-
-[workspace.lints.clippy]
-large_futures = "deny"

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -5,6 +5,8 @@
 //! between the Linera protocol (compiled from Rust to native code) and Linera
 //! applications (compiled from Rust to Wasm).
 
+#![deny(missing_docs)]
+#![deny(clippy::large_futures)]
 #![allow(async_fn_in_trait)]
 
 use std::fmt;

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! This module manages the state of a Linera chain, including cross-chain communication.
 
+#![deny(clippy::large_futures)]
+
 pub mod block;
 mod certificate;
 

--- a/linera-client/src/lib.rs
+++ b/linera-client/src/lib.rs
@@ -4,6 +4,7 @@
 //! This module provides a convenient library for writing a Linera client application.
 
 #![recursion_limit = "256"]
+#![deny(clippy::large_futures)]
 #![allow(async_fn_in_trait)]
 
 pub mod chain_listener;

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -5,6 +5,7 @@
 //! This module defines the core Linera protocol.
 
 #![recursion_limit = "256"]
+#![deny(clippy::large_futures)]
 
 mod chain_worker;
 pub mod client;

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -4,6 +4,8 @@
 //! This module manages the execution of the system application and the user applications in a
 //! Linera chain.
 
+#![deny(clippy::large_futures)]
+
 pub mod committee;
 pub mod evm;
 mod execution;

--- a/linera-rpc/src/lib.rs
+++ b/linera-rpc/src/lib.rs
@@ -4,6 +4,7 @@
 //! This module provides network abstractions and the data schemas for remote procedure
 //! calls (RPCs) in the Linera protocol.
 
+#![deny(clippy::large_futures)]
 // `tracing::instrument` is not compatible with this nightly Clippy lint
 #![allow(unknown_lints)]
 

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -24,6 +24,8 @@
 //! The [`examples`](https://github.com/linera-io/linera-protocol/tree/main/examples)
 //! directory contains some example applications.
 
+#![deny(missing_docs)]
+
 #[macro_use]
 pub mod util;
 

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![recursion_limit = "256"]
+#![deny(clippy::large_futures)]
 
 use std::{
     collections::{BTreeMap, BTreeSet},

--- a/linera-service/src/cli/mod.rs
+++ b/linera-service/src/cli/mod.rs
@@ -3,5 +3,7 @@
 
 //! Helper module for the Linera CLI binary.
 
+#![deny(clippy::large_futures)]
+
 pub mod command;
 pub mod net_up_utils;

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -4,6 +4,8 @@
 
 //! This module provides the executables needed to operate a Linera service, including a placeholder wallet acting as a GraphQL service for user interfaces.
 
+#![deny(clippy::large_futures)]
+
 pub mod cli;
 pub mod cli_wrappers;
 pub mod config;

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![deny(clippy::large_futures)]
+
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
 use anyhow::{anyhow, bail, ensure, Result};

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -2,6 +2,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![deny(clippy::large_futures)]
+
 use std::{
     borrow::Cow,
     num::NonZeroU16,

--- a/linera-storage-service/src/lib.rs
+++ b/linera-storage-service/src/lib.rs
@@ -4,6 +4,8 @@
 //! This module provides a shared key-value store server based on the RocksDB store and the in-memory store of `linera-views`.
 //! The corresponding client implements the `KeyValueStore` and `KeyValueDatabase` traits.
 
+#![deny(clippy::large_futures)]
+
 pub mod key_value_store {
     tonic::include_proto!("key_value_store.v1");
 }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! This module defines the storage abstractions for individual chains and certificates.
 
+#![deny(clippy::large_futures)]
+
 mod db_storage;
 
 use std::{collections::BTreeMap, ops::RangeInclusive, sync::Arc};

--- a/linera-summary/src/lib.rs
+++ b/linera-summary/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! This crate provides the internal tool to summarize performance changes in PRs.
 
+#![deny(clippy::large_futures)]
 #![allow(missing_docs)]
 
 pub mod ci_runtime_comparison;

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -58,6 +58,8 @@ The following views implement the `View` trait:
 The `LogView` can be seen as an analog of `VecDeque` while `MapView` is an analog of `BTreeMap`.
 */
 
+#![deny(missing_docs)]
+#![deny(clippy::large_futures)]
 // These traits have `Send` variants where possible.
 #![allow(async_fn_in_trait)]
 

--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -5,6 +5,8 @@
 //!
 //! This crate contains the procedural macros used by the `linera-witty` crate.
 
+#![deny(missing_docs)]
+
 mod util;
 mod wit_export;
 mod wit_import;
@@ -23,6 +25,9 @@ use syn::{parse_macro_input, Data, DeriveInput, Ident, ItemTrait};
 
 use self::util::{apply_specialization_attribute, AttributeParameters, Specializations};
 
+/// Derives `WitType` for a Rust type.
+///
+/// All fields in the type must also implement `WitType`.
 #[proc_macro_error]
 #[proc_macro_derive(WitType, attributes(witty, witty_specialize_with))]
 pub fn derive_wit_type(input: TokenStream) -> TokenStream {

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -9,6 +9,8 @@
 //!
 //! [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
 
+#![deny(missing_docs)]
+
 #[macro_use]
 mod macro_utils;
 


### PR DESCRIPTION
## Motivation

#4474 doesn't actually work: We have to add `lints.workspace = true` to all `Cargo.toml`s. And if I do that, there are _lots_ of errors.

## Proposal

Revert this for now. I will try again later, and also add the missing comments.

## Test Plan

This only reverts an earlier PR.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Reverts #4474.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
