### PR TITLE
Lower Scylla commitlog size

### DIFF
--- a/kubernetes/linera-validator/templates/scylla-config.yaml
+++ b/kubernetes/linera-validator/templates/scylla-config.yaml
@@ -6,4 +6,4 @@ metadata:
 data:
   scylla.yaml: |
     query_tombstone_page_limit: 200000
-    commitlog_segment_size_in_mb: 256
+    commitlog_segment_size_in_mb: 64


### PR DESCRIPTION
## Motivation

The current commitlog size value works better for read heavy workloads. That's not the case for the testnet, and it damages the reads even more because it generates more SSTables before triggering a compaction.

## Proposal

Lower the commitlog size just on the testnet for now

## Test Plan

Will deploy this. No new docker image is necessary, as this is just a config change.

