### PR TITLE
Rm serde bytes from Event variant of OracleResponse

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1044,12 +1044,7 @@ pub enum OracleResponse {
     /// The block's validation round.
     Round(Option<u32>),
     /// An event was read.
-    Event(
-        EventId,
-        #[debug(with = "hex_debug")]
-        #[serde(with = "serde_bytes")]
-        Vec<u8>,
-    ),
+    Event(EventId, #[debug(with = "hex_debug")] Vec<u8>),
     /// An event exists.
     EventExists(EventId),
 }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -853,7 +853,7 @@ OracleResponse:
       Event:
         TUPLE:
           - TYPENAME: EventId
-          - BYTES
+          - SEQ: U8
     6:
       EventExists:
         NEWTYPE:


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/4518 changed the format for `Event` variant of the `OracleResponse`.

## Proposal

Even though the remote tests against testnet conway passed, we can err on the side of caution and revert back that change.

## Test Plan

CI

## Release Plan


- Nothing to do / These changes follow the usual release cycle (we're already on testnet branch)

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
