### PR TITLE
Fix demo deployment workflow and CDN cache invalidation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LINERA_BIN := ./target/release/linera
 # These defaults point to the public Linera demo infrastructure
 # Override these variables for private/internal deployments
 PUBLIC_GCS_BUCKET := gs://demos.linera.net
-PUBLIC_URL_MAP := linera-apps-url-map
+PUBLIC_URL_MAP := demos-linera-net
 
 # Allow overrides for private deployments
 GCS_BUCKET ?= $(PUBLIC_GCS_BUCKET)


### PR DESCRIPTION
## Motivation

The demo deployment workflow had several issues:
1. Cache invalidation was not working via CLI (wrong URL map name)
2. No way to rebuild frontends without redeploying blockchain apps (missing .env retrieval)
3. MetaMask demo deployment broken due to absolute asset paths

## Proposal

**Infrastructure Fixes:**
- Fixed CDN cache invalidation by using correct URL map `demos-linera-net` (was using `linera-apps-url-map` which points to different bucket)
- Removed redundant confirmation prompts (deployment already asks for YES)

**Workflow Improvements:**
- Added `fetch-env-counter`, `fetch-env-fungible`, `fetch-env-all` targets to retrieve .env files from GCS
- Updated `*-quick` deployment targets to auto-fetch .env before building frontends
- Enables frontend-only updates without blockchain redeployment

**Build Fixes:**
- Fixed pnpm install step
- Removed flawed/unneeded checks in Makefile

## Test Plan

- [x] Verified cache invalidation works with correct URL map
- [x] Tested `fetch-env-*` targets retrieve .env from GCS successfully
- [x] Confirmed `quick-deploy` workflow: fetch .env → build → deploy → invalidate cache
- [x] Manual deployment to testnet-conway demos site

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)