### PR TITLE
[testnet] Backport the "fn root_key" and the MissingEntries change (#4916)

### DIFF
--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -111,6 +111,10 @@ impl ReadableKeyValueStore for KeyValueStore {
         1
     }
 
+    fn root_key(&self) -> Result<Vec<u8>, KeyValueStoreError> {
+        Ok(Vec::new())
+    }
+
     async fn contains_key(&self, key: &[u8]) -> Result<bool, KeyValueStoreError> {
         ensure!(
             key.len() <= Self::MAX_KEY_SIZE,

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -361,7 +361,7 @@ where
             }
             ViewError::NotFound(_)
             | ViewError::CannotAcquireCollectionEntry
-            | ViewError::MissingEntries => Status::not_found(err.to_string()),
+            | ViewError::MissingEntries(_) => Status::not_found(err.to_string()),
         };
         status.set_source(Arc::new(err));
         status

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -98,6 +98,10 @@ impl ReadableKeyValueStore for StorageServiceStoreInternal {
         self.max_stream_queries
     }
 
+    fn root_key(&self) -> Result<Vec<u8>, StorageServiceStoreError> {
+        Ok(self.start_key[self.prefix_len..].to_vec())
+    }
+
     async fn read_value_bytes(
         &self,
         key: &[u8],

--- a/linera-storage/src/migration.rs
+++ b/linera-storage/src/migration.rs
@@ -135,7 +135,7 @@ where
                 .await?;
             let mut batch = MultiPartitionBatch::new();
             for (base_key, value) in chunk_base_keys.iter().zip(values) {
-                let value = value.ok_or(ViewError::MissingEntries)?;
+                let value = value.ok_or(ViewError::MissingEntries(Vec::new()))?;
                 let (root_key, key) = map_base_key(base_key)?;
                 batch.put_key_value(root_key, key, value);
             }
@@ -169,7 +169,7 @@ where
                 return Ok(());
             }
             let result = self.migrate_v0_to_v1().await;
-            if let Err(ViewError::MissingEntries) = result {
+            if let Err(ViewError::MissingEntries(_)) = result {
                 tracing::warn!(
                     "It looks like a migration is already in progress on this database. \
                      I will wait for {:?} minutes and retry.",

--- a/linera-views/src/backends/dual.rs
+++ b/linera-views/src/backends/dual.rs
@@ -96,6 +96,13 @@ where
         }
     }
 
+    fn root_key(&self) -> Result<Vec<u8>, Self::Error> {
+        Ok(match self {
+            Self::First(store) => store.root_key().map_err(DualStoreError::First)?,
+            Self::Second(store) => store.root_key().map_err(DualStoreError::Second)?,
+        })
+    }
+
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         let result = match self {
             Self::First(store) => store

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -719,6 +719,11 @@ impl ReadableKeyValueStore for DynamoDbStoreInternal {
         self.max_stream_queries
     }
 
+    fn root_key(&self) -> Result<Vec<u8>, DynamoDbStoreInternalError> {
+        assert!(self.start_key.starts_with(EMPTY_ROOT_KEY));
+        Ok(self.start_key[EMPTY_ROOT_KEY.len()..].to_vec())
+    }
+
     async fn read_value_bytes(
         &self,
         key: &[u8],

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -119,6 +119,12 @@ impl ReadableKeyValueStore for IndexedDbStore {
         self.max_stream_queries
     }
 
+    fn root_key(&self) -> Result<Vec<u8>, IndexedDbStoreError> {
+        assert!(self.start_key.starts_with(&ROOT_KEY_DOMAIN));
+        let root_key = self.start_key[ROOT_KEY_DOMAIN.len()..].to_vec();
+        Ok(root_key)
+    }
+
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, IndexedDbStoreError> {
         let key = self.full_key(key);
         let key = js_sys::Uint8Array::from(key.as_slice());

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -123,6 +123,10 @@ where
         self.store.max_stream_queries()
     }
 
+    fn root_key(&self) -> Result<Vec<u8>, Self::Error> {
+        self.store.root_key()
+    }
+
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         self.store.read_value_bytes(key).await
     }

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -291,6 +291,10 @@ where
         self.store.max_stream_queries()
     }
 
+    fn root_key(&self) -> Result<Vec<u8>, Self::Error> {
+        self.store.root_key()
+    }
+
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         let Some(cache) = &self.cache else {
             return self.store.read_value_bytes(key).await;

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -73,6 +73,7 @@ impl MemoryDatabases {
         let map = store.clone();
         Ok(MemoryStore {
             map,
+            root_key: root_key.to_vec(),
             max_stream_queries,
         })
     }
@@ -111,6 +112,8 @@ static MEMORY_DATABASES: LazyLock<Mutex<MemoryDatabases>> =
 pub struct MemoryStore {
     /// The map used for storing the data.
     map: Arc<RwLock<MemoryStoreMap>>,
+    /// The root key.
+    root_key: Vec<u8>,
     /// The maximum number of queries used for a stream.
     max_stream_queries: usize,
 }
@@ -128,6 +131,10 @@ impl ReadableKeyValueStore for MemoryStore {
 
     fn max_stream_queries(&self) -> usize {
         self.max_stream_queries
+    }
+
+    fn root_key(&self) -> Result<Vec<u8>, MemoryStoreError> {
+        Ok(self.root_key.clone())
     }
 
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MemoryStoreError> {
@@ -247,6 +254,7 @@ impl MemoryStore {
     pub fn new_for_testing() -> Self {
         Self {
             map: Arc::default(),
+            root_key: Vec::new(),
             max_stream_queries: TEST_MEMORY_MAX_STREAM_QUERIES,
         }
     }

--- a/linera-views/src/backends/metering.rs
+++ b/linera-views/src/backends/metering.rs
@@ -312,6 +312,10 @@ where
         self.store.max_stream_queries()
     }
 
+    fn root_key(&self) -> Result<Vec<u8>, Self::Error> {
+        self.store.root_key()
+    }
+
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         let _latency = self.counter.read_value_bytes_latency.measure_latency();
         self.counter

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -431,6 +431,12 @@ impl ReadableKeyValueStore for RocksDbStoreInternal {
         self.max_stream_queries
     }
 
+    fn root_key(&self) -> Result<Vec<u8>, RocksDbStoreInternalError> {
+        assert!(self.executor.start_key.starts_with(&ROOT_KEY_DOMAIN));
+        let root_key = self.executor.start_key[ROOT_KEY_DOMAIN.len()..].to_vec();
+        Ok(root_key)
+    }
+
     async fn read_value_bytes(
         &self,
         key: &[u8],

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -613,6 +613,10 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
         self.max_stream_queries
     }
 
+    fn root_key(&self) -> Result<Vec<u8>, ScyllaDbStoreInternalError> {
+        Ok(self.root_key[1..].to_vec())
+    }
+
     async fn read_value_bytes(
         &self,
         key: &[u8],

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -96,6 +96,10 @@ where
         self.store.max_stream_queries()
     }
 
+    fn root_key(&self) -> Result<Vec<u8>, Self::Error> {
+        Ok(self.store.root_key()?)
+    }
+
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         let mut big_key = key.to_vec();
         big_key.extend(&[0, 0, 0, 0]);
@@ -426,6 +430,10 @@ impl ReadableKeyValueStore for LimitedTestMemoryStore {
 
     fn max_stream_queries(&self) -> usize {
         self.inner.max_stream_queries()
+    }
+
+    fn root_key(&self) -> Result<Vec<u8>, MemoryStoreError> {
+        self.inner.root_key()
     }
 
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MemoryStoreError> {

--- a/linera-views/src/error.rs
+++ b/linera-views/src/error.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use linera_base::hex;
+
 /// Main error type for the crate.
 #[derive(thiserror::Error, Debug)]
 pub enum ViewError {
@@ -54,8 +56,8 @@ pub enum ViewError {
     InconsistentEntries,
 
     /// The database is corrupt: Some entries are missing
-    #[error("missing database entries")]
-    MissingEntries,
+    #[error("missing database entrie for the root key {}", hex::encode(.0))]
+    MissingEntries(Vec<u8>),
 
     /// The values are incoherent.
     #[error("post load values error")]

--- a/linera-views/src/error.rs
+++ b/linera-views/src/error.rs
@@ -56,7 +56,7 @@ pub enum ViewError {
     InconsistentEntries,
 
     /// The database is corrupt: Some entries are missing
-    #[error("missing database entrie for the root key {}", hex::encode(.0))]
+    #[error("missing database entries for the root key {}", hex::encode(.0))]
     MissingEntries(Vec<u8>),
 
     /// The values are incoherent.

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -47,6 +47,9 @@ pub trait ReadableKeyValueStore: WithError {
     /// Retrieve the number of stream queries.
     fn max_stream_queries(&self) -> usize;
 
+    /// Gets the root key of the store.
+    fn root_key(&self) -> Result<Vec<u8>, Self::Error>;
+
     /// Retrieves a `Vec<u8>` from the database using the provided `key`.
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
 
@@ -291,6 +294,10 @@ pub mod inactive_store {
 
         fn max_stream_queries(&self) -> usize {
             0
+        }
+
+        fn root_key(&self) -> Result<Vec<u8>, Self::Error> {
+            panic!("attempt to read from an inactive store!")
         }
 
         async fn read_value_bytes(&self, _key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -453,9 +453,14 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
                     let index = *index;
                     if !bucket.is_loaded() {
                         let key = self.get_index_key(index)?;
-                        let value = self.context.store().read_value_bytes(&key).await?;
-                        let value = value.ok_or(ViewError::MissingEntries)?;
-                        let data = bcs::from_bytes(&value)?;
+                        let data = self.context.store().read_value(&key).await?;
+                        let data = match data {
+                            Some(value) => value,
+                            None => {
+                                let root_key = self.context.store().root_key()?;
+                                return Err(ViewError::MissingEntries(root_key));
+                            }
+                        };
                         self.stored_data[i_block].1 = Bucket::Loaded { data };
                     }
                 }
@@ -529,9 +534,14 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
         };
         if !bucket.is_loaded() {
             let key = self.get_index_key(*index)?;
-            let value = self.context.store().read_value_bytes(&key).await?;
-            let value = value.as_ref().ok_or(ViewError::MissingEntries)?;
-            let data = bcs::from_bytes::<Vec<T>>(value)?;
+            let data = self.context.store().read_value(&key).await?;
+            let data = match data {
+                Some(data) => data,
+                None => {
+                    let root_key = self.context.store().root_key()?;
+                    return Err(ViewError::MissingEntries(root_key));
+                }
+            };
             self.stored_data.back_mut().unwrap().1 = Bucket::Loaded { data };
         }
         let bucket = &self.stored_data.back_mut().unwrap().1;
@@ -577,9 +587,13 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
                 let vec = match bucket {
                     Bucket::Loaded { data } => data,
                     Bucket::NotLoaded { .. } => {
-                        let value = values[value_pos]
-                            .as_ref()
-                            .ok_or(ViewError::MissingEntries)?;
+                        let value = match &values[value_pos] {
+                            Some(value) => value,
+                            None => {
+                                let root_key = self.context.store().root_key()?;
+                                return Err(ViewError::MissingEntries(root_key));
+                            }
+                        };
                         value_pos += 1;
                         &bcs::from_bytes::<Vec<T>>(value)?
                     }

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -1237,6 +1237,10 @@ impl<C: Context> ReadableKeyValueStore for ViewContainer<C> {
         1
     }
 
+    fn root_key(&self) -> Result<Vec<u8>, ViewContainerError> {
+        Ok(Vec::new())
+    }
+
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, ViewContainerError> {
         let view = self.view.read().await;
         Ok(view.get(key).await?)

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -282,7 +282,8 @@ where
         for entry in self.context.store().read_multi_values(keys).await? {
             match entry {
                 None => {
-                    return Err(ViewError::MissingEntries);
+                    let root_key = self.context.store().root_key()?;
+                    return Err(ViewError::MissingEntries(root_key));
                 }
                 Some(value) => values.push(value),
             }

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -311,7 +311,8 @@ where
         for entry in self.context.store().read_multi_values(keys).await? {
             match entry {
                 None => {
-                    return Err(ViewError::MissingEntries);
+                    let root_key = self.context.store().root_key()?;
+                    return Err(ViewError::MissingEntries(root_key));
                 }
                 Some(value) => values.push(value),
             }


### PR DESCRIPTION
Backport https://github.com/linera-io/linera-protocol/pull/4916.

## Motivation

The "fn root_key(&self)" function and the "MissingEntries(Vec<u8>)" are of interest to TestNet usage.

## Proposal

Backport the change.
It is not completely straightforward, since the handling of `root_key` has changed in main for RocksDB and StorageService (see https://github.com/linera-io/linera-protocol/pull/4859 and https://github.com/linera-io/linera-protocol/pull/4858).

## Test Plan

The same test function has been added.

## Release Plan

To TestNet Conway.

## Links

None.