### PR TITLE
Remove one dependency.

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -42,7 +42,6 @@ getrandom = { version = "0.2.12", default-features = false, features = [
 ] }
 hex = "0.4.3"
 linera-sdk = { path = "../linera-sdk" }
-linera-views = { path = "../linera-views", default-features = false }
 log = "0.4.20"
 num-bigint = "0.4.3"
 num-traits = "0.2.16"


### PR DESCRIPTION
## Motivation

The dependency `linera-view` in the `examples` directory is not needed since it is provided by the `linera-sdk`.

## Proposal

Simply remove it.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

None.