### PR TITLE
Use bigger GH runner for Docker Image CI

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 40
 
     steps:


### PR DESCRIPTION
## Motivation

We're timing out right now, and we won't want to wait for longer

## Proposal

Use a bigger GH runner for now, but we'll eventually move these out of GH runners

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
