### PR TITLE
Storage initialization is idempotent

### DIFF
--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -172,16 +172,16 @@ impl GenesisConfig {
         }
         let network_description = self.network_description();
         storage
+            .write_network_description(&network_description)
+            .await
+            .map_err(linera_chain::ChainError::from)?;
+        storage
             .write_blob(&self.committee_blob())
             .await
             .map_err(linera_chain::ChainError::from)?;
         for description in &self.chains {
             storage.create_chain(description.clone()).await?;
         }
-        storage
-            .write_network_description(&network_description)
-            .await
-            .map_err(linera_chain::ChainError::from)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Motivation

Currently, initializing a storage is a one-time only operation meaning that if we try to do it again it will return an error.

## Proposal

Storage initialization is an idempotent operation – we only write blobs under specific keys. 

Do not return an error, instead return early with `Ok(())`, if storage is already initialized.

## Test Plan

CI

## Release Plan


- These changes follow the usual release cycle.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK
  
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
