### PR TITLE
Use the BTreeMap for the `multi_get` in `LogView`.

### DIFF
--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -269,8 +269,11 @@ where
             }
             let values = self.context.store().read_multi_values(keys).await?;
             for (positions, value) in vec_positions.into_iter().zip(values) {
-                for position in positions {
-                    *result.get_mut(position).unwrap() = value.clone();
+                if let Some((&last, rest)) = positions.split_last() {
+                    for &position in rest {
+                        *result.get_mut(position).unwrap() = value.clone();
+                    }
+                    *result.get_mut(last).unwrap() = value;
                 }
             }
         }


### PR DESCRIPTION
## Motivation

It has emerged from #4789 that a `merge_get` is being done on some indices that can overlap.
This makes the `multi_get` a little bit slower than it should be.

## Proposal

Use a `BTreeMap` for accessing the keys.

## Test Plan

The CI.

## Release Plan

This change could be backported to the TestNet Conway.

## Links

None