### PR TITLE
Download missing blobs when retrying outgoing messages

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2171,10 +2171,28 @@ impl<Env: Environment> ChainClient<Env> {
         let stream = FuturesUnordered::from_iter(other_sender_chains.into_iter().map(|chain_id| {
             let local_node = self.client.local_node.clone();
             async move {
-                if let Err(error) = local_node
+                if let Err(error) = match local_node
                     .retry_pending_cross_chain_requests(chain_id)
                     .await
                 {
+                    Ok(()) => Ok(()),
+                    Err(LocalNodeError::BlobsNotFound(blob_ids)) => {
+                        if let Err(error) = self
+                            .client
+                            .receive_certificates_for_blobs(blob_ids.clone())
+                            .await
+                        {
+                            error!(
+                                "Error while attempting to download blobs during retrying outgoing \
+                                messages: {blob_ids:?}: {error}"
+                            );
+                        }
+                        local_node
+                            .retry_pending_cross_chain_requests(chain_id)
+                            .await
+                    }
+                    err => err,
+                } {
                     error!("Failed to retry outgoing messages from {chain_id}: {error}");
                 }
             }


### PR DESCRIPTION
## Motivation

We were seeing `Failed to retry outgoing messages` errors on Testnet Conway due to blobs missing on the client side.

## Proposal

If blobs are missing during execution of this part of the code, download them and retry.

The change is purely client-side, so it is safe to be backported to the testnet branch.

## Test Plan

Manual testing showed that the errors disappear.

## Release Plan

- These changes should be backported to the latest `testnet` branch

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
