### PR TITLE
Update Rust toolchain from 1.86.0 to 1.90.0

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -8,6 +8,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_NET_RETRY: 10
+  RUST_VERSION: 1.90.0
 
 jobs:
   benchmark:
@@ -17,6 +18,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Clear up some space
       run: |
         sudo rm -rf /usr/share/dotnet

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -23,6 +23,7 @@ env:
   RUSTUP_MAX_RETRIES: 10
   RUST_LOG: warn
   DOCKER_COMPOSE_WAIT: "true"
+  RUST_VERSION: 1.90.0
 
 permissions:
   contents: read
@@ -38,6 +39,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ vars.RUST_VERSION }}
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  RUST_VERSION: 1.90.0
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -18,6 +21,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ vars.RUST_VERSION }}
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,6 +25,7 @@ env:
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
   LINERA_PACKAGES: "packages.txt"
+  RUST_VERSION: 1.90.0
 
 permissions:
   contents: read
@@ -41,6 +42,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
@@ -63,6 +66,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -26,6 +26,7 @@ env:
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
   RUST_LOG: warn
+  RUST_VERSION: 1.90.0
 
 permissions:
   contents: read
@@ -39,6 +40,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -20,6 +20,7 @@ env:
   RUST_BACKTRACE: short
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
+  RUST_VERSION: 1.90.0
 
 permissions:
   contents: read
@@ -54,6 +55,8 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Check toolchain symlinks
       run: |
         cd linera-explorer

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -21,6 +21,7 @@ env:
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
+  RUST_VERSION: 1.90.0
   RUST_LOG: warn
   DOCKER_COMPOSE_WAIT: "true"
 
@@ -39,6 +40,8 @@ jobs:
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install cargo-all-features
       run: |
         cargo install --git https://github.com/ma2bd/cargo-all-features --branch workspace_metadata --locked

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -15,6 +15,7 @@ env:
   RUST_LOG: warn
   RUST_LOG_FORMAT: plain
   LINERA_TEST_ITERATIONS: 1000
+  RUST_VERSION: 1.90.0
 
 jobs:
   long-faucet-chain-test:
@@ -25,6 +26,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Clear up some space
       run: |
         sudo rm -rf /usr/share/dotnet

--- a/.github/workflows/performance_summary.yml
+++ b/.github/workflows/performance_summary.yml
@@ -17,6 +17,9 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  RUST_VERSION: 1.90.0
+
 jobs:
   performance-summary:
     runs-on: ubuntu-latest
@@ -24,6 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ vars.RUST_VERSION }}
       - name: Post Performance Summary comment on PR
         if: ${{ github.event.workflow_run.event == 'pull_request' }}
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,7 @@ env:
   LINERA_KEYSTORE: /tmp/local-linera-net/keystore_0.json
   LINERA_STORAGE: rocksdb:/tmp/local-linera-net/client_0.db
   LINERA_FAUCET_URL: http://localhost:8079
+  RUST_VERSION: 1.90.0
 
 permissions:
   contents: read
@@ -64,6 +65,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
+
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
@@ -103,6 +107,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Run some extra execution tests with wasmtime
       run: |
         cargo test --locked -p linera-execution --features wasmtime
@@ -116,6 +122,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Run metrics tests
       run: |
         cargo test --locked -p linera-base --features metrics
@@ -129,6 +137,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
@@ -147,6 +157,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
@@ -171,6 +183,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
@@ -193,6 +207,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
@@ -217,6 +233,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - uses: foundry-rs/foundry-toolchain@v1.4.0
     - name: Ensure Solc Directory Exists
       run: mkdir -p /home/runner/.solc
@@ -279,6 +297,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
@@ -304,6 +324,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Check WIT files
       run: |
         cargo run --bin wit-generator -- -c
@@ -349,6 +371,8 @@ jobs:
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install cargo-machete
       run: |
         cargo install cargo-machete@0.7.0 --locked
@@ -368,6 +392,8 @@ jobs:
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Check formatting
       run: |
         cargo fmt -- --check
