### PR TITLE
[Backport of #4674] Use bigger GH runner for Docker Image CI

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 40
 
     steps:


### PR DESCRIPTION
## Motivation

Backport of https://github.com/linera-io/linera-protocol/pull/4674

## Proposal

Backport it

## Test Plan

CI
