### PR TITLE
Return error if we try to initialize storage with new genesis

### DIFF
--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -169,6 +169,15 @@ impl GenesisConfig {
             .await
             .map_err(linera_chain::ChainError::from)?
         {
+            if description != self.network_description() {
+                // We can't initialize storage with a different network description.
+                tracing::error!(
+                    current_network=?description,
+                    new_network=?self.network_description(),
+                    "storage already initialized"
+                );
+                return Err(Error::StorageIsAlreadyInitialized(Box::new(description)));
+            }
             tracing::debug!(?description, "storage already initialized");
             return Ok(());
         }


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/4543 started treating storage initialization as idempotent but it is still useful to detect if we try to initialize it for a network that has a different Genesis config.

## Proposal

Return (and log) an error if the new genesis config is different from the one our storage is initialized with.

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,


## Links
https://github.com/linera-io/linera-protocol/pull/4543
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
