### PR TITLE
Fix Docker Compose image tags for testnet_conway

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -46,7 +46,7 @@ services:
         condition: service_completed_successfully
 
   proxy:
-    image: "${LINERA_IMAGE:-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest}"
+    image: "${LINERA_IMAGE:-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:testnet_conway_release}"
     container_name: proxy
     ports:
       - "19100:19100"
@@ -60,7 +60,7 @@ services:
         condition: service_completed_successfully
 
   shard:
-    image: "${LINERA_IMAGE:-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest}"
+    image: "${LINERA_IMAGE:-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:testnet_conway_release}"
     deploy:
       replicas: 4
     command: ["./compose-server-entrypoint.sh", "scylladb:tcp:scylla:9042", "1"]
@@ -73,7 +73,7 @@ services:
         condition: service_completed_successfully
 
   shard-init:
-    image: "${LINERA_IMAGE:-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest}"
+    image: "${LINERA_IMAGE:-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:testnet_conway_release}"
     container_name: shard-init
     command: ["./compose-server-init.sh", "scylladb:tcp:scylla:9042", "1"]
     volumes:


### PR DESCRIPTION
## Summary
- Updates default Docker image tags in docker-compose.yml to use `testnet_conway_release` instead of `latest`
- Ensures consistent image versions across proxy, shard, and shard-init services

## Changes
- Changed default `LINERA_IMAGE` from `linera:latest` to `linera:testnet_conway_release` for:
  - proxy service
  - shard service (4 replicas)
  - shard-init service

## Why this change?
The `testnet_conway` branch should use the stable `testnet_conway_release` image by default rather than `latest` to ensure compatibility and stability for the testnet environment.

## Test plan
Docker Compose configuration tested locally to ensure services start correctly with the new image tags.

🤖 Generated with [Claude Code](https://claude.ai/code)