### PR TITLE
`linera-web`: bump to 0.15.4

### DIFF
--- a/linera-web/package.json
+++ b/linera-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linera/client",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Web client for the Linera blockchain",
   "publishConfig": {
     "access": "public"

--- a/linera-web/signer/package.json
+++ b/linera-web/signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linera/signer",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Implementations of Signer interface for the Linera blockchain",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Motivation

I released 0.15.4 for https://github.com/linera-io/linera-protocol/pull/4595 and we should record that fact.

## Proposal

Bump the versions in the codebase.

## Test Plan

No code changes.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
