### PR TITLE
Run CI on OVH runner instead

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   compose:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: ubuntu-latest-16-cores
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
 
   publish-docs:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 20
 
     # We only publish docs for the main branch.
@@ -57,7 +57,7 @@ jobs:
         force_orphan: true
 
   test-crates-and-docrs:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
 
   test:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
   changed-files:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -47,7 +47,7 @@ jobs:
   test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   lint-check-all-features:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: ubuntu-latest-16-cores
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 50
 
     steps:

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   long-faucet-chain-test:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: ubuntu-latest-16-cores
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/performance_summary.yml
+++ b/.github/workflows/performance_summary.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   performance-summary:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
   changed-files:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -58,7 +58,7 @@ jobs:
   remote-net-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest-8-cores
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 40
 
     steps:
@@ -101,7 +101,7 @@ jobs:
   remote-kubernetes-net-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest-16-cores
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 90
 
     steps:
@@ -139,7 +139,7 @@ jobs:
   execution-wasmtime-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 10
 
     steps:
@@ -152,7 +152,7 @@ jobs:
   metrics-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 10
 
     steps:
@@ -165,7 +165,7 @@ jobs:
   wasm-application-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 15
 
     steps:
@@ -183,7 +183,7 @@ jobs:
   linera-sdk-tests-fixtures:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 10
 
     steps:
@@ -206,7 +206,7 @@ jobs:
   default-features-and-witty-integration-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest-8-cores
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 40
 
     steps:
@@ -230,7 +230,7 @@ jobs:
   check-outdated-cli-md:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 10
 
     steps:
@@ -252,7 +252,7 @@ jobs:
   benchmark-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 40
 
     steps:
@@ -278,7 +278,7 @@ jobs:
   ethereum-tests:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 30
 
     steps:
@@ -343,7 +343,7 @@ jobs:
   storage-service-tests:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest-16-cores
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -371,7 +371,7 @@ jobs:
   check-wit-files:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -382,7 +382,7 @@ jobs:
   lint-unexpected-chain-load-operations:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 2
 
     steps:
@@ -394,7 +394,7 @@ jobs:
   lint-check-copyright-headers:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 2
 
     steps:
@@ -411,7 +411,7 @@ jobs:
   lint-cargo-machete:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 2
 
     steps:
@@ -430,7 +430,7 @@ jobs:
   lint-cargo-fmt:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 2
 
     steps:
@@ -446,7 +446,7 @@ jobs:
   lint-taplo-fmt:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 5
 
     steps:
@@ -460,7 +460,7 @@ jobs:
   lint-check-for-outdated-readme:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 5
 
     steps:
@@ -489,7 +489,7 @@ jobs:
   lint-wasm-applications:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 10
 
     steps:
@@ -514,7 +514,7 @@ jobs:
   lint-cargo-clippy:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 20
 
     steps:
@@ -540,7 +540,7 @@ jobs:
   lint-cargo-doc:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 20
 
     steps:
@@ -560,7 +560,7 @@ jobs:
   lint-check-linera-service-graphql-schema:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
 
   test:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 50
 
     steps:

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   test-readme-scripts:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: ubuntu-latest-16-cores
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   changed-files:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -58,7 +58,7 @@ jobs:
   web:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ovh-k8s-infra
     timeout-minutes: 20
 
     steps:


### PR DESCRIPTION
## Motivation

Github CI is very expensive, more than even GCP.

## Proposal

Switch to using our new OVH Runners instead (thanks @eldios for writing all the infra for this!) and save money

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
