### PR TITLE
Support querying state at cached views; New BlockExecuted notification

### DIFF
--- a/examples/counter/index.html
+++ b/examples/counter/index.html
@@ -84,22 +84,26 @@
               logs.insertBefore(entry, logs.firstChild);
           }
 
-          async function updateCount() {
-              const response = await counter.query('{ "query": "query { value }" }');
+          async function updateCount(block_hash) {
+              const response = await counter.query('{ "query": "query { value }" }', block_hash || '');
               document.getElementById('count').innerText
                   = JSON.parse(response).data.value;
           }
 
-          updateCount();
+          updateCount(null);
           client.onNotification(notification => {
               let newBlock = notification.reason.NewBlock;
-              if (!newBlock) return;
-              addLogEntry(newBlock);
-              updateCount();
+              if (notification.reason.BlockExecuted) {
+                let hash = notification.reason.BlockExecuted.hash;
+                updateCount(hash);
+              } else if(newBlock) {
+                addLogEntry(newBlock);
+                updateCount(null);
+              }
           });
 
           incrementButton.addEventListener('click', () => {
-              counter.query('{ "query": "mutation { increment(value: 1) }" }');
+              counter.query('{ "query": "mutation { increment(value: 1) }" }', '');
           });
       }
 

--- a/examples/native-fungible/index.html
+++ b/examples/native-fungible/index.html
@@ -165,11 +165,11 @@
           parent.insertBefore(entry, parent.firstChild);
       }
 
-      async function updateBalance(application) {
-          const response = JSON.parse(await application.query(gql(`query { tickerSymbol, accounts { entries { key value } } }`)));
+      async function updateBalance(application, owner, blockHash) {
+          const response = JSON.parse(await application.query(gql(`query { tickerSymbol, accounts { entry(key: "${owner}") { value } } }`), blockHash || ''));
           console.debug('application response:', response);
           document.querySelector('#ticker-symbol').textContent = response.data.tickerSymbol;
-          document.querySelector('#balance').textContent = (+(response?.data?.accounts?.entries?.[0]?.value || 0)).toFixed(2);
+          document.querySelector('#balance').textContent = (+(response?.data?.accounts?.entry.value || 0)).toFixed(2);
       }
 
       async function transfer(application, donor, amount, recipient) {
@@ -195,7 +195,7 @@
                   recipient: { owner: match[1], chainId: match[2] },
               });
 
-              errors = JSON.parse(await application.query(query)).errors || [];
+              errors = JSON.parse(await application.query(query, '')).errors || [];
           } catch (e) {
               console.error(e);
               errors.push({ message: e.message });
@@ -238,13 +238,19 @@
 
           const application = await client.frontend().application(import.meta.env.LINERA_APPLICATION_ID);
 
-          await updateBalance(application);
+          await updateBalance(application, owner, null);
 
           client.onNotification(notification => {
               let newBlock = notification.reason.NewBlock;
-              if (!newBlock) return;
-              prependEntry(document.querySelector('#logs'), newBlock);
-              updateBalance(application);
+              console.debug('notification:', notification);
+              if (notification.reason.BlockExecuted) {
+                let blockHash = notification.reason.BlockExecuted.hash;
+                updateBalance(application, owner, blockHash);
+              } else {
+                if (!newBlock) return;
+                prependEntry(document.querySelector('#logs'), newBlock);
+                updateBalance(application, owner, null);
+              }
           });
 
           submitButton.disabled = false;

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -281,6 +281,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
                 }
                 self.process_new_events(notification.chain_id).await?;
             }
+            Reason::BlockExecuted { .. } => {}
         }
         Self::sleep(self.config.delay_after_ms).await;
         Ok(())

