### PR TITLE
Fix deploy-validator script to use remote Docker images by default

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -46,7 +46,7 @@ services:
         condition: service_completed_successfully
 
   proxy:
-    image: "${LINERA_IMAGE:-linera}"
+    image: "${LINERA_IMAGE:-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest}"
     container_name: proxy
     ports:
       - "19100:19100"
@@ -60,7 +60,7 @@ services:
         condition: service_completed_successfully
 
   shard:
-    image: "${LINERA_IMAGE:-linera}"
+    image: "${LINERA_IMAGE:-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest}"
     deploy:
       replicas: 4
     command: ["./compose-server-entrypoint.sh", "scylladb:tcp:scylla:9042", "1"]
@@ -73,7 +73,7 @@ services:
         condition: service_completed_successfully
 
   shard-init:
-    image: "${LINERA_IMAGE:-linera}"
+    image: "${LINERA_IMAGE:-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest}"
     container_name: shard-init
     command: ["./compose-server-init.sh", "scylladb:tcp:scylla:9042", "1"]
     volumes:


### PR DESCRIPTION
## Summary

This PR updates the `deploy-validator.sh` script and Docker Compose configuration to use pre-built Docker images from the official registry by default, instead of building locally.

## Problem

Previously, the default `LINERA_IMAGE` in the script was just `linera`, which assumed a locally built image. This caused issues when validators tried to deploy without explicitly building the image first.

## Solution

### Changes Made:

1. **`scripts/deploy-validator.sh`**:
   - Changed default behavior to use remote images from `us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera`
   - Added `--local-build` flag for explicitly building Docker images locally
   - Made `--remote-image` flag deprecated (remote is now the default)
   - Updated image tag logic: uses `latest` for main branch, `{branch}_release` for other branches
   - Updated help text and examples to reflect the new behavior

2. **`docker/docker-compose.yml`**:
   - Updated default `LINERA_IMAGE` from `linera` to `us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest`
   - Applied to all services using the Linera image (proxy, shard, shard-init)

## Impact

- **Improved UX**: Validators can now deploy without building images locally
- **Faster deployments**: No need to wait for local builds (which can take several minutes)
- **Consistency**: All validators use the same official images by default
- **Backwards compatible**: Users can still build locally using `--local-build`

## Testing

The script has been tested with:
- Dry run mode to verify image selection logic
- Syntax validation with `bash -n`
- Help output verification

## Related PR

Documentation updates: linera-io/linera-documentation#241

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>