### PR TITLE
Use release_max_level_trace instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,7 +259,7 @@ tonic-web = "0.14"
 tonic-web-wasm-client = "0.8.0"
 tower = "0.4.13"
 tower-http = "0.6.6"
-tracing = { version = "0.1.40", features = ["release_max_level_debug"] }
+tracing = { version = "0.1.40", features = ["release_max_level_trace"] }
 tracing-chrome = "0.7.2"
 tracing-opentelemetry = "0.31.0"
 tracing-subscriber = { version = "0.3.18", default-features = false, features = [


### PR DESCRIPTION
## Motivation

We currently compile out trace logs, even though the overhead is minimal (it's 2 CPU instructions https://www.reddit.com/r/rust/comments/x9nypb/comment/inutkiv/)

## Proposal

Stop compiling it out, so we can have `trace` logs if we want for debugging with just a restart, without having to recompile the binary.

## Test Plan

I'm benchmarking networks with this, saw no visible performance regression

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
