### PR TITLE
Control creation of network actions when handling `ChainInfoQuery`. 

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -246,6 +246,7 @@ where
         &mut self,
         query: ChainInfoQuery,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
+        let create_network_actions = query.create_network_actions;
         if let Some((height, round)) = query.request_leader_timeout {
             self.vote_for_leader_timeout(height, round).await?;
         }
@@ -254,7 +255,11 @@ where
         }
         let response = self.prepare_chain_info_response(query).await?;
         // Trigger any outgoing cross-chain messages that haven't been confirmed yet.
-        let actions = self.create_network_actions(None).await?;
+        let actions = if create_network_actions {
+            self.create_network_actions(None).await?
+        } else {
+            NetworkActions::default()
+        };
         Ok((response, actions))
     }
 

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -95,6 +95,14 @@ pub struct ChainInfoQuery {
     /// Query for certificate hashes at block heights.
     #[debug(skip_if = Vec::is_empty)]
     pub request_sent_certificate_hashes_by_heights: Vec<BlockHeight>,
+    #[serde(default = "default_true")]
+    pub create_network_actions: bool,
+}
+
+// Default value for create_network_actions.
+// Default for bool returns false.
+fn default_true() -> bool {
+    true
 }
 
 impl ChainInfoQuery {
@@ -111,6 +119,7 @@ impl ChainInfoQuery {
             request_leader_timeout: None,
             request_fallback: false,
             request_sent_certificate_hashes_by_heights: Vec::new(),
+            create_network_actions: false,
         }
     }
 
@@ -156,6 +165,11 @@ impl ChainInfoQuery {
 
     pub fn with_fallback(mut self) -> Self {
         self.request_fallback = true;
+        self
+    }
+
+    pub fn with_network_actions(mut self) -> Self {
+        self.create_network_actions = true;
         self
     }
 }

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -257,7 +257,7 @@ where
         let (_response, actions) = self
             .node
             .state
