### PR TITLE
Adding some faucet metrics

### DIFF
--- a/linera-faucet/server/build.rs
+++ b/linera-faucet/server/build.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    cfg_aliases::cfg_aliases! {
+        with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
+    };
+}

--- a/linera-faucet/server/src/tests.rs
+++ b/linera-faucet/server/src/tests.rs
@@ -264,6 +264,8 @@ async fn test_batch_size_reduction_on_limit_errors() {
             pending_requests_guard.push_back(super::PendingRequest {
                 owner,
                 responder: tx,
+                #[cfg(with_metrics)]
+                queued_at: std::time::Instant::now(),
             });
         }
     }

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1991,10 +1991,16 @@ async fn kill_all_processes(pids: &[u32]) {
     }
 }
 
+fn should_init_opentelemetry(command: &ClientCommand) -> bool {
+    matches!(command, ClientCommand::Faucet { .. })
+}
+
 fn main() -> anyhow::Result<()> {
     let options = ClientOptions::init();
 
-    linera_base::tracing::init(&options.command.log_file_name());
+    if !should_init_opentelemetry(&options.command) {
+        linera_base::tracing::init(&options.command.log_file_name());
+    }
 
     let mut runtime = if options.tokio_threads == Some(1) {
         tokio::runtime::Builder::new_current_thread()
@@ -2034,6 +2040,10 @@ fn main() -> anyhow::Result<()> {
 }
 
 async fn run(options: &ClientOptions) -> Result<i32, Error> {
+    if should_init_opentelemetry(&options.command) {
+        linera_base::tracing::init_with_opentelemetry(&options.command.log_file_name()).await;
+    }
+
     match &options.command {
         ClientCommand::HelpMarkdown => {
             clap_markdown::print_help_markdown::<ClientOptions>();


### PR DESCRIPTION
## Motivation

The current metrics we have on the faucet its stuff that we're exporting in the client code, but we don't have any faucet specific metrics.

## Proposal

Add some faucet specific metrics.

## Test Plan

Deploy a network with this code, see the faucet metrics being exported. Used this to create a dashboard as well with these metrics:

![Screenshot 2025-09-30 at 01.01.20.png](https://app.graphite.dev/user-attachments/assets/ffb1efc3-117a-45c6-8153-4031724d569a.png)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
