### PR TITLE
Docker Compose: fix Caddy configuration for gRPC-Web

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -5,10 +5,21 @@
 {$DOMAIN:localhost} {
     # Automatic HTTPS with Let's Encrypt (or self-signed for localhost)
 
-    # Set gRPC content-type header for all requests
-    header Content-Type application/grpc
+    # Handle OPTIONS preflight requests (let backend handle CORS headers)
+    @options {
+        method OPTIONS
+    }
+    handle @options {
+        reverse_proxy https://proxy:443 {
+            transport http {
+                versions 2
+                tls_insecure_skip_verify
+            }
+        }
+    }
 
-    # Reverse proxy to the Linera proxy container (gRPC over HTTPS)
+    # Simple reverse proxy for all gRPC traffic
+    # Let the backend handle both gRPC and gRPC-Web (including CORS)
     reverse_proxy https://proxy:443 {
         # Configure for gRPC with self-signed certificate
         transport http {
@@ -27,8 +38,6 @@
 
         # Disable buffering for gRPC streaming
         flush_interval -1
-
-        # Don't add extra headers that might interfere with gRPC
     }
 
     # Enable access logs in JSON format


### PR DESCRIPTION
## Summary

This PR fixes the Caddy configuration in Docker Compose to properly handle gRPC-Web traffic by:

1. **Removing incorrect `Content-Type` header override** - Caddy was forcing all requests to have `application/grpc` content-type, which breaks gRPC-Web that requires `application/grpc-web+proto`
2. **Adding explicit OPTIONS handling** - Ensures CORS preflight requests are properly forwarded to the backend
3. **Simplifying proxy configuration** - Let the backend handle both gRPC and gRPC-Web protocols including CORS headers

## Problem

The previous configuration was overriding all Content-Type headers to `application/grpc`, which prevented gRPC-Web clients from working correctly as they require specific content types like `application/grpc-web+proto`.

## Solution

- Removed the forced Content-Type header
- Added explicit handling for OPTIONS preflight requests
- Let the backend (Linera proxy) handle protocol-specific headers and CORS

## Testing

This configuration should allow both standard gRPC and gRPC-Web clients to communicate with the Linera proxy through Caddy.

Fixes issues with web-based gRPC clients connecting through the Docker Compose setup.