### PR TITLE
Restore `BlobsNotFound` handling on `retry_pending_cross_chain_requests`.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2175,10 +2175,34 @@ impl<Env: Environment> ChainClient<Env> {
         let stream = FuturesUnordered::from_iter(other_sender_chains.into_iter().map(|chain_id| {
             let local_node = self.client.local_node.clone();
             async move {
-                if let Err(error) = local_node
+                if let Err(error) = match local_node
                     .retry_pending_cross_chain_requests(chain_id)
                     .await
                 {
+                    Ok(()) => Ok(()),
+                    Err(LocalNodeError::BlobsNotFound(blob_ids)) => {
+                        match self.client.validator_nodes().await {
+                            Err(error) => Err(error),
+                            Ok(nodes) => {
+                                if let Err(error) = self
+                                    .client
+                                    .update_local_node_with_blobs_from(blob_ids.clone(), &nodes)
+                                    .await
+                                {
+                                    error!(
+                                        "Error while attempting to download blobs during retrying \
+                                        outgoing messages: {blob_ids:?}: {error}"
+                                    );
+                                }
+                                local_node
+                                    .retry_pending_cross_chain_requests(chain_id)
+                                    .await
+                                    .map_err(Into::into)
+                            }
+                        }
+                    }
+                    Err(err) => Err(err.into()),
+                } {
                     error!("Failed to retry outgoing messages from {chain_id}: {error}");
                 }
             }


### PR DESCRIPTION
## Motivation

I removed `BlobsNotFound` handling here in https://github.com/linera-io/linera-protocol/pull/4688 because I thought it was unreachable, but I can see this error in `testnet_conway` sometimes.

## Proposal

Restore handling logic: download blobs if necessary.

## Test Plan

It fixed that error for me on `testnet_conway`.

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a new SDK.

## Links

- Introduced in #4688.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
