### PR TITLE
[testnet] Don't sync automatically if only super owners. (#4699)

### DIFF
--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -179,9 +179,9 @@ impl ChainOwnership {
         Some(next_round)
     }
 
-    /// Returns whether the given owner is the only owner, and a super owner.
-    pub fn is_single_super_owner(&self, owner: &AccountOwner) -> bool {
-        self.owners.is_empty() && self.super_owners.len() == 1 && self.super_owners.contains(owner)
+    /// Returns whether the given owner a super owner and there are no regular owners.
+    pub fn is_super_owner_no_regular_owners(&self, owner: &AccountOwner) -> bool {
+        self.owners.is_empty() && self.super_owners.contains(owner)
     }
 }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1896,11 +1896,12 @@ impl<Env: Environment> ChainClient<Env> {
             .handle_chain_info_query(query)
             .await?
             .info;
-        if self
-            .preferred_owner
-            .is_some_and(|owner| info.manager.ownership.is_single_super_owner(&owner))
-        {
-            // We are the only owner, so we should be up to date.
+        if self.preferred_owner.is_some_and(|owner| {
+            info.manager
+                .ownership
+                .is_super_owner_no_regular_owners(&owner)
+        }) {
+            // There are only super owners; they are expected to sync manually.
             ensure!(
                 info.next_block_height >= self.initial_next_block_height,
                 ChainClientError::WalletSynchronizationError
@@ -2060,11 +2061,13 @@ impl<Env: Environment> ChainClient<Env> {
 
         let mut info = self.synchronize_to_known_height().await?;
 
-        if self
-            .preferred_owner
-            .is_none_or(|owner| !info.manager.ownership.is_single_super_owner(&owner))
-        {
-            // If we are not a single super owner, we could be missing recent
+        if self.preferred_owner.is_none_or(|owner| {
+            !info
+                .manager
+                .ownership
+                .is_super_owner_no_regular_owners(&owner)
+        }) {
+            // If we are not a super owner or there are regular owners, we could be missing recent
             // certificates created by other clients. Further synchronize blocks from the network.
             // This is a best-effort that depends on network conditions.
             info = self.client.synchronize_chain_state(self.chain_id).await?;


### PR DESCRIPTION
Backport of #4699.

## Motivation

As discussed [here](https://github.com/linera-io/linera-protocol/pull/4688#discussion_r2389522578), we don't need to automatically sync even if there are multiple super owners.

## Proposal

Change `is_single_super_owner` accordingly.

## Test Plan

CI

## Release Plan

- These changes should be released in a new SDK.

## Links

- PR to main: #4699
- Discussion: https://github.com/linera-io/linera-protocol/pull/4688#discussion_r2389522578
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
