### PR TITLE
`linera-base`: expunge `wasmtimer` in favour of `kywasmtime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "wasmtimer 0.4.2",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -492,7 +492,7 @@ dependencies = [
  "tower 0.5.2",
  "tracing",
  "url",
- "wasmtimer 0.4.2",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -687,7 +687,7 @@ dependencies = [
  "tower 0.5.2",
  "tracing",
  "url",
- "wasmtimer 0.4.2",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -4922,6 +4922,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kywasmtime"
+version = "0.1.0"
+source = "git+https://github.com/linera-io/kywasmtime?rev=480df00badbe80520d5b990855138d3638c56159#480df00badbe80520d5b990855138d3638c56159"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "kzg-rs"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5124,6 +5134,7 @@ dependencies = [
  "hex",
  "is-terminal",
  "k256",
+ "kywasmtime",
  "linera-base",
  "linera-witty",
  "port-selector",
@@ -5150,7 +5161,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm_thread",
- "wasmtimer 0.2.1",
  "web-sys",
  "web-time",
  "zstd",
@@ -11103,20 +11113,6 @@ dependencies = [
  "heck 0.4.1",
  "indexmap 2.10.0",
  "wit-parser 0.217.1",
-]
-
-[[package]]
-name = "wasmtimer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ed9d8b15c7fb594d72bfb4b5a276f3d2029333cd93a932f376f5937f6f80ee"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot",
- "pin-utils",
- "slab",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -269,7 +269,6 @@ wasmtime = { version = "25.0.0", default-features = false, features = [
     "runtime",
     "std",
 ] }
-wasmtimer = "0.2.0"
 web-sys = "0.3.69"
 web-time = "1.1.0"
 wit-bindgen = "0.24.0"
@@ -325,6 +324,10 @@ version = "1.6.3"
 default-features = false
 features = ["rt-tokio", "rustls"]
 version = "1.76.0"
+
+[workspace.dependencies.kywasmtime]
+git = "https://github.com/linera-io/kywasmtime"
+rev = "480df00badbe80520d5b990855138d3638c56159"
 
 [profile.release]
 lto = "thin"

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -21,16 +21,16 @@ revm = []
 test = ["test-strategy", "proptest"]
 web = [
     "getrandom/js",
+    "kywasmtime",
     "rand/getrandom",
     "rand/std",
     "rand/std_rng",
     "tracing-web",
-    "wasmtimer",
     "wasm-bindgen",
     "wasm-bindgen-futures",
     "wasm_thread",
-    "web-time",
     "web-sys",
+    "web-time",
 ]
 
 [dependencies]
@@ -50,6 +50,7 @@ getrandom = { workspace = true, optional = true }
 hex.workspace = true
 is-terminal.workspace = true
 k256.workspace = true
+kywasmtime = { workspace = true, optional = true }
 linera-witty = { workspace = true, features = ["macros"] }
 prometheus = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true, features = ["alloc"] }
@@ -70,7 +71,6 @@ trait-variant.workspace = true
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
 wasm_thread = { workspace = true, optional = true }
-wasmtimer = { workspace = true, optional = true }
 web-sys = { workspace = true, optional = true }
 web-time = { workspace = true, optional = true }
 

--- a/linera-base/src/time.rs
+++ b/linera-base/src/time.rs
@@ -7,8 +7,10 @@ Abstractions over time that can be used natively or on the Web.
 
 cfg_if::cfg_if! {
     if #[cfg(web)] {
+        // This must remain conditional as otherwise it pulls in JavaScript symbols
+        // on-chain (on any Wasm target).
         pub use web_time::*;
-        pub use wasmtimer::tokio as timer;
+        pub use kywasmtime as timer;
     } else {
         pub use std::time::*;
         pub use tokio::time as timer;


### PR DESCRIPTION
Backport #4561.