### PR TITLE
Always fetch the chain description on `follow-chain`. (Backport of #4532)

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2735,6 +2735,14 @@ impl<Env: Environment> ChainClient<Env> {
         self.transfer(owner, amount, recipient).await
     }
 
+    #[instrument(level = "trace")]
+    pub async fn fetch_chain_info(&self) -> Result<Box<ChainInfo>, ChainClientError> {
+        let validators = self.client.validator_nodes().await?;
+        self.client
+            .fetch_chain_info(self.chain_id, &validators)
+            .await
+    }
+
     /// Attempts to synchronize chains that have sent us messages and populate our local
     /// inbox.
     ///

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -4124,6 +4124,13 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     // Verify that a third party can also follow the chain.
     client3.follow_chain(chain2, true).await?;
     assert!(client3.local_balance(account2).await? > Amount::ZERO);
+    assert!(client3.load_wallet()?.chain_ids().contains(&chain2));
+
+    // Verify that trying to follow a chain that does not exist will fail, even without --sync.
+    let wrong_id = ChainId(CryptoHash::test_hash("wrong chain ID"));
+    let result = client3.follow_chain(wrong_id, false).await;
+    assert!(result.is_err());
+    assert!(!client3.load_wallet()?.chain_ids().contains(&wrong_id));
 
     net.ensure_is_running().await?;
     net.terminate().await?;


### PR DESCRIPTION
Backport of #4532.

## Motivation

`follow-chain` synchronizes the new chain only if `--sync` is specified. Otherwise it doesn't even verify that the chain exists.

## Proposal

Without `--sync`, still download the chain description. If that fails, don't add the chain to the wallet.

## Test Plan

An end-to-end test was extended.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK.

## Links

- Original PR to the main branch: #4532.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
