### PR TITLE
Fix ruzstd version 0.8.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,9 @@ revm-state = { version = "4.0.1", default-features = false, features = [
     "serde",
 ] }
 rocksdb = "0.21.0"
-ruzstd = "0.8.1"
+# 0.8.2 doesn't build with Rust 1.87. Remove `=` once
+# https://github.com/linera-io/linera-protocol/issues/4742 is resolved.
+ruzstd = "=0.8.1"
 scylla = "~1.1.0"
 semver = "1.0.22"
 serde = { version = "1.0.197", features = ["derive"] }


### PR DESCRIPTION
Backport of #4894.

## Motivation

`test_project_publish` started failing because ruzstd 0.8.2 was published and doesn't build with Rust 1.86.0. Due to https://github.com/linera-io/linera-protocol/issues/4742, we cannot upgrade to 1.87.0 or later at the moment.

## Proposal

Fix the ruzstd version to `=0.8.1`.

## Test Plan

CI should pass now. It fixed the test for me locally.

## Release Plan

- Nothing to do.

## Links

- PR to main: #4894
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
