### PR TITLE
`linera-service`: faucet URL env var

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -983,7 +983,9 @@ Initialize a wallet from the genesis configuration
 
 ###### **Options:**
 
-* `--genesis <GENESIS_CONFIG_PATH>` — The path to the genesis configuration for a Linera deployment. Either this or `--faucet` must be specified
+* `--genesis <GENESIS_CONFIG_PATH>` — The path to the genesis configuration for a Linera deployment. Either this or `--faucet` must be specified.
+
+   Overrides `--faucet` if provided.
 * `--faucet <FAUCET>` — The address of a faucet
 * `--testing-prng-seed <TESTING_PRNG_SEED>` — Force this wallet to generate keys using a PRNG and a given seed. USE FOR TESTING ONLY
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5702,6 +5702,7 @@ dependencies = [
  "futures",
  "heck 0.4.1",
  "http 1.3.1",
+ "insta",
  "k8s-openapi",
  "kube",
  "linera-base",

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -89,6 +89,7 @@ fs_extra = { workspace = true, optional = true }
 futures.workspace = true
 heck.workspace = true
 http.workspace = true
+insta.workspace = true
 k8s-openapi = { workspace = true, optional = true }
 kube = { workspace = true, optional = true }
 linera-base.workspace = true

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -138,7 +138,7 @@ pub enum BenchmarkCommand {
         processes: usize,
 
         /// The faucet (which implicitly defines the network)
-        #[arg(long)]
+        #[arg(long, env = "LINERA_FAUCET_URL")]
         faucet: String,
 
         /// If specified, a directory with a random name will be created in this directory, and the
@@ -1208,7 +1208,7 @@ pub enum WalletCommand {
         genesis_config_path: Option<PathBuf>,
 
         /// The address of a faucet.
-        #[arg(long = "faucet")]
+        #[arg(long, env = "LINERA_FAUCET_URL")]
         faucet: Option<String>,
 
         /// Force this wallet to generate keys using a PRNG and a given seed. USE FOR
@@ -1220,7 +1220,7 @@ pub enum WalletCommand {
     /// Request a new chain from a faucet and add it to the wallet.
     RequestChain {
         /// The address of a faucet.
-        #[arg(long)]
+        #[arg(long, env = "LINERA_FAUCET_URL")]
         faucet: String,
 
         /// Whether this chain should become the default chain.

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -1204,6 +1204,8 @@ pub enum WalletCommand {
     Init {
         /// The path to the genesis configuration for a Linera deployment. Either this or `--faucet`
         /// must be specified.
+        ///
+        /// Overrides `--faucet` if provided.
         #[arg(long = "genesis")]
         genesis_config_path: Option<PathBuf>,
 

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1588,8 +1588,12 @@ impl Runnable for Job {
                 );
             }
 
-            Wallet(WalletCommand::Init { faucet, .. }) => {
-                let Some(faucet_url) = faucet else {
+            Wallet(WalletCommand::Init {
+                faucet,
+                genesis_config_path,
+                ..
+            }) => {
+                let (Some(faucet_url), None) = (faucet, genesis_config_path) else {
                     return Ok(());
                 };
                 let Some(network_description) = storage.read_network_description().await? else {
@@ -2447,7 +2451,10 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
             } => {
                 let start_time = Instant::now();
                 let genesis_config: GenesisConfig = match (genesis_config_path, faucet) {
-                    (Some(genesis_config_path), None) => util::read_json(genesis_config_path)?,
+                    (None, None) => {
+                        anyhow::bail!("please specify one of `--faucet` or `--genesis`.")
+                    }
+                    (Some(genesis_config_path), _) => util::read_json(genesis_config_path)?,
                     (None, Some(url)) => {
                         let faucet = cli_wrappers::Faucet::new(url.clone());
                         let version_info = faucet
@@ -2473,7 +2480,6 @@ Make sure to use a Linera client compatible with this network.
                             .await
                             .context("Failed to obtain the genesis configuration from the faucet")?
                     }
-                    (_, _) => bail!("Either --faucet or --genesis must be specified, but not both"),
                 };
                 let mut keystore = options.create_keystore(*testing_prng_seed)?;
                 keystore.persist().await?;

--- a/linera-service/src/cli/net_up_utils.rs
+++ b/linera-service/src/cli/net_up_utils.rs
@@ -318,21 +318,21 @@ async fn print_messages_and_create_faucet(
         "{}",
         format!(
             "export LINERA_WALLET=\"{}\"",
-            client.wallet_path().display()
+            client.wallet_path().display(),
         )
-        .bold()
+        .bold(),
     );
     println!(
         "{}",
         format!(
             "export LINERA_KEYSTORE=\"{}\"",
-            client.keystore_path().display()
+            client.keystore_path().display(),
         )
         .bold()
     );
     println!(
         "{}",
-        format!("export LINERA_STORAGE=\"{}\"\n", client.storage_path()).bold()
+        format!("export LINERA_STORAGE=\"{}\"\n", client.storage_path()).bold(),
     );
 
     let wallet = client.load_wallet()?;
@@ -344,16 +344,23 @@ async fn print_messages_and_create_faucet(
             assert!(
                 num_other_initial_chains > faucet_chain_idx,
                 "num_other_initial_chains must be strictly greater than the faucet chain index if \
-            with_faucet is true"
+                 with_faucet is true"
             );
+
+            eprintln!("To connect to this network, you can use the following faucet URL:");
+            println!(
+                "\n{}\n",
+                format!("export LINERA_FAUCET_URL=\"http://localhost:{faucet_port}\"").bold(),
+            );
+
             // This picks a lexicographically faucet_chain_idx-th non-admin chain.
             Some(
                 chains
                     .into_iter()
                     .filter(|chain_id| *chain_id != wallet.genesis_admin_chain())
                     .nth(faucet_chain_idx as usize)
-                    .unwrap(),
-            ) // we checked that there are enough chains above, so this should be safe
+                    .expect("there should be at least one non-admin chain"),
+            )
         } else {
             None
         };

--- a/linera-service/src/cli/net_up_utils.rs
+++ b/linera-service/src/cli/net_up_utils.rs
@@ -332,7 +332,7 @@ async fn print_messages_and_create_faucet(
     );
     println!(
         "{}",
-        format!("export LINERA_STORAGE=\"{}\"\n", client.storage_path()).bold(),
+        format!("export LINERA_STORAGE=\"{}\"", client.storage_path()).bold(),
     );
 
     let wallet = client.load_wallet()?;
@@ -349,7 +349,7 @@ async fn print_messages_and_create_faucet(
 
             eprintln!("To connect to this network, you can use the following faucet URL:");
             println!(
-                "\n{}\n",
+                "{}",
                 format!("export LINERA_FAUCET_URL=\"http://localhost:{faucet_port}\"").bold(),
             );
 
@@ -371,6 +371,8 @@ async fn print_messages_and_create_faucet(
     } else {
         None
     };
+
+    println!();
 
     eprintln!(
         "\nREADY!\nPress ^C to terminate the local test network and clean the temporary directory."

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -571,7 +571,7 @@ impl ClientWrapper {
                 info!("Faucet has started");
                 return Ok(FaucetService::new(port, child, temp_dir));
             } else {
-                warn!("Waiting for faucet to start");
+                tracing::debug!("Waiting for faucet to start");
             }
         }
         bail!("Failed to start faucet");

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -697,41 +697,40 @@ async fn test_storage_service_linera_net_up_simple() -> Result<()> {
     let mut lines = stderr.lines();
 
     let mut is_ready = false;
+    eprintln!("waiting for network to be ready");
     for line in &mut lines {
         let line = line?;
+        eprintln!("[net up]: {line}");
         if line.starts_with("READY!") {
             is_ready = true;
             break;
         }
     }
-    assert!(is_ready, "Unexpected EOF for stderr");
+
+    if !is_ready {
+        assert!(is_ready, "unexpected EOF for stderr");
+    } else {
+        eprintln!("network is ready");
+    }
 
     // Echo faucet stderr for debugging and to empty the buffer.
     std::thread::spawn(move || {
         for line in lines {
-            let line = line.unwrap();
-            eprintln!("{}", line);
+            eprintln!("[net up] {}", line.unwrap());
         }
     });
 
-    let mut exports = stdout.lines();
-    assert!(exports
-        .next()
-        .unwrap()?
-        .starts_with("export LINERA_WALLET="));
-    assert!(exports
-        .next()
-        .unwrap()?
-        .starts_with("export LINERA_KEYSTORE="));
-    assert!(exports
-        .next()
-        .unwrap()?
-        .starts_with("export LINERA_STORAGE="));
-    assert!(exports
-        .next()
-        .unwrap()?
-        .starts_with("export LINERA_FAUCET_URL="));
-    assert_eq!(exports.next().unwrap()?, "");
+    insta::assert_snapshot!(stdout
+        .lines()
+        .map_while(|line| {
+            println!("{line:?}");
+            line.unwrap()
+                .split_once("=")
+                .map(|x| x.0.to_owned())
+                .filter(|line| line.starts_with("export"))
+        })
+        .collect::<Vec<_>>()
+        .join("\n"));
 
     // Test faucet.
     let faucet = Faucet::new(format!("http://localhost:{}/", port));
@@ -742,7 +741,6 @@ async fn test_storage_service_linera_net_up_simple() -> Result<()> {
         .args(["-s", "INT", &child.id().to_string()])
         .output()?;
 
-    assert!(exports.next().is_none());
     assert!(child.wait()?.success());
     return Ok(());
 }

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -727,6 +727,10 @@ async fn test_storage_service_linera_net_up_simple() -> Result<()> {
         .next()
         .unwrap()?
         .starts_with("export LINERA_STORAGE="));
+    assert!(exports
+        .next()
+        .unwrap()?
+        .starts_with("export LINERA_FAUCET_URL="));
     assert_eq!(exports.next().unwrap()?, "");
 
     // Test faucet.

--- a/linera-service/tests/snapshots/local_net_tests__storage_service_linera_net_up_simple.snap
+++ b/linera-service/tests/snapshots/local_net_tests__storage_service_linera_net_up_simple.snap
@@ -1,0 +1,8 @@
+---
+source: linera-service/tests/local_net_tests.rs
+expression: "stdout.lines().map_while(|line|\n{\n    println!(\"{line:?}\");\n    line.unwrap().split_once(\"=\").map(|x|\n    x.0.to_owned()).filter(|line| line.starts_with(\"export\"))\n}).collect::<Vec<_>>().join(\"\\n\")"
+---
+export LINERA_WALLET
+export LINERA_KEYSTORE
+export LINERA_STORAGE
+export LINERA_FAUCET_URL


### PR DESCRIPTION
## Motivation

Quality of life: it's pretty annoying when using `linera net up` to have to repeat the faucet URL all the time.

## Proposal

Support setting the faucet URL through an environment variable for the CLI, akin to `LINERA_WALLET` and friends.  This reduces the need for repeating the URL a lot when testing on a local network.

## Test Plan

Used locally.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
