### PR TITLE
[testnet] Test remote compatibility on the testnet branch

### DIFF
--- a/.github/workflows/remote_compatibility.yml
+++ b/.github/workflows/remote_compatibility.yml
@@ -27,29 +27,7 @@ permissions:
   contents: read
 
 jobs:
-  # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
-  changed-files:
-    runs-on: ubuntu-latest
-    outputs:
-      should-run: ${{ steps.files-changed.outputs.paths }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Filter paths
-        uses: dorny/paths-filter@v3
-        id: files-changed
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            paths:
-              - '!docker/**'
-              - '!docker_scylla/**'
-              - '!configuration/**'
-              - '!kubernetes/**'
-              - '!CONTRIBUTING.md'
-              - '!INSTALL.md'
   remote-net-test:
-    needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 40
 

--- a/.github/workflows/remote_compatibility.yml
+++ b/.github/workflows/remote_compatibility.yml
@@ -1,0 +1,65 @@
+name: Compatibility with existing testnet
+
+on:
+  push:
+    branches: [ 'testnet_conway' ]
+  merge_group:
+  pull_request:
+    branches:
+      - "**"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: full
+  # We allow redundant explicit links because `cargo rdme` doesn't know how to resolve implicit intra-crate links.
+  RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
+  RUSTFLAGS: -D warnings
+  RUSTUP_MAX_RETRIES: 10
+  RUST_LOG: linera=debug
+  RUST_LOG_FORMAT: plain
+  # The remote faucet for this branch
+  LINERA_FAUCET_URL: https://faucet.testnet-conway.linera.net
+
+permissions:
+  contents: read
+
+jobs:
+  # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
+  changed-files:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.files-changed.outputs.paths }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Filter paths
+        uses: dorny/paths-filter@v3
+        id: files-changed
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            paths:
+              - '!docker/**'
+              - '!docker_scylla/**'
+              - '!configuration/**'
+              - '!kubernetes/**'
+              - '!CONTRIBUTING.md'
+              - '!INSTALL.md'
+  remote-net-test:
+    needs: changed-files
+    if: needs.changed-files.outputs.should-run == 'true'
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 40
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run the remote-net tests
+      run: |
+        cargo test -p linera-service remote_net_grpc --features remote-net


### PR DESCRIPTION
## Motivation

Test that we don't break clients (and to some degree validators) on the testnet branch

## Proposal

Run the e2e tests against the existing testnet in CI


Future work:
* An alternative approach would to set up a local network (validator + faucet) with exactly the same commit as the production environment. This could be done in different ways but requires more design.
* It would be nice to also hosted web applications somehow.

## Test Plan

CI
