### PR TITLE
Restore old behavior: Don't record oracle if blob known from same block.

### DIFF
--- a/examples/publish-read-data-blob/README.md
+++ b/examples/publish-read-data-blob/README.md
@@ -1,8 +1,8 @@
 # Publish and read a data blob
 
 This example shows how to create a blob and how to read it.
-This example should be read in conjunction with the end-to-end
-test `test_wasm_end_to_end_publish_read_data_blob`.
+This example should be read in conjunction with the client
+test `run_test_publish_read_data_blob`.
 
 It shows 3 scenarios:
 * Publishing and reading blobs with the publishing and reading in different

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -1066,7 +1066,7 @@ where
 
     // publishing the data.
     let publish_op = publish_read_data_blob::Operation::CreateDataBlob(test_data.clone());
-    client
+    let certificate = client
         .execute_operation(Operation::user(application_id, &publish_op)?)
         .await
         .unwrap_ok_committed();
@@ -1081,14 +1081,16 @@ where
         .execute_operation(Operation::user(application_id, &read_op)?)
         .await
         .unwrap_ok_committed();
+    assert_eq!(certificate.block().body.oracle_responses[0].len(), 0);
 
     // Method 2: Publishing and reading in the same transaction
     let test_data = b"This is test data for method 2.".to_vec();
     let combined_op = publish_read_data_blob::Operation::CreateAndReadDataBlob(test_data);
-    client
+    let certificate = client
         .execute_operation(Operation::user(application_id, &combined_op)?)
         .await
         .unwrap_ok_committed();
+    assert_eq!(certificate.block().body.oracle_responses[0].len(), 0);
 
     // Method 3: Publishing and reading in the same block but different transactions
     let test_data = b"This is test data for method 3.".to_vec();
@@ -1098,10 +1100,12 @@ where
     let read_op = publish_read_data_blob::Operation::ReadDataBlob(hash, test_data);
     let op1 = Operation::user(application_id, &publish_op)?;
     let op2 = Operation::user(application_id, &read_op)?;
-    client
+    let certificate = client
         .execute_operations(vec![op1, op2], vec![])
         .await
         .unwrap_ok_committed();
+    assert_eq!(certificate.block().body.oracle_responses[0].len(), 0);
+    assert_eq!(certificate.block().body.oracle_responses[1].len(), 0);
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -1081,6 +1081,8 @@ where
         .execute_operation(Operation::user(application_id, &read_op)?)
         .await
         .unwrap_ok_committed();
+    // None of the following blocks should have oracle responses: all read blobs were created
+    // on the same chain, so no oracle is needed.
     assert_eq!(certificate.block().body.oracle_responses[0].len(), 0);
 
     // Method 2: Publishing and reading in the same transaction

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -452,17 +452,12 @@ where
                             .await?
                             .track_blob_read(content.bytes().len() as u64)?;
                     }
+                    self.state
+                        .system
+                        .blob_used(self.txn_tracker, blob_id)
+                        .await?;
                     content
                 };
-                let is_new = self
-                    .state
-                    .system
-                    .blob_used(self.txn_tracker, blob_id)
-                    .await?;
-                if is_new {
-                    self.txn_tracker
-                        .replay_oracle_response(OracleResponse::Blob(blob_id))?;
-                }
                 callback.respond(content)
             }
 


### PR DESCRIPTION
## Motivation

#4413 introduced a bug where we record redundant oracle responses:
* `blob_used` itself already records the response, so there is no need to call `replay_oracle_response`.
* If the blob was published or created by this block, there is no reason to record an oracle response either.

## Proposal

Restore the old behavior.

## Test Plan

This caused the remote tests against Testnet Conway to break, and with this fix on the `testnet_conway` branch, they work again.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
