### PR TITLE
Add support for chrome trace exporter

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -146,6 +146,9 @@ Client implementation and command-line tool for the Linera blockchain
 * `--max-retries <MAX_RETRIES>` — Number of times to retry connecting to a validator
 
   Default value: `10`
+* `--chrome-trace-exporter` — Enable OpenTelemetry Chrome JSON exporter for trace data analysis
+* `--otel-trace-file <OTEL_TRACE_FILE>` — Output file path for Chrome trace JSON format. Can be visualized in chrome://tracing or Perfetto UI
+* `--otel-exporter-otlp-endpoint <OTEL_EXPORTER_OTLP_ENDPOINT>` — OpenTelemetry OTLP exporter endpoint (requires tempo feature)
 * `--wait-for-outgoing-messages` — Whether to wait until a quorum of validators has confirmed that all sent cross-chain messages have been delivered
 * `--long-lived-services` — (EXPERIMENTAL) Whether application services can persist in some cases between queries
 * `--blanket-message-policy <BLANKET_MESSAGE_POLICY>` — The policy for handling incoming messages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5116,6 +5116,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_with",
+ "tempfile",
  "test-case",
  "test-strategy",
  "thiserror 1.0.69",
@@ -5123,6 +5124,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "tracing-chrome",
  "tracing-opentelemetry",
  "tracing-subscriber 0.3.19",
  "tracing-web",
@@ -10540,6 +10542,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber 0.3.19",
+]
+
+[[package]]
 name = "tracing-core"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10610,9 +10623,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
  "tracing-serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,6 +260,7 @@ tonic-web-wasm-client = "0.8.0"
 tower = "0.4.13"
 tower-http = "0.6.6"
 tracing = { version = "0.1.40", features = ["release_max_level_debug"] }
