### PR TITLE
Add sqlite3 to Indexer image

### DIFF
--- a/docker/Dockerfile.indexer
+++ b/docker/Dockerfile.indexer
@@ -117,7 +117,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     pkg-config \
     protobuf-compiler \
     clang \
-    netcat-openbsd
+    netcat-openbsd \
+    sqlite3
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN update-ca-certificates
 


### PR DESCRIPTION
## Motivation

We need `sqlite3` there in case we want to do any operations to the SQLite DB as it's running.

## Proposal

Add `sqlite3` to the image.

## Test Plan

I'll merge this and sync the indexer with it

