### PR TITLE
Make `--min-votes` a named option.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -487,12 +487,15 @@ Show the version and genesis config hash of a new validator, and print a warning
 
 Show the current set of validators for a chain. Also print some information about the given chain while we are at it
 
-**Usage:** `linera query-validators [CHAIN_ID] [MIN_VOTES]`
+**Usage:** `linera query-validators [OPTIONS] [CHAIN_ID]`
 
 ###### **Arguments:**
 
 * `<CHAIN_ID>` — The chain to query. If omitted, query the default chain of the wallet
-* `<MIN_VOTES>` — Skip validators with less voting weight that this
+
+###### **Options:**
+
+* `--min-votes <MIN_VOTES>` — Skip validators with less voting weight that this
 
 
 

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -351,6 +351,7 @@ pub enum ClientCommand {
         /// The chain to query. If omitted, query the default chain of the wallet.
         chain_id: Option<ChainId>,
         /// Skip validators with less voting weight that this.
+        #[arg(long)]
         min_votes: Option<u64>,
     },
 


### PR DESCRIPTION
## Motivation

`query-validators` allows filtering by weight. The minimum voting weight is a positional argument, which is confusing and less explicit.

## Proposal

Make it a named option.

## Test Plan

The change is reflected in the auto-generated `CLI.md`.

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a new SDK. (Low priority.)

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
