### PR TITLE
[testnet] Update linera web client to 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6075,7 +6075,7 @@ dependencies = [
 
 [[package]]
 name = "linera-web"
-version = "0.14.0"
+version = "0.15.1"
 dependencies = [
  "console_error_panic_hook",
  "futures",

--- a/linera-web/Cargo.toml
+++ b/linera-web/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linera-web"
 description = "The Linera Web client"
-version = "0.14.0"
+version = "0.15.1"
 authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 repository = "https://github.com/linera-io/linera-protocol/"

--- a/linera-web/package.json
+++ b/linera-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linera/client",
-  "version": "0.14.0",
+  "version": "0.15.1",
   "description": "Web client for the Linera blockchain",
   "main": "dist/linera_web.js",
   "types": "dist/linera_web.d.ts",

--- a/linera-web/signer/package.json
+++ b/linera-web/signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linera/signer",
-  "version": "0.1.0",
+  "version": "0.15.1",
   "description": "Implementations of Signer interface for the Linera blockchain",
   "files": [
     "dist"


### PR DESCRIPTION
## Motivation

Release a new `linera/client` npm package

## Proposal

* Follow the version number of the rest of the crates.
* Changed the signer version from 0.1 to 0.15.1 as well

## Test Plan

CI