### PR TITLE
Use `thread_rng` instead of `from_entropy`.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -57,11 +57,7 @@ use linera_execution::{
 };
 use linera_storage::{Clock as _, ResultReadCertificates, Storage as _};
 use linera_views::ViewError;
-use rand::{
-    distributions::{Distribution, WeightedIndex},
-    rngs::StdRng,
-    SeedableRng,
-};
+use rand::distributions::{Distribution, WeightedIndex};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::{mpsc, OwnedRwLockReadGuard};
@@ -324,13 +320,12 @@ impl<Env: Environment> Client<Env> {
     fn weighted_select(
         remaining_validators: &mut Vec<RemoteNode<Env::ValidatorNode>>,
         remaining_weights: &mut Vec<u64>,
-        rng: &mut StdRng,
     ) -> Option<RemoteNode<Env::ValidatorNode>> {
         if remaining_weights.is_empty() {
             return None;
         }
         let dist = WeightedIndex::new(remaining_weights.clone()).unwrap();
-        let idx = dist.sample(rng);
+        let idx = dist.sample(&mut rand::thread_rng());
         remaining_weights.remove(idx);
         Some(remaining_validators.remove(idx))
     }
@@ -355,10 +350,9 @@ impl<Env: Environment> Client<Env> {
                 validator_state.votes
             })
             .collect::<Vec<_>>();
-        let mut rng: StdRng = StdRng::from_entropy();
 
         while let Some(remote_node) =
-            Self::weighted_select(&mut remaining_validators, &mut remaining_weights, &mut rng)
+            Self::weighted_select(&mut remaining_validators, &mut remaining_weights)
         {
             if target_next_block_height <= info.next_block_height {
                 return Ok(info);


### PR DESCRIPTION
## Motivation

[`from_entropy` uses `getrandom` and is slower than `thread_rng`](https://docs.rs/rand/0.8.5/rand/trait.SeedableRng.html#method.from_entropy).

## Proposal

Use `thread_rng` to select validators: This does not need to be high-quality randomness.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Original PR: #4505
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
