### PR TITLE
Change the shuffling to take into account the weight.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -62,7 +62,7 @@ use linera_execution::{
 };
 use linera_storage::{Clock as _, ResultReadCertificates, Storage as _};
 use linera_views::ViewError;
-use rand::Rng;
+use rand::distributions::{Distribution, WeightedIndex};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::{mpsc, OwnedRwLockReadGuard};
@@ -317,46 +317,29 @@ impl<Env: Environment> Client<Env> {
         }
     }
 
-    fn get_validator_number(weights: &[Option<u64>], target: u64) -> (usize, u64) {
-        let mut position = 0;
-        for (index, weight) in weights.iter().enumerate() {
-            if let Some(weight) = weight {
-                position += weight;
-                if position >= target {
-                    return (index, *weight);
-                }
-            }
-        }
-        panic!("target could not be reached");
-    }
-
-    /// Shuffles validators using their voting weights for better randomness distribution.
-    fn weighted_shuffle_validators(
+    async fn weighted_shuffle(
         &self,
-        validators: &[RemoteNode<Env::ValidatorNode>],
-        committee: &Committee,
-    ) -> Vec<RemoteNode<Env::ValidatorNode>> {
-        let mut rng = rand::thread_rng();
-
-        let number_validator = validators.len();
-        let mut weights: Vec<Option<u64>> = validators
+    ) -> Result<Vec<RemoteNode<Env::ValidatorNode>>, ChainClientError> {
+        let (_, committee) = self.admin_committee().await?;
+        let mut remaining_validators = self.make_nodes(&committee)?;
+        // Shuffle validators using their weights
+        let mut remaining_weights = remaining_validators
             .iter()
             .map(|validator| {
                 let validator_state = committee.validators.get(&validator.public_key).unwrap();
-                Some(validator_state.votes)
+                validator_state.votes
             })
             .collect::<Vec<_>>();
-        let mut remaining_weight = weights.iter().map(|s| s.unwrap()).sum();
-        let mut weighted_validators = Vec::new();
-        for _ in 0..number_validator {
-            let target = rng.gen_range(0..remaining_weight);
-            let (index, weight) = Self::get_validator_number(&weights, target);
-            remaining_weight -= weight;
-            weights[index] = None;
-            weighted_validators.push(validators[index].clone());
+        let mut rng = rand::thread_rng();
+        let mut shuffled_validators = Vec::new();
+        while !remaining_validators.is_empty() {
+            let dist = WeightedIndex::new(&remaining_weights).unwrap();
+            let idx = dist.sample(&mut rng);
+            remaining_weights.remove(idx);
+            let validator = remaining_validators.remove(idx);
+            shuffled_validators.push(validator);
         }
-
-        weighted_validators
+        Ok(shuffled_validators)
     }
 
     /// Downloads and processes all certificates up to (excluding) the specified height.
@@ -366,14 +349,11 @@ impl<Env: Environment> Client<Env> {
         chain_id: ChainId,
         target_next_block_height: BlockHeight,
     ) -> Result<Box<ChainInfo>, ChainClientError> {
-        let (_, committee) = self.admin_committee().await?;
-        let validators = self.make_nodes(&committee)?;
-        // Shuffle validators using their weights
-        let weighted_validators = self.weighted_shuffle_validators(&validators, &committee);
+        let shuffled_validators = self.weighted_shuffle().await?;
         let mut info = self
-            .fetch_chain_info(chain_id, &weighted_validators)
+            .fetch_chain_info(chain_id, &shuffled_validators)
             .await?;
-        for remote_node in weighted_validators {
+        for remote_node in shuffled_validators {
             if target_next_block_height <= info.next_block_height {
                 return Ok(info);
             }


### PR DESCRIPTION
## Motivation

Not all validators are equal. Taking into account their weight during the shuffling makes the validators with more weight more responsible for accessing the

Fixes #2616 

## Proposal

We simply count the weights when doing the random shuffling.

## Test Plan

The CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.