### PR TITLE
Fix small bug on exporter config

### DIFF
--- a/kubernetes/linera-validator/templates/block-exporter.yaml
+++ b/kubernetes/linera-validator/templates/block-exporter.yaml
@@ -67,7 +67,7 @@ spec:
               memory: "128Mi"
               cpu: "100m"
           command:
-            - sh
+            - bash
             - -c
             - |
               set -euo pipefail
@@ -128,7 +128,7 @@ spec:
             - sh
             - -c
             - |
-              set -euo pipefail
+              set -eu
               # Validate extracted values
               if [ -z "$INDEXER_ENDPOINT" ] || [ -z "$INDEXER_PORT" ]; then
                 echo "Error: INDEXER_ENDPOINT or INDEXER_PORT is empty"


### PR DESCRIPTION
## Motivation

`sh` doesn't support `set -euo pipefail`, I missed this in a previous PR

## Proposal

Use `bash` when available, otherwise use `set -eu` instead.

## Test Plan

Deployed a network, exporter starts as expected now.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.
