### PR TITLE
Add support for exporter/indexer/explorer stack deployment

### DIFF
--- a/docker/Dockerfile.indexer
+++ b/docker/Dockerfile.indexer
@@ -73,9 +73,9 @@ ENV GIT_COMMIT=${git_commit}
 ENV RUSTFLAGS=${rustflags}
 
 
-# Build block exporter with scylladb and metrics features
+# Build linera CLI and block exporter with scylladb and metrics features
 RUN cargo build ${build_flag:+"$build_flag"} \
-    -p linera-service \
+    --bin linera \
     --bin linera-exporter \
     --features $build_features
 
@@ -86,6 +86,7 @@ RUN cargo build ${build_flag:+"$build_flag"} \
 
 # Move binaries to avoid directory conflicts and clean up to save space
 RUN mv \
+    target/"$build_folder"/linera \
     target/"$build_folder"/linera-exporter \
     target/"$build_folder"/linera-indexer-grpc \
     ./
@@ -94,6 +95,7 @@ RUN mv \
 FROM scratch AS builder_copy
 ARG binaries
 COPY \
+    "$binaries"/linera \
     "$binaries"/linera-exporter \
     "$binaries"/linera-indexer-grpc \
     ./
@@ -121,8 +123,9 @@ RUN update-ca-certificates
 
 ARG target
 
-# Copy only indexer and exporter binaries
+# Copy linera CLI, indexer and exporter binaries
 COPY --from=binaries \
+    linera \
     linera-indexer-grpc  \
     linera-exporter \
     ./

--- a/kubernetes/linera-validator/Chart.lock
+++ b/kubernetes/linera-validator/Chart.lock
@@ -12,4 +12,4 @@ dependencies:
   repository: https://grafana.github.io/helm-charts
   version: 1.3.1
 digest: sha256:295a8fc7b332a0b3c3223c2192ee1dbff016f8707760c5b4b22d76403d6d7af4
-generated: "2025-10-21T02:26:24.01435788+02:00"
+generated: "2025-10-28T00:45:17.142689-03:00"

--- a/kubernetes/linera-validator/exporter-config.toml.tpl
+++ b/kubernetes/linera-validator/exporter-config.toml.tpl
@@ -15,9 +15,15 @@ kind = "Logging"
 
 [[destination_config.destinations]]
 kind = "Indexer"
+{{- if .Values.blockExporter.indexerEndpoint }}
+tls = "Tls"
+port = 443
+endpoint = "{{ .Values.blockExporter.indexerEndpoint }}"
+{{- else }}
 tls = "ClearText"
-port = {{ .Values.indexer.port }}
-endpoint = "linera-indexer"
+port = {{ .Values.blockExporter.indexerPort }}
+endpoint = "linera-indexer-{{ .Values.networkName }}.linera-indexer.svc.cluster.local"
+{{- end }}
 
 [limits]
 persistence_period_ms = 299000

--- a/kubernetes/linera-validator/templates/block-exporter.yaml
+++ b/kubernetes/linera-validator/templates/block-exporter.yaml
@@ -49,6 +49,44 @@ spec:
         effect: NoSchedule
       {{- end }}
       initContainers:
