### PR TITLE
`examples/native-fungible`: don't forget the import map

### DIFF
--- a/examples/native-fungible/index.html
+++ b/examples/native-fungible/index.html
@@ -139,6 +139,15 @@
       </div>
     </div>
 
+    <script type="importmap">
+      {
+          "imports": {
+              "@linera/client": "./js/@linera/client/linera_web.js",
+              "@linera/signer": "./js/@linera/signer/index.js"
+          }
+      }
+    </script>
+
     <script type="module">
       import * as linera from '@linera/client';
       import { PrivateKey } from '@linera/signer';


### PR DESCRIPTION
## Motivation

The import map got lost somewhere, which breaks the example.

## Proposal

Put it back.

## Test Plan

Tested in production!

## Release Plan

- These changes should be backported to the latest `testnet` branch

## Links
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
