### PR TITLE
Track the admin chain by default. (#4641)

### DIFF
--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -45,7 +45,7 @@ impl Wallet {
     }
 
     pub fn insert(&mut self, chain: UserChain) {
-        if self.default.is_none() {
+        if self.default.is_none() && chain.owner.is_some() {
             self.default = Some(chain.chain_id);
         }
 

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1672,7 +1672,7 @@ impl Runnable for Job {
                 let Some(network_description) = storage.read_network_description().await? else {
                     anyhow::bail!("Missing network description");
                 };
-                let context = ClientContext::new(
+                let mut context = ClientContext::new(
                     storage,
                     options.context_options.clone(),
                     wallet,
@@ -1684,6 +1684,7 @@ impl Runnable for Job {
                 chain_client
                     .synchronize_chain_state_from_committee(committee)
                     .await?;
+                context.update_wallet_from_client(&chain_client).await?;
             }
 
             Wallet(WalletCommand::FollowChain { chain_id, sync }) => {

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -1928,7 +1928,7 @@ async fn test_wasm_end_to_end_allowances_fungible(config: impl LineraNetConfig) 
     let client3 = net.make_client().await;
     client3.wallet_init(None).await?;
 
-    let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
+    let chain1 = *client1.load_wallet()?.owned_chain_ids().first().unwrap();
 
     // Generate keys for all clients.
     let owner1 = client1.keygen().await?;
@@ -2254,7 +2254,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     // Get a chain different than the default
     let chain2 = client1
         .load_wallet()?
-        .chain_ids()
+        .owned_chain_ids()
         .into_iter()
         .find(|chain_id| chain_id != &chain1)
         .expect("Failed to obtain a chain ID from the wallet");
@@ -3809,7 +3809,7 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) -> Resul
     client2.wallet_init(None).await?;
 
     // Get some chain owned by Client 1.
-    let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
+    let chain1 = *client1.load_wallet()?.owned_chain_ids().first().unwrap();
 
     // Generate a key for Client 2.
     let owner2 = client2.keygen().await?;
@@ -3854,7 +3854,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) ->
     let client2 = net.make_client().await;
     client2.wallet_init(None).await?;
 
-    let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
+    let chain1 = *client1.load_wallet()?.owned_chain_ids().first().unwrap();
 
     // Generate keys for both clients.
     let owner1 = client1.keygen().await?;
@@ -3968,7 +3968,7 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     let client3 = net.make_client().await;
     client3.wallet_init(None).await?;
 
-    let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
+    let chain1 = *client1.load_wallet()?.owned_chain_ids().first().unwrap();
 
     // Generate keys for client 2.
     let owner2 = client2.keygen().await?;
@@ -4358,7 +4358,7 @@ async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> 
     let (mut net, client1) = config.instantiate().await?;
     let client2 = net.make_client().await;
     client2.wallet_init(None).await?;
-    let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
+    let chain1 = *client1.load_wallet()?.owned_chain_ids().first().unwrap();
 
     // Open a chain owned by both clients, with only single-leader rounds.
     let owner1 = client1.keygen().await?;

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -509,7 +509,7 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetConfig) -> Re
 
     let (chain, chain1) = {
         let wallet = client1.load_wallet()?;
-        let chains = wallet.chain_ids();
+        let chains = wallet.owned_chain_ids();
         (chains[0], chains[1])
     };
 
@@ -576,7 +576,7 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetConfig) -> Result<(
     let (mut net, client) = config.instantiate().await?;
     let (chain_id, chain1) = {
         let wallet = client.load_wallet()?;
-        let chains = wallet.chain_ids();
+        let chains = wallet.owned_chain_ids();
         (chains[0], chains[1])
     };
     let account = Account::chain(chain_id);


### PR DESCRIPTION
Backport of https://github.com/linera-io/linera-protocol/pull/4641.

## Motivation

It's useful to see the admin chain in the wallet, even for non-admin users.

## Proposal

Add the admin chain on `wallet init`.

Do not make chains the default unless we own them.

## Test Plan

CI
I also ran the README tests locally.

## Release Plan

- These changes _could_ be backported to the latest `testnet` branch, then
    - be released in a new SDK.

## Links

- PR on main: https://github.com/linera-io/linera-protocol/pull/4641
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
