### PR TITLE
Fix scylla dep to 1.1; doesn't build with later versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,7 @@ revm-state = { version = "4.0.1", default-features = false, features = [
 ] }
 rocksdb = "0.21.0"
 ruzstd = "0.8.1"
-scylla = "1.1.0"
+scylla = "~1.1.0"
 semver = "1.0.22"
 serde = { version = "1.0.197", features = ["derive"] }
 serde-command-opts = "0.1.1"


### PR DESCRIPTION
## Motivation

`cargo update && cargo build -p linera-views --features scylladb` currently fails, because some types in `scylla` are `Sync` in 1.1 but not 1.2 and later. This breaks `cargo install` in some cases.

Thanks to @kikakkz for pointing this out!

## Proposal

Fix the dependency to 1.1.

## Test Plan

I did `cargo update` with this change and everything compiled without errors.

(In a separate PR, we could commit the updated lock file, too.)

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a new SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
