### PR TITLE
Add more instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5838,6 +5838,7 @@ dependencies = [
  "papaya",
  "prometheus",
  "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3828,6 +3828,7 @@ dependencies = [
  "papaya",
  "prometheus",
  "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -462,7 +462,7 @@ where
                         .ok_or(WorkerError::InvalidLiteCertificate)?,
                 ))
             }
-            _ => return Err(WorkerError::InvalidLiteCertificate),
+            _ => Err(WorkerError::InvalidLiteCertificate),
         }
     }
 }
@@ -555,7 +555,11 @@ where
     }
 
     /// Executes a [`Query`] for an application's state on a specific chain.
-    #[instrument(level = "trace", skip(self, chain_id, query))]
+    #[instrument(
+        level = "trace",
+        target = "telemetry_only",
+        skip(self, chain_id, query)
+    )]
     pub async fn query_application(
         &self,
         chain_id: ChainId,
@@ -567,7 +571,11 @@ where
         .await
     }
 
-    #[instrument(level = "trace", skip(self, chain_id, application_id))]
+    #[instrument(level = "trace", target = "telemetry_only", skip(self, chain_id, application_id), fields(
+        nickname = %self.nickname,
+        chain_id = %chain_id,
+        application_id = %application_id
+    ))]
     pub async fn describe_application(
         &self,
         chain_id: ChainId,
@@ -585,7 +593,13 @@ where
     /// Processes a confirmed block (aka a commit).
     #[instrument(
         level = "trace",
-        skip(self, certificate, notify_when_messages_are_delivered)
+        target = "telemetry_only",
+        skip(self, certificate, notify_when_messages_are_delivered),
+        fields(
+            nickname = %self.nickname,
+            chain_id = %certificate.block().header.chain_id,
+            block_height = %certificate.block().header.height
+        )
     )]
     async fn process_confirmed_block(
         &self,
@@ -604,7 +618,11 @@ where
     }
 
     /// Processes a validated block issued from a multi-owner chain.
-    #[instrument(level = "trace", skip(self, certificate))]
+    #[instrument(level = "trace", target = "telemetry_only", skip(self, certificate), fields(
+        nickname = %self.nickname,
+        chain_id = %certificate.block().header.chain_id,
+        block_height = %certificate.block().header.height
+    ))]
     async fn process_validated_block(
         &self,
         certificate: ValidatedBlockCertificate,
@@ -620,7 +638,11 @@ where
     }
 
     /// Processes a leader timeout issued from a multi-owner chain.
-    #[instrument(level = "trace", skip(self, certificate))]
+    #[instrument(level = "trace", target = "telemetry_only", skip(self, certificate), fields(
+        nickname = %self.nickname,
+        chain_id = %certificate.value().chain_id(),
+        height = %certificate.value().height()
+    ))]
     async fn process_timeout(
         &self,
         certificate: TimeoutCertificate,
@@ -635,7 +657,12 @@ where
         .await
     }
 
-    #[instrument(level = "trace", skip(self, origin, recipient, bundles))]
+    #[instrument(level = "trace", target = "telemetry_only", skip(self, origin, recipient, bundles), fields(
+        nickname = %self.nickname,
+        origin = %origin,
+        recipient = %recipient,
+        num_bundles = %bundles.len()
+    ))]
     async fn process_cross_chain_update(
         &self,
         origin: ChainId,
@@ -653,7 +680,11 @@ where
     }
 
     /// Returns a stored [`ConfirmedBlockCertificate`] for a chain's block.
-    #[instrument(level = "trace", skip(self, chain_id, height))]
+    #[instrument(level = "trace", target = "telemetry_only", skip(self, chain_id, height), fields(
+        nickname = %self.nickname,
+        chain_id = %chain_id,
+        height = %height
+    ))]
     #[cfg(with_testing)]
     pub async fn read_certificate(
         &self,
@@ -671,7 +702,10 @@ where
     ///
     /// The returned view holds a lock on the chain state, which prevents the worker from changing
     /// the state of that chain.
-    #[instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", target = "telemetry_only", skip(self), fields(
+        nickname = %self.nickname,
+        chain_id = %chain_id
+    ))]
     pub async fn chain_state_view(
         &self,
         chain_id: ChainId,
@@ -682,7 +716,10 @@ where
         .await
     }
 
