### PR TITLE
`linera_service::proxy::grpc`: make sure to add CORS layer

### DIFF
--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -276,7 +276,12 @@ where
                         .layer(PrometheusMetricsMiddlewareLayer)
                         .into_inner(),
                 )
-                .layer(tower_http::cors::CorsLayer::permissive())
+                .layer(
+                    // enable
+                    // [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS)
+                    // for the proxy to originate anywhere
+                    tower_http::cors::CorsLayer::permissive(),
+                )
                 .layer(GrpcWebLayer::new())
                 .accept_http1(true)
                 .add_service(health_service)

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -265,14 +265,18 @@ where
             .build_v1()?;
         let public_server = join_set.spawn_task(
             self.public_server()?
-                .max_concurrent_streams(Some(u32::MAX - 1)) // we subtract one to make sure
-                // that the value is not
-                // interpreted as "not set"
+                .max_concurrent_streams(
+                    // we subtract one to make sure
+                    // that the value is not
+                    // interpreted as "not set"
+                    Some(u32::MAX - 1),
+                )
                 .layer(
                     ServiceBuilder::new()
                         .layer(PrometheusMetricsMiddlewareLayer)
                         .into_inner(),
                 )
+                .layer(tower_http::cors::CorsLayer::permissive())
                 .layer(GrpcWebLayer::new())
                 .accept_http1(true)
                 .add_service(health_service)


### PR DESCRIPTION
## Motivation

We upgraded `tonic-web` in #4446, but in doing so accidentally disabled CORS.

## Proposal

Enable CORS again using the new API (i.e. just postcompose with `tower_http::cors::CorsLayer`).

## Test Plan

Local.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

(#4446 hasn't made it onto the testnet yet)

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
