### PR TITLE
 Rename `ensure_is_active` to make it clear that it modifies the chain. #4646 

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -487,8 +487,8 @@ where
         self.execution_state.system.is_active()
     }
 
-    /// Invariant for the states of active chains.
-    pub async fn ensure_is_active(&mut self, local_time: Timestamp) -> Result<(), ChainError> {
+    /// Initializes the chain if it is not active yet.
+    pub async fn initialize_if_needed(&mut self, local_time: Timestamp) -> Result<(), ChainError> {
         // Initialize ourselves.
         if self
             .execution_state
@@ -497,7 +497,7 @@ where
             .await
             .with_execution_context(ChainExecutionContext::Block)?
         {
-            // the chain was already initialized
+            // The chain was already initialized.
             return Ok(());
         }
         // Recompute the state hash.
@@ -603,7 +603,7 @@ where
             height: bundle.height,
         };
 
-        match self.ensure_is_active(local_time).await {
+        match self.initialize_if_needed(local_time).await {
             Ok(_) => (),
             // if the only issue was that we couldn't initialize the chain because of a
             // missing chain description blob, we might still want to update the inbox
@@ -901,7 +901,7 @@ where
             self.execution_state.context().extra().chain_id()
         );
 
-        self.ensure_is_active(local_time).await?;
+        self.initialize_if_needed(local_time).await?;
 
         let chain_timestamp = *self.execution_state.system.timestamp.get();
         ensure!(

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -192,7 +192,7 @@ async fn test_block_size_limit() -> anyhow::Result<()> {
 
     // Initialize the chain.
 
-    chain.ensure_is_active(time).await.unwrap();
+    chain.initialize_if_needed(time).await.unwrap();
 
     let valid_block = make_first_block(chain_id)
         .with_authenticated_signer(Some(owner))
@@ -294,7 +294,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
         .await?;
 
     // Initialize the chain, with a chain application.
-    chain.ensure_is_active(time).await?;
+    chain.initialize_if_needed(time).await?;
 
     // An operation that doesn't belong to the app isn't allowed.
     let invalid_block = make_first_block(chain_id).with_simple_transfer(chain_id, Amount::ONE);
@@ -715,7 +715,7 @@ async fn prepare_test_with_dummy_mock_application(
         .add_blobs(env.description_blobs())
         .await?;
 
-    chain.ensure_is_active(time).await?;
+    chain.initialize_if_needed(time).await?;
 
     // Create a mock application.
     let (app_description, contract_blob, service_blob) = env.make_app_description();

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -530,7 +530,7 @@ where
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         // Check that the chain is active and ready for this timeout.
         // Verify the certificate. Returns a catch-all error to make client code more robust.
-        self.ensure_is_active().await?;
+        self.initialize_and_save_if_needed().await?;
         let (chain_epoch, committee) = self.chain.current_committee()?;
         ensure!(
             certificate.inner().epoch() == chain_epoch,
@@ -624,7 +624,7 @@ where
         let height = header.height;
         // Check that the chain is active and ready for this validated block.
         // Verify the certificate. Returns a catch-all error to make client code more robust.
-        self.ensure_is_active().await?;
+        self.initialize_and_save_if_needed().await?;
         let (epoch, committee) = self.chain.current_committee()?;
         check_block_epoch(epoch, header.chain_id, header.epoch)?;
         certificate.check(committee)?;
@@ -783,7 +783,7 @@ where
         // If we got here, `height` is equal to `tip.next_block_height` and the block is
         // properly chained. Verify that the chain is active and that the epoch we used for
         // verifying the certificate is actually the active one on the chain.
-        self.ensure_is_active().await?;
+        self.initialize_and_save_if_needed().await?;
         let (epoch, _) = self.chain.current_committee()?;
         check_block_epoch(epoch, chain_id, block.header.epoch)?;
 
@@ -799,7 +799,7 @@ where
         // because we already wrote the blob state above, so the client can now upload the
         // blob, which will get accepted, and retry.
         if height == BlockHeight::ZERO {
-            self.ensure_is_active().await?;
+            self.initialize_and_save_if_needed().await?;
             let (epoch, _) = self.chain.current_committee()?;
             check_block_epoch(epoch, chain_id, block.header.epoch)?;
         }
@@ -1104,7 +1104,7 @@ where
         &mut self,
         height: BlockHeight,
     ) -> Result<Option<ConfirmedBlockCertificate>, WorkerError> {
-        self.ensure_is_active().await?;
+        self.initialize_and_save_if_needed().await?;
         let certificate_hash = match self.chain.confirmed_log.get(height.try_into()?).await? {
             Some(hash) => hash,
             None => return Ok(None),
@@ -1126,7 +1126,7 @@ where
         &mut self,
         query: Query,
     ) -> Result<QueryOutcome, WorkerError> {
-        self.ensure_is_active().await?;
+        self.initialize_and_save_if_needed().await?;
         let local_time = self.storage.clock().current_time();
         let outcome = self
             .chain
@@ -1144,7 +1144,7 @@ where
         &mut self,
         application_id: ApplicationId,
     ) -> Result<ApplicationDescription, WorkerError> {
-        self.ensure_is_active().await?;
+        self.initialize_and_save_if_needed().await?;
         let response = self.chain.describe_application(application_id).await?;
         Ok(response)
     }
@@ -1160,7 +1160,7 @@ where
         round: Option<u32>,
         published_blobs: &[Blob],
     ) -> Result<(Block, ChainInfoResponse), WorkerError> {
-        self.ensure_is_active().await?;
+        self.initialize_and_save_if_needed().await?;
         let local_time = self.storage.clock().current_time();
         let signer = block.authenticated_signer;
         let (_, committee) = self.chain.current_committee()?;
@@ -1194,7 +1194,7 @@ where
         &mut self,
         proposal: BlockProposal,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
-        self.ensure_is_active().await?;
+        self.initialize_and_save_if_needed().await?;
         proposal
             .check_invariants()
             .map_err(|msg| WorkerError::InvalidBlockProposal(msg.to_string()))?;
@@ -1340,7 +1340,7 @@ where
         &mut self,
         query: ChainInfoQuery,
     ) -> Result<ChainInfoResponse, WorkerError> {
-        self.ensure_is_active().await?;
+        self.initialize_and_save_if_needed().await?;
         let chain = &self.chain;
         let mut info = ChainInfo::from(chain);
         if query.request_committees {
@@ -1428,11 +1428,11 @@ where
         Ok(outcome)
     }
 
-    /// Ensures that the current chain is active, returning an error otherwise.
-    async fn ensure_is_active(&mut self) -> Result<(), WorkerError> {
+    /// Initializes and saves the current chain if it is not active yet.
+    async fn initialize_and_save_if_needed(&mut self) -> Result<(), WorkerError> {
         if !self.knows_chain_is_active {
             let local_time = self.storage.clock().current_time();
-            self.chain.ensure_is_active(local_time).await?;
+            self.chain.initialize_if_needed(local_time).await?;
             self.save().await?;
             self.knows_chain_is_active = true;
         }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -257,7 +257,7 @@ pub trait Storage: Sized {
         let mut chain = self.load_chain(id).await?;
         assert!(!chain.is_active(), "Attempting to create a chain twice");
         let current_time = self.clock().current_time();
-        chain.ensure_is_active(current_time).await?;
+        chain.initialize_if_needed(current_time).await?;
         chain.save().await?;
         Ok(())
     }


### PR DESCRIPTION
Backport of https://github.com/linera-io/linera-protocol/pull/4646.

## Motivation

A function shouldn't be called `ensure_` if it modifies the state.

## Proposal

Rename them.

In a follow-up PR, we should investigate whether we really need to `save()` in all these cases.

## Test Plan

(Only renaming.)

## Release Plan

- Nothing to do.

## Links

- Backport of #4646
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
