### PR TITLE
Deserialize errors in the proxy.

### DIFF
--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -19,6 +19,7 @@ use futures::{future::BoxFuture, FutureExt as _};
 use linera_base::identifiers::ChainId;
 use linera_core::{
     data_types::{CertificatesByHeightRequest, ChainInfo, ChainInfoQuery},
+    node::NodeError,
     notifier::ChannelNotifier,
     JoinSetExt as _,
 };
@@ -744,9 +745,12 @@ where
                 chain_info.requested_sent_certificate_hashes
             }
             Some(api::chain_info_result::Inner::Error(error)) => {
+                let error =
+                    bincode::deserialize(&error).unwrap_or_else(|err| NodeError::GrpcError {
+                        error: format!("failed to unmarshal error message: {}", err),
+                    });
                 return Err(Status::internal(format!(
-                    "Chain info query failed: {:?}",
-                    error
+                    "Chain info query failed: {error}"
                 )));
             }
             None => {
@@ -787,9 +791,12 @@ where
                 chain_info.requested_sent_certificate_hashes
             }
             Some(api::chain_info_result::Inner::Error(error)) => {
+                let error =
+                    bincode::deserialize(&error).unwrap_or_else(|err| NodeError::GrpcError {
+                        error: format!("failed to unmarshal error message: {}", err),
+                    });
                 return Err(Status::internal(format!(
-                    "Chain info query failed: {:?}",
-                    error
+                    "Chain info query failed: {error}"
                 )));
             }
             None => {


### PR DESCRIPTION
## Motivation

Errors in chain info results are currently turned into a list of integers (their serialized bytes).

## Proposal

Deserialize and `Display` them instead.

## Test Plan

CI

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a validator hotfix.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