@@ -381,6 +407,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install `taplo-cli`
       run: RUSTFLAGS='' cargo install taplo-cli@0.9.3 --locked
     - name: Check if `Cargo.toml` files are formatted
@@ -398,6 +426,8 @@ jobs:
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install cargo-rdme
       run: |
         cargo install cargo-rdme --locked
@@ -427,6 +457,8 @@ jobs:
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
@@ -452,6 +484,8 @@ jobs:
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
@@ -478,6 +512,8 @@ jobs:
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
@@ -495,6 +531,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -28,6 +28,7 @@ env:
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
   RUST_LOG: warn
+  RUST_VERSION: 1.90.0
 
 permissions:
   contents: read
@@ -41,6 +42,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -24,6 +24,7 @@ env:
   RUSTUP_MAX_RETRIES: 10
   RUST_LOG: linera=debug
   RUST_LOG_FORMAT: plain
+  RUST_VERSION: 1.90.0
   LINERA_STORAGE_SERVICE: 127.0.0.1:1235
   LINERA_WALLET: /tmp/local-linera-net/wallet_0.json
   LINERA_KEYSTORE: /tmp/local-linera-net/keystore_0.json
@@ -44,6 +45,8 @@ jobs:
       with:
         version: 10.11.0
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -25,6 +25,7 @@ env:
   RUSTUP_MAX_RETRIES: 10
   RUST_LOG: linera=debug
   RUST_LOG_FORMAT: plain
+  RUST_VERSION: 1.90.0
   LINERA_STORAGE_SERVICE: 127.0.0.1:1235
   LINERA_WALLET: /tmp/local-linera-net/wallet_0.json
   LINERA_KEYSTORE: /tmp/local-linera-net/keystore_0.json
@@ -67,6 +68,8 @@ jobs:
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ vars.RUST_VERSION }}
     - uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/publish-read-data-blob/src/state.rs
+++ b/examples/publish-read-data-blob/src/state.rs
@@ -6,6 +6,7 @@ use linera_sdk::{
     views::{linera_views, RegisterView, RootView, ViewStorageContext},
 };
 
+#[allow(dead_code)]
 #[derive(RootView)]
 #[view(context = ViewStorageContext)]
 pub struct PublishReadDataBlobState {

--- a/examples/rfq/src/state.rs
+++ b/examples/rfq/src/state.rs
@@ -73,6 +73,7 @@ pub struct RequestData {
     state: RequestState,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, Serialize, Deserialize, SimpleObject)]
 pub struct TempChainTokenHolder {
     pub account_owner: AccountOwner,

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -459,7 +459,7 @@ where
         key_pair: Option<&ValidatorSecretKey>,
         local_time: Timestamp,
         blobs: BTreeMap<BlobId, Blob>,
-    ) -> Result<Option<ValidatedOrConfirmedVote>, ChainError> {
+    ) -> Result<Option<ValidatedOrConfirmedVote<'_>>, ChainError> {
         let round = proposal.content.round;
 
         match &proposal.original_proposal {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1141,7 +1141,7 @@ impl<Env: Environment> Client<Env> {
                     if let LocalNodeError::BlobsNotFound(blob_ids) = &err {
                         self.update_local_node_with_blobs_from(
                             blob_ids.clone(),
-                            &[remote_node.clone()],
+                            std::slice::from_ref(remote_node),
                         )
                         .await?;
                         // We found the missing blobs: retry.

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -231,7 +231,7 @@ where
     let create_certificate = env.make_certificate(create_block_proposal);
 
     storage
-        .write_blobs(&[application_description_blob.clone()])
+        .write_blobs(std::slice::from_ref(&application_description_blob))
         .await?;
     creator_state
         .context()

--- a/linera-ethereum/tests/ethereum_test.rs
+++ b/linera-ethereum/tests/ethereum_test.rs
@@ -68,7 +68,7 @@ async fn test_event_numerics() -> anyhow::Result<()> {
         ],
         block_number: 1,
     };
-    assert_eq!(*events, [target_event.clone()]);
+    assert_eq!(&events[..], std::slice::from_ref(&target_event));
     let events = ethereum_client_simp
         .read_events(&contract_address, event_name_expanded, from_block, to_block)
         .await?;
@@ -110,7 +110,7 @@ async fn test_simple_token_events() -> anyhow::Result<()> {
         ],
         block_number: 2,
     };
-    assert_eq!(*events, [target_event.clone()]);
+    assert_eq!(&events[..], std::slice::from_ref(&target_event));
     // Using the simplified client
     let events = ethereum_client_simp
         .read_events(&contract_address, event_name_expanded, from_block, to_block)

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -394,7 +394,7 @@ where
         };
 
         self.server.packets_processed += 1;
