### PR TITLE
Rename `ensure_is_active` to make it clear that it modifies the chain.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -491,10 +491,7 @@ where
     }
 
     /// Initializes the chain if it is not active yet.
-    pub async fn initialize_if_inactive(
-        &mut self,
-        local_time: Timestamp,
-    ) -> Result<(), ChainError> {
+    pub async fn initialize_if_needed(&mut self, local_time: Timestamp) -> Result<(), ChainError> {
         // Initialize ourselves.
         if self
             .execution_state
@@ -609,7 +606,7 @@ where
             height: bundle.height,
         };
 
-        match self.initialize_if_inactive(local_time).await {
+        match self.initialize_if_needed(local_time).await {
             Ok(_) => (),
             // if the only issue was that we couldn't initialize the chain because of a
             // missing chain description blob, we might still want to update the inbox
@@ -907,7 +904,7 @@ where
             self.execution_state.context().extra().chain_id()
         );
 
-        self.initialize_if_inactive(local_time).await?;
+        self.initialize_if_needed(local_time).await?;
 
         let chain_timestamp = *self.execution_state.system.timestamp.get();
         ensure!(

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -192,7 +192,7 @@ async fn test_block_size_limit() -> anyhow::Result<()> {
 
     // Initialize the chain.
 
-    chain.initialize_if_inactive(time).await.unwrap();
+    chain.initialize_if_needed(time).await.unwrap();
 
     let valid_block = make_first_block(chain_id)
         .with_authenticated_signer(Some(owner))
@@ -294,7 +294,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
         .await?;
 
     // Initialize the chain, with a chain application.
-    chain.initialize_if_inactive(time).await?;
+    chain.initialize_if_needed(time).await?;
 
     // An operation that doesn't belong to the app isn't allowed.
     let invalid_block = make_first_block(chain_id).with_simple_transfer(chain_id, Amount::ONE);
@@ -715,7 +715,7 @@ async fn prepare_test_with_dummy_mock_application(
         .add_blobs(env.description_blobs())
         .await?;
 
-    chain.initialize_if_inactive(time).await?;
+    chain.initialize_if_needed(time).await?;
 
     // Create a mock application.
     let (app_description, contract_blob, service_blob) = env.make_app_description();

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -257,7 +257,7 @@ pub trait Storage: Sized {
         let mut chain = self.load_chain(id).await?;
         assert!(!chain.is_active(), "Attempting to create a chain twice");
         let current_time = self.clock().current_time();
-        chain.initialize_if_inactive(current_time).await?;
+        chain.initialize_if_needed(current_time).await?;
         chain.save().await?;
         Ok(())
     }


### PR DESCRIPTION
## Motivation

A function shouldn't be called `ensure_` if it modifies the state.

## Proposal

Rename them.

In a follow-up PR, we should investigate whether we really need to `save()` in all these cases.

## Test Plan

(Only renaming.)

## Release Plan

- These changes could be backported to `testnet_conway`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
