### PR TITLE
Remove node selector for exporter

### DIFF
--- a/kubernetes/linera-validator/templates/block-exporter.yaml
+++ b/kubernetes/linera-validator/templates/block-exporter.yaml
@@ -40,14 +40,6 @@ spec:
       labels:
         app: linera-block-exporter
     spec:
-      {{- if eq .Values.environment "GCP" }}
-      nodeSelector:
-        workload: system
-      tolerations:
-      - key: system
-        value: "true"
-        effect: NoSchedule
-      {{- end }}
       initContainers:
         - name: linera-exporter-initializer
           image: {{ .Values.indexer.image }}

--- a/kubernetes/linera-validator/templates/explorer.yaml
+++ b/kubernetes/linera-validator/templates/explorer.yaml
@@ -28,14 +28,6 @@ spec:
       labels:
         app: linera-explorer
     spec:
-      {{- if eq .Values.environment "GCP" }}
-      nodeSelector:
-        workload: system
-      tolerations:
-      - key: system
-        value: "true"
-        effect: NoSchedule
-      {{- end }}
       containers:
         - name: linera-explorer
           image: {{ .Values.explorer.image }}

--- a/kubernetes/linera-validator/templates/indexer.yaml
+++ b/kubernetes/linera-validator/templates/indexer.yaml
@@ -26,14 +26,6 @@ spec:
       labels:
         app: linera-indexer
     spec:
-      {{- if eq .Values.environment "GCP" }}
-      nodeSelector:
-        workload: system
-      tolerations:
-      - key: system
-        value: "true"
-        effect: NoSchedule
-      {{- end }}
       containers:
         - name: linera-indexer
           image: {{ .Values.indexer.image }}


### PR DESCRIPTION
## Motivation

When backporting the PR, we forgot to remove the node selectors (we don't have a system VM in the current testnet).

## Proposal

Remove the node selectors

## Test Plan

Deployed `conway-test` with this, saw that the exporter successfully gets allocated to a VM now.