-        if self.server.packets_processed % 5000 == 0 {
+        if self.server.packets_processed.is_multiple_of(5000) {
             debug!(
                 "[{}] {}:{} (shard {}) has processed {} packets",
                 self.server.state.nickname(),

--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -383,7 +383,7 @@ where
     ) -> Result<(), std::io::Error> {
         let listener = TcpListener::bind(address).await?;
 
-        let mut accept_stream = stream::try_unfold(listener, |listener| async move {
+        let accept_stream = stream::try_unfold(listener, |listener| async move {
             let (socket, _) = listener.accept().await?;
             Ok::<_, io::Error>(Some((socket, listener)))
         });

--- a/linera-sdk/src/util.rs
+++ b/linera-sdk/src/util.rs
@@ -58,7 +58,7 @@ where
 {
     type Output = AnyFuture::Output;
 
-    fn blocking_wait(mut self) -> Self::Output {
+    fn blocking_wait(self) -> Self::Output {
         let waker = task::noop_waker();
         let mut task_context = Context::from_waker(&waker);
         let mut future = pin!(self);

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -522,7 +522,7 @@ impl TestClock {
         self.lock().time
     }
 
-    fn lock(&self) -> std::sync::MutexGuard<TestClockInner> {
+    fn lock(&self) -> std::sync::MutexGuard<'_, TestClockInner> {
         self.0.lock().expect("poisoned TestClock mutex")
     }
 }

--- a/linera-summary/src/github.rs
+++ b/linera-summary/src/github.rs
@@ -310,7 +310,7 @@ impl Github {
         Ok(jobs_filtered)
     }
 
-    pub fn workflows_handler(&self) -> WorkflowsHandler {
+    pub fn workflows_handler(&self) -> WorkflowsHandler<'_> {
         self.octocrab.workflows(
             self.context.repository.owner.clone(),
             self.context.repository.name.clone(),

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -166,7 +166,10 @@ impl RocksDbStoreExecutor {
         Ok(entries.into_iter().collect::<Result<_, _>>()?)
     }
 
-    fn get_find_prefix_iterator(&self, prefix: &[u8]) -> rocksdb::DBRawIteratorWithThreadMode<DB> {
+    fn get_find_prefix_iterator(
+        &self,
+        prefix: &[u8],
+    ) -> rocksdb::DBRawIteratorWithThreadMode<'_, DB> {
         // Configure ReadOptions optimized for SSDs and iterator performance
         let mut read_opts = rocksdb::ReadOptions::default();
         // Enable async I/O for better concurrency

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -268,7 +268,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
     pub async fn try_load_entry(
         &self,
         short_key: &[u8],
-    ) -> Result<Option<ReadGuardedView<W>>, ViewError> {
+    ) -> Result<Option<ReadGuardedView<'_, W>>, ViewError> {
         let mut updates = self
             .updates
             .try_write()
@@ -822,7 +822,7 @@ impl<I: Serialize, W: View> CollectionView<W::Context, I, W> {
     pub async fn try_load_entry<Q>(
         &self,
         index: &Q,
-    ) -> Result<Option<ReadGuardedView<W>>, ViewError>
+    ) -> Result<Option<ReadGuardedView<'_, W>>, ViewError>
     where
         I: Borrow<Q>,
         Q: Serialize + ?Sized,
@@ -1172,7 +1172,7 @@ impl<I: CustomSerialize, W: View> CustomCollectionView<W::Context, I, W> {
     pub async fn try_load_entry<Q>(
         &self,
         index: &Q,
-    ) -> Result<Option<ReadGuardedView<W>>, ViewError>
+    ) -> Result<Option<ReadGuardedView<'_, W>>, ViewError>
     where
         I: Borrow<Q>,
         Q: CustomSerialize,
@@ -1456,7 +1456,7 @@ mod graphql {
         async fn entry(
             &self,
             key: K,
-        ) -> Result<Entry<K, ReadGuardedView<V>>, async_graphql::Error> {
+        ) -> Result<Entry<K, ReadGuardedView<'_, V>>, async_graphql::Error> {
             let value = self
                 .try_load_entry(&key)
                 .await?
@@ -1467,7 +1467,7 @@ mod graphql {
         async fn entries(
             &self,
             input: Option<MapInput<K>>,
-        ) -> Result<Vec<Entry<K, ReadGuardedView<V>>>, async_graphql::Error> {
+        ) -> Result<Vec<Entry<K, ReadGuardedView<'_, V>>>, async_graphql::Error> {
             let keys = if let Some(keys) = input
                 .and_then(|input| input.filters)
                 .and_then(|filters| filters.keys)
@@ -1522,7 +1522,7 @@ mod graphql {
         async fn entry(
             &self,
             key: K,
-        ) -> Result<Entry<K, ReadGuardedView<V>>, async_graphql::Error> {
+        ) -> Result<Entry<K, ReadGuardedView<'_, V>>, async_graphql::Error> {
             let value = self
                 .try_load_entry(&key)
                 .await?
@@ -1533,7 +1533,7 @@ mod graphql {
         async fn entries(
             &self,
             input: Option<MapInput<K>>,
-        ) -> Result<Vec<Entry<K, ReadGuardedView<V>>>, async_graphql::Error> {
+        ) -> Result<Vec<Entry<K, ReadGuardedView<'_, V>>>, async_graphql::Error> {
             let keys = if let Some(keys) = input
                 .and_then(|input| input.filters)
                 .and_then(|filters| filters.keys)

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -123,7 +123,7 @@ impl<UserData> AsStoreMut for EntrypointInstance<UserData> {
 impl<UserData> EntrypointInstance<UserData> {
     /// Returns mutable references to the [`Store`] and the [`wasmer::Instance`] stored inside this
     /// [`EntrypointInstance`].
-    pub fn as_store_and_instance_mut(&mut self) -> (StoreMut, &mut wasmer::Instance) {
+    pub fn as_store_and_instance_mut(&mut self) -> (StoreMut<'_>, &mut wasmer::Instance) {
         (self.store.as_store_mut(), &mut self.instance)
     }
 }

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -41,13 +41,13 @@ impl<UserData> EntrypointInstance<UserData> {
 impl<UserData> AsContext for EntrypointInstance<UserData> {
     type Data = UserData;
 
-    fn as_context(&self) -> StoreContext<UserData> {
+    fn as_context(&self) -> StoreContext<'_, UserData> {
         self.store.as_context()
     }
 }
 
 impl<UserData> AsContextMut for EntrypointInstance<UserData> {
-    fn as_context_mut(&mut self) -> StoreContextMut<UserData> {
+    fn as_context_mut(&mut self) -> StoreContextMut<'_, UserData> {
         self.store.as_context_mut()
     }
 }

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -89,5 +89,6 @@ pub struct StructWithLists {
 }
 
 /// A type that wraps a slice.
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitStore)]
 pub struct SliceWrapper<'slice>(pub &'slice [TupleWithoutPadding]);

--- a/toolchains/stable/rust-toolchain.toml
+++ b/toolchains/stable/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.90.0"
 components = [ "clippy", "rustfmt", "rust-src" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
## Motivation

Rust 1.90.0 has `lld` as the default linker 🤩

## Proposal

Update Rust to 1.90.0

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.