### PR TITLE
Small fixes after #4570

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -113,7 +113,7 @@ Client implementation and command-line tool for the Linera blockchain
 * `assign` — Link the owner to the chain. Expects that the caller has a private key corresponding to the `public_key`, otherwise block proposals will fail when signing with it
 * `retry-pending-block` — Retry a block we unsuccessfully tried to propose earlier
 * `wallet` — Show the contents of the wallet
-* `chain` — Show the contents of the wallet
+* `chain` — Show the information about a chain
 * `project` — Manage Linera projects
 * `net` — Manage a local Linera Network
 * `storage` — Operation on the storage
@@ -1032,7 +1032,7 @@ Forgets the specified chain, including the associated key pair
 
 ## `linera chain`
 
-Show the contents of the wallet
+Show the information about a chain
 
 **Usage:** `linera chain <COMMAND>`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ default-members = [
     "linera-summary",
     "linera-views",
     "linera-views-derive",
-    # "linera-web", # not this one
     "linera-witty",
     "linera-witty-macros",
     "linera-witty/test-modules",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ default-members = [
     "linera-summary",
     "linera-views",
     "linera-views-derive",
+    # "linera-web", # not this one
     "linera-witty",
     "linera-witty-macros",
     "linera-witty/test-modules",

--- a/linera-base/src/crypto/hash.rs
+++ b/linera-base/src/crypto/hash.rs
@@ -168,7 +168,7 @@ impl fmt::Display for CryptoHash {
 
 impl fmt::Debug for CryptoHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(&self.0[..8]))
+        write!(f, "{}", hex::encode(&self.0[..]))
     }
 }
 

--- a/linera-base/src/crypto/hash.rs
+++ b/linera-base/src/crypto/hash.rs
@@ -168,7 +168,7 @@ impl fmt::Display for CryptoHash {
 
 impl fmt::Debug for CryptoHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(&self.0[..]))
+        write!(f, "{}", hex::encode(&self.0))
     }
 }
 

--- a/linera-base/src/crypto/hash.rs
+++ b/linera-base/src/crypto/hash.rs
@@ -168,7 +168,7 @@ impl fmt::Display for CryptoHash {
 
 impl fmt::Debug for CryptoHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(&self.0))
+        write!(f, "{}", hex::encode(self.0))
     }
 }
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -45,8 +45,8 @@ impl fmt::Debug for AccountOwner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Reserved(byte) => f.debug_tuple("Reserved").field(byte).finish(),
-            Self::Address32(hash) => write!(f, "Address32({:?}..)", hash),
-            Self::Address20(bytes) => write!(f, "Address20({}..)", hex::encode(&bytes[..])),
+            Self::Address32(hash) => write!(f, "Address32({:?})", hash),
+            Self::Address20(bytes) => write!(f, "Address20({})", hex::encode(&bytes)),
         }
     }
 }

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -46,7 +46,7 @@ impl fmt::Debug for AccountOwner {
         match self {
             Self::Reserved(byte) => f.debug_tuple("Reserved").field(byte).finish(),
             Self::Address32(hash) => write!(f, "Address32({:?})", hash),
-            Self::Address20(bytes) => write!(f, "Address20({})", hex::encode(&bytes)),
+            Self::Address20(bytes) => write!(f, "Address20({})", hex::encode(bytes)),
         }
     }
 }

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -46,7 +46,7 @@ impl fmt::Debug for AccountOwner {
         match self {
             Self::Reserved(byte) => f.debug_tuple("Reserved").field(byte).finish(),
             Self::Address32(hash) => write!(f, "Address32({:?}..)", hash),
-            Self::Address20(bytes) => write!(f, "Address20({}..)", hex::encode(&bytes[..8])),
+            Self::Address20(bytes) => write!(f, "Address20({}..)", hex::encode(&bytes[..])),
         }
     }
 }

--- a/linera-base/src/unit_tests.rs
+++ b/linera-base/src/unit_tests.rs
@@ -160,9 +160,9 @@ fn chain_ownership_test_case() -> ChainOwnership {
 fn account_owner_debug_format() {
     assert_eq!(&format!("{:?}", AccountOwner::Reserved(10)), "Reserved(10)");
     let addr32 = AccountOwner::Address32(CryptoHash::from([10u8; 32]));
-    let debug32 = "Address32(0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a..)";
+    let debug32 = "Address32(0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a)";
     assert_eq!(&format!("{addr32:?}"), debug32);
     let addr20 = AccountOwner::Address20([10u8; 20]);
-    let debug20 = "Address20(0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a..)";
+    let debug20 = "Address20(0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a)";
     assert_eq!(&format!("{addr20:?}"), debug20);
 }

--- a/linera-base/src/unit_tests.rs
+++ b/linera-base/src/unit_tests.rs
@@ -160,9 +160,9 @@ fn chain_ownership_test_case() -> ChainOwnership {
 fn account_owner_debug_format() {
     assert_eq!(&format!("{:?}", AccountOwner::Reserved(10)), "Reserved(10)");
     let addr32 = AccountOwner::Address32(CryptoHash::from([10u8; 32]));
-    let debug32 = "Address32(0a0a0a0a0a0a0a0a..)";
+    let debug32 = "Address32(0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a..)";
     assert_eq!(&format!("{addr32:?}"), debug32);
     let addr20 = AccountOwner::Address20([10u8; 20]);
-    let debug20 = "Address20(0a0a0a0a0a0a0a0a..)";
+    let debug20 = "Address20(0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a..)";
     assert_eq!(&format!("{addr20:?}"), debug20);
 }

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -927,7 +927,7 @@ pub enum ClientCommand {
     #[command(subcommand)]
     Wallet(WalletCommand),
 
-    /// Show the contents of the wallet.
+    /// Show the information about a chain.
     #[command(subcommand)]
     Chain(ChainCommand),
 


### PR DESCRIPTION
## Motivation

Changes from #4570 left a few small oversights.

## Proposal

Fix an incorrect doc string, restore a deleted line from Cargo.toml, change the Debug implementation for CryptoHash (so that the commands printing out chain IDs are actually useful).

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