-            .handle_chain_info_query(ChainInfoQuery::new(sender_chain))
+            .handle_chain_info_query(ChainInfoQuery::new(sender_chain).with_network_actions())
             .await?;
         let mut requests = VecDeque::from_iter(actions.cross_chain_requests);
         while let Some(request) = requests.pop_front() {

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -338,11 +338,11 @@ where
                     .await?;
                 }
                 Err(NodeError::MissingCrossChainUpdate { .. }) if !sent_cross_chain_updates => {
-                    sent_cross_chain_updates = true;
                     // Some received certificates may be missing for this validator
                     // (e.g. to create the chain or make the balance sufficient) so we are going to
                     // synchronize them now and retry.
                     self.send_chain_information_for_senders(chain_id).await?;
+                    sent_cross_chain_updates = true;
                 }
                 Err(NodeError::EventsNotFound(event_ids)) => {
                     let mut publisher_heights = BTreeMap::new();
@@ -482,20 +482,26 @@ where
         let (remote_height, remote_round) = (info.next_block_height, info.manager.current_round);
         // Obtain the missing blocks and the manager state from the local node.
         let range = remote_height..target_block_height;
-        let keys = {
-            let chain = self.local_node.chain_state_view(chain_id).await?;
-            chain.block_hashes(range).await?
-        };
-        if !keys.is_empty() {
+        let validator_missing_hashes = self
+            .local_node
+            .chain_state_view(chain_id)
+            .await?
+            .block_hashes(range)
+            .await?;
+        if !validator_missing_hashes.is_empty() {
             // Send the requested certificates in order.
-            let storage = self.local_node.storage_client();
-            let certificates = storage.read_certificates(keys.clone()).await?;
-            let certificates = match ResultReadCertificates::new(certificates, keys) {
-                ResultReadCertificates::Certificates(certificates) => certificates,
-                ResultReadCertificates::InvalidHashes(hashes) => {
-                    return Err(ChainClientError::ReadCertificatesError(hashes))
-                }
-            };
+            let certificates = self
+                .local_node
+                .storage_client()
+                .read_certificates(validator_missing_hashes.clone())
+                .await?;
+            let certificates =
+                match ResultReadCertificates::new(certificates, validator_missing_hashes) {
+                    ResultReadCertificates::Certificates(certificates) => certificates,
+                    ResultReadCertificates::InvalidHashes(hashes) => {
+                        return Err(ChainClientError::ReadCertificatesError(hashes))
+                    }
+                };
             for certificate in certificates {
                 self.send_confirmed_certificate(certificate, delivery)
                     .await?;
@@ -513,38 +519,40 @@ where
 
     async fn send_chain_info_up_to_heights(
         &mut self,
-        chain_heights: BTreeMap<ChainId, BlockHeight>,
+        chain_heights: impl IntoIterator<Item = (ChainId, BlockHeight)>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<(), ChainClientError> {
-        let stream =
-            FuturesUnordered::from_iter(chain_heights.into_iter().map(|(chain_id, height)| {
-                let mut updater = self.clone();
-                async move {
-                    updater
-                        .send_chain_information(chain_id, height, delivery)
-                        .await
-                }
-            }));
-        stream.try_collect::<Vec<_>>().await?;
+        FuturesUnordered::from_iter(chain_heights.into_iter().map(|(chain_id, height)| {
+            let mut updater = self.clone();
+            async move {
+                updater
+                    .send_chain_information(chain_id, height, delivery)
+                    .await
+            }
+        }))
+        .try_collect::<Vec<_>>()
+        .await?;
         Ok(())
     }
 
+    /// Updates validator with certificates for all chains that have sent messages to `chain_id`.
     async fn send_chain_information_for_senders(
         &mut self,
         chain_id: ChainId,
     ) -> Result<(), ChainClientError> {
-        let mut sender_heights = BTreeMap::new();
-        {
-            let chain = self.local_node.chain_state_view(chain_id).await?;
-            let pairs = chain.inboxes.try_load_all_entries().await?;
-            for (origin, inbox) in pairs {
-                let inbox_next_height = inbox.next_block_height_to_receive()?;
-                sender_heights
-                    .entry(origin)
-                    .and_modify(|h| *h = inbox_next_height.max(*h))
-                    .or_insert(inbox_next_height);
-            }
-        }
+        let sender_heights = self
+            .local_node
+            .chain_state_view(chain_id)
+            .await?
+            .inboxes
+            .try_load_all_entries()
+            .await?
+            .iter()
+            .map(|(origin, inbox)| {
+                let next_height = inbox.next_block_height_to_receive()?;
+                Ok((*origin, next_height))
+            })
+            .collect::<Result<Vec<(ChainId, BlockHeight)>, ChainClientError>>()?;
 
         self.send_chain_info_up_to_heights(sender_heights, CrossChainMessageDelivery::Blocking)
             .await?;

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -233,6 +233,9 @@ message ChainInfoQuery {
 
   // Query for certificate hashes at block heights sent from the chain.
   optional bytes request_sent_certificate_hashes_by_heights = 11;
+
+  // Whether to create network actions as part of the query.
+  optional bool create_network_actions = 12;
 }
 
 // An authenticated proposal for a new block.

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -614,6 +614,7 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
             request_fallback: chain_info_query.request_fallback,
             request_sent_certificate_hashes_by_heights,
             request_sent_certificate_hashes_in_range: None,
+            create_network_actions: chain_info_query.create_network_actions.unwrap_or(true),
         })
     }
 }
@@ -644,6 +645,7 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
             request_manager_values: chain_info_query.request_manager_values,
             request_leader_timeout,
             request_fallback: chain_info_query.request_fallback,
+            create_network_actions: Some(chain_info_query.create_network_actions),
         })
     }
 }
@@ -1172,6 +1174,7 @@ pub mod tests {
             request_fallback: true,
             request_sent_certificate_hashes_by_heights: (3..8).map(BlockHeight::from).collect(),
             request_sent_certificate_hashes_in_range: None,
+            create_network_actions: true,
         };
         round_trip_check::<_, api::ChainInfoQuery>(chain_info_query_some);
     }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -365,6 +365,7 @@ ChainInfoQuery:
     - request_sent_certificate_hashes_by_heights:
         SEQ:
           TYPENAME: BlockHeight
+    - create_network_actions: BOOL
 ChainInfoResponse:
   STRUCT:
     - info:


### PR DESCRIPTION
## Motivation

Creating network actions requires reading certificates – this takes a lot of CPU time (reading from storage, deserializing certificates, etc.) but it's not always needed. Network actions are created in couple of places but one surprising one was when handling a `ChainInfoQuery`.

## Proposal

Add a boolean field to `ChainInfoQuery` struct that controls whether the caller wants to create network actions. By default it is set to `true` to maintain backwards compatibility but clients can call `no_network_actions` to set it to false.

## Test Plan

CI.

## Release Plan


- Nothing to do / These changes follow the usual release cycle.

This is already backported to testnet (https://github.com/linera-io/linera-protocol/pull/4518)

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)