+        - name: linera-exporter-initializer
+          image: {{ .Values.indexer.image }}
+          imagePullPolicy: {{ .Values.indexer.imagePullPolicy }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+          command:
+            - sh
+            - -c
+            - |
+              set -euo pipefail
+              while true; do
+                output=$(./linera storage check-existence --storage "{{ .Values.storage }}" 2>&1)
+                status=$?
+                if [ "$status" -eq 0 ]; then
+                  echo "Database already exists, no need to initialize."
+                  exit 0
+                else
+                  if [ "$status" -eq 1 ]; then
+                    echo "Database does not exist, retrying in {{ .Values.blockExporter.initRetryIntervalSeconds | default 5 }} seconds..."
+                  else
+                    echo "An unexpected error occurred (status: $status): $output"
+                    echo "Retrying in {{ .Values.blockExporter.initRetryIntervalSeconds | default 5 }} seconds..."
+                  fi
+                  sleep {{ .Values.blockExporter.initRetryIntervalSeconds | default 5 }}
+                fi
+              done
         - name: config-selector
           image: busybox
           command:
@@ -62,6 +100,65 @@ spec:
               mountPath: /configmap
             - name: config
               mountPath: /config
+        - name: indexer-readiness-check
+          image: curlimages/curl:latest
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "25m"
+            limits:
+              memory: "64Mi"
+              cpu: "50m"
+          env:
+            - name: INDEXER_ENDPOINT
+              value: {{ if .Values.blockExporter.indexerEndpoint }}"{{ .Values.blockExporter.indexerEndpoint }}"{{ else }}"linera-indexer-{{ .Values.networkName }}.linera-indexer.svc.cluster.local"{{ end }}
+            - name: INDEXER_PORT
+              value: {{ if .Values.blockExporter.indexerEndpoint }}"443"{{ else }}"{{ .Values.blockExporter.indexerPort }}"{{ end }}
+            - name: INDEXER_TLS
+              value: {{ if .Values.blockExporter.indexerEndpoint }}"true"{{ else }}"false"{{ end }}
+          command:
+            - sh
+            - -c
+            - |
+              set -euo pipefail
+              # Validate extracted values
+              if [ -z "$INDEXER_ENDPOINT" ] || [ -z "$INDEXER_PORT" ]; then
+                echo "Error: INDEXER_ENDPOINT or INDEXER_PORT is empty"
+                exit 1
+              fi
+
+              if [ "$INDEXER_TLS" = "true" ]; then
+                INDEXER_URL="https://${INDEXER_ENDPOINT}:${INDEXER_PORT}"
+              else
+                INDEXER_URL="http://${INDEXER_ENDPOINT}:${INDEXER_PORT}"
+              fi
+
+              echo "Checking indexer readiness at ${INDEXER_URL}..."
+
+              while true; do
+                # Try to connect to the indexer (just check if it's listening)
+                # Using --insecure for init container readiness check only
+                # This is acceptable because:
+                # 1. Only checking if service is reachable, not exchanging sensitive data
+                # 2. External endpoints may use self-signed certs in dev/staging
+                # 3. Actual exporter traffic uses proper TLS validation
+                if curl --max-time 5 --connect-timeout 5 --silent --fail --insecure "${INDEXER_URL}" > /dev/null 2>&1 || \
+                   curl --max-time 5 --connect-timeout 5 --silent --head --insecure "${INDEXER_URL}" > /dev/null 2>&1; then
+                  echo "Indexer is reachable, exporter can start."
+                  exit 0
+                else
+                  echo "Indexer not ready yet, retrying in {{ .Values.blockExporter.initRetryIntervalSeconds | default 5 }} seconds..."
+                  sleep {{ .Values.blockExporter.initRetryIntervalSeconds | default 5 }}
+                fi
+              done
       containers:
         - name: linera-block-exporter
           image: {{ .Values.indexer.image }}

--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -16,7 +16,7 @@ spec:
       name: metrics
   selector:
     app: proxy
-  clusterIp: None
+  clusterIP: None
 
 ---
 apiVersion: v1


### PR DESCRIPTION
## Motivation

Deploying the exporter/indexer/explorer stack requires careful dependency ordering and runtime checks:

1. **Exporters need database to exist** before starting (ScyllaDB must be initialized)
2. **Exporters need indexer to be ready** before attempting connections
3. **Indexer image needs linera CLI** to perform database checks
4. **Configuration needs flexibility** to support both internal cluster DNS and external endpoints with TLS

Without these capabilities, deployments fail with race conditions where exporters start before dependencies are ready, causing crash loops and manual intervention.

## Proposal

Add comprehensive deployment support through init containers that wait for dependencies, include linera CLI in the indexer image for database checks, and make indexer endpoints configurable to support both internal and external deployments with automatic TLS handling.

## Test Plan

1. Deploy fresh network with exporter/indexer/explorer stack:
   - Verify ScyllaDB init container waits for database
   - Verify indexer readiness init container waits for indexer
   - Confirm exporters start only after both checks pass
   
2. Test with external indexer endpoint:
   - Configure `blockExporter.indexerEndpoint` with external URL
   - Verify TLS configuration is applied
   - Confirm connectivity works

3. Test failure scenarios:
   - Deploy without indexer, verify exporter init container retries indefinitely
   - Kill indexer, verify exporters restart and wait for it to return

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.
