### PR TITLE
[testnet] Add a bool to `ChainInfoQuery` to control creation of network actions.

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -246,6 +246,7 @@ where
         &mut self,
         query: ChainInfoQuery,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
+        let create_network_actions = query.create_network_actions;
         if let Some((height, round)) = query.request_leader_timeout {
             self.vote_for_leader_timeout(height, round).await?;
         }
@@ -254,7 +255,11 @@ where
         }
         let response = self.prepare_chain_info_response(query).await?;
         // Trigger any outgoing cross-chain messages that haven't been confirmed yet.
-        let actions = self.create_network_actions(None).await?;
+        let actions = if create_network_actions {
+            self.create_network_actions(None).await?
+        } else {
+            NetworkActions::default()
+        };
         Ok((response, actions))
     }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -403,7 +403,9 @@ impl<Env: Environment> Client<Env> {
         &self,
         chain_id: ChainId,
     ) -> Result<Box<ChainInfo>, LocalNodeError> {
-        let query = ChainInfoQuery::new(chain_id).with_committees();
+        let query = ChainInfoQuery::new(chain_id)
+            .with_committees()
+            .no_network_actions();
         let info = self.local_node.handle_chain_info_query(query).await?.info;
         Ok(info)
     }
@@ -760,7 +762,9 @@ impl<Env: Environment> Client<Env> {
         let (max_epoch, committees) = self.admin_committees().await?;
 
         // Retrieve the list of newly received certificates from this validator.
-        let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_n(tracker);
+        let query = ChainInfoQuery::new(chain_id)
+            .with_received_log_excluding_first_n(tracker)
+            .no_network_actions();
         let info = remote_node.handle_chain_info_query(query).await?;
         let remote_log = info.requested_received_log;
         let remote_heights = Self::heights_per_chain(&remote_log);
@@ -969,7 +973,9 @@ impl<Env: Environment> Client<Env> {
         chain_id: ChainId,
     ) -> Result<(), ChainClientError> {
         let mut local_info = self.local_node.chain_info(chain_id).await?;
-        let query = ChainInfoQuery::new(chain_id).with_manager_values();
+        let query = ChainInfoQuery::new(chain_id)
+            .with_manager_values()
+            .no_network_actions();
         let remote_info = remote_node.handle_chain_info_query(query).await?;
         if let Some(new_info) = self
             .download_certificates_from(remote_node, chain_id, remote_info.next_block_height)
@@ -1701,7 +1707,7 @@ impl<Env: Environment> ChainClient<Env> {
     /// Obtains the basic `ChainInfo` data for the local chain.
     #[instrument(level = "trace")]
     pub async fn chain_info(&self) -> Result<Box<ChainInfo>, LocalNodeError> {
-        let query = ChainInfoQuery::new(self.chain_id);
+        let query = ChainInfoQuery::new(self.chain_id).no_network_actions();
         let response = self
             .client
             .local_node
@@ -1714,7 +1720,9 @@ impl<Env: Environment> ChainClient<Env> {
     /// Obtains the basic `ChainInfo` data for the local chain, with chain manager values.
     #[instrument(level = "trace")]
     async fn chain_info_with_manager_values(&self) -> Result<Box<ChainInfo>, LocalNodeError> {
-        let query = ChainInfoQuery::new(self.chain_id).with_manager_values();
+        let query = ChainInfoQuery::new(self.chain_id)
+            .with_manager_values()
+            .no_network_actions();
         let response = self
             .client
             .local_node
@@ -1738,7 +1746,9 @@ impl<Env: Environment> ChainClient<Env> {
             return Ok(Vec::new());
         }
 
-        let query = ChainInfoQuery::new(self.chain_id).with_pending_message_bundles();
+        let query = ChainInfoQuery::new(self.chain_id)
+            .with_pending_message_bundles()
+            .no_network_actions();
         let info = self
             .client
             .local_node
@@ -2699,7 +2709,7 @@ impl<Env: Environment> ChainClient<Env> {
             self.chain_info().await?.next_block_height >= self.initial_next_block_height,
             ChainClientError::WalletSynchronizationError
         );
-        let mut query = ChainInfoQuery::new(self.chain_id);
+        let mut query = ChainInfoQuery::new(self.chain_id).no_network_actions();
         query.request_owner_balance = owner;
         let response = self
             .client
@@ -3844,7 +3854,7 @@ impl<Env: Environment> ChainClient<Env> {
         remote_node: Env::ValidatorNode,
     ) -> Result<(), ChainClientError> {
         let validator_next_block_height = match remote_node
-            .handle_chain_info_query(ChainInfoQuery::new(self.chain_id))
+            .handle_chain_info_query(ChainInfoQuery::new(self.chain_id).no_network_actions())
             .await
         {
             Ok(info) => info.info.next_block_height.0,

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -95,6 +95,14 @@ pub struct ChainInfoQuery {
     /// Query for certificate hashes at block heights.
     #[debug(skip_if = Vec::is_empty)]
     pub request_sent_certificate_hashes_by_heights: Vec<BlockHeight>,
+    #[serde(default = "default_true")]
+    pub create_network_actions: bool,
+}
+
+// Default value for create_network_actions.
+// Default for bool returns false.
+fn default_true() -> bool {
+    true
 }
 
 impl ChainInfoQuery {
@@ -111,6 +119,7 @@ impl ChainInfoQuery {
             request_leader_timeout: None,
             request_fallback: false,
             request_sent_certificate_hashes_by_heights: Vec::new(),
+            create_network_actions: true,
         }
     }
 
@@ -156,6 +165,11 @@ impl ChainInfoQuery {
 
     pub fn with_fallback(mut self) -> Self {
         self.request_fallback = true;
+        self
+    }
+
+    pub fn no_network_actions(mut self) -> Self {
+        self.create_network_actions = false;
         self
     }
 }

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -116,7 +116,11 @@ where
         query: ChainInfoQuery,
     ) -> Result<ChainInfoResponse, LocalNodeError> {
         // In local nodes, we can trust fully_handle_certificate to carry all actions eventually.
-        let (response, _actions) = self.node.state.handle_chain_info_query(query).await?;
+        let (response, _actions) = self
+            .node
+            .state
+            .handle_chain_info_query(query.no_network_actions())
+            .await?;
         Ok(response)
     }
 

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -293,7 +293,9 @@ where
         &mut self,
         chain_id: ChainId,
     ) -> Result<Box<ChainInfo>, NodeError> {
-        let query = ChainInfoQuery::new(chain_id).with_manager_values();
+        let query = ChainInfoQuery::new(chain_id)
+            .with_manager_values()
+            .no_network_actions();
         let response = self.handle_chain_info_query(query).await?;
         Ok(response.info)
     }
@@ -1042,7 +1044,8 @@ where
         target_count: usize,
     ) -> Option<ConfirmedBlockCertificate> {
         let query = ChainInfoQuery::new(chain_id)
-            .with_sent_certificate_hashes_by_heights(vec![block_height]);
+            .with_sent_certificate_hashes_by_heights(vec![block_height])
+            .no_network_actions();
         let mut count = 0;
         let mut certificate = None;
         for validator in self.node_provider.all_nodes() {
@@ -1080,7 +1083,7 @@ where
         round: Round,
         target_count: usize,
     ) {
-        let query = ChainInfoQuery::new(chain_id);
+        let query = ChainInfoQuery::new(chain_id).no_network_actions();
         let mut count = 0;
         for validator in self.node_provider.all_nodes() {
             if let Ok(response) = validator.handle_chain_info_query(query.clone()).await {

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2269,7 +2269,9 @@ where
         );
         assert_eq!(recipient_chain.received_log.count(), 1);
     }
-    let query = ChainInfoQuery::new(chain_2).with_received_log_excluding_first_n(0);
+    let query = ChainInfoQuery::new(chain_2)
+        .with_received_log_excluding_first_n(0)
+        .no_network_actions();
     let (response, _actions) = env.worker().handle_chain_info_query(query).await?;
     assert_eq!(response.info.requested_received_log.len(), 1);
     assert_eq!(
@@ -3339,7 +3341,9 @@ where
     );
 
     // The round hasn't timed out yet, so the validator won't sign a leader timeout vote yet.
-    let query = ChainInfoQuery::new(chain_1).with_timeout(BlockHeight(1), Round::SingleLeader(0));
+    let query = ChainInfoQuery::new(chain_1)
+        .with_timeout(BlockHeight(1), Round::SingleLeader(0))
+        .no_network_actions();
     let result = env.worker().handle_chain_info_query(query.clone()).await;
     assert_matches!(result, Err(WorkerError::ChainError(ref error))
         if matches!(**error, ChainError::NotTimedOutYet(_))
@@ -3428,7 +3432,9 @@ where
     env.worker()
         .handle_validated_certificate(certificate)
         .await?;
-    let query_values = ChainInfoQuery::new(chain_1).with_manager_values();
+    let query_values = ChainInfoQuery::new(chain_1)
+        .with_manager_values()
+        .no_network_actions();
     let (response, _) = env
         .worker()
         .handle_chain_info_query(query_values.clone())
@@ -3589,7 +3595,9 @@ where
     );
 
     // The round hasn't timed out yet, so the validator won't sign a leader timeout vote yet.
-    let query = ChainInfoQuery::new(chain_id).with_timeout(BlockHeight(1), Round::Fast);
+    let query = ChainInfoQuery::new(chain_id)
+        .with_timeout(BlockHeight(1), Round::Fast)
+        .no_network_actions();
     let result = env.worker().handle_chain_info_query(query.clone()).await;
     assert_matches!(result, Err(WorkerError::ChainError(ref error))
         if matches!(**error, ChainError::NotTimedOutYet(_))
@@ -3625,7 +3633,9 @@ where
         .unwrap();
     let (_, actions) = env.worker().handle_block_proposal(proposal1).await?;
     assert_matches!(actions.notifications[0].reason, Reason::NewRound { .. });
-    let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
+    let query_values = ChainInfoQuery::new(chain_id)
+        .with_manager_values()
+        .no_network_actions();
     let (response, _) = env.worker().handle_chain_info_query(query_values).await?;
     assert_eq!(response.info.manager.current_round, Round::MultiLeader(1));
     Ok(())
@@ -3841,7 +3851,9 @@ where
     .unwrap();
     let lite_value2 = LiteValue::new(&value2);
     let (_, _) = env.worker().handle_block_proposal(proposal).await?;
-    let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
+    let query_values = ChainInfoQuery::new(chain_id)
+        .with_manager_values()
+        .no_network_actions();
     let (response, _) = env.worker().handle_chain_info_query(query_values).await?;
     assert_eq!(
         response.info.manager.requested_locking,
@@ -3917,7 +3929,8 @@ where
     // Now we need to switch the query to check chain_2 since that's where the incoming message is
     let query_chain_2 = ChainInfoQuery::new(chain_2)
         .with_fallback()
-        .with_committees();
+        .with_committees()
+        .no_network_actions();
 
     // The message only just arrived: No fallback mode.
     let (response, _) = env

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -419,7 +419,7 @@ where
                     }) =>
                     {
                         // The chain is missing epoch events. Send all blocks.
-                        let query = ChainInfoQuery::new(chain_id);
+                        let query = ChainInfoQuery::new(chain_id).no_network_actions();
                         self.remote_node.handle_chain_info_query(query).await?
                     }
                     Err(err) => return Err(err),
@@ -431,11 +431,11 @@ where
                     "send_chain_information called with height {target_block_height},
                     but {chain_id:.8} does not have that block"
                 );
-                let query = ChainInfoQuery::new(chain_id);
+                let query = ChainInfoQuery::new(chain_id).no_network_actions();
                 self.remote_node.handle_chain_info_query(query).await?
             }
         } else {
-            let query = ChainInfoQuery::new(chain_id);
+            let query = ChainInfoQuery::new(chain_id).no_network_actions();
             self.remote_node.handle_chain_info_query(query).await?
         };
         let initial_block_height = remote_info.next_block_height;
@@ -546,7 +546,9 @@ where
                 })?
             }
             CommunicateAction::RequestTimeout { round, height, .. } => {
-                let query = ChainInfoQuery::new(chain_id).with_timeout(height, round);
+                let query = ChainInfoQuery::new(chain_id)
+                    .with_timeout(height, round)
+                    .no_network_actions();
                 let info = self.remote_node.handle_chain_info_query(query).await?;
                 info.manager.timeout_vote.ok_or_else(|| {
                     NodeError::MissingVoteInValidatorResponse("request a timeout".into())

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -229,6 +229,9 @@ message ChainInfoQuery {
 
   // Query for certificate hashes at block heights sent from the chain.
   optional bytes request_sent_certificate_hashes_by_heights = 11;
+
+  // Whether to create network actions as part of the query.
+  optional bool create_network_actions = 12;
 }
 
 // An authenticated proposal for a new block.

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -614,6 +614,7 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
             request_fallback: chain_info_query.request_fallback,
             request_sent_certificate_hashes_by_heights,
             request_sent_certificate_hashes_in_range: None,
+            create_network_actions: chain_info_query.create_network_actions.unwrap_or(true),
         })
     }
 }
@@ -644,6 +645,7 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
             request_manager_values: chain_info_query.request_manager_values,
             request_leader_timeout,
             request_fallback: chain_info_query.request_fallback,
+            create_network_actions: Some(chain_info_query.create_network_actions),
         })
     }
 }
@@ -1172,6 +1174,7 @@ pub mod tests {
             request_fallback: true,
             request_sent_certificate_hashes_by_heights: (3..8).map(BlockHeight::from).collect(),
             request_sent_certificate_hashes_in_range: None,
+            create_network_actions: true,
         };
         round_trip_check::<_, api::ChainInfoQuery>(chain_info_query_some);
     }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -365,6 +365,7 @@ ChainInfoQuery:
     - request_sent_certificate_hashes_by_heights:
         SEQ:
           TYPENAME: BlockHeight
+    - create_network_actions: BOOL
 ChainInfoResponse:
   STRUCT:
     - info:

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -299,7 +299,11 @@ impl ActiveChain {
         let (information, _) = self
             .validator
             .worker()
-            .handle_chain_info_query(ChainInfoQuery::new(chain_id).with_pending_message_bundles())
+            .handle_chain_info_query(
+                ChainInfoQuery::new(chain_id)
+                    .with_pending_message_bundles()
+                    .no_network_actions(),
+            )
             .await
             .expect("Failed to query chain's pending messages");
         let messages = information.info.requested_pending_message_bundles;

--- a/linera-service/src/exporter/tests.rs
+++ b/linera-service/src/exporter/tests.rs
@@ -75,7 +75,7 @@ async fn test_linera_exporter(database: Database, network: Network) -> Result<()
 
     let validator_client = net.validator_client(1).await?;
     let chain_info = validator_client
-        .handle_chain_info_query(ChainInfoQuery::new(chain))
+        .handle_chain_info_query(ChainInfoQuery::new(chain).no_network_actions())
         .await?;
 
     // Check that the block exporter has exported the block.

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -637,7 +637,8 @@ where
     ) -> Result<Response<CertificatesBatchResponse>, Status> {
         let original_request: CertificatesByHeightRequest = request.into_inner().try_into()?;
         let chain_info_request = ChainInfoQuery::new(original_request.chain_id)
-            .with_sent_certificate_hashes_by_heights(original_request.heights);
+            .with_sent_certificate_hashes_by_heights(original_request.heights)
+            .no_network_actions();
 
         // Use handle_chain_info_query to get the certificate hashes
         let chain_info_response = self

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -906,7 +906,7 @@ async fn test_sync_validator(config: LocalNetConfig) -> Result<()> {
     let lagging_validator = net.validator_client(LAGGING_VALIDATOR_INDEX).await?;
 
     let state_before_sync = lagging_validator
-        .handle_chain_info_query(ChainInfoQuery::new(sender_chain))
+        .handle_chain_info_query(ChainInfoQuery::new(sender_chain).no_network_actions())
         .await?;
     assert_eq!(state_before_sync.info.next_block_height, BlockHeight::ZERO);
 
@@ -918,7 +918,7 @@ async fn test_sync_validator(config: LocalNetConfig) -> Result<()> {
         .expect("Missing lagging validator name");
 
     let state_after_sync = lagging_validator
-        .handle_chain_info_query(ChainInfoQuery::new(sender_chain))
+        .handle_chain_info_query(ChainInfoQuery::new(sender_chain).no_network_actions())
         .await?;
     assert_eq!(
         state_after_sync.info.next_block_height,
@@ -989,7 +989,7 @@ async fn test_sync_child_chain(config: LocalNetConfig) -> Result<()> {
     let lagging_validator = net.validator_client(LAGGING_VALIDATOR_INDEX).await?;
 
     let state_before_sync = lagging_validator
-        .handle_chain_info_query(ChainInfoQuery::new(sender_chain))
+        .handle_chain_info_query(ChainInfoQuery::new(sender_chain).no_network_actions())
         .await?;
     assert_eq!(state_before_sync.info.next_block_height, BlockHeight::ZERO);
 
@@ -1002,13 +1002,13 @@ async fn test_sync_child_chain(config: LocalNetConfig) -> Result<()> {
 
     // The parent chain should remain out of sync.
     let state_after_sync = lagging_validator
-        .handle_chain_info_query(ChainInfoQuery::new(sender_chain))
+        .handle_chain_info_query(ChainInfoQuery::new(sender_chain).no_network_actions())
         .await?;
     assert_eq!(state_after_sync.info.next_block_height, BlockHeight::ZERO);
 
     // But the second child chain should be synchronized properly.
     let second_chain_state_after_sync = lagging_validator
-        .handle_chain_info_query(ChainInfoQuery::new(second_child_chain))
+        .handle_chain_info_query(ChainInfoQuery::new(second_child_chain).no_network_actions())
         .await?;
     assert_eq!(
         second_chain_state_after_sync.info.next_block_height,
@@ -1070,7 +1070,7 @@ async fn test_update_validator_sender_gaps(config: LocalNetConfig) -> Result<()>
     let unaware_validator = net.validator_client(UNAWARE_VALIDATOR_INDEX).await?;
 
     let sender_state_before_sync = unaware_validator
-        .handle_chain_info_query(ChainInfoQuery::new(sender_chain))
+        .handle_chain_info_query(ChainInfoQuery::new(sender_chain).no_network_actions())
         .await?;
     assert_eq!(
         sender_state_before_sync.info.next_block_height,
@@ -1078,7 +1078,7 @@ async fn test_update_validator_sender_gaps(config: LocalNetConfig) -> Result<()>
     );
 
     let receiver_state_before_sync = unaware_validator
-        .handle_chain_info_query(ChainInfoQuery::new(receiver_chain))
+        .handle_chain_info_query(ChainInfoQuery::new(receiver_chain).no_network_actions())
         .await?;
     assert_eq!(
         receiver_state_before_sync.info.next_block_height,
@@ -1099,7 +1099,7 @@ async fn test_update_validator_sender_gaps(config: LocalNetConfig) -> Result<()>
         .expect("Missing lagging validator name");
 
     let sender_state_after_sync = unaware_validator
-        .handle_chain_info_query(ChainInfoQuery::new(sender_chain))
+        .handle_chain_info_query(ChainInfoQuery::new(sender_chain).no_network_actions())
         .await?;
     // The next block height should be 1 - only block 0 has been processed fully, block 2
     // has only been preprocessed.
@@ -1109,7 +1109,7 @@ async fn test_update_validator_sender_gaps(config: LocalNetConfig) -> Result<()>
     );
 
     let receiver_state_after_sync = unaware_validator
-        .handle_chain_info_query(ChainInfoQuery::new(receiver_chain))
+        .handle_chain_info_query(ChainInfoQuery::new(receiver_chain).no_network_actions())
         .await?;
     // On the receiver side, block 0 received the transfers from sender and block 1 made a
     // transfer.


### PR DESCRIPTION
## Motivation

Creating network actions requires reading certificates – this takes a lot of CPU time (reading from storage, deserializing certificates, etc.) but it's not always needed. Network actions are created in couple of places but one surprising one was when handling a `ChainInfoQuery`.

## Proposal

Add a boolean field to `ChainInfoQuery` struct that controls whether the caller wants to create network actions. By default it is set to `true` to maintain backwards compatibility but clients can call `no_network_actions` to set it to false.

## Test Plan

CI.

## Release Plan


- Nothing to do / These changes follow the usual release cycle.

This is already a testnet backport.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
