### PR TITLE
Limit remote log conway (with CLI option)

### DIFF
--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -27,6 +27,8 @@ pub struct ChainWorkerConfig {
     /// TTL for sender chains.
     // We don't want them to keep in memory forever since usually they're short-lived.
     pub sender_chain_ttl: Duration,
+    /// Override the default size to truncate receive log entries in chain info responses.
+    pub override_chain_info_max_received_log_entries: Option<usize>,
 }
 
 impl ChainWorkerConfig {

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -14,5 +14,5 @@ pub(crate) use self::state::CrossChainUpdateHelper;
 pub(crate) use self::{
     actor::{ChainWorkerActor, ChainWorkerRequest},
     config::ChainWorkerConfig,
-    state::BlockOutcome,
+    state::{BlockOutcome, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES},
 };

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -14,5 +14,8 @@ pub(crate) use self::state::CrossChainUpdateHelper;
 pub(crate) use self::{
     actor::{ChainWorkerActor, ChainWorkerRequest},
     config::ChainWorkerConfig,
-    state::{BlockOutcome, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES},
+    state::{
+        BlockOutcome, CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_DEFAULT,
+        CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_VAR,
+    },
 };

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -14,8 +14,5 @@ pub(crate) use self::state::CrossChainUpdateHelper;
 pub(crate) use self::{
     actor::{ChainWorkerActor, ChainWorkerRequest},
     config::ChainWorkerConfig,
-    state::{
-        BlockOutcome, CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_DEFAULT,
-        CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_VAR,
-    },
+    state::{BlockOutcome, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES},
 };

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -14,5 +14,5 @@ pub(crate) use self::state::CrossChainUpdateHelper;
 pub(crate) use self::{
     actor::{ChainWorkerActor, ChainWorkerRequest},
     config::ChainWorkerConfig,
-    state::{BlockOutcome, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES},
+    state::BlockOutcome,
 };

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -50,7 +50,7 @@ use crate::{
 
 /// The maximum number of entries in a `received_log` included in a `ChainInfo` response.
 // TODO(#4638): Revisit the number.
-pub const CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES: usize = 1000;
+pub const CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES: usize = 50_000;
 
 /// The state of the chain worker.
 pub struct ChainWorkerState<StorageClient>

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -50,9 +50,7 @@ use crate::{
 
 /// The maximum number of entries in a `received_log` included in a `ChainInfo` response.
 // TODO(#4638): Revisit the number.
-pub const CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_DEFAULT: usize = 1000;
-pub const CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_VAR: &str =
-    "LINERA_CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES";
+pub const CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES: usize = 50_000;
 
 /// The state of the chain worker.
 pub struct ChainWorkerState<StorageClient>
@@ -1413,11 +1411,8 @@ where
         info.requested_sent_certificate_hashes = hashes;
         if let Some(start) = query.request_received_log_excluding_first_n {
             let start = usize::try_from(start).map_err(|_| ArithmeticError::Overflow)?;
-            let max_entries = std::env::var(CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_VAR)
-                .ok()
-                .and_then(|var| var.parse().ok())
-                .unwrap_or(CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_DEFAULT);
-            let end = (start.saturating_add(max_entries)).min(chain.received_log.count());
+            let end = (start.saturating_add(CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES))
+                .min(chain.received_log.count());
             info.requested_received_log = chain.received_log.read(start..end).await?;
         }
         if query.request_manager_values {

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -48,6 +48,10 @@ use crate::{
     worker::{NetworkActions, Notification, Reason, WorkerError},
 };
 
+/// The maximum number of entries in a `received_log` included in a `ChainInfo` response.
+// TODO(#4638): Revisit the number.
+pub const CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES: usize = 1000;
+
 /// The state of the chain worker.
 pub struct ChainWorkerState<StorageClient>
 where
@@ -1407,7 +1411,9 @@ where
         info.requested_sent_certificate_hashes = hashes;
         if let Some(start) = query.request_received_log_excluding_first_n {
             let start = usize::try_from(start).map_err(|_| ArithmeticError::Overflow)?;
-            info.requested_received_log = chain.received_log.read(start..).await?;
+            let end = (start.saturating_add(CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES))
+                .min(chain.received_log.count());
+            info.requested_received_log = chain.received_log.read(start..end).await?;
         }
         if query.request_manager_values {
             info.manager.add_values(&chain.manager);

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -50,7 +50,9 @@ use crate::{
 
 /// The maximum number of entries in a `received_log` included in a `ChainInfo` response.
 // TODO(#4638): Revisit the number.
-pub const CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES: usize = 50_000;
+pub const CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_DEFAULT: usize = 1000;
+pub const CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_VAR: &str =
+    "LINERA_CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES";
 
 /// The state of the chain worker.
 pub struct ChainWorkerState<StorageClient>
@@ -1411,8 +1413,11 @@ where
         info.requested_sent_certificate_hashes = hashes;
         if let Some(start) = query.request_received_log_excluding_first_n {
             let start = usize::try_from(start).map_err(|_| ArithmeticError::Overflow)?;
-            let end = (start.saturating_add(CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES))
-                .min(chain.received_log.count());
+            let max_entries = std::env::var(CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_VAR)
+                .ok()
+                .and_then(|var| var.parse().ok())
+                .unwrap_or(CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_DEFAULT);
+            let end = (start.saturating_add(max_entries)).min(chain.received_log.count());
             info.requested_received_log = chain.received_log.read(start..end).await?;
         }
         if query.request_manager_values {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -64,7 +64,9 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, info, instrument, warn, Instrument as _};
 
 use crate::{
-    chain_worker::CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
+    chain_worker::{
+        CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_DEFAULT, CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_VAR,
+    },
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, ClientOutcome, RoundTimeout},
     environment::Environment,
     local_node::{LocalChainInfoExt as _, LocalNodeClient, LocalNodeError},
@@ -763,13 +765,17 @@ impl<Env: Environment> Client<Env> {
         // Retrieve the list of newly received certificates from this validator.
         let mut remote_log = Vec::new();
         let mut offset = tracker;
+        let max_entries = std::env::var(CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_VAR)
+            .ok()
+            .and_then(|var| var.parse().ok())
+            .unwrap_or(CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_DEFAULT);
         loop {
             let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_n(offset);
             let info = remote_node.handle_chain_info_query(query).await?;
             let received_entries = info.requested_received_log.len();
             offset += received_entries as u64;
             remote_log.extend(info.requested_received_log);
-            if received_entries < CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES {
+            if received_entries < max_entries {
                 break;
             }
         }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -64,7 +64,6 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, info, instrument, warn, Instrument as _};
 
 use crate::{
-    chain_worker::CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, ClientOutcome, RoundTimeout},
     environment::Environment,
     local_node::{LocalChainInfoExt as _, LocalNodeClient, LocalNodeError},
@@ -76,6 +75,7 @@ use crate::{
     remote_node::RemoteNode,
     updater::{communicate_with_quorum, CommunicateAction, CommunicationError, ValidatorUpdater},
     worker::{Notification, ProcessableCertificate, Reason, WorkerError, WorkerState},
+    CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
 
 mod chain_client_state;

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -64,6 +64,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, info, instrument, warn, Instrument as _};
 
 use crate::{
+    chain_worker::CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, ClientOutcome, RoundTimeout},
     environment::Environment,
     local_node::{LocalChainInfoExt as _, LocalNodeClient, LocalNodeError},
@@ -760,9 +761,18 @@ impl<Env: Environment> Client<Env> {
         let (max_epoch, committees) = self.admin_committees().await?;
 
         // Retrieve the list of newly received certificates from this validator.
-        let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_n(tracker);
-        let info = remote_node.handle_chain_info_query(query).await?;
-        let remote_log = info.requested_received_log;
+        let mut remote_log = Vec::new();
+        let mut offset = tracker;
+        loop {
+            let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_n(offset);
+            let info = remote_node.handle_chain_info_query(query).await?;
+            let received_entries = info.requested_received_log.len();
+            offset += received_entries as u64;
+            remote_log.extend(info.requested_received_log);
+            if received_entries < CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES {
+                break;
+            }
+        }
         let remote_heights = Self::heights_per_chain(&remote_log);
 
         // Obtain the next block height we need in the local node, for each chain.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -64,9 +64,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, info, instrument, warn, Instrument as _};
 
 use crate::{
-    chain_worker::{
-        CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_DEFAULT, CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_VAR,
-    },
+    chain_worker::CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, ClientOutcome, RoundTimeout},
     environment::Environment,
     local_node::{LocalChainInfoExt as _, LocalNodeClient, LocalNodeError},
@@ -765,17 +763,13 @@ impl<Env: Environment> Client<Env> {
         // Retrieve the list of newly received certificates from this validator.
         let mut remote_log = Vec::new();
         let mut offset = tracker;
-        let max_entries = std::env::var(CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_VAR)
-            .ok()
-            .and_then(|var| var.parse().ok())
-            .unwrap_or(CHAIN_INFO_RECEIVED_LOG_MAX_ENTRIES_DEFAULT);
         loop {
             let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_n(offset);
             let info = remote_node.handle_chain_info_query(query).await?;
             let received_entries = info.requested_received_log.len();
             offset += received_entries as u64;
             remote_log.extend(info.requested_received_log);
-            if received_entries < max_entries {
+            if received_entries < CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES {
                 break;
             }
         }

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -29,3 +29,7 @@ pub use crate::join_set_ext::{JoinSetExt, TaskHandle};
 
 pub mod environment;
 pub use environment::Environment;
+
+/// The maximum number of entries in a `received_log` included in a `ChainInfo` response.
+// TODO(#4638): Revisit the number.
+pub const CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES: usize = 50_000;

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -32,4 +32,4 @@ pub use environment::Environment;
 
 /// The maximum number of entries in a `received_log` included in a `ChainInfo` response.
 // TODO(#4638): Revisit the number.
-pub const CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES: usize = 50_000;
+pub const CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES: usize = 20_000;

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -32,4 +32,4 @@ pub use environment::Environment;
 
 /// The maximum number of entries in a `received_log` included in a `ChainInfo` response.
 // TODO(#4638): Revisit the number.
-pub const CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES: usize = 20_000;
+pub const CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES: usize = 100_000;

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -43,6 +43,7 @@ use crate::{
     join_set_ext::{JoinSet, JoinSetExt},
     notifier::Notifier,
     value_cache::ValueCache,
+    CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
 
 const BLOCK_CACHE_SIZE: usize = 5_000;
@@ -418,6 +419,27 @@ where
     #[instrument(level = "trace", skip(self))]
     pub fn with_sender_chain_worker_ttl(mut self, sender_chain_worker_ttl: Duration) -> Self {
         self.chain_worker_config.sender_chain_ttl = sender_chain_worker_ttl;
+        self
+    }
+
+    /// Returns an instance with the specified maximum size for received_log entries.
+    ///
+    /// Sizes below `CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES` should be avoided.
+    #[instrument(level = "trace", skip(self))]
+    pub fn with_chain_info_max_received_log_entries(
+        mut self,
+        chain_info_max_received_log_entries: usize,
+    ) -> Self {
+        if chain_info_max_received_log_entries < CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES {
+            warn!(
+                "The value set for the maximum size of received_log entries \
+                   may not be compatible with the latest clients: {} instead of {}",
+                chain_info_max_received_log_entries, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES
+            );
+        }
+        self.chain_worker_config
+            .override_chain_info_max_received_log_entries =
+            Some(chain_info_max_received_log_entries);
         self
     }
 


### PR DESCRIPTION
## Motivation

variation on #4643 (feel free to cherry-pick commits)

## Proposal

* Do not parse env variables from linera-core
* Make the value not configurable from clients
* Add an option for validators to experiment
* Set the value to 20000

## Test Plan

CI
