### PR TITLE
Add gRPC keepalive configuration to detect stale connections

### DIFF
--- a/linera-rpc/src/grpc/transport.rs
+++ b/linera-rpc/src/grpc/transport.rs
@@ -34,7 +34,11 @@ cfg_if::cfg_if! {
             options: &Options,
         ) -> Result<Channel, Error> {
             let mut endpoint = tonic::transport::Endpoint::from_shared(address)?
-                .tls_config(tonic::transport::channel::ClientTlsConfig::default().with_webpki_roots())?;
+                .tls_config(tonic::transport::channel::ClientTlsConfig::default().with_webpki_roots())?
+                .tcp_keepalive(Some(std::time::Duration::from_secs(60)))
+                .http2_keep_alive_interval(std::time::Duration::from_secs(30))
+                .keep_alive_timeout(std::time::Duration::from_secs(10))
+                .keep_alive_while_idle(true);
 
             if let Some(timeout) = options.connect_timeout {
                 endpoint = endpoint.connect_timeout(timeout);


### PR DESCRIPTION
## Motivation

This is a forward port of #4908.

Seems that `connect_lazy` doesn't reconnect automatically unless we
specify a keep alive https://github.com/hyperium/tonic/issues/1254
There's some evidence we might be seeing that on the testnet on the
proxy, as the user from the issue is seeing the same errors we're
seeing.

## Proposal

Add keep alives so that they can expire and `connect_lazy` can reconnect
automatically.

## Test Plan

This has been deployed to `testnet-conway`

## Release Plan

- These changes have already been backported to the latest `testnet` branch
