### PR TITLE
Used `HashedMapView` for the `stream_events_count`.

### DIFF
--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -6,13 +6,12 @@ use std::{collections::BTreeMap, vec};
 use futures::{FutureExt, StreamExt};
 use linera_base::{
     data_types::{BlobContent, BlockHeight, StreamUpdate},
-    identifiers::{AccountOwner, BlobId, StreamId},
+    identifiers::{AccountOwner, BlobId},
     time::Instant,
 };
 use linera_views::{
     context::Context,
     key_value_store_view::KeyValueStoreView,
-    map_view::HashedMapView,
     reentrant_collection_view::HashedReentrantCollectionView,
     views::{ClonableView, ReplaceContext, View},
 };
@@ -43,8 +42,6 @@ pub struct ExecutionStateView<C> {
     pub system: SystemExecutionStateView<C>,
     /// User applications.
     pub users: HashedReentrantCollectionView<C, ApplicationId, KeyValueStoreView<C>>,
-    /// The number of events in the streams that this chain is writing to.
-    pub stream_event_counts: HashedMapView<C, StreamId, u32>,
 }
 
 impl<C: Context, C2: Context> ReplaceContext<C2> for ExecutionStateView<C> {
@@ -57,7 +54,6 @@ impl<C: Context, C2: Context> ReplaceContext<C2> for ExecutionStateView<C> {
         ExecutionStateView {
             system: self.system.with_context(ctx.clone()).await,
             users: self.users.with_context(ctx.clone()).await,
-            stream_event_counts: self.stream_event_counts.with_context(ctx.clone()).await,
         }
     }
 }

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -488,6 +488,7 @@ where
             } => {
                 let count = self
                     .state
+                    .system
                     .stream_event_counts
                     .get_mut_or_default(&stream_id)
                     .await?;

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -88,6 +88,8 @@ pub struct SystemExecutionStateView<C> {
     pub used_blobs: HashedSetView<C, BlobId>,
     /// The event stream subscriptions of applications on this chain.
     pub event_subscriptions: HashedMapView<C, (ChainId, StreamId), EventSubscriptions>,
+    /// The number of events in the streams that this chain is writing to.
+    pub stream_event_counts: HashedMapView<C, StreamId, u32>,
 }
 
 impl<C: Context, C2: Context> ReplaceContext<C2> for SystemExecutionStateView<C> {
@@ -110,6 +112,7 @@ impl<C: Context, C2: Context> ReplaceContext<C2> for SystemExecutionStateView<C>
             application_permissions: self.application_permissions.with_context(ctx.clone()).await,
             used_blobs: self.used_blobs.with_context(ctx.clone()).await,
             event_subscriptions: self.event_subscriptions.with_context(ctx.clone()).await,
+            stream_event_counts: self.stream_event_counts.with_context(ctx.clone()).await,
         }
     }
 }

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -341,6 +341,7 @@ impl ActiveChain {
                         .await
                         .expect("Failed to query chain state view")
                         .execution_state
+                        .system
                         .stream_event_counts
                         .get(&stream_id)
                         .await


### PR DESCRIPTION
## Motivation

For unclear reasons, the `stream_event_counts` of `MapView` is not using memoization.

## Proposal

Use `HashedMapView`.

## Test Plan

The CI.

## Release Plan

This is a significant breaking change for TestNet/DevNet.

## Links

None.