### PR TITLE
Add helper script to generate cpu profiles when debugging

### DIFF
--- a/docker/debug/Dockerfile.debug
+++ b/docker/debug/Dockerfile.debug
@@ -15,7 +15,7 @@
 #       3) Load the image into the kind cluster:
 #           kind load docker-image --name 97461 us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera-debug:latest
 #       4) Create a debugging container that shares the same processes as the pod you're interested in debugging, and get a shell into it:
-#           kubectl debug -n default shards-0 -it --image=us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera-debug:latest --target=linera-server --share-processes --image-pull-policy=IfNotPresent --profile=sysadmin -- bash
+#           kubectl debug -n default shards-0 -it --image=us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera-debug:latest --target=linera-server --share-processes --image-pull-policy=IfNotPresent --profile=sysadmin --custom docker/debug/custom-spec.json -- bash
 
 #   * For debugging a GCP cluster:
 #       1) Connect to the cluster:
@@ -23,10 +23,17 @@
 #             in region `us-east1-b`. Run:
 #               gcloud container clusters get-credentials testnet-babbage-validator-1-cluster --region us-east1-b
 #       2) Create a debugging container that shares the same processes as the pod you're interested in debugging, and get a shell into it:
-#           kubectl debug -n default shards-0 -it --image=us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera-debug:latest --target=linera-server --share-processes --image-pull-policy=Always --profile=sysadmin -- bash
-# 
+#           kubectl debug -n default shards-0 -it --image=us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera-debug:latest --target=linera-server --share-processes --image-pull-policy=Always --profile=sysadmin --custom docker/debug/custom-spec.json -- bash
+#
 # You should now have a shell in this debugging container, with all the different debugging tools
 # installed below, but without bloating the production Docker image.
+#
+# To copy files from the debug container:
+#   * First, note the debug container name from the kubectl debug output (e.g., `debugger-rcg58`)
+#   * Use kubectl cp to copy files:
+#       kubectl cp <namespace>/<pod-name>:/path/in/container /local/path -c <debug-container-name> --context <context-name>
+#   * Example:
+#       kubectl cp default/shards-0:/tmp/cpu-profile.svg ~/cpu-profile.svg -c debugger-rcg58 --context gke_linera-io-dev_us-east1-b_some-cluster
 
 FROM debian:latest
 ENV DEBIAN_FRONTEND=noninteractive
@@ -50,7 +57,8 @@ RUN git clone --depth=1 https://github.com/brendangregg/FlameGraph /opt/FlameGra
     ln -s /opt/FlameGraph/flamegraph.pl /usr/local/bin/flamegraph
 
 COPY scripts/memleak_translate.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/memleak_translate.sh
+COPY scripts/cpu-profile.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/memleak_translate.sh /usr/local/bin/cpu-profile.sh
 
 ARG GRPCURL_VERSION=v1.9.3
 

--- a/docker/debug/custom-spec.json
+++ b/docker/debug/custom-spec.json
@@ -1,0 +1,10 @@
+{
+  "securityContext": {
+    "runAsUser": 0,
+    "runAsNonRoot": false
+  },
+  "podSecurityContext": {
+    "runAsUser": 0,
+    "runAsNonRoot": false
+  }
+}

--- a/scripts/cpu-profile.sh
+++ b/scripts/cpu-profile.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# CPU profiling wrapper script for easy flamegraph generation
+# Usage: cpu-profile.sh <PID> [duration_seconds]
+
+if [ $# -lt 1 ]; then
+    echo "Usage: cpu-profile.sh <PID> [duration_seconds]"
+    echo "Example: cpu-profile.sh 1234 30"
+    exit 1
+fi
+
+PID=$1
+DURATION=${2:-30}
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+PERF_DATA="/tmp/cpu-profile-${PID}-${TIMESTAMP}.perf.data"
+FOLDED_FILE="/tmp/cpu-profile-${PID}-${TIMESTAMP}.folded"
+SVG_FILE="/tmp/cpu-profile-${PID}-${TIMESTAMP}.svg"
+
+echo "Profiling PID $PID for $DURATION seconds..."
+echo "NOTE: The process must be actively using CPU for samples to be collected."
+echo "      If profiling an idle server, generate load during this time."
+echo ""
+
+# Profile using perf (works without kernel headers)
+perf record -F 99 -p $PID -g -o $PERF_DATA -- sleep $DURATION
+
+if [ $? -ne 0 ]; then
+    echo "ERROR: perf record failed. The process may have exited or perf may not have permissions."
+    exit 1
+fi
+
+echo "Perf data: $PERF_DATA"
+
+echo "Converting to folded format..."
+# Convert perf data to folded format
+perf script -i $PERF_DATA | stackcollapse-perf > $FOLDED_FILE
+
+if [ ! -s "$FOLDED_FILE" ]; then
+    echo "WARNING: Folded file is empty. This likely means:"
+    echo "  - The process was idle (not using CPU) during profiling"
+    echo "  - No samples were collected"
+    echo ""
+    echo "For an idle server, generate some load and try again."
+    exit 1
+fi
+
+echo "Folded output: $FOLDED_FILE"
+
+echo "Generating flamegraph..."
+# Generate flamegraph
+flamegraph $FOLDED_FILE > $SVG_FILE
+echo "SVG output: $SVG_FILE"
+
+echo ""
+echo "CPU profiling complete:"
+echo "  Perf data:   $PERF_DATA"
+echo "  Folded data: $FOLDED_FILE"
+echo "  Flamegraph:  $SVG_FILE"


### PR DESCRIPTION
## Motivation

Right now if you wanna manually trigger a CPU profile while within a container, while debugging, there's no straight forward way of doing it.

## Proposal

Create a `cpu-profile.sh` script that can be run to get an on demand CPU profile, if needed.

## Test Plan

Created a debug container in a pod in a network, and used the script:
```
root@shards-0:/# cpu-profile.sh 1 5
Profiling PID 1 for 5 seconds...
[ perf record: Woken up 1 times to write data ]
[ perf record: Captured and wrote 0.020 MB /tmp/cpu-profile-1-20251001_230439.perf.data (11 samples) ]
Perf data: /tmp/cpu-profile-1-20251001_230439.perf.data
Converting to folded format...
Folded output: /tmp/cpu-profile-1-20251001_230439.folded
Generating flamegraph...
SVG output: /tmp/cpu-profile-1-20251001_230439.svg

CPU profiling complete:
  Perf data:   /tmp/cpu-profile-1-20251001_230439.perf.data
  Folded data: /tmp/cpu-profile-1-20251001_230439.folded
  Flamegraph:  /tmp/cpu-profile-1-20251001_230439.svg
```

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