--- a/linera-client/src/util.rs
+++ b/linera-client/src/util.rs
@@ -45,7 +45,7 @@ pub async fn wait_for_next_round(stream: &mut NotificationStream, timeout: Round
     let mut stream = stream.filter(|notification| match &notification.reason {
         Reason::NewBlock { height, .. } => *height >= timeout.next_block_height,
         Reason::NewRound { round, .. } => *round > timeout.current_round,
-        Reason::NewIncomingBundle { .. } => false,
+        Reason::NewIncomingBundle { .. } | Reason::BlockExecuted { .. } => false,
     });
     future::select(
         Box::pin(stream.next()),

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -63,6 +63,7 @@ where
     /// Query an application's state.
     QueryApplication {
         query: Query,
+        block_hash: Option<CryptoHash>,
         #[debug(skip)]
         callback: oneshot::Sender<Result<QueryOutcome, WorkerError>>,
     },

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -31,7 +31,7 @@ use linera_chain::{
     ChainError, ChainExecutionContext, ChainStateView, ExecutionResultExt as _,
 };
 use linera_execution::{
-    system::EPOCH_STREAM_NAME, Committee, ExecutionStateView, Query, QueryOutcome,
+    system::EPOCH_STREAM_NAME, Committee, ExecutionStateView, Query, QueryContext, QueryOutcome,
     ServiceRuntimeEndpoint,
 };
 use linera_storage::{Clock as _, ResultReadCertificates, Storage};
@@ -126,9 +126,13 @@ where
             ChainWorkerRequest::GetChainStateView { callback } => {
                 callback.send(self.chain_state_view().await).is_ok()
             }
-            ChainWorkerRequest::QueryApplication { query, callback } => {
-                callback.send(self.query_application(query).await).is_ok()
-            }
+            ChainWorkerRequest::QueryApplication {
+                query,
+                block_hash,
+                callback,
+            } => callback
+                .send(self.query_application(query, block_hash).await)
+                .is_ok(),
             ChainWorkerRequest::DescribeApplication {
                 application_id,
                 callback,
@@ -1254,14 +1258,55 @@ where
     pub(super) async fn query_application(
         &mut self,
         query: Query,
+        block_hash: Option<CryptoHash>,
     ) -> Result<QueryOutcome, WorkerError> {
         self.initialize_and_save_if_needed().await?;
         let local_time = self.storage.clock().current_time();
-        let outcome = self
-            .chain
-            .query_application(local_time, query, self.service_runtime_endpoint.as_mut())
-            .await?;
-        Ok(outcome)
+        if let Some(requested_block) = block_hash {
+            if let Some(mut state) = self.execution_state_cache.remove(&requested_block) {
+                // We try to use a cached execution state for the requested block.
+                // We want to pretend that this block is committed, so we set the next block height.
+                let next_block_height = self
+                    .chain
+                    .tip_state
+                    .get()
+                    .next_block_height
+                    .try_add_one()
+                    .expect("block height to not overflow");
+                let context = QueryContext {
+                    chain_id: self.chain_id(),
+                    next_block_height,
+                    local_time,
+                };
+                let outcome = state
+                    .with_context(|ctx| {
+                        self.chain
+                            .execution_state
+                            .context()
+                            .clone_with_base_key(ctx.base_key().bytes.clone())
+                    })
+                    .await
+                    .query_application(context, query, self.service_runtime_endpoint.as_mut())
+                    .await
+                    .with_execution_context(ChainExecutionContext::Query)?;
+                self.execution_state_cache
+                    .insert_owned(&requested_block, state);
+                Ok(outcome)
+            } else {
+                tracing::debug!(requested_block = %requested_block, "requested block hash not found in cache, querying committed state");
+                let outcome = self
+                    .chain
+                    .query_application(local_time, query, self.service_runtime_endpoint.as_mut())
+                    .await?;
+                Ok(outcome)
+            }
+        } else {
+            let outcome = self
+                .chain
+                .query_application(local_time, query, self.service_runtime_endpoint.as_mut())
+                .await?;
+            Ok(outcome)
+        }
     }
 
     /// Returns an application's description.

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -9,7 +9,7 @@ use std::{
 
 use futures::{stream::FuturesUnordered, TryStreamExt as _};
 use linera_base::{
-    crypto::ValidatorPublicKey,
+    crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{ArithmeticError, Blob, BlockHeight, Epoch},
     identifiers::{BlobId, ChainId},
 };
@@ -240,8 +240,13 @@ where
         &self,
         chain_id: ChainId,
         query: Query,
+        block_hash: Option<CryptoHash>,
     ) -> Result<QueryOutcome, LocalNodeError> {
-        let outcome = self.node.state.query_application(chain_id, query).await?;
+        let outcome = self
+            .node
+            .state
+            .query_application(chain_id, query, block_hash)
+            .await?;
         Ok(outcome)
     }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2159,7 +2159,7 @@ where
     let chain_3 = chain_3_desc.id();
     assert_eq!(
         env.worker()
-            .query_application(chain_1, Query::System(SystemQuery))
+            .query_application(chain_1, Query::System(SystemQuery), None)
             .await?,
         QueryOutcome {
             response: QueryResponse::System(SystemResponse {
@@ -2171,7 +2171,7 @@ where
     );
     assert_eq!(
         env.worker()
-            .query_application(chain_2, Query::System(SystemQuery))
+            .query_application(chain_2, Query::System(SystemQuery), None)
             .await?,
         QueryOutcome {
             response: QueryResponse::System(SystemResponse {
@@ -2206,7 +2206,7 @@ where
     assert!(info.manager.pending.is_none());
     assert_eq!(
         env.worker()
-            .query_application(chain_1, Query::System(SystemQuery))
+            .query_application(chain_1, Query::System(SystemQuery), None)
             .await?,
         QueryOutcome {
             response: QueryResponse::System(SystemResponse {
@@ -2246,7 +2246,7 @@ where
 
     assert_eq!(
         env.worker()
-            .query_application(chain_2, Query::System(SystemQuery))
+            .query_application(chain_2, Query::System(SystemQuery), None)
             .await?,
         QueryOutcome {
             response: QueryResponse::System(SystemResponse {
@@ -4036,7 +4036,7 @@ where
 
         assert_eq!(
             env.worker()
-                .query_application(chain_id, query.clone())
+                .query_application(chain_id, query.clone(), None)
                 .await?,
             QueryOutcome {
                 response: QueryResponse::User(vec![]),
@@ -4135,7 +4135,7 @@ where
 
         assert_eq!(
             env.worker()
-                .query_application(chain_1, query.clone())
+                .query_application(chain_1, query.clone(), None)
                 .await?,
             QueryOutcome {
                 response: QueryResponse::User(vec![]),
@@ -4162,7 +4162,7 @@ where
 
         assert_eq!(
             env.worker()
-                .query_application(chain_1, query.clone())
+                .query_application(chain_1, query.clone(), None)
                 .await?,
             QueryOutcome {
                 response: QueryResponse::User(vec![]),
@@ -4210,7 +4210,7 @@ where
 
         assert_eq!(
             env.worker()
-                .query_application(chain_1, query.clone())
+                .query_application(chain_1, query.clone(), None)
                 .await?,
             QueryOutcome {
                 response: QueryResponse::User(vec![]),

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -147,6 +147,10 @@ pub enum Reason {
         height: BlockHeight,
         round: Round,
     },
+    BlockExecuted {
+        height: BlockHeight,
+        hash: CryptoHash,
+    },
 }
 
 /// Error type for worker operations.
@@ -628,14 +632,22 @@ where
     }
 
     /// Executes a [`Query`] for an application's state on a specific chain.
+    ///
+    /// If `block_hash` is specified, system will query the application's state
+    /// at that block. If it doesn't exist, it uses latest state.
     #[instrument(level = "trace", skip(self, chain_id, query))]
     pub async fn query_application(
         &self,
         chain_id: ChainId,
         query: Query,
+        block_hash: Option<CryptoHash>,
     ) -> Result<QueryOutcome, WorkerError> {
         self.query_chain_worker(chain_id, move |callback| {
-            ChainWorkerRequest::QueryApplication { query, callback }
+            ChainWorkerRequest::QueryApplication {
+                query,
+                block_hash,
+                callback,
+            }
         })
         .await
     }

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -115,7 +115,7 @@ impl ActiveChain {
         let QueryOutcome { response, .. } = self
             .validator
             .worker()
-            .query_application(self.id(), query)
+            .query_application(self.id(), query, None)
             .await
             .expect("Failed to query chain's balance");
 
@@ -622,6 +622,7 @@ impl ActiveChain {
                     application_id: application_id.forget_abi(),
                     bytes: query_bytes,
                 },
+                None,
             )
             .await?;
 

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -912,12 +912,13 @@ where
         application_id: ApplicationId,
         request: Vec<u8>,
         chain_id: ChainId,
+        block_hash: Option<CryptoHash>,
     ) -> Result<Vec<u8>, NodeServiceError> {
         let QueryOutcome {
             response,
             operations,
         } = self
-            .query_user_application(application_id, request, chain_id)
+            .query_user_application(application_id, request, chain_id, block_hash)
             .await?;
         if operations.is_empty() {
             return Ok(response);
@@ -948,6 +949,7 @@ where
         application_id: ApplicationId,
         bytes: Vec<u8>,
         chain_id: ChainId,
+        block_hash: Option<CryptoHash>,
     ) -> Result<QueryOutcome<Vec<u8>>, NodeServiceError> {
         let query = Query::User {
             application_id,
@@ -957,7 +959,7 @@ where
         let QueryOutcome {
             response,
             operations,
-        } = client.query_application(query).await?;
+        } = client.query_application(query, block_hash).await?;
         match response {
             QueryResponse::System(_) => {
                 unreachable!("cannot get a system response for a user query")
@@ -991,12 +993,14 @@ where
         let application_id: ApplicationId = application_id.parse()?;
 
         debug!(
-            "Processing request for application {application_id} on chain {chain_id}:\n{:?}",
+            %chain_id,
+            %application_id,
+            "processing request for application:\n{:?}",
             &request
         );
         let response = service
             .0
-            .handle_service_request(application_id, request.into_bytes(), chain_id)
+            .handle_service_request(application_id, request.into_bytes(), chain_id, None)
             .await?;
 
         Ok(response)

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -4671,6 +4671,9 @@ async fn test_end_to_end_repeated_transfers(config: impl LineraNetConfig) -> Res
                 reason @ Reason::NewRound { .. } => {
                     panic!("Unexpected notification about transfer #{i} {reason:?}")
                 }
+                Reason::BlockExecuted { .. } => {
+                    // Ignored
+                }
             }
         };
 

--- a/linera-web/src/lib.rs
+++ b/linera-web/src/lib.rs
@@ -466,6 +466,9 @@ impl Frontend {
 impl Application {
     /// Performs a query against an application's service.
     ///
+    /// If `block_hash` is non-empty, it specifies the block at which to
+    /// perform the query; otherwise, the latest block is used.
+    ///
     /// # Errors
     /// If the application ID is invalid, the query is incorrect, or
     /// the response isn't valid UTF-8.
@@ -475,18 +478,25 @@ impl Application {
     #[wasm_bindgen]
     // TODO(#14) allow passing bytes here rather than just strings
     // TODO(#15) a lot of this logic is shared with `linera_service::node_service`
-    pub async fn query(&self, query: &str) -> JsResult<String> {
+    pub async fn query(&self, query: &str, block_hash: &str) -> JsResult<String> {
         tracing::debug!("querying application: {query}");
         let chain_client = self.client.default_chain_client().await?;
-
+        let block_hash = if block_hash.is_empty() {
+            None
+        } else {
+            Some(block_hash.parse()?)
+        };
         let linera_execution::QueryOutcome {
             response: linera_execution::QueryResponse::User(response),
             operations,
         } = chain_client
-            .query_application(linera_execution::Query::User {
-                application_id: self.id,
-                bytes: query.as_bytes().to_vec(),
-            })
+            .query_application(
+                linera_execution::Query::User {
+                    application_id: self.id,
+                    bytes: query.as_bytes().to_vec(),
+                },
+                block_hash,
+            )
             .await?
         else {
             panic!("system response to user query")


### PR DESCRIPTION
Backport of #4867 

## Motivation

Some applications may decide that it is safe to update their UIs whenever the block proposal is handled locally (i.e. it's executed, set as pending proposal and sent to validators) instead of waiting for the confirmed block notification.

## Proposal

Add new notification `Reason::BlockExecuted { height, hash }` which is emitted after staging the block locally (i.e. it's set as pending and executed). The `hash` can be used to query the applications state even before it's committed. To support this the `query_application` functionality was extended to support querying at intermediate, cached, execution state views. When querying, no hash is provided, we query the committed state. Similarly, if the provided hash is no longer in the cache (b/c it was already committted in the meantime or some other proposal superseeded this one), the committed state is queried.

## Test Plan

A test with notifications was extended to verify that the event is emitted.

## Release Plan

- These changes should
    - backported to Testnet.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
