### PR TITLE
Don't do heavy syncing of sender chains unless requested. (#4706)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -729,6 +729,9 @@ Run a GraphQL service to explore and extend the chains of the wallet
 
   Default value: `0`
 * `--port <PORT>` — The port on which to run the server
+* `--sync-sleep-ms <SYNC_SLEEP_MS>` — Milliseconds to sleep between batches during background certificate synchronization
+
+  Default value: `500`
 
 
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -539,6 +539,33 @@ where
         Ok(())
     }
 
+    /// Collects all missing sender blocks from removed bundles across all inboxes.
+    /// Returns a map of origin chain IDs to their respective missing block heights.
+    #[instrument(target = "telemetry_only", skip_all, fields(
+        chain_id = %self.chain_id()
+    ))]
+    pub async fn collect_missing_sender_blocks(
+        &self,
+    ) -> Result<BTreeMap<ChainId, Vec<BlockHeight>>, ChainError> {
+        let pairs = self.inboxes.try_load_all_entries().await?;
+        let max_stream_queries = self.context().store().max_stream_queries();
+        let stream = stream::iter(pairs)
+            .map(|(origin, inbox)| async move {
+                let mut missing_heights = Vec::new();
+                let bundles = inbox.removed_bundles.elements().await?;
+                for bundle in bundles {
+                    missing_heights.push(bundle.height);
+                }
+                Ok::<(ChainId, Vec<BlockHeight>), ChainError>((origin, missing_heights))
+            })
+            .buffer_unordered(max_stream_queries);
+        let results: Vec<(ChainId, Vec<BlockHeight>)> = stream.try_collect().await?;
+        Ok(results
+            .into_iter()
+            .filter(|(_, heights)| !heights.is_empty())
+            .collect())
+    }
+
     pub async fn next_block_height_to_receive(
         &self,
         origin: &ChainId,

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -56,7 +56,7 @@ pub enum ChainError {
         height: BlockHeight,
     },
     #[error(
-        "Message in block proposed to {chain_id:?} does not match the previously received messages from \
+        "Message in block proposed to {chain_id} does not match the previously received messages from \
         origin {origin:?}: was {bundle:?} instead of {previous_bundle:?}"
     )]
     UnexpectedMessage {
@@ -66,7 +66,7 @@ pub enum ChainError {
         previous_bundle: Box<MessageBundle>,
     },
     #[error(
-        "Message in block proposed to {chain_id:?} is out of order compared to previous messages \
+        "Message in block proposed to {chain_id} is out of order compared to previous messages \
          from origin {origin:?}: {bundle:?}. Block and height should be at least: \
          {next_height}, {next_index}"
     )]
@@ -78,7 +78,7 @@ pub enum ChainError {
         next_index: u32,
     },
     #[error(
