### PR TITLE
Show logs of network starting on remote net tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,21 +79,20 @@ jobs:
     - name: Build binaries
       run: |
         cargo build --features storage-service --bin linera-server --bin linera-proxy --bin linera
-    - name: Run the validators
+    - name: Run the validators and faucet, wait for faucet to be ready
       run: |
         mkdir /tmp/local-linera-net
         cargo run --features storage-service --bin linera -- net up --storage service:tcp:$LINERA_STORAGE_SERVICE:table --policy-config testnet --path /tmp/local-linera-net --validators 2 --shards 2 &
-    - name: Create two epochs and run the faucet
-      # See https://github.com/linera-io/linera-protocol/pull/2835 for details.
-      run: |
+        # Create two epochs and run the faucet.
+        # See https://github.com/linera-io/linera-protocol/pull/2835 for details.
         mkdir /tmp/linera-faucet
         cargo run --bin linera -- resource-control-policy --http-request-timeout-ms 1000
         cargo run --bin linera -- resource-control-policy --http-request-timeout-ms 500
         FAUCET_PORT=$(echo "$LINERA_FAUCET_URL" | cut -d: -f3)
-        cargo run --bin linera -- faucet --storage-path /tmp/linera-faucet/faucet_storage.sqlite --amount 1000 --port $FAUCET_PORT &
-    - name: Wait for faucet to be ready
-      run: |
-        until curl -s $LINERA_FAUCET_URL >/dev/null; do sleep 1; done
+        LOG_FILE="/tmp/linera-net-up.log"
+        cargo run --bin linera -- faucet --storage-path /tmp/linera-faucet/faucet_storage.sqlite --amount 1000 --port $FAUCET_PORT > "$LOG_FILE" 2>&1 &
+        FAUCET_PID=$!
+        bash scripts/wait-for-kubernetes-service.sh "$LINERA_FAUCET_URL" "$FAUCET_PID" "$LOG_FILE"
     - name: Run the remote-net tests
       run: |
         cargo test -p linera-service remote_net_grpc --features remote-net
@@ -124,14 +123,14 @@ jobs:
     - name: Build binaries
       run: |
         cargo build --features storage-service --bin linera-server --bin linera-proxy --bin linera
-    - name: Run the validators with Kubernetes
+    - name: Run the validators with Kubernetes and wait for faucet
       run: |
         mkdir /tmp/local-linera-net
         FAUCET_PORT=$(echo "$LINERA_FAUCET_URL" | cut -d: -f3)
-        cargo run --bin linera --features kubernetes -- net up --kubernetes --policy-config testnet --path /tmp/local-linera-net --validators 1 --shards 2 --with-faucet --faucet-port $FAUCET_PORT --faucet-amount 1000 &
-    - name: Wait for faucet to be ready
-      run: |
-        until curl -s $LINERA_FAUCET_URL >/dev/null; do sleep 1; done
+        LOG_FILE="/tmp/linera-net-up-kubernetes.log"
+        cargo run --bin linera --features kubernetes -- net up --kubernetes --policy-config testnet --path /tmp/local-linera-net --validators 1 --shards 2 --with-faucet --faucet-port $FAUCET_PORT --faucet-amount 1000 > "$LOG_FILE" 2>&1 &
+        NETWORK_PID=$!
+        bash scripts/wait-for-kubernetes-service.sh "$LINERA_FAUCET_URL" "$NETWORK_PID" "$LOG_FILE"
     - name: Run the Kubernetes tests
       run: |
         cargo test -p linera-service remote_net_grpc --features remote-net

--- a/scripts/wait-for-kubernetes-service.sh
+++ b/scripts/wait-for-kubernetes-service.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright (c) Zefchain Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SERVICE_URL="${1:-}"
+PROCESS_PID="${2:-}"
+LOG_FILE="${3:-}"
+
+if [ -z "$SERVICE_URL" ] || [ -z "$PROCESS_PID" ] || [ -z "$LOG_FILE" ]; then
+    echo "Usage: $0 <service-url> <process-pid> <log-file>" >&2
+    echo "Example: $0 http://localhost:8079 12345 /tmp/output.log" >&2
+    exit 1
+fi
+
+echo "Waiting for service at $SERVICE_URL to be ready..."
+echo "Monitoring process PID: $PROCESS_PID"
+echo "Streaming logs from: $LOG_FILE"
+echo ""
+
+tail -f "$LOG_FILE" 2>/dev/null &
+TAIL_PID=$!
+trap "kill $TAIL_PID 2>/dev/null || true" EXIT
+
+while true; do
+    if ! kill -0 "$PROCESS_PID" 2>/dev/null; then
+        wait "$PROCESS_PID" 2>/dev/null || EXIT_CODE=$?
+        echo ""
+        echo "ERROR: Network creation process (PID: $PROCESS_PID) terminated unexpectedly with exit code: ${EXIT_CODE:-unknown}" >&2
+        echo "Check the logs above for errors." >&2
+        exit 1
+    fi
+
+    if curl -sf "$SERVICE_URL" >/dev/null 2>&1; then
+        echo ""
+        echo "SUCCESS: Service at $SERVICE_URL is ready!"
+        exit 0
+    fi
+
+    sleep 1
+done


### PR DESCRIPTION
## Motivation

Right now the networks get started as a bg process. So if it fails, we can't really see the logs showing why it failed to start.

## Proposal

Write a simple script, to give us the logs while waiting for the faucet to start.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
