### PR TITLE
Fix image loading on net up --kubernetes

### DIFF
--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -561,8 +561,10 @@ impl LocalKubernetesNet {
             let future = async move {
                 let cluster_id = kind_cluster.id();
                 kind_cluster.load_docker_image(&docker_image_name).await?;
-                kind_cluster.load_docker_image(&indexer_image_name).await?;
-                kind_cluster.load_docker_image(&explorer_image_name).await?;
+                if num_block_exporters > 0 {
+                    kind_cluster.load_docker_image(&indexer_image_name).await?;
+                    kind_cluster.load_docker_image(&explorer_image_name).await?;
+                }
 
                 let server_config_filename = format!("server_{}.json", validator_number);
                 fs_err::copy(


### PR DESCRIPTION
## Motivation

Seems like there was some race condition on the block exporer stuff merging, which made CI not catch this bug.

## Proposal

Only load images when the exporter mode is enabled.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
