### PR TITLE
Fix consensus issues related to timeouts, rounds, ownership. (Part of #4688)

### DIFF
--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -559,27 +559,46 @@ where
 
     /// Updates `current_round` and `round_timeout` if necessary.
     ///
-    /// This must be after every change to `timeout`, `locking` or `proposed`.
+    /// This must be called after every change to `timeout`, `locking`, `proposed` or
+    /// `signed_proposal`.
+    ///
+    /// The current round starts at `Fast` if there is a super owner, `MultiLeader(0)` if at least
+    /// one multi-leader round is configured, or otherwise `SingleLeader(0)`.
+    ///
+    /// Single-leader rounds can only be ended by a timeout certificate for that round.
+    ///
+    /// The presence of any validated block certificate is also proof that a quorum of validators
+    /// is already in that round, even if we have not seen the corresponding timeout.
+    ///
+    /// Multi-leader rounds can always be skipped, so any correctly signed block proposal in a
+    /// later round ends a multi-leader round.
+    /// Since we don't accept proposals that violate that rule, we can compute the current round in
+    /// general by taking the maximum of all the above.
     fn update_current_round(&mut self, local_time: Timestamp) {
         let current_round = self
             .timeout
             .get()
             .iter()
+            // A timeout certificate starts the next round.
             .map(|certificate| {
                 self.ownership
                     .get()
                     .next_round(certificate.round)
                     .unwrap_or(Round::Validator(u32::MAX))
             })
+            // A locking block or a proposal is proof we have accepted that we are at least in
+            // this round.
             .chain(self.locking_block.get().as_ref().map(LockingBlock::round))
             .chain(
                 self.proposed
                     .get()
                     .iter()
+                    .chain(self.signed_proposal.get())
                     .map(|proposal| proposal.content.round),
             )
             .max()
             .unwrap_or_default()
+            // Otherwise compute the first round for this chain configuration.
             .max(self.ownership.get().first_round());
         if current_round <= self.current_round() {
             return;
@@ -682,10 +701,17 @@ where
         self.ownership.get().super_owners.contains(owner)
     }
 
-    /// Sets the signed proposal, if it is newer than the known one, and not from a single-leader
-    /// round. Returns whether it was updated.
-    pub fn update_signed_proposal(&mut self, proposal: &BlockProposal) -> bool {
-        if proposal.content.round > Round::MultiLeader(u32::MAX) {
+    /// Sets the signed proposal, if it is newer than the known one, at most from the first
+    /// single-leader round. Returns whether it was updated.
+    ///
+    /// We don't update the signed proposal for any rounds later than `SingleLeader(0)`,
+    /// because single-leader rounds cannot be skipped without a timeout certificate.
+    pub fn update_signed_proposal(
+        &mut self,
+        proposal: &BlockProposal,
+        local_time: Timestamp,
+    ) -> bool {
+        if proposal.content.round > Round::SingleLeader(0) {
             return false;
         }
         if let Some(old_proposal) = self.signed_proposal.get() {
@@ -699,6 +725,7 @@ where
             }
         }
         self.signed_proposal.set(Some(proposal.clone()));
+        self.update_current_round(local_time);
         true
     }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1281,10 +1281,15 @@ where
             // We already voted for this block.
             return Ok((self.chain_info_response(), NetworkActions::default()));
         }
+        let local_time = self.storage.clock().current_time();
 
         // Make sure we remember that a proposal was signed, to determine the correct round to
         // propose in.
-        if self.chain.manager.update_signed_proposal(&proposal) {
+        if self
+            .chain
+            .manager
+            .update_signed_proposal(&proposal, local_time)
+        {
             self.save().await?;
         }
 
@@ -1295,7 +1300,6 @@ where
             outcome,
         } = content;
 
-        let local_time = self.storage.clock().current_time();
         ensure!(
             block.timestamp.duration_since(local_time) <= self.config.grace_period,
             WorkerError::InvalidTimestamp


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/4688 fixes several issues (see the description), but there is still an issue with the Kubernetes tests.

## Proposal

Address a subset of the fixes; if it doesn't break any existing tests, we can backport this and deploy it on Testnet Conway.

## Test Plan

https://github.com/linera-io/linera-protocol/pull/4688 adds a regression test that passes with these and a few additional changes.

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- Part of https://github.com/linera-io/linera-protocol/issues/4686 and #4688.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
