### PR TITLE
Improve a few error and log message strings. (#4734)

### DIFF
--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -107,7 +107,8 @@ pub enum ChainError {
     #[error("The signature was not created by a valid entity")]
     InvalidSigner,
     #[error(
-        "Was expecting block height {expected_block_height} but found {found_block_height} instead"
+        "Chain is expecting a next block at height {expected_block_height} but the given block \
+        is at height {found_block_height} instead"
     )]
     UnexpectedBlockHeight {
         expected_block_height: BlockHeight,

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1376,11 +1376,12 @@ where
                 .await?;
         }
         if let Some(next_block_height) = query.test_next_block_height {
+            // If not, send the same error as if a block with next_block_height was proposed.
             ensure!(
                 chain.tip_state.get().next_block_height == next_block_height,
                 WorkerError::UnexpectedBlockHeight {
-                    expected_block_height: next_block_height,
-                    found_block_height: chain.tip_state.get().next_block_height
+                    expected_block_height: chain.tip_state.get().next_block_height,
+                    found_block_height: next_block_height,
                 }
             );
         }

--- a/linera-core/src/client/chain_client_state.rs
+++ b/linera-core/src/client/chain_client_state.rs
@@ -68,8 +68,8 @@ impl ChainClientState {
     pub(super) fn update_from_info(&mut self, info: &ChainInfo) {
         if let Some(pending) = &self.pending_proposal {
             if pending.block.height < info.next_block_height {
-                tracing::info!(
-                    "Clearing pending proposal: another block was committed at height {}",
+                tracing::debug!(
+                    "Clearing pending proposal: a block was committed at height {}",
                     pending.block.height
                 );
                 self.clear_pending_proposal();

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -230,7 +230,8 @@ pub enum NodeError {
     WrongRound(Round),
 
     #[error(
-        "Was expecting block height {expected_block_height} but found {found_block_height} instead"
+        "Chain is expecting a next block at height {expected_block_height} but the given block \
+        is at height {found_block_height} instead"
     )]
     UnexpectedBlockHeight {
         expected_block_height: BlockHeight,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -177,13 +177,14 @@ pub enum WorkerError {
 
     // Chaining
     #[error(
-        "Was expecting block height {expected_block_height} but found {found_block_height} instead"
+        "Chain is expecting a next block at height {expected_block_height} but the given block \
+        is at height {found_block_height} instead"
     )]
     UnexpectedBlockHeight {
         expected_block_height: BlockHeight,
         found_block_height: BlockHeight,
     },
-    #[error("Unexpected epoch {epoch:}: chain {chain_id:} is at {chain_epoch:}")]
+    #[error("Unexpected epoch {epoch}: chain {chain_id} is at {chain_epoch}")]
     InvalidEpoch {
         chain_id: ChainId,
         chain_epoch: Epoch,


### PR DESCRIPTION
Backport of #4734.

## Motivation

The pending block clearing message is INFO-level, but it's spammy because it also shows for each successfully committed block.

The `UnexpectedBlockHeight` error is confusing, because it's not clear which height is which.

## Proposal

Make the pending block message DEBUG.

Change the message of `UnexpectedBlockHeight`.

## Test Plan

CI

## Release Plan

- Not urgent, but will be included in:
    - next SDK,
    - next validator hotfix.

## Links

- PR to main: #4734
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
