### PR TITLE
Eliminate completely the "fn load" implementation from the native views

### DIFF
--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -189,12 +189,6 @@ where
         })
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let keys = Self::pre_load(&context)?;
-        let values = context.store().read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
-    }
-
     fn rollback(&mut self) {
         self.delete_storage_first = false;
         self.cursor = Cursor::new(self.stored_data.len(), self.stored_position);

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -121,10 +121,6 @@ impl<W: View> View for ByteCollectionView<W::Context, W> {
         })
     }
 
-    async fn load(context: Self::Context) -> Result<Self, ViewError> {
-        Self::post_load(context, &[])
-    }
-
     fn rollback(&mut self) {
         self.delete_storage_first = false;
         self.updates.get_mut().clear();
@@ -922,10 +918,6 @@ where
         })
     }
 
-    async fn load(context: Self::Context) -> Result<Self, ViewError> {
-        Self::post_load(context, &[])
-    }
-
     fn rollback(&mut self) {
         self.collection.rollback()
     }
@@ -1372,10 +1364,6 @@ impl<I: Send + Sync, W: View> View for CustomCollectionView<W::Context, I, W> {
             collection,
             _phantom: PhantomData,
         })
-    }
-
-    async fn load(context: Self::Context) -> Result<Self, ViewError> {
-        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {

--- a/linera-views/src/views/hashable_wrapper.rs
+++ b/linera-views/src/views/hashable_wrapper.rs
@@ -13,7 +13,6 @@ use crate::{
     batch::Batch,
     common::from_bytes_option,
     context::Context,
-    store::ReadableKeyValueStore as _,
     views::{ClonableView, HashableView, Hasher, ReplaceContext, View, ViewError, MIN_VIEW_TAG},
 };
 
@@ -94,12 +93,6 @@ where
             hash: Mutex::new(hash),
             inner,
         })
-    }
-
-    async fn load(context: Self::Context) -> Result<Self, ViewError> {
-        let keys = Self::pre_load(&context)?;
-        let values = context.store().read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
     }
 
     fn rollback(&mut self) {

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -272,12 +272,6 @@ impl<C: Context> View for KeyValueStoreView<C> {
         })
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let keys = Self::pre_load(&context)?;
-        let values = context.store().read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
-    }
-
     fn rollback(&mut self) {
         self.deletion_set.rollback();
         self.updates.clear();

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -83,12 +83,6 @@ where
         })
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let keys = Self::pre_load(&context)?;
-        let values = context.store().read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
-    }
-
     fn rollback(&mut self) {
         self.delete_storage_first = false;
         self.new_values.clear();

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -143,10 +143,6 @@ where
         })
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        Self::post_load(context, &[])
-    }
-
     fn rollback(&mut self) {
         self.updates.clear();
         self.deletion_set.rollback();
@@ -1040,10 +1036,6 @@ where
         })
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        Self::post_load(context, &[])
-    }
-
     fn rollback(&mut self) {
         self.map.rollback()
     }
@@ -1596,10 +1588,6 @@ where
             map,
             _phantom: PhantomData,
         })
-    }
-
-    async fn load(context: C) -> Result<Self, ViewError> {
-        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -85,12 +85,6 @@ where
         })
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let keys = Self::pre_load(&context)?;
-        let values = context.store().read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
-    }
-
     fn rollback(&mut self) {
         self.delete_storage_first = false;
         self.front_delete_count = 0;

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -148,10 +148,6 @@ impl<W: View> View for ReentrantByteCollectionView<W::Context, W> {
         })
     }
 
-    async fn load(context: Self::Context) -> Result<Self, ViewError> {
-        Self::post_load(context, &[])
-    }
-
     fn rollback(&mut self) {
         self.delete_storage_first = false;
         self.updates.clear();
@@ -1135,10 +1131,6 @@ where
         })
     }
 
-    async fn load(context: Self::Context) -> Result<Self, ViewError> {
-        Self::post_load(context, &[])
-    }
-
     fn rollback(&mut self) {
         self.collection.rollback()
     }
@@ -1696,10 +1688,6 @@ where
             collection,
             _phantom: PhantomData,
         })
-    }
-
-    async fn load(context: Self::Context) -> Result<Self, ViewError> {
-        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {

--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -10,7 +10,6 @@ use crate::{
     common::{from_bytes_option_or_default, HasherOutput},
     context::Context,
     hashable_wrapper::WrappedHashableContainerView,
-    store::ReadableKeyValueStore as _,
     views::{ClonableView, HashableView, Hasher, ReplaceContext, View},
     ViewError,
 };
@@ -90,12 +89,6 @@ where
             stored_value,
             update: None,
         })
-    }
-
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let keys = Self::pre_load(&context)?;
-        let values = context.store().read_multi_values_bytes(keys).await?;
-        Self::post_load(context, &values)
     }
 
     fn rollback(&mut self) {

--- a/linera-views/src/views/set_view.rs
+++ b/linera-views/src/views/set_view.rs
@@ -78,10 +78,6 @@ impl<C: Context> View for ByteSetView<C> {
         })
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        Self::post_load(context, &[])
-    }
-
     fn rollback(&mut self) {
         self.delete_storage_first = false;
         self.updates.clear();
@@ -414,10 +410,6 @@ impl<C: Context, I: Send + Sync + Serialize> View for SetView<C, I> {
         })
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        Self::post_load(context, &[])
-    }
-
     fn rollback(&mut self) {
         self.set.rollback()
     }
@@ -677,10 +669,6 @@ where
             set,
             _phantom: PhantomData,
         })
-    }
-
-    async fn load(context: C) -> Result<Self, ViewError> {
-        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {


### PR DESCRIPTION
## Motivation

The function "`fn load`" was of two different forms. Either pre-load, read the values, and post-load.  Or just post-load.

## Proposal

Implement the code directly in the trait.
The same work is not done for the derived code because the derive code contains the metrics.

## Test Plan

The CI.

## Release Plan

Normal release cycle. Could be merged in TestNet Conway, but that is not needed.

## Links

None.