### PR TITLE
Don't pass empty string, it's optional

### DIFF
--- a/examples/counter/index.html
+++ b/examples/counter/index.html
@@ -85,7 +85,7 @@
           }
 
           async function updateCount(block_hash) {
-              const response = await counter.query('{ "query": "query { value }" }', block_hash || '');
+              const response = await counter.query('{ "query": "query { value }" }', block_hash);
               document.getElementById('count').innerText
                   = JSON.parse(response).data.value;
           }

--- a/examples/native-fungible/index.html
+++ b/examples/native-fungible/index.html
@@ -166,7 +166,7 @@
       }
 
       async function updateBalance(application, owner, blockHash) {
-          const response = JSON.parse(await application.query(gql(`query { tickerSymbol, accounts { entry(key: "${owner}") { value } } }`), blockHash || ''));
+          const response = JSON.parse(await application.query(gql(`query { tickerSymbol, accounts { entry(key: "${owner}") { value } } }`)));
           console.debug('application response:', response);
           document.querySelector('#ticker-symbol').textContent = response.data.tickerSymbol;
           document.querySelector('#balance').textContent = (+(response?.data?.accounts?.entry.value || 0)).toFixed(2);


### PR DESCRIPTION
## Motivation

We are seeing errors in the console, coming from the Linera web client, about CryptoHash expecting 32-bytes but getting 0.

## Proposal

This happens b/c frontends pass empty string (`''`) to a method (`query`) that expects `Option<CryptoHash>` and assuming that if it's `Some(_)` it must be correct slice.

After fixing `query` in #4904 I forgot to update this.

## Test Plan

Manual. Verified that with this fix we no longer get the errors.

## Release Plan

- Release web demos to the frontend
- Backport fix to `main`

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
