### PR TITLE
Crash exporter if block processor task crashes

### DIFF
--- a/linera-service/src/exporter/main.rs
+++ b/linera-service/src/exporter/main.rs
@@ -116,10 +116,17 @@ impl Runnable for ExporterContext {
         );
 
         let service = ExporterService::new(sender);
-        service
-            .run(shutdown_notifier, self.config.service_config.port)
-            .await?;
-        handle.join().unwrap()
+
+        let mut block_processor_task = tokio::task::spawn_blocking(move || handle.join().unwrap());
+        tokio::select! {
+            result = service.run(shutdown_notifier, self.config.service_config.port) => {
+                result?;
+                block_processor_task.await.expect("block processor task panicked")
+            }
+            result = &mut block_processor_task => {
+                result.expect("block processor task panicked")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Motivation

Right now, if the block processor returns an error, since we await the service first, we'll never see that error unless the service receives some shutdown signal or itself finishes for some reason, which in most cases doesn't happen.
If the block processor returns an error, we should see that error and propagate it, even if the service is still running and receiving notifications.

## Proposal

poll both futures at once with `select!` so that if the block processor returns an error, we can panic as we should

## Test Plan

TBD