+tracing-chrome = "0.7.2"
 tracing-opentelemetry = "0.31.0"
 tracing-subscriber = { version = "0.3.18", default-features = false, features = [
     "env-filter",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3608,6 +3608,8 @@ dependencies = [
  "is-terminal",
  "k256",
  "linera-witty",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "port-selector",
  "prometheus",
  "proptest",
@@ -3625,6 +3627,8 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "tracing-chrome",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "trait-variant",
  "zstd",
@@ -4498,6 +4502,38 @@ name = "oneshot"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e296cf87e61c9cfc1a61c3c63a0f7f286ed4554e0e22be84e8a38e1d264a2a29"
+
+[[package]]
+name = "opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.9",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.0",
+ "serde_json",
+ "thiserror 2.0.9",
+ "tokio",
+ "tokio-stream",
+]
 
 [[package]]
 name = "overload"
@@ -6593,6 +6629,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-core"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6612,6 +6659,35 @@ dependencies = [
  "futures-task",
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -6637,9 +6713,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
  "tracing-serde",
 ]
 
@@ -7019,6 +7097,16 @@ name = "web-sys"
 version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -18,12 +18,7 @@ workspace = true
 metrics = ["prometheus"]
 reqwest = ["dep:reqwest"]
 revm = []
-tempo = [
-    "opentelemetry",
-    "opentelemetry-otlp",
-    "opentelemetry_sdk",
-    "tracing-opentelemetry",
-]
+tempo = ["opentelemetry-otlp"]
 test = ["test-strategy", "proptest"]
 web = [
     "getrandom/js",
@@ -86,10 +81,11 @@ tracing-web = { optional = true, workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono.workspace = true
-opentelemetry = { workspace = true, optional = true }
+opentelemetry.workspace = true
 opentelemetry-otlp = { workspace = true, optional = true }
-opentelemetry_sdk = { workspace = true, optional = true }
-tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk.workspace = true
+tracing-chrome.workspace = true
+tracing-opentelemetry.workspace = true
 rand = { workspace = true, features = ["getrandom", "std", "std_rng"] }
 tokio = { workspace = true, features = [
     "process",
@@ -107,6 +103,7 @@ assert_matches.workspace = true
 bcs.workspace = true
 linera-base = { path = ".", default-features = false, features = ["test"] }
 linera-witty = { workspace = true, features = ["test"] }
+tempfile.workspace = true
 test-case.workspace = true
 
 [build-dependencies]

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -40,6 +40,8 @@ pub use task::Blocking;
 pub mod time;
 #[cfg_attr(web, path = "tracing_web.rs")]
 pub mod tracing;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod tracing_otel;
 #[cfg(test)]
 mod unit_tests;
 

--- a/linera-base/src/tracing.rs
+++ b/linera-base/src/tracing.rs
@@ -12,8 +12,6 @@ use std::{
 
 use is_terminal::IsTerminal as _;
 use tracing::Subscriber;
-#[cfg(all(not(target_arch = "wasm32"), feature = "tempo"))]
-use tracing_subscriber::filter::{filter_fn, FilterExt as _};
 use tracing_subscriber::{
     fmt::{
         self,
@@ -24,17 +22,51 @@ use tracing_subscriber::{
     layer::{Layer, SubscriberExt as _},
     registry::LookupSpan,
     util::SubscriberInitExt,
+    EnvFilter,
 };
-#[cfg(all(not(target_arch = "wasm32"), feature = "tempo"))]
-use {
-    opentelemetry::{global, trace::TracerProvider},
-    opentelemetry_otlp::{SpanExporter, WithExportConfig},
-    opentelemetry_sdk::{
-        trace::{self as sdktrace, SdkTracerProvider},
-        Resource,
-    },
-    tracing_opentelemetry::OpenTelemetryLayer,
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::tracing_otel::{
+    init_with_chrome_trace_exporter, init_with_opentelemetry, ChromeTraceGuard,
 };
+
+pub(crate) struct EnvConfig {
+    pub(crate) env_filter: EnvFilter,
+    span_events: FmtSpan,
+    format: Option<String>,
+    color_output: bool,
+    log_name: String,
+}
+
+impl EnvConfig {
+    pub(crate) fn stderr_layer<S>(&self) -> Box<dyn Layer<S> + Send + Sync>
+    where
+        S: Subscriber + for<'span> LookupSpan<'span>,
+    {
+        prepare_formatted_layer(
+            self.format.as_deref(),
+            fmt::layer()
+                .with_span_events(self.span_events.clone())
+                .with_writer(std::io::stderr)
+                .with_ansi(self.color_output),
+        )
+    }
+
+    pub(crate) fn maybe_log_file_layer<S>(&self) -> Option<Box<dyn Layer<S> + Send + Sync>>
+    where
+        S: Subscriber + for<'span> LookupSpan<'span>,
+    {
+        open_log_file(&self.log_name).map(|file_writer| {
+            prepare_formatted_layer(
+                self.format.as_deref(),
+                fmt::layer()
+                    .with_span_events(self.span_events.clone())
+                    .with_writer(Arc::new(file_writer))
+                    .with_ansi(false),
+            )
+        })
+    }
+}
 
 /// Initializes tracing in a standard way.
 ///
@@ -46,65 +78,19 @@ use {
 /// store log files. If it is set, a file named `log_name` with the `log` extension is
 /// created in the directory.
 pub fn init(log_name: &str) {
-    init_internal(log_name, false);
+    let config = get_env_config(log_name);
+    let maybe_log_file_layer = config.maybe_log_file_layer();
+    let stderr_layer = config.stderr_layer();
+
+    tracing_subscriber::registry()
+        .with(config.env_filter)
+        .with(maybe_log_file_layer)
+        .with(stderr_layer)
+        .init();
 }
 
-/// Initializes tracing with full OpenTelemetry support.
-///
-/// **IMPORTANT**: This function must be called from within a Tokio runtime context
-/// as it initializes OpenTelemetry background tasks for span batching and export.
-///
-/// This sets up complete tracing with OpenTelemetry integration, including the
-/// OpenTelemetry layer in the subscriber to export spans to Tempo.
-///
-/// ## Span Filtering for Performance
-///
-/// By default, spans created by `#[instrument]` are logged to console AND sent
-/// to OpenTelemetry. In order to not spam stderr, you can set a low level, and use the
-/// `telemetry_only` target:
-///
-/// ```rust
-/// use tracing::{instrument, Level};
-///
-/// // Always sent to telemetry; console output controlled by level
-/// #[instrument(level = "trace", target = "telemetry_only")]
-/// fn my_called_too_frequently_function() {
-///     // Will be sent to OpenTelemetry regardless of RUST_LOG level
-///     // Will only appear in console if RUST_LOG includes trace level
-/// }
-///
-/// // Higher level - more likely to appear in console
-/// #[instrument(level = "info", target = "telemetry_only")]
-/// fn my_important_function() {
-///     // Will be sent to OpenTelemetry regardless of RUST_LOG level
-///     // Will appear in console if RUST_LOG includes info level or higher
-/// }
-/// ```
-///
-/// **Key behaviors:**
-/// - If span level >= RUST_LOG level: span goes to BOTH telemetry AND console (regardless of target)
-/// - If span level < RUST_LOG level AND target = "telemetry_only": span goes to telemetry ONLY
-/// - If span level < RUST_LOG level AND target != "telemetry_only": span is filtered out completely
-/// - Default level for `telemetry_only` should be `trace` for minimal console noise
-/// - All explicit log calls (tracing::info!(), etc.) are always printed regardless of span filtering
-pub async fn init_with_opentelemetry(log_name: &str) {
-    #[cfg(feature = "tempo")]
-    {
-        init_internal(log_name, true);
-    }
-
-    #[cfg(not(feature = "tempo"))]
-    {
-        tracing::warn!(
-            "OpenTelemetry initialization requested but 'tempo' feature is not enabled. \
-             Initializing standard tracing without OpenTelemetry support."
-        );
-        init_internal(log_name, false);
-    }
-}
-
-fn init_internal(log_name: &str, with_opentelemetry: bool) {
-    let env_filter = tracing_subscriber::EnvFilter::builder()
+pub(crate) fn get_env_config(log_name: &str) -> EnvConfig {
+    let env_filter = EnvFilter::builder()
         .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
         .from_env_lossy();
 
@@ -116,87 +102,12 @@ fn init_internal(log_name: &str, with_opentelemetry: bool) {
     let color_output =
         !std::env::var("NO_COLOR").is_ok_and(|x| !x.is_empty()) && std::io::stderr().is_terminal();
 
-    let stderr_layer = prepare_formatted_layer(
-        format.as_deref(),
-        fmt::layer()
-            .with_span_events(span_events.clone())
-            .with_writer(std::io::stderr)
-            .with_ansi(color_output),
-    );
-
-    let maybe_log_file_layer = open_log_file(log_name).map(|file_writer| {
-        prepare_formatted_layer(
-            format.as_deref(),
-            fmt::layer()
-                .with_span_events(span_events)
-                .with_writer(Arc::new(file_writer))
-                .with_ansi(false),
-        )
-    });
-
-    #[cfg(any(target_arch = "wasm32", not(feature = "tempo")))]
-    {
-        let _ = with_opentelemetry;
-        tracing_subscriber::registry()
-            .with(env_filter)
-            .with(maybe_log_file_layer)
-            .with(stderr_layer)
-            .init();
-    }
-
-    #[cfg(all(not(target_arch = "wasm32"), feature = "tempo"))]
-    {
-        if with_opentelemetry {
-            // Initialize OpenTelemetry within async context
-            let otlp_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
-                .unwrap_or_else(|_| "http://tempo.tempo.svc.cluster.local:4317".to_string());
-
-            let exporter = SpanExporter::builder()
-                .with_tonic()
-                .with_endpoint(otlp_endpoint)
-                .build()
-                .expect("Failed to create OTLP exporter");
-
-            let resource = Resource::builder()
-                .with_service_name(log_name.to_string())
-                .build();
-
-            let tracer_provider = SdkTracerProvider::builder()
-                .with_resource(resource)
-                .with_batch_exporter(exporter)
-                .with_sampler(sdktrace::Sampler::AlwaysOn)
-                .build();
-
-            // Set the global tracer provider
-            global::set_tracer_provider(tracer_provider.clone());
-
-            let tracer = tracer_provider.tracer("linera");
-
-            let telemetry_only_filter =
-                filter_fn(|metadata| metadata.is_span() && metadata.target() == "telemetry_only");
-
-            let otel_env_filter = tracing_subscriber::EnvFilter::builder()
-                .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
-                .from_env_lossy();
-
-            let opentelemetry_filter = otel_env_filter.or(telemetry_only_filter);
-
-            let opentelemetry_layer =
-                OpenTelemetryLayer::new(tracer).with_filter(opentelemetry_filter);
-
-            tracing_subscriber::registry()
-                .with(env_filter)
-                .with(maybe_log_file_layer)
-                .with(stderr_layer)
-                .with(opentelemetry_layer)
-                .init();
-        } else {
-            tracing_subscriber::registry()
-                .with(env_filter)
-                .with(maybe_log_file_layer)
-                .with(stderr_layer)
-                .init();
-        }
+    EnvConfig {
+        env_filter,
+        span_events,
+        format,
+        color_output,
+        log_name: log_name.to_string(),
     }
 }
 
@@ -206,7 +117,7 @@ fn init_internal(log_name: &str, with_opentelemetry: bool) {
 /// and its name by the `log_name` parameter.
 ///
 /// Returns [`None`] if the `LINERA_LOG_DIR` environment variable is not set.
-fn open_log_file(log_name: &str) -> Option<File> {
+pub(crate) fn open_log_file(log_name: &str) -> Option<File> {
     let log_directory = env::var_os("LINERA_LOG_DIR")?;
     let mut log_file_path = Path::new(&log_directory).join(log_name);
     log_file_path.set_extension("log");
@@ -223,7 +134,7 @@ fn open_log_file(log_name: &str) -> Option<File> {
 /// Applies a requested `formatting` to the log output of the provided `layer`.
 ///
 /// Returns a boxed [`Layer`] with the formatting applied to the original `layer`.
-fn prepare_formatted_layer<S, N, W, T>(
+pub(crate) fn prepare_formatted_layer<S, N, W, T>(
     formatting: Option<&str>,
     layer: fmt::Layer<S, N, Format<Full, T>, W>,
 ) -> Box<dyn Layer<S> + Send + Sync>
@@ -243,7 +154,7 @@ where
     }
 }
 
-fn fmt_span_from_str(events: &str) -> FmtSpan {
+pub(crate) fn fmt_span_from_str(events: &str) -> FmtSpan {
     let mut fmt_span = FmtSpan::NONE;
     for event in events.split(',') {
         fmt_span |= match event {

--- a/linera-base/src/tracing_otel.rs
+++ b/linera-base/src/tracing_otel.rs
@@ -1,0 +1,109 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! OpenTelemetry integration for tracing with OTLP export to Tempo and Chrome trace export.
+
+use tracing_chrome::ChromeLayerBuilder;
+use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _};
+#[cfg(feature = "tempo")]
+use {
+    opentelemetry::{global, trace::TracerProvider},
+    opentelemetry_otlp::{SpanExporter, WithExportConfig},
+    opentelemetry_sdk::{trace::SdkTracerProvider, Resource},
+    tracing_opentelemetry::OpenTelemetryLayer,
+    tracing_subscriber::{
+        filter::{filter_fn, FilterExt as _},
+        layer::Layer,
+    },
+};
+
+/// Initializes tracing with OpenTelemetry OTLP exporter to Tempo.
+///
+/// Exports traces to Tempo using the OTLP protocol. Requires the `tempo` feature.
+#[cfg(feature = "tempo")]
+pub fn init_with_opentelemetry(log_name: &str, otlp_endpoint: Option<&str>) {
+    let endpoint = otlp_endpoint.unwrap_or("http://tempo.tempo.svc.cluster.local:4317");
+
+    let resource = Resource::builder()
+        .with_service_name(log_name.to_string())
+        .build();
+
+    let exporter = SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(endpoint)
+        .build()
+        .expect("Failed to create OTLP exporter");
+
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_resource(resource)
+        .with_batch_exporter(exporter)
+        .with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn)
+        .build();
+
+    global::set_tracer_provider(tracer_provider.clone());
+    let tracer = tracer_provider.tracer("linera");
+
+    let telemetry_only_filter =
+        filter_fn(|metadata| metadata.is_span() && metadata.target() == "telemetry_only");
+
+    let otel_env_filter = tracing_subscriber::EnvFilter::builder()
+        .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    let opentelemetry_filter = otel_env_filter.or(telemetry_only_filter);
+    let opentelemetry_layer = OpenTelemetryLayer::new(tracer).with_filter(opentelemetry_filter);
+
+    let config = crate::tracing::get_env_config(log_name);
+    let maybe_log_file_layer = config.maybe_log_file_layer();
+    let stderr_layer = config.stderr_layer();
+
+    tracing_subscriber::registry()
+        .with(opentelemetry_layer)
+        .with(config.env_filter)
+        .with(maybe_log_file_layer)
+        .with(stderr_layer)
+        .init();
+}
+
+/// Fallback when tempo feature is not enabled.
+#[cfg(not(feature = "tempo"))]
+pub fn init_with_opentelemetry(log_name: &str, _otlp_endpoint: Option<&str>) {
+    eprintln!(
+        "OTLP export requires the 'tempo' feature to be enabled! Falling back to default tracing initialization."
+    );
+    crate::tracing::init(log_name);
+}
+
+/// Guard that flushes Chrome trace file when dropped.
+///
+/// Store this guard in a variable that lives for the duration of your program.
+/// When it's dropped, the trace file will be completed and closed.
+pub type ChromeTraceGuard = tracing_chrome::FlushGuard;
+
+/// Initializes tracing with Chrome Trace JSON exporter.
+///
+/// Returns a guard that must be kept alive for the duration of the program.
+/// When the guard is dropped, the trace data is flushed and completed.
+///
+/// Exports traces to Chrome Trace JSON format which can be visualized in:
+/// - Chrome: `chrome://tracing`
+/// - Perfetto UI: <https://ui.perfetto.dev>
+pub fn init_with_chrome_trace_exporter<W>(log_name: &str, writer: W) -> ChromeTraceGuard
+where
+    W: std::io::Write + Send + 'static,
+{
+    let (chrome_layer, guard) = ChromeLayerBuilder::new().writer(writer).build();
+
+    let config = crate::tracing::get_env_config(log_name);
+    let maybe_log_file_layer = config.maybe_log_file_layer();
+    let stderr_layer = config.stderr_layer();
+
+    tracing_subscriber::registry()
+        .with(chrome_layer)
+        .with(config.env_filter)
+        .with(maybe_log_file_layer)
+        .with(stderr_layer)
+        .init();
+
+    guard
+}

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -103,6 +103,19 @@ pub struct ClientContextOptions {
     #[arg(long, default_value = "10")]
     pub max_retries: u32,
 
+    /// Enable OpenTelemetry Chrome JSON exporter for trace data analysis.
+    #[arg(long)]
+    pub chrome_trace_exporter: bool,
+
+    /// Output file path for Chrome trace JSON format.
+    /// Can be visualized in chrome://tracing or Perfetto UI.
+    #[arg(long, env = "LINERA_OTEL_TRACE_FILE")]
+    pub otel_trace_file: Option<String>,
+
+    /// OpenTelemetry OTLP exporter endpoint (requires tempo feature).
+    #[arg(long, env = "LINERA_OTEL_EXPORTER_OTLP_ENDPOINT")]
+    pub otel_exporter_otlp_endpoint: Option<String>,
+
     /// Whether to wait until a quorum of validators has confirmed that all sent cross-chain
     /// messages have been delivered.
     #[arg(long)]

--- a/linera-sdk/tests/fixtures/Cargo.lock
+++ b/linera-sdk/tests/fixtures/Cargo.lock
@@ -2152,6 +2152,8 @@ dependencies = [
  "is-terminal",
  "k256",
  "linera-witty",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "port-selector",
  "prometheus",
  "proptest",
@@ -2169,6 +2171,8 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "tracing-chrome",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "trait-variant",
  "zstd",
@@ -2828,6 +2832,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ce411919553d3f9fa53a0880544cda985a112117a0444d5ff1e870a893d6ea"
 
 [[package]]
+name = "opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.16",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "serde_json",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3245,6 +3281,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
+ "rand_chacha 0.9.0",
  "rand_core 0.9.3",
  "serde",
 ]
@@ -4512,6 +4549,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-core"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4519,6 +4567,35 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -4544,9 +4621,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
  "tracing-serde",
 ]
 
@@ -4876,6 +4955,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -2001,17 +2001,47 @@ async fn kill_all_processes(pids: &[u32]) {
     }
 }
 
-fn should_init_opentelemetry(command: &ClientCommand) -> bool {
-    matches!(command, ClientCommand::Faucet { .. })
+#[cfg(not(target_arch = "wasm32"))]
+fn init_tracing(
+    options: &ClientOptions,
+) -> anyhow::Result<Option<linera_base::tracing::ChromeTraceGuard>> {
+    if matches!(&options.command, ClientCommand::Faucet { .. }) {
+        linera_base::tracing::init_with_opentelemetry(
+            &options.command.log_file_name(),
+            options
+                .context_options
+                .otel_exporter_otlp_endpoint
+                .as_deref(),
+        );
+        Ok(None)
+    } else if options.context_options.chrome_trace_exporter {
+        let trace_file_path = options
+            .context_options
+            .otel_trace_file
+            .as_deref()
+            .map_or_else(
+                || format!("{}.trace.json", options.command.log_file_name()),
+                |s| s.to_string(),
+            );
+        let writer = std::fs::File::create(&trace_file_path)?;
+        Ok(Some(linera_base::tracing::init_with_chrome_trace_exporter(
+            &options.command.log_file_name(),
+            writer,
+        )))
+    } else {
+        linera_base::tracing::init(&options.command.log_file_name());
+        Ok(None)
+    }
 }
 
-fn main() -> anyhow::Result<()> {
+#[cfg(target_arch = "wasm32")]
+fn init_tracing(options: &ClientOptions) {
+    linera_base::tracing::init(&options.command.log_file_name());
+}
+
+fn main() -> anyhow::Result<process::ExitCode> {
     let options = ClientOptions::init();
-
-    if !should_init_opentelemetry(&options.command) {
-        linera_base::tracing::init(&options.command.log_file_name());
-    }
-
+    let _guard = init_tracing(&options)?;
     let mut runtime = if options.tokio_threads == Some(1) {
         tokio::runtime::Builder::new_current_thread()
     } else {
@@ -2035,25 +2065,20 @@ fn main() -> anyhow::Result<()> {
 
     let result = runtime
         .enable_all()
-        .build()
-        .expect("Failed to create Tokio runtime")
+        .build()?
         .block_on(run(&options).instrument(span));
 
-    let error_code = match result {
-        Ok(code) => code,
+    Ok(match result {
+        Ok(0) => process::ExitCode::SUCCESS,
+        Ok(code) => process::ExitCode::from(code as u8),
         Err(msg) => {
             error!("Error is {:?}", msg);
-            2
+            process::ExitCode::FAILURE
         }
-    };
-    process::exit(error_code);
+    })
 }
 
 async fn run(options: &ClientOptions) -> Result<i32, Error> {
-    if should_init_opentelemetry(&options.command) {
-        linera_base::tracing::init_with_opentelemetry(&options.command.log_file_name()).await;
-    }
-
     match &options.command {
         ClientCommand::HelpMarkdown => {
             clap_markdown::print_help_markdown::<ClientOptions>();

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -484,8 +484,10 @@ impl ProxyOptions {
         let server_config: ValidatorServerConfig =
             util::read_json(&self.config_path).expect("Fail to read server config");
         let public_key = &server_config.validator.public_key;
-        linera_base::tracing::init_with_opentelemetry(&format!("validator-{public_key}-proxy"))
-            .await;
+        linera_base::tracing::init_with_opentelemetry(
+            &format!("validator-{public_key}-proxy"),
+            None,
+        );
 
         let store_config = self
             .storage_config

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -508,7 +508,7 @@ fn log_file_name_for(command: &ServerCommand) -> Cow<'static, str> {
 }
 
 async fn run(options: ServerOptions) {
-    linera_base::tracing::init_with_opentelemetry(&log_file_name_for(&options.command)).await;
+    linera_base::tracing::init_with_opentelemetry(&log_file_name_for(&options.command), None);
 
     match options.command {
         ServerCommand::Run {

--- a/web/@linera/client/src/lib.rs
+++ b/web/@linera/client/src/lib.rs
@@ -97,6 +97,9 @@ pub const OPTIONS: ClientContextOptions = ClientContextOptions {
     wallet_state_path: None,
     keystore_path: None,
     with_wallet: None,
+    chrome_trace_exporter: false,
+    otel_trace_file: None,
+    otel_exporter_otlp_endpoint: None,
 };
 
 const BLOCK_CACHE_SIZE: usize = 5000;


### PR DESCRIPTION
## Motivation

Right now for tracing information we can only visualize it using Tempo, which doesn't really work for local client runs.

## Proposal

Add support for `ChromeTraceExporter`, which generates a JSON file that can be ingested by the Perfetto UI for visualization.

## Test Plan

Ran the client locally with the `--chrome-trace-exporter`, got the JSON file and managed to see the tracing data in the Perfetto UI
https://ui.perfetto.dev/#!/viewer?local_cache_key=00000000-0000-0000-f5e0-334428275111

By default it will save the profile JSON in the current directory, but that can be changed using the `--otel-trace-file` option, or the `LINERA_OTEL_TRACE_FILE` env variable.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
