### PR TITLE
Implement the syncing with all validators functionality.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -20,6 +20,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera query-validator`↴](#linera-query-validator)
 * [`linera query-validators`↴](#linera-query-validators)
 * [`linera sync-validator`↴](#linera-sync-validator)
+* [`linera sync-all-validators`↴](#linera-sync-all-validators)
 * [`linera set-validator`↴](#linera-set-validator)
 * [`linera remove-validator`↴](#linera-remove-validator)
 * [`linera revoke-epochs`↴](#linera-revoke-epochs)
@@ -87,6 +88,7 @@ Client implementation and command-line tool for the Linera blockchain
 * `query-validator` — Show the version and genesis config hash of a new validator, and print a warning if it is incompatible. Also print some information about the given chain while we are at it
 * `query-validators` — Show the current set of validators for a chain. Also print some information about the given chain while we are at it
 * `sync-validator` — Synchronizes a validator with the local state of chains
+* `sync-all-validators` — Synchronizes all validators with the local state of chains
 * `set-validator` — Add or modify a validator (admin only)
 * `remove-validator` — Remove a validator (admin only)
 * `revoke-epochs` — Deprecates all committees up to and including the specified one
@@ -433,6 +435,18 @@ Synchronizes a validator with the local state of chains
 ###### **Arguments:**
 
 * `<ADDRESS>` — The public address of the validator to synchronize
+
+###### **Options:**
+
+* `--chains <CHAINS>` — The chains to synchronize, or the default chain if empty
+
+
+
+## `linera sync-all-validators`
+
+Synchronizes all validators with the local state of chains
+
+**Usage:** `linera sync-all-validators [OPTIONS]`
 
 ###### **Options:**
 

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -352,6 +352,13 @@ pub enum ClientCommand {
         chains: Vec<ChainId>,
     },
 
+    /// Synchronizes all validators with the local state of chains.
+    SyncAllValidators {
+        /// The chains to synchronize, or the default chain if empty.
+        #[arg(long, num_args = 0..)]
+        chains: Vec<ChainId>,
+    },
+
     /// Add or modify a validator (admin only)
     SetValidator {
         /// The public key of the validator.
@@ -969,6 +976,7 @@ impl ClientCommand {
             | ClientCommand::QueryValidator { .. }
             | ClientCommand::QueryValidators { .. }
             | ClientCommand::SyncValidator { .. }
+            | ClientCommand::SyncAllValidators { .. }
             | ClientCommand::SetValidator { .. }
             | ClientCommand::RemoveValidator { .. }
             | ClientCommand::ResourceControlPolicy { .. }

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -586,9 +586,7 @@ impl Runnable for Job {
                 let committee = context.wallet().genesis_config().committee.clone();
 
                 for (_validator_name, network_address) in committee.validator_addresses() {
-                    let validator = context
-                        .make_node_provider()
-                        .make_node(network_address)?;
+                    let validator = context.make_node_provider().make_node(network_address)?;
 
                     for chain_id in &chains {
                         let chain = context.make_chain_client(*chain_id);

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -592,7 +592,8 @@ impl Runnable for Job {
                         let context = context.clone();
                         let chains = chains.clone();
                         async move {
-                            let validator = context.make_node_provider().make_node(network_address)?;
+                            let validator =
+                                context.make_node_provider().make_node(network_address)?;
                             // For each validator, sync all chains sequentially
                             for chain_id in &chains {
                                 let chain = context.make_chain_client(*chain_id);


### PR DESCRIPTION
## Motivation

In operations, it is useful to be able to sync with all validators in one single operation.

Fixes #4488 

## Proposal

The implementation is straightforward.

## Test Plan

The CI.
I did test with README.md kind of files and added a `linera sync-all-validators` function. And it does access to the validators without error.
I did not test that the syncing does happen, though.

I created issue #4535 that shows some idea for improving the syncing with validators.

## Release Plan

Fully compatible with existing DevNet / TestNet.

## Links

None.