### PR TITLE
Add AssertStorage for `linera-proxy` and `linera-server`.

### DIFF
--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -41,7 +41,7 @@ use linera_rpc::{
 };
 use linera_sdk::linera_base_types::Blob;
 use linera_service::{
-    storage::{CommonStorageOptions, Runnable, StorageConfig},
+    storage::{AssertStorageV1, CommonStorageOptions, Runnable, StorageConfig},
     util,
 };
 use linera_storage::{ResultReadCertificates, Storage};
@@ -496,6 +496,7 @@ impl ProxyOptions {
         let store_config = self
             .storage_config
             .add_common_storage_options(&self.common_storage_options)?;
+        store_config.clone().run_with_store(AssertStorageV1).await?;
         store_config
             .run_with_storage(None, ProxyContext::from_options(self)?)
             .boxed()

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -54,7 +54,7 @@ use linera_rpc::{
 };
 use linera_sdk::linera_base_types::{AccountSecretKey, ValidatorKeypair};
 use linera_service::{
-    storage::{CommonStorageOptions, Runnable, StorageConfig},
+    storage::{AssertStorageV1, CommonStorageOptions, Runnable, StorageConfig},
     util,
 };
 use linera_storage::Storage;
@@ -542,6 +542,11 @@ async fn run(options: ServerOptions) {
             let wasm_runtime = wasm_runtime.with_wasm_default();
             let store_config = storage_config
                 .add_common_storage_options(&common_storage_options)
+                .unwrap();
+            store_config
+                .clone()
+                .run_with_store(AssertStorageV1)
+                .await
                 .unwrap();
             store_config
                 .run_with_storage(wasm_runtime, job)

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -758,6 +758,32 @@ impl RunnableWithStore for StorageMigration {
     }
 }
 
+pub struct AssertStorageV1;
+
+#[async_trait]
+impl RunnableWithStore for AssertStorageV1 {
+    type Output = ();
+
+    async fn run<D>(
+        self,
+        config: D::Config,
+        namespace: String,
+    ) -> Result<Self::Output, anyhow::Error>
+    where
+        D: KeyValueDatabase + Clone + Send + Sync + 'static,
+        D::Store: KeyValueStore + Clone + Send + Sync + 'static,
+        D::Error: Send + Sync,
+    {
+        if D::exists(&config, &namespace).await? {
+            let wasm_runtime = None;
+            let storage =
+                DbStorage::<D, WallClock>::connect(&config, &namespace, wasm_runtime).await?;
+            storage.assert_is_migrated_storage().await?;
+        }
+        Ok(())
+    }
+}
+
 #[test]
 fn test_memory_storage_config_from_str() {
     assert_eq!(


### PR DESCRIPTION
## Motivation

When running `linera-proxy` / `linera-server`, we should check that the storage has been migrated.

## Proposal

The wrong idea (that was attempted before) was to check in `linera-storage`). This is the wrong place
since it does not have access to the context of the call.

Instead, the idea is to introduce an `IsStorageV1` in parallel to `StorageMigration` and to test it in
`linera-proxy` / `linera-server` near to the main.rs.+

## Test Plan

The CI.

## Release Plan

To be merged in TestNet Conway.

## Links

None.