### PR TITLE
`pnpm-workspace.yaml`: name `native-fungible` as workspace member

### DIFF
--- a/examples/pnpm-workspace.yaml
+++ b/examples/pnpm-workspace.yaml
@@ -3,4 +3,4 @@ packages:
 - ../linera-web/signer
 - counter
 - counter/metamask
-- fungible
+- native-fungible


### PR DESCRIPTION
## Motivation

`fungible` was incorrectly named as the workspace member, instead of `native-fungible`, which could lead to some confusing issues when building the `native-fungible` frontend (e.g. `vite` would not be found during a Vite build step).

## Proposal

Fix it.

## Test Plan

`pnpm install` in the `native-fungible` directory.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
