### PR TITLE
Delete ClusterIP for now

### DIFF
--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -16,7 +16,6 @@ spec:
       name: metrics
   selector:
     app: proxy
-  clusterIP: None
 
 ---
 apiVersion: v1


### PR DESCRIPTION
## Motivation

One of the PRs we backported from main was fixing this typo. The typo caused us to make one of the proxy services not be headless. This is not a huge deal, but ideally we'll fix it in the next testnet.

## Proposal

Just delete the `ClusterIP` line for now, and keep it as is.

## Test Plan

This is deployed on `validator-2` of `testnet-conway`.

