### PR TITLE
Custom Debug impl for CreateAndCall request

### DIFF
--- a/examples/create-and-call/src/lib.rs
+++ b/examples/create-and-call/src/lib.rs
@@ -3,6 +3,8 @@
 
 /*! ABI of the Create and Call Example Application that does not use GraphQL */
 
+use std::fmt::Debug;
+
 use linera_sdk::linera_base_types::{ContractAbi, ServiceAbi};
 use serde::{Deserialize, Serialize};
 
@@ -18,13 +20,48 @@ impl ServiceAbi for CreateAndCallAbi {
     type QueryResponse = u64;
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub enum CreateAndCallRequest {
     Query,
     CreateAndCall(Vec<u8>, Vec<u8>, u64, u64),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub enum CreateAndCallOperation {
     CreateAndCall(Vec<u8>, Vec<u8>, u64, u64),
+}
+
+impl Debug for CreateAndCallRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CreateAndCallRequest::Query => write!(f, "CreateAndCallRequest::Query"),
+            CreateAndCallRequest::CreateAndCall(code, calldata, initial_value, increment) => {
+                write!(
+                    f,
+                    "CreateAndCallRequest::CreateAndCall(code: <{} bytes>, calldata: <{} bytes>, initial value: {}, increment: {})",
+                    code.len(),
+                    calldata.len(),
+                    initial_value,
+                    increment
+                )
+            }
+        }
+    }
+}
+
+impl Debug for CreateAndCallOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CreateAndCallOperation::CreateAndCall(code, calldata, initial_value, increment) => {
+                write!(
+                    f,
+                    "CreateAndCall(code: <{} bytes>, calldata: <{} bytes>, initial_value: {}, increment: {})",
+                    code.len(),
+                    calldata.len(),
+                    initial_value,
+                    increment
+                )
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Motivation

Before this PR the derived `Debug` implementation prints whole `Vec<u8>` bytes:

```
2025-09-23T12:21:27.8588391Z "{\"CreateAndCall\":[[0,97,115,109,1,0,0,0,1,226,1,31,96,2,127,127,0,96,3,127,127 ....
```

## Proposal

Custom impl that prints the lengths.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- These changes should be backported to the latest `testnet` branch

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
