### PR TITLE
Do the migration and assert in a more modular fashion.

### DIFF
--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -1110,19 +1110,6 @@ pub enum DatabaseToolCommand {
     ListChainIds,
 }
 
-impl DatabaseToolCommand {
-    pub fn assert_storage_v1(&self) -> bool {
-        matches!(
-            self,
-            DatabaseToolCommand::ListBlobIds | DatabaseToolCommand::ListChainIds
-        )
-    }
-
-    pub fn need_migration(&self) -> bool {
-        matches!(self, DatabaseToolCommand::Initialize { .. })
-    }
-}
-
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, clap::Parser)]
 pub enum NetCommand {

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -2580,8 +2580,11 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
         },
 
         ClientCommand::Storage(command) => {
-            let assert_storage_v1 = command.assert_storage_v1();
-            let need_migration = command.need_migration();
+            let assert_storage_v1 = matches!(
+                command,
+                DatabaseToolCommand::ListBlobIds | DatabaseToolCommand::ListChainIds
+            );
+            let need_migration = matches!(command, DatabaseToolCommand::Initialize { .. });
             Ok(options
                 .run_with_store(assert_storage_v1, need_migration, DatabaseToolJob(command))
                 .await?)


### PR DESCRIPTION
## Motivation

In `linera ....` operations, we are systematically migrating the namespace. This led to some inconsistent behavior like `linera storage check-existence` triggering the migration. This is wrong for two reasons:
* It is thought of a read-operation.
* It does not require to be migrated in order for the answer to be obtained.

## Proposal

The behavior is now the following:
* linera { service, faucet, query-validators, transfer, ...} => migrate if needed. It is a write operation.
* linera storage initialize => migrate if needed. It is a write operation. Now that if there is already a state, then it is migrated and the rest of the initialization is a noop.
* linera-storage check-existence delete* list-namespace => All of those operations do not consider the namespaces themselves. Therefore, there is no need for any check.
* linera storage list-chain-ids / list-blob-ids => only assert that the storage is migrated. This is needed because the storage needs to be migrated in order to access this information. But those operations are read data, so it is uncomfortable to do a migration in them.

## Test Plan

CI.

## Release Plan

In TestNet Conway.

## Links

None.