### PR TITLE
Implement the fees for the events.

### DIFF
--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -493,6 +493,10 @@ where
                     .await?;
                 let index = *count;
                 *count = count.checked_add(1).ok_or(ArithmeticError::Overflow)?;
+                self.resource_controller
+                    .with_state(&mut self.state.system)
+                    .await?
+                    .track_event_published(&value)?;
                 self.txn_tracker.add_event(stream_id, index, value);
                 callback.respond(index)
             }
@@ -510,6 +514,10 @@ where
                     })
                     .await?
                     .to_event(&event_id)?;
+                self.resource_controller
+                    .with_state(&mut self.state.system)
+                    .await?
+                    .track_event_read(event.len() as u64)?;
                 callback.respond(event);
             }
 


### PR DESCRIPTION
## Motivation

Events costs need to be accounted for.

Fixes #4259

## Proposal

Since events are implemented as blobs, it makes sense to have their costs identical to those of blobs.
In that way, we avoid having some economic imbalance.

## Test Plan

The CI.

## Release Plan

This does change the costs for validators and so it is a breaking change.

## Links

None.