### PR TITLE
Synchronize before applying changes to the committee.

### DIFF
--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -667,7 +667,11 @@ impl Runnable for Job {
                     }
                     _ => {}
                 }
-                let chain_client = context.make_chain_client(context.wallet.genesis_admin_chain());
+                let admin_id = context.wallet.genesis_admin_chain();
+                let chain_client = context.make_chain_client(admin_id);
+                // Synchronize the chain state to make sure we're applying the changes to the
+                // latest committee.
+                chain_client.synchronize_chain_state(admin_id).await?;
                 let maybe_certificate = context
                     .apply_client_command(&chain_client, |chain_client| {
                         let chain_client = chain_client.clone();


### PR DESCRIPTION
## Motivation

At the moment it would probably not commit anything, but in the future it might become dangerous to use `change-validators` (or `set-validator` or `remove-validator`) without first using `sync`: It would take an outdated committee, apply the modifications, and then use the result as the new committee.

## Proposal

Synchronize the admin chain before getting the committee.

## Test Plan

This is just a safeguard so that we don't introduce a footgun in the future, if we modify the client to automatically and silently fetch the missing blocks inside `execute_operations`.

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a new SDK.

## Links

- Related: #4833
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
