### PR TITLE
Put a clearer error string in GraphQL error.

### DIFF
--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -73,7 +73,22 @@ impl Faucet {
             .await?;
 
         if let Some(errors) = response.errors {
-            Err(ErrorInner::GraphQl(errors).into())
+            // Extract just the error messages, ignore locations and path
+            let messages = errors
+                .iter()
+                .filter_map(|error| {
+                    error
+                        .get("message")
+                        .and_then(|msg| msg.as_str())
+                        .map(|s| s.to_string())
+                })
+                .collect::<Vec<_>>();
+
+            if messages.is_empty() {
+                Err(ErrorInner::GraphQl(errors).into())
+            } else {
+                Err(ErrorInner::GraphQl(vec![serde_json::Value::String(messages.join("; "))]).into())
+            }
         } else {
             Ok(response
                 .data
@@ -111,7 +126,6 @@ impl Faucet {
         struct Response {
             claim: ChainDescription,
         }
-
         Ok(self
             .query::<Response>(format!("mutation {{ claim(owner: \"{owner}\") }}"))
             .await?


### PR DESCRIPTION
## Motivation

The GraphQL error messages can be quite obscure. Here we attempt to clarify what is going on

Fixes #4459 

## Proposal

The cryptic error message indicates the following:
* The "location" indicate in a cryptic way that the claim was problematic.
* The "Request processing was cancelled" is due to the grouping of issues in the faucet. Let us make all queries fail for the same reason.
* The array indicates the operation being used. Maybe it could be left.

So, the change is to keep the message and make it clear. After those changes, the error message is now
```GraphQL
ERROR linera: Error is GraphQL error: [String("Signer doesn't have key to sign for chain 03bea8b215a1c415ad4affec891fa62ef2bd39cb4f9b774dda86cdc0b05583fd")]
```

which is much clearer.

## Test Plan

The CI.
No attempt has been made to add a test. The original error was that the `LINERA_KEYSTORE` was not set.


## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.