### PR TITLE
Always fetch the chain description on `follow-chain`.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2804,6 +2804,14 @@ impl<Env: Environment> ChainClient<Env> {
         self.transfer(owner, amount, recipient).await
     }
 
+    #[instrument(level = "trace")]
+    pub async fn fetch_chain_info(&self) -> Result<Box<ChainInfo>, ChainClientError> {
+        let validators = self.client.validator_nodes().await?;
+        self.client
+            .fetch_chain_info(self.chain_id, &validators)
+            .await
+    }
+
     /// Attempts to synchronize chains that have sent us messages and populate our local
     /// inbox.
     ///

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1634,25 +1634,25 @@ impl Runnable for Job {
                     .await?;
             }
 
-            Wallet(WalletCommand::FollowChain {
-                chain_id,
-                sync: true,
-            }) => {
+            Wallet(WalletCommand::FollowChain { chain_id, sync }) => {
                 let mut context = ClientContext::new(
                     storage,
                     options.context_options.clone(),
                     wallet,
                     signer.into_value(),
                 );
+                let start_time = Instant::now();
+                context.client.track_chain(chain_id);
                 let chain_client = context.make_chain_client(chain_id);
-                info!("Synchronizing chain information");
-                let time_start = Instant::now();
-                chain_client.synchronize_from_validators().await?;
+                if sync {
+                    chain_client.synchronize_from_validators().await?;
+                } else {
+                    chain_client.fetch_chain_info().await?;
+                }
                 context.update_wallet_from_client(&chain_client).await?;
-                let time_total = time_start.elapsed();
                 info!(
-                    "Synchronized chain information in {} ms",
-                    time_total.as_millis()
+                    "Chain followed and added in {} ms",
+                    start_time.elapsed().as_millis()
                 );
             }
 
@@ -2382,23 +2382,6 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                 Ok(0)
             }
 
-            WalletCommand::FollowChain { chain_id, sync } => {
-                let start_time = Instant::now();
-                options
-                    .wallet()
-                    .await?
-                    .mutate(|w| w.extend([UserChain::make_other(*chain_id, Timestamp::now())]))
-                    .await?;
-                if *sync {
-                    options.run_with_storage(Job(options.clone())).await??;
-                }
-                info!(
-                    "Chain followed and added in {} ms",
-                    start_time.elapsed().as_millis()
-                );
-                Ok(0)
-            }
-
             WalletCommand::ForgetChain { chain_id } => {
                 let start_time = Instant::now();
                 options
@@ -2407,11 +2390,6 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                     .mutate(|w| w.forget_chain(chain_id))
                     .await??;
                 info!("Chain forgotten in {} ms", start_time.elapsed().as_millis());
-                Ok(0)
-            }
-
-            WalletCommand::RequestChain { .. } => {
-                options.run_with_storage(Job(options.clone())).await??;
                 Ok(0)
             }
 
@@ -2459,6 +2437,11 @@ Make sure to use a Linera client compatible with this network.
                     "Wallet initialized in {} ms",
                     start_time.elapsed().as_millis()
                 );
+                Ok(0)
+            }
+
+            WalletCommand::FollowChain { .. } | WalletCommand::RequestChain { .. } => {
+                options.run_with_storage(Job(options.clone())).await??;
                 Ok(0)
             }
         },

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -4209,6 +4209,13 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     // Verify that a third party can also follow the chain.
     client3.follow_chain(chain2, true).await?;
     assert!(client3.local_balance(account2).await? > Amount::ZERO);
+    assert!(client3.load_wallet()?.chain_ids().contains(&chain2));
+
+    // Verify that trying to follow a chain that does not exist will fail, even without --sync.
+    let wrong_id = ChainId(CryptoHash::test_hash("wrong chain ID"));
+    let result = client3.follow_chain(wrong_id, false).await;
+    assert!(result.is_err());
+    assert!(!client3.load_wallet()?.chain_ids().contains(&wrong_id));
 
     net.ensure_is_running().await?;
     net.terminate().await?;


### PR DESCRIPTION
## Motivation

`follow-chain` synchronizes the new chain only if `--sync` is specified. Otherwise it doesn't even verify that the chain exists.

## Proposal

Without `--sync`, still download the chain description. If that fails, don't add the chain to the wallet.

## Test Plan

An end-to-end test was extended.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/4529.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
