### PR TITLE
Forbid anonymous enum variants in `GraphQLMutationRoot`.

### DIFF
--- a/linera-sdk-derive/src/lib.rs
+++ b/linera-sdk-derive/src/lib.rs
@@ -59,7 +59,7 @@ fn generate_mutation_root_code(input: ItemEnum, crate_root: &str) -> TokenStream
             }
             Fields::Unnamed(_) => {
                 return syn::Error::new_spanned(
-                    &variant_name,
+                    variant_name,
                     "Unnamed fields are not supported in GraphQL mutation root derivation",
                 )
                 .to_compile_error();


### PR DESCRIPTION
## Motivation

The `MutationRoot` implementation can be difficult to write down (but we have 4 examples doing that in the `examples` directory). Therefore, we have a trait `GraphQLMutationRoot` and a derive macro that allows implementing the `MutationRoot` more easily.

That macro represents the choices that we think are the right ones for smart contract writers. For example, we do not allow structs by design. It has recently emerged that `field0` is not a favored design. Therefore, it makes full sense that the macro should not allow it.

Note that we do not force programmers to use the `GraphQLMutationRoot`. We also do not force them to use `GraphQL`. However, the `GraphQLMutationRoot` that we provide should represent the choices that we think are the right ones.

## Proposal

Explicitly, forbid that check.

## Test Plan

The CI. 
Added a test for testing that this scenario is not allowed.

## Release Plan

Safe to backport to the TestNet / DevNet.

## Links

None.