### PR TITLE
Native fungible demo accepts 32-byte long address

### DIFF
--- a/examples/native-fungible/index.html
+++ b/examples/native-fungible/index.html
@@ -171,8 +171,12 @@
 
           let errors = [];
           try {
-              const match = recipient.match(/^(0x[0-9a-f]{40})@([0-9a-f]{64})$/);
+              // I failed to make it work with a single regex,
+              // the regex with group alternatives for the owner produces different `match` array
+              // with different group indices so we can't extract it deterministicly when parsing as `recipient` down below.
+              const match = recipient.match(/^(0x[0-9a-f]{40})@([0-9a-f]{64})$/) || recipient.match(/^(0x[0-9a-f]{64})@([0-9a-f]{64})$/);
               if (!match) throw new Error('Invalid recipient address: expected `owner@chain_id`');
+              console.log('Match: ', match);
 
               const query = gql(`mutation(
                   $donor: AccountOwner!,

--- a/examples/native-fungible/index.html
+++ b/examples/native-fungible/index.html
@@ -171,10 +171,7 @@
 
           let errors = [];
           try {
-              // I failed to make it work with a single regex,
-              // the regex with group alternatives for the owner produces different `match` array
-              // with different group indices so we can't extract it deterministicly when parsing as `recipient` down below.
-              const match = recipient.match(/^(0x[0-9a-f]{40})@([0-9a-f]{64})$/) || recipient.match(/^(0x[0-9a-f]{64})@([0-9a-f]{64})$/);
+              const match = recipient.match(/^(0x[0-9a-f]{40}|0x[0-9a-f]{64})@([0-9a-f]{64})$/i);
               if (!match) throw new Error('Invalid recipient address: expected `owner@chain_id`');
 
               const query = gql(`mutation(

--- a/examples/native-fungible/index.html
+++ b/examples/native-fungible/index.html
@@ -176,7 +176,6 @@
               // with different group indices so we can't extract it deterministicly when parsing as `recipient` down below.
               const match = recipient.match(/^(0x[0-9a-f]{40})@([0-9a-f]{64})$/) || recipient.match(/^(0x[0-9a-f]{64})@([0-9a-f]{64})$/);
               if (!match) throw new Error('Invalid recipient address: expected `owner@chain_id`');
-              console.log('Match: ', match);
 
               const query = gql(`mutation(
                   $donor: AccountOwner!,


### PR DESCRIPTION
## Motivation

Fungible demo frontend accepted only 20-byte accounts.

## Proposal

Modify the regex to also accept 32-bytes (64 chars).

## Test Plan

Manual.

## Release Plan

This is a testnet branch. Updates fungible demo can be released from it.

## Links
Solves https://github.com/linera-io/linera-protocol/issues/4562
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
