### PR TITLE
Add an option to limit how many tasks are joined concurrently.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -169,6 +169,9 @@ Client implementation and command-line tool for the Linera blockchain
 * `--certificate-download-batch-size <CERTIFICATE_DOWNLOAD_BATCH_SIZE>` — Maximum number of certificates that we download at a time from one validator when synchronizing one of our chains
 
   Default value: `500`
+* `--max-joined-tasks <MAX_JOINED_TASKS>` — Maximum number of tasks that can are joined concurrently in the client
+
+  Default value: `100`
 * `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
 * `--storage-max-concurrent-queries <STORAGE_MAX_CONCURRENT_QUERIES>` — The maximal number of simultaneous queries to the database
 * `--storage-max-stream-queries <STORAGE_MAX_STREAM_QUERIES>` — The maximal number of simultaneous stream queries to the database

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -141,6 +141,10 @@ pub struct ClientContextOptions {
         default_value_t = DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
     )]
     pub certificate_download_batch_size: u64,
+
+    /// Maximum number of tasks that can are joined concurrently in the client.
+    #[arg(long, default_value = "100")]
+    pub max_joined_tasks: usize,
 }
 
 impl ClientContextOptions {
@@ -159,6 +163,7 @@ impl ClientContextOptions {
             grace_period: self.grace_period,
             blob_download_timeout: self.blob_download_timeout,
             certificate_download_batch_size: self.certificate_download_batch_size,
+            max_joined_tasks: self.max_joined_tasks,
         }
     }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -14,7 +14,7 @@ use chain_client_state::ChainClientState;
 use custom_debug_derive::Debug;
 use futures::{
     future::{self, Either, FusedFuture, Future},
-    stream::{self, AbortHandle, FusedStream, FuturesUnordered, StreamExt},
+    stream::{self, AbortHandle, FusedStream, FuturesUnordered, StreamExt, TryStreamExt},
 };
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
@@ -882,10 +882,8 @@ impl<Env: Environment> Client<Env> {
             },
         ))
         .buffer_unordered(self.options.max_joined_tasks)
-        .collect::<Vec<_>>()
-        .await
-        .into_iter()
-        .collect::<Result<Vec<_>, _>>()?
+        .try_collect::<Vec<_>>()
+        .await?
         .into_iter()
         .flatten()
         .collect::<Vec<_>>();
@@ -1888,10 +1886,8 @@ impl<Env: Environment> ChainClient<Env> {
             });
         let updates = futures::stream::iter(futures)
             .buffer_unordered(self.options.max_joined_tasks)
-            .collect::<Vec<_>>()
-            .await
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?
+            .try_collect::<Vec<_>>()
+            .await?
             .into_iter()
             .flatten()
             .collect::<Vec<_>>();

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -14,7 +14,7 @@ use chain_client_state::ChainClientState;
 use custom_debug_derive::Debug;
 use futures::{
     future::{self, Either, FusedFuture, Future},
-    stream::{self, AbortHandle, FusedStream, FuturesUnordered, StreamExt},
+    stream::{self, AbortHandle, FusedStream, FuturesUnordered, StreamExt, TryStreamExt},
 };
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
@@ -450,10 +450,13 @@ impl<Env: Environment> Client<Env> {
             let mut result = self.handle_certificate(certificate.clone()).await;
 
             if let Err(LocalNodeError::BlobsNotFound(blob_ids)) = &result {
-                let blobs = future::join_all(blob_ids.iter().map(|blob_id| async move {
-                    remote_node.try_download_blob(*blob_id).await.unwrap()
-                }))
-                .await;
+                let blobs =
+                    futures::stream::iter(blob_ids.iter().copied().map(|blob_id| async move {
+                        remote_node.try_download_blob(blob_id).await.unwrap()
+                    }))
+                    .buffer_unordered(self.options.max_joined_tasks)
+                    .collect::<Vec<_>>()
+                    .await;
                 self.local_node.store_blobs(&blobs).await?;
                 result = self.handle_certificate(certificate.clone()).await;
             }
@@ -853,7 +856,7 @@ impl<Env: Environment> Client<Env> {
         // put all their sent messages into the inbox.
         let mut other_sender_chains = Vec::new();
 
-        let certificates = future::try_join_all(remote_heights.into_iter().filter_map(
+        let certificates = stream::iter(remote_heights.into_iter().filter_map(
             |(sender_chain_id, remote_heights)| {
                 let local_next = *local_next_heights.get(&sender_chain_id)?;
                 if let Ok(height) = local_next.try_sub_one() {
@@ -878,6 +881,8 @@ impl<Env: Environment> Client<Env> {
                 })
             },
         ))
+        .buffer_unordered(self.options.max_joined_tasks)
+        .try_collect::<Vec<_>>()
         .await?
         .into_iter()
         .flatten()
@@ -1196,7 +1201,7 @@ impl<Env: Environment> Client<Env> {
         remote_nodes: &[RemoteNode<Env::ValidatorNode>],
     ) -> Result<Vec<Blob>, ChainClientError> {
         let timeout = self.options.blob_download_timeout;
-        future::try_join_all(blob_ids.into_iter().map(|blob_id| async move {
+        stream::iter(blob_ids.into_iter().map(|blob_id| async move {
             let mut stream = remote_nodes
                 .iter()
                 .zip(0..)
@@ -1226,6 +1231,8 @@ impl<Env: Environment> Client<Env> {
             }
             Err(LocalNodeError::BlobsNotFound(vec![blob_id]).into())
         }))
+        .buffer_unordered(self.options.max_joined_tasks)
+        .try_collect()
         .await
     }
 
@@ -1447,6 +1454,8 @@ pub struct ChainClientOptions {
     /// Maximum number of certificates that we download at a time from one validator when
     /// synchronizing one of our chains.
     pub certificate_download_batch_size: u64,
+    /// Maximum number of tasks that can be joined concurrently using buffer_unordered.
+    pub max_joined_tasks: usize,
 }
 
 pub static DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE: u64 = 500;
@@ -1463,6 +1472,7 @@ impl ChainClientOptions {
             grace_period: DEFAULT_GRACE_PERIOD,
             blob_download_timeout: Duration::from_secs(1),
             certificate_download_batch_size: DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
+            max_joined_tasks: 100,
         }
     }
 }
@@ -1872,7 +1882,9 @@ impl<Env: Environment> ChainClient<Env> {
                     }
                 }
             });
-        let updates = future::try_join_all(futures)
+        let updates = futures::stream::iter(futures)
+            .buffer_unordered(self.options.max_joined_tasks)
+            .try_collect::<Vec<_>>()
             .await?
             .into_iter()
             .flatten()
@@ -2234,11 +2246,13 @@ impl<Env: Environment> ChainClient<Env> {
             .chain(iter::once(self.client.admin_id))
             .filter(|chain_id| *chain_id != self.chain_id)
             .collect::<BTreeSet<_>>();
-        future::try_join_all(
+        stream::iter(
             chain_ids
                 .into_iter()
                 .map(|chain_id| self.client.synchronize_chain_state(chain_id)),
         )
+        .buffer_unordered(self.options.max_joined_tasks)
+        .try_collect::<Vec<_>>()
         .await?;
         Ok(())
     }

--- a/web/@linera/client/src/lib.rs
+++ b/web/@linera/client/src/lib.rs
@@ -88,6 +88,7 @@ pub const OPTIONS: ClientContextOptions = ClientContextOptions {
     certificate_download_batch_size: linera_core::client::DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
     chain_worker_ttl: Duration::from_secs(30),
     grace_period: linera_core::DEFAULT_GRACE_PERIOD,
+    max_joined_tasks: 100,
 
     // TODO(linera-protocol#2944): separate these out from the
     // `ClientOptions` struct, since they apply only to the CLI/native


### PR DESCRIPTION
## Motivation

Joining an unbounded number of concurrent tasks can cause spikes in memory usage.

## Proposal

Replace all the `[try_]join_all` calls in the client module with `buffer_unordered`, with a configurable limit.

## Test Plan

CI

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a new SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
