### PR TITLE
Make all heap profile logs trace

### DIFF
--- a/linera-metrics/src/memory_profiler.rs
+++ b/linera-metrics/src/memory_profiler.rs
@@ -51,7 +51,7 @@ impl MemoryProfiler {
 
     /// HTTP endpoint for heap profile - returns fresh pprof data
     pub async fn heap_profile() -> Result<impl IntoResponse, StatusCode> {
-        info!("Serving heap profile via /debug/pprof");
+        trace!("Serving heap profile via /debug/pprof");
 
         match Self::collect_heap_profile().await {
             Ok(profile_data) => {


### PR DESCRIPTION
## Motivation

In a previous change, we lowered the log level for heap profile operations from INFO to TRACE to reduce log noise from frequent monitoring polls. However, we missed one log statement in the heap profile HTTP endpoint that still uses INFO level.

This inconsistency means that while most heap profile operations log at TRACE level, the HTTP endpoint still creates excessive log noise with `"Serving heap profile via /debug/pprof"` messages appearing in default logs every time the endpoint is polled.

## Proposal

Change the remaining log statement in `linera-metrics/src/memory_profiler.rs` from `info!` to `trace!` for the heap profile endpoint message, completing the consistency improvement started in the earlier change.

## Test Plan

1. Deploy network with memory profiling enabled
2. Verify heap profile endpoint still works (returns pprof data)
3. Observe that default logs no longer contain repetitive "Serving heap profile" messages
4. Enable TRACE logging and verify messages appear as expected
5. Confirm consistency with other heap profile logging

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.
