### PR TITLE
Retry certificate reads for up to a second before erroring.

### DIFF
--- a/linera-service/src/exporter/runloops/block_processor/mod.rs
+++ b/linera-service/src/exporter/runloops/block_processor/mod.rs
@@ -31,7 +31,7 @@ where
     committee_destination_update: bool,
     // Temporary solution.
     // Tracks certificates that failed to be read from storage
-    // along with the time of the failure to avoid retrying too often.
+    // along with the time of the failure to avoid retrying for too long.
     retried_certs: HashMap<CryptoHash, (u8, Instant)>,
 }
 


### PR DESCRIPTION
## Motivation

In Testnet deployment we see that block processor fails to find the certificate in the DB. 

## Proposal

Scylla is eventually consistent database and maybe processor tries to read the cert before Scylla fully commits.

Retry certificate read for up to a second since the first try/failure.

## Test Plan

CI/manual.

## Release Plan

- These changes should be released to testnet deployment of exporter, and
- If successful backported to `main`.
- 
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
