### PR TITLE
update linera web client to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "linera-web"
-version = "0.14.0"
+version = "0.16.0"
 dependencies = [
  "console_error_panic_hook",
  "futures",

--- a/linera-web/Cargo.toml
+++ b/linera-web/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linera-web"
 description = "The Linera Web client"
-version = "0.14.0"
+version = "0.16.0"
 authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 repository = "https://github.com/linera-io/linera-protocol/"

--- a/linera-web/package.json
+++ b/linera-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linera/client",
-  "version": "0.14.0",
+  "version": "0.16.0",
   "description": "Web client for the Linera blockchain",
   "main": "dist/linera_web.js",
   "types": "dist/linera_web.d.ts",


### PR DESCRIPTION
## Motivation

Prepare future releases

## Proposal

Follow the same version number as the rest of the repo.

## Test Plan

CI

## Release Plan

The testnet branch follows a different PR: https://github.com/linera-io/linera-protocol/pull/4507