### PR TITLE
Implement migration on existing old storage.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5811,7 +5811,11 @@ dependencies = [
  "linera-views",
  "papaya",
  "prometheus",
+ "rand 0.8.5",
  "serde",
+ "test-case",
+ "test-log",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5451,6 +5451,7 @@ dependencies = [
  "linera-chain",
  "linera-core",
  "linera-execution",
+ "linera-service",
  "linera-service-graphql-client",
  "linera-version",
  "linera-views",

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -604,6 +604,8 @@ impl std::str::FromStr for StreamId {
     Debug,
     PartialEq,
     Eq,
+    Ord,
+    PartialOrd,
     Hash,
     Clone,
     Serialize,

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -604,8 +604,6 @@ impl std::str::FromStr for StreamId {
     Debug,
     PartialEq,
     Eq,
-    Ord,
-    PartialOrd,
     Hash,
     Clone,
     Serialize,

--- a/linera-indexer/lib/Cargo.toml
+++ b/linera-indexer/lib/Cargo.toml
@@ -37,6 +37,7 @@ linera-base = { workspace = true, features = ["test"] }
 linera-chain.workspace = true
 linera-core.workspace = true
 linera-execution.workspace = true
+linera-service.workspace = true
 linera-service-graphql-client.workspace = true
 linera-version.workspace = true
 linera-views.workspace = true

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -98,6 +98,7 @@ impl RocksDbRunner {
             inner_config,
             storage_cache_config,
         };
+        store_config.clone().migrate_if_needed().await?;
         let namespace = config.client.namespace.clone();
         let database = RocksDbDatabase::maybe_create_and_connect(&store_config, &namespace).await?;
         Self::new(config, database).await

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -92,6 +92,7 @@ impl ScyllaDbRunner {
             inner_config,
             storage_cache_config,
         };
+        store_config.clone().migrate_if_needed().await?;
         let namespace = config.client.table.clone();
         let database = ScyllaDbDatabase::connect(&store_config, &namespace).await?;
         Self::new(config, database).await

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -203,6 +203,10 @@ name = "linera-proxy"
 path = "src/proxy/main.rs"
 
 [[bin]]
+name = "linera-migration"
+path = "src/migration/main.rs"
+
+[[bin]]
 name = "linera-schema-export"
 path = "src/schema_export.rs"
 

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -79,7 +79,7 @@ use linera_service::{
     cli_wrappers::{self, local_net::PathProvider, ClientWrapper, Network, OnClientDrop},
     node_service::NodeService,
     project::{self, Project},
-    storage::{CommonStorageOptions, Runnable, RunnableWithStore, StorageConfig},
+    storage::{CommonStorageOptions, StorageMigration, Runnable, RunnableWithStore, StorageConfig},
     util, wallet,
 };
 use linera_storage::{DbStorage, Storage};
@@ -1895,6 +1895,10 @@ impl ClientOptions {
         debug!("Running command using storage configuration: {storage_config}");
         let store_config =
             storage_config.add_common_storage_options(&self.common_storage_options)?;
+        store_config
+            .clone()
+            .run_with_store(StorageMigration)
+            .await?;
         let output =
             Box::pin(store_config.run_with_storage(self.wasm_runtime.with_wasm_default(), job))
                 .await?;
@@ -1906,6 +1910,10 @@ impl ClientOptions {
         debug!("Running command using storage configuration: {storage_config}");
         let store_config =
             storage_config.add_common_storage_options(&self.common_storage_options)?;
+        store_config
+            .clone()
+            .run_with_store(StorageMigration)
+            .await?;
         let output = Box::pin(store_config.run_with_store(job)).await?;
         Ok(output)
     }
@@ -1915,6 +1923,10 @@ impl ClientOptions {
         debug!("Initializing storage using configuration: {storage_config}");
         let store_config =
             storage_config.add_common_storage_options(&self.common_storage_options)?;
+        store_config
+            .clone()
+            .run_with_store(StorageMigration)
+            .await?;
         let wallet = self.wallet()?;
         store_config.initialize(wallet.genesis_config()).await?;
         Ok(())

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -79,7 +79,7 @@ use linera_service::{
     cli_wrappers::{self, local_net::PathProvider, ClientWrapper, Network, OnClientDrop},
     node_service::NodeService,
     project::{self, Project},
-    storage::{CommonStorageOptions, StorageMigration, Runnable, RunnableWithStore, StorageConfig},
+    storage::{CommonStorageOptions, Runnable, RunnableWithStore, StorageConfig, StorageMigration},
     util, wallet,
 };
 use linera_storage::{DbStorage, Storage};

--- a/linera-service/src/exporter/main.rs
+++ b/linera-service/src/exporter/main.rs
@@ -14,7 +14,7 @@ use linera_metrics::monitoring_server;
 use linera_rpc::NodeOptions;
 use linera_service::{
     config::BlockExporterConfig,
-    storage::{CommonStorageOptions, Runnable, StorageConfig},
+    storage::{CommonStorageOptions, Runnable, StorageConfig, StorageMigration},
     util,
 };
 use linera_storage::Storage;
@@ -176,7 +176,10 @@ impl ExporterOptions {
                 .storage_config
                 .add_common_storage_options(&self.common_storage_options)
                 .unwrap();
-            store_config.clone().migrate_if_needed().await?;
+            store_config
+                .clone()
+                .run_with_store(StorageMigration)
+                .await?;
             store_config.run_with_storage(None, context).boxed().await
         };
 

--- a/linera-service/src/exporter/main.rs
+++ b/linera-service/src/exporter/main.rs
@@ -176,6 +176,7 @@ impl ExporterOptions {
                 .storage_config
                 .add_common_storage_options(&self.common_storage_options)
                 .unwrap();
+            store_config.clone().migrate_if_needed().await?;
             store_config.run_with_storage(None, context).boxed().await
         };
 

--- a/linera-service/src/migration/main.rs
+++ b/linera-service/src/migration/main.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use linera_service::storage::{CommonStorageOptions, StorageMigration, StorageConfig};
+
+/// Options for running the proxy.
+#[derive(clap::Parser, Debug, Clone)]
+#[command(
+    name = "Linera Migration",
+    about = "A migration tool for the storage",
+    version = linera_version::VersionInfo::default_clap_str(),
+)]
+pub struct MigrationOptions {
+    /// Storage configuration for the blockchain history, chain states and binary blobs.
+    #[arg(long = "storage")]
+    storage_config: StorageConfig,
+
+    /// Common storage options.
+    #[command(flatten)]
+    common_storage_options: CommonStorageOptions,
+}
+
+fn main() -> Result<()> {
+    let options = <MigrationOptions as clap::Parser>::parse();
+
+    let mut runtime = tokio::runtime::Builder::new_current_thread();
+
+    runtime.enable_all().build()?.block_on(options.run())
+}
+
+impl MigrationOptions {
+    async fn run(&self) -> Result<()> {
+        let store_config = self
+            .storage_config
+            .add_common_storage_options(&self.common_storage_options)?;
+        store_config.run_with_store(StorageMigration).await?;
+        Ok(())
+    }
+}

--- a/linera-service/src/migration/main.rs
+++ b/linera-service/src/migration/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use linera_service::storage::{CommonStorageOptions, StorageMigration, StorageConfig};
+use linera_service::storage::{CommonStorageOptions, StorageConfig, StorageMigration};
 
 /// Options for running the proxy.
 #[derive(clap::Parser, Debug, Clone)]

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -756,10 +756,10 @@ impl RunnableWithStore for InitializeStorageJob<'_> {
     }
 }
 
-pub struct MigrationStorage;
+pub struct StorageMigration;
 
 #[async_trait]
-impl RunnableWithStore for MigrationStorage {
+impl RunnableWithStore for StorageMigration {
     type Output = ();
 
     async fn run<D>(

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -19,6 +19,9 @@ revm = ["linera-execution/revm"]
 test = ["linera-execution/test", "linera-views/test"]
 wasmer = ["linera-execution/wasmer"]
 wasmtime = ["linera-execution/wasmtime"]
+scylladb = ["linera-views/scylladb"]
+dynamodb = ["linera-views/dynamodb"]
+rocksdb = ["linera-views/rocksdb"]
 metrics = [
     "linera-base/metrics",
     "linera-chain/metrics",
@@ -50,6 +53,10 @@ tracing.workspace = true
 [dev-dependencies]
 anyhow.workspace = true
 linera-storage = { path = ".", default-features = false, features = ["test"] }
+rand.workspace = true
+test-case.workspace = true
+test-log = { workspace = true, features = ["trace"] }
+tokio.workspace = true
 
 [build-dependencies]
 cfg_aliases.workspace = true

--- a/linera-storage/build.rs
+++ b/linera-storage/build.rs
@@ -8,6 +8,9 @@ fn main() {
         with_wasmer: { all(any(feature = "web", not(target_arch = "wasm32")), feature = "wasmer") },
         with_wasmtime: { all(not(target_arch = "wasm32"), feature = "wasmtime") },
         with_wasm_runtime: { any(with_wasmer, with_wasmtime) },
+        with_dynamodb: { all(not(target_arch = "wasm32"), feature = "dynamodb") },
+        with_rocksdb: { all(not(target_arch = "wasm32"), feature = "rocksdb") },
+        with_scylladb: { all(not(target_arch = "wasm32"), feature = "scylladb") },
         with_revm: { feature = "revm" },
         web: { all(target_arch = "wasm32", feature = "web") },
     };

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -226,30 +226,30 @@ pub mod metrics {
 }
 
 /// The default key used when the root_key contains the information.
-const DEFAULT_KEY: &[u8] = &[0];
+pub(crate) const DEFAULT_KEY: &[u8] = &[0];
 
 /// The second key used when the root_key contains the information.
-const ONE_KEY: &[u8] = &[1];
+pub(crate) const ONE_KEY: &[u8] = &[1];
 
 fn get_01_keys() -> Vec<Vec<u8>> {
     vec![vec![0], vec![1]]
 }
 
 #[derive(Default)]
-struct MultiPartitionBatch {
+pub(crate) struct MultiPartitionBatch {
     keys_value_bytes: Vec<(Vec<u8>, Vec<u8>, Vec<u8>)>,
 }
 
 impl MultiPartitionBatch {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
-    fn put_key_value_bytes(&mut self, root_key: Vec<u8>, key: Vec<u8>, value: Vec<u8>) {
+    pub(crate) fn put_key_value_bytes(&mut self, root_key: Vec<u8>, key: Vec<u8>, value: Vec<u8>) {
         self.keys_value_bytes.push((root_key, key, value));
     }
 
-    fn put_key_value<T: Serialize>(
+    pub(crate) fn put_key_value<T: Serialize>(
         &mut self,
         root_key: Vec<u8>,
         value: &T,
@@ -319,7 +319,7 @@ impl MultiPartitionBatch {
 /// Main implementation of the [`Storage`] trait.
 #[derive(Clone)]
 pub struct DbStorage<Database, Clock = WallClock> {
-    database: Arc<Database>,
+    pub(crate) database: Arc<Database>,
     clock: Clock,
     wasm_runtime: Option<WasmRuntime>,
     user_contracts: Arc<papaya::HashMap<ApplicationId, UserContractCode>>,
@@ -328,7 +328,7 @@ pub struct DbStorage<Database, Clock = WallClock> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-enum RootKey {
+pub(crate) enum RootKey {
     ChainState(ChainId),
     CryptoHash(CryptoHash),
     Blob(BlobId),
@@ -338,12 +338,12 @@ enum RootKey {
 }
 
 impl RootKey {
-    fn bytes(&self) -> Vec<u8> {
+    pub(crate) fn bytes(&self) -> Vec<u8> {
         bcs::to_bytes(self).unwrap()
     }
 }
 
-fn event_key(event_id: &EventId) -> Vec<u8> {
+pub(crate) fn event_key(event_id: &EventId) -> Vec<u8> {
     let mut key = bcs::to_bytes(&event_id.stream_id).unwrap();
     key.extend(bcs::to_bytes(&event_id.index).unwrap());
     key
@@ -403,7 +403,7 @@ mod tests {
     }
 
     // The listing of the events in `read_events_from_index` depends on the
-    // serialization of `BaseKey::Event`.
+    // serialization of `RootKey::Event`.
     #[test]
     fn test_root_key_event_serialization() {
         let hash = CryptoHash::test_hash("49");
@@ -1035,7 +1035,7 @@ where
     }
 
     #[instrument(skip_all, fields(batch_size = batch.keys_value_bytes.len()))]
-    async fn write_batch(&self, batch: MultiPartitionBatch) -> Result<(), ViewError> {
+    pub(crate) async fn write_batch(&self, batch: MultiPartitionBatch) -> Result<(), ViewError> {
         if batch.keys_value_bytes.is_empty() {
             return Ok(());
         }
@@ -1163,272 +1163,5 @@ where
     ) -> Result<Self, Database::Error> {
         let database = Database::recreate_and_connect(&config, namespace).await?;
         Ok(Self::new(database, wasm_runtime, clock))
-    }
-}
-
-#[derive(Default, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[repr(u8)]
-enum SchemaDescription {
-    /// Version 0, all the blobs, certificates, confirmed blocks, events and network description on the same partition.
-    /// This is marked as default since it does not exist in the old scheme and would be obtained from unwrap_or_default
-    #[default]
-    Version0,
-    /// Version 1, spreading by ChainId, CryptoHash, and BlobId.
-    Version1,
-}
-
-/// The key containing the schema of the storage.
-const SCHEMA_ROOT_KEY: &[u8] = &[0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233];
-
-#[derive(Debug, Serialize, Deserialize)]
-enum BaseKey {
-    ChainState(ChainId),
-    Certificate(CryptoHash),
-    ConfirmedBlock(CryptoHash),
-    Blob(BlobId),
-    BlobState(BlobId),
-    Event(EventId),
-    BlockExporterState(u32),
-    NetworkDescription,
-}
-
-const BASE_KEY_BLOCK_EXPORTER: u8 = 6;
-
-const UNUSED_EMPTY_KEY: &[u8] = &[];
-// The keys corresponding to `ChainState` are not moved.
-// The keys in `BlockExporterState` are moved, but belong to separate root keys.
-const MOVABLE_KEYS_0_1: &[u8] = &[1, 2, 3, 4, 5, 7];
-
-/// The total number of keys being migrated in a block.
-/// we use chunks to avoid OOM
-const BLOCK_KEY_SIZE: usize = 90;
-
-fn map_base_key(base_key: &[u8]) -> Result<(Vec<u8>, Vec<u8>), ViewError> {
-    let base_key = bcs::from_bytes::<BaseKey>(base_key)?;
-    match base_key {
-        BaseKey::ChainState(chain_id) => {
-            let root_key = RootKey::ChainState(chain_id).bytes();
-            Ok((root_key, UNUSED_EMPTY_KEY.to_vec()))
-        }
-        BaseKey::Certificate(hash) => {
-            let root_key = RootKey::CryptoHash(hash).bytes();
-            Ok((root_key, DEFAULT_KEY.to_vec()))
-        }
-        BaseKey::ConfirmedBlock(hash) => {
-            let root_key = RootKey::CryptoHash(hash).bytes();
-            Ok((root_key, ONE_KEY.to_vec()))
-        }
-        BaseKey::Blob(blob_id) => {
-            let root_key = RootKey::Blob(blob_id).bytes();
-            Ok((root_key, DEFAULT_KEY.to_vec()))
-        }
-        BaseKey::BlobState(blob_id) => {
-            let root_key = RootKey::Blob(blob_id).bytes();
-            Ok((root_key, ONE_KEY.to_vec()))
-        }
-        BaseKey::Event(event_id) => {
-            let root_key = RootKey::Event(event_id.chain_id).bytes();
-            let key = event_key(&event_id);
-            Ok((root_key, key))
-        }
-        BaseKey::BlockExporterState(index) => {
-            let root_key = RootKey::BlockExporterState(index).bytes();
-            Ok((root_key, UNUSED_EMPTY_KEY.to_vec()))
-        }
-        BaseKey::NetworkDescription => {
-            let root_key = RootKey::NetworkDescription.bytes();
-            Ok((root_key, DEFAULT_KEY.to_vec()))
-        }
-    }
-}
-
-impl<Database, C> DbStorage<Database, C>
-where
-    Database: KeyValueDatabase + Clone + Send + Sync + 'static,
-    Database::Store: KeyValueStore + Clone + Send + Sync + 'static,
-    C: Clock + Clone + Send + Sync + 'static,
-    Database::Error: Send + Sync,
-{
-    async fn migrate_single_block_export_partition(
-        &self,
-        root_base_key: Vec<u8>,
-    ) -> Result<(), ViewError> {
-        let store_read = self.database.open_exclusive(&root_base_key)?;
-        let key_values = store_read.find_key_values_by_prefix(&[]).await?;
-        let root_key = map_base_key(&root_base_key)?.0;
-        let mut batch_write = Batch::new();
-        let mut batch_delete = Batch::new();
-        for (key, value) in key_values {
-            batch_write.put_key_value_bytes(key.clone(), value);
-            batch_delete.delete_key(key);
-        }
-        let store_write = self.database.open_exclusive(&root_key)?;
-        store_write.write_batch(batch_write).await?;
-        store_read.write_batch(batch_delete).await?;
-        Ok(())
-    }
-
-    async fn migrate_all_block_exports_partitions(&self) -> Result<(), ViewError> {
-        let root_keys = self.database.list_root_keys().await?;
-        for root_key in root_keys {
-            if !root_key.is_empty() && root_key[0] == BASE_KEY_BLOCK_EXPORTER {
-                self.migrate_single_block_export_partition(root_key).await?;
-            }
-        }
-        Ok(())
-    }
-
-    async fn migrate_storage_shared_partition(
-        &self,
-        first_byte: &u8,
-        keys: Vec<Vec<u8>>,
-    ) -> Result<(), ViewError> {
-        tracing::info!(
-            "migrate_storage_shared_partition with first_byte={first_byte} for |base_keys|={}",
-            keys.len()
-        );
-        for (index, chunk_keys) in keys.chunks(BLOCK_KEY_SIZE).enumerate() {
-            tracing::info!(
-                "index={index} processing chunk of size {}",
-                chunk_keys.len()
-            );
-            let chunk_base_keys = chunk_keys
-                .iter()
-                .map(|key| {
-                    let mut base_key = vec![*first_byte];
-                    base_key.extend(key);
-                    base_key
-                })
-                .collect::<Vec<Vec<u8>>>();
-            let store = self.database.open_shared(&[])?;
-            let values = store
-                .read_multi_values_bytes(chunk_base_keys.to_vec())
-                .await?;
-            let mut batch = MultiPartitionBatch::new();
-            for (base_key, value) in chunk_base_keys.iter().zip(values) {
-                let value = value.ok_or(ViewError::MissingEntries)?;
-                tracing::info!("base_key={base_key:?} value={value:?}");
-                let (root_key, key) = map_base_key(base_key)?;
-                batch.put_key_value_bytes(root_key, key, value);
-            }
-            self.write_batch(batch).await?;
-            // Now delete the keys
-            let mut batch = Batch::new();
-            for key in chunk_base_keys {
-                batch.delete_key(key.to_vec());
-            }
-            store.write_batch(batch).await?;
-        }
-        Ok(())
-    }
-
-    async fn migrate_client_shared_partition(
-        &self,
-        first_byte: &u8,
-        keys: Vec<Vec<u8>>,
-    ) -> Result<(), ViewError> {
-        tracing::info!(
-            "migrate_storage_shared_partition with first_byte={first_byte} for |base_keys|={}",
-            keys.len()
-        );
-        for (index, chunk_keys) in keys.chunks(BLOCK_KEY_SIZE).enumerate() {
-            tracing::info!(
-                "index={index} processing chunk of size {}",
-                chunk_keys.len()
-            );
-            // full_keys, since they are of the form root_key + key
-            let chunk_base_keys = chunk_keys
-                .iter()
-                .map(|key| {
-                    let mut base_key = vec![*first_byte];
-                    base_key.extend(key);
-                    base_key
-                })
-                .collect::<Vec<Vec<u8>>>();
-            let store = self.database.open_shared(&[])?;
-            let values = store
-                .read_multi_values_bytes(chunk_base_keys.to_vec())
-                .await?;
-            let values = values
-                .into_iter()
-                .map(|value| value.ok_or(ViewError::MissingEntries))
-                .collect::<Result<Vec<Vec<u8>>, ViewError>>()?;
-            let mut batch = MultiPartitionBatch::new();
-            for (base_key, value) in chunk_base_keys.iter().zip(values) {
-                tracing::info!("base_key={base_key:?} value={value:?}");
-                let (root_key, key) = map_base_key(base_key)?;
-                batch.put_key_value_bytes(root_key, key, value);
-            }
-            self.write_batch(batch).await?;
-            // Now delete the keys
-            let mut batch = Batch::new();
-            for key in chunk_base_keys {
-                batch.delete_key(key.to_vec());
-            }
-            store.write_batch(batch).await?;
-        }
-        Ok(())
-    }
-
-    async fn migrate_storage_v0_to_v1(&self) -> Result<(), ViewError> {
-        for first_byte in MOVABLE_KEYS_0_1 {
-            let store = self.database.open_shared(&[])?;
-            let keys = store.find_keys_by_prefix(&[*first_byte]).await?;
-            self.migrate_storage_shared_partition(first_byte, keys)
-                .await?;
-            // Some keys can be left in the value-splitting.
-            let mut batch = Batch::new();
-            batch.delete_key_prefix(vec![*first_byte]);
-            store.write_batch(batch).await?;
-        }
-        Ok(())
-    }
-
-    async fn migrate_client_v0_to_v1(&self) -> Result<(), ViewError> {
-        for first_byte in MOVABLE_KEYS_0_1 {
-            let store = self.database.open_shared(&[])?;
-            let keys = store.find_keys_by_prefix(&[*first_byte]).await?;
-            self.migrate_client_shared_partition(first_byte, keys)
-                .await?;
-        }
-        Ok(())
-    }
-    async fn migrate_v0_to_v1(&self) -> Result<(), ViewError> {
-        self.migrate_all_block_exports_partitions().await?;
-        let name = Database::get_name();
-        if &name == "lru caching value splitting rocksdb internal" {
-            return self.migrate_client_v0_to_v1().await;
-        }
-        if &name == "lru caching value splitting journaling dynamodb internal"
-            || &name == "lru caching value splitting journaling scylladb internal"
-        {
-            return self.migrate_storage_v0_to_v1().await;
-        }
-        let error = format!("No support for migration of storage named {name}");
-        Err(ViewError::NotFound(error))
-    }
-
-    async fn get_database_schema(&self) -> Result<SchemaDescription, ViewError> {
-        let store = self.database.open_shared(SCHEMA_ROOT_KEY)?;
-        let value = store.read_value::<SchemaDescription>(DEFAULT_KEY).await?;
-        let value = value.unwrap_or_default();
-        Ok(value)
-    }
-
-    async fn write_database_schema(&self, schema: &SchemaDescription) -> Result<(), ViewError> {
-        let mut batch = Batch::new();
-        batch.put_key_value(DEFAULT_KEY.to_vec(), schema)?;
-        let store = self.database.open_shared(SCHEMA_ROOT_KEY)?;
-        Ok(store.write_batch(batch).await?)
-    }
-
-    pub async fn migrate_if_needed(&self) -> Result<(), ViewError> {
-        let schema = self.get_database_schema().await?;
-        if schema == SchemaDescription::Version0 {
-            self.migrate_v0_to_v1().await?;
-        }
-        self.write_database_schema(&SchemaDescription::Version1)
-            .await?;
-        Ok(())
     }
 }

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -333,8 +333,9 @@ pub(crate) enum RootKey {
     CryptoHash(CryptoHash),
     Blob(BlobId),
     Event(ChainId),
-    BlockExporterState(u32),
+    SchemaDescription,
     NetworkDescription,
+    BlockExporterState(u32),
 }
 
 impl RootKey {

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -1049,7 +1049,13 @@ where
     }
 }
 
-impl<Database, C> DbStorage<Database, C> {
+impl<Database, C> DbStorage<Database, C>
+where
+    Database: KeyValueDatabase + Clone + Send + Sync + 'static,
+    Database::Error: Send + Sync,
+    Database::Store: KeyValueStore + Clone + Send + Sync + 'static,
+    C: Clock + Clone + Send + Sync + 'static,
+{
     fn new(database: Database, wasm_runtime: Option<WasmRuntime>, clock: C) -> Self {
         Self {
             database: Arc::new(database),
@@ -1157,5 +1163,269 @@ where
     ) -> Result<Self, Database::Error> {
         let database = Database::recreate_and_connect(&config, namespace).await?;
         Ok(Self::new(database, wasm_runtime, clock))
+    }
+}
+
+#[derive(Default, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[repr(u8)]
+enum SchemaDescription {
+    /// Version 0, all the blobs, certificates, confirmed blocks, events and network description on the same partition.
+    /// This is marked as default since it does not exist in the old scheme and would be obtained from unwrap_or_default
+    #[default]
+    Version0SingleBlobPartition,
+    /// Version 1, spreading by ChainId, CryptoHash, and BlobId.
+    Version1MultiBlobPartition,
+}
+
+/// The key containing the schema of the storage.
+const SCHEMA_ROOT_KEY: &[u8] = &[0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233];
+
+#[derive(Debug, Serialize, Deserialize)]
+enum BaseKey {
+    ChainState(ChainId),
+    Certificate(CryptoHash),
+    ConfirmedBlock(CryptoHash),
+    Blob(BlobId),
+    BlobState(BlobId),
+    Event(EventId),
+    BlockExporterState(u32),
+    NetworkDescription,
+}
+
+const BASE_KEY_BLOCK_EXPORTER: usize = 6;
+
+const UNUSED_EMPTY_KEY: &[u8] = &[];
+// The keys corresponding to `ChainState` are not moved.
+// The keys in `BlockExporterState` are moved, but belong to separate root keys.
+const MOVABLE_KEYS_0_1: &[u8] = &[1, 2, 3, 4, 5, 7];
+
+
+/// The total number of keys being migrated in a block.
+/// we use chunks to avoid OOM
+const BLOCK_KEY_SIZE: usize = 90;
+
+fn map_base_key(base_key: &[u8]) -> Result<(Vec<u8>, Vec<u8>), ViewError> {
+    let base_key = bcs::from_bytes::<BaseKey>(base_key)?;
+    match base_key {
+        BaseKey::ChainState(chain_id) => {
+            let root_key = RootKey::ChainState(chain_id).bytes();
+            Ok((root_key, UNUSED_EMPTY_KEY.to_vec()))
+        }
+        BaseKey::Certificate(hash) => {
+            let root_key = RootKey::CryptoHash(hash).bytes();
+            Ok((root_key, DEFAULT_KEY.to_vec()))
+        }
+        BaseKey::ConfirmedBlock(hash) => {
+            let root_key = RootKey::CryptoHash(hash).bytes();
+            Ok((root_key, ONE_KEY.to_vec()))
+        }
+        BaseKey::Blob(blob_id) => {
+            let root_key = RootKey::Blob(blob_id).bytes();
+            Ok((root_key, DEFAULT_KEY.to_vec()))
+        }
+        BaseKey::BlobState(blob_id) => {
+            let root_key = RootKey::Blob(blob_id).bytes();
+            Ok((root_key, ONE_KEY.to_vec()))
+        }
+        BaseKey::Event(event_id) => {
+            let root_key = RootKey::Event(event_id.chain_id).bytes();
+            let key = event_key(&event_id);
+            Ok((root_key, key))
+        }
+        BaseKey::BlockExporterState(index) => {
+            let root_key = RootKey::BlockExporterState(index).bytes();
+            Ok((root_key, UNUSED_EMPTY_KEY.to_vec()))
+        }
+        BaseKey::NetworkDescription => {
+            let root_key = RootKey::NetworkDescription.bytes();
+            Ok((root_key, DEFAULT_KEY.to_vec()))
+        }
+    }
+}
+
+impl<Database, C> DbStorage<Database, C>
+where
+    Database: KeyValueDatabase + Clone + Send + Sync + 'static,
+    Database::Store: KeyValueStore + Clone + Send + Sync + 'static,
+    C: Clock + Clone + Send + Sync + 'static,
+    Database::Error: Send + Sync,
+{
+    async fn migrate_single_block_export(&self, root_base_key: Vec<u8>) -> Result<(), ViewError> {
+        let store_read = self.database,open_exclusive(&root_base_key)?;
+        let key_values = store_read.find_key_values_by_prefix(&[]).await?;
+        let root_key = map_base_key(&root_base_key)?.0;
+        let mut batch_write = Batch::new();
+        let mut batch_delete = Batch::new();
+        for (key, value) in key_values {
+            batch_write.put_key_value_bytes(key.clone(), value);
+            batch_delete.delete_key(key);
+        }
+        let store_write = self.database.open_exclusive(&root_key)?;
+        store_write.write_batch(batch_write)?;
+        store_read.write_batch(batch_delete)?;
+        OK(())
+    }
+
+    async fn migrate_all_block_exports(&self) -> Result<(), ViewError> {
+        let root_keys = self.database.list_root_keys().await?;
+        for root_key in root_keys {
+            if !root_key.is_empty() && root_key[0] == BASE_KEY_BLOCK_EXPORTER {
+                self.migrate_single_block_export(root_key).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn migrate_storage_key_set(
+        &self,
+        first_byte: &u8,
+        base_keys: Vec<Vec<u8>>,
+    ) -> Result<(), ViewError> {
+        tracing::info!(
+            "migrate_storage_key_set with first_byte={first_byte} for |base_keys|={}",
+            base_keys.len()
+        );
+        for (index, chunk_base_keys) in base_keys.chunks(BLOCK_KEY_SIZE).enumerate() {
+            tracing::info!(
+                "index={index} processing chunk of size {}",
+                chunk_base_keys.len()
+            );
+            let store = self.database.open_shared(&[])?;
+            let values = store
+                .read_multi_values_bytes(chunk_base_keys.to_vec())
+                .await?;
+            let values = values
+                .into_iter()
+                .map(|value| value.ok_or(ViewError::MissingEntries))
+                .collect::<Result<Vec<Vec<u8>>, ViewError>>()?;
+            let mut batch = MultiPartitionBatch::new();
+            for (base_key, value) in chunk_base_keys.iter().zip(values) {
+                tracing::info!("base_key={base_key:?} value={value:?}");
+                let (root_key, key) = map_base_key(base_key)?;
+                batch.put_key_value_bytes(root_key, key, value);
+            }
+            self.write_batch(batch).await?;
+            // Now delete the keys
+            let mut batch = Batch::new();
+            for key in chunk_base_keys {
+                batch.delete_key(key.to_vec());
+            }
+            store.write_batch(batch).await?;
+        }
+        Ok(())
+    }
+
+    async fn migrate_client_key_set(
+        &self,
+        first_byte: &u8,
+        base_keys: Vec<Vec<u8>>,
+    ) -> Result<(), ViewError> {
+        tracing::info!(
+            "migrate_storage_key_set with first_byte={first_byte} for |base_keys|={}",
+            base_keys.len()
+        );
+        for (index, chunk_base_keys) in base_keys.chunks(BLOCK_KEY_SIZE).enumerate() {
+            tracing::info!(
+                "index={index} processing chunk of size {}",
+                chunk_base_keys.len()
+            );
+            let store = self.database.open_shared(&[])?;
+            let values = store
+                .read_multi_values_bytes(chunk_base_keys.to_vec())
+                .await?;
+            let values = values
+                .into_iter()
+                .map(|value| value.ok_or(ViewError::MissingEntries))
+                .collect::<Result<Vec<Vec<u8>>, ViewError>>()?;
+            let mut batch = MultiPartitionBatch::new();
+            for (base_key, value) in chunk_base_keys.iter().zip(values) {
+                tracing::info!("base_key={base_key:?} value={value:?}");
+                let (root_key, key) = map_base_key(base_key)?;
+                batch.put_key_value_bytes(root_key, key, value);
+            }
+            self.write_batch(batch).await?;
+            // Now delete the keys
+            let mut batch = Batch::new();
+            for key in chunk_base_keys {
+                batch.delete_key(key.to_vec());
+            }
+            store.write_batch(batch).await?;
+        }
+        Ok(())
+    }
+
+    async fn migrate_storage_0_to_1(&self) -> Result<(), ViewError> {
+        for first_byte in MOVABLE_KEYS_0_1 {
+            let store = self.database.open_shared(&[])?;
+            let keys = store.find_keys_by_prefix(&[*first_byte]).await?;
+            let base_keys = keys
+                .into_iter()
+                .map(|key| {
+                    let mut base_key = vec![*first_byte];
+                    base_key.extend(key);
+                    base_key
+                })
+                .collect::<Vec<Vec<u8>>>();
+            self.migrate_storage_key_set(first_byte, base_keys).await?;
+            // Some keys can be left in the value-splitting.
+            let mut batch = Batch::new();
+            batch.delete_key_prefix(vec![*first_byte]);
+            store.write_batch(batch).await?;
+        }
+        Ok(())
+    }
+
+    async fn migrate_client_0_to_1(&self) -> Result<(), ViewError> {
+        for first_byte in MOVABLE_KEYS_0_1 {
+            let store = self.database.open_shared(&[])?;
+            let keys = store.find_keys_by_prefix(&[*first_byte]).await?;
+            // full_keys, since they are of the form root_key + key
+            let full_keys = keys
+                .into_iter()
+                .map(|key| {
+                    let mut base_key = vec![*first_byte];
+                    base_key.extend(key);
+                    base_key
+                })
+                .collect::<Vec<Vec<u8>>>();
+            self.migrate_client_key_set(first_byte, full_keys).await?;
+        }
+        Ok(())
+    }
+    async fn migrate_0_to_1(&self) -> Result<(), ViewError> {
+        self.migrate_all_block_exports().await?;
+        let name = Database::get_name();
+        if &name == "lru caching value splitting rocksdb internal" {
+            return self.migrate_client_0_to_1().await;
+        }
+        if &name == "lru caching value splitting journaling dynamodb internal" || &name == "lru caching value splitting journaling scylladb internal" {
+            return self.migrate_storage_0_to_1().await;
+        }
+        let error = format!("No support for migration of storage named {name}");
+        Err(ViewError::NotFound(error))
+    }
+
+    async fn get_database_schema(&self) -> Result<SchemaDescription, ViewError> {
+        let store = self.database.open_shared(SCHEMA_ROOT_KEY)?;
+        let value = store.read_value::<SchemaDescription>(DEFAULT_KEY).await?;
+        let value = value.unwrap_or_default();
+        Ok(value)
+    }
+
+    async fn write_database_schema(&self, schema: &SchemaDescription) -> Result<(), ViewError> {
+        let mut batch = Batch::new();
+        batch.put_key_value(DEFAULT_KEY.to_vec(), schema)?;
+        let store = self.database.open_shared(SCHEMA_ROOT_KEY)?;
+        Ok(store.write_batch(batch).await?)
+    }
+
+    pub async fn migrate_if_needed(&self) -> Result<(), ViewError> {
+        let schema = self.get_database_schema().await?;
+        if schema == SchemaDescription::Version0SingleBlobPartition {
+            self.migrate_client_0_to_1().await?;
+        }
+        self.write_database_schema(&SchemaDescription::Version1MultiBlobPartition)
+            .await?;
+        Ok(())
     }
 }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -4,6 +4,7 @@
 //! This module defines the storage abstractions for individual chains and certificates.
 
 mod db_storage;
+mod migration;
 
 use std::{collections::BTreeMap, ops::RangeInclusive, sync::Arc};
 

--- a/linera-storage/src/migration.rs
+++ b/linera-storage/src/migration.rs
@@ -322,7 +322,7 @@ mod tests {
     use crate::{
         DbStorage,
         db_storage::RestrictedEventId,
-        migration::{BaseKey, DEFAULT_KEY, ONE_KEY, RootKey, SCHEMA_ROOT_KEY},
+        migration::{BaseKey, BASE_KEY_BLOCK_EXPORTER, DEFAULT_KEY, ONE_KEY, RootKey, SCHEMA_ROOT_KEY},
         WallClock,
     };
 
@@ -381,7 +381,7 @@ mod tests {
         let key_size = 10;
         let value_size = 100;
         // 0: the chain states.
-        let n_chain_id = 0;
+        let n_chain_id = 1;
         let n_key = 1;
         let mut chain_ids_key_values = BTreeMap::new();
         for _i_chain in 0..n_chain_id {
@@ -438,7 +438,7 @@ mod tests {
             events.insert(event_id, value);
         }
         // 6: the block exports
-        let n_block_exports = 2;
+        let n_block_exports = 0;
         let n_key = 2;
         let mut block_exporter_states = BTreeMap::new();
         for _i_block_export in 0..n_block_exports {
@@ -525,9 +525,15 @@ mod tests {
 
     fn is_valid_root_key(root_key: &[u8]) -> bool {
         if root_key.is_empty() {
+            // It corresponds to the &[]
             return false;
         }
         if root_key == SCHEMA_ROOT_KEY {
+            // It corresponds to the key of the schema database.
+            return false;
+        }
+        if root_key[0] == BASE_KEY_BLOCK_EXPORTER {
+            // It corresponds to a block exporter root key.
             return false;
         }
         true

--- a/linera-storage/src/migration.rs
+++ b/linera-storage/src/migration.rs
@@ -29,9 +29,6 @@ enum SchemaDescription {
     Version1,
 }
 
-/// The key containing the schema of the storage.
-const SCHEMA_ROOT_KEY: &[u8] = &[13, 21, 34, 55, 89, 144, 233];
-
 #[derive(Debug, Serialize, Deserialize)]
 enum BaseKey {
     ChainState(ChainId),
@@ -43,8 +40,6 @@ enum BaseKey {
     BlockExporterState(u32),
     NetworkDescription,
 }
-
-const BASE_KEY_BLOCK_EXPORTER: u8 = 6;
 
 const UNUSED_EMPTY_KEY: &[u8] = &[];
 // The keys corresponding to `ChainState` are not moved.
@@ -101,36 +96,6 @@ where
     C: Clock + Clone + Send + Sync + 'static,
     Database::Error: From<bcs::Error> + Send + Sync,
 {
-    async fn migrate_single_block_export_partition(
-        &self,
-        root_base_key: Vec<u8>,
-    ) -> Result<(), ViewError> {
-        let store_read = self.database.open_exclusive(&root_base_key)?;
-        let key_values = store_read.find_key_values_by_prefix(&[]).await?;
-        let root_key = map_base_key(&root_base_key)?.0;
-        let mut batch_write = Batch::new();
-        let mut batch_delete = Batch::new();
-        for (key, value) in key_values {
-            batch_write.put_key_value_bytes(key.clone(), value);
-            batch_delete.delete_key(key);
-        }
-        let store_write = self.database.open_exclusive(&root_key)?;
-        store_write.write_batch(batch_write).await?;
-        store_read.write_batch(batch_delete).await?;
-        Ok(())
-    }
-
-    async fn migrate_all_block_exports_partitions(&self) -> Result<(), ViewError> {
-        let root_keys = self.database.list_root_keys().await?;
-        for root_key in root_keys {
-            if !root_key.is_empty() && root_key[0] == BASE_KEY_BLOCK_EXPORTER {
-                self.migrate_single_block_export_partition(root_key).await?;
-            }
-        }
-        Ok(())
-    }
-
-
     async fn migrate_storage_shared_partition(
         &self,
         first_byte: &u8,
@@ -182,14 +147,11 @@ where
         keys: Vec<Vec<u8>>,
     ) -> Result<(), ViewError> {
         tracing::info!("migrate_storage_shared_partition with first_byte={first_byte} for |keys|={}", keys.len());
-        println!("migrate_storage_shared_partition with first_byte={first_byte} for |keys|={}", keys.len());
-        println!("keys={keys:?}");
         for (index, chunk_keys) in keys.chunks(BLOCK_KEY_SIZE).enumerate() {
             tracing::info!(
                 "index={index} processing chunk of size {}",
                 chunk_keys.len()
             );
-            println!("chunk_keys={chunk_keys:?}");
             // full_keys, since they are of the form root_key + key
             let chunk_base_keys = chunk_keys
                 .iter()
@@ -199,7 +161,6 @@ where
                     base_key
                 })
                 .collect::<Vec<Vec<u8>>>();
-            println!("chunk_base_keys={chunk_base_keys:?}");
             let store = self.database.open_shared(&[])?;
             let values = store
                 .read_multi_values_bytes(chunk_base_keys.to_vec())
@@ -241,20 +202,17 @@ where
     }
 
     async fn migrate_client_v0_to_v1(&self) -> Result<(), ViewError> {
-        let list_root_keys = self.list_root_keys().await?;
         for first_byte in MOVABLE_KEYS_0_1 {
             let store = self.database.open_shared(&[])?;
             let keys = store.find_keys_by_prefix(&[*first_byte]).await?;
-            self.migrate_client_shared_partition(first_byte, keys, list_root_keys)
+            self.migrate_client_shared_partition(first_byte, keys)
                 .await?;
         }
         Ok(())
     }
     async fn migrate_v0_to_v1(&self) -> Result<(), ViewError> {
-        self.migrate_all_block_exports_partitions().await?;
         let name = Database::get_name();
         if &name == "lru caching value splitting rocksdb internal" {
-            println!("Calling migrate_client_v0_to_v1");
             return self.migrate_client_v0_to_v1().await;
         }
         if &name == "memory" || &name == "lru caching value splitting journaling dynamodb internal"
@@ -267,16 +225,18 @@ where
     }
 
     async fn get_database_schema(&self) -> Result<SchemaDescription, ViewError> {
-        let store = self.database.open_shared(SCHEMA_ROOT_KEY)?;
+        let root_key = RootKey::SchemaDescription.bytes();
+        let store = self.database.open_shared(&root_key)?;
         let value = store.read_value::<SchemaDescription>(DEFAULT_KEY).await?;
         let value = value.unwrap_or_default();
         Ok(value)
     }
 
     async fn write_database_schema(&self, schema: &SchemaDescription) -> Result<(), ViewError> {
+        let root_key = RootKey::SchemaDescription.bytes();
         let mut batch = Batch::new();
         batch.put_key_value(DEFAULT_KEY.to_vec(), schema)?;
-        let store = self.database.open_shared(SCHEMA_ROOT_KEY)?;
+        let store = self.database.open_shared(&root_key)?;
         Ok(store.write_batch(batch).await?)
     }
 
@@ -304,8 +264,6 @@ mod tests {
         crypto::CryptoHash,
         identifiers::{BlobId, BlobType, ChainId, EventId, GenericApplicationId, StreamId, StreamName},
     };
-    #[cfg(feature = "dynamodb")]
-    use linera_views::dynamo_db::DynamoDbDatabase;
     #[cfg(feature = "rocksdb")]
     use linera_views::rocks_db::RocksDbDatabase;
     #[cfg(feature = "scylladb")]
@@ -325,7 +283,7 @@ mod tests {
     use crate::{
         DbStorage,
         db_storage::RestrictedEventId,
-        migration::{BaseKey, BASE_KEY_BLOCK_EXPORTER, DEFAULT_KEY, ONE_KEY, RootKey, SCHEMA_ROOT_KEY},
+        migration::{BaseKey, DEFAULT_KEY, ONE_KEY, RootKey},
         WallClock,
     };
 
@@ -384,7 +342,7 @@ mod tests {
         let key_size = 5;
         let value_size = 10;
         // 0: the chain states.
-        let n_chain_id = 0;
+        let n_chain_id = 2;
         let n_key = 1;
         let mut chain_ids_key_values = BTreeMap::new();
         for _i_chain in 0..n_chain_id {
@@ -399,7 +357,7 @@ mod tests {
             chain_ids_key_values.insert(chain_id, reorder_key_values(key_values));
         }
         // 1: the certificates
-        let n_certificate = 0;
+        let n_certificate = 2;
         let mut certificates = BTreeMap::new();
         for _i_certificate in 0..n_certificate {
             let hash = get_hash(&mut rng);
@@ -407,7 +365,7 @@ mod tests {
             certificates.insert(hash, value);
         }
         // 2: the confirmed blocks
-        let n_blocks = 0;
+        let n_blocks = 2;
         let mut confirmed_blocks = BTreeMap::new();
         for _i_block in 0..n_blocks {
             let hash = get_hash(&mut rng);
@@ -415,7 +373,7 @@ mod tests {
             confirmed_blocks.insert(hash, value);
         }
         // 3: the blobs
-        let n_blobs = 0;
+        let n_blobs = 2;
         let mut blobs = BTreeMap::new();
         for _i_blob in 0..n_blobs {
             let hash = get_hash(&mut rng);
@@ -424,7 +382,7 @@ mod tests {
             blobs.insert(blob_id, value);
         }
         // 4: the blob states
-        let n_blob_states = 0;
+        let n_blob_states = 2;
         let mut blob_states = BTreeMap::new();
         for _i_blob_state in 0..n_blob_states {
             let hash = get_hash(&mut rng);
@@ -433,7 +391,7 @@ mod tests {
             blob_states.insert(blob_id, value);
         }
         // 5: the events
-        let n_events = 0;
+        let n_events = 2;
         let mut events = BTreeMap::new();
         for _i_event in 0..n_events {
             let event_id = get_event_id(&mut rng);
@@ -441,7 +399,7 @@ mod tests {
             events.insert(event_id, value);
         }
         // 6: the block exports
-        let n_block_exports = 1;
+        let n_block_exports = 2;
         let n_key = 1;
         let mut block_exporter_states = BTreeMap::new();
         for _i_block_export in 0..n_block_exports {
@@ -481,7 +439,6 @@ mod tests {
             for (key, value) in key_values {
                 batch.put_key_value_bytes(key, value);
             }
-            println!("chain_id={chain_id} batch={batch:?}");
             store.write_batch(batch).await?;
         }
         for (index, key_values) in storage_state.block_exporter_states {
@@ -491,7 +448,6 @@ mod tests {
             for (key, value) in key_values {
                 batch.put_key_value_bytes(key, value);
             }
-            println!("index={index} batch={batch:?}");
             store.write_batch(batch).await?;
         }
         // Writing in the shared partition
@@ -520,7 +476,6 @@ mod tests {
             let key = bcs::to_bytes(&BaseKey::NetworkDescription)?;
             batch.put_key_value_bytes(key, network_description);
         }
-        println!("shared batch={batch:?}");
         let store = database.open_shared(&[])?;
         store.write_batch(batch).await?;
         Ok(())
@@ -531,12 +486,8 @@ mod tests {
             // It corresponds to the &[]
             return false;
         }
-        if root_key == SCHEMA_ROOT_KEY {
+        if root_key == &[4] {
             // It corresponds to the key of the schema database.
-            return false;
-        }
-        if root_key[0] == BASE_KEY_BLOCK_EXPORTER {
-            // It corresponds to a block exporter root key.
             return false;
         }
         true
@@ -557,13 +508,9 @@ mod tests {
         let mut block_exporter_states = BTreeMap::new();
         let mut network_description = None;
         let bcs_root_keys = database.list_root_keys().await?;
-        println!("|bcs_root_keys|={}", bcs_root_keys.len());
-        println!("bcs_root_keys={bcs_root_keys:?}");
         for bcs_root_key in bcs_root_keys {
             if is_valid_root_key(&bcs_root_key) {
-                println!("|bcs_root_key|={} bcs_root_key={bcs_root_key:?}", bcs_root_key.len());
                 let root_key = bcs::from_bytes(&bcs_root_key)?;
-                println!("root_key={root_key:?}");
                 match root_key {
                     RootKey::ChainState(chain_id) => {
                         let store = database.open_shared(&bcs_root_key)?;
@@ -601,10 +548,8 @@ mod tests {
                             events.insert(event_id, value);
                         }
                     }
-                    RootKey::BlockExporterState(index) => {
-                        let store = database.open_shared(&bcs_root_key)?;
-                        let key_values = store.find_key_values_by_prefix(&[]).await?;
-                        block_exporter_states.insert(index, key_values);
+                    RootKey::SchemaDescription => {
+                        // Not part of the state
                     }
                     RootKey::NetworkDescription => {
                         let store = database.open_shared(&bcs_root_key)?;
@@ -612,6 +557,11 @@ mod tests {
                         if let Some(value) = value {
                             network_description = Some(value);
                         }
+                    }
+                    RootKey::BlockExporterState(index) => {
+                        let store = database.open_shared(&bcs_root_key)?;
+                        let key_values = store.find_key_values_by_prefix(&[]).await?;
+                        block_exporter_states.insert(index, key_values);
                     }
                 }
             }
@@ -634,21 +584,13 @@ mod tests {
         D::Store: KeyValueStore + Clone + Send + Sync + 'static,
         D::Error: Send + Sync,
     {
-        println!("test_storage_migration, step 1");
         let database = D::connect_test_namespace().await?;
-        println!("test_storage_migration, step 2");
         let storage_state = get_storage_state();
-        println!("test_storage_migration, step 3");
         write_storage_state_old_schema(&database, storage_state.clone()).await?;
-        println!("test_storage_migration, step 4");
         let storage = DbStorage::<D, WallClock>::new(database, None, WallClock);
-        println!("test_storage_migration, step 5");
         storage.migrate_if_needed().await?;
-        println!("test_storage_migration, step 6");
         let read_storage_state = read_storage_state_new_schema(storage.database.deref()).await?;
-        println!("test_storage_migration, step 7");
         assert_eq!(read_storage_state, storage_state);
-        println!("test_storage_migration, step 8");
         Ok(())
     }
 

--- a/linera-storage/src/migration.rs
+++ b/linera-storage/src/migration.rs
@@ -1,0 +1,296 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use linera_base::{
+    crypto::CryptoHash,
+    identifiers::{BlobId, ChainId, EventId},
+};
+use linera_views::{
+    batch::Batch,
+    store::{KeyValueDatabase, KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore},
+    ViewError,
+};
+use serde::{Deserialize, Serialize};
+
+
+use crate::{
+    Clock,
+    db_storage::{DbStorage, DEFAULT_KEY, event_key, MultiPartitionBatch, ONE_KEY, RootKey},
+};
+
+#[derive(Default, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[repr(u8)]
+enum SchemaDescription {
+    /// Version 0, all the blobs, certificates, confirmed blocks, events and network description on the same partition.
+    /// This is marked as default since it does not exist in the old scheme and would be obtained from unwrap_or_default
+    #[default]
+    Version0,
+    /// Version 1, spreading by ChainId, CryptoHash, and BlobId.
+    Version1,
+}
+
+/// The key containing the schema of the storage.
+const SCHEMA_ROOT_KEY: &[u8] = &[0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233];
+
+#[derive(Debug, Serialize, Deserialize)]
+enum BaseKey {
+    ChainState(ChainId),
+    Certificate(CryptoHash),
+    ConfirmedBlock(CryptoHash),
+    Blob(BlobId),
+    BlobState(BlobId),
+    Event(EventId),
+    BlockExporterState(u32),
+    NetworkDescription,
+}
+
+const BASE_KEY_BLOCK_EXPORTER: u8 = 6;
+
+const UNUSED_EMPTY_KEY: &[u8] = &[];
+// The keys corresponding to `ChainState` are not moved.
+// The keys in `BlockExporterState` are moved, but belong to separate root keys.
+const MOVABLE_KEYS_0_1: &[u8] = &[1, 2, 3, 4, 5, 7];
+
+/// The total number of keys being migrated in a block.
+/// we use chunks to avoid OOM
+const BLOCK_KEY_SIZE: usize = 90;
+
+fn map_base_key(base_key: &[u8]) -> Result<(Vec<u8>, Vec<u8>), ViewError> {
+    let base_key = bcs::from_bytes::<BaseKey>(base_key)?;
+    match base_key {
+        BaseKey::ChainState(chain_id) => {
+            let root_key = RootKey::ChainState(chain_id).bytes();
+            Ok((root_key, UNUSED_EMPTY_KEY.to_vec()))
+        }
+        BaseKey::Certificate(hash) => {
+            let root_key = RootKey::CryptoHash(hash).bytes();
+            Ok((root_key, DEFAULT_KEY.to_vec()))
+        }
+        BaseKey::ConfirmedBlock(hash) => {
+            let root_key = RootKey::CryptoHash(hash).bytes();
+            Ok((root_key, ONE_KEY.to_vec()))
+        }
+        BaseKey::Blob(blob_id) => {
+            let root_key = RootKey::Blob(blob_id).bytes();
+            Ok((root_key, DEFAULT_KEY.to_vec()))
+        }
+        BaseKey::BlobState(blob_id) => {
+            let root_key = RootKey::Blob(blob_id).bytes();
+            Ok((root_key, ONE_KEY.to_vec()))
+        }
+        BaseKey::Event(event_id) => {
+            let root_key = RootKey::Event(event_id.chain_id).bytes();
+            let key = event_key(&event_id);
+            Ok((root_key, key))
+        }
+        BaseKey::BlockExporterState(index) => {
+            let root_key = RootKey::BlockExporterState(index).bytes();
+            Ok((root_key, UNUSED_EMPTY_KEY.to_vec()))
+        }
+        BaseKey::NetworkDescription => {
+            let root_key = RootKey::NetworkDescription.bytes();
+            Ok((root_key, DEFAULT_KEY.to_vec()))
+        }
+    }
+}
+
+impl<Database, C> DbStorage<Database, C>
+where
+    Database: KeyValueDatabase + Clone + Send + Sync + 'static,
+    Database::Store: KeyValueStore + Clone + Send + Sync + 'static,
+    C: Clock + Clone + Send + Sync + 'static,
+    Database::Error: Send + Sync,
+{
+    async fn migrate_single_block_export_partition(
+        &self,
+        root_base_key: Vec<u8>,
+    ) -> Result<(), ViewError> {
+        let store_read = self.database.open_exclusive(&root_base_key)?;
+        let key_values = store_read.find_key_values_by_prefix(&[]).await?;
+        let root_key = map_base_key(&root_base_key)?.0;
+        let mut batch_write = Batch::new();
+        let mut batch_delete = Batch::new();
+        for (key, value) in key_values {
+            batch_write.put_key_value_bytes(key.clone(), value);
+            batch_delete.delete_key(key);
+        }
+        let store_write = self.database.open_exclusive(&root_key)?;
+        store_write.write_batch(batch_write).await?;
+        store_read.write_batch(batch_delete).await?;
+        Ok(())
+    }
+
+    async fn migrate_all_block_exports_partitions(&self) -> Result<(), ViewError> {
+        let root_keys = self.database.list_root_keys().await?;
+        for root_key in root_keys {
+            if !root_key.is_empty() && root_key[0] == BASE_KEY_BLOCK_EXPORTER {
+                self.migrate_single_block_export_partition(root_key).await?;
+            }
+        }
+        Ok(())
+    }
+
+
+    async fn migrate_storage_shared_partition(
+        &self,
+        first_byte: &u8,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<(), ViewError> {
+        tracing::info!(
+            "migrate_storage_shared_partition with first_byte={first_byte} for |base_keys|={}",
+            keys.len()
+        );
+        for (index, chunk_keys) in keys.chunks(BLOCK_KEY_SIZE).enumerate() {
+            tracing::info!(
+                "index={index} processing chunk of size {}",
+                chunk_keys.len()
+            );
+            let chunk_base_keys = chunk_keys
+                .iter()
+                .map(|key| {
+                    let mut base_key = vec![*first_byte];
+                    base_key.extend(key);
+                    base_key
+                })
+                .collect::<Vec<Vec<u8>>>();
+            let store = self.database.open_shared(&[])?;
+            let values = store
+                .read_multi_values_bytes(chunk_base_keys.to_vec())
+                .await?;
+            let mut batch = MultiPartitionBatch::new();
+            for (base_key, value) in chunk_base_keys.iter().zip(values) {
+                let value = value.ok_or(ViewError::MissingEntries)?;
+                tracing::info!("base_key={base_key:?} value={value:?}");
+                let (root_key, key) = map_base_key(base_key)?;
+                batch.put_key_value_bytes(root_key, key, value);
+            }
+            self.write_batch(batch).await?;
+            // Now delete the keys
+            let mut batch = Batch::new();
+            for key in chunk_base_keys {
+                batch.delete_key(key.to_vec());
+            }
+            store.write_batch(batch).await?;
+        }
+        Ok(())
+    }
+
+
+    async fn migrate_client_shared_partition(
+        &self,
+        first_byte: &u8,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<(), ViewError> {
+        tracing::info!(
+            "migrate_storage_shared_partition with first_byte={first_byte} for |base_keys|={}",
+            keys.len()
+        );
+        for (index, chunk_keys) in keys.chunks(BLOCK_KEY_SIZE).enumerate() {
+            tracing::info!(
+                "index={index} processing chunk of size {}",
+                chunk_keys.len()
+            );
+            // full_keys, since they are of the form root_key + key
+            let chunk_base_keys = chunk_keys
+                .iter()
+                .map(|key| {
+                    let mut base_key = vec![*first_byte];
+                    base_key.extend(key);
+                    base_key
+                })
+                .collect::<Vec<Vec<u8>>>();
+            let store = self.database.open_shared(&[])?;
+            let values = store
+                .read_multi_values_bytes(chunk_base_keys.to_vec())
+                .await?;
+            let values = values
+                .into_iter()
+                .map(|value| value.ok_or(ViewError::MissingEntries))
+                .collect::<Result<Vec<Vec<u8>>, ViewError>>()?;
+            let mut batch = MultiPartitionBatch::new();
+            for (base_key, value) in chunk_base_keys.iter().zip(values) {
+                tracing::info!("base_key={base_key:?} value={value:?}");
+                let (root_key, key) = map_base_key(base_key)?;
+                batch.put_key_value_bytes(root_key, key, value);
+            }
+            self.write_batch(batch).await?;
+            // Now delete the keys
+            let mut batch = Batch::new();
+            for key in chunk_base_keys {
+                batch.delete_key(key.to_vec());
+            }
+            store.write_batch(batch).await?;
+        }
+        Ok(())
+    }
+
+
+    async fn migrate_storage_v0_to_v1(&self) -> Result<(), ViewError> {
+        for first_byte in MOVABLE_KEYS_0_1 {
+            let store = self.database.open_shared(&[])?;
+            let keys = store.find_keys_by_prefix(&[*first_byte]).await?;
+            self.migrate_storage_shared_partition(first_byte, keys)
+                .await?;
+            // Some keys can be left in the value-splitting.
+            let mut batch = Batch::new();
+            batch.delete_key_prefix(vec![*first_byte]);
+            store.write_batch(batch).await?;
+        }
+        Ok(())
+    }
+
+    async fn migrate_client_v0_to_v1(&self) -> Result<(), ViewError> {
+        for first_byte in MOVABLE_KEYS_0_1 {
+            let store = self.database.open_shared(&[])?;
+            let keys = store.find_keys_by_prefix(&[*first_byte]).await?;
+            self.migrate_client_shared_partition(first_byte, keys)
+                .await?;
+        }
+        Ok(())
+    }
+    async fn migrate_v0_to_v1(&self) -> Result<(), ViewError> {
+        self.migrate_all_block_exports_partitions().await?;
+        let name = Database::get_name();
+        if &name == "lru caching value splitting rocksdb internal" {
+            return self.migrate_client_v0_to_v1().await;
+        }
+        if &name == "lru caching value splitting journaling dynamodb internal"
+            || &name == "lru caching value splitting journaling scylladb internal"
+        {
+            return self.migrate_storage_v0_to_v1().await;
+        }
+        let error = format!("No support for migration of storage named {name}");
+        Err(ViewError::NotFound(error))
+    }
+
+    async fn get_database_schema(&self) -> Result<SchemaDescription, ViewError> {
+        let store = self.database.open_shared(SCHEMA_ROOT_KEY)?;
+        let value = store.read_value::<SchemaDescription>(DEFAULT_KEY).await?;
+        let value = value.unwrap_or_default();
+        Ok(value)
+    }
+
+    async fn write_database_schema(&self, schema: &SchemaDescription) -> Result<(), ViewError> {
+        let mut batch = Batch::new();
+        batch.put_key_value(DEFAULT_KEY.to_vec(), schema)?;
+        let store = self.database.open_shared(SCHEMA_ROOT_KEY)?;
+        Ok(store.write_batch(batch).await?)
+    }
+
+    pub async fn migrate_if_needed(&self) -> Result<(), ViewError> {
+        let schema = self.get_database_schema().await?;
+        if schema == SchemaDescription::Version0 {
+            self.migrate_v0_to_v1().await?;
+        }
+        self.write_database_schema(&SchemaDescription::Version1)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn assert_is_migrated_database(&self) -> Result<(), ViewError> {
+        let schema = self.get_database_schema().await?;
+        assert_eq!(schema, SchemaDescription::Version1);
+        Ok(())
+    }
+
+}


### PR DESCRIPTION
## Motivation

We are working with several storage. One being the storage of the old schema (where blobs are all on the same partition) and the new schema (where blobs are spread out).

## Proposal

When creating the storage instance, check the version by accessing the `SchemaDescription`. If incorrect, then upgrade.

Note:
* It would be advantageous to disable cache since during migration, we know it is not 

## Test Plan

Tests are clearly missing in this PR and need to be added.

## Release Plan

The goal is to put this code in TestNet Conway in order to deal with ScyllaDb performance.

## Links

None.