-    #[instrument(level = "trace", skip(self, request_builder))]
+    #[instrument(level = "trace", target = "telemetry_only", skip(self, request_builder), fields(
+        nickname = %self.nickname,
+        chain_id = %chain_id
+    ))]
     /// Sends a request to the [`ChainWorker`] for a [`ChainId`] and waits for the `Response`.
     async fn query_chain_worker<Response>(
         &self,
@@ -705,7 +742,10 @@ where
 
     /// Retrieves an endpoint to a [`ChainWorkerActor`] from the cache, creating one and adding it
     /// to the cache if needed.
-    #[instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", target = "telemetry_only", skip(self), fields(
+        nickname = %self.nickname,
+        chain_id = %chain_id
+    ))]
     async fn get_chain_worker_endpoint(
         &self,
         chain_id: ChainId,
@@ -754,7 +794,10 @@ where
     /// and add it to the cache if needed.
     ///
     /// Returns [`None`] if the cache is full and no candidate for eviction was found.
-    #[instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", target = "telemetry_only", skip(self), fields(
+        nickname = %self.nickname,
+        chain_id = %chain_id
+    ))]
     #[expect(clippy::type_complexity)]
     fn try_get_chain_worker_endpoint(
         &self,
@@ -1067,6 +1110,11 @@ where
     }
 
     /// Updates the received certificate trackers to at least the given values.
+    #[instrument(target = "telemetry_only", skip_all, fields(
+        nickname = %self.nickname,
+        chain_id = %chain_id,
+        num_trackers = %new_trackers.len()
+    ))]
     pub async fn update_received_certificate_trackers(
         &self,
         chain_id: ChainId,

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -303,6 +303,7 @@ where
         }
     }
 
+    #[instrument(target = "telemetry_only", skip_all, fields(remote_addr = ?request.remote_addr(), chain_id = ?request.get_ref().chain_id()))]
     fn worker_client<R>(
         &self,
         request: Request<R>,
@@ -374,7 +375,12 @@ where
 {
     type SubscribeStream = UnboundedReceiverStream<Result<Notification, Status>>;
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "handle_block_proposal")
+    )]
     async fn handle_block_proposal(
         &self,
         request: Request<BlockProposal>,
@@ -386,7 +392,12 @@ where
         )
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "handle_lite_certificate")
+    )]
     async fn handle_lite_certificate(
         &self,
         request: Request<LiteCertificate>,
@@ -398,7 +409,12 @@ where
         )
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "handle_confirmed_certificate")
+    )]
     async fn handle_confirmed_certificate(
         &self,
         request: Request<api::HandleConfirmedCertificateRequest>,
@@ -410,7 +426,12 @@ where
         )
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "handle_validated_certificate")
+    )]
     async fn handle_validated_certificate(
         &self,
         request: Request<api::HandleValidatedCertificateRequest>,
@@ -422,7 +443,12 @@ where
         )
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "handle_timeout_certificate")
+    )]
     async fn handle_timeout_certificate(
         &self,
         request: Request<api::HandleTimeoutCertificateRequest>,
@@ -434,7 +460,12 @@ where
         )
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "handle_chain_info_query")
+    )]
     async fn handle_chain_info_query(
         &self,
         request: Request<api::ChainInfoQuery>,
@@ -446,7 +477,12 @@ where
         )
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "subscribe")
+    )]
     async fn subscribe(
         &self,
         request: Request<SubscriptionRequest>,
@@ -475,7 +511,12 @@ where
         Ok(Response::new(linera_version::VersionInfo::default().into()))
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "get_network_description")
+    )]
     async fn get_network_description(
         &self,
         _request: Request<()>,
@@ -490,7 +531,12 @@ where
         Ok(Response::new(description.into()))
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "upload_blob")
+    )]
     async fn upload_blob(&self, request: Request<BlobContent>) -> Result<Response<BlobId>, Status> {
         let content: linera_sdk::linera_base_types::BlobContent =
             request.into_inner().try_into()?;
@@ -503,7 +549,12 @@ where
         Ok(Response::new(id.try_into()?))
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "download_blob")
+    )]
     async fn download_blob(
         &self,
         request: Request<BlobId>,
@@ -519,7 +570,12 @@ where
         Ok(Response::new(blob.into_content().try_into()?))
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "download_pending_blob")
+    )]
     async fn download_pending_blob(
         &self,
         request: Request<PendingBlobRequest>,
@@ -544,7 +600,12 @@ where
         }
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "handle_pending_blob")
+    )]
     async fn handle_pending_blob(
         &self,
         request: Request<HandlePendingBlobRequest>,
@@ -569,7 +630,12 @@ where
         }
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "download_certificate")
+    )]
     async fn download_certificate(
         &self,
         request: Request<CryptoHash>,
@@ -586,7 +652,12 @@ where
         Ok(Response::new(certificate.try_into()?))
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "download_certificates")
+    )]
     async fn download_certificates(
         &self,
         request: Request<CertificatesBatchRequest>,
@@ -632,7 +703,12 @@ where
         )?))
     }
 
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "download_certificates_by_heights")
+    )]
     async fn download_certificates_by_heights(
         &self,
         request: Request<api::DownloadCertificatesByHeightsRequest>,
@@ -747,7 +823,9 @@ where
         }))
     }
 
