### PR TITLE
Correct the test `test_end_to_end_listen_for_new_rounds`

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -4617,7 +4617,7 @@ async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> 
             vec![owner1, owner2],
             vec![100, 100],
             0,
-            Amount::from_tokens(9),
+            Amount::from_tokens(11),
             u64::MAX,
         )
         .await?;
@@ -4641,7 +4641,6 @@ async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> 
         chain2,
         chain1,
     ));
-
     /// Runs the `client` in a task, so that it can race to produce blocks transferring tokens.
     ///
     /// Stops when transferring fails or the `notifier` channel is closed. When exiting, it will


### PR DESCRIPTION
## Motivation

This test has the error "Error is Failed to make transfer

Caused by:
    chain client error: Local node operation failed: Worker operation failed: Execution error: The transferred amount must not exceed the balance of the current account 0x00: 0.99984 during Operation(0)"

This error is unfortunate for two reasons:
* Such errors can reveal some underlying problem.
* By polluting the logs with ERROR that we tolerate, the importance of real ERROR statements diminishes, and we fail to pay attention to real problems.

## Proposal

The underlying problem is that the `error_code` being created at
```rust
    let error_code = match result {
        Ok(code) => code,
        Err(msg) => {
            error!("Error is {:?}", msg);
            2
        }
    };
    process::exit(error_code);
```

is not being processed. But there are several errors to address before we can fully take them into account.

In the test code, we have a budget of 8 sends in the `mpsc`. The chain is being created with 9 tokens, and each transfer is followed by a send operation. When the send fails, then infinite loop gets exited on and the function terminates.

8 tokens will not suffice since we have some operation fee of 0.0002 per transfer. However, 9 tokens will not suffice because when a `send()` fails the previous operation was a transfer. 10 has the same problem. 11 is the right amount in order to avoid  transfer errors.

## Test Plan

The CI is the point of this PR.

## Release Plan

This PR cleans up the error. But it can also be backported to testnet-conway. There are several errors in the CI and it is important that any error corresponds to a real one.

## Links

None.