### PR TITLE
Make connection and process_inbox logs less noisy. (#4672)

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -464,11 +464,14 @@ impl<C: ClientContext> ChainListener<C> {
                 debug!(%chain_id, "Cannot find key for chain");
             }
             Err(error) => warn!(%error, "Failed to process inbox."),
-            Ok((certs, None)) => info!("Done processing inbox. {} blocks created.", certs.len()),
+            Ok((certs, None)) => info!(
+                "Done processing inbox of chain. {} blocks created on chain {chain_id}.",
+                certs.len()
+            ),
             Ok((certs, Some(new_timeout))) => {
                 info!(
-                    "{} blocks created. Will try processing the inbox later based \
-                     on the given round timeout: {new_timeout:?}",
+                    "{} blocks created on chain {chain_id}. Will try processing the inbox later \
+                    based on the round timeout: {new_timeout:?}",
                     certs.len(),
                 );
                 listening_client.timeout = new_timeout.timestamp;

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -3844,7 +3844,7 @@ impl<Env: Environment> ChainClient<Env> {
                 if let Err(error) = &result {
                     warn!(?error, "Could not connect to validator {public_key}");
                 } else {
-                    info!("Connected to validator {public_key}");
+                    debug!("Connected to validator {public_key}");
                 }
                 result.ok()
             })


### PR DESCRIPTION
Backport of #4672.

## Motivation

Some `INFO` log messages are rather noisy if there are lots of chains in a wallet.

## Proposal

Make them `DEBUG`-level instead.

## Test Plan

(Only logging changes.)

## Release Plan

- These changes should be released in a new SDK. (Not urgent.)

## Links

- PR to main: #4672
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
