### PR TITLE
Make chain manager recover from `current_round` bug.

### DIFF
--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -699,6 +699,16 @@ where
         }
         if let Some(old_proposal) = self.signed_proposal.get() {
             if old_proposal.content.round >= proposal.content.round {
+                if *self.current_round.get() < old_proposal.content.round {
+                    tracing::warn!(
+                        chain_id = %proposal.content.block.chain_id,
+                        current_round = ?self.current_round.get(),
+                        proposal_round = ?old_proposal.content.round,
+                        "Proposal round is greater than current round. Updating."
+                    );
+                    self.update_current_round(local_time);
+                    return true;
+                }
                 return false;
             }
         }


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/4688 fixed a bug where the chain manager would set its `signed_proposal` but not update the current round accordingly. However, some existing chains may already be in a bad state.

## Proposal

Detect the bad state and recompute the current round.

## Test Plan

Backport and see if it makes the affected chains recover. Otherwise we should never see the warning log.

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- Original bug fix: https://github.com/linera-io/linera-protocol/pull/4688
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
