### PR TITLE
Backport: Extend MessagePolicy filtering to events (#4877)

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1883,6 +1883,13 @@ impl<Env: Environment> ChainClient<Env> {
         // Collect the indices of all new events.
         let futures = subscription_map
             .into_iter()
+            .filter(|((chain_id, _), _)| {
+                self.options
+                    .message_policy
+                    .restrict_chain_ids_to
+                    .as_ref()
+                    .is_none_or(|chain_set| chain_set.contains(chain_id))
+            })
             .map(|((chain_id, stream_id), subscriptions)| {
                 let client = self.client.clone();
                 async move {


### PR DESCRIPTION
## Motivation

`MessagePolicy` can already be used to decide which messages we want to receive. We would like to be able to control events as well.

## Proposal

Use the list of chains from `MessagePolicy` to restrict which chains' events are processed as well.
This is a backport of #4877 

## Test Plan

CI

## Release Plan

- These changes should be released in a new SDK

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
