### PR TITLE
Add a limit for the number of received_log entries in a chain info response

### DIFF
--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -14,5 +14,5 @@ pub(crate) use self::state::CrossChainUpdateHelper;
 pub(crate) use self::{
     actor::{ChainWorkerActor, ChainWorkerRequest},
     config::ChainWorkerConfig,
-    state::{BlockOutcome, READ_MAX_RECEIVED_LOG_ENTRIES},
+    state::{BlockOutcome, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES},
 };

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -14,5 +14,8 @@ pub(crate) use self::state::CrossChainUpdateHelper;
 pub(crate) use self::{
     actor::{ChainWorkerActor, ChainWorkerRequest},
     config::ChainWorkerConfig,
-    state::{BlockOutcome, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES},
+    state::{
+        BlockOutcome, CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_DEFAULT,
+        CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_VAR,
+    },
 };

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -14,5 +14,5 @@ pub(crate) use self::state::CrossChainUpdateHelper;
 pub(crate) use self::{
     actor::{ChainWorkerActor, ChainWorkerRequest},
     config::ChainWorkerConfig,
-    state::BlockOutcome,
+    state::{BlockOutcome, READ_MAX_RECEIVED_LOG_ENTRIES},
 };

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -50,7 +50,7 @@ use crate::{
 
 /// The maximum number of entries in a `received_log` included in a `ChainInfo` response.
 // TODO(#4638): Revisit the number.
-pub const CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES: usize = 1000;
+pub const CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES: usize = 50_000;
 
 /// The state of the chain worker.
 pub(crate) struct ChainWorkerState<StorageClient>

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -48,7 +48,7 @@ use crate::{
     worker::{NetworkActions, Notification, Reason, WorkerError},
 };
 
-/// The maximum number of entries in a received_log included in a ChainInfo response.
+/// The maximum number of entries in a `received_log` included in a `ChainInfo` response.
 // TODO(#4638): Revisit the number.
 pub const CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES: usize = 1000;
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -50,7 +50,9 @@ use crate::{
 
 /// The maximum number of entries in a `received_log` included in a `ChainInfo` response.
 // TODO(#4638): Revisit the number.
-pub const CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES: usize = 50_000;
+pub const CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_DEFAULT: usize = 1000;
+pub const CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_VAR: &str =
+    "LINERA_CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES";
 
 /// The state of the chain worker.
 pub(crate) struct ChainWorkerState<StorageClient>
@@ -1415,8 +1417,11 @@ where
         info.requested_sent_certificate_hashes = hashes;
         if let Some(start) = query.request_received_log_excluding_first_n {
             let start = usize::try_from(start).map_err(|_| ArithmeticError::Overflow)?;
-            let end = (start.saturating_add(CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES))
-                .min(chain.received_log.count());
+            let max_entries = std::env::var(CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_VAR)
+                .ok()
+                .and_then(|var| var.parse().ok())
+                .unwrap_or(CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_DEFAULT);
+            let end = (start.saturating_add(max_entries)).min(chain.received_log.count());
             info.requested_received_log = chain.received_log.read(start..end).await?;
         }
         if query.request_manager_values {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -69,6 +69,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, info, instrument, trace, warn, Instrument as _};
 
 use crate::{
+    chain_worker::CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, ClientOutcome, RoundTimeout},
     environment::Environment,
     local_node::{LocalChainInfoExt as _, LocalNodeClient, LocalNodeError},
@@ -842,9 +843,18 @@ impl<Env: Environment> Client<Env> {
         let (max_epoch, committees) = self.admin_committees().await?;
 
         // Retrieve the list of newly received certificates from this validator.
-        let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_n(tracker);
-        let info = remote_node.handle_chain_info_query(query).await?;
-        let remote_log = info.requested_received_log;
+        let mut remote_log = Vec::new();
+        let mut offset = tracker;
+        loop {
+            let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_n(offset);
+            let info = remote_node.handle_chain_info_query(query).await?;
+            let received_entries = info.requested_received_log.len();
+            offset += received_entries as u64;
+            remote_log.extend(info.requested_received_log);
+            if received_entries < CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES {
+                break;
+            }
+        }
         let remote_heights = Self::heights_per_chain(&remote_log);
 
         // Obtain the next block height we need in the local node, for each chain.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -69,7 +69,9 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, info, instrument, trace, warn, Instrument as _};
 
 use crate::{
-    chain_worker::CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
+    chain_worker::{
+        CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_DEFAULT, CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_VAR,
+    },
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, ClientOutcome, RoundTimeout},
     environment::Environment,
     local_node::{LocalChainInfoExt as _, LocalNodeClient, LocalNodeError},
@@ -845,13 +847,17 @@ impl<Env: Environment> Client<Env> {
         // Retrieve the list of newly received certificates from this validator.
         let mut remote_log = Vec::new();
         let mut offset = tracker;
+        let max_entries = std::env::var(CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_VAR)
+            .ok()
+            .and_then(|var| var.parse().ok())
+            .unwrap_or(CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_DEFAULT);
         loop {
             let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_n(offset);
             let info = remote_node.handle_chain_info_query(query).await?;
             let received_entries = info.requested_received_log.len();
             offset += received_entries as u64;
             remote_log.extend(info.requested_received_log);
-            if received_entries < CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES {
+            if received_entries < max_entries {
                 break;
             }
         }


### PR DESCRIPTION
## Motivation

The huge amount of entries in the `received_log` seems to be making it impossible to sync the old GoL chain on Testnet Conway.

## Proposal

Limit the number of returned entries in a single response. Client should request more entries with an increased offset until the number of returned entries is less than the limit (indicating that there are no more entries).

## Test Plan

CI; Manual testing on the testnet will show whether this fixes the syncing issue

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
