### PR TITLE
Add more info and diff to `query-validator[s]`.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -14,7 +14,7 @@ use linera_base::{
 use linera_chain::types::ConfirmedBlockCertificate;
 use linera_core::{
     client::{ChainClient, Client, ListeningMode},
-    data_types::{ChainInfoQuery, ClientOutcome},
+    data_types::{ChainInfo, ChainInfoQuery, ClientOutcome},
     join_set_ext::JoinSet,
     node::ValidatorNode,
     Environment, JoinSetExt as _,
@@ -62,6 +62,128 @@ use crate::{
     wallet::{UserChain, Wallet},
     Error,
 };
+
+/// Results from querying a validator about version, network description, and chain info.
+pub struct ValidatorQueryResults {
+    /// The validator's version information.
+    pub version_info: Result<VersionInfo, Error>,
+    /// The validator's genesis config hash.
+    pub genesis_config_hash: Result<CryptoHash, Error>,
+    /// The validator's chain info (if valid and signature check passed).
+    pub chain_info: Result<ChainInfo, Error>,
+}
+
+impl ValidatorQueryResults {
+    /// Returns a vector of references to all errors in the query results.
+    pub fn errors(&self) -> Vec<&Error> {
+        let mut errors = Vec::new();
+        if let Err(e) = &self.version_info {
+            errors.push(e);
+        }
+        if let Err(e) = &self.genesis_config_hash {
+            errors.push(e);
+        }
+        if let Err(e) = &self.chain_info {
+            errors.push(e);
+        }
+        errors
+    }
+
+    /// Prints validator information to stdout.
+    ///
+    /// Prints public key, address, and optionally weight, version info, and chain info.
+    /// If `reference` is provided, only prints fields that differ from the reference.
+    pub fn print(
+        &self,
+        public_key: Option<&ValidatorPublicKey>,
+        address: Option<&str>,
+        weight: Option<u64>,
+        reference: Option<&ValidatorQueryResults>,
+    ) {
+        if let Some(key) = public_key {
+            println!("Public key: {}", key);
+        }
+        if let Some(address) = address {
+            println!("Address: {}", address);
+        }
+        if let Some(w) = weight {
+            println!("Weight: {}", w);
+        }
+
+        let ref_version = reference.and_then(|ref_results| ref_results.version_info.as_ref().ok());
+        match &self.version_info {
+            Ok(version_info) => {
+                if ref_version.is_none_or(|ref_v| ref_v.crate_version != version_info.crate_version)
+                {
+                    println!("Linera protocol: v{}", version_info.crate_version);
+                }
+                if ref_version.is_none_or(|ref_v| ref_v.rpc_hash != version_info.rpc_hash) {
+                    println!("RPC API hash: {}", version_info.rpc_hash);
+                }
+                if ref_version.is_none_or(|ref_v| ref_v.graphql_hash != version_info.graphql_hash) {
+                    println!("GraphQL API hash: {}", version_info.graphql_hash);
+                }
+                if ref_version.is_none_or(|ref_v| ref_v.wit_hash != version_info.wit_hash) {
+                    println!("WIT API hash: v{}", version_info.wit_hash);
+                }
+                if ref_version.is_none_or(|ref_v| {
+                    (&ref_v.git_commit, ref_v.git_dirty)
+                        != (&version_info.git_commit, version_info.git_dirty)
+                }) {
+                    println!(
+                        "Source code: {}/tree/{}{}",
+                        env!("CARGO_PKG_REPOSITORY"),
+                        version_info.git_commit,
+                        if version_info.git_dirty {
+                            " (dirty)"
+                        } else {
+                            ""
+                        }
+                    );
+                }
+            }
+            Err(err) => println!("Error getting version info: {err}"),
+        }
+
+        let ref_genesis_hash =
+            reference.and_then(|ref_results| ref_results.genesis_config_hash.as_ref().ok());
+        match &self.genesis_config_hash {
+            Ok(hash) if ref_genesis_hash.is_some_and(|ref_hash| ref_hash == hash) => {}
+            Ok(hash) => println!("Genesis config hash: {hash}"),
+            Err(err) => println!("Error getting genesis config: {err}"),
+        }
+
+        let ref_info = reference.and_then(|ref_results| ref_results.chain_info.as_ref().ok());
+        match &self.chain_info {
+            Ok(info) => {
+                if ref_info.is_none_or(|ref_info| info.block_hash != ref_info.block_hash) {
+                    if let Some(hash) = info.block_hash {
+                        println!("Block hash: {}", hash);
+                    } else {
+                        println!("Block hash: None");
+                    }
+                }
+                if ref_info
+                    .is_none_or(|ref_info| info.next_block_height != ref_info.next_block_height)
+                {
+                    println!("Next height: {}", info.next_block_height);
+                }
+                if ref_info.is_none_or(|ref_info| info.timestamp != ref_info.timestamp) {
+                    println!("Timestamp: {}", info.timestamp);
+                }
+                if ref_info.is_none_or(|ref_info| info.epoch != ref_info.epoch) {
+                    println!("Epoch: {}", info.epoch);
+                }
+                if ref_info.is_none_or(|ref_info| {
+                    info.manager.current_round != ref_info.manager.current_round
+                }) {
+                    println!("Round: {}", info.manager.current_round);
+                }
+            }
+            Err(err) => println!("Error getting chain info: {err}"),
+        }
+    }
+}
 
 pub struct ClientContext<Env: Environment, W> {
     pub wallet: W,
@@ -528,7 +650,7 @@ impl<Env: Environment, W: Persist<Target = Wallet>> ClientContext<Env, W> {
     ) -> Result<VersionInfo, Error> {
         match node.get_version_info().await {
             Ok(version_info) if version_info.is_compatible_with(&linera_version::VERSION_INFO) => {
-                info!(
+                debug!(
                     "Version information for validator {address}: {}",
                     version_info
                 );
@@ -579,17 +701,17 @@ impl<Env: Environment, W: Persist<Target = Wallet>> ClientContext<Env, W> {
         address: &str,
         node: &impl ValidatorNode,
         chain_id: ChainId,
-    ) -> Result<(), Error> {
+    ) -> Result<ChainInfo, Error> {
         let query = ChainInfoQuery::new(chain_id);
         match node.handle_chain_info_query(query).await {
             Ok(response) => {
-                info!(
+                debug!(
                     "Validator {address} sees chain {chain_id} at block height {} and epoch {:?}",
                     response.info.next_block_height, response.info.epoch,
                 );
                 if let Some(public_key) = public_key {
                     if response.check(*public_key).is_ok() {
-                        info!("Signature for public key {public_key} is OK.");
+                        debug!("Signature for public key {public_key} is OK.");
                     } else {
                         return Err(error::Inner::InvalidSignature {
                             public_key: *public_key,
@@ -599,7 +721,7 @@ impl<Env: Environment, W: Persist<Target = Wallet>> ClientContext<Env, W> {
                 } else {
                     warn!("Not checking signature as public key was not given");
                 }
-                Ok(())
+                Ok(*response.info)
             }
             Err(error) => Err(error::Inner::UnavailableChainInfo {
                 address: address.to_string(),
@@ -607,6 +729,53 @@ impl<Env: Environment, W: Persist<Target = Wallet>> ClientContext<Env, W> {
                 error: Box::new(error),
             }
             .into()),
+        }
+    }
+
+    /// Query a validator for version info, network description, and chain info.
+    ///
+    /// Returns a `ValidatorQueryResults` struct with the results of all three queries.
+    pub async fn query_validator(
+        &self,
+        address: &str,
+        node: &impl ValidatorNode,
+        chain_id: ChainId,
+        public_key: Option<&ValidatorPublicKey>,
+    ) -> ValidatorQueryResults {
+        let version_info = self.check_compatible_version_info(address, node).await;
+        let genesis_config_hash = self.check_matching_network_description(address, node).await;
+        let chain_info = self
+            .check_validator_chain_info_response(public_key, address, node, chain_id)
+            .await;
+
+        ValidatorQueryResults {
+            version_info,
+            genesis_config_hash,
+            chain_info,
+        }
+    }
+
+    /// Query the local node for version info, network description, and chain info.
+    ///
+    /// Returns a `ValidatorQueryResults` struct with the local node's information.
+    pub async fn query_local_node(&self, chain_id: ChainId) -> ValidatorQueryResults {
+        let version_info = Ok(linera_version::VERSION_INFO.clone());
+        let genesis_config_hash = Ok(self
+            .wallet()
+            .genesis_config()
+            .network_description()
+            .genesis_config_hash);
+        let chain_info = self
+            .make_chain_client(chain_id)
+            .chain_info()
+            .await
+            .map(|info| *info)
+            .map_err(|e| e.into());
+
+        ValidatorQueryResults {
+            version_info,
+            genesis_config_hash,
+            chain_info,
         }
     }
 }

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -499,9 +499,15 @@ impl ClientWrapper {
         let mut command = self.command().await?;
         command.arg("query-validator").arg(address);
         let stdout = command.spawn_and_wait_for_stdout().await?;
+
+        // Parse the genesis config hash from the output.
+        // It's on a line like "Genesis config hash: <hash>"
         let hash = stdout
-            .trim()
-            .parse()
+            .lines()
+            .find_map(|line| {
+                line.strip_prefix("Genesis config hash: ")
+                    .and_then(|hash_str| hash_str.trim().parse().ok())
+            })
             .context("error while parsing the result of `linera query-validator`")?;
         Ok(hash)
     }


### PR DESCRIPTION
## Motivation

It helps with debugging consensus issues to get a quick overview of which round the validators are in, and if there are any other discrepancies compared to the local node.

## Proposal

Add more information to `query-validator[s]`. In `query-validators`, show any data that differs from the local node, for every validator.

Example `query-validators` output from the `testnet_conway` port:

```
Querying validators about chain 3e6bdd095d2e4e30f12e8da38ea1409f2442696b01badbda4226577df09479ff.

Local Node:
Linera protocol: v0.15.4
RPC API hash: dYdv0oSjieFam5sNCUoabG3O2HkATGwTHFKiudkk94o
GraphQL API hash: WkChYtBRBRRD6+FZP+CxcpytMknWIi3dgV3nEBcUkck
WIT API hash: vwRMPCb+RzZbBCJ3PmC6AprU5ns+1ivKT6xQTMxrs58E
Source code: https://github.com/linera-io/linera-protocol/tree/919d8b98eb (dirty)
Genesis config hash: 5c7d9d274b85444d8fe9824c300b4bc2d8fc3c0fdb937f80180f8cf63b095589
Block hash: f7a8dd540e60a9c7822f3746ed41cf5b5c29186c2b692368ccea2fdc20bb85f1
Next height: 45
Timestamp: 2025-10-06 08:55:57.418186
Epoch: 13
Round: single-leader round 40

Public key: 021b2bb25d442272865e26569c6c3a61dae538a844a1405cfe1fc83c1106d70d6c
Address: grpcs:linera-test.artifact.systems:443
Weight: 1
Source code: https://github.com/linera-io/linera-protocol/tree/b3604f3fa0b4214027e12cb599ad110cd8c7745a
Block hash: d2b34b803f9f5ea84c6feb4b852dcac129cef4d61867149fd661f4b59cc428e5
Next height: 46
Timestamp: 2025-10-06 11:35:30.451316
Round: single-leader round 0
```

## Test Plan

I tried this out with `testnet_conway` and got the above output.

## Release Plan

- These changes should be released in a new SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)