### PR TITLE
Web client: make block_hash optional arg of query fn

### DIFF
--- a/examples/counter/index.html
+++ b/examples/counter/index.html
@@ -103,7 +103,7 @@
           });
 
           incrementButton.addEventListener('click', () => {
-              counter.query('{ "query": "mutation { increment(value: 1) }" }', '');
+              counter.query('{ "query": "mutation { increment(value: 1) }" }');
           });
       }
 

--- a/linera-web/src/lib.rs
+++ b/linera-web/src/lib.rs
@@ -477,13 +477,13 @@ impl Application {
     #[wasm_bindgen]
     // TODO(#14) allow passing bytes here rather than just strings
     // TODO(#15) a lot of this logic is shared with `linera_service::node_service`
-    pub async fn query(&self, query: &str, block_hash: &str) -> JsResult<String> {
+    pub async fn query(&self, query: &str, block_hash: Option<String>) -> JsResult<String> {
         tracing::debug!("querying application: {query}");
         let chain_client = self.client.default_chain_client().await?;
-        let block_hash = if block_hash.is_empty() {
-            None
+        let block_hash = if let Some(hash) = block_hash {
+            Some(hash.as_str().parse()?)
         } else {
-            Some(block_hash.parse()?)
+            None
         };
         let linera_execution::QueryOutcome {
             response: linera_execution::QueryResponse::User(response),


### PR DESCRIPTION
Backport of #4905 

## Motivation

In previous PRs we introduced an option to query app's state at a specific block (hash). It made the `query` method NOT backwards compatible b/c it required the new argument to be present.

## Proposal

Make argument optional. This allows `wasm-bindgen` to generate a code that does not fail when argument is not passed in.

## Test Plan

Manual. I tested the metamask demo – which doesn't supply the argument – and it worked.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.


## Links


- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
