### PR TITLE
Use `multi_get` for preprocessed_blocks.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -1116,10 +1116,17 @@ where
             Vec::new()
         };
         // Everything after (including) next_height in preprocessed_blocks if we have it.
-        for height in start.max(next_height).0..=end.0 {
-            if let Some(hash) = self.preprocessed_blocks.get(&BlockHeight(height)).await? {
-                hashes.push(hash);
-            }
+        let block_heights = (start.max(next_height).0..=end.0)
+            .map(BlockHeight)
+            .collect::<Vec<_>>();
+        for hash in self
+            .preprocessed_blocks
+            .multi_get(&block_heights)
+            .await?
+            .into_iter()
+            .flatten()
+        {
+            hashes.push(hash);
         }
         Ok(hashes)
     }


### PR DESCRIPTION
## Motivation

The function `block_hashes` has emerged as a limiting factor for the running of the system.
An iteration of `get` operations is ripe for optimization.

## Proposal

We use a `multi_get`. Since what is downloaded is just a hash, there is no risk of memory problems.

## Test Plan

The CI.

## Release Plan

This kind of acceleration can be backported to TestNet Conway easily.

## Links

None.