### PR TITLE
Add command to show ownership configuration of a chain

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -8,6 +8,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera transfer`↴](#linera-transfer)
 * [`linera open-chain`↴](#linera-open-chain)
 * [`linera open-multi-owner-chain`↴](#linera-open-multi-owner-chain)
+* [`linera show-ownership`↴](#linera-show-ownership)
 * [`linera change-ownership`↴](#linera-change-ownership)
 * [`linera set-preferred-owner`↴](#linera-set-preferred-owner)
 * [`linera change-application-permissions`↴](#linera-change-application-permissions)
@@ -80,6 +81,7 @@ Client implementation and command-line tool for the Linera blockchain
 * `transfer` — Transfer funds
 * `open-chain` — Open (i.e. activate) a new chain deriving the UID from an existing one
 * `open-multi-owner-chain` — Open (i.e. activate) a new multi-owner chain deriving the UID from an existing one
+* `show-ownership` — Display who owns the chain, and how the owners work together proposing blocks
 * `change-ownership` — Change who owns the chain, and how the owners work together proposing blocks
 * `set-preferred-owner` — Change the preferred owner of a chain
 * `change-application-permissions` — Changes the application permissions configuration
@@ -273,6 +275,18 @@ Open (i.e. activate) a new multi-owner chain deriving the UID from an existing o
 * `--initial-balance <BALANCE>` — The initial balance of the new chain. This is subtracted from the parent chain's balance
 
   Default value: `0`
+
+
+
+## `linera show-ownership`
+
+Display who owns the chain, and how the owners work together proposing blocks
+
+**Usage:** `linera show-ownership [OPTIONS]`
+
+###### **Options:**
+
+* `--chain-id <CHAIN_ID>` — The ID of the chain whose owners will be changed
 
 
 

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -466,6 +466,13 @@ impl<Env: Environment, W: Persist<Target = Wallet>> ClientContext<Env, W> {
         }
     }
 
+    pub async fn ownership(&mut self, chain_id: Option<ChainId>) -> Result<ChainOwnership, Error> {
+        let chain_id = chain_id.unwrap_or_else(|| self.default_chain());
+        let client = self.make_chain_client(chain_id);
+        let info = client.chain_info().await?;
+        Ok(info.manager.ownership)
+    }
+
     pub async fn change_ownership(
         &mut self,
         chain_id: Option<ChainId>,

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -192,33 +192,33 @@ impl ClientContextOptions {
 pub struct ChainOwnershipConfig {
     /// The new super owners.
     #[arg(long, num_args(0..))]
-    super_owners: Vec<AccountOwner>,
+    pub super_owners: Vec<AccountOwner>,
 
     /// The new regular owners.
     #[arg(long, num_args(0..))]
-    owners: Vec<AccountOwner>,
+    pub owners: Vec<AccountOwner>,
 
     /// Weights for the new owners.
     ///
     /// If they are specified there must be exactly one weight for each owner.
     /// If no weights are given, every owner will have weight 100.
     #[arg(long, num_args(0..))]
-    owner_weights: Vec<u64>,
+    pub owner_weights: Vec<u64>,
 
     /// The number of rounds in which every owner can propose blocks, i.e. the first round
     /// number in which only a single designated leader is allowed to propose blocks.
     #[arg(long)]
-    multi_leader_rounds: Option<u32>,
+    pub multi_leader_rounds: Option<u32>,
 
     /// Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners.
     /// This should only be `true` on chains with restrictive application permissions and an
     /// application-based mechanism to select block proposers.
     #[arg(long)]
-    open_multi_leader_rounds: bool,
+    pub open_multi_leader_rounds: bool,
 
     /// The duration of the fast round, in milliseconds.
     #[arg(long = "fast-round-ms", value_parser = util::parse_millis_delta)]
-    fast_round_duration: Option<TimeDelta>,
+    pub fast_round_duration: Option<TimeDelta>,
 
     /// The duration of the first single-leader and all multi-leader rounds.
     #[arg(
@@ -226,7 +226,7 @@ pub struct ChainOwnershipConfig {
         default_value = "10000",
         value_parser = util::parse_millis_delta
     )]
-    base_timeout: TimeDelta,
+    pub base_timeout: TimeDelta,
 
     /// The number of milliseconds by which the timeout increases after each
     /// single-leader round.
@@ -235,7 +235,7 @@ pub struct ChainOwnershipConfig {
         default_value = "1000",
         value_parser = util::parse_millis_delta
     )]
-    timeout_increment: TimeDelta,
+    pub timeout_increment: TimeDelta,
 
     /// The age of an incoming tracked or protected message after which the validators start
     /// transitioning the chain to fallback mode, in milliseconds.

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -227,6 +227,13 @@ pub enum ClientCommand {
         balance: Amount,
     },
 
+    /// Display who owns the chain, and how the owners work together proposing blocks.
+    ShowOwnership {
+        /// The ID of the chain whose owners will be changed.
+        #[clap(long)]
+        chain_id: Option<ChainId>,
+    },
+
     /// Change who owns the chain, and how the owners work together proposing blocks.
     ///
     /// Specify the complete set of new owners, by public key. Existing owners that are
@@ -984,6 +991,7 @@ impl ClientCommand {
             ClientCommand::Transfer { .. }
             | ClientCommand::OpenChain { .. }
             | ClientCommand::OpenMultiOwnerChain { .. }
+            | ClientCommand::ShowOwnership { .. }
             | ClientCommand::ChangeOwnership { .. }
             | ClientCommand::SetPreferredOwner { .. }
             | ClientCommand::ChangeApplicationPermissions { .. }

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -265,6 +265,13 @@ impl Runnable for Job {
                 chain_id,
                 ownership_config,
             } => {
+                ensure!(
+                    !ownership_config.super_owners.is_empty()
+                        || !ownership_config.owners.is_empty(),
+                    "This command requires at least one owner or super owner to be set. \
+                     To close a chain, use `close-chain`. To show the current config, use `show-ownership`."
+                );
+
                 let mut context =
                     options.create_client_context(storage, wallet, signer.into_value());
                 context.change_ownership(chain_id, ownership_config).await?

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -253,6 +253,14 @@ impl Runnable for Job {
                 println!("{}", id);
             }
 
+            ShowOwnership { chain_id } => {
+                let mut context =
+                    options.create_client_context(storage, wallet, signer.into_value());
+                let ownership = context.ownership(chain_id).await?;
+                let json = serde_json::to_string_pretty(&ownership)?;
+                println!("{}", json);
+            }
+
             ChangeOwnership {
                 chain_id,
                 ownership_config,

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -345,7 +345,8 @@ impl Runnable for Job {
 
             ShowNetworkDescription => {
                 let network_description = storage.read_network_description().await?;
-                println!("Network description: \n{:#?}", network_description);
+                let json = serde_json::to_string_pretty(&network_description)?;
+                println!("{}", json);
             }
 
             LocalBalance { account } => {


### PR DESCRIPTION
## Motivation

`change-ownership` is pretty hard to use (and unsafe)

## Proposal

* Add a command show-ownership
* Refuse to change ownerwhip to 0 owners
* Use JSON outputs consistently

## Test Plan

CI + tested manually

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
