### PR TITLE
Fix `test_wasm_end_to_end_allowances_fungible` timing issue.

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2059,10 +2059,18 @@ async fn test_wasm_end_to_end_allowances_fungible(config: impl LineraNetConfig) 
     let mut notifications3 = node_service3.notifications(chain2).await?;
     // Wait until clients 2 and 3 see the initialized application state.
     let (_, height) = node_service1.chain_tip(chain2).await?.unwrap();
-    if node_service2.chain_tip(chain2).await?.unwrap().1 < height {
+    if node_service2
+        .chain_tip(chain2)
+        .await?
+        .is_none_or(|(_, h)| h < height)
+    {
         notifications2.wait_for_block(height).await?;
     }
-    if node_service3.chain_tip(chain2).await?.unwrap().1 < height {
+    if node_service3
+        .chain_tip(chain2)
+        .await?
+        .is_none_or(|(_, h)| h < height)
+    {
         notifications3.wait_for_block(height).await?;
     }
 


### PR DESCRIPTION
## Motivation

In #4834 a lot of tests were changed to wait for notifications instead of retrying in a loop. The `test_wasm_end_to_end_allowances_fungible` specifically creates multiple node services for the same chain. While service 1 has already used the chain, services 2 and 3 need to synchronize it. So we check the chain tip and if it is lower than the one seen by service 1, we wait for the corresponding notification.

[In the ScyllaDB tests this panics](https://github.com/linera-io/linera-protocol/actions/runs/18822090732/job/53699169562), because we unwrap the chain tip, and it is `None` if the node service does not have any block yet.

## Proposal

If it is `None`, also wait for the notification.

## Test Plan

CI

## Release Plan

- These changes should be backported to `testnet_conway`.

## Links

- Problem introduced in #4834.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