-        "Block proposed to {chain_id:?} is attempting to reject protected message \
+        "Block proposed to {chain_id} is attempting to reject protected message \
         {posted_message:?}"
     )]
     CannotRejectMessage {
@@ -87,7 +87,7 @@ pub enum ChainError {
         posted_message: Box<PostedMessage>,
     },
     #[error(
-        "Block proposed to {chain_id:?} is attempting to skip a message bundle \
+        "Block proposed to {chain_id} is attempting to skip a message bundle \
          that cannot be skipped: {bundle:?}"
     )]
     CannotSkipMessage {
@@ -96,7 +96,7 @@ pub enum ChainError {
         bundle: Box<MessageBundle>,
     },
     #[error(
-        "Incoming message bundle in block proposed to {chain_id:?} has timestamp \
+        "Incoming message bundle in block proposed to {chain_id} has timestamp \
         {bundle_timestamp:}, which is later than the block timestamp {block_timestamp:}."
     )]
     IncorrectBundleTimestamp {

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -126,7 +126,9 @@ impl<Env: Environment> Benchmark<Env> {
         let notifier = Arc::new(Notify::new());
         let barrier = Arc::new(Barrier::new(num_chains + 1));
 
-        let chain_listener_result = chain_listener.run().await;
+        let chain_listener_result = chain_listener
+            .run(Some(500)) // Default sync_sleep_ms for benchmarks
+            .await;
 
         let chain_listener_handle =
             tokio::spawn(async move { chain_listener_result?.await }.in_current_span());

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -148,7 +148,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     let cancellation_token = CancellationToken::new();
     let child_token = cancellation_token.child_token();
     let chain_listener = ChainListener::new(config, context, storage, child_token)
-        .run()
+        .run(None) // Unit test doesn't need background sync
         .await
         .unwrap();
 
@@ -210,7 +210,7 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
     let cancellation_token = CancellationToken::new();
     let child_token = cancellation_token.child_token();
     let chain_listener = ChainListener::new(config, context, storage.clone(), child_token)
-        .run()
+        .run(None) // Unit test doesn't need background sync
         .await
         .unwrap();
 

--- a/linera-core/src/notifier.rs
+++ b/linera-core/src/notifier.rs
@@ -64,7 +64,7 @@ where
     pub fn notify_chain(&self, chain_id: &ChainId, notification: &N) {
         self.inner.pin().compute(*chain_id, |senders| {
             let Some((_key, senders)) = senders else {
-                trace!("Chain {chain_id:?} has no subscribers.");
+                trace!("Chain {chain_id} has no subscribers.");
                 return papaya::Operation::Abort(());
             };
             let live_senders = senders
@@ -73,7 +73,7 @@ where
                 .cloned()
                 .collect::<Vec<_>>();
             if live_senders.is_empty() {
-                trace!("No more subscribers for chain {chain_id:?}. Removing entry.");
+                trace!("No more subscribers for chain {chain_id}. Removing entry.");
                 return papaya::Operation::Remove;
             }
             papaya::Operation::Insert(live_senders)

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2780,3 +2780,105 @@ where
 
     Ok(())
 }
+
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_prepare_chain_with_cross_chain_messages<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, signer)
+        .await?
+        .with_policy(ResourceControlPolicy::only_fuel());
+
+    // Create sender and receiver chains.
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let receiver = builder.add_root_chain(2, Amount::ZERO).await?;
+    let sender2 = builder.add_root_chain(3, Amount::from_tokens(2)).await?;
+
+    // Both senders transfer to receiver.
+    let amount1 = Amount::from_tokens(2);
+    sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            amount1,
+            Account::chain(receiver.chain_id()),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    // Receiver synchronizes and processes the message.
+    receiver.synchronize_from_validators().await?;
+    receiver.process_inbox().await?;
+
+    let amount2 = Amount::from_tokens(1);
+    sender2
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            amount2,
+            Account::chain(receiver.chain_id()),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    // It does not process the second message.
+    receiver.synchronize_from_validators().await?;
+
+    // Verify the first message was processed, but not the second.
+    assert_eq!(receiver.local_balance().await.unwrap(), amount1);
+
+    // Create a new client for the same chain. This new client will have the processed
+    // inbox message (the removed_bundles state), but won't have the sender blocks yet
+    // because we're creating it fresh.
+    let receiver_info = receiver.chain_info().await?;
+    let receiver2 = builder
+        .make_client(
+            receiver.chain_id(),
+            receiver_info.block_hash,
+            receiver_info.next_block_height,
+        )
+        .await?;
+
+    // Test that prepare_chain downloads only the sender blocks for acknowledged messages.
+    // The new client has the inbox state showing that a message from sender was processed,
+    // but needs to download the sender block. The message from sender2 hasn't been
+    // processed yet, so its block should NOT be downloaded.
+    let info = receiver2.prepare_chain().await?;
+    assert_eq!(info.next_block_height, BlockHeight::from(1));
+
+    // Verify that sender's block WAS downloaded.
+    let local_node = &receiver2.client.local_node;
+    let sender_info = local_node.chain_info(sender.chain_id()).await?;
+    assert_eq!(
+        sender_info.next_block_height,
+        BlockHeight::from(1),
+        "prepare_chain should download acknowledged sender blocks"
+    );
+
+    // Verify that sender2's block was NOT downloaded.
+    let sender2_info = local_node.chain_info(sender2.chain_id()).await;
+    assert!(
+        sender2_info.is_err() || sender2_info.unwrap().next_block_height == BlockHeight::ZERO,
+        "prepare_chain should not download unacknowledged sender blocks"
+    );
+
+    // The new client should now be able to make a transfer successfully.
+    let amount3 = Amount::from_tokens(1);
+    receiver2
+        .transfer(
+            AccountOwner::CHAIN,
+            amount3,
+            Account::chain(sender.chain_id()),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    assert_eq!(receiver2.local_balance().await.unwrap(), amount1 - amount3);
+
+    Ok(())
+}

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -711,7 +711,7 @@ where
             self.storage,
             cancellation_token.clone(),
         )
-        .run()
+        .run(None) // Faucet doesn't receive messages, so no need for background sync
         .await?;
         let batch_processor_task = batch_processor.run(cancellation_token.clone());
         let tcp_listener =

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -767,6 +767,17 @@ type MutationRoot {
 	"""
 	processInbox(chainId: ChainId!): [CryptoHash!]!
 	"""
+	Synchronizes the chain with the validators. Returns the chain's length.
+	
+	This is only used for testing, to make sure that a client is up to date.
+	"""
+	sync(
+		"""
+		The chain being synchronized.
+		"""
+		chainId: ChainId!
+	): Int!
+	"""
 	Retries the pending block that was unsuccessfully proposed earlier.
 	"""
 	retryPendingBlock(chainId: ChainId!): CryptoHash

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -729,6 +729,14 @@ pub enum ClientCommand {
         #[arg(long)]
         port: NonZeroU16,
 
+        /// Milliseconds to sleep between batches during background certificate synchronization.
+        #[arg(
+            long = "sync-sleep-ms",
+            default_value = "500",
+            env = "LINERA_SYNC_SLEEP_MS"
+        )]
+        sync_sleep_ms: u64,
+
         /// The port to expose metrics on.
         #[cfg(with_metrics)]
         #[arg(long)]

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1253,6 +1253,7 @@ impl Runnable for Job {
             Service {
                 config,
                 port,
+                sync_sleep_ms,
                 #[cfg(with_metrics)]
                 metrics_port,
             } => {
@@ -1274,7 +1275,7 @@ impl Runnable for Job {
                 );
                 let cancellation_token = CancellationToken::new();
                 tokio::spawn(listen_for_shutdown_signals(cancellation_token.clone()));
-                service.run(cancellation_token).await?;
+                service.run(cancellation_token, sync_sleep_ms).await?;
             }
 
             Faucet {
@@ -1698,7 +1699,7 @@ impl Runnable for Job {
                 context.client.track_chain(chain_id);
                 let chain_client = context.make_chain_client(chain_id);
                 if sync {
-                    chain_client.synchronize_from_validators().await?;
+                    chain_client.synchronize_chain_state(chain_id).await?;
                 } else {
                     chain_client.fetch_chain_info().await?;
                 }

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -1257,6 +1257,12 @@ impl NodeService {
         Ok(serde_json::from_value(data["processInbox"].take())?)
     }
 
+    pub async fn sync(&self, chain_id: &ChainId) -> Result<u64> {
+        let query = format!("mutation {{ sync(chainId: \"{chain_id}\") }}");
+        let mut data = self.query_node(query).await?;
+        Ok(serde_json::from_value(data["sync"].take())?)
+    }
+
     pub async fn balance(&self, account: &Account) -> Result<Amount> {
         let chain = account.chain_id;
         let owner = account.owner;

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -180,8 +180,7 @@ where
         let mut hashes = Vec::new();
         loop {
             let client = self.context.lock().await.make_chain_client(chain_id);
-            client.synchronize_from_validators().await?;
-            let result = client.process_inbox_without_prepare().await;
+            let result = client.process_inbox().await;
             self.context.lock().await.update_wallet(&client).await?;
             let (certificates, maybe_timeout) = result?;
             hashes.extend(certificates.into_iter().map(|cert| cert.hash()));
@@ -194,6 +193,20 @@ where
                 }
             }
         }
+    }
+
+    /// Synchronizes the chain with the validators. Returns the chain's length.
+    ///
+    /// This is only used for testing, to make sure that a client is up to date.
+    // TODO(#4718): Remove this mutation.
+    async fn sync(
+        &self,
+        #[graphql(desc = "The chain being synchronized.")] chain_id: ChainId,
+    ) -> Result<u64, Error> {
+        let client = self.context.lock().await.make_chain_client(chain_id);
+        let info = client.synchronize_from_validators().await?;
+        self.context.lock().await.update_wallet(&client).await?;
+        Ok(info.next_block_height.0)
     }
 
     /// Retries the pending block that was unsuccessfully proposed earlier.
@@ -852,7 +865,11 @@ where
 
     /// Runs the node service.
     #[instrument(name = "node_service", level = "info", skip_all, fields(port = ?self.port))]
-    pub async fn run(self, cancellation_token: CancellationToken) -> Result<(), anyhow::Error> {
+    pub async fn run(
+        self,
+        cancellation_token: CancellationToken,
+        sync_sleep_ms: u64,
+    ) -> Result<(), anyhow::Error> {
         let port = self.port.get();
         let index_handler = axum::routing::get(util::graphiql).post(Self::index_handler);
         let application_handler =
@@ -883,7 +900,7 @@ where
             storage,
             cancellation_token.clone(),
         )
-        .run()
+        .run(Some(sync_sleep_ms))
         .await?;
         let mut chain_listener = Box::pin(chain_listener).fuse();
         let tcp_listener =

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -1018,7 +1018,16 @@ async fn test_evm_execute_message_end_to_end_counter(config: impl LineraNetConfi
     let mutation = EvmQuery::Mutation(mutation);
     application1.run_json_query(mutation).await?;
 
-    node_service2.process_inbox(&chain2).await?;
+    assert!(
+        eventually(|| async {
+            !node_service2
+                .process_inbox(&chain2)
+                .await
+                .unwrap()
+                .is_empty()
+        })
+        .await
+    );
 
     // Third: Checking the values after the move
 
@@ -1218,7 +1227,16 @@ async fn test_evm_process_streams_end_to_end_counters(config: impl LineraNetConf
 
     // Third: process the inbox on chain2
 
-    node_service2.process_inbox(&chain2).await?;
+    assert!(
+        eventually(|| async {
+            !node_service2
+                .process_inbox(&chain2)
+                .await
+                .unwrap()
+                .is_empty()
+        })
+        .await
+    );
 
     // Fourth: getting the value
 
@@ -1615,7 +1633,16 @@ async fn test_evm_erc20_shared(config: impl LineraNetConfig) -> Result<()> {
     let mutation = EvmQuery::Mutation(mutation.abi_encode());
     application1.run_json_query(mutation).await?;
 
-    node_service2.process_inbox(&chain2).await?;
+    assert!(
+        eventually(|| async {
+            !node_service2
+                .process_inbox(&chain2)
+                .await
+                .unwrap()
+                .is_empty()
+        })
+        .await
+    );
 
     // Checking the balances on both chains.
 
@@ -1924,19 +1951,21 @@ async fn test_wasm_end_to_end_allowances_fungible(config: impl LineraNetConfig) 
     app2.assert_balances(expected_balances).await;
     app3.assert_balances(expected_balances).await;
 
-    // Approving a transfer
+    // Approving a transfer.
     app1.approve(&owner1, &owner2, Amount::from_tokens(93))
         .await;
 
     app1.assert_allowance(&owner1, &owner2, Amount::from_tokens(93))
         .await;
 
-    // Call process inbox in order to synchronize from validators
-    node_service2.process_inbox(&chain2).await?;
-    app2.assert_allowance(&owner1, &owner2, Amount::from_tokens(93))
-        .await;
+    assert!(
+        eventually(|| async {
+            app2.get_allowance(&owner1, &owner2).await == Amount::from_tokens(93)
+        })
+        .await
+    );
 
-    // Doing the transfer from
+    // Doing the transfer from owner 1.
     app2.transfer_from(
         &owner1,
         &owner2,
@@ -2094,7 +2123,10 @@ async fn test_wasm_end_to_end_fungible(
     app1.assert_entries(expected_balances).await;
     app1.assert_keys([account_owner1, account_owner2]).await;
 
-    assert_eq!(node_service2.process_inbox(&chain2).await?.len(), 1);
+    assert!(
+        eventually(|| async { node_service2.process_inbox(&chain2).await.unwrap().len() == 1 })
+            .await
+    );
 
     // Fungible didn't exist on chain2 initially but now it does and we can talk to it.
     let app2 = NativeFungibleApp(node_service2.make_application(&chain2, &application_id)?);
@@ -2123,8 +2155,14 @@ async fn test_wasm_end_to_end_fungible(
     .await;
 
     // Make sure that the cross-chain communication happens fast enough.
-    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
-    assert_eq!(node_service2.process_inbox(&chain2).await?.len(), 1);
+    assert!(
+        eventually(|| async { node_service1.process_inbox(&chain1).await.unwrap().len() == 1 })
+            .await
+    );
+    assert!(
+        eventually(|| async { node_service2.process_inbox(&chain2).await.unwrap().len() == 1 })
+            .await
+    );
 
     // Checking the final value
     let expected_balances = [
@@ -2228,7 +2266,10 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     )
     .await;
 
-    assert_eq!(node_service.process_inbox(&chain2).await?.len(), 1);
+    assert!(
+        eventually(|| async { node_service.process_inbox(&chain2).await.unwrap().len() == 1 })
+            .await
+    );
 
     // Checking the final values on chain1 and chain2.
     let expected_balances = [
@@ -2348,7 +2389,10 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     )
     .await;
 
-    assert_eq!(node_service2.process_inbox(&chain2).await?.len(), 1);
+    assert!(
+        eventually(|| async { node_service2.process_inbox(&chain2).await.unwrap().len() == 1 })
+            .await
+    );
 
     // Checking the NFT is removed from chain1
     assert!(app1.get_nft(&nft1_id).await.is_err());
@@ -2382,8 +2426,14 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     .await;
 
     // Make sure that the cross-chain communication happens fast enough.
-    assert_eq!(node_service2.process_inbox(&chain2).await?.len(), 1);
-    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
+    assert!(
+        eventually(|| async { node_service2.process_inbox(&chain2).await.unwrap().len() == 1 })
+            .await
+    );
+    assert!(
+        eventually(|| async { node_service1.process_inbox(&chain1).await.unwrap().len() == 1 })
+            .await
+    );
 
     // Checking the NFT is removed from chain2
     assert!(app2.get_nft(&nft1_id).await.is_err());
@@ -2409,7 +2459,10 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     .await;
 
     // The transfer is received by chain2 and needs to be processed.
-    assert_eq!(node_service2.process_inbox(&chain2).await?.len(), 1);
+    assert!(
+        eventually(|| async { node_service2.process_inbox(&chain2).await.unwrap().len() == 1 })
+            .await
+    );
 
     // Checking the NFT is removed from chain1
     assert!(app1.get_nft(&nft1_id).await.is_err());
@@ -2477,7 +2530,10 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     .await;
 
     // The transfer from chain2 has to be received from chain1.
-    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
+    assert!(
+        eventually(|| async { node_service1.process_inbox(&chain1).await.unwrap().len() == 1 })
+            .await
+    );
 
     // Checking the NFT is removed from chain2
     assert!(app2.get_nft(&nft2_id).await.is_err());
@@ -2507,8 +2563,14 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     .await;
 
     // Make sure that the cross-chain communication happens fast enough.
-    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
-    assert_eq!(node_service2.process_inbox(&chain2).await?.len(), 1);
+    assert!(
+        eventually(|| async { node_service1.process_inbox(&chain1).await.unwrap().len() == 1 })
+            .await
+    );
+    assert!(
+        eventually(|| async { node_service2.process_inbox(&chain2).await.unwrap().len() == 1 })
+            .await
+    );
 
     // Checking the final state
 
@@ -2624,7 +2686,10 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
         .await;
 
     // Make sure that the transfer is received before we try to pledge.
-    node_service2.process_inbox(&chain2).await?;
+    assert!(
+        eventually(|| async { node_service2.process_inbox(&chain2).await.unwrap().len() == 1 })
+            .await
+    );
 
     let app_crowd2 = node_service2.make_application(&chain2, &application_id_crowd)?;
 
@@ -2637,7 +2702,10 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
     app_crowd2.mutate(mutation).await?;
 
     // Make sure that the pledge is processed fast enough by client1.
-    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
+    assert!(
+        eventually(|| async { node_service1.process_inbox(&chain1).await.unwrap().len() == 1 })
+            .await
+    );
 
     // Ending the campaign.
     app_crowd1.mutate("collect").await?;
@@ -2831,11 +2899,14 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     // The orders are sent on chain_a / chain_b. First they are
     // rerouted to the admin chain for processing. This leads
     // to order being sent to chain_a / chain_b.
+    node_service_admin.sync(&chain_admin).await?;
     assert_eq!(
         node_service_admin.process_inbox(&chain_admin).await?.len(),
         1
     );
+    node_service_a.sync(&chain_a).await?;
     assert_eq!(node_service_a.process_inbox(&chain_a).await?.len(), 1);
+    node_service_b.sync(&chain_b).await?;
     assert_eq!(node_service_b.process_inbox(&chain_b).await?.len(), 1);
 
     // Now reading the order_ids
@@ -2863,12 +2934,15 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
             .await;
     }
 
+    node_service_admin.sync(&chain_admin).await?;
     // Same logic as for the insertion of orders.
     assert_eq!(
         node_service_admin.process_inbox(&chain_admin).await?.len(),
         1
     );
+    node_service_a.sync(&chain_a).await?;
     assert_eq!(node_service_a.process_inbox(&chain_a).await?.len(), 1);
+    node_service_b.sync(&chain_b).await?;
     assert_eq!(node_service_b.process_inbox(&chain_b).await?.len(), 1);
 
     // Check balances
@@ -3038,8 +3112,14 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
         )
         .await;
 
-    assert_eq!(node_service0.process_inbox(&chain0).await?.len(), 1);
-    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
+    assert!(
+        eventually(|| async { node_service0.process_inbox(&chain0).await.unwrap().len() == 1 })
+            .await
+    );
+    assert!(
+        eventually(|| async { node_service1.process_inbox(&chain1).await.unwrap().len() == 1 })
+            .await
+    );
 
     let app_fungible0_0 = FungibleApp(node_service0.make_application(&chain0, &token0)?);
     let app_fungible1_0 = FungibleApp(node_service0.make_application(&chain0, &token1)?);
@@ -3135,7 +3215,17 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
         .add_liquidity(owner0, Amount::from_tokens(100), Amount::from_tokens(100))
         .await?;
 
-    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
+    assert!(
+        eventually(|| async {
+            node_service_amm
+                .process_inbox(&chain_amm)
+                .await
+                .unwrap()
+                .len()
+                == 1
+        })
+        .await
+    );
 
     // Ownership of the used owner_amm_chain's tokens should be with the AMM now
     app_fungible0_amm
@@ -3194,8 +3284,21 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
         .add_liquidity(owner1, Amount::from_tokens(120), Amount::from_tokens(100))
         .await?;
 
-    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
-    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
+    assert!(
+        eventually(|| async {
+            node_service_amm
+                .process_inbox(&chain_amm)
+                .await
+                .unwrap()
+                .len()
+                == 1
+        })
+        .await
+    );
+    assert!(
+        eventually(|| async { node_service1.process_inbox(&chain1).await.unwrap().len() == 1 })
+            .await
+    );
 
     app_fungible0_amm
         .assert_balances([
@@ -3254,8 +3357,21 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
         .expect_err("Swapping from the AMM chain should fail");
 
     app_amm1.swap(owner1, 0, Amount::from_tokens(50)).await?;
-    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
-    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
+    assert!(
+        eventually(|| async {
+            node_service_amm
+                .process_inbox(&chain_amm)
+                .await
+                .unwrap()
+                .len()
+                == 1
+        })
+        .await
+    );
+    assert!(
+        eventually(|| async { node_service1.process_inbox(&chain1).await.unwrap().len() == 1 })
+            .await
+    );
 
     app_fungible0_amm
         .assert_balances([
@@ -3323,8 +3439,17 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
     app_amm1
         .remove_liquidity(owner1, 0, Amount::from_tokens(500))
         .await?;
-    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
-    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 0);
+    assert!(
+        eventually(|| async {
+            node_service_amm
+                .process_inbox(&chain_amm)
+                .await
+                .unwrap()
+                .len()
+                == 1
+        })
+        .await
+    );
 
     // Balances will be unaltered
     app_fungible0_amm
@@ -3379,8 +3504,21 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
         .await;
 
     app_amm1.swap(owner1, 1, Amount::from_tokens(40)).await?;
-    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
-    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
+    assert!(
+        eventually(|| async {
+            node_service_amm
+                .process_inbox(&chain_amm)
+                .await
+                .unwrap()
+                .len()
+                == 1
+        })
+        .await
+    );
+    assert!(
+        eventually(|| async { node_service1.process_inbox(&chain1).await.unwrap().len() == 1 })
+            .await
+    );
 
     app_fungible0_amm
         .assert_balances([
@@ -3436,8 +3574,21 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
     app_amm1
         .remove_liquidity(owner1, 0, Amount::from_tokens(100))
         .await?;
-    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
-    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
+    assert!(
+        eventually(|| async {
+            node_service_amm
+                .process_inbox(&chain_amm)
+                .await
+                .unwrap()
+                .len()
+                == 1
+        })
+        .await
+    );
+    assert!(
+        eventually(|| async { node_service1.process_inbox(&chain1).await.unwrap().len() == 1 })
+            .await
+    );
 
     app_fungible0_amm
         .assert_balances([
@@ -3491,8 +3642,21 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
         .await;
 
     app_amm0.swap(owner0, 1, Amount::from_tokens(25)).await?;
-    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
-    assert_eq!(node_service0.process_inbox(&chain0).await?.len(), 1);
+    assert!(
+        eventually(|| async {
+            node_service_amm
+                .process_inbox(&chain_amm)
+                .await
+                .unwrap()
+                .len()
+                == 1
+        })
+        .await
+    );
+    assert!(
+        eventually(|| async { node_service0.process_inbox(&chain0).await.unwrap().len() == 1 })
+            .await
+    );
 
     app_fungible0_amm
         .assert_balances([
@@ -3546,8 +3710,21 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
         .await;
 
     app_amm0.remove_all_added_liquidity(owner0).await?;
-    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
-    assert_eq!(node_service0.process_inbox(&chain0).await?.len(), 1);
+    assert!(
+        eventually(|| async {
+            node_service_amm
+                .process_inbox(&chain_amm)
+                .await
+                .unwrap()
+                .len()
+                == 1
+        })
+        .await
+    );
+    assert!(
+        eventually(|| async { node_service0.process_inbox(&chain0).await.unwrap().len() == 1 })
+            .await
+    );
 
     app_fungible0_amm
         .assert_balances([
@@ -3690,11 +3867,11 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()
     )
     .await;
 
-    // The chain2 must process the received transfer
-    node_service.process_inbox(&chain2).await?;
+    // The chain2 must receive the transfer
+    let app2 = FungibleApp(node_service.make_application(&chain2, &application_id)?);
+    assert!(eventually(|| async { app2.get_amount(&owner).await == Amount::from_tokens(8) }).await);
 
     // Send 4 tokens back.
-    let app2 = FungibleApp(node_service.make_application(&chain2, &application_id)?);
     app2.transfer(
         &owner,
         Amount::from_tokens(4),
@@ -4405,10 +4582,8 @@ async fn test_end_to_end_repeated_transfers(config: impl LineraNetConfig) -> Res
         .run_node_service(port2, ProcessInbox::Automatic)
         .await?;
 
-    // Make sure all incoming messages are processed, and get both chains' heights.
     let mut next_height1 = {
         let node_service1 = client1.run_node_service(port1, ProcessInbox::Skip).await?;
-        node_service1.process_inbox(&chain_id1).await?;
         let mut chain = node_service1
             .query_node(&format!(
                 "query {{ chain(chainId: \"{chain_id1}\") {{ tipState {{ nextBlockHeight }} }} }}"
@@ -4417,7 +4592,6 @@ async fn test_end_to_end_repeated_transfers(config: impl LineraNetConfig) -> Res
         serde_json::from_value::<BlockHeight>(chain["chain"]["tipState"]["nextBlockHeight"].take())?
     };
     let mut next_height2 = {
-        node_service2.process_inbox(&chain_id2).await?;
         let mut chain = node_service2
             .query_node(&format!(
                 "query {{ chain(chainId: \"{chain_id2}\") {{ tipState {{ nextBlockHeight }} }} }}"

--- a/linera-web/src/lib.rs
+++ b/linera-web/src/lib.rs
@@ -237,7 +237,7 @@ impl Client {
             storage,
             tokio_util::sync::CancellationToken::new(),
         )
-        .run()
+        .run(Some(500)) // Enable background sync with 500ms sleep
         .boxed_local()
         .await?
         .boxed_local();


### PR DESCRIPTION
Backport of #4706.

Merge conflicts:
* `linera-client/src/benchmark.rs`
* `linera-service/src/cli_wrappers/wallet.rs`

## Motivation

`find_received_certificates_from_validator` and `find_received_certificates` can take a lot of time (and memory) if there are a lot of incoming messages.

## Proposal

Only do them as part of `synchronize_from_validators`. On notification, `prepare_chain` and when we're about to propose a block, only download what's necessary.

Download and process sender certificates in batches, to avoid the high memory usage.

Download them in a background task in the node service, with some sleep time in between, to limit interference with the other node service tasks.

(Mostly written with Claude Sonnet 4.5.)

## Test Plan

CI
A new test was added for the updated `prepare_chain`. `test_sparse_sender_chain` already exists, and tests notification handling with a sparse chain.

## Release Plan

- These changes should be released in a new SDK.

## Links

- PR to main: #4706
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
