### PR TITLE
`linera-service`: print faucet URL even if no faucet chain is given

### DIFF
--- a/linera-service/src/cli/net_up_utils.rs
+++ b/linera-service/src/cli/net_up_utils.rs
@@ -364,7 +364,7 @@ async fn print_messages_and_create_faucet(
             "{}",
             format!("export LINERA_FAUCET_URL=\"http://localhost:{faucet_port}\"").bold(),
         );
-        
+
         let service = client
             .run_faucet(Some(faucet_port.into()), faucet_chain, faucet_amount)
             .await?;


### PR DESCRIPTION
## Motivation

The faucet URL is accidentally not printed if `--faucet-chain` is not passed explicitly.

## Proposal

Print it whenever `--with-faucet` is used.

## Test Plan

Tested locally, but we don't rely on this behaviour anywhere.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
