### PR TITLE
Add some useful client commands

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -12,6 +12,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera set-preferred-owner`↴](#linera-set-preferred-owner)
 * [`linera change-application-permissions`↴](#linera-change-application-permissions)
 * [`linera close-chain`↴](#linera-close-chain)
+* [`linera show-network-description`↴](#linera-show-network-description)
 * [`linera local-balance`↴](#linera-local-balance)
 * [`linera query-balance`↴](#linera-query-balance)
 * [`linera sync-balance`↴](#linera-sync-balance)
@@ -48,6 +49,9 @@ This document contains the help content for the `linera` command-line program.
 * [`linera wallet follow-chain`↴](#linera-wallet-follow-chain)
 * [`linera wallet forget-keys`↴](#linera-wallet-forget-keys)
 * [`linera wallet forget-chain`↴](#linera-wallet-forget-chain)
+* [`linera chain`↴](#linera-chain)
+* [`linera chain show-block`↴](#linera-chain-show-block)
+* [`linera chain show-chain-description`↴](#linera-chain-show-chain-description)
 * [`linera project`↴](#linera-project)
 * [`linera project new`↴](#linera-project-new)
 * [`linera project test`↴](#linera-project-test)
@@ -79,6 +83,7 @@ Client implementation and command-line tool for the Linera blockchain
 * `set-preferred-owner` — Change the preferred owner of a chain
 * `change-application-permissions` — Changes the application permissions configuration
 * `close-chain` — Close an existing chain
+* `show-network-description` — Print out the network description
 * `local-balance` — Read the current native-token balance of the given account directly from the local state
 * `query-balance` — Simulate the execution of one block made of pending messages from the local inbox, then read the native-token balance of the account from the local state
 * `sync-balance` — (DEPRECATED) Synchronize the local state of the chain with a quorum validators, then query the local balance
@@ -106,6 +111,7 @@ Client implementation and command-line tool for the Linera blockchain
 * `assign` — Link the owner to the chain. Expects that the caller has a private key corresponding to the `public_key`, otherwise block proposals will fail when signing with it
 * `retry-pending-block` — Retry a block we unsuccessfully tried to propose earlier
 * `wallet` — Show the contents of the wallet
+* `chain` — Show the contents of the wallet
 * `project` — Manage Linera projects
 * `net` — Manage a local Linera Network
 * `storage` — Operation on the storage
@@ -326,6 +332,14 @@ A closed chain cannot execute operations or accept messages anymore. It can stil
 ###### **Arguments:**
 
 * `<CHAIN_ID>` — Chain ID (must be one of our chains)
+
+
+
+## `linera show-network-description`
+
+Print out the network description
+
+**Usage:** `linera show-network-description`
 
 
 
@@ -999,6 +1013,44 @@ Forgets the specified chain, including the associated key pair
 ###### **Arguments:**
 
 * `<CHAIN_ID>`
+
+
+
+## `linera chain`
+
+Show the contents of the wallet
+
+**Usage:** `linera chain <COMMAND>`
+
+###### **Subcommands:**
+
+* `show-block` — Show the contents of a block
+* `show-chain-description` — Show the chain description of a chain
+
+
+
+## `linera chain show-block`
+
+Show the contents of a block
+
+**Usage:** `linera chain show-block <HEIGHT> [CHAIN_ID]`
+
+###### **Arguments:**
+
+* `<HEIGHT>` — The height of the block
+* `<CHAIN_ID>` — The chain to show the block (if not specified, the default chain from the wallet is used)
+
+
+
+## `linera chain show-chain-description`
+
+Show the chain description of a chain
+
+**Usage:** `linera chain show-chain-description [CHAIN_ID]`
+
+###### **Arguments:**
+
+* `<CHAIN_ID>` — The chain ID to show (if not specified, the default chain from the wallet is used)
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ default-members = [
     "linera-summary",
     "linera-views",
     "linera-views-derive",
-    # "linera-web", # not this one
     "linera-witty",
     "linera-witty-macros",
     "linera-witty/test-modules",

--- a/linera-indexer/lib/Cargo.toml
+++ b/linera-indexer/lib/Cargo.toml
@@ -55,8 +55,8 @@ tracing.workspace = true
 assert_matches.workspace = true
 
 [build-dependencies]
-tonic-prost-build.workspace = true
 tonic-prost.workspace = true
+tonic-prost-build.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = ["prost", "tonic-prost"]

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -6,7 +6,7 @@ use std::{borrow::Cow, num::NonZeroU16, path::PathBuf};
 use chrono::{DateTime, Utc};
 use linera_base::{
     crypto::{AccountPublicKey, CryptoHash, ValidatorPublicKey},
-    data_types::{Amount, Epoch},
+    data_types::{Amount, BlockHeight, Epoch},
     identifiers::{Account, AccountOwner, ApplicationId, ChainId, ModuleId, StreamId},
     time::Duration,
     vm::VmRuntime,
@@ -269,6 +269,9 @@ pub enum ClientCommand {
         /// Chain ID (must be one of our chains)
         chain_id: ChainId,
     },
+
+    /// Print out the network description.
+    ShowNetworkDescription,
 
     /// Read the current native-token balance of the given account directly from the local
     /// state.
@@ -917,6 +920,10 @@ pub enum ClientCommand {
     #[command(subcommand)]
     Wallet(WalletCommand),
 
+    /// Show the contents of the wallet.
+    #[command(subcommand)]
+    Chain(ChainCommand),
+
     /// Manage Linera projects.
     #[command(subcommand)]
     Project(ProjectCommand),
@@ -961,6 +968,7 @@ impl ClientCommand {
             | ClientCommand::SetPreferredOwner { .. }
             | ClientCommand::ChangeApplicationPermissions { .. }
             | ClientCommand::CloseChain { .. }
+            | ClientCommand::ShowNetworkDescription
             | ClientCommand::LocalBalance { .. }
             | ClientCommand::QueryBalance { .. }
             | ClientCommand::SyncBalance { .. }
@@ -983,6 +991,7 @@ impl ClientCommand {
             | ClientCommand::Keygen
             | ClientCommand::Assign { .. }
             | ClientCommand::Wallet { .. }
+            | ClientCommand::Chain { .. }
             | ClientCommand::RetryPendingBlock { .. } => "client".into(),
             ClientCommand::Benchmark(BenchmarkCommand::Single { .. }) => "single-benchmark".into(),
             ClientCommand::Benchmark(BenchmarkCommand::Multi { .. }) => "multi-benchmark".into(),
@@ -1204,6 +1213,23 @@ pub enum WalletCommand {
 
     /// Forgets the specified chain, including the associated key pair.
     ForgetChain { chain_id: ChainId },
+}
+
+#[derive(Clone, clap::Subcommand)]
+pub enum ChainCommand {
+    /// Show the contents of a block.
+    ShowBlock {
+        /// The chain to show the block.
+        chain_id: Option<ChainId>,
+        /// The height of the block.
+        height: BlockHeight,
+    },
+
+    /// Show the chain description of a chain.
+    ShowChainDescription {
+        /// The chain ID to show.
+        chain_id: Option<ChainId>,
+    },
 }
 
 #[derive(Clone, clap::Parser)]

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -1219,15 +1219,17 @@ pub enum WalletCommand {
 pub enum ChainCommand {
     /// Show the contents of a block.
     ShowBlock {
-        /// The chain to show the block.
-        chain_id: Option<ChainId>,
         /// The height of the block.
         height: BlockHeight,
+        /// The chain to show the block (if not specified, the default chain from the
+        /// wallet is used).
+        chain_id: Option<ChainId>,
     },
 
     /// Show the chain description of a chain.
     ShowChainDescription {
-        /// The chain ID to show.
+        /// The chain ID to show (if not specified, the default chain from the wallet is
+        /// used).
         chain_id: Option<ChainId>,
     },
 }

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -54,8 +54,8 @@ test-strategy.workspace = true
 
 [build-dependencies]
 cfg_aliases.workspace = true
-tonic-prost-build = { workspace = true, features = ["transport"] }
 tonic-prost.workspace = true
+tonic-prost-build = { workspace = true, features = ["transport"] }
 
 [package.metadata.cargo-machete]
 ignored = ["proptest", "prost", "tonic-prost"]


### PR DESCRIPTION
## Motivation

It is hard to find out the ID of the admin chain, or to check the contents of blocks using the CLI client.

## Proposal

This PR adds some useful commands to the client: `show-network-description` (which contains the admin chain ID), `chain show-chain-description` and `chain show-block`.

## Test Plan

Tested manually.

## Release Plan

TBD (could be backported to the testnet and devnet branches, but it's not strictly necessary).

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
