### PR TITLE
Allow multi-read in `CollectionView`

### DIFF
--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -20,8 +20,11 @@ type HasherOutputSize = <sha3::Sha3_256 as sha3::digest::OutputSizeUser>::Output
 pub type HasherOutput = generic_array::GenericArray<u8, HasherOutputSize>;
 
 #[derive(Clone, Debug)]
-pub(crate) enum Update<T> {
+/// An update, for example to a view.
+pub enum Update<T> {
+    /// The entry is removed.
     Removed,
+    /// The entry is set to the following.
     Set(T),
 }
 

--- a/linera-views/src/error.rs
+++ b/linera-views/src/error.rs
@@ -8,6 +8,10 @@ pub enum ViewError {
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
 
+    /// We failed to acquire an entry in a `CollectionView`.
+    #[error("trying to access a collection view while some entries are still being accessed")]
+    CannotAcquireCollectionEntry,
+
     /// Input output error.
     #[error("I/O error")]
     IoError(#[from] std::io::Error),

--- a/linera-views/src/error.rs
+++ b/linera-views/src/error.rs
@@ -8,10 +8,6 @@ pub enum ViewError {
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
 
-    /// We failed to acquire an entry in a `CollectionView`.
-    #[error("trying to access a collection view while some entries are still being accessed")]
-    CannotAcquireCollectionEntry,
-
     /// Input output error.
     #[error("I/O error")]
     IoError(#[from] std::io::Error),

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -356,7 +356,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
                     Update::Removed => {
                         results.push(None);
                     }
-                    _ => {
+                    Update::Set(_) => {
                         let updates = self.updates.read().await;
                         results.push(Some(ReadGuardedView::Loaded {
                             updates,
@@ -1640,14 +1640,11 @@ mod graphql {
             };
 
             let values = self.try_load_entries(&keys).await?;
-            values
+            Ok(values
                 .into_iter()
                 .zip(keys)
-                .map(|(value, key)| match value {
-                    None => Err(missing_key_error(&key)),
-                    Some(value) => Ok(Entry { value, key }),
-                })
-                .collect()
+                .filter_map(|(value, key)| value.map(|value| Entry { value, key }))
+                .collect())
         }
     }
 
@@ -1703,14 +1700,11 @@ mod graphql {
             };
 
             let values = self.try_load_entries(&keys).await?;
-            values
+            Ok(values
                 .into_iter()
                 .zip(keys)
-                .map(|(value, key)| match value {
-                    None => Err(missing_key_error(&key)),
-                    Some(value) => Ok(Entry { value, key }),
-                })
-                .collect()
+                .filter_map(|(value, key)| value.map(|value| Entry { value, key }))
+                .collect())
         }
     }
 }

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -9,7 +9,7 @@ use std::{
     mem,
 };
 
-use async_lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use async_lock::{RwLock, RwLockReadGuard};
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
 use serde::{de::DeserializeOwned, Serialize};
@@ -51,19 +51,39 @@ pub struct ByteCollectionView<C, W> {
 }
 
 /// A read-only accessor for a particular subview in a [`CollectionView`].
-pub struct ReadGuardedView<'a, W> {
-    guard: RwLockReadGuard<'a, BTreeMap<Vec<u8>, Update<W>>>,
-    short_key: Vec<u8>,
+pub enum ReadGuardedView<'a, W> {
+    /// The view is loaded in the updates
+    Loaded {
+        /// The guard for the updates.
+        updates: RwLockReadGuard<'a, BTreeMap<Vec<u8>, Update<W>>>,
+        /// The key in question.
+        short_key: Vec<u8>,
+    },
+    /// The view is not loaded in the updates
+    NotLoaded {
+        /// The guard for the updates. It is needed so that it prevents
+        /// opening the view as write separately.
+        _updates: RwLockReadGuard<'a, BTreeMap<Vec<u8>, Update<W>>>,
+        /// The view obtained from the storage
+        view: W,
+    },
 }
 
 impl<W> std::ops::Deref for ReadGuardedView<'_, W> {
     type Target = W;
 
     fn deref(&self) -> &W {
-        let Update::Set(view) = self.guard.get(&self.short_key).unwrap() else {
-            unreachable!();
-        };
-        view
+        match self {
+            ReadGuardedView::Loaded { updates, short_key } => {
+                let Update::Set(view) = updates.get(short_key).unwrap() else {
+                    unreachable!();
+                };
+                view
+            }
+            ReadGuardedView::NotLoaded { _updates, view } => {
+                view
+            }
+        }
     }
 }
 
@@ -269,25 +289,23 @@ impl<W: View> ByteCollectionView<W::Context, W> {
         &self,
         short_key: &[u8],
     ) -> Result<Option<ReadGuardedView<W>>, ViewError> {
-        let mut updates = self
+        let updates = self
             .updates
-            .try_write()
-            .ok_or(ViewError::CannotAcquireCollectionEntry)?;
-        match updates.entry(short_key.to_vec()) {
-            btree_map::Entry::Occupied(entry) => {
-                let entry = entry.into_mut();
-                match entry {
-                    Update::Set(_) => {
-                        let guard = RwLockWriteGuard::downgrade(updates);
-                        Ok(Some(ReadGuardedView {
-                            guard,
+            .read()
+            .await;
+        match updates.get(short_key) {
+            Some(update) => {
+                match update {
+                    Update::Removed => Ok(None),
+                    _ => {
+                        Ok(Some(ReadGuardedView::Loaded {
+                            updates,
                             short_key: short_key.to_vec(),
                         }))
                     }
-                    Update::Removed => Ok(None),
                 }
             }
-            btree_map::Entry::Vacant(entry) => {
+            None => {
                 let key_index = self
                     .context
                     .base_key()
@@ -301,11 +319,9 @@ impl<W: View> ByteCollectionView<W::Context, W> {
                         .base_tag_index(KeyTag::Subview as u8, short_key);
                     let context = self.context.clone_with_base_key(key);
                     let view = W::load(context).await?;
-                    entry.insert(Update::Set(view));
-                    let guard = RwLockWriteGuard::downgrade(updates);
-                    Ok(Some(ReadGuardedView {
-                        guard,
-                        short_key: short_key.to_vec(),
+                    Ok(Some(ReadGuardedView::NotLoaded {
+                        _updates: updates,
+                        view,
                     }))
                 } else {
                     Ok(None)

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -291,7 +291,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
         match updates.get(short_key) {
             Some(update) => match update {
                 Update::Removed => Ok(None),
-                _ => Ok(Some(ReadGuardedView::Loaded {
+                Update::Set(_) => Ok(Some(ReadGuardedView::Loaded {
                     updates,
                     short_key: short_key.to_vec(),
                 })),

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -1326,8 +1326,7 @@ impl<I: CustomSerialize, W: View> CustomCollectionView<W::Context, I, W> {
     /// {
     ///     let _subview = view.load_entry_or_insert(&23).await.unwrap();
     /// }
-    /// let indices = vec![23, 24];
-    /// let subviews = view.try_load_entries(indices).await.unwrap();
+    /// let subviews = view.try_load_entries(&[23, 42]).await.unwrap();
     /// let value0 = subviews[0].as_ref().unwrap().get();
     /// assert_eq!(*value0, String::default());
     /// # })

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -1565,7 +1565,7 @@ mod graphql {
 
     use super::{CollectionView, CustomCollectionView, ReadGuardedView};
     use crate::{
-        graphql::{hash_name, mangle, missing_key_error, Entry, MapFilters, MapInput},
+        graphql::{hash_name, mangle, missing_key_error, Entry, MapInput},
         views::View,
     };
 
@@ -1610,8 +1610,6 @@ mod graphql {
             + serde::de::DeserializeOwned
             + std::fmt::Debug,
         V: View + async_graphql::OutputType,
-        MapInput<K>: async_graphql::InputType,
-        MapFilters<K>: async_graphql::InputType,
     {
         async fn keys(&self) -> Result<Vec<K>, async_graphql::Error> {
             Ok(self.indices().await?)
@@ -1675,8 +1673,6 @@ mod graphql {
             + crate::common::CustomSerialize
             + std::fmt::Debug,
         V: View + async_graphql::OutputType,
-        MapInput<K>: async_graphql::InputType,
-        MapFilters<K>: async_graphql::InputType,
     {
         async fn keys(&self) -> Result<Vec<K>, async_graphql::Error> {
             Ok(self.indices().await?)

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -1186,7 +1186,7 @@ where
 impl<I, W> ReentrantCollectionView<W::Context, I, W>
 where
     W: View,
-    I: Sync + Clone + Send + Serialize + DeserializeOwned,
+    I: Sync + Send + Serialize + DeserializeOwned,
 {
     /// Loads a subview for the data at the given index in the collection. If an entry
     /// is absent then a default entry is put on the collection. The obtained view can
@@ -1339,7 +1339,7 @@ where
 impl<I, W> ReentrantCollectionView<W::Context, I, W>
 where
     W: View,
-    I: Sync + Clone + Send + Serialize + DeserializeOwned,
+    I: Sync + Send + Serialize + DeserializeOwned,
 {
     /// Load multiple entries for writing at once.
     /// The entries in indices have to be all distinct.
@@ -1485,7 +1485,7 @@ where
 impl<I, W> ReentrantCollectionView<W::Context, I, W>
 where
     W: View,
-    I: Sync + Clone + Send + Serialize + DeserializeOwned,
+    I: Sync + Send + Serialize + DeserializeOwned,
 {
     /// Returns the list of indices in the collection in an order determined
     /// by serialization.
@@ -1693,7 +1693,7 @@ where
 impl<I, W> ReentrantCustomCollectionView<W::Context, I, W>
 where
     W: View,
-    I: Sync + Clone + Send + CustomSerialize,
+    I: Sync + Send + CustomSerialize,
 {
     /// Loads a subview for the data at the given index in the collection. If an entry
     /// is absent then a default entry is put in the collection on this index.
@@ -1846,7 +1846,7 @@ where
 
 impl<I, W: View> ReentrantCustomCollectionView<W::Context, I, W>
 where
-    I: Sync + Clone + Send + CustomSerialize,
+    I: Sync + Send + CustomSerialize,
 {
     /// Load multiple entries for writing at once.
     /// The entries in indices have to be all distinct.
@@ -1867,13 +1867,13 @@ where
     /// assert_eq!(*value2, String::default());
     /// # })
     /// ```
-    pub async fn try_load_entries_mut<Q>(
+    pub async fn try_load_entries_mut<'a, Q>(
         &mut self,
-        indices: impl IntoIterator<Item = Q>,
+        indices: impl IntoIterator<Item = &'a Q>,
     ) -> Result<Vec<WriteGuardedView<W>>, ViewError>
     where
         I: Borrow<Q>,
-        Q: CustomSerialize,
+        Q: CustomSerialize + 'a,
     {
         let short_keys = indices
             .into_iter()
@@ -1903,13 +1903,13 @@ where
     /// assert_eq!(*value0, String::default());
     /// # })
     /// ```
-    pub async fn try_load_entries<Q>(
+    pub async fn try_load_entries<'a, Q>(
         &self,
-        indices: impl IntoIterator<Item = Q>,
+        indices: impl IntoIterator<Item = &'a Q>,
     ) -> Result<Vec<Option<ReadGuardedView<W>>>, ViewError>
     where
         I: Borrow<Q>,
-        Q: CustomSerialize,
+        Q: CustomSerialize + 'a,
     {
         let short_keys = indices
             .into_iter()
@@ -1990,7 +1990,7 @@ where
 impl<I, W> ReentrantCustomCollectionView<W::Context, I, W>
 where
     W: View,
-    I: Sync + Clone + Send + CustomSerialize,
+    I: Sync + Send + CustomSerialize,
 {
     /// Returns the list of indices in the collection. The order is determined by
     /// the custom serialization.
@@ -2191,8 +2191,7 @@ mod graphql {
             + async_graphql::OutputType
             + serde::ser::Serialize
             + serde::de::DeserializeOwned
-            + std::fmt::Debug
-            + Clone,
+            + std::fmt::Debug,
         V: View + async_graphql::OutputType,
         MapInput<K>: async_graphql::InputType,
         MapFilters<K>: async_graphql::InputType,
@@ -2260,8 +2259,7 @@ mod graphql {
         K: async_graphql::InputType
             + async_graphql::OutputType
             + crate::common::CustomSerialize
-            + std::fmt::Debug
-            + Clone,
+            + std::fmt::Debug,
         V: View + async_graphql::OutputType,
         MapInput<K>: async_graphql::InputType,
         MapFilters<K>: async_graphql::InputType,
@@ -2294,7 +2292,7 @@ mod graphql {
                 self.indices().await?
             };
 
-            let values = self.try_load_entries(keys.clone()).await?;
+            let values = self.try_load_entries(&keys).await?;
             values
                 .into_iter()
                 .zip(keys)

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -2228,12 +2228,10 @@ mod graphql {
             values
                 .into_iter()
                 .zip(keys)
-                .map(|(value, key)|
-                     match value {
-                         None => Err(missing_key_error(&key)),
-                         Some(value) => Ok(Entry { value, key })
-                     }
-                )
+                .map(|(value, key)| match value {
+                    None => Err(missing_key_error(&key)),
+                    Some(value) => Ok(Entry { value, key }),
+                })
                 .collect()
         }
     }
@@ -2296,12 +2294,10 @@ mod graphql {
             values
                 .into_iter()
                 .zip(keys)
-                .map(|(value, key)|
-                     match value {
-                         None => Err(missing_key_error(&key)),
-                         Some(value) => Ok(Entry { value, key })
-                     }
-                )
+                .map(|(value, key)| match value {
+                    None => Err(missing_key_error(&key)),
+                    Some(value) => Ok(Entry { value, key }),
+                })
                 .collect()
         }
     }

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -1859,8 +1859,7 @@ where
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
     ///     ReentrantCustomCollectionView::load(context).await.unwrap();
-    /// let indices = vec![23, 42];
-    /// let subviews = view.try_load_entries_mut(indices).await.unwrap();
+    /// let subviews = view.try_load_entries_mut(&[23, 42]).await.unwrap();
     /// let value1 = subviews[0].get();
     /// let value2 = subviews[1].get();
     /// assert_eq!(*value1, String::default());
@@ -1896,8 +1895,7 @@ where
     /// {
     ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
     /// }
-    /// let indices = vec![23, 42];
-    /// let subviews = view.try_load_entries(indices).await.unwrap();
+    /// let subviews = view.try_load_entries(&[23, 42]).await.unwrap();
     /// assert!(subviews[1].is_none());
     /// let value0 = subviews[0].as_ref().unwrap().get();
     /// assert_eq!(*value0, String::default());

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -2146,7 +2146,7 @@ mod graphql {
 
     use super::{ReadGuardedView, ReentrantCollectionView};
     use crate::{
-        graphql::{hash_name, mangle, missing_key_error, Entry, MapFilters, MapInput},
+        graphql::{hash_name, mangle, missing_key_error, Entry, MapInput},
         views::View,
     };
 
@@ -2191,8 +2191,6 @@ mod graphql {
             + serde::de::DeserializeOwned
             + std::fmt::Debug,
         V: View + async_graphql::OutputType,
-        MapInput<K>: async_graphql::InputType,
-        MapFilters<K>: async_graphql::InputType,
     {
         async fn keys(&self) -> Result<Vec<K>, async_graphql::Error> {
             Ok(self.indices().await?)
@@ -2257,8 +2255,6 @@ mod graphql {
             + crate::common::CustomSerialize
             + std::fmt::Debug,
         V: View + async_graphql::OutputType,
-        MapInput<K>: async_graphql::InputType,
-        MapFilters<K>: async_graphql::InputType,
     {
         async fn keys(&self) -> Result<Vec<K>, async_graphql::Error> {
             Ok(self.indices().await?)

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -2221,14 +2221,11 @@ mod graphql {
             };
 
             let values = self.try_load_entries(&keys).await?;
-            values
+            Ok(values
                 .into_iter()
                 .zip(keys)
-                .map(|(value, key)| match value {
-                    None => Err(missing_key_error(&key)),
-                    Some(value) => Ok(Entry { value, key }),
-                })
-                .collect()
+                .filter_map(|(value, key)| value.map(|value| Entry { value, key }))
+                .collect())
         }
     }
 
@@ -2285,14 +2282,11 @@ mod graphql {
             };
 
             let values = self.try_load_entries(&keys).await?;
-            values
+            Ok(values
                 .into_iter()
                 .zip(keys)
-                .map(|(value, key)| match value {
-                    None => Err(missing_key_error(&key)),
-                    Some(value) => Ok(Entry { value, key }),
-                })
-                .collect()
+                .filter_map(|(value, key)| value.map(|value| Entry { value, key }))
+                .collect())
         }
     }
 }

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -2225,16 +2225,17 @@ mod graphql {
                 self.indices().await?
             };
 
-            let mut values = vec![];
-            for key in keys {
-                let value = self
-                    .try_load_entry(&key)
-                    .await?
-                    .ok_or_else(|| missing_key_error(&key))?;
-                values.push(Entry { value, key })
-            }
-
-            Ok(values)
+            let values = self.try_load_entries(&keys).await?;
+            values
+                .into_iter()
+                .zip(keys)
+                .map(|(value, key)|
+                     match value {
+                         None => Err(missing_key_error(&key)),
+                         Some(value) => Ok(Entry { value, key })
+                     }
+                )
+                .collect()
         }
     }
 
@@ -2293,16 +2294,17 @@ mod graphql {
                 self.indices().await?
             };
 
-            let mut values = vec![];
-            for key in keys {
-                let value = self
-                    .try_load_entry(&key)
-                    .await?
-                    .ok_or_else(|| missing_key_error(&key))?;
-                values.push(Entry { value, key })
-            }
-
-            Ok(values)
+            let values = self.try_load_entries(keys.clone()).await?;
+            values
+                .into_iter()
+                .zip(keys)
+                .map(|(value, key)|
+                     match value {
+                         None => Err(missing_key_error(&key)),
+                         Some(value) => Ok(Entry { value, key })
+                     }
+                )
+                .collect()
         }
     }
 }

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -518,7 +518,7 @@ where
             if config.with_collection {
                 let subview = view.collection2.load_entry_mut("ciao").await?;
                 let subsubview = subview.try_load_entry("!").await?.unwrap();
-                let _subsubview = subview.try_load_entry("!").await?.unwrap();
+                subview.try_load_entry("!").await?.unwrap();
                 assert_eq!(subsubview.get(), &3);
                 assert_eq!(view.collection.indices().await?, vec!["hola".to_string()]);
                 view.collection.remove_entry("hola")?;

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -518,7 +518,7 @@ where
             if config.with_collection {
                 let subview = view.collection2.load_entry_mut("ciao").await?;
                 let subsubview = subview.try_load_entry("!").await?.unwrap();
-                assert!(subview.try_load_entry("!").await.is_err());
+                let _subsubview = subview.try_load_entry("!").await?.unwrap();
                 assert_eq!(subsubview.get(), &3);
                 assert_eq!(view.collection.indices().await?, vec!["hola".to_string()]);
                 view.collection.remove_entry("hola")?;


### PR DESCRIPTION
## Motivation

The reading of multiple keys in `CollectionView` does not work. This is unfortunate since the underlying
container of `CollectionView` is `async_lock::RwLock` which allows multiple read or one write. We `CollectionView`
should have the same semantics.

Fixes #4588 

## Proposal

The following steps are made:
* The `ReadGuardedView` is now an enum. The `Loaded` entry is when it is present in updates. The `NotLoaded` when accessed from storage.
* The `NotLoaded` contains some lock so as to avoid a write to be created and lead to incoherent state.
* As a consequence, when doing the `try_load_entry` of a view on storage, the updates is not changed. But that is fine, since it is anyway in the LRU cache.
* A `try_load_entries` has been introduced since we can now read multiple keys at once.
* The code of `fn entries` has been simplifed to use those functions.
* The `try_load_entries` no longer take values since only references are needed.
* The `Clone` requirement have been alleviated in `CollectionView` / `ReentrantCollectionView`.


## Test Plan

The CI.
The unit tests in the code should be sufficient for the functionality.

## Release Plan

It addresses an issue that showed up in the GameOfLife. So, moving it to TestNet seems like.a good idea.

## Links

None.