### PR TITLE
Use --with-faucet on remote-net-test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,18 +81,17 @@ jobs:
         cargo build --features storage-service --bin linera-server --bin linera-proxy --bin linera
     - name: Run the validators and faucet, wait for faucet to be ready
       run: |
-        mkdir /tmp/local-linera-net
-        cargo run --features storage-service --bin linera -- net up --storage service:tcp:$LINERA_STORAGE_SERVICE:table --policy-config testnet --path /tmp/local-linera-net --validators 2 --shards 2 &
-        # Create two epochs and run the faucet.
-        # See https://github.com/linera-io/linera-protocol/pull/2835 for details.
-        mkdir /tmp/linera-faucet
-        cargo run --bin linera -- resource-control-policy --http-request-timeout-ms 1000
-        cargo run --bin linera -- resource-control-policy --http-request-timeout-ms 500
         FAUCET_PORT=$(echo "$LINERA_FAUCET_URL" | cut -d: -f3)
         LOG_FILE="/tmp/linera-net-up.log"
-        cargo run --bin linera -- faucet --storage-path /tmp/linera-faucet/faucet_storage.sqlite --amount 1000 --port $FAUCET_PORT > "$LOG_FILE" 2>&1 &
+        mkdir /tmp/local-linera-net
+        cargo run --features storage-service --bin linera -- net up --storage service:tcp:$LINERA_STORAGE_SERVICE:table --policy-config testnet --path /tmp/local-linera-net --validators 2 --shards 2 --with-faucet --faucet-port $FAUCET_PORT --faucet-amount 1000 > "$LOG_FILE" 2>&1 &
         FAUCET_PID=$!
         bash scripts/wait-for-kubernetes-service.sh "$LINERA_FAUCET_URL" "$FAUCET_PID" "$LOG_FILE"
+        # Create two epochs
+        # See https://github.com/linera-io/linera-protocol/pull/2835 for details.
+        LINERA_STORAGE=rocksdb:/tmp/local-linera-net/client_1.db cargo run --bin linera -- storage initialize --genesis /tmp/local-linera-net/genesis.json
+        LINERA_STORAGE=rocksdb:/tmp/local-linera-net/client_1.db cargo run --bin linera -- resource-control-policy --http-request-timeout-ms 1000
+        LINERA_STORAGE=rocksdb:/tmp/local-linera-net/client_1.db cargo run --bin linera -- resource-control-policy --http-request-timeout-ms 500
     - name: Run the remote-net tests
       run: |
         cargo test -p linera-service remote_net_grpc --features remote-net


### PR DESCRIPTION
## Motivation

The order of things got messed up in a previous PR

## Proposal

Fix it, and make sure everything is setup before calling the `resource-control-policy` commands.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
