### PR TITLE
Do not process inboxes of non-owned chains

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -572,6 +572,10 @@ impl<C: ClientContext + 'static> ChainListener<C> {
             debug!("Not processing inbox for non-tracked chain {chain_id:.8}");
             return Ok(());
         }
+        if listening_client.client.preferred_owner().is_none() {
+            debug!("Not processing inbox for non-owned chain {chain_id:.8}");
+            return Ok(());
+        }
         debug!("Processing inbox for {chain_id:.8}");
         listening_client.timeout = Timestamp::from(u64::MAX);
         match listening_client


### PR DESCRIPTION
## Motivation

A service running without skipping process-inbox would spam the logs with a `warn` level message if it followed a non-owned chain.

## Proposal

Skip processing the inbox in the listener if the chain isn't owned.

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
