### PR TITLE
Backport: Check the block height before the epoch in `process_timeout` (#4811)

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -562,14 +562,6 @@ where
         // Verify the certificate. Returns a catch-all error to make client code more robust.
         self.initialize_and_save_if_needed().await?;
         let (chain_epoch, committee) = self.chain.current_committee()?;
-        ensure!(
-            certificate.inner().epoch() == chain_epoch,
-            WorkerError::InvalidEpoch {
-                chain_id: certificate.inner().chain_id(),
-                chain_epoch,
-                epoch: certificate.inner().epoch()
-            }
-        );
         certificate.check(committee)?;
         if self
             .chain
@@ -579,6 +571,14 @@ where
         {
             return Ok((self.chain_info_response(), NetworkActions::default()));
         }
+        ensure!(
+            certificate.inner().epoch() == chain_epoch,
+            WorkerError::InvalidEpoch {
+                chain_id: certificate.inner().chain_id(),
+                chain_epoch,
+                epoch: certificate.inner().epoch()
+            }
+        );
         let old_round = self.chain.manager.current_round();
         self.chain
             .manager


### PR DESCRIPTION
## Motivation

When processing a timeout, we check whether the epoch of the certificate is correct before checking whether the height is correct - this may lead to spurious `InvalidEpoch` errors.

## Proposal

Validate the height first.

This is the backport of #4811 to the testnet branch.

## Test Plan

CI

## Release Plan

- Nothing to do

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
