### PR TITLE
Add otlp_exporter_endpoint option to proxy/server as well

### DIFF
--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -96,6 +96,10 @@ pub struct ProxyOptions {
     /// Runs a specific proxy instance.
     #[arg(long)]
     id: Option<usize>,
+
+    /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
+    #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
+    otlp_exporter_endpoint: Option<String>,
 }
 
 /// A Linera Proxy, either gRPC or over 'Simple Transport', meaning TCP or UDP.
@@ -496,7 +500,7 @@ impl ProxyOptions {
         let public_key = &server_config.validator.public_key;
         linera_base::tracing::init_with_opentelemetry(
             &format!("validator-{public_key}-proxy"),
-            None,
+            self.otlp_exporter_endpoint.as_deref(),
         );
 
         let store_config = self


### PR DESCRIPTION
## Motivation

Currently, only the client supports the `--otlp-exporter-endpoint` flag and `LINERA_OTLP_EXPORTER_ENDPOINT` environment variable for OpenTelemetry configuration. The proxy and server binaries always default to checking the environment variable but don't expose the command-line option, which is inconsistent with the client.

## Proposal

This PR adds the `otlp_exporter_endpoint` option to both proxy and server for consistency:

- **Proxy** (`linera-service/src/proxy/main.rs`):
  - Added `otlp_exporter_endpoint: Option<String>` field to `ProxyOptions`
  - Updated `init_with_opentelemetry` call to pass the endpoint instead of `None`

- **Server** (`linera-service/src/server.rs`):
  - Added `otlp_exporter_endpoint: Option<String>` field to `ServerCommand::Run` variant
  - Created helper function `otlp_exporter_endpoint_for()` to extract endpoint from command
  - Updated `init_with_opentelemetry` call to use the helper function
  - Boxed `CommonStorageOptions` in `ServerCommand::Run` to fix clippy `large_enum_variant` warning (the `Run` variant became too large after adding the new field)

Both binaries now consistently accept `--otlp-exporter-endpoint` flag and `LINERA_OTLP_EXPORTER_ENDPOINT` environment variable, matching the client's behavior.

## Test Plan

- Verified clippy passes with all features
- Verified clippy passes with no default features
- Confirmed both binaries compile successfully

## Release Plan

- Nothing to do / These changes follow the usual release cycle.