### PR TITLE
[testnet] Sync if we learn about a new round while requesting a timeout.

### DIFF
--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2184,7 +2184,8 @@ where
         )
         .await;
 
-    // The transfer should succeed after the client discovers it's actually the leader in the validator's current round.
+    // The transfer should succeed after the client discovers it's actually the leader in the
+    // validator's current round.
     match result {
         Ok(ClientOutcome::Committed(_)) => {
             // Success! The client handled the round mismatch and completed the transfer.

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -4,6 +4,8 @@
 
 //! This module provides the executables needed to operate a Linera service, including a placeholder wallet acting as a GraphQL service for user interfaces.
 
+#![recursion_limit = "256"]
+
 pub mod cli;
 pub mod cli_wrappers;
 pub mod config;


### PR DESCRIPTION
## Motivation

If a client requests a timeout certificate and the validators return a `WrongRound` error with a _higher_ round, the client currently fails to update its local node about the new round, and thus cannot propose a block.

## Proposal

Synchronize the chain state if we get a `WrongRound` error with a round higher than the one we see locally. (Almost all done by Claude!)

## Test Plan

A regression test was added.

## Release Plan

- These changes should be ported to `main`.
- These changes should be released in a new SDK.

## Links

- Fixes #4909.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