-    #[instrument(skip_all, err(level = Level::WARN))]
+    #[instrument(target = "telemetry_only", skip_all, err(level = Level::WARN), fields(
+        method = "blob_last_used_by"
+    ))]
     async fn blob_last_used_by(
         &self,
         request: Request<BlobId>,
@@ -767,7 +845,9 @@ where
         Ok(Response::new(last_used_by.into()))
     }
 
-    #[instrument(skip_all, err(level = Level::WARN))]
+    #[instrument(target = "telemetry_only", skip_all, err(level = Level::WARN), fields(
+        method = "blob_last_used_by_certificate"
+    ))]
     async fn blob_last_used_by_certificate(
         &self,
         request: Request<BlobId>,
@@ -777,7 +857,9 @@ where
         self.download_certificate(request).await
     }
 
-    #[instrument(skip_all, err(level = Level::WARN))]
+    #[instrument(target = "telemetry_only", skip_all, err(level = Level::WARN), fields(
+        method = "missing_blob_ids"
+    ))]
     async fn missing_blob_ids(
         &self,
         request: Request<BlobIds>,
@@ -798,7 +880,12 @@ impl<S> NotifierService for GrpcProxy<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    #[instrument(skip_all, err(Display))]
+    #[instrument(
+        target = "telemetry_only",
+        skip_all,
+        err(Display),
+        fields(method = "notify")
+    )]
     async fn notify(&self, request: Request<Notification>) -> Result<Response<()>, Status> {
         let notification = request.into_inner();
         let chain_id = notification

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -45,6 +45,7 @@ linera-views.workspace = true
 papaya.workspace = true
 prometheus.workspace = true
 serde.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -28,6 +28,7 @@ use linera_views::{
     ViewError,
 };
 use serde::{Deserialize, Serialize};
+use tracing::instrument;
 #[cfg(with_testing)]
 use {
     futures::channel::oneshot::{self, Receiver},
@@ -544,6 +545,7 @@ where
         &self.clock
     }
 
+    #[instrument(level = "trace", target = "telemetry_only", skip_all, fields(chain_id = %chain_id))]
     async fn load_chain(
         &self,
         chain_id: ChainId,
@@ -563,6 +565,7 @@ where
         ChainStateView::load(context).await
     }
 
+    #[instrument(level = "trace", target = "telemetry_only", skip_all, fields(blob_id = %blob_id))]
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {
         let store = self.database.open_shared(&[])?;
         let blob_key = bcs::to_bytes(&BaseKey::Blob(blob_id))?;
@@ -572,6 +575,7 @@ where
         Ok(test)
     }
 
+    #[instrument(target = "telemetry_only", skip_all, fields(blob_count = blob_ids.len()))]
     async fn missing_blobs(&self, blob_ids: &[BlobId]) -> Result<Vec<BlobId>, ViewError> {
         let store = self.database.open_shared(&[])?;
         let mut keys = Vec::new();
@@ -602,6 +606,7 @@ where
         Ok(test)
     }
 
+    #[instrument(target = "telemetry_only", skip_all, fields(hash = %hash))]
     async fn read_confirmed_block(
         &self,
         hash: CryptoHash,
@@ -616,6 +621,7 @@ where
         Ok(value)
     }
 
+    #[instrument(target = "telemetry_only", skip_all, fields(blob_id = %blob_id))]
     async fn read_blob(&self, blob_id: BlobId) -> Result<Option<Blob>, ViewError> {
         let store = self.database.open_shared(&[])?;
         let blob_key = bcs::to_bytes(&BaseKey::Blob(blob_id))?;
@@ -682,6 +688,7 @@ where
         Ok(blob_states)
     }
 
+    #[instrument(target = "telemetry_only", skip_all, fields(blob_id = %blob.id()))]
     async fn write_blob(&self, blob: &Blob) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         batch.add_blob(blob)?;
@@ -996,6 +1003,7 @@ where
         Ok(())
     }
 
+    #[instrument(target = "telemetry_only", skip_all, fields(batch_size = batch.key_value_bytes.len()))]
     async fn write_batch(&self, batch: Batch) -> Result<(), ViewError> {
         if batch.key_value_bytes.is_empty() {
             return Ok(());


### PR DESCRIPTION
## Motivation

Now that we have distributed tracing (after https://github.com/linera-io/linera-protocol/pull/4556), we need more instrumentation so we have data about more functions in the breakdowns.

## Proposal

Instrument more functions with `telemetry_only` so that we don't get spammed in our logs, but the spans still get sent to Tempo.

## Test Plan

Tested this with https://github.com/linera-io/linera-protocol/pull/4556, saw the spans properly show in the breakdowns.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
