### PR TITLE
`linera-client`: don't override chain worker TTL

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -149,7 +149,7 @@ where
             options.long_lived_services,
             chain_ids,
             name,
-            Duration::from_secs(30),
+            options.chain_worker_ttl,
             options.to_chain_client_options(),
         );
 


### PR DESCRIPTION
## Motivation

We have a CLI option for setting the chain worker TTL, but currently it is overridden with a static value.

## Proposal

Respect the passed value.

## Test Plan

Compiles, and I used it to test #4444.

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,

## Links
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
