### PR TITLE
Add feature to use jemalloc as memory allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5705,6 +5705,7 @@ dependencies = [
  "test-log",
  "test-strategy",
  "thiserror 1.0.69",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -9783,6 +9784,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,6 +234,7 @@ test-log = { version = "0.2.15", default-features = false, features = [
 test-strategy = "0.3.1"
 thiserror = "1.0.65"
 thiserror-context = "0.1.1"
+tikv-jemallocator = "0.6.0"
 tokio = "1.36.0"
 tokio-stream = "0.1.14"
 tokio-test = "0.4.3"

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -52,6 +52,7 @@ metrics = [
     "linera-faucet-server/metrics",
     "linera-metrics",
 ]
+jemalloc = ["tikv-jemallocator"]
 storage-service = ["linera-storage-service"]
 
 [dependencies]
@@ -119,6 +120,10 @@ serde_json.workspace = true
 stdext = { workspace = true, optional = true }
 tempfile.workspace = true
 thiserror.workspace = true
+tikv-jemallocator = { workspace = true, features = [
+    "profiling",
+    "unprefixed_malloc_on_supported_platforms",
+], optional = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream.workspace = true
 tokio-util.workspace = true

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -4,6 +4,10 @@
 
 #![recursion_limit = "256"]
 
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use std::{
     collections::{BTreeMap, BTreeSet},
     env,

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
 use anyhow::{anyhow, bail, ensure, Result};

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -2,6 +2,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use std::{
     borrow::Cow,
     num::NonZeroU16,


### PR DESCRIPTION
## Motivation

jemalloc is more performant than the system allocator (and was even the Rust default for a while)

## Proposal

Add a feature that when enabled will use jemalloc as the allocator. We might decide to have this feature on by default eventually, but for now it'll be used for memory profiling, which is coming in the following PRs.

## Test Plan

Deployed a network with this featured turned on, saw a slight performance improvement, and tested with the profiling code.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
