### PR TITLE
Add support for "null" in case of missing values and add integration test for `GraphQL`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -184,7 +184,7 @@ jobs:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v4

--- a/linera-explorer/src/components/Chain.vue
+++ b/linera-explorer/src/components/Chain.vue
@@ -195,20 +195,20 @@ function pendingBundleCount(): number {
                     <strong>From</strong>
                     <a @click="$root.route(undefined, [['chain', inbox.key]])" class="btn btn-link btn-sm p-0 font-monospace">{{ short_hash(inbox.key) }}</a>
                   </span>
-                  <span v-if="inbox.value.addedBundles?.entries?.length" class="badge bg-warning text-dark">{{ inbox.value.addedBundles.entries.length }} pending</span>
+                  <span v-if="inbox.value?.addedBundles?.entries?.length" class="badge bg-warning text-dark">{{ inbox.value.addedBundles.entries.length }} pending</span>
                 </div>
                 <div class="card-body">
                   <div class="row mb-2 small">
                     <div class="col-md-6">
                       <strong>Next cursor to add:</strong>
-                      <span v-if="inbox.value.nextCursorToAdd" class="ms-1">h={{ displayValue(inbox.value.nextCursorToAdd.height) }}, i={{ displayValue(inbox.value.nextCursorToAdd.index) }}</span>
+                      <span v-if="inbox.value?.nextCursorToAdd" class="ms-1">h={{ displayValue(inbox.value.nextCursorToAdd.height) }}, i={{ displayValue(inbox.value.nextCursorToAdd.index) }}</span>
                     </div>
                     <div class="col-md-6">
                       <strong>Next cursor to remove:</strong>
-                      <span v-if="inbox.value.nextCursorToRemove" class="ms-1">h={{ displayValue(inbox.value.nextCursorToRemove.height) }}, i={{ displayValue(inbox.value.nextCursorToRemove.index) }}</span>
+                      <span v-if="inbox.value?.nextCursorToRemove" class="ms-1">h={{ displayValue(inbox.value.nextCursorToRemove.height) }}, i={{ displayValue(inbox.value.nextCursorToRemove.index) }}</span>
                     </div>
                   </div>
-                  <div v-if="inbox.value.addedBundles?.entries?.length" class="mb-2">
+                  <div v-if="inbox.value?.addedBundles?.entries?.length" class="mb-2">
                     <details>
                       <summary class="small"><strong>Added Bundles</strong> ({{ inbox.value.addedBundles.entries.length }})</summary>
                       <div v-for="(bundle, bi) in inbox.value.addedBundles.entries" :key="bi" class="border rounded p-2 mb-1 mt-1 small">
@@ -261,7 +261,7 @@ function pendingBundleCount(): number {
                       </div>
                     </details>
                   </div>
-                  <div v-if="inbox.value.removedBundles?.entries?.length">
+                  <div v-if="inbox.value?.removedBundles?.entries?.length">
                     <details>
                       <summary class="small"><strong>Removed Bundles</strong> ({{ inbox.value.removedBundles.entries.length }})</summary>
                       <div v-for="(bundle, bi) in inbox.value.removedBundles.entries" :key="bi" class="border rounded p-2 mb-1 mt-1 small">
@@ -331,14 +331,14 @@ function pendingBundleCount(): number {
                     <strong>To</strong>
                     <a @click="$root.route(undefined, [['chain', outbox.key]])" class="btn btn-link btn-sm p-0 font-monospace">{{ short_hash(outbox.key) }}</a>
                   </span>
-                  <span v-if="outbox.value.queue?.entries?.length" class="badge bg-warning text-dark">{{ outbox.value.queue.entries.length }} queued</span>
+                  <span v-if="outbox.value?.queue?.entries?.length" class="badge bg-warning text-dark">{{ outbox.value.queue.entries.length }} queued</span>
                 </div>
                 <div class="card-body small">
-                  <div class="mb-2">
+                  <div v-if="outbox.value" class="mb-2">
                     <strong>Next height to schedule:</strong>
                     <span class="ms-1">{{ displayValue(outbox.value.nextHeightToSchedule) }}</span>
                   </div>
-                  <div v-if="outbox.value.queue?.entries?.length">
+                  <div v-if="outbox.value?.queue?.entries?.length">
                     <details>
                       <summary><strong>Queue</strong> ({{ outbox.value.queue.entries.length }})</summary>
                       <Json :data="outbox.value.queue.entries"/>

--- a/linera-sdk/tests/fixtures/Cargo.lock
+++ b/linera-sdk/tests/fixtures/Cargo.lock
@@ -1672,6 +1672,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "graph-ql-queries"
+version = "0.1.0"
+dependencies = [
+ "async-graphql",
+ "linera-sdk",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/linera-sdk/tests/fixtures/Cargo.toml
+++ b/linera-sdk/tests/fixtures/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "create-and-call",
     "event-emitter",
     "event-subscriber",
+    "graph-ql-queries",
     "meta-counter",
     "publish-read-data-blob",
     "time-expiry",
@@ -25,6 +26,7 @@ counter = { path = "../../../examples/counter" }
 counter-no-graphql = { path = "../../../examples/counter-no-graphql" }
 create-and-call = { path = "./create-and-call" }
 event-emitter = { path = "./event-emitter" }
+graph-ql-queries = { path = "./graph-ql-queries" }
 meta-counter = { path = "./meta-counter" }
 publish-read-data-blob = { path = "./publish-read-data-blob" }
 time-expiry = { path = "./time-expiry" }

--- a/linera-sdk/tests/fixtures/graph-ql-queries/Cargo.toml
+++ b/linera-sdk/tests/fixtures/graph-ql-queries/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "graph-ql-queries"
+version = "0.1.0"
+authors = ["Linera <contact@linera.io>"]
+edition = "2021"
+
+[dependencies]
+async-graphql.workspace = true
+linera-sdk.workspace = true
+serde.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+linera-sdk = { workspace = true, features = ["test", "wasmer"] }
+tokio = { workspace = true, features = ["rt", "sync"] }
+
+[dev-dependencies]
+linera-sdk = { workspace = true, features = ["test"] }
+
+[[bin]]
+name = "graph_ql_queries_contract"
+path = "src/contract.rs"
+
+[[bin]]
+name = "graph_ql_queries_service"
+path = "src/service.rs"

--- a/linera-sdk/tests/fixtures/graph-ql-queries/src/contract.rs
+++ b/linera-sdk/tests/fixtures/graph-ql-queries/src/contract.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+mod state;
+
+use graph_ql_queries::{GraphQlQueriesAbi, GraphQlQueriesOperation, GraphQlQueriesOperation::*};
+use linera_sdk::{
+    linera_base_types::WithContractAbi,
+    views::{RootView, View},
+    Contract, ContractRuntime,
+};
+
+use self::state::GraphQlQueriesState;
+
+pub struct GraphQlQueriesContract {
+    state: GraphQlQueriesState,
+}
+
+linera_sdk::contract!(GraphQlQueriesContract);
+
+impl WithContractAbi for GraphQlQueriesContract {
+    type Abi = GraphQlQueriesAbi;
+}
+
+impl Contract for GraphQlQueriesContract {
+    type Message = ();
+    type InstantiationArgument = ();
+    type Parameters = ();
+    type EventValue = ();
+
+    async fn load(runtime: ContractRuntime<Self>) -> Self {
+        let state = GraphQlQueriesState::load(runtime.root_view_storage_context())
+            .await
+            .expect("Failed to load state");
+        GraphQlQueriesContract { state }
+    }
+
+    async fn instantiate(&mut self, _value: ()) {}
+
+    async fn execute_operation(&mut self, operation: GraphQlQueriesOperation) {
+        match operation {
+            SetRegister { value } => {
+                self.state.reg.set(value);
+            }
+            InsertMapString { key, value } => {
+                self.state.map_s.insert(&key, value).unwrap();
+            }
+            InsertCollString { key, value } => {
+                let subview = self.state.coll_s.load_entry_mut(&key).await.unwrap();
+                subview.set(value);
+            }
+            InsertCollMap { key1, key2, value } => {
+                let subview = self.state.coll_map.load_entry_mut(&key1).await.unwrap();
+                subview.insert(&key2, value).unwrap();
+            }
+        }
+    }
+
+    async fn execute_message(&mut self, _message: ()) {
+        panic!("Counter application doesn't support any cross-chain messages");
+    }
+
+    async fn store(mut self) {
+        self.state.save().await.expect("Failed to save state");
+    }
+}

--- a/linera-sdk/tests/fixtures/graph-ql-queries/src/lib.rs
+++ b/linera-sdk/tests/fixtures/graph-ql-queries/src/lib.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*! ABI of the Counter Example Application */
+
+use async_graphql::{Request, Response};
+use linera_sdk::{
+    graphql::GraphQLMutationRoot,
+    linera_base_types::{ContractAbi, ServiceAbi},
+};
+use serde::{Deserialize, Serialize};
+
+pub struct GraphQlQueriesAbi;
+
+#[derive(Debug, Deserialize, Serialize, GraphQLMutationRoot)]
+pub enum GraphQlQueriesOperation {
+    /// Set the register
+    SetRegister { value: u64 },
+    /// Insert in MapView
+    InsertMapString { key: String, value: u8 },
+    /// Insert in CollectionView
+    InsertCollString { key: String, value: u8 },
+    /// Insertion in the CollectionView / MapView
+    InsertCollMap {
+        key1: String,
+        key2: String,
+        value: u64,
+    },
+}
+
+impl ContractAbi for GraphQlQueriesAbi {
+    type Operation = GraphQlQueriesOperation;
+    type Response = ();
+}
+
+impl ServiceAbi for GraphQlQueriesAbi {
+    type Query = Request;
+    type QueryResponse = Response;
+}

--- a/linera-sdk/tests/fixtures/graph-ql-queries/src/service.rs
+++ b/linera-sdk/tests/fixtures/graph-ql-queries/src/service.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+mod state;
+
+use std::sync::Arc;
+
+use async_graphql::{EmptySubscription, Request, Response, Schema};
+use graph_ql_queries::{GraphQlQueriesAbi, GraphQlQueriesOperation};
+use linera_sdk::{
+    graphql::GraphQLMutationRoot as _, linera_base_types::WithServiceAbi, views::View, Service,
+    ServiceRuntime,
+};
+
+use self::state::GraphQlQueriesState;
+
+pub struct GraphQlQueriesService {
+    state: Arc<GraphQlQueriesState>,
+    runtime: Arc<ServiceRuntime<Self>>,
+}
+
+linera_sdk::service!(GraphQlQueriesService);
+
+impl WithServiceAbi for GraphQlQueriesService {
+    type Abi = GraphQlQueriesAbi;
+}
+
+impl Service for GraphQlQueriesService {
+    type Parameters = ();
+
+    async fn new(runtime: ServiceRuntime<Self>) -> Self {
+        let state = GraphQlQueriesState::load(runtime.root_view_storage_context())
+            .await
+            .expect("Failed to load state");
+        GraphQlQueriesService {
+            state: Arc::new(state),
+            runtime: Arc::new(runtime),
+        }
+    }
+
+    async fn handle_query(&self, request: Request) -> Response {
+        let schema = Schema::build(
+            self.state.clone(),
+            GraphQlQueriesOperation::mutation_root(self.runtime.clone()),
+            EmptySubscription,
+        )
+        .finish();
+        schema.execute(request).await
+    }
+}

--- a/linera-sdk/tests/fixtures/graph-ql-queries/src/state.rs
+++ b/linera-sdk/tests/fixtures/graph-ql-queries/src/state.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use linera_sdk::views::{
+    linera_views, CollectionView, MapView, RegisterView, RootView, ViewStorageContext,
+};
+
+/// The application state.
+#[derive(RootView, async_graphql::SimpleObject)]
+#[view(context = ViewStorageContext)]
+pub struct GraphQlQueriesState {
+    pub reg: RegisterView<u64>,
+    pub map_s: MapView<String, u8>,
+    pub coll_s: CollectionView<String, RegisterView<u8>>,
+    pub coll_map: CollectionView<String, MapView<String, u64>>,
+}

--- a/linera-sdk/tests/fixtures/graph-ql-queries/tests/graph_ql_operation.rs
+++ b/linera-sdk/tests/fixtures/graph-ql-queries/tests/graph_ql_operation.rs
@@ -1,0 +1,95 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the Matching Engine application
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use graph_ql_queries::{GraphQlQueriesAbi, GraphQlQueriesOperation};
+use linera_sdk::test::{QueryOutcome, TestValidator};
+
+#[tokio::test]
+async fn test_queries() {
+    let (validator, module_id) =
+        TestValidator::with_current_module::<GraphQlQueriesAbi, (), ()>().await;
+
+    let mut chain = validator.new_chain().await;
+
+    let application_id = chain.create_application(module_id, (), (), vec![]).await;
+
+    let operation1 = GraphQlQueriesOperation::SetRegister { value: 124 };
+    let operation2 = GraphQlQueriesOperation::InsertMapString {
+        key: "a".into(),
+        value: 91,
+    };
+    let operation3 = GraphQlQueriesOperation::InsertCollString {
+        key: "a".into(),
+        value: 91,
+    };
+    let operation4 = GraphQlQueriesOperation::InsertCollMap {
+        key1: "A".into(),
+        key2: "X".into(),
+        value: 49,
+    };
+
+    chain
+        .add_block(|block| {
+            block
+                .with_operation(application_id, operation1)
+                .with_operation(application_id, operation2)
+                .with_operation(application_id, operation3)
+                .with_operation(application_id, operation4);
+        })
+        .await;
+
+    // READ1
+
+    for (query, expected_response) in [
+        ("reg", "{\"reg\":124}"),
+        ("mapS { keys }", "{\"mapS\":{\"keys\":[\"a\"]}}"),
+        ("mapS { entry(key: \"a\") { key, value } }", "{\"mapS\":{\"entry\":{\"key\":\"a\",\"value\":91}}}"),
+        ("mapS { entries { key, value } }", "{\"mapS\":{\"entries\":[{\"key\":\"a\",\"value\":91}]}}"),
+        ("mapS { entries(input: {}) { key, value } }", "{\"mapS\":{\"entries\":[{\"key\":\"a\",\"value\":91}]}}"),
+        ("mapS { entries(input: { filters: {} }) { key, value } }", "{\"mapS\":{\"entries\":[{\"key\":\"a\",\"value\":91}]}}"),
+        ("mapS { entries(input: { filters: { keys: [\"a\"]} }) { key, value } }", "{\"mapS\":{\"entries\":[{\"key\":\"a\",\"value\":91}]}}"),
+        ("mapS { entries(input: { filters: { keys: [\"b\"]} }) { key, value } }", "{\"mapS\":{\"entries\":[{\"key\":\"b\",\"value\":null}]}}"),
+        ("mapS { count }", "{\"mapS\":{\"count\":1}}"),
+        ("collS { keys }", "{\"collS\":{\"keys\":[\"a\"]}}"),
+        ("collS { entry(key: \"a\") { key, value } }", "{\"collS\":{\"entry\":{\"key\":\"a\",\"value\":91}}}"),
+        ("collS { entries { key, value } }", "{\"collS\":{\"entries\":[{\"key\":\"a\",\"value\":91}]}}"),
+        ("collS { entries(input: {}) { key, value } }", "{\"collS\":{\"entries\":[{\"key\":\"a\",\"value\":91}]}}"),
+        ("collS { entries(input: { filters: {} }) { key, value } }", "{\"collS\":{\"entries\":[{\"key\":\"a\",\"value\":91}]}}"),
+        ("collS { entries(input: { filters: { keys: [\"a\"]} }) { key, value } }", "{\"collS\":{\"entries\":[{\"key\":\"a\",\"value\":91}]}}"),
+        ("collS { entries(input: { filters: { keys: [\"b\"]} }) { key, value } }", "{\"collS\":{\"entries\":[{\"key\":\"b\",\"value\":null}]}}"),
+        ("collS { count }", "{\"collS\":{\"count\":1}}"),
+        ("collMap { keys }", "{\"collMap\":{\"keys\":[\"A\"]}}"),
+        ("collMap { entries { key, value { count } } }", "{\"collMap\":{\"entries\":[{\"key\":\"A\",\"value\":{\"count\":1}}]}}"),
+        ("collMap { count }", "{\"collMap\":{\"count\":1}}"),
+        ("collMap { entry(key: \"A\") { key, value { count } } }", "{\"collMap\":{\"entry\":{\"key\":\"A\",\"value\":{\"count\":1}}}}"),
+        ("collMap { entry(key: \"B\") { key, value { count } } }", "{\"collMap\":{\"entry\":{\"key\":\"B\",\"value\":null}}}"),
+        ("collMap { entry(key: \"A\") { key, value { entries(input: {}) { key, value } } } }",
+         "{\"collMap\":{\"entry\":{\"key\":\"A\",\"value\":{\"entries\":[{\"key\":\"X\",\"value\":49}]}}}}"),
+        ("collMap { entries(input: {}) { key, value { count } } }",
+         "{\"collMap\":{\"entries\":[{\"key\":\"A\",\"value\":{\"count\":1}}]}}"),
+        ("collMap { entries(input: {}) { key, value { entries(input: {}) { key, value } } } }",
+         "{\"collMap\":{\"entries\":[{\"key\":\"A\",\"value\":{\"entries\":[{\"key\":\"X\",\"value\":49}]}}]}}"),
+        ("collMap { entries { key, value { keys } } }",
+         "{\"collMap\":{\"entries\":[{\"key\":\"A\",\"value\":{\"keys\":[\"X\"]}}]}}"),
+        ("collMap { entries(input: {}) { key, value { keys } } }",
+         "{\"collMap\":{\"entries\":[{\"key\":\"A\",\"value\":{\"keys\":[\"X\"]}}]}}"),
+        ("collMap { entries(input: { filters: {} }) { key, value { keys } } }",
+         "{\"collMap\":{\"entries\":[{\"key\":\"A\",\"value\":{\"keys\":[\"X\"]}}]}}"),
+        ("collMap { entries(input: { filters: { keys: [\"A\"] } }) { key, value { keys } } }",
+         "{\"collMap\":{\"entries\":[{\"key\":\"A\",\"value\":{\"keys\":[\"X\"]}}]}}"),
+        ("collMap { entries(input: { filters: { keys: [\"B\"] } }) { key, value { keys } } }",
+         "{\"collMap\":{\"entries\":[{\"key\":\"B\",\"value\":null}]}}"),
+    ] {
+        println!("query={}", query);
+        let new_query = format!("query {{ {} }}", query);
+        let QueryOutcome { response, .. } = chain.graphql_query(application_id, new_query).await;
+        println!("expected_response={expected_response}");
+        println!("response={response}");
+        assert_eq!(format!("{response}"), expected_response);
+        println!();
+    }
+}

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -32,15 +32,6 @@ A unique identifier for a user or an application.
 scalar AccountOwner
 
 """
-Admin operation metadata.
-"""
-type AdminOperationMetadata {
-	adminOperationType: String!
-	epoch: Int
-	blobHash: CryptoHash
-}
-
-"""
 A non-negative amount of tokens.
 """
 scalar Amount
@@ -77,10 +68,13 @@ input ApplicationPermissions {
 	"""
 	mandatoryApplications: [ApplicationId!]! = []
 	"""
-	These applications are allowed to close the current chain, change the application
-	permissions, and change the ownership.
+	These applications are allowed to close the current chain.
 	"""
-	manageChain: [ApplicationId!]! = []
+	closeChain: [ApplicationId!]! = []
+	"""
+	These applications are allowed to change the application permissions.
+	"""
+	changeApplicationPermissions: [ApplicationId!]! = []
 	"""
 	These applications are allowed to perform calls to services as oracles.
 	"""
@@ -89,16 +83,6 @@ input ApplicationPermissions {
 	These applications are allowed to perform HTTP requests.
 	"""
 	makeHttpRequests: [ApplicationId!] = null
-}
-
-"""
-Application permissions metadata for GraphQL.
-"""
-type ApplicationPermissionsMetadata {
-	"""
-	JSON serialized `ApplicationPermissions`.
-	"""
-	permissionsJson: String!
 }
 
 """
@@ -244,6 +228,30 @@ A block height to identify blocks in a chain
 """
 scalar BlockHeight
 
+type BucketQueueView_BlockHeight_e824a938 {
+	count: Int!
+	entries(count: Int): [BlockHeight!]!
+}
+
+type BucketQueueView_TimestampedBundleInInbox_5a630c55 {
+	count: Int!
+	entries(count: Int): [TimestampedBundleInInbox!]!
+}
+
+"""
+An origin and cursor of a unskippable bundle that is no longer in our inbox.
+"""
+type BundleInInbox {
+	"""
+	The origin from which we received the bundle.
+	"""
+	origin: ChainId!
+	"""
+	The cursor of the bundle in the inbox.
+	"""
+	cursor: Cursor!
+}
+
 """
 A module bytecode (WebAssembly or EVM)
 """
@@ -311,22 +319,16 @@ Represents the owner(s) of a chain
 """
 scalar ChainOwnership
 
-"""
-Chain ownership metadata for GraphQL.
-"""
-type ChainOwnershipMetadata {
-	"""
-	JSON serialized `ChainOwnership` for full representation.
-	"""
-	ownershipJson: String!
-}
-
 type ChainStateExtendedView {
 	chainId: ChainId!
 	"""
 	Execution state, including system and user applications.
 	"""
 	executionState: ExecutionStateView!
+	"""
+	Hash of the execution state.
+	"""
+	executionStateHash: CryptoHash
 	"""
 	Block-chaining state.
 	"""
@@ -345,11 +347,10 @@ type ChainStateExtendedView {
 	"""
 	pendingProposedBlobs: ReentrantCollectionView_AccountOwner_PendingBlobsView_d58d342d!
 	"""
-	Hashes of all known blocks in this chain, indexed by their height. A block at
-	`height < next_block_height` is executed; a block at `height >= next_block_height`
-	is preprocessed (verified but not yet executed) and may not be contiguous.
+	Hashes of all certified blocks for this sender.
+	This ends with `block_hash` and has length `usize::from(next_block_height)`.
 	"""
-	blockHashes: CustomMapView_BlockHeight_CryptoHash_1bae6d76!
+	confirmedLog: LogView_CryptoHash_87fbb60c!
 	"""
 	Sender chain and height of all certified blocks known as a receiver (local ordering).
 	"""
@@ -362,6 +363,22 @@ type ChainStateExtendedView {
 	Mailboxes used to receive messages indexed by their origin.
 	"""
 	inboxes: ReentrantCollectionView_ChainId_InboxStateView_466640be!
+	"""
+	A queue of unskippable bundles, with the timestamp when we added them to the inbox.
+	"""
+	unskippableBundles: BucketQueueView_TimestampedBundleInInbox_5a630c55!
+	"""
+	Unskippable bundles that have been removed but are still in the queue.
+	"""
+	removedUnskippableBundles: SetView_BundleInInbox_092a4377!
+	"""
+	The heights of previous blocks that sent messages to the same recipients.
+	"""
+	previousMessageBlocks: MapView_ChainId_BlockHeight_f2e56e12!
+	"""
+	The heights of previous blocks that published events to the same streams.
+	"""
+	previousEventBlocks: MapView_StreamId_BlockHeight_e6657ad9!
 	"""
 	Mailboxes used to send messages, indexed by their target.
 	"""
@@ -381,26 +398,9 @@ type ChainStateExtendedView {
 	"""
 	nonemptyOutboxes: [ChainId!]!
 	"""
-	Inboxes with at least one pending added bundle. This allows us to avoid loading all inboxes.
+	Blocks that have been verified but not executed yet, and that may not be contiguous.
 	"""
-	nonemptyInboxes: [ChainId!]!
-	"""
-	The local wall-clock time when block 0 was last executed. Used to prevent
-	reset-on-incorrect-outcome from looping: if not enough time has elapsed since
-	the last reset, the error is returned instead.
-	"""
-	blockZeroExecutedAt: Timestamp!
-	"""
-	The height at which the next block can be preprocessed: one past the highest
-	height in `block_hashes` (executed or preprocessed), or `next_block_height` if
-	`block_hashes` is empty.
-	
-	Maintained as an O(1) shortcut for `next_height_to_preprocess`, since
-	`CustomMapView` does not yet expose a `last_index` lookup. Once
-	`linera-views` gains efficient first/last key support, this field can be
-	removed in favor of `block_hashes.last_index()`.
-	"""
-	nextHeightToPreprocess: BlockHeight!
+	preprocessedBlocks: MapView_BlockHeight_CryptoHash_1bae6d76!
 }
 
 """
@@ -435,35 +435,6 @@ type Chains {
 }
 
 """
-Change application permissions operation metadata.
-"""
-type ChangeApplicationPermissionsMetadata {
-	permissions: ApplicationPermissionsMetadata!
-}
-
-"""
-Change ownership operation metadata.
-"""
-type ChangeOwnershipOperationMetadata {
-	superOwners: [AccountOwner!]!
-	owners: [OwnerWithWeight!]!
-	firstLeader: AccountOwner
-	multiLeaderRounds: Int!
-	openMultiLeaderRounds: Boolean!
-	timeoutConfig: TimeoutConfigMetadata!
-}
-
-"""
-Claim operation metadata.
-"""
-type ClaimOperationMetadata {
-	owner: AccountOwner!
-	targetId: ChainId!
-	recipient: AccountOutput!
-	amount: Amount!
-}
-
-"""
 A set of validators (identified by their public keys) and their voting rights.
 """
 input Committee {
@@ -480,8 +451,7 @@ input Committee {
 	"""
 	quorumThreshold: Int!
 	"""
-	The threshold to prove the validity of a statement. I.e. the assumption is that strictly
-	less than `validity_threshold` are faulty.
+	The threshold to prove the validity of a statement.
 	"""
 	validityThreshold: Int!
 	"""
@@ -497,25 +467,6 @@ type ConfirmedBlock {
 }
 
 """
-Create application operation metadata.
-"""
-type CreateApplicationOperationMetadata {
-	moduleId: String!
-	parametersHex: String!
-	instantiationArgumentHex: String!
-	requiredApplicationIds: [ApplicationId!]!
-}
-
-"""
-Credit message metadata.
-"""
-type CreditMessageMetadata {
-	target: AccountOwner!
-	amount: Amount!
-	source: AccountOwner!
-}
-
-"""
 A Keccak256 value
 """
 scalar CryptoHash
@@ -525,16 +476,10 @@ type Cursor {
 	index: Int!
 }
 
-type CustomMapView_BlockHeight_CryptoHash_1bae6d76 {
-	keys(count: Int): [BlockHeight!]!
-	entry(key: BlockHeight!): Entry_BlockHeight_CryptoHash_74e16b71!
-	entries(input: MapInput_BlockHeight_e824a938): [Entry_BlockHeight_CryptoHash_74e16b71!]!
-}
-
 """
 A GraphQL-visible map item, complete with key.
 """
-type Entry_AccountOwner_Amount_aaf96548 {
+type Entry_AccountOwner_Amount_11ef1379 {
 	key: AccountOwner!
 	value: Amount
 }
@@ -544,13 +489,13 @@ A GraphQL-visible map item, complete with key.
 """
 type Entry_AccountOwner_PendingBlobsView_5d91edcf {
 	key: AccountOwner!
-	value: PendingBlobsView!
+	value: PendingBlobsView
 }
 
 """
 A GraphQL-visible map item, complete with key.
 """
-type Entry_BlobId_Blob_50b95aa1 {
+type Entry_BlobId_Blob_3711e760 {
 	key: BlobId!
 	value: Blob
 }
@@ -566,7 +511,7 @@ type Entry_BlobId_Blob_9f0b41f3 {
 """
 A GraphQL-visible map item, complete with key.
 """
-type Entry_BlockHeight_CryptoHash_74e16b71 {
+type Entry_BlockHeight_CryptoHash_1bae6d76 {
 	key: BlockHeight!
 	value: CryptoHash
 }
@@ -574,9 +519,17 @@ type Entry_BlockHeight_CryptoHash_74e16b71 {
 """
 A GraphQL-visible map item, complete with key.
 """
+type Entry_ChainId_BlockHeight_f2e56e12 {
+	key: ChainId!
+	value: BlockHeight
+}
+
+"""
+A GraphQL-visible map item, complete with key.
+"""
 type Entry_ChainId_InboxStateView_a9e4d828 {
 	key: ChainId!
-	value: InboxStateView!
+	value: InboxStateView
 }
 
 """
@@ -584,13 +537,21 @@ A GraphQL-visible map item, complete with key.
 """
 type Entry_ChainId_OutboxStateView_855dcf53 {
 	key: ChainId!
-	value: OutboxStateView!
+	value: OutboxStateView
 }
 
 """
 A GraphQL-visible map item, complete with key.
 """
-type Entry_StreamId_Int_459c4ec3 {
+type Entry_StreamId_BlockHeight_e6657ad9 {
+	key: StreamId!
+	value: BlockHeight
+}
+
+"""
+A GraphQL-visible map item, complete with key.
+"""
+type Entry_StreamId_Int_3d7f5335 {
 	key: StreamId!
 	value: Int
 }
@@ -694,11 +655,6 @@ type IndexAndEvent {
 }
 
 """
-A scalar that can represent any JSON value.
-"""
-scalar JSON
-
-"""
 A scalar that can represent any JSON Object value.
 """
 scalar JSONObject
@@ -706,6 +662,11 @@ scalar JSONObject
 type LogView_ChainAndHeight_7af83576 {
 	count: Int!
 	entries(start: Int, end: Int): [ChainAndHeight!]!
+}
+
+type LogView_CryptoHash_87fbb60c {
+	count: Int!
+	entries(start: Int, end: Int): [CryptoHash!]!
 }
 
 input MapFilters_AccountOwner_d6668c53 {
@@ -751,29 +712,50 @@ input MapInput_StreamIdInput_b7c3909d {
 type MapView_AccountOwner_Amount_11ef1379 {
 	keys(count: Int): [AccountOwner!]!
 	count: Int!
-	entry(key: AccountOwner!): Entry_AccountOwner_Amount_aaf96548!
-	entries(input: MapInput_AccountOwner_d6668c53): [Entry_AccountOwner_Amount_aaf96548!]!
+	entry(key: AccountOwner!): Entry_AccountOwner_Amount_11ef1379!
+	entries(input: MapInput_AccountOwner_d6668c53): [Entry_AccountOwner_Amount_11ef1379!]!
 }
 
 type MapView_BlobId_Blob_3711e760 {
+	keys(count: Int): [BlobId!]!
+	count: Int!
+	entry(key: BlobId!): Entry_BlobId_Blob_3711e760!
+	entries(input: MapInput_BlobId_4d2a0555): [Entry_BlobId_Blob_3711e760!]!
+}
+
+type MapView_BlobId_Blob_9f0b41f3 {
 	keys(count: Int): [BlobId!]!
 	count: Int!
 	entry(key: BlobId!): Entry_BlobId_Blob_9f0b41f3!
 	entries(input: MapInput_BlobId_4d2a0555): [Entry_BlobId_Blob_9f0b41f3!]!
 }
 
-type MapView_BlobId_Blob_9f0b41f3 {
-	keys(count: Int): [BlobId!]!
+type MapView_BlockHeight_CryptoHash_1bae6d76 {
+	keys(count: Int): [BlockHeight!]!
 	count: Int!
-	entry(key: BlobId!): Entry_BlobId_Blob_50b95aa1!
-	entries(input: MapInput_BlobId_4d2a0555): [Entry_BlobId_Blob_50b95aa1!]!
+	entry(key: BlockHeight!): Entry_BlockHeight_CryptoHash_1bae6d76!
+	entries(input: MapInput_BlockHeight_e824a938): [Entry_BlockHeight_CryptoHash_1bae6d76!]!
+}
+
+type MapView_ChainId_BlockHeight_f2e56e12 {
+	keys(count: Int): [ChainId!]!
+	count: Int!
+	entry(key: ChainId!): Entry_ChainId_BlockHeight_f2e56e12!
+	entries(input: MapInput_ChainId_37f83aa9): [Entry_ChainId_BlockHeight_f2e56e12!]!
+}
+
+type MapView_StreamId_BlockHeight_e6657ad9 {
+	keys(count: Int): [StreamId!]!
+	count: Int!
+	entry(key: StreamIdInput!): Entry_StreamId_BlockHeight_e6657ad9!
+	entries(input: MapInput_StreamIdInput_b7c3909d): [Entry_StreamId_BlockHeight_e6657ad9!]!
 }
 
 type MapView_StreamId_Int_3d7f5335 {
 	keys(count: Int): [StreamId!]!
 	count: Int!
-	entry(key: StreamIdInput!): Entry_StreamId_Int_459c4ec3!
-	entries(input: MapInput_StreamIdInput_b7c3909d): [Entry_StreamId_Int_459c4ec3!]!
+	entry(key: StreamIdInput!): Entry_StreamId_Int_3d7f5335!
+	entries(input: MapInput_StreamIdInput_b7c3909d): [Entry_StreamId_Int_3d7f5335!]!
 }
 
 """
@@ -816,28 +798,6 @@ type MessageBundle {
 The kind of outgoing message being sent
 """
 scalar MessageKind
-
-"""
-Structured representation of a message for GraphQL.
-"""
-type MessageMetadata {
-	"""
-	The type of message: "System" or "User"
-	"""
-	messageType: String!
-	"""
-	For user messages, the application ID
-	"""
-	applicationId: ApplicationId
-	"""
-	For user messages, the serialized bytes (as a hex string for GraphQL)
-	"""
-	userBytesHex: String
-	"""
-	For system messages, structured representation
-	"""
-	systemMessage: SystemMessageMetadata
-}
 
 """
 A unique identifier for an application module
@@ -1036,10 +996,6 @@ type MutationRoot {
 		"""
 		openMultiLeaderRounds: Boolean!,
 		"""
-		The leader of the first single-leader round. If not set, this is random like other rounds.
-		"""
-		firstLeader: AccountOwner,
-		"""
 		The duration of the fast round, in milliseconds; default: no timeout
 		"""
 		fastRoundMs: Int,
@@ -1065,9 +1021,9 @@ type MutationRoot {
 		"""
 		chainId: ChainId!,
 		"""
-		These applications are allowed to manage the chain: close it, change application permissions, and change ownership.
+		These applications are allowed to close the current chain.
 		"""
-		manageChain: [ApplicationId!]!,
+		closeChain: [ApplicationId!]!,
 		"""
 		If this is `None`, all system operations and application operations are allowed.
 		If it is `Some`, only operations from the specified applications are allowed,
@@ -1078,6 +1034,10 @@ type MutationRoot {
 		At least one operation or incoming message from each of these applications must occur in every block.
 		"""
 		mandatoryApplications: [ApplicationId!]!,
+		"""
+		These applications are allowed to change the application permissions.
+		"""
+		changeApplicationPermissions: [ApplicationId!]!,
 		"""
 		These applications are allowed to perform calls to services as oracles.
 		"""
@@ -1165,15 +1125,6 @@ Notify that a chain has a new certified block or a new message
 """
 scalar Notification
 
-"""
-Open chain operation metadata.
-"""
-type OpenChainOperationMetadata {
-	balance: Amount!
-	ownership: ChainOwnershipMetadata!
-	applicationPermissions: ApplicationPermissionsMetadata!
-}
-
 type Operation {
 	"""
 	The type of operation: "System" or "User"
@@ -1188,9 +1139,9 @@ type Operation {
 	"""
 	userBytesHex: String
 	"""
-	For system operations, structured representation
+	For system operations, the serialized bytes (as a hex string for GraphQL)
 	"""
-	systemOperation: SystemOperationMetadata
+	systemBytesHex: String
 }
 
 """
@@ -1221,7 +1172,7 @@ type OutboxStateView {
 	Keep sending these certified blocks of ours until they are acknowledged by
 	receivers.
 	"""
-	queue: QueueView_BlockHeight_e824a938!
+	queue: BucketQueueView_BlockHeight_e824a938!
 }
 
 """
@@ -1252,14 +1203,6 @@ type OutgoingMessage {
 	The message itself.
 	"""
 	message: Message!
-}
-
-"""
-Owner with weight metadata.
-"""
-type OwnerWithWeight {
-	owner: AccountOwner!
-	weight: String!
 }
 
 """
@@ -1312,24 +1255,6 @@ type PostedMessage {
 	The message itself.
 	"""
 	message: Message!
-	"""
-	Structured message metadata for GraphQL.
-	"""
-	messageMetadata: MessageMetadata!
-}
-
-"""
-Publish data blob operation metadata.
-"""
-type PublishDataBlobMetadata {
-	blobHash: CryptoHash!
-}
-
-"""
-Publish module operation metadata.
-"""
-type PublishModuleMetadata {
-	moduleId: String!
 }
 
 type QueryRoot {
@@ -1343,11 +1268,6 @@ type QueryRoot {
 	Returns the version information on this node service.
 	"""
 	version: VersionInfo!
-}
-
-type QueueView_BlockHeight_e824a938 {
-	count: Int!
-	entries(count: Int): [BlockHeight!]!
 }
 
 type QueueView_MessageBundle_f4399f0b {
@@ -1385,6 +1305,11 @@ scalar ResourceControlPolicyScalar
 A number to identify successive attempts to decide a value in a consensus protocol.
 """
 scalar Round
+
+type SetView_BundleInInbox_092a4377 {
+	elements(count: Int): [BundleInInbox!]!
+	count: Int!
+}
 
 """
 An event stream ID.
@@ -1424,31 +1349,13 @@ type SubscriptionRoot {
 	Subscribes to notifications from the specified chain.
 	"""
 	notifications(chainId: ChainId!): Notification!
-	"""
-	Subscribes to the result of a pre-registered GraphQL query.
-	Re-executes the query on every new block and pushes changed results.
-	"""
-	queryResult(
-		"""
-		Name of the registered subscription query.
-		"""
-		name: String!,
-		"""
-		The chain to watch.
-		"""
-		chainId: ChainId!,
-		"""
-		The application to query.
-		"""
-		applicationId: ApplicationId!
-	): JSON!
 }
 
 type SystemExecutionStateView {
 	description: ChainDescription
 	epoch: Epoch!
-	adminChainId: ChainId
-	committeeHash: CryptoHash
+	adminId: ChainId
+	committees: JSONObject!
 	ownership: ChainOwnership!
 	balance: Amount!
 	balances: MapView_AccountOwner_Amount_11ef1379!
@@ -1456,108 +1363,23 @@ type SystemExecutionStateView {
 }
 
 """
-Structured representation of a system message for GraphQL.
-"""
-type SystemMessageMetadata {
-	"""
-	The type of system message
-	"""
-	systemMessageType: String!
-	"""
-	Credit message details
-	"""
-	credit: CreditMessageMetadata
-	"""
-	Withdraw message details
-	"""
-	withdraw: WithdrawMessageMetadata
-}
-
-"""
-Structured representation of a system operation for GraphQL.
-"""
-type SystemOperationMetadata {
-	"""
-	The type of system operation
-	"""
-	systemOperationType: String!
-	"""
-	Transfer operation details
-	"""
-	transfer: TransferOperationMetadata
-	"""
-	Claim operation details
-	"""
-	claim: ClaimOperationMetadata
-	"""
-	Open chain operation details
-	"""
-	openChain: OpenChainOperationMetadata
-	"""
-	Change ownership operation details
-	"""
-	changeOwnership: ChangeOwnershipOperationMetadata
-	"""
-	Change application permissions operation details
-	"""
-	changeApplicationPermissions: ChangeApplicationPermissionsMetadata
-	"""
-	Admin operation details
-	"""
-	admin: AdminOperationMetadata
-	"""
-	Create application operation details
-	"""
-	createApplication: CreateApplicationOperationMetadata
-	"""
-	Publish data blob operation details
-	"""
-	publishDataBlob: PublishDataBlobMetadata
-	"""
-	Verify blob operation details
-	"""
-	verifyBlob: VerifyBlobMetadata
-	"""
-	Publish module operation details
-	"""
-	publishModule: PublishModuleMetadata
-	"""
-	Epoch operation details (`ProcessNewEpoch`)
-	"""
-	epoch: Int
-	"""
-	`UpdateStream` operation details
-	"""
-	updateStream: UpdateStreamMetadata
-}
-
-"""
-Timeout configuration metadata for GraphQL.
-"""
-type TimeoutConfigMetadata {
-	"""
-	The duration of the fast round in milliseconds.
-	"""
-	fastRoundMs: String
-	"""
-	The duration of the first single-leader and all multi-leader rounds in milliseconds.
-	"""
-	baseTimeoutMs: String!
-	"""
-	The duration by which the timeout increases after each single-leader round in milliseconds.
-	"""
-	timeoutIncrementMs: String!
-	"""
-	The age of an incoming tracked or protected message after which validators start
-	transitioning to fallback mode, in milliseconds.
-	"""
-	fallbackDurationMs: String!
-}
-
-"""
 A timestamp, in microseconds since the Unix epoch
 """
 scalar Timestamp
+
+"""
+An origin, cursor and timestamp of a unskippable bundle in our inbox.
+"""
+type TimestampedBundleInInbox {
+	"""
+	The origin and cursor of the bundle.
+	"""
+	entry: BundleInInbox!
+	"""
+	The timestamp when the bundle was added to the inbox.
+	"""
+	seen: Timestamp!
+}
 
 """
 GraphQL-compatible metadata about a transaction.
@@ -1577,44 +1399,9 @@ type TransactionMetadata {
 	operation: Operation
 }
 
-"""
-Transfer operation metadata.
-"""
-type TransferOperationMetadata {
-	owner: AccountOwner!
-	recipient: AccountOutput!
-	amount: Amount!
-}
-
-"""
-Update stream metadata.
-"""
-type UpdateStreamMetadata {
-	applicationId: String!
-	chainId: ChainId!
-	streamId: String!
-	nextIndex: Int!
-}
-
-"""
-Verify blob operation metadata.
-"""
-type VerifyBlobMetadata {
-	blobId: String!
-}
-
 scalar VersionInfo
 
 scalar VmRuntime
-
-"""
-Withdraw message metadata.
-"""
-type WithdrawMessageMetadata {
-	owner: AccountOwner!
-	amount: Amount!
-	recipient: AccountOutput!
-}
 
 """
 Directs the executor to include this field or fragment only when the `if` argument is true.

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -32,6 +32,15 @@ A unique identifier for a user or an application.
 scalar AccountOwner
 
 """
+Admin operation metadata.
+"""
+type AdminOperationMetadata {
+	adminOperationType: String!
+	epoch: Int
+	blobHash: CryptoHash
+}
+
+"""
 A non-negative amount of tokens.
 """
 scalar Amount
@@ -68,13 +77,10 @@ input ApplicationPermissions {
 	"""
 	mandatoryApplications: [ApplicationId!]! = []
 	"""
-	These applications are allowed to close the current chain.
+	These applications are allowed to close the current chain, change the application
+	permissions, and change the ownership.
 	"""
-	closeChain: [ApplicationId!]! = []
-	"""
-	These applications are allowed to change the application permissions.
-	"""
-	changeApplicationPermissions: [ApplicationId!]! = []
+	manageChain: [ApplicationId!]! = []
 	"""
 	These applications are allowed to perform calls to services as oracles.
 	"""
@@ -83,6 +89,16 @@ input ApplicationPermissions {
 	These applications are allowed to perform HTTP requests.
 	"""
 	makeHttpRequests: [ApplicationId!] = null
+}
+
+"""
+Application permissions metadata for GraphQL.
+"""
+type ApplicationPermissionsMetadata {
+	"""
+	JSON serialized `ApplicationPermissions`.
+	"""
+	permissionsJson: String!
 }
 
 """
@@ -228,30 +244,6 @@ A block height to identify blocks in a chain
 """
 scalar BlockHeight
 
-type BucketQueueView_BlockHeight_e824a938 {
-	count: Int!
-	entries(count: Int): [BlockHeight!]!
-}
-
-type BucketQueueView_TimestampedBundleInInbox_5a630c55 {
-	count: Int!
-	entries(count: Int): [TimestampedBundleInInbox!]!
-}
-
-"""
-An origin and cursor of a unskippable bundle that is no longer in our inbox.
-"""
-type BundleInInbox {
-	"""
-	The origin from which we received the bundle.
-	"""
-	origin: ChainId!
-	"""
-	The cursor of the bundle in the inbox.
-	"""
-	cursor: Cursor!
-}
-
 """
 A module bytecode (WebAssembly or EVM)
 """
@@ -319,16 +311,22 @@ Represents the owner(s) of a chain
 """
 scalar ChainOwnership
 
+"""
+Chain ownership metadata for GraphQL.
+"""
+type ChainOwnershipMetadata {
+	"""
+	JSON serialized `ChainOwnership` for full representation.
+	"""
+	ownershipJson: String!
+}
+
 type ChainStateExtendedView {
 	chainId: ChainId!
 	"""
 	Execution state, including system and user applications.
 	"""
 	executionState: ExecutionStateView!
-	"""
-	Hash of the execution state.
-	"""
-	executionStateHash: CryptoHash
 	"""
 	Block-chaining state.
 	"""
@@ -347,10 +345,11 @@ type ChainStateExtendedView {
 	"""
 	pendingProposedBlobs: ReentrantCollectionView_AccountOwner_PendingBlobsView_d58d342d!
 	"""
-	Hashes of all certified blocks for this sender.
-	This ends with `block_hash` and has length `usize::from(next_block_height)`.
+	Hashes of all known blocks in this chain, indexed by their height. A block at
+	`height < next_block_height` is executed; a block at `height >= next_block_height`
+	is preprocessed (verified but not yet executed) and may not be contiguous.
 	"""
-	confirmedLog: LogView_CryptoHash_87fbb60c!
+	blockHashes: CustomMapView_BlockHeight_CryptoHash_1bae6d76!
 	"""
 	Sender chain and height of all certified blocks known as a receiver (local ordering).
 	"""
@@ -363,22 +362,6 @@ type ChainStateExtendedView {
 	Mailboxes used to receive messages indexed by their origin.
 	"""
 	inboxes: ReentrantCollectionView_ChainId_InboxStateView_466640be!
-	"""
-	A queue of unskippable bundles, with the timestamp when we added them to the inbox.
-	"""
-	unskippableBundles: BucketQueueView_TimestampedBundleInInbox_5a630c55!
-	"""
-	Unskippable bundles that have been removed but are still in the queue.
-	"""
-	removedUnskippableBundles: SetView_BundleInInbox_092a4377!
-	"""
-	The heights of previous blocks that sent messages to the same recipients.
-	"""
-	previousMessageBlocks: MapView_ChainId_BlockHeight_f2e56e12!
-	"""
-	The heights of previous blocks that published events to the same streams.
-	"""
-	previousEventBlocks: MapView_StreamId_BlockHeight_e6657ad9!
 	"""
 	Mailboxes used to send messages, indexed by their target.
 	"""
@@ -398,9 +381,26 @@ type ChainStateExtendedView {
 	"""
 	nonemptyOutboxes: [ChainId!]!
 	"""
-	Blocks that have been verified but not executed yet, and that may not be contiguous.
+	Inboxes with at least one pending added bundle. This allows us to avoid loading all inboxes.
 	"""
-	preprocessedBlocks: MapView_BlockHeight_CryptoHash_1bae6d76!
+	nonemptyInboxes: [ChainId!]!
+	"""
+	The local wall-clock time when block 0 was last executed. Used to prevent
+	reset-on-incorrect-outcome from looping: if not enough time has elapsed since
+	the last reset, the error is returned instead.
+	"""
+	blockZeroExecutedAt: Timestamp!
+	"""
+	The height at which the next block can be preprocessed: one past the highest
+	height in `block_hashes` (executed or preprocessed), or `next_block_height` if
+	`block_hashes` is empty.
+	
+	Maintained as an O(1) shortcut for `next_height_to_preprocess`, since
+	`CustomMapView` does not yet expose a `last_index` lookup. Once
+	`linera-views` gains efficient first/last key support, this field can be
+	removed in favor of `block_hashes.last_index()`.
+	"""
+	nextHeightToPreprocess: BlockHeight!
 }
 
 """
@@ -435,6 +435,35 @@ type Chains {
 }
 
 """
+Change application permissions operation metadata.
+"""
+type ChangeApplicationPermissionsMetadata {
+	permissions: ApplicationPermissionsMetadata!
+}
+
+"""
+Change ownership operation metadata.
+"""
+type ChangeOwnershipOperationMetadata {
+	superOwners: [AccountOwner!]!
+	owners: [OwnerWithWeight!]!
+	firstLeader: AccountOwner
+	multiLeaderRounds: Int!
+	openMultiLeaderRounds: Boolean!
+	timeoutConfig: TimeoutConfigMetadata!
+}
+
+"""
+Claim operation metadata.
+"""
+type ClaimOperationMetadata {
+	owner: AccountOwner!
+	targetId: ChainId!
+	recipient: AccountOutput!
+	amount: Amount!
+}
+
+"""
 A set of validators (identified by their public keys) and their voting rights.
 """
 input Committee {
@@ -451,7 +480,8 @@ input Committee {
 	"""
 	quorumThreshold: Int!
 	"""
-	The threshold to prove the validity of a statement.
+	The threshold to prove the validity of a statement. I.e. the assumption is that strictly
+	less than `validity_threshold` are faulty.
 	"""
 	validityThreshold: Int!
 	"""
@@ -467,6 +497,25 @@ type ConfirmedBlock {
 }
 
 """
+Create application operation metadata.
+"""
+type CreateApplicationOperationMetadata {
+	moduleId: String!
+	parametersHex: String!
+	instantiationArgumentHex: String!
+	requiredApplicationIds: [ApplicationId!]!
+}
+
+"""
+Credit message metadata.
+"""
+type CreditMessageMetadata {
+	target: AccountOwner!
+	amount: Amount!
+	source: AccountOwner!
+}
+
+"""
 A Keccak256 value
 """
 scalar CryptoHash
@@ -474,6 +523,12 @@ scalar CryptoHash
 type Cursor {
 	height: BlockHeight!
 	index: Int!
+}
+
+type CustomMapView_BlockHeight_CryptoHash_1bae6d76 {
+	keys(count: Int): [BlockHeight!]!
+	entry(key: BlockHeight!): Entry_BlockHeight_CryptoHash_1bae6d76!
+	entries(input: MapInput_BlockHeight_e824a938): [Entry_BlockHeight_CryptoHash_1bae6d76!]!
 }
 
 """
@@ -519,14 +574,6 @@ type Entry_BlockHeight_CryptoHash_1bae6d76 {
 """
 A GraphQL-visible map item, complete with key.
 """
-type Entry_ChainId_BlockHeight_f2e56e12 {
-	key: ChainId!
-	value: BlockHeight
-}
-
-"""
-A GraphQL-visible map item, complete with key.
-"""
 type Entry_ChainId_InboxStateView_a9e4d828 {
 	key: ChainId!
 	value: InboxStateView
@@ -538,14 +585,6 @@ A GraphQL-visible map item, complete with key.
 type Entry_ChainId_OutboxStateView_855dcf53 {
 	key: ChainId!
 	value: OutboxStateView
-}
-
-"""
-A GraphQL-visible map item, complete with key.
-"""
-type Entry_StreamId_BlockHeight_e6657ad9 {
-	key: StreamId!
-	value: BlockHeight
 }
 
 """
@@ -655,6 +694,11 @@ type IndexAndEvent {
 }
 
 """
+A scalar that can represent any JSON value.
+"""
+scalar JSON
+
+"""
 A scalar that can represent any JSON Object value.
 """
 scalar JSONObject
@@ -662,11 +706,6 @@ scalar JSONObject
 type LogView_ChainAndHeight_7af83576 {
 	count: Int!
 	entries(start: Int, end: Int): [ChainAndHeight!]!
-}
-
-type LogView_CryptoHash_87fbb60c {
-	count: Int!
-	entries(start: Int, end: Int): [CryptoHash!]!
 }
 
 input MapFilters_AccountOwner_d6668c53 {
@@ -730,27 +769,6 @@ type MapView_BlobId_Blob_9f0b41f3 {
 	entries(input: MapInput_BlobId_4d2a0555): [Entry_BlobId_Blob_9f0b41f3!]!
 }
 
-type MapView_BlockHeight_CryptoHash_1bae6d76 {
-	keys(count: Int): [BlockHeight!]!
-	count: Int!
-	entry(key: BlockHeight!): Entry_BlockHeight_CryptoHash_1bae6d76!
-	entries(input: MapInput_BlockHeight_e824a938): [Entry_BlockHeight_CryptoHash_1bae6d76!]!
-}
-
-type MapView_ChainId_BlockHeight_f2e56e12 {
-	keys(count: Int): [ChainId!]!
-	count: Int!
-	entry(key: ChainId!): Entry_ChainId_BlockHeight_f2e56e12!
-	entries(input: MapInput_ChainId_37f83aa9): [Entry_ChainId_BlockHeight_f2e56e12!]!
-}
-
-type MapView_StreamId_BlockHeight_e6657ad9 {
-	keys(count: Int): [StreamId!]!
-	count: Int!
-	entry(key: StreamIdInput!): Entry_StreamId_BlockHeight_e6657ad9!
-	entries(input: MapInput_StreamIdInput_b7c3909d): [Entry_StreamId_BlockHeight_e6657ad9!]!
-}
-
 type MapView_StreamId_Int_3d7f5335 {
 	keys(count: Int): [StreamId!]!
 	count: Int!
@@ -798,6 +816,28 @@ type MessageBundle {
 The kind of outgoing message being sent
 """
 scalar MessageKind
+
+"""
+Structured representation of a message for GraphQL.
+"""
+type MessageMetadata {
+	"""
+	The type of message: "System" or "User"
+	"""
+	messageType: String!
+	"""
+	For user messages, the application ID
+	"""
+	applicationId: ApplicationId
+	"""
+	For user messages, the serialized bytes (as a hex string for GraphQL)
+	"""
+	userBytesHex: String
+	"""
+	For system messages, structured representation
+	"""
+	systemMessage: SystemMessageMetadata
+}
 
 """
 A unique identifier for an application module
@@ -996,6 +1036,10 @@ type MutationRoot {
 		"""
 		openMultiLeaderRounds: Boolean!,
 		"""
+		The leader of the first single-leader round. If not set, this is random like other rounds.
+		"""
+		firstLeader: AccountOwner,
+		"""
 		The duration of the fast round, in milliseconds; default: no timeout
 		"""
 		fastRoundMs: Int,
@@ -1021,9 +1065,9 @@ type MutationRoot {
 		"""
 		chainId: ChainId!,
 		"""
-		These applications are allowed to close the current chain.
+		These applications are allowed to manage the chain: close it, change application permissions, and change ownership.
 		"""
-		closeChain: [ApplicationId!]!,
+		manageChain: [ApplicationId!]!,
 		"""
 		If this is `None`, all system operations and application operations are allowed.
 		If it is `Some`, only operations from the specified applications are allowed,
@@ -1034,10 +1078,6 @@ type MutationRoot {
 		At least one operation or incoming message from each of these applications must occur in every block.
 		"""
 		mandatoryApplications: [ApplicationId!]!,
-		"""
-		These applications are allowed to change the application permissions.
-		"""
-		changeApplicationPermissions: [ApplicationId!]!,
 		"""
 		These applications are allowed to perform calls to services as oracles.
 		"""
@@ -1125,6 +1165,15 @@ Notify that a chain has a new certified block or a new message
 """
 scalar Notification
 
+"""
+Open chain operation metadata.
+"""
+type OpenChainOperationMetadata {
+	balance: Amount!
+	ownership: ChainOwnershipMetadata!
+	applicationPermissions: ApplicationPermissionsMetadata!
+}
+
 type Operation {
 	"""
 	The type of operation: "System" or "User"
@@ -1139,9 +1188,9 @@ type Operation {
 	"""
 	userBytesHex: String
 	"""
-	For system operations, the serialized bytes (as a hex string for GraphQL)
+	For system operations, structured representation
 	"""
-	systemBytesHex: String
+	systemOperation: SystemOperationMetadata
 }
 
 """
@@ -1172,7 +1221,7 @@ type OutboxStateView {
 	Keep sending these certified blocks of ours until they are acknowledged by
 	receivers.
 	"""
-	queue: BucketQueueView_BlockHeight_e824a938!
+	queue: QueueView_BlockHeight_e824a938!
 }
 
 """
@@ -1203,6 +1252,14 @@ type OutgoingMessage {
 	The message itself.
 	"""
 	message: Message!
+}
+
+"""
+Owner with weight metadata.
+"""
+type OwnerWithWeight {
+	owner: AccountOwner!
+	weight: String!
 }
 
 """
@@ -1255,6 +1312,24 @@ type PostedMessage {
 	The message itself.
 	"""
 	message: Message!
+	"""
+	Structured message metadata for GraphQL.
+	"""
+	messageMetadata: MessageMetadata!
+}
+
+"""
+Publish data blob operation metadata.
+"""
+type PublishDataBlobMetadata {
+	blobHash: CryptoHash!
+}
+
+"""
+Publish module operation metadata.
+"""
+type PublishModuleMetadata {
+	moduleId: String!
 }
 
 type QueryRoot {
@@ -1268,6 +1343,11 @@ type QueryRoot {
 	Returns the version information on this node service.
 	"""
 	version: VersionInfo!
+}
+
+type QueueView_BlockHeight_e824a938 {
+	count: Int!
+	entries(count: Int): [BlockHeight!]!
 }
 
 type QueueView_MessageBundle_f4399f0b {
@@ -1305,11 +1385,6 @@ scalar ResourceControlPolicyScalar
 A number to identify successive attempts to decide a value in a consensus protocol.
 """
 scalar Round
-
-type SetView_BundleInInbox_092a4377 {
-	elements(count: Int): [BundleInInbox!]!
-	count: Int!
-}
 
 """
 An event stream ID.
@@ -1349,13 +1424,31 @@ type SubscriptionRoot {
 	Subscribes to notifications from the specified chain.
 	"""
 	notifications(chainId: ChainId!): Notification!
+	"""
+	Subscribes to the result of a pre-registered GraphQL query.
+	Re-executes the query on every new block and pushes changed results.
+	"""
+	queryResult(
+		"""
+		Name of the registered subscription query.
+		"""
+		name: String!,
+		"""
+		The chain to watch.
+		"""
+		chainId: ChainId!,
+		"""
+		The application to query.
+		"""
+		applicationId: ApplicationId!
+	): JSON!
 }
 
 type SystemExecutionStateView {
 	description: ChainDescription
 	epoch: Epoch!
-	adminId: ChainId
-	committees: JSONObject!
+	adminChainId: ChainId
+	committeeHash: CryptoHash
 	ownership: ChainOwnership!
 	balance: Amount!
 	balances: MapView_AccountOwner_Amount_11ef1379!
@@ -1363,23 +1456,108 @@ type SystemExecutionStateView {
 }
 
 """
+Structured representation of a system message for GraphQL.
+"""
+type SystemMessageMetadata {
+	"""
+	The type of system message
+	"""
+	systemMessageType: String!
+	"""
+	Credit message details
+	"""
+	credit: CreditMessageMetadata
+	"""
+	Withdraw message details
+	"""
+	withdraw: WithdrawMessageMetadata
+}
+
+"""
+Structured representation of a system operation for GraphQL.
+"""
+type SystemOperationMetadata {
+	"""
+	The type of system operation
+	"""
+	systemOperationType: String!
+	"""
+	Transfer operation details
+	"""
+	transfer: TransferOperationMetadata
+	"""
+	Claim operation details
+	"""
+	claim: ClaimOperationMetadata
+	"""
+	Open chain operation details
+	"""
+	openChain: OpenChainOperationMetadata
+	"""
+	Change ownership operation details
+	"""
+	changeOwnership: ChangeOwnershipOperationMetadata
+	"""
+	Change application permissions operation details
+	"""
+	changeApplicationPermissions: ChangeApplicationPermissionsMetadata
+	"""
+	Admin operation details
+	"""
+	admin: AdminOperationMetadata
+	"""
+	Create application operation details
+	"""
+	createApplication: CreateApplicationOperationMetadata
+	"""
+	Publish data blob operation details
+	"""
+	publishDataBlob: PublishDataBlobMetadata
+	"""
+	Verify blob operation details
+	"""
+	verifyBlob: VerifyBlobMetadata
+	"""
+	Publish module operation details
+	"""
+	publishModule: PublishModuleMetadata
+	"""
+	Epoch operation details (`ProcessNewEpoch`)
+	"""
+	epoch: Int
+	"""
+	`UpdateStream` operation details
+	"""
+	updateStream: UpdateStreamMetadata
+}
+
+"""
+Timeout configuration metadata for GraphQL.
+"""
+type TimeoutConfigMetadata {
+	"""
+	The duration of the fast round in milliseconds.
+	"""
+	fastRoundMs: String
+	"""
+	The duration of the first single-leader and all multi-leader rounds in milliseconds.
+	"""
+	baseTimeoutMs: String!
+	"""
+	The duration by which the timeout increases after each single-leader round in milliseconds.
+	"""
+	timeoutIncrementMs: String!
+	"""
+	The age of an incoming tracked or protected message after which validators start
+	transitioning to fallback mode, in milliseconds.
+	"""
+	fallbackDurationMs: String!
+}
+
+"""
 A timestamp, in microseconds since the Unix epoch
 """
 scalar Timestamp
-
-"""
-An origin, cursor and timestamp of a unskippable bundle in our inbox.
-"""
-type TimestampedBundleInInbox {
-	"""
-	The origin and cursor of the bundle.
-	"""
-	entry: BundleInInbox!
-	"""
-	The timestamp when the bundle was added to the inbox.
-	"""
-	seen: Timestamp!
-}
 
 """
 GraphQL-compatible metadata about a transaction.
@@ -1399,9 +1577,44 @@ type TransactionMetadata {
 	operation: Operation
 }
 
+"""
+Transfer operation metadata.
+"""
+type TransferOperationMetadata {
+	owner: AccountOwner!
+	recipient: AccountOutput!
+	amount: Amount!
+}
+
+"""
+Update stream metadata.
+"""
+type UpdateStreamMetadata {
+	applicationId: String!
+	chainId: ChainId!
+	streamId: String!
+	nextIndex: Int!
+}
+
+"""
+Verify blob operation metadata.
+"""
+type VerifyBlobMetadata {
+	blobId: String!
+}
+
 scalar VersionInfo
 
 scalar VmRuntime
+
+"""
+Withdraw message metadata.
+"""
+type WithdrawMessageMetadata {
+	owner: AccountOwner!
+	amount: Amount!
+	recipient: AccountOutput!
+}
 
 """
 Directs the executor to include this field or fragment only when the `if` argument is true.

--- a/linera-views/src/graphql.rs
+++ b/linera-views/src/graphql.rs
@@ -36,7 +36,7 @@ pub struct Entry<
     V: async_graphql::OutputType + Send + Sync,
 > {
     pub key: K,
-    pub value: V,
+    pub value: Option<V>,
 }
 
 impl<K: async_graphql::OutputType, V: async_graphql::OutputType> async_graphql::TypeName
@@ -216,13 +216,5 @@ impl<K: async_graphql::InputType> async_graphql::InputType for MapInput<K> {
 
     fn as_raw_value(&self) -> Option<&Self::RawValueType> {
         Some(self)
-    }
-}
-
-pub(crate) fn missing_key_error(key: &impl std::fmt::Debug) -> async_graphql::Error {
-    async_graphql::Error {
-        message: format!("The key={key:?} is missing in collection"),
-        source: None,
-        extensions: None,
     }
 }

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -1774,7 +1774,7 @@ mod graphql {
 
     use super::{CollectionView, CustomCollectionView, ReadGuardedView};
     use crate::{
-        graphql::{hash_name, mangle, missing_key_error, Entry, MapInput},
+        graphql::{hash_name, mangle, Entry, MapInput},
         views::View,
     };
 
@@ -1833,10 +1833,7 @@ mod graphql {
             &self,
             key: K,
         ) -> Result<Entry<K, ReadGuardedView<'_, V>>, async_graphql::Error> {
-            let value = self
-                .try_load_entry(&key)
-                .await?
-                .ok_or_else(|| missing_key_error(&key))?;
+            let value = self.try_load_entry(&key).await?;
             Ok(Entry { value, key })
         }
 
@@ -1857,7 +1854,7 @@ mod graphql {
             Ok(values
                 .into_iter()
                 .zip(keys)
-                .filter_map(|(value, key)| value.map(|value| Entry { value, key }))
+                .map(|(value, key)| Entry { value, key })
                 .collect())
         }
     }
@@ -1898,10 +1895,7 @@ mod graphql {
             &self,
             key: K,
         ) -> Result<Entry<K, ReadGuardedView<'_, V>>, async_graphql::Error> {
-            let value = self
-                .try_load_entry(&key)
-                .await?
-                .ok_or_else(|| missing_key_error(&key))?;
+            let value = self.try_load_entry(&key).await?;
             Ok(Entry { value, key })
         }
 
@@ -1922,7 +1916,7 @@ mod graphql {
             Ok(values
                 .into_iter()
                 .zip(keys)
-                .filter_map(|(value, key)| value.map(|value| Entry { value, key }))
+                .map(|(value, key)| Entry { value, key })
                 .collect())
         }
     }

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -2197,10 +2197,7 @@ mod graphql {
             })
         }
 
-        async fn entry(
-            &self,
-            key: Vec<u8>,
-        ) -> Result<Entry<Vec<u8>, Option<V>>, async_graphql::Error> {
+        async fn entry(&self, key: Vec<u8>) -> Result<Entry<Vec<u8>, V>, async_graphql::Error> {
             Ok(Entry {
                 value: self.get(&key).await?,
                 key,
@@ -2210,7 +2207,7 @@ mod graphql {
         async fn entries(
             &self,
             input: Option<MapInput<Vec<u8>>>,
-        ) -> Result<Vec<Entry<Vec<u8>, Option<V>>>, async_graphql::Error> {
+        ) -> Result<Vec<Entry<Vec<u8>, V>>, async_graphql::Error> {
             let keys = input
                 .and_then(|input| input.filters)
                 .and_then(|filters| filters.keys);
@@ -2282,7 +2279,7 @@ mod graphql {
             Ok(self.iterative_count().await? as u32)
         }
 
-        async fn entry(&self, key: I) -> Result<Entry<I, Option<V>>, async_graphql::Error> {
+        async fn entry(&self, key: I) -> Result<Entry<I, V>, async_graphql::Error> {
             Ok(Entry {
                 value: self.get(&key).await?,
                 key,
@@ -2292,7 +2289,7 @@ mod graphql {
         async fn entries(
             &self,
             input: Option<MapInput<I>>,
-        ) -> Result<Vec<Entry<I, Option<V>>>, async_graphql::Error> {
+        ) -> Result<Vec<Entry<I, V>>, async_graphql::Error> {
             let keys = input
                 .and_then(|input| input.filters)
                 .and_then(|filters| filters.keys);
@@ -2355,7 +2352,7 @@ mod graphql {
             })
         }
 
-        async fn entry(&self, key: I) -> Result<Entry<I, Option<V>>, async_graphql::Error> {
+        async fn entry(&self, key: I) -> Result<Entry<I, V>, async_graphql::Error> {
             Ok(Entry {
                 value: self.get(&key).await?,
                 key,
@@ -2365,7 +2362,7 @@ mod graphql {
         async fn entries(
             &self,
             input: Option<MapInput<I>>,
-        ) -> Result<Vec<Entry<I, Option<V>>>, async_graphql::Error> {
+        ) -> Result<Vec<Entry<I, V>>, async_graphql::Error> {
             let keys = input
                 .and_then(|input| input.filters)
                 .and_then(|filters| filters.keys);

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -2298,7 +2298,7 @@ mod graphql {
 
     use super::{ReadGuardedView, ReentrantCollectionView};
     use crate::{
-        graphql::{hash_name, mangle, missing_key_error, Entry, MapInput},
+        graphql::{hash_name, mangle, Entry, MapInput},
         views::View,
     };
 
@@ -2357,10 +2357,7 @@ mod graphql {
             &self,
             key: K,
         ) -> Result<Entry<K, ReadGuardedView<V>>, async_graphql::Error> {
-            let value = self
-                .try_load_entry(&key)
-                .await?
-                .ok_or_else(|| missing_key_error(&key))?;
+            let value = self.try_load_entry(&key).await?;
             Ok(Entry { value, key })
         }
 
@@ -2381,7 +2378,7 @@ mod graphql {
             Ok(values
                 .into_iter()
                 .zip(keys)
-                .filter_map(|(value, key)| value.map(|value| Entry { value, key }))
+                .map(|(value, key)| Entry { value, key })
                 .collect())
         }
     }
@@ -2418,10 +2415,7 @@ mod graphql {
             &self,
             key: K,
         ) -> Result<Entry<K, ReadGuardedView<V>>, async_graphql::Error> {
-            let value = self
-                .try_load_entry(&key)
-                .await?
-                .ok_or_else(|| missing_key_error(&key))?;
+            let value = self.try_load_entry(&key).await?;
             Ok(Entry { value, key })
         }
 
@@ -2442,7 +2436,7 @@ mod graphql {
             Ok(values
                 .into_iter()
                 .zip(keys)
-                .filter_map(|(value, key)| value.map(|value| Entry { value, key }))
+                .map(|(value, key)| Entry { value, key })
                 .collect())
         }
     }


### PR DESCRIPTION
## Motivation

GraphQL is the canonical way to access Wasm application state on Linera. Therefore, it is of paramount
importance of having excellent support for GraphQL in the `linera-views`.

The canonical way of handling missing values in a query is to return `null`. Ignoring it and pretending that it was
not queried is not the recommended way. This is for example visible on [GraphQL Search and Filter – How to search and filter results with GraphQL](https://www.apollographql.com/blog/how-to-search-and-filter-results-with-graphql).
In this exposition, we see that the GraphQL schema types are
```GraphQL
type Query {
  album(id: ID!): Album
  albums(genre: Genre, ids: [ID!]): [Album]! 
}
```

The meaning of that schema is that the function `album` returns something that may be null, and that `albums` returns a list of entries that may be `null`. This is because by default in GraphQL a variable can be nulled. If not it has a postfix of "!".


The GraphQL standard does not say that if a request is failing to return null. However, if returning null is not allowed, then in case of a missing key, you should return null at a higher level. See [GraphQL, Section 7.1.2](https://spec.graphql.org/June2018/#sec-Errors). Therefore for our case, it is better to return a null value in case of missing key.

## Proposal

The `Entry` is changed in order to have a value that is an `Option<V>`. The change go surprisingly smoothly.

## Test Plan

The CI.

Due to the importance of GraphQL in Linera applications, a specific smart contract has been created for which we can test the 

## Release Plan

This changes are also relevant to the Game Of Life test.

## Links

See above.