### PR TITLE
Don't set base timeout to u64::MAX on test_end_to_end_listen_for_new_rounds

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -4577,7 +4577,7 @@ async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> 
             vec![100, 100],
             0,
             Amount::from_tokens(9),
-            u64::MAX,
+            10_000,
         )
         .await?;
     client1.assign(owner1, chain2).await?;


### PR DESCRIPTION
## Motivation

We're setting the base timeout for the chain we're opening to `u64::MAX`. However, since this test is racey by design, if we happen to get a `RoundTimeout` in proposals in both of the chains, we'll effectively wait forever and the test will never return.

## Proposal

Set the base timeout to something more reasonable. Setting to 10 seconds, as it's what the rest of the file is using.

## Test Plan

Had a consistent repro of this happening and the test hanging forever. After this change, the test passes.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
