### PR TITLE
Add monitoring to node service

### DIFF
--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -702,7 +702,9 @@ where
         let batch_processor_task = batch_processor.run(cancellation_token.clone());
         let tcp_listener =
             tokio::net::TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], port))).await?;
-        let server = axum::serve(tcp_listener, app).into_future();
+        let server = axum::serve(tcp_listener, app)
+            .with_graceful_shutdown(cancellation_token.cancelled_owned())
+            .into_future();
         futures::select! {
             result = Box::pin(chain_listener).fuse() => result?,
             _ = Box::pin(batch_processor_task).fuse() => {},

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -742,6 +742,11 @@ pub enum ClientCommand {
         /// The port on which to run the server
         #[arg(long)]
         port: NonZeroU16,
+
+        /// The port to expose metrics on.
+        #[cfg(with_metrics)]
+        #[arg(long)]
+        metrics_port: NonZeroU16,
     },
 
     /// Run a GraphQL service that exposes a faucet where users can claim tokens.

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -11,9 +11,17 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 // jemalloc configuration for memory profiling with jemalloc_pprof
 // prof:true,prof_active:true - Enable profiling from start
 // lg_prof_sample:19 - Sample every 512KB for good detail/overhead balance
-#[cfg(feature = "memory-profiling")]
+
+// Linux/other platforms: use unprefixed malloc (with unprefixed_malloc_on_supported_platforms)
+#[cfg(all(feature = "memory-profiling", not(target_os = "macos")))]
 #[allow(non_upper_case_globals)]
 #[export_name = "malloc_conf"]
+pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+
+// macOS: use prefixed malloc (without unprefixed_malloc_on_supported_platforms)
+#[cfg(all(feature = "memory-profiling", target_os = "macos"))]
+#[allow(non_upper_case_globals)]
+#[export_name = "_rjem_malloc_conf"]
 pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 
 use std::{

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1307,7 +1307,12 @@ impl Runnable for Job {
                 info!("Notification stream ended.");
             }
 
-            Service { config, port } => {
+            Service {
+                config,
+                port,
+                #[cfg(with_metrics)]
+                metrics_port,
+            } => {
                 let context = ClientContext::new(
                     storage,
                     options.context_options.clone(),
@@ -1316,11 +1321,17 @@ impl Runnable for Job {
                 );
 
                 let default_chain = context.wallet().default_chain();
-                let service = NodeService::new(config, port, default_chain, context);
+                let service = NodeService::new(
+                    config,
+                    port,
+                    #[cfg(with_metrics)]
+                    metrics_port,
+                    default_chain,
+                    context,
+                );
                 let cancellation_token = CancellationToken::new();
-                let child_token = cancellation_token.child_token();
-                tokio::spawn(listen_for_shutdown_signals(cancellation_token));
-                service.run(child_token).await?;
+                tokio::spawn(listen_for_shutdown_signals(cancellation_token.clone()));
+                service.run(cancellation_token).await?;
             }
 
             Faucet {

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -8,9 +8,17 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 // jemalloc configuration for memory profiling with jemalloc_pprof
 // prof:true,prof_active:true - Enable profiling from start
 // lg_prof_sample:19 - Sample every 512KB for good detail/overhead balance
-#[cfg(feature = "memory-profiling")]
+
+// Linux/other platforms: use unprefixed malloc (with unprefixed_malloc_on_supported_platforms)
+#[cfg(all(feature = "memory-profiling", not(target_os = "macos")))]
 #[allow(non_upper_case_globals)]
 #[export_name = "malloc_conf"]
+pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+
+// macOS: use prefixed malloc (without unprefixed_malloc_on_supported_platforms)
+#[cfg(all(feature = "memory-profiling", target_os = "macos"))]
+#[allow(non_upper_case_globals)]
+#[export_name = "_rjem_malloc_conf"]
 pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 
 use std::{net::SocketAddr, path::PathBuf, time::Duration};

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -228,6 +228,8 @@ async fn main() -> std::io::Result<()> {
     let service = NodeService::new(
         ChainListenerConfig::default(),
         std::num::NonZeroU16::new(8080).unwrap(),
+        #[cfg(with_metrics)]
+        std::num::NonZeroU16::new(8081).unwrap(),
         None,
         DummyContext,
     );

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -9,9 +9,17 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 // jemalloc configuration for memory profiling with jemalloc_pprof
 // prof:true,prof_active:true - Enable profiling from start
 // lg_prof_sample:19 - Sample every 512KB for good detail/overhead balance
-#[cfg(feature = "memory-profiling")]
+
+// Linux/other platforms: use unprefixed malloc (with unprefixed_malloc_on_supported_platforms)
+#[cfg(all(feature = "memory-profiling", not(target_os = "macos")))]
 #[allow(non_upper_case_globals)]
 #[export_name = "malloc_conf"]
+pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+
+// macOS: use prefixed malloc (without unprefixed_malloc_on_supported_platforms)
+#[cfg(all(feature = "memory-profiling", target_os = "macos"))]
+#[allow(non_upper_case_globals)]
+#[export_name = "_rjem_malloc_conf"]
 pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 
 use std::{


### PR DESCRIPTION
## Motivation

Currently, if we start a node service we get no metrics or memory profiling.

## Proposal

Add support for metrics and memory profiling from node service. Also fix the fact that it doesn't terminate with Ctrl+C (the faucet had the same thing, so I fixed it there too).

## Test Plan

Start a node service locally, see that memory profile is enabled and working, and that killing it with Ctrl+C actually kills it

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
