### PR TITLE
Check the block height before the epoch in `process_timeout`

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -565,14 +565,6 @@ where
         // Verify the certificate. Returns a catch-all error to make client code more robust.
         self.initialize_and_save_if_needed().await?;
         let (chain_epoch, committee) = self.chain.current_committee()?;
-        ensure!(
-            certificate.inner().epoch() == chain_epoch,
-            WorkerError::InvalidEpoch {
-                chain_id: certificate.inner().chain_id(),
-                chain_epoch,
-                epoch: certificate.inner().epoch()
-            }
-        );
         certificate.check(committee)?;
         if self
             .chain
@@ -582,6 +574,14 @@ where
         {
             return Ok((self.chain_info_response(), NetworkActions::default()));
         }
+        ensure!(
+            certificate.inner().epoch() == chain_epoch,
+            WorkerError::InvalidEpoch {
+                chain_id: certificate.inner().chain_id(),
+                chain_epoch,
+                epoch: certificate.inner().epoch()
+            }
+        );
         let old_round = self.chain.manager.current_round();
         self.chain
             .manager


### PR DESCRIPTION
## Motivation

When processing a timeout, we check whether the epoch of the certificate is correct before checking whether the height is correct - this may lead to spurious `InvalidEpoch` errors.

## Proposal

Validate the height first.

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
