### PR TITLE
Add sqlite3 to Indexer image

### DIFF
--- a/docker/Dockerfile.indexer
+++ b/docker/Dockerfile.indexer
@@ -117,7 +117,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     pkg-config \
     protobuf-compiler \
     clang \
-    netcat-openbsd
+    netcat-openbsd \
+    sqlite3
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN update-ca-certificates
 


### PR DESCRIPTION
## Motivation

This is useful for debugging, in case we want to go into the pod and see what's going on with the sqlite db.
We can't use the debug docker image for this, because sharing the same disk as the main container is trickier to setup.

## Proposal

Add `sqlite3` to the image.

## Test Plan

CI, this should be pretty harmless, and I've checked that `sqlite3` is possible to be installed there.

## Release Plan

- These changes have already been backported to the latest `testnet` branch
