### PR TITLE
Don't do heavy syncing of sender chains unless requested.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -747,7 +747,13 @@ Run a GraphQL service to explore and extend the chains of the wallet
 * `--listener-delay-after-ms <DELAY_AFTER_MS>` — Wait after processing any notification (useful for rate limiting)
 
   Default value: `0`
+* `--listener-sync-batch-size <SYNC_BATCH_SIZE>` — Number of certificates to fetch per batch during background synchronization
+
+  Default value: `100`
 * `--port <PORT>` — The port on which to run the server
+* `--sync-sleep-ms <SYNC_SLEEP_MS>` — Milliseconds to sleep between batches during background certificate synchronization
+
+  Default value: `500`
 
 
 
@@ -775,6 +781,9 @@ Run a GraphQL service that exposes a faucet where users can claim tokens. This g
 * `--listener-delay-after-ms <DELAY_AFTER_MS>` — Wait after processing any notification (useful for rate limiting)
 
   Default value: `0`
+* `--listener-sync-batch-size <SYNC_BATCH_SIZE>` — Number of certificates to fetch per batch during background synchronization
+
+  Default value: `100`
 * `--storage-path <STORAGE_PATH>` — Path to the persistent storage file for faucet mappings
 * `--max-batch-size <MAX_BATCH_SIZE>` — Maximum number of operations to include in a single block (default: 100)
 

--- a/CLI.md
+++ b/CLI.md
@@ -747,9 +747,6 @@ Run a GraphQL service to explore and extend the chains of the wallet
 * `--listener-delay-after-ms <DELAY_AFTER_MS>` — Wait after processing any notification (useful for rate limiting)
 
   Default value: `0`
-* `--listener-sync-batch-size <SYNC_BATCH_SIZE>` — Number of certificates to fetch per batch during background synchronization
-
-  Default value: `100`
 * `--port <PORT>` — The port on which to run the server
 * `--sync-sleep-ms <SYNC_SLEEP_MS>` — Milliseconds to sleep between batches during background certificate synchronization
 
@@ -781,9 +778,6 @@ Run a GraphQL service that exposes a faucet where users can claim tokens. This g
 * `--listener-delay-after-ms <DELAY_AFTER_MS>` — Wait after processing any notification (useful for rate limiting)
 
   Default value: `0`
-* `--listener-sync-batch-size <SYNC_BATCH_SIZE>` — Number of certificates to fetch per batch during background synchronization
-
-  Default value: `100`
 * `--storage-path <STORAGE_PATH>` — Path to the persistent storage file for faucet mappings
 * `--max-batch-size <MAX_BATCH_SIZE>` — Maximum number of operations to include in a single block (default: 100)
 

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -56,7 +56,7 @@ pub enum ChainError {
         height: BlockHeight,
     },
     #[error(
-        "Message in block proposed to {chain_id:?} does not match the previously received messages from \
+        "Message in block proposed to {chain_id} does not match the previously received messages from \
         origin {origin:?}: was {bundle:?} instead of {previous_bundle:?}"
     )]
     UnexpectedMessage {
@@ -66,7 +66,7 @@ pub enum ChainError {
         previous_bundle: Box<MessageBundle>,
     },
     #[error(
-        "Message in block proposed to {chain_id:?} is out of order compared to previous messages \
+        "Message in block proposed to {chain_id} is out of order compared to previous messages \
          from origin {origin:?}: {bundle:?}. Block and height should be at least: \
          {next_height}, {next_index}"
     )]
@@ -78,7 +78,7 @@ pub enum ChainError {
         next_index: u32,
     },
     #[error(
-        "Block proposed to {chain_id:?} is attempting to reject protected message \
+        "Block proposed to {chain_id} is attempting to reject protected message \
         {posted_message:?}"
     )]
     CannotRejectMessage {
@@ -87,7 +87,7 @@ pub enum ChainError {
         posted_message: Box<PostedMessage>,
     },
     #[error(
-        "Block proposed to {chain_id:?} is attempting to skip a message bundle \
+        "Block proposed to {chain_id} is attempting to skip a message bundle \
          that cannot be skipped: {bundle:?}"
     )]
     CannotSkipMessage {
@@ -96,7 +96,7 @@ pub enum ChainError {
         bundle: Box<MessageBundle>,
     },
     #[error(
-        "Incoming message bundle in block proposed to {chain_id:?} has timestamp \
+        "Incoming message bundle in block proposed to {chain_id} has timestamp \
         {bundle_timestamp:}, which is later than the block timestamp {block_timestamp:}."
     )]
     IncorrectBundleTimestamp {

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -133,7 +133,7 @@ impl<Env: Environment> Benchmark<Env> {
         let barrier = Arc::new(Barrier::new(num_chains + 1));
 
         let chain_listener_future = chain_listener
-            .run()
+            .run(Some(500)) // Default sync_sleep_ms for benchmarks
             .await
             .map_err(|_| BenchmarkError::ChainListenerStartupError)?;
         let chain_listener_handle = tokio::spawn(chain_listener_future.in_current_span());

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -422,6 +422,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
         cancellation_token: CancellationToken,
     ) -> Result<(), Error> {
         info!("Starting background certificate sync for chain {chain_id}");
+        let client = context.lock().await.make_chain_client(chain_id);
 
         loop {
             // Check if we should stop.
@@ -434,7 +435,6 @@ impl<C: ClientContext + 'static> ChainListener<C> {
             Self::sleep(sync_sleep_ms).await;
 
             // Sync one batch.
-            let client = context.lock().await.make_chain_client(chain_id);
             match client.sync_received_certificates_batch().await {
                 Ok(has_more) => {
                     if !has_more {

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -213,7 +213,7 @@ impl<C: ClientContext> ChainListener<C> {
             let admin_chain_id = guard.wallet().genesis_admin_chain();
             guard
                 .make_chain_client(admin_chain_id)
-                .synchronize_from_validators()
+                .synchronize_chain_state(admin_chain_id)
                 .await?;
             BTreeMap::from_iter(
                 guard

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -58,14 +58,6 @@ pub struct ChainListenerConfig {
         env = "LINERA_LISTENER_DELAY_AFTER"
     )]
     pub delay_after_ms: u64,
-
-    /// Number of certificates to fetch per batch during background synchronization.
-    #[arg(
-        long = "listener-sync-batch-size",
-        default_value = "100",
-        env = "LINERA_LISTENER_SYNC_BATCH_SIZE"
-    )]
-    pub sync_batch_size: usize,
 }
 
 type ContextChainClient<C> = ChainClient<<C as ClientContext>::Environment>;
@@ -240,17 +232,14 @@ impl<C: ClientContext + 'static> ChainListener<C> {
         // if enabled (sync_sleep_ms is Some).
         if let Some(sync_sleep_ms) = sync_sleep_ms {
             let context = Arc::clone(&self.context);
-            let config = Arc::clone(&self.config);
             let cancellation_token = self.cancellation_token.clone();
             for chain_id in chain_ids.keys() {
                 let context = Arc::clone(&context);
-                let config = Arc::clone(&config);
                 let cancellation_token = cancellation_token.clone();
                 let chain_id = *chain_id;
                 drop(linera_base::task::spawn(async move {
                     if let Err(e) = Self::background_sync_received_certificates(
                         context,
-                        config,
                         sync_sleep_ms,
                         chain_id,
                         cancellation_token,
@@ -425,10 +414,9 @@ impl<C: ClientContext + 'static> ChainListener<C> {
 
     /// Background task that syncs received certificates in small batches.
     /// This discovers unacknowledged sender blocks gradually without overwhelming the system.
-    #[instrument(skip(context, config, cancellation_token))]
+    #[instrument(skip(context, cancellation_token))]
     async fn background_sync_received_certificates(
         context: Arc<Mutex<C>>,
-        config: Arc<ChainListenerConfig>,
         sync_sleep_ms: u64,
         chain_id: ChainId,
         cancellation_token: CancellationToken,
@@ -447,10 +435,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
 
             // Sync one batch.
             let client = context.lock().await.make_chain_client(chain_id);
-            match client
-                .sync_received_certificates_batch(config.sync_batch_size)
-                .await
-            {
+            match client.sync_received_certificates_batch().await {
                 Ok(has_more) => {
                     if !has_more {
                         info!("Background sync completed for chain {chain_id}");

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -257,7 +257,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
                     )
                     .await
                     {
-                        warn!("Background sync failed for chain {}: {}", chain_id, e);
+                        warn!("Background sync failed for chain {chain_id}: {e}");
                     }
                 }));
             }
@@ -433,15 +433,12 @@ impl<C: ClientContext + 'static> ChainListener<C> {
         chain_id: ChainId,
         cancellation_token: CancellationToken,
     ) -> Result<(), Error> {
-        info!(
-            "Starting background certificate sync for chain {}",
-            chain_id
-        );
+        info!("Starting background certificate sync for chain {chain_id}");
 
         loop {
             // Check if we should stop.
             if cancellation_token.is_cancelled() {
-                info!("Background sync cancelled for chain {}", chain_id);
+                info!("Background sync cancelled for chain {chain_id}");
                 break;
             }
 
@@ -456,15 +453,12 @@ impl<C: ClientContext + 'static> ChainListener<C> {
             {
                 Ok(has_more) => {
                     if !has_more {
-                        info!("Background sync completed for chain {}", chain_id);
+                        info!("Background sync completed for chain {chain_id}");
                         break;
                     }
                 }
                 Err(e) => {
-                    warn!(
-                        "Error syncing batch for chain {}: {}. Will retry.",
-                        chain_id, e
-                    );
+                    warn!("Error syncing batch for chain {chain_id}: {e}. Will retry.");
                     // Continue trying despite errors - validators might be temporarily unavailable.
                 }
             }

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -154,7 +154,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     let cancellation_token = CancellationToken::new();
     let child_token = cancellation_token.child_token();
     let chain_listener = ChainListener::new(config, context, storage, child_token)
-        .run()
+        .run(None) // Unit test doesn't need background sync
         .await
         .unwrap();
 
@@ -217,7 +217,7 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
     let cancellation_token = CancellationToken::new();
     let child_token = cancellation_token.child_token();
     let chain_listener = ChainListener::new(config, context, storage.clone(), child_token)
-        .run()
+        .run(None) // Unit test doesn't need background sync
         .await
         .unwrap();
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2301,12 +2301,7 @@ impl<Env: Environment> ChainClient<Env> {
         let _latency = metrics::FIND_RECEIVED_CERTIFICATES_LATENCY.measure_latency();
 
         // Sync in batches until all received certificates are downloaded.
-        loop {
-            let has_more = self.sync_received_certificates_batch().await?;
-            if !has_more {
-                break;
-            }
-        }
+        while self.sync_received_certificates_batch().await? {}
         Ok(())
     }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2969,7 +2969,7 @@ impl<Env: Environment> ChainClient<Env> {
     pub async fn process_pending_block(
         &self,
     ) -> Result<ClientOutcome<Option<ConfirmedBlockCertificate>>, ChainClientError> {
-        self.synchronize_from_validators().await?;
+        self.prepare_chain().await?;
         self.process_pending_block_without_prepare().await
     }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1229,7 +1229,7 @@ impl<Env: Environment> Client<Env> {
                         .storage_client()
                         .read_blob(blob_id)
                         .await?
-                        .ok_or_else(|| NodeError::BlobsNotFound(vec![blob_id]))?;
+                        .ok_or_else(|| LocalNodeError::BlobsNotFound(vec![blob_id]))?;
                     Result::<_, ChainClientError>::Ok(blob)
                 })
                 .collect::<FuturesUnordered<_>>();

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2467,12 +2467,8 @@ impl<Env: Environment> ChainClient<Env> {
         let mut certificates = BTreeMap::new();
         let mut current_height = height;
 
-        loop {
-            // Stop if we've reached the height we've already processed.
-            if current_height < next_outbox_height {
-                break;
-            }
-
+        // Stop if we've reached the height we've already processed.
+        while current_height >= next_outbox_height {
             // Download the certificate for this height.
             let downloaded = remote_node
                 .download_certificates_by_heights(sender_chain_id, vec![current_height])

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -820,153 +820,6 @@ impl<Env: Environment> Client<Env> {
         Ok(())
     }
 
-    /// Downloads and preprocesses all confirmed block certificates that sent any message to this
-    /// chain.
-    #[instrument(level = "trace", skip(self))]
-    async fn synchronize_received_certificates_from_validator(
-        &self,
-        chain_id: ChainId,
-        remote_node: &RemoteNode<Env::ValidatorNode>,
-    ) -> Result<ReceivedCertificatesFromValidator, ChainClientError> {
-        let mut tracker = self
-            .local_node
-            .chain_state_view(chain_id)
-            .await?
-            .received_certificate_trackers
-            .get()
-            .get(&remote_node.public_key)
-            .copied()
-            .unwrap_or(0);
-        let (max_epoch, committees) = self.admin_committees().await?;
-
-        // Retrieve the list of newly received certificates from this validator.
-        let mut remote_log = Vec::new();
-        let mut offset = tracker;
-        loop {
-            let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_n(offset);
-            let info = remote_node.handle_chain_info_query(query).await?;
-            let received_entries = info.requested_received_log.len();
-            offset += received_entries as u64;
-            remote_log.extend(info.requested_received_log);
-            if received_entries < CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES {
-                break;
-            }
-        }
-        let remote_heights = Self::heights_per_chain(&remote_log);
-
-        // Obtain the next block height we need in the local node, for each chain.
-        let local_next_heights = self
-            .local_node
-            .next_outbox_heights(remote_heights.keys(), chain_id)
-            .await?;
-
-        // We keep track of the height we've successfully downloaded and checked, per chain.
-        let mut downloaded_heights = BTreeMap::new();
-        // And we make a list of chains we already fully have locally. We need to make sure to
-        // put all their sent messages into the inbox.
-        let mut other_sender_chains = Vec::new();
-
-        let certificates = stream::iter(remote_heights.into_iter().filter_map(
-            |(sender_chain_id, remote_heights)| {
-                let local_next = *local_next_heights.get(&sender_chain_id)?;
-                if let Ok(height) = local_next.try_sub_one() {
-                    downloaded_heights.insert(sender_chain_id, height);
-                }
-                let remote_heights = remote_heights
-                    .into_iter()
-                    .filter(|h| *h >= local_next)
-                    .collect::<Vec<_>>();
-                if remote_heights.is_empty() {
-                    // Our highest, locally executed block is higher than any block height
-                    // from the current batch. Skip this batch, but remember to wait for
-                    // the messages to be delivered to the inboxes.
-                    other_sender_chains.push(sender_chain_id);
-                    return None;
-                };
-                Some(async move {
-                    let certificates = remote_node
-                        .download_certificates_by_heights(sender_chain_id, remote_heights)
-                        .await?;
-                    Ok::<Vec<_>, ChainClientError>(certificates)
-                })
-            },
-        ))
-        .buffer_unordered(self.options.max_joined_tasks)
-        .try_collect::<Vec<_>>()
-        .await?
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
-
-        let mut certificates_by_height_by_chain = BTreeMap::new();
-
-        // Check the signatures and keep only the ones that are valid.
-        for confirmed_block_certificate in certificates {
-            let block_header = &confirmed_block_certificate.inner().block().header;
-            let sender_chain_id = block_header.chain_id;
-            let height = block_header.height;
-            let epoch = block_header.epoch;
-            match Self::check_certificate(max_epoch, &committees, &confirmed_block_certificate)? {
-                CheckCertificateResult::FutureEpoch => {
-                    warn!(
-                        "Postponing received certificate from {sender_chain_id:.8} at height \
-                         {height} from future epoch {epoch}"
-                    );
-                    // Do not process this certificate now. It can still be
-                    // downloaded later, once our committee is updated.
-                }
-                CheckCertificateResult::OldEpoch => {
-                    // This epoch is not recognized any more. Let's skip the certificate.
-                    // If a higher block with a recognized epoch comes up later from the
-                    // same chain, the call to `receive_certificate` below will download
-                    // the skipped certificate again.
-                    warn!("Skipping received certificate from past epoch {epoch:?}");
-                }
-                CheckCertificateResult::New => {
-                    certificates_by_height_by_chain
-                        .entry(sender_chain_id)
-                        .or_insert_with(BTreeMap::new)
-                        .insert(height, confirmed_block_certificate);
-                }
-            }
-        }
-
-        // Increase the tracker up to the first position we haven't downloaded.
-        for entry in remote_log {
-            if certificates_by_height_by_chain
-                .get(&entry.chain_id)
-                .is_some_and(|certs| certs.contains_key(&entry.height))
-            {
-                tracker += 1;
-            } else {
-                break;
-            }
-        }
-
-        for (sender_chain_id, certs) in &mut certificates_by_height_by_chain {
-            if certs
-                .values()
-                .any(|cert| !cert.block().recipients().contains(&chain_id))
-            {
-                warn!(
-                    "Skipping received certificates from chain {sender_chain_id:.8}:
-                    No messages for {chain_id:.8}."
-                );
-                certs.clear();
-            }
-        }
-
-        Ok(ReceivedCertificatesFromValidator {
-            public_key: remote_node.public_key,
-            tracker,
-            certificates: certificates_by_height_by_chain
-                .into_values()
-                .flat_map(BTreeMap::into_values)
-                .collect(),
-            other_sender_chains,
-        })
-    }
-
     /// Downloads a limited batch of received certificates from a validator.
     /// Returns the updated tracker and whether there are more certificates to fetch.
     #[instrument(level = "trace", skip(self))]
@@ -2314,7 +2167,7 @@ impl<Env: Environment> ChainClient<Env> {
             .await
     }
 
-    /// Processes the results of [`synchronize_received_certificates_from_validator`] and updates
+    /// Processes the results of [`synchronize_received_certificates_batch_from_validator`] and updates
     /// the trackers for the validators.
     #[tracing::instrument(level = "trace", skip(received_certificates_batches))]
     async fn receive_certificates_from_validators(
@@ -2450,42 +2303,14 @@ impl<Env: Environment> ChainClient<Env> {
         #[cfg(with_metrics)]
         let _latency = metrics::FIND_RECEIVED_CERTIFICATES_LATENCY.measure_latency();
 
-        // Use network information from the local chain.
-        let chain_id = self.chain_id;
-        let (_, committee) = self.admin_committee().await?;
-        let nodes = self.client.make_nodes(&committee)?;
-        // Proceed to downloading received certificates.
-        let result = communicate_with_quorum(
-            &nodes,
-            &committee,
-            |_| (),
-            |remote_node| {
-                let client = &self.client;
-                Box::pin(async move {
-                    client
-                        .synchronize_received_certificates_from_validator(chain_id, &remote_node)
-                        .await
-                })
-            },
-            self.options.grace_period,
-        )
-        .await;
-        let received_certificate_batches = match result {
-            Ok(((), received_certificate_batches)) => received_certificate_batches
-                .into_iter()
-                .map(|(_, batch)| batch)
-                .collect(),
-            Err(CommunicationError::Trusted(NodeError::InactiveChain(id))) if id == chain_id => {
-                // The chain is visibly not active (yet or any more) so there is no need
-                // to synchronize received certificates.
-                return Ok(());
+        // Sync in batches until all received certificates are downloaded.
+        const BATCH_SIZE: usize = 1000;
+        loop {
+            let has_more = self.sync_received_certificates_batch(BATCH_SIZE).await?;
+            if !has_more {
+                break;
             }
-            Err(error) => {
-                return Err(error.into());
-            }
-        };
-        self.receive_certificates_from_validators(received_certificate_batches)
-            .await;
+        }
         Ok(())
     }
 
@@ -4556,7 +4381,7 @@ impl Drop for AbortOnDrop {
     }
 }
 
-/// The result of `synchronize_received_certificates_from_validator`.
+/// The result of `synchronize_received_certificates_batch_from_validator`.
 struct ReceivedCertificatesFromValidator {
     /// The name of the validator we downloaded from.
     public_key: ValidatorPublicKey,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1595,7 +1595,7 @@ pub enum ChainClientError {
 
     #[error(
         "Failed to download certificates and update local node to the next height \
-         {target_next_block_height} of chain {chain_id:?}"
+         {target_next_block_height} of chain {chain_id}"
     )]
     CannotDownloadCertificates {
         chain_id: ChainId,
@@ -1626,7 +1626,7 @@ pub enum ChainClientError {
     EpochAlreadyRevoked,
 
     #[error(
-        "Failed to download missing sender blocks from chain {chain_id:?} at heights {heights:?}"
+        "Failed to download missing sender blocks from chain {chain_id} at heights {heights:?}"
     )]
     CannotDownloadMissingSenderBlocks {
         chain_id: ChainId,

--- a/linera-core/src/notifier.rs
+++ b/linera-core/src/notifier.rs
@@ -64,7 +64,7 @@ where
     pub fn notify_chain(&self, chain_id: &ChainId, notification: &N) {
         self.inner.pin().compute(*chain_id, |senders| {
             let Some((_key, senders)) = senders else {
-                trace!("Chain {chain_id:?} has no subscribers.");
+                trace!("Chain {chain_id} has no subscribers.");
                 return papaya::Operation::Abort(());
             };
             let live_senders = senders
@@ -73,7 +73,7 @@ where
                 .cloned()
                 .collect::<Vec<_>>();
             if live_senders.is_empty() {
-                trace!("No more subscribers for chain {chain_id:?}. Removing entry.");
+                trace!("No more subscribers for chain {chain_id}. Removing entry.");
                 return papaya::Operation::Remove;
             }
             papaya::Operation::Insert(live_senders)

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2869,19 +2869,17 @@ where
     );
 
     // The new client should now be able to make a transfer successfully.
+    let amount3 = Amount::from_tokens(1);
     receiver2
         .transfer(
             AccountOwner::CHAIN,
-            Amount::from_tokens(1),
+            amount3,
             Account::chain(sender.chain_id()),
         )
         .await
         .unwrap_ok_committed();
 
-    assert_eq!(
-        receiver2.local_balance().await.unwrap(),
-        Amount::from_tokens(3)
-    );
+    assert_eq!(receiver2.local_balance().await.unwrap(), amount1 - amount3);
 
     Ok(())
 }

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -946,7 +946,7 @@ where
             self.storage,
             cancellation_token.clone(),
         )
-        .run()
+        .run(None) // Faucet doesn't receive messages, so no need for background sync
         .await?;
         let batch_processor_task = batch_processor.run(cancellation_token.clone());
         let tcp_listener =

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -815,6 +815,17 @@ type MutationRoot {
 		chainId: ChainId!
 	): [CryptoHash!]!
 	"""
+	Synchronizes the chain with the validators. Returns the chain's length.
+	
+	This is only used for testing, to make sure that a client is up to date.
+	"""
+	sync(
+		"""
+		The chain being synchronized.
+		"""
+		chainId: ChainId!
+	): Int!
+	"""
 	Retries the pending block that was unsuccessfully proposed earlier.
 	"""
 	retryPendingBlock(

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -815,15 +815,6 @@ type MutationRoot {
 		chainId: ChainId!
 	): [CryptoHash!]!
 	"""
-	Synchronizes the chain with the validators. Returns the chain's length.
-	"""
-	sync(
-		"""
-		The chain being synchronized.
-		"""
-		chainId: ChainId!
-	): Int!
-	"""
 	Retries the pending block that was unsuccessfully proposed earlier.
 	"""
 	retryPendingBlock(

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -815,6 +815,15 @@ type MutationRoot {
 		chainId: ChainId!
 	): [CryptoHash!]!
 	"""
+	Synchronizes the chain with the validators. Returns the chain's length.
+	"""
+	sync(
+		"""
+		The chain being synchronized.
+		"""
+		chainId: ChainId!
+	): Int!
+	"""
 	Retries the pending block that was unsuccessfully proposed earlier.
 	"""
 	retryPendingBlock(

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -743,6 +743,14 @@ pub enum ClientCommand {
         #[arg(long)]
         port: NonZeroU16,
 
+        /// Milliseconds to sleep between batches during background certificate synchronization.
+        #[arg(
+            long = "sync-sleep-ms",
+            default_value = "500",
+            env = "LINERA_SYNC_SLEEP_MS"
+        )]
+        sync_sleep_ms: u64,
+
         /// The port to expose metrics on.
         #[cfg(with_metrics)]
         #[arg(long)]

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1225,6 +1225,7 @@ impl Runnable for Job {
             Service {
                 config,
                 port,
+                sync_sleep_ms,
                 #[cfg(with_metrics)]
                 metrics_port,
             } => {
@@ -1241,7 +1242,7 @@ impl Runnable for Job {
                 );
                 let cancellation_token = CancellationToken::new();
                 tokio::spawn(listen_for_shutdown_signals(cancellation_token.clone()));
-                service.run(cancellation_token).await?;
+                service.run(cancellation_token, sync_sleep_ms).await?;
             }
 
             Faucet {

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1614,7 +1614,7 @@ impl Runnable for Job {
                 context.client.track_chain(chain_id);
                 let chain_client = context.make_chain_client(chain_id);
                 if sync {
-                    chain_client.synchronize_from_validators().await?;
+                    chain_client.synchronize_chain_state(chain_id).await?;
                 } else {
                     chain_client.fetch_chain_info().await?;
                 }

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -1259,6 +1259,12 @@ impl NodeService {
         Ok(serde_json::from_value(data["processInbox"].take())?)
     }
 
+    pub async fn sync(&self, chain_id: &ChainId) -> Result<u64> {
+        let query = format!("mutation {{ sync(chainId: \"{chain_id}\") }}");
+        let mut data = self.query_node(query).await?;
+        Ok(serde_json::from_value(data["sync"].take())?)
+    }
+
     pub async fn transfer(
         &self,
         chain_id: ChainId,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -199,6 +199,9 @@ where
     }
 
     /// Synchronizes the chain with the validators. Returns the chain's length.
+    ///
+    /// This is only used for testing, to make sure that a client is up to date.
+    #[cfg(with_testing)] // TODO(#4718): Remove this mutation.
     async fn sync(
         &self,
         #[graphql(desc = "The chain being synchronized.")] chain_id: ChainId,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -183,8 +183,7 @@ where
         let mut hashes = Vec::new();
         loop {
             let client = self.context.lock().await.make_chain_client(chain_id);
-            client.synchronize_from_validators().await?;
-            let result = client.process_inbox_without_prepare().await;
+            let result = client.process_inbox().await;
             self.context.lock().await.update_wallet(&client).await?;
             let (certificates, maybe_timeout) = result?;
             hashes.extend(certificates.into_iter().map(|cert| cert.hash()));

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -886,7 +886,11 @@ where
 
     /// Runs the node service.
     #[instrument(name = "node_service", level = "info", skip_all, fields(port = ?self.port))]
-    pub async fn run(self, cancellation_token: CancellationToken) -> Result<(), anyhow::Error> {
+    pub async fn run(
+        self,
+        cancellation_token: CancellationToken,
+        sync_sleep_ms: u64,
+    ) -> Result<(), anyhow::Error> {
         let port = self.port.get();
         let index_handler = axum::routing::get(util::graphiql).post(Self::index_handler);
         let application_handler =
@@ -917,7 +921,7 @@ where
             storage,
             cancellation_token.clone(),
         )
-        .run()
+        .run(Some(sync_sleep_ms))
         .await?;
         let mut chain_listener = Box::pin(chain_listener).fuse();
         let tcp_listener =

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -201,7 +201,7 @@ where
     /// Synchronizes the chain with the validators. Returns the chain's length.
     ///
     /// This is only used for testing, to make sure that a client is up to date.
-    #[cfg(with_testing)] // TODO(#4718): Remove this mutation.
+    // TODO(#4718): Remove this mutation.
     async fn sync(
         &self,
         #[graphql(desc = "The chain being synchronized.")] chain_id: ChainId,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -198,6 +198,17 @@ where
         }
     }
 
+    /// Synchronizes the chain with the validators. Returns the chain's length.
+    async fn sync(
+        &self,
+        #[graphql(desc = "The chain being synchronized.")] chain_id: ChainId,
+    ) -> Result<u64, Error> {
+        let client = self.context.lock().await.make_chain_client(chain_id);
+        let info = client.synchronize_from_validators().await?;
+        self.context.lock().await.update_wallet(&client).await?;
+        Ok(info.next_block_height.0)
+    }
+
     /// Retries the pending block that was unsuccessfully proposed earlier.
     async fn retry_pending_block(
         &self,

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2956,11 +2956,8 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     let port1 = get_node_port().await;
     let port2 = get_node_port().await;
     let port3 = get_node_port().await;
-
-    // We let the admin chain automatically process its inbox, since that always creates a
-    // response to the other chains.
     let mut node_service_admin = client_admin
-        .run_node_service(port1, ProcessInbox::Automatic)
+        .run_node_service(port1, ProcessInbox::Skip)
         .await?;
     let mut node_service_a = client_a.run_node_service(port2, ProcessInbox::Skip).await?;
     let mut node_service_b = client_b.run_node_service(port3, ProcessInbox::Skip).await?;
@@ -3058,14 +3055,15 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     // The orders are sent on chain_a / chain_b. First they are
     // rerouted to the admin chain for processing. This leads
     // to order being sent to chain_a / chain_b.
-    assert!(
-        eventually(|| async { node_service_a.process_inbox(&chain_a).await.unwrap().len() == 1 })
-            .await
+    node_service_admin.sync(&chain_admin).await?;
+    assert_eq!(
+        node_service_admin.process_inbox(&chain_admin).await?.len(),
+        1
     );
-    assert!(
-        eventually(|| async { node_service_b.process_inbox(&chain_b).await.unwrap().len() == 1 })
-            .await
-    );
+    node_service_a.sync(&chain_a).await?;
+    assert_eq!(node_service_a.process_inbox(&chain_a).await?.len(), 1);
+    node_service_b.sync(&chain_b).await?;
+    assert_eq!(node_service_b.process_inbox(&chain_b).await?.len(), 1);
 
     // Now reading the order_ids
     let order_ids_a = app_matching_admin.get_account_info(&owner_a).await;
@@ -3092,15 +3090,16 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
             .await;
     }
 
+    node_service_admin.sync(&chain_admin).await?;
     // Same logic as for the insertion of orders.
-    assert!(
-        eventually(|| async { node_service_a.process_inbox(&chain_a).await.unwrap().len() == 1 })
-            .await
+    assert_eq!(
+        node_service_admin.process_inbox(&chain_admin).await?.len(),
+        1
     );
-    assert!(
-        eventually(|| async { node_service_b.process_inbox(&chain_b).await.unwrap().len() == 1 })
-            .await
-    );
+    node_service_a.sync(&chain_a).await?;
+    assert_eq!(node_service_a.process_inbox(&chain_a).await?.len(), 1);
+    node_service_b.sync(&chain_b).await?;
+    assert_eq!(node_service_b.process_inbox(&chain_b).await?.len(), 1);
 
     // Check balances
     app_fungible0_a

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2119,7 +2119,6 @@ async fn test_wasm_end_to_end_allowances_fungible(config: impl LineraNetConfig) 
     app1.assert_allowance(&owner1, &owner2, Amount::from_tokens(93))
         .await;
 
-    // Call process inbox in order to synchronize from validators.
     assert!(
         eventually(|| async {
             app2.get_allowance(&owner1, &owner2).await == Amount::from_tokens(93)

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2112,28 +2112,22 @@ async fn test_wasm_end_to_end_allowances_fungible(config: impl LineraNetConfig) 
     app2.assert_balances(expected_balances).await;
     app3.assert_balances(expected_balances).await;
 
-    // Approving a transfer
+    // Approving a transfer.
     app1.approve(&owner1, &owner2, Amount::from_tokens(93))
         .await;
 
     app1.assert_allowance(&owner1, &owner2, Amount::from_tokens(93))
         .await;
 
-    // Call process inbox in order to synchronize from validators
+    // Call process inbox in order to synchronize from validators.
     assert!(
         eventually(|| async {
-            !node_service2
-                .process_inbox(&chain2)
-                .await
-                .unwrap()
-                .is_empty()
+            app2.get_allowance(&owner1, &owner2).await == Amount::from_tokens(93)
         })
         .await
     );
-    app2.assert_allowance(&owner1, &owner2, Amount::from_tokens(93))
-        .await;
 
-    // Doing the transfer from
+    // Doing the transfer from owner 1.
     app2.transfer_from(
         &owner1,
         &owner2,

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2956,8 +2956,11 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     let port1 = get_node_port().await;
     let port2 = get_node_port().await;
     let port3 = get_node_port().await;
+
+    // We let the admin chain automatically process its inbox, since that always creates a
+    // response to the other chains.
     let mut node_service_admin = client_admin
-        .run_node_service(port1, ProcessInbox::Skip)
+        .run_node_service(port1, ProcessInbox::Automatic)
         .await?;
     let mut node_service_a = client_a.run_node_service(port2, ProcessInbox::Skip).await?;
     let mut node_service_b = client_b.run_node_service(port3, ProcessInbox::Skip).await?;
@@ -3056,17 +3059,6 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     // rerouted to the admin chain for processing. This leads
     // to order being sent to chain_a / chain_b.
     assert!(
-        eventually(|| async {
-            node_service_admin
-                .process_inbox(&chain_admin)
-                .await
-                .unwrap()
-                .len()
-                == 1
-        })
-        .await
-    );
-    assert!(
         eventually(|| async { node_service_a.process_inbox(&chain_a).await.unwrap().len() == 1 })
             .await
     );
@@ -3101,17 +3093,6 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     }
 
     // Same logic as for the insertion of orders.
-    assert!(
-        eventually(|| async {
-            node_service_admin
-                .process_inbox(&chain_admin)
-                .await
-                .unwrap()
-                .len()
-                == 1
-        })
-        .await
-    );
     assert!(
         eventually(|| async { node_service_a.process_inbox(&chain_a).await.unwrap().len() == 1 })
             .await

--- a/web/@linera/client/src/lib.rs
+++ b/web/@linera/client/src/lib.rs
@@ -242,7 +242,7 @@ impl Client {
             storage,
             tokio_util::sync::CancellationToken::new(),
         )
-        .run()
+        .run(Some(500)) // Enable background sync with 500ms sleep
         .boxed_local()
         .await?
         .boxed_local();


### PR DESCRIPTION
## Motivation

`find_received_certificates_from_validator` and `find_received_certificates` can take a lot of time (and memory) if there are a lot of incoming messages.

## Proposal

Only do them as part of `synchronize_from_validators`. On notification, `prepare_chain` and when we're about to propose a block, only download what's necessary.

Download and process sender certificates in batches, to avoid the high memory usage.

Download them in a background task in the node service, with some sleep time in between, to limit interference with the other node service tasks.

(Mostly written with Claude Sonnet 4.5.)

## Test Plan

CI
A new test was added for the updated `prepare_chain`. `test_sparse_sender_chain` already exists, and tests notification handling with a sparse chain.

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a new SDK.

## Links

- Closes #4705.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
