### PR TITLE
Turn block heights list into ranges to load more at once from storage.

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1524,7 +1524,7 @@ where
             info.requested_pending_message_bundles = bundles;
         }
         let mut hashes = Vec::new();
-        let height_ranges = Self::into_ranges(query.request_sent_certificate_hashes_by_heights);
+        let height_ranges = into_ranges(query.request_sent_certificate_hashes_by_heights);
         for height_range in height_ranges {
             hashes.extend(chain.block_hashes(height_range).await?);
         }
@@ -1602,21 +1602,21 @@ where
         self.chain.save().await?;
         Ok(())
     }
+}
 
-    /// Returns an iterator of inclusive ranges that exactly cover the list of block heights.
-    fn into_ranges(
-        values: impl IntoIterator<Item = BlockHeight>,
-    ) -> impl Iterator<Item = RangeInclusive<BlockHeight>> {
-        let mut values_iter = values.into_iter().peekable();
-        iter::from_fn(move || {
-            let start = values_iter.next()?;
-            let mut end = start;
-            while values_iter.peek() == end.try_add_one().ok().as_ref() {
-                end = values_iter.next()?;
-            }
-            Some(start..=end)
-        })
-    }
+/// Returns an iterator of inclusive ranges that exactly cover the list of block heights.
+fn into_ranges(
+    values: impl IntoIterator<Item = BlockHeight>,
+) -> impl Iterator<Item = RangeInclusive<BlockHeight>> {
+    let mut values_iter = values.into_iter().peekable();
+    iter::from_fn(move || {
+        let start = values_iter.next()?;
+        let mut end = start;
+        while values_iter.peek() == end.try_add_one().ok().as_ref() {
+            end = values_iter.next()?;
+        }
+        Some(start..=end)
+    })
 }
 
 /// Returns the keys whose value is `None`.
@@ -1730,4 +1730,22 @@ impl<'a> CrossChainUpdateHelper<'a> {
         };
         Ok(bundles)
     }
+}
+
+#[test]
+fn test_into_ranges() {
+    assert_eq!(
+        into_ranges(vec![
+            BlockHeight(2),
+            BlockHeight(3),
+            BlockHeight(4),
+            BlockHeight(6)
+        ],)
+        .collect::<Vec<_>>(),
+        vec![
+            BlockHeight(2)..=BlockHeight(4),
+            BlockHeight(6)..=BlockHeight(6)
+        ]
+    );
+    assert_eq!(into_ranges(vec![]).collect::<Vec<_>>(), vec![]);
 }


### PR DESCRIPTION
## Motivation

When handling a chain info query asking for sender certificate hashes, we currently load those hashes from the chain state view one by one: `chain.block_hashes(height..=height).await?`. In most cases, the block heights are actually contiguous.

## Proposal

Turn the list into an equivalent list of ranges, and load each range at once.

## Test Plan

CI should catch any regressions. We should find a way to try out if this improves performance, or even addresses the problems on the testnet.

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
