### PR TITLE
`linera-web`: expose `skip_process_inbox` option

### DIFF
--- a/web/@linera/client/src/lib.rs
+++ b/web/@linera/client/src/lib.rs
@@ -206,7 +206,11 @@ impl Client {
     /// On transport or protocol error, or if persistent storage is
     /// unavailable.
     #[wasm_bindgen(constructor)]
-    pub async fn new(wallet: PersistentWallet, signer: JsSigner) -> Result<Client, JsError> {
+    pub async fn new(
+        wallet: PersistentWallet,
+        signer: JsSigner,
+        skip_process_inbox: bool,
+    ) -> Result<Client, JsError> {
         let mut storage = get_storage().await?;
         wallet
             .0
@@ -223,7 +227,10 @@ impl Client {
         )));
         let client_context_clone = client_context.clone();
         let chain_listener = ChainListener::new(
-            ChainListenerConfig::default(),
+            ChainListenerConfig {
+                skip_process_inbox,
+                ..ChainListenerConfig::default()
+            },
             client_context_clone,
             storage,
             tokio_util::sync::CancellationToken::new(),


### PR DESCRIPTION
## Motivation

Sometimes we have applications that don't need to receive messages, and then it's unpleasant to bother the user to sign message blocks.

## Proposal

Allow disabling auto-receipt of messages.

## Test Plan

Binding tested locally by modifying the `counter` example.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
