### PR TITLE
Break out of the proposal staging loop if rejected message fails.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1314,6 +1314,9 @@ impl<Env: Environment> Client<Env> {
                             "Protected incoming message failed to execute locally"
                         )
                     );
+                    if message.action == MessageAction::Reject {
+                        return result;
+                    }
                     // Reject the faulty message from the block and continue.
                     // TODO(#1420): This is potentially a bit heavy-handed for
                     // retryable errors.


### PR DESCRIPTION
## Motivation

The staging loop loops forever if a rejected message fails. (It sets it to `Rejected`, which it already is, and tries again!)

After the `FLAG_FREE_REJECT` activation, this shouldn't be reachable anymore, but it makes sense to detect this case anyway.

## Proposal

Break out of the loop if a rejected message fails.

## Test Plan

I tried it locally.

## Release Plan

- Release in a new SDK. (Not urgent.)

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
