### PR TITLE
Increase lint-check-all-features timeout

### DIFF
--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -31,7 +31,7 @@ jobs:
   lint-check-all-features:
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 40
+    timeout-minutes: 50
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation

This has been timing out and causing PRs to be removed from the merge queue. Example: https://github.com/linera-io/linera-protocol/actions/runs/18041117669/job/51339986171

## Proposal

Increase the timeout to 50 minutes

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
