### PR TITLE
Improve `wallet show`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,17 +2277,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "comfy-table"
-version = "7.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
-dependencies = [
- "crossterm",
- "unicode-segmentation",
- "unicode-width 0.2.1",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2749,28 +2738,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags 2.9.1",
- "crossterm_winapi",
- "parking_lot",
- "rustix 0.38.44",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "crowd-funding"
@@ -5718,7 +5685,6 @@ dependencies = [
  "clap",
  "clap-markdown",
  "colored",
- "comfy-table",
  "convert_case",
  "counter",
  "counter-no-graphql",
@@ -10811,12 +10777,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11418,7 +11378,7 @@ dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
- "unicode-width 0.1.14",
+ "unicode-width",
  "wasm-encoder 0.217.1",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,6 @@ chrono = { version = "0.4.35", default-features = false }
 clap = { version = "4", features = ["cargo", "derive", "env"] }
 clap-markdown = "0.1.3"
 colored = "2.1.0"
-comfy-table = "7.1.0"
 console_error_panic_hook = "0.1.7"
 convert_case = "0.6.0"
 criterion = { version = "0.5.1", default-features = false }

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -751,6 +751,14 @@ impl ChainOrigin {
     pub fn is_child(&self) -> bool {
         matches!(self, ChainOrigin::Child { .. })
     }
+
+    /// Returns the root chain number, if this is a root chain.
+    pub fn root(&self) -> Option<u32> {
+        match self {
+            ChainOrigin::Root(i) => Some(*i),
+            ChainOrigin::Child { .. } => None,
+        }
+    }
 }
 
 /// A number identifying the configuration of the chain (aka the committee).

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -80,7 +80,6 @@ chrono = { workspace = true, features = ["clock"] }
 clap.workspace = true
 clap-markdown.workspace = true
 colored.workspace = true
-comfy-table.workspace = true
 convert_case.workspace = true
 current_platform = "0.2.0"
 custom_debug_derive.workspace = true

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -2355,7 +2355,6 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                 short,
                 owned,
             } => {
-                let start_time = Instant::now();
                 let wallet = options.wallet()?;
                 let chain_ids = if let Some(chain_id) = chain_id {
                     ensure!(!owned, "Cannot specify both --owned and a chain ID");
@@ -2372,7 +2371,6 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                 } else {
                     wallet::pretty_print(&wallet, chain_ids);
                 }
-                info!("Wallet shown in {} ms", start_time.elapsed().as_millis());
                 Ok(0)
             }
 

--- a/linera-service/src/wallet.rs
+++ b/linera-service/src/wallet.rs
@@ -16,7 +16,8 @@ pub fn pretty_print(wallet: &Wallet, chain_ids: impl IntoIterator<Item = ChainId
         return;
     }
 
-    println!("\n\x1b[1mWALLET CHAINS ({} total)\x1b[0m", total_chains);
+    let plural_s = if total_chains == 1 { "" } else { "s" };
+    println!("\n\x1b[1mWALLET ({total_chains} chain{plural_s} in total)\x1b[0m",);
 
     let mut chains = chain_ids
         .into_iter()

--- a/linera-service/src/wallet.rs
+++ b/linera-service/src/wallet.rs
@@ -1,72 +1,99 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use comfy_table::{
-    modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Attribute, Cell, Color, ContentArrangement,
-    Table,
+use linera_base::{
+    data_types::{ChainDescription, ChainOrigin},
+    identifiers::ChainId,
 };
-use linera_base::identifiers::ChainId;
 pub use linera_client::wallet::*;
 
 pub fn pretty_print(wallet: &Wallet, chain_ids: impl IntoIterator<Item = ChainId>) {
-    let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_header(vec![
-            Cell::new("Chain ID").add_attribute(Attribute::Bold),
-            Cell::new("Latest Block").add_attribute(Attribute::Bold),
-        ]);
+    let chain_ids: Vec<_> = chain_ids.into_iter().collect();
+    let total_chains = chain_ids.len();
 
-    for chain_id in chain_ids {
+    if total_chains == 0 {
+        println!("No chains in wallet.");
+        return;
+    }
+
+    println!("\n\x1b[1mWALLET CHAINS ({} total)\x1b[0m", total_chains);
+
+    let mut chains = chain_ids
+        .into_iter()
+        .map(|chain_id| ChainDetails::new(chain_id, wallet))
+        .collect::<Vec<_>>();
+    // Print first the default, then the admin chain, then other root chains, and finally the
+    // child chains.
+    chains.sort_unstable_by_key(|chain| {
+        let root_id = chain
+            .origin
+            .and_then(|origin| origin.root())
+            .unwrap_or(u32::MAX);
+        let chain_id = chain.user_chain.chain_id;
+        (!chain.is_default, !chain.is_admin, root_id, chain_id)
+    });
+    for chain in chains {
+        println!();
+        chain.print_paragraph();
+    }
+}
+
+struct ChainDetails<'a> {
+    is_default: bool,
+    is_admin: bool,
+    origin: Option<ChainOrigin>,
+    user_chain: &'a UserChain,
+}
+
+impl<'a> ChainDetails<'a> {
+    fn new(chain_id: ChainId, wallet: &'a Wallet) -> Self {
         let Some(user_chain) = wallet.chains.get(&chain_id) else {
             panic!("Chain {} not found.", chain_id);
         };
-        update_table_with_chain(
-            &mut table,
-            chain_id,
+        ChainDetails {
+            is_default: Some(chain_id) == wallet.default,
+            is_admin: chain_id == wallet.genesis_admin_chain(),
+            origin: wallet
+                .genesis_config()
+                .chains
+                .iter()
+                .find(|description| description.id() == chain_id)
+                .map(ChainDescription::origin),
             user_chain,
-            Some(chain_id) == wallet.default,
-        );
+        }
     }
-    println!("{}", table);
-}
 
-fn update_table_with_chain(
-    table: &mut Table,
-    chain_id: ChainId,
-    user_chain: &UserChain,
-    is_default_chain: bool,
-) {
-    let epoch = user_chain.epoch;
-    let chain_id_cell = if is_default_chain {
-        Cell::new(format!("{}", chain_id)).fg(Color::Green)
-    } else {
-        Cell::new(format!("{}", chain_id))
-    };
-    let epoch_str = match epoch {
-        None => "-".to_string(),
-        Some(epoch) => format!("{}", epoch),
-    };
-    let account_owner = user_chain.owner;
-    table.add_row(vec![
-        chain_id_cell,
-        Cell::new(format!(
-            r#"AccountOwner:       {}
-Block Hash:         {}
-Timestamp:          {}
-Next Block Height:  {}
-Epoch:              {}"#,
-            account_owner
-                .as_ref()
-                .map_or_else(|| "-".to_string(), |o| o.to_string()),
-            user_chain
-                .block_hash
-                .map_or_else(|| "-".to_string(), |bh| bh.to_string()),
-            user_chain.timestamp,
-            user_chain.next_block_height,
-            epoch_str
-        )),
-    ]);
+    fn print_paragraph(&self) {
+        let title = if self.is_admin {
+            "Admin Chain".to_string()
+        } else {
+            match self.origin {
+                Some(ChainOrigin::Root(i)) => format!("Root Chain {i}"),
+                _ => "Child Chain".to_string(),
+            }
+        };
+        let default_marker = if self.is_default { " [DEFAULT]" } else { "" };
+
+        // Print chain header in bold
+        println!("\x1b[1m{}{}\x1b[0m", title, default_marker);
+        println!("  Chain ID:     {}", self.user_chain.chain_id);
+        if let Some(owner) = &self.user_chain.owner {
+            println!("  Owner:        {owner}");
+        } else {
+            println!("  Owner:        No owner key");
+        }
+        println!("  Timestamp:    {}", self.user_chain.timestamp);
+        println!("  Blocks:       {}", self.user_chain.next_block_height);
+        if let Some(epoch) = self.user_chain.epoch {
+            println!("  Epoch:        {epoch}");
+        } else {
+            println!("  Epoch:        -");
+        }
+        if let Some(hash) = self.user_chain.block_hash {
+            println!("  Latest Block: {}", hash);
+        }
+        if self.user_chain.pending_proposal.is_some() {
+            println!("  Status:       ⚠ Pending proposal");
+        }
+    }
 }


### PR DESCRIPTION
## Motivation

It's hard to tell from `wallet show` which chain is the admin chain. The table layout uses a lot of horizontal space.

## Proposal

Improve the `wallet show` output:

```
WALLET (4 chains in total)

Child Chain [DEFAULT]
  Chain ID:     a08244c18c828b7b89289f7164428e0b861fb462042416f6c2cfb1f4b53c8621
  Owner:        0x86843df3f162b0a820724d37612ecde13c9a022d0cc96b765be127d34cec2d19
  Timestamp:    2025-09-24 12:54:53.051239
  Blocks:       0
  Epoch:        0

Admin Chain
  Chain ID:     82fc0ff002b793c66db0c57e657c05a30a98cd49d335f8125d0c3bdc4997ffa1
  Owner:        No owner key
  Timestamp:    2025-09-24 12:53:29.841442
  Blocks:       0
  Epoch:        0

Root Chain 1
  Chain ID:     0b67f224ab915776d170eeb7d497e8d1ed831126f22eaf9138de48e3c47c8639
  Owner:        No owner key
  Timestamp:    2025-09-24 12:55:04.030389
  Blocks:       2
  Epoch:        0
  Latest Block: f67e7ee881b6f9235f1a4cc6f2515d9ce4afccb1bd799f8780987901a581ac03

Child Chain
  Chain ID:     87c4ef0bfc8d6581529dc32c98d05ba99be9e9202f8f788f9c0c2a872c02fdf6
  Owner:        0x9010b58faf7b4908de3069aa7aa042ba4f2eb0de13724059960aaa5be33aa6a6
  Timestamp:    2025-09-24 12:55:04.030389
  Blocks:       0
  Epoch:        0
```

## Test Plan

* Discuss the new layout!
* CI
* I ran the README tests locally.

## Release Plan

- These changes _could_ be backported to `testnet_conway`, and
- released in a new SDK.

## Links

- Original attempt: https://github.com/linera-io/linera-protocol/pull/4541
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
