### PR TITLE
`linera-base`: expunge `wasmtimer` in favour of `kywasmtime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "wasmtimer 0.4.2",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -492,7 +492,7 @@ dependencies = [
  "tower 0.5.2",
  "tracing",
  "url",
- "wasmtimer 0.4.2",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -687,7 +687,7 @@ dependencies = [
  "tower 0.5.2",
  "tracing",
  "url",
- "wasmtimer 0.4.2",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -4866,6 +4866,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kywasmtime"
+version = "0.1.0"
+source = "git+https://github.com/linera-io/kywasmtime?rev=480df00badbe80520d5b990855138d3638c56159#480df00badbe80520d5b990855138d3638c56159"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "kzg-rs"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5068,6 +5078,7 @@ dependencies = [
  "hex",
  "is-terminal",
  "k256",
+ "kywasmtime",
  "linera-base",
  "linera-witty",
  "port-selector",
@@ -5094,7 +5105,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm_thread",
- "wasmtimer 0.2.1",
  "web-sys",
  "web-time",
  "zstd",
@@ -11068,20 +11078,6 @@ dependencies = [
  "heck 0.4.1",
  "indexmap 2.10.0",
  "wit-parser 0.217.1",
-]
-
-[[package]]
-name = "wasmtimer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ed9d8b15c7fb594d72bfb4b5a276f3d2029333cd93a932f376f5937f6f80ee"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot",
- "pin-utils",
- "slab",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,7 +271,6 @@ wasmtime = { version = "25.0.0", default-features = false, features = [
     "runtime",
     "std",
 ] }
-wasmtimer = "0.2.0"
 web-sys = "0.3.69"
 web-time = "1.1.0"
 wit-bindgen = "0.24.0"
@@ -327,6 +326,10 @@ version = "1.6.3"
 default-features = false
 features = ["rt-tokio", "rustls"]
 version = "1.76.0"
+
+[workspace.dependencies.kywasmtime]
+git = "https://github.com/linera-io/kywasmtime"
+rev = "480df00badbe80520d5b990855138d3638c56159"
 
 [profile.release]
 lto = "thin"

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -21,16 +21,16 @@ revm = []
 test = ["test-strategy", "proptest"]
 web = [
     "getrandom/js",
+    "kywasmtime",
     "rand/getrandom",
     "rand/std",
     "rand/std_rng",
     "tracing-web",
-    "wasmtimer",
     "wasm-bindgen",
     "wasm-bindgen-futures",
     "wasm_thread",
-    "web-time",
     "web-sys",
+    "web-time",
 ]
 
 [dependencies]
@@ -50,6 +50,7 @@ getrandom = { workspace = true, optional = true }
 hex.workspace = true
 is-terminal.workspace = true
 k256.workspace = true
+kywasmtime = { workspace = true, optional = true }
 linera-witty = { workspace = true, features = ["macros"] }
 prometheus = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true, features = ["alloc"] }
@@ -70,7 +71,6 @@ trait-variant.workspace = true
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
 wasm_thread = { workspace = true, optional = true }
-wasmtimer = { workspace = true, optional = true }
 web-sys = { workspace = true, optional = true }
 web-time = { workspace = true, optional = true }
 

--- a/linera-base/src/time.rs
+++ b/linera-base/src/time.rs
@@ -7,8 +7,10 @@ Abstractions over time that can be used natively or on the Web.
 
 cfg_if::cfg_if! {
     if #[cfg(web)] {
+        // This must remain conditional as otherwise it pulls in JavaScript symbols
+        // on-chain (on any Wasm target).
         pub use web_time::*;
-        pub use wasmtimer::tokio as timer;
+        pub use kywasmtime as timer;
     } else {
         pub use std::time::*;
         pub use tokio::time as timer;


### PR DESCRIPTION
## Motivation

We ran into a variant of https://github.com/whizsid/wasmtimer-rs/issues/22, which was drastically slowing down the operation of `@linera/client` (see #4444 for details).  Additionally, `wasmtimer` doesn't look thread-safe: it uses [`parking_lot`](https://crates.io/crates/parking_lot), which will panic on Wasm if the lock ever tries to park.

## Proposal

Replace our dependency on `wasmtimer` with a [Linera fork](https://github.com/linera-io/kywasmtime/) of [`kywasmtime`](https://github.com/rom1v/kywasmtime), a package that exposes the same API but using the browser `clearTimeout` APIs instead of implementing its own priority queue.

I made a couple of patches to be more helpful for our usage, which are PR'd upstream as https://github.com/rom1v/kywasmtime/pull/3 and https://github.com/rom1v/kywasmtime/pull/4.

Since `kywasmtime` isn't published to crates.io, we use it as a git dependency.  This is okay, since `linera-web` is also never published to crates.io (only to npm), and the SDK crates that we do publish don't rely on it.

## Test Plan

Manually tested according to the reproduction instructions in #4444.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Fixes #4444.
