### PR TITLE
Avoid clone operation in `read_multi_values_internal`.

### DIFF
--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -358,8 +358,11 @@ impl ScyllaDbClient {
 
         while let Some(row) = rows.next().await {
             let (key, value) = row?;
-            for i_key in &map[&key] {
-                values[*i_key] = Some(value.clone());
+            if let Some((&last, rest)) = map[&key].split_last() {
+                for position in rest {
+                    values[*position] = Some(value.clone());
+                }
+                values[last] = Some(value);
             }
         }
         Ok(values)


### PR DESCRIPTION
## Motivation

The function `read_multi_values_internal` has to deal with the fact that keys can repeat. So a HashMap is built for storing the key indices. Unfortunately, this leads to a clone operation, while we could have avoided the clone operation for the last one. This is especially bad since in most cases, we would have just one entry.

## Proposal

Use the `split_last()` in the access to the indices.


## Test Plan

The CI.

## Release Plan

That can be backported to TestNet Conway.
And this can be a good idea since read operations are problematic on TestNet Conway.

## Links

None.