### PR TITLE
Add macOS support for memory profiling

### DIFF
--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -11,9 +11,17 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 // jemalloc configuration for memory profiling with jemalloc_pprof
 // prof:true,prof_active:true - Enable profiling from start
 // lg_prof_sample:19 - Sample every 512KB for good detail/overhead balance
-#[cfg(feature = "memory-profiling")]
+
+// Linux/other platforms: use unprefixed malloc (with unprefixed_malloc_on_supported_platforms)
+#[cfg(all(feature = "memory-profiling", not(target_os = "macos")))]
 #[allow(non_upper_case_globals)]
 #[export_name = "malloc_conf"]
+pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+
+// macOS: use prefixed malloc (without unprefixed_malloc_on_supported_platforms)
+#[cfg(all(feature = "memory-profiling", target_os = "macos"))]
+#[allow(non_upper_case_globals)]
+#[export_name = "_rjem_malloc_conf"]
 pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 
 use std::{

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -8,9 +8,17 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 // jemalloc configuration for memory profiling with jemalloc_pprof
 // prof:true,prof_active:true - Enable profiling from start
 // lg_prof_sample:19 - Sample every 512KB for good detail/overhead balance
-#[cfg(feature = "memory-profiling")]
+
+// Linux/other platforms: use unprefixed malloc (with unprefixed_malloc_on_supported_platforms)
+#[cfg(all(feature = "memory-profiling", not(target_os = "macos")))]
 #[allow(non_upper_case_globals)]
 #[export_name = "malloc_conf"]
+pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+
+// macOS: use prefixed malloc (without unprefixed_malloc_on_supported_platforms)
+#[cfg(all(feature = "memory-profiling", target_os = "macos"))]
+#[allow(non_upper_case_globals)]
+#[export_name = "_rjem_malloc_conf"]
 pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 
 use std::{net::SocketAddr, path::PathBuf, time::Duration};

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -9,9 +9,17 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 // jemalloc configuration for memory profiling with jemalloc_pprof
 // prof:true,prof_active:true - Enable profiling from start
 // lg_prof_sample:19 - Sample every 512KB for good detail/overhead balance
-#[cfg(feature = "memory-profiling")]
+
+// Linux/other platforms: use unprefixed malloc (with unprefixed_malloc_on_supported_platforms)
+#[cfg(all(feature = "memory-profiling", not(target_os = "macos")))]
 #[allow(non_upper_case_globals)]
 #[export_name = "malloc_conf"]
+pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+
+// macOS: use prefixed malloc (without unprefixed_malloc_on_supported_platforms)
+#[cfg(all(feature = "memory-profiling", target_os = "macos"))]
+#[allow(non_upper_case_globals)]
+#[export_name = "_rjem_malloc_conf"]
 pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 
 use std::{


### PR DESCRIPTION
## Motivation

We're using the `unprefixed_malloc_on_supported_platforms` feature to be able to use `malloc_conf` instead of the prefixed `_rjem_malloc_conf`, as it's recommended, but MacOS is not one of the supported platforms.

## Proposal

Use the prefixed version for MacOS

## Test Plan

Ran `linera net up` with memory profiling enabled from my MacOS, it works now

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
