### PR TITLE
Add memory profiling dashboard

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/profiling/jemalloc-memory.json
+++ b/kubernetes/linera-validator/grafana-dashboards/profiling/jemalloc-memory.json
@@ -1,0 +1,146 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "P02E4190217B50628"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "displayMode": "flamegraph"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "P02E4190217B50628"
+          },
+          "groupBy": [],
+          "labelSelector": "{service_name=\"memory/default/shards/\"}",
+          "profileTypeId": "memory:inuse_space:bytes:space:bytes",
+          "queryType": "profile",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Allocation Flamegraph - Server",
+      "type": "flamegraph"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 2,
+      "options": {
+        "displayMode": "flamegraph"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "${datasource}"
+          },
+          "groupBy": [],
+          "labelSelector": "{service_name=\"memory/default/proxy/\"}",
+          "profileTypeId": "memory:inuse_space:bytes:space:bytes",
+          "queryType": "profile",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Allocation Flamegraph - Proxy",
+      "type": "flamegraph"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "linera",
+    "memory",
+    "profiling"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Pyroscope",
+          "value": "P02E4190217B50628"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Pyroscope Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "grafana-pyroscope-datasource",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus Datasource",
+        "multi": false,
+        "name": "prometheus_datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Memory",
+  "uid": "linera-memory-profiling",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kubernetes/linera-validator/templates/grafana-pyroscope-dashboard-config.yaml
+++ b/kubernetes/linera-validator/templates/grafana-pyroscope-dashboard-config.yaml
@@ -8,3 +8,4 @@ metadata:
     grafana_folder: "Profiling"
 data:
   cpu_profiling.json: {{ .Files.Get "grafana-dashboards/profiling/cpu.json" | quote }}
+  memory_profiling.json: {{ .Files.Get "grafana-dashboards/profiling/jemalloc-memory.json" | quote }}


### PR DESCRIPTION
## Motivation

If we want to keep the investigation centered on Grafana, it would be useful to also have a memory profiling dashboard containing the flamegraphs

## Proposal

Add a dashboard containing the memory profile flamegraphs to Grafana

## Test Plan

Will update with a screenshot

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
