### PR TITLE
Use crypto_hash_mut whenever possible

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -502,7 +502,7 @@ where
             return Ok(());
         }
         // Recompute the state hash.
-        let hash = self.execution_state.crypto_hash().await?;
+        let hash = self.execution_state.crypto_hash_mut().await?;
         self.execution_state_hash.set(Some(hash));
         let maybe_committee = self.execution_state.system.current_committee().into_iter();
         // Last, reset the consensus state based on the current ownership.
@@ -867,7 +867,7 @@ where
         let state_hash = {
             #[cfg(with_metrics)]
             let _hash_latency = metrics::STATE_HASH_COMPUTATION_LATENCY.measure_latency();
-            chain.crypto_hash().await?
+            chain.crypto_hash_mut().await?
         };
 
         let (messages, oracle_responses, events, blobs, operation_results) =

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -218,7 +218,7 @@ where
             previous_message_blocks: BTreeMap::new(),
             previous_event_blocks: BTreeMap::new(),
             events: vec![Vec::new()],
-            state_hash: creator_state.crypto_hash().await?,
+            state_hash: creator_state.crypto_hash_mut().await?,
             oracle_responses: vec![vec![
                 OracleResponse::Blob(contract_blob_id),
                 OracleResponse::Blob(service_blob_id),
@@ -298,7 +298,7 @@ where
             previous_event_blocks: BTreeMap::new(),
             events: vec![Vec::new()],
             blobs: vec![Vec::new()],
-            state_hash: creator_state.crypto_hash().await?,
+            state_hash: creator_state.crypto_hash_mut().await?,
             oracle_responses: vec![vec![]],
             operation_results: vec![OperationResult(bcs::to_bytes(&15u64)?)],
         }

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -70,8 +70,8 @@ impl SystemExecutionState {
     }
 
     pub async fn into_hash(self) -> CryptoHash {
-        let view = self.into_view().await;
-        view.crypto_hash()
+        let mut view = self.into_view().await;
+        view.crypto_hash_mut()
             .await
             .expect("hashing from memory should not fail")
     }

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -48,7 +48,7 @@ async fn classic_collection_view_check() -> Result<()> {
     let nmax: u8 = 25;
     for _ in 0..n {
         let mut view = CollectionStateView::load(context.clone()).await?;
-        let hash = view.crypto_hash().await?;
+        let hash = view.crypto_hash_mut().await?;
         let save = rng.gen::<bool>();
         //
         let count_oper = rng.gen_range(0..25);
@@ -102,7 +102,7 @@ async fn classic_collection_view_check() -> Result<()> {
                 new_map = map.clone();
             }
             // Checking the hash
-            let new_hash = view.crypto_hash().await?;
+            let new_hash = view.crypto_hash_mut().await?;
             if map == new_map {
                 assert_eq!(new_hash, hash);
             } else {
@@ -262,7 +262,7 @@ async fn run_map_view_mutability<R: RngCore + Clone>(rng: &mut R) -> Result<()> 
         let mut view = ByteMapStateView::load(context.clone()).await?;
         let save = rng.gen::<bool>();
         let read_state = view.map.key_values().await?;
-        let read_hash = view.crypto_hash().await?;
+        let read_hash = view.crypto_hash_mut().await?;
         let state_vec = state_map.clone().into_iter().collect::<Vec<_>>();
         assert_eq!(state_vec, read_state);
         //
@@ -351,7 +351,7 @@ async fn run_map_view_mutability<R: RngCore + Clone>(rng: &mut R) -> Result<()> 
                 new_state_map.insert(key, new_value);
             }
             new_state_vec = new_state_map.clone().into_iter().collect();
-            let new_hash = view.crypto_hash().await?;
+            let new_hash = view.crypto_hash_mut().await?;
             if state_vec == new_state_vec {
                 assert_eq!(new_hash, read_hash);
             } else {
@@ -415,7 +415,7 @@ async fn bucket_queue_view_mutability_check() -> Result<()> {
     let n = 200;
     for _ in 0..n {
         let mut view = BucketQueueStateView::load(context.clone()).await?;
-        let hash = view.crypto_hash().await?;
+        let hash = view.crypto_hash_mut().await?;
         let save = rng.gen::<bool>();
         let elements = view.queue.elements().await?;
         assert_eq!(elements, vector);
@@ -469,7 +469,7 @@ async fn bucket_queue_view_mutability_check() -> Result<()> {
                 new_vector.clone_from(&vector);
             }
             let new_elements = view.queue.elements().await?;
-            let new_hash = view.crypto_hash().await?;
+            let new_hash = view.crypto_hash_mut().await?;
             if elements == new_elements {
                 assert_eq!(new_hash, hash);
             } else {
@@ -557,7 +557,7 @@ async fn nested_collection_map_view_check() -> Result<()> {
     let n = 20;
     for _ in 0..n {
         let mut view = NestedCollectionMapView::load(context.clone()).await?;
-        let hash = view.crypto_hash().await?;
+        let hash = view.crypto_hash_mut().await?;
         let save = rng.gen::<bool>();
 
         let count_oper = rng.gen_range(0..25);
@@ -614,7 +614,7 @@ async fn nested_collection_map_view_check() -> Result<()> {
                 state_view, new_state_map,
                 "state_view should match new_state_map"
             );
-            let new_hash = view.crypto_hash().await?;
+            let new_hash = view.crypto_hash_mut().await?;
             if state_map == new_state_map {
                 assert_eq!(new_hash, hash);
             } else {
@@ -653,7 +653,7 @@ async fn queue_view_mutability_check() -> Result<()> {
     let n = 20;
     for _ in 0..n {
         let mut view = QueueStateView::load(context.clone()).await?;
-        let hash = view.crypto_hash().await?;
+        let hash = view.crypto_hash_mut().await?;
         let save = rng.gen::<bool>();
         let elements = view.queue.elements().await?;
         assert_eq!(elements, vector);
@@ -711,7 +711,7 @@ async fn queue_view_mutability_check() -> Result<()> {
             let front2 = new_vector.first().copied();
             assert_eq!(front1, front2);
             let new_elements = view.queue.elements().await?;
-            let new_hash = view.crypto_hash().await?;
+            let new_hash = view.crypto_hash_mut().await?;
             if elements == new_elements {
                 assert_eq!(new_hash, hash);
             } else {
@@ -762,7 +762,7 @@ async fn reentrant_collection_view_check() -> Result<()> {
     let nmax: u8 = 25;
     for _ in 0..n {
         let mut view = ReentrantCollectionStateView::load(context.clone()).await?;
-        let hash = view.crypto_hash().await?;
+        let hash = view.crypto_hash_mut().await?;
         let key_values = view.key_values().await?;
         assert_eq!(key_values, map);
         //
@@ -861,7 +861,7 @@ async fn reentrant_collection_view_check() -> Result<()> {
                 }
             }
             // Checking the hash
-            let new_hash = view.crypto_hash().await?;
+            let new_hash = view.crypto_hash_mut().await?;
             if new_map == map {
                 assert_eq!(hash, new_hash);
             } else {


### PR DESCRIPTION
## Motivation

`hash_mut` has fewer locks + I'm looking to simplify the implementation of the historical hash

## Proposal

Use `crypto_hash_mut` whenever possible 

I'm tempted to remove the non-mut version but I suppose that's a different discussion.

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
