### PR TITLE
[testnet] Add `BlobLastUsedByCertificate` endpoint to the validator proxy.

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -157,6 +157,12 @@ pub trait ValidatorNode {
 
     /// Returns the missing `Blob`s by their IDs.
     async fn missing_blob_ids(&self, blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError>;
+
+    /// Returns the certificate that last used the blob.
+    async fn blob_last_used_by_certificate(
+        &self,
+        blob_id: BlobId,
+    ) -> Result<ConfirmedBlockCertificate, NodeError>;
 }
 
 /// Turn an address into a validator node.

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -97,6 +97,9 @@ service ValidatorNode {
 
   // Return the `BlobId`s that are not contained as `Blob`.
   rpc MissingBlobIds(BlobIds) returns (BlobIds);
+
+  // Returns the certificate that last used the blob.
+  rpc BlobLastUsedByCertificate(BlobId) returns (Certificate);
 }
 
 // Batch of raw certificates.

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -284,4 +284,18 @@ impl ValidatorNode for Client {
             Client::Simple(simple_client) => simple_client.missing_blob_ids(blob_ids).await?,
         })
     }
+
+    async fn blob_last_used_by_certificate(
+        &self,
+        blob_id: BlobId,
+    ) -> Result<ConfirmedBlockCertificate, NodeError> {
+        Ok(match self {
+            Client::Grpc(grpc_client) => grpc_client.blob_last_used_by_certificate(blob_id).await?,
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => {
+                simple_client.blob_last_used_by_certificate(blob_id).await?
+            }
+        })
+    }
 }

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -478,4 +478,12 @@ impl ValidatorNode for GrpcClient {
     async fn missing_blob_ids(&self, blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError> {
         Ok(client_delegate!(self, missing_blob_ids, blob_ids)?.try_into()?)
     }
+
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
+    async fn blob_last_used_by_certificate(
+        &self,
+        blob_id: BlobId,
+    ) -> Result<ConfirmedBlockCertificate, NodeError> {
+        Ok(client_delegate!(self, blob_last_used_by_certificate, blob_id)?.try_into()?)
+    }
 }

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -62,6 +62,9 @@ pub enum RpcMessage {
 
     // Internal to a validator
     CrossChainRequest(Box<CrossChainRequest>),
+
+    BlobLastUsedByCertificate(Box<BlobId>),
+    BlobLastUsedByCertificateResponse(Box<ConfirmedBlockCertificate>),
 }
 
 impl RpcMessage {
@@ -100,6 +103,8 @@ impl RpcMessage {
             | DownloadCertificates(_)
             | BlobLastUsedBy(_)
             | BlobLastUsedByResponse(_)
+            | BlobLastUsedByCertificate(_)
+            | BlobLastUsedByCertificateResponse(_)
             | MissingBlobIds(_)
             | MissingBlobIdsResponse(_)
             | DownloadCertificatesResponse(_) => {
@@ -122,6 +127,7 @@ impl RpcMessage {
             | DownloadBlob(_)
             | DownloadConfirmedBlock(_)
             | BlobLastUsedBy(_)
+            | BlobLastUsedByCertificate(_)
             | MissingBlobIds(_)
             | DownloadCertificates(_)
             | DownloadCertificatesByHeights(_, _) => true,
@@ -144,6 +150,7 @@ impl RpcMessage {
             | DownloadBlobResponse(_)
             | DownloadConfirmedBlockResponse(_)
             | BlobLastUsedByResponse(_)
+            | BlobLastUsedByCertificateResponse(_)
             | MissingBlobIdsResponse(_)
             | DownloadCertificatesResponse(_)
             | DownloadCertificatesByHeightsResponse(_) => false,
@@ -190,6 +197,17 @@ impl TryFrom<RpcMessage> for ConfirmedBlock {
     fn try_from(message: RpcMessage) -> Result<Self, Self::Error> {
         match message {
             RpcMessage::DownloadConfirmedBlockResponse(certificate) => Ok(*certificate),
+            RpcMessage::Error(error) => Err(*error),
+            _ => Err(NodeError::UnexpectedMessage),
+        }
+    }
+}
+
+impl TryFrom<RpcMessage> for ConfirmedBlockCertificate {
+    type Error = NodeError;
+    fn try_from(message: RpcMessage) -> Result<Self, Self::Error> {
+        match message {
+            RpcMessage::BlobLastUsedByCertificateResponse(certificate) => Ok(*certificate),
             RpcMessage::Error(error) => Err(*error),
             _ => Err(NodeError::UnexpectedMessage),
         }

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -249,4 +249,14 @@ impl ValidatorNode for SimpleClient {
     async fn missing_blob_ids(&self, blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError> {
         self.query(RpcMessage::MissingBlobIds(blob_ids)).await
     }
+
+    async fn blob_last_used_by_certificate(
+        &self,
+        blob_id: BlobId,
+    ) -> Result<ConfirmedBlockCertificate, NodeError> {
+        self.query::<ConfirmedBlockCertificate>(RpcMessage::BlobLastUsedByCertificate(Box::new(
+            blob_id,
+        )))
+        .await
+    }
 }

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -379,6 +379,8 @@ where
             | RpcMessage::DownloadConfirmedBlockResponse(_)
             | RpcMessage::BlobLastUsedBy(_)
             | RpcMessage::BlobLastUsedByResponse(_)
+            | RpcMessage::BlobLastUsedByCertificate(_)
+            | RpcMessage::BlobLastUsedByCertificateResponse(_)
             | RpcMessage::MissingBlobIds(_)
             | RpcMessage::MissingBlobIdsResponse(_)
             | RpcMessage::DownloadCertificates(_)

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -1134,6 +1134,14 @@ RpcMessage:
       CrossChainRequest:
         NEWTYPE:
           TYPENAME: CrossChainRequest
+    31:
+      BlobLastUsedByCertificate:
+        NEWTYPE:
+          TYPENAME: BlobId
+    32:
+      BlobLastUsedByCertificateResponse:
+        NEWTYPE:
+          TYPENAME: ConfirmedBlockCertificate
 Secp256k1PublicKey:
   NEWTYPESTRUCT:
     TUPLEARRAY:

--- a/linera-service/src/exporter/test_utils.rs
+++ b/linera-service/src/exporter/test_utils.rs
@@ -373,6 +373,13 @@ impl ValidatorNode for DummyValidator {
     ) -> Result<Response<BlobIds>, Status> {
         unimplemented!()
     }
+
+    async fn blob_last_used_by_certificate(
+        &self,
+        _request: Request<linera_rpc::grpc::api::BlobId>,
+    ) -> Result<Response<linera_rpc::grpc::api::Certificate>, Status> {
+        unimplemented!()
+    }
 }
 
 #[async_trait]

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -779,6 +779,16 @@ where
             .map_err(Self::view_error_to_status)?;
         Ok(Response::new(missing_blob_ids.try_into()?))
     }
+
+    #[instrument(skip_all, err(level = Level::WARN))]
+    async fn blob_last_used_by_certificate(
+        &self,
+        request: Request<BlobId>,
+    ) -> Result<Response<Certificate>, Status> {
+        let cert_hash = self.blob_last_used_by(request).await?;
+        let request = Request::new(cert_hash.into_inner());
+        self.download_certificate(request).await
+    }
 }
 
 #[async_trait]

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -400,6 +400,21 @@ where
             MissingBlobIds(blob_ids) => Ok(Some(RpcMessage::MissingBlobIdsResponse(
                 self.storage.missing_blobs(&blob_ids).await?,
             ))),
+            BlobLastUsedByCertificate(blob_id) => {
+                let blob_state = self.storage.read_blob_state(*blob_id).await?;
+                let blob_state = blob_state.ok_or_else(|| anyhow!("Blob not found {}", blob_id))?;
+                let last_used_by = blob_state
+                    .last_used_by
+                    .ok_or_else(|| anyhow!("Blob not found {}", blob_id))?;
+                let certificate = self
+                    .storage
+                    .read_certificate(last_used_by)
+                    .await?
+                    .ok_or_else(|| anyhow!("Certificate not found {}", last_used_by))?;
+                Ok(Some(RpcMessage::BlobLastUsedByCertificateResponse(
+                    Box::new(certificate),
+                )))
+            }
             BlockProposal(_)
             | LiteCertificate(_)
             | TimeoutCertificate(_)
@@ -417,6 +432,7 @@ where
             | DownloadPendingBlobResponse(_)
             | HandlePendingBlob(_)
             | BlobLastUsedByResponse(_)
+            | BlobLastUsedByCertificateResponse(_)
             | MissingBlobIdsResponse(_)
             | DownloadConfirmedBlockResponse(_)
             | DownloadCertificatesResponse(_)

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -146,6 +146,13 @@ impl ValidatorNode for DummyValidatorNode {
     async fn missing_blob_ids(&self, _: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
+
+    async fn blob_last_used_by_certificate(
+        &self,
+        _blob_id: BlobId,
+    ) -> Result<ConfirmedBlockCertificate, NodeError> {
+        Err(NodeError::UnexpectedMessage)
+    }
 }
 
 struct DummyValidatorNodeProvider;


### PR DESCRIPTION
## Motivation

This is a Conway backport of https://github.com/linera-io/linera-protocol/pull/4420

## Proposal

In this PR we add the validator side only of the new endpoint. Importantly, clients do not use it yet (see [download_certificate_for_blob](https://github.com/linera-io/linera-protocol/blob/main/linera-core/src/remote_node.rs#L187) on `main`). This will be added after validators are updated.

## Test Plan

CI.

## Release Plan
- This is already a testnet branch - updating validators.
- After validators' update we update clients.

## Links

https://github.com/linera-io/linera-protocol/pull/4420
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
