### PR TITLE
Eliminate the `BlobsNotFound` error from the test `test_end_to_end_assign_greatgrandchild_chain`

### DIFF
--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1635,9 +1635,14 @@ impl Runnable for Job {
                 };
                 match result {
                     Err(ChainClientError::RemoteNodeError(NodeError::BlobsNotFound(blob_ids)))
-                        if blob_ids == vec![BlobId { blob_type: BlobType::ChainDescription, hash: chain_id.0 }] => {
-                            bail!("Error following chain {chain_id}: It does not exist");
-                        }
+                        if blob_ids
+                            == vec![BlobId {
+                                blob_type: BlobType::ChainDescription,
+                                hash: chain_id.0,
+                            }] =>
+                    {
+                        bail!("Error following chain {chain_id}: It does not exist");
+                    }
                     Err(e) => return Err(e.into()),
                     Ok(_) => {}
                 }


### PR DESCRIPTION
## Motivation

The test `test_end_to_end_assign_greatgrandchild_chain` returns a `BlobsNotFound` error.
This error arises from the 
```rust
    let wrong_id = ChainId(CryptoHash::test_hash("wrong chain ID"));
    let result = client3.follow_chain(wrong_id, false).await;
    assert!(result.is_err());
```

The problem is that the `FollowChain` is a functionality that any user could use. On the other hand, the `BlobsNotFound` is an internal error of the protocol and client code:
* This is confusing for users: Instead of having a clear error of a non-existing chain, the user gets an internal error message.
* This is confusing for developers: It leaves the impression that there are still some protocol errors.

The `BlobsNotFound` error is present in `NodeError` and `LocalNodeError`. This is one degree of uncertainty in the error.

## Proposal

Catch the specific `BlobsNotFound` error and reformulate the error.
This makes the system work.

## Test Plan

The test remains the same. There is still an ERROR statement, but the one that shows up is now quite clear.

## Release Plan

This is of interest to the TestNet Conway.
It means that if a `BlobsNotFound` error occurs in the test, then we know that they are not related to wrong input.

## Links

None.