### PR TITLE
Change the argument of `handle_query`.

### DIFF
--- a/examples/create-and-call/src/contract.rs
+++ b/examples/create-and-call/src/contract.rs
@@ -75,7 +75,7 @@ impl Contract for CreateAndCallContract {
         // Step 3: Call the service. It should return the value before
         // the initialization of this contract and thus zero.
         let counter_request = CounterRequest::Query;
-        let value = self.runtime.query_service(application_id, counter_request);
+        let value = self.runtime.query_service(application_id, &counter_request);
         assert_eq!(value, 0);
 
         // Step 4: Call the contract with counter increment operation

--- a/examples/ethereum-tracker/src/contract.rs
+++ b/examples/ethereum-tracker/src/contract.rs
@@ -82,7 +82,7 @@ impl EthereumTrackerContract {
         let request = async_graphql::Request::new("query { readInitialEvent }");
 
         let application_id = self.runtime.application_id();
-        let response = self.runtime.query_service(application_id, request);
+        let response = self.runtime.query_service(application_id, &request);
 
         let async_graphql::Value::Object(data_object) = response.data else {
             panic!("Unexpected response from `readInitialEvent`: {response:#?}");
@@ -115,7 +115,7 @@ impl EthereumTrackerContract {
         ));
 
         let application_id = self.runtime.application_id();
-        let response = self.runtime.query_service(application_id, request);
+        let response = self.runtime.query_service(application_id, &request);
 
         let async_graphql::Value::Object(data_object) = response.data else {
             panic!("Unexpected response from `readTransferEvents`: {response:#?}");

--- a/examples/how-to/perform-http-requests/src/contract.rs
+++ b/examples/how-to/perform-http-requests/src/contract.rs
@@ -84,7 +84,7 @@ impl Contract {
         let application_id = self.runtime.application_id();
         let request = async_graphql::Request::new("query { performHttpRequest }");
 
-        let graphql_response = self.runtime.query_service(application_id, request);
+        let graphql_response = self.runtime.query_service(application_id, &request);
 
         let async_graphql::Value::Object(graphql_response_data) = graphql_response.data else {
             panic!("Unexpected response from service: {graphql_response:#?}");

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -74,7 +74,7 @@ impl Contract for MetaCounterContract {
             let counter_id = self.counter_id();
             let _ = self
                 .runtime
-                .query_service(counter_id, "query { value }".into());
+                .query_service(counter_id, &"query { value }".into());
         }
         message.send_to(recipient_id);
     }

--- a/examples/publish-read-data-blob/src/contract.rs
+++ b/examples/publish-read-data-blob/src/contract.rs
@@ -39,7 +39,7 @@ impl Contract for PublishReadDataBlobContract {
     async fn execute_operation(&mut self, operation: Operation) {
         match operation {
             Operation::CreateDataBlob(data) => {
-                self.runtime.create_data_blob(data);
+                self.runtime.create_data_blob(&data);
             }
             Operation::ReadDataBlob(hash, expected_data) => {
                 let data = self.runtime.read_data_blob(hash);
@@ -49,7 +49,7 @@ impl Contract for PublishReadDataBlobContract {
                 );
             }
             Operation::CreateAndReadDataBlob(data) => {
-                let hash: DataBlobHash = self.runtime.create_data_blob(data.clone());
+                let hash: DataBlobHash = self.runtime.create_data_blob(&data);
                 let data_read = self.runtime.read_data_blob(hash);
                 assert_eq!(data_read, data);
             }

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -305,9 +305,9 @@ where
     pub fn query_service<A: ServiceAbi + Send>(
         &mut self,
         application_id: ApplicationId<A>,
-        query: A::Query,
+        query: &A::Query,
     ) -> A::QueryResponse {
-        let query = serde_json::to_vec(&query).expect("Failed to serialize service query");
+        let query = serde_json::to_vec(query).expect("Failed to serialize service query");
         let response = contract_wit::query_service(application_id.forget_abi().into(), &query);
         serde_json::from_slice(&response).expect("Failed to deserialize service response")
     }
@@ -375,8 +375,8 @@ where
     }
 
     /// Creates a new data blob and returns its hash.
-    pub fn create_data_blob(&mut self, bytes: Vec<u8>) -> DataBlobHash {
-        let hash = contract_wit::create_data_blob(&bytes);
+    pub fn create_data_blob(&mut self, bytes: &[u8]) -> DataBlobHash {
+        let hash = contract_wit::create_data_blob(bytes);
         hash.into()
     }
 

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -803,7 +803,7 @@ where
     }
 
     /// Creates a new data blob and returns its hash.
-    pub fn create_data_blob(&mut self, bytes: Vec<u8>) -> DataBlobHash {
+    pub fn create_data_blob(&mut self, bytes: &[u8]) -> DataBlobHash {
         let ExpectedCreateDataBlobCall {
             bytes: expected_bytes,
             blob_id,
@@ -811,7 +811,7 @@ where
             .expected_create_data_blob_calls
             .pop_front()
             .expect("Unexpected create_data_blob call");
-        assert_eq!(bytes, expected_bytes);
+        assert_eq!(bytes, &expected_bytes);
         DataBlobHash(blob_id.hash)
     }
 
@@ -946,13 +946,13 @@ where
     pub fn query_service<A: ServiceAbi + Send>(
         &mut self,
         application_id: ApplicationId<A>,
-        query: A::Query,
+        query: &A::Query,
     ) -> A::QueryResponse {
         let maybe_query = self.expected_service_queries.pop_front();
         let (expected_id, expected_query, response) =
             maybe_query.expect("Unexpected service query");
         assert_eq!(application_id.forget_abi(), expected_id);
-        let query = serde_json::to_string(&query).expect("Failed to serialize query");
+        let query = serde_json::to_string(query).expect("Failed to serialize query");
         assert_eq!(query, expected_query);
         serde_json::from_str(&response).expect("Failed to deserialize response")
     }


### PR DESCRIPTION
## Motivation

The `call_application` and `instantiate` are taking a reference, but in contrast to those functions the `handle_query`
is taking a value which is immediate serialized. There is no reason for that. 



## Proposal

Make the change of having `handle_query` take a reference.
Also change `create_data_blob`.

## Test Plan

The CI.

## Release Plan

This is definitely breaking the smart contracts, though not the validator code.

## Links

None.