### PR TITLE
Don't record block metrics when preprocessing.

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -840,11 +840,8 @@ where
             .tip_state
             .get()
             .next_block_height
-            > certificate.block().header.height
+            == certificate.block().header.height
         {
-            // Block already processed, no metrics to report.
-            None
-        } else {
             Some((
                 certificate.inner().to_log_str(),
                 certificate.round.type_name(),
@@ -856,6 +853,9 @@ where
                     .map(|(validator_name, _)| validator_name.to_string())
                     .collect::<Vec<_>>(),
             ))
+        } else {
+            // Block already processed or will only be preprocessed, no metrics to report.
+            None
         };
 
         let result = self


### PR DESCRIPTION
## Motivation

Now that we have sparse chains, `handle_confirmed_certificate` can be called for blocks higher than `next_block_height`. Those won't be _executed_, but we still store their blobs and events etc.

## Proposal

Only record block metrics for the blocks that actually get executed.

## Test Plan

We should see more reasonable metrics.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
