### PR TITLE
Add a notion of lease in journaling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5960,6 +5960,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-test",
+ "tokio-util",
  "tracing",
  "trait-variant",
  "wasm-bindgen",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3927,6 +3927,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.65",
  "tokio",
+ "tokio-util",
  "tracing",
  "trait-variant",
  "web-sys",

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -62,7 +62,7 @@ sync_wrapper.workspace = true
 sysinfo.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["rt", "sync"] }
+tokio = { workspace = true, features = ["rt", "sync", "macros"] }
 tokio-util.workspace = true
 tracing.workspace = true
 trait-variant.workspace = true

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -63,6 +63,7 @@ sysinfo.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "sync"] }
+tokio-util.workspace = true
 tracing.workspace = true
 trait-variant.workspace = true
 

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -18,9 +18,11 @@ use aws_sdk_dynamodb::{
     operation::{
         batch_get_item::BatchGetItemError,
         create_table::CreateTableError,
+        delete_item::DeleteItemError,
         delete_table::DeleteTableError,
         get_item::GetItemError,
         list_tables::ListTablesError,
+        put_item::PutItemError,
         query::{QueryError, QueryOutput},
         transact_write_items::TransactWriteItemsError,
     },
@@ -47,8 +49,8 @@ use crate::{
     journaling::{JournalConsistencyError, JournalingKeyValueDatabase},
     lru_caching::{LruCachingConfig, LruCachingDatabase},
     store::{
-        DirectWritableKeyValueStore, KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore,
-        WithError,
+        DirectWritableKeyValueStore, KeyValueDatabase, KeyValueStoreError, LeaseConflict,
+        ReadableKeyValueStore, WithError,
     },
     value_splitting::{ValueSplittingDatabase, ValueSplittingError},
     FutureSyncExt as _,
@@ -105,6 +107,12 @@ const VALUE_ATTRIBUTE: &str = "item_value";
 
 /// The attribute for obtaining the primary key (used as a sort key) with the stored value.
 const KEY_VALUE_ATTRIBUTE: &str = "item_key, item_value";
+
+/// The attribute name for lease UUID (stored as a string).
+const LEASE_UUID_ATTRIBUTE: &str = "lease_uuid";
+
+/// The attribute name for lease expiration timestamp.
+const LEASE_EXPIRATION_ATTRIBUTE: &str = "lease_expiration";
 
 /// TODO(#1084): The scheme below with the `MAX_VALUE_SIZE` has to be checked
 /// This is the maximum size of a raw value in DynamoDB.
@@ -203,6 +211,37 @@ fn build_key_value(
         (
             VALUE_ATTRIBUTE.to_owned(),
             AttributeValue::B(Blob::new(value)),
+        ),
+    ]
+    .into()
+}
+
+/// Builds a lease item with UUID and expiration as separate attributes for condition expressions.
+fn build_lease_item(
+    start_key: &[u8],
+    key: Vec<u8>,
+    uuid: u64,
+    expiration: u64,
+) -> HashMap<String, AttributeValue> {
+    let mut prefixed_key = vec![1];
+    prefixed_key.extend(key);
+
+    [
+        (
+            PARTITION_ATTRIBUTE.to_owned(),
+            AttributeValue::B(Blob::new(start_key.to_vec())),
+        ),
+        (
+            KEY_ATTRIBUTE.to_owned(),
+            AttributeValue::B(Blob::new(prefixed_key)),
+        ),
+        (
+            LEASE_UUID_ATTRIBUTE.to_owned(),
+            AttributeValue::N(uuid.to_string()),
+        ),
+        (
+            LEASE_EXPIRATION_ATTRIBUTE.to_owned(),
+            AttributeValue::N(expiration.to_string()),
         ),
     ]
     .into()
@@ -938,6 +977,150 @@ impl DirectWritableKeyValueStore for DynamoDbStoreInternal {
         }
         Ok(())
     }
+
+    async fn obtain_lease(
+        &self,
+        key: Vec<u8>,
+        uuid: u64,
+        ttl: std::time::Duration,
+    ) -> Result<Result<(), LeaseConflict>, DynamoDbStoreInternalError> {
+        check_key_size(&key)?;
+
+        // Calculate expiration timestamp
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let expiration = now + ttl.as_secs();
+
+        // Build the key_db for potential error handling
+        let key_db = build_key(&self.start_key, key.clone());
+
+        // Build the lease item with separate UUID and expiration attributes
+        let item = build_lease_item(&self.start_key, key, uuid, expiration);
+
+        // Use condition expression to ensure atomic operation:
+        // Allow write if:
+        // 1. Item doesn't exist (attribute_not_exists), OR
+        // 2. UUID matches (:uuid), OR
+        // 3. Expiration has passed (< :now)
+        let condition = format!(
+            "attribute_not_exists({}) OR {} = :uuid OR {} < :now",
+            LEASE_UUID_ATTRIBUTE, LEASE_UUID_ATTRIBUTE, LEASE_EXPIRATION_ATTRIBUTE
+        );
+
+        let result = self
+            .client
+            .put_item()
+            .table_name(&self.namespace)
+            .set_item(Some(item))
+            .condition_expression(condition)
+            .expression_attribute_values(":uuid", AttributeValue::N(uuid.to_string()))
+            .expression_attribute_values(":now", AttributeValue::N(now.to_string()))
+            .send()
+            .boxed_sync()
+            .await;
+
+        // Handle conditional check failure
+        match result {
+            Ok(_) => Ok(Ok(())),
+            Err(err) => {
+                // Check if this is a conditional check failure
+                if let SdkError::ServiceError(ref service_err) = err {
+                    if service_err.err().is_conditional_check_failed_exception() {
+                        // Read the existing lease UUID and expiration for the error message
+                        let response = self
+                            .client
+                            .get_item()
+                            .table_name(&self.namespace)
+                            .set_key(Some(key_db))
+                            .projection_expression(format!(
+                                "{}, {}",
+                                LEASE_UUID_ATTRIBUTE, LEASE_EXPIRATION_ATTRIBUTE
+                            ))
+                            .send()
+                            .boxed_sync()
+                            .await?;
+
+                        let (existing_uuid, expiration) = if let Some(item) = response.item {
+                            let uuid = item
+                                .get(LEASE_UUID_ATTRIBUTE)
+                                .and_then(|attr| {
+                                    if let AttributeValue::N(n) = attr {
+                                        n.parse::<u64>().ok()
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .unwrap_or(0);
+
+                            let exp = item
+                                .get(LEASE_EXPIRATION_ATTRIBUTE)
+                                .and_then(|attr| {
+                                    if let AttributeValue::N(n) = attr {
+                                        n.parse::<u64>().ok()
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .unwrap_or(0);
+
+                            (uuid, exp)
+                        } else {
+                            (0, 0)
+                        };
+
+                        return Ok(Err(LeaseConflict {
+                            uuid: existing_uuid,
+                            timestamp: expiration,
+                        }));
+                    }
+                }
+                Err(err.into())
+            }
+        }
+    }
+
+    async fn discard_lease(
+        &self,
+        key: Vec<u8>,
+        uuid: u64,
+    ) -> Result<(), DynamoDbStoreInternalError> {
+        check_key_size(&key)?;
+
+        // Build the key for deletion
+        let key_db = build_key(&self.start_key, key);
+
+        // Use condition expression to ensure atomic operation:
+        // Only delete if the UUID matches
+        let condition = format!("{} = :uuid", LEASE_UUID_ATTRIBUTE);
+
+        let result = self
+            .client
+            .delete_item()
+            .table_name(&self.namespace)
+            .set_key(Some(key_db.clone()))
+            .condition_expression(condition)
+            .expression_attribute_values(":uuid", AttributeValue::N(uuid.to_string()))
+            .send()
+            .boxed_sync()
+            .await;
+
+        // Handle conditional check failure
+        match result {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                // Check if this is a conditional check failure
+                if let SdkError::ServiceError(ref service_err) = err {
+                    if service_err.err().is_conditional_check_failed_exception() {
+                        tracing::warn!("Failed to discard lease");
+                        return Ok(());
+                    }
+                }
+                Err(err.into())
+            }
+        }
+    }
 }
 
 /// Error when validating a namespace
@@ -970,6 +1153,14 @@ pub enum DynamoDbStoreInternalError {
     /// An error occurred while writing a transaction of items.
     #[error(transparent)]
     TransactWriteItem(#[from] Box<SdkError<TransactWriteItemsError>>),
+
+    /// An error occurred while putting an item.
+    #[error(transparent)]
+    PutItem(#[from] Box<SdkError<PutItemError>>),
+
+    /// An error occurred while deleting an item.
+    #[error(transparent)]
+    DeleteItem(#[from] Box<SdkError<DeleteItemError>>),
 
     /// An error occurred while doing a Query.
     #[error(transparent)]

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -47,8 +47,8 @@ use crate::{
     journaling::{JournalConsistencyError, JournalingKeyValueDatabase},
     lru_caching::{LruCachingConfig, LruCachingDatabase},
     store::{
-        DirectWritableKeyValueStore, KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore,
-        WithError,
+        DirectWritableKeyValueStore, KeyValueDatabase, KeyValueStoreError, LeaseConflict,
+        ReadableKeyValueStore, WithError,
     },
     value_splitting::{ValueSplittingDatabase, ValueSplittingError},
     FutureSyncExt as _,
@@ -116,6 +116,9 @@ struct ScyllaDbClient {
     find_key_values_by_prefix_bounded: PreparedStatement,
     multi_key_values: papaya::HashMap<usize, PreparedStatement>,
     multi_keys: papaya::HashMap<usize, PreparedStatement>,
+    lease_obtain_lwt: PreparedStatement,
+    lease_delete_lwt: PreparedStatement,
+    lease_read_lease_info: PreparedStatement,
 }
 
 impl ScyllaDbClient {
@@ -191,6 +194,40 @@ impl ScyllaDbClient {
             ))
             .await?;
 
+        // Lightweight transaction for lease obtain/renewal
+        // In CQL, when a row doesn't exist, columns are NULL in the condition
+        // This single statement handles:
+        // - Insert if row doesn't exist (lease_uuid = NULL)
+        // - Update if UUID matches (lease_uuid = ?)
+        // - Update if lease has expired (lease_expiration < ?)
+        let lease_obtain_lwt = session
+            .prepare(format!(
+                "UPDATE {}.\"{}\" SET lease_uuid = ?, lease_expiration = ? \
+                WHERE root_key = ? AND k = ? \
+                IF lease_uuid = NULL OR lease_uuid = ? OR lease_expiration < ?",
+                KEYSPACE, namespace
+            ))
+            .await?;
+
+        // Lightweight transaction for lease deletion
+        // Only delete if UUID matches
+        let lease_delete_lwt = session
+            .prepare(format!(
+                "DELETE FROM {}.\"{}\" \
+                WHERE root_key = ? AND k = ? \
+                IF lease_uuid = ?",
+                KEYSPACE, namespace
+            ))
+            .await?;
+
+        // Read lease UUID and expiration for error messages
+        let lease_read_lease_info = session
+            .prepare(format!(
+                "SELECT lease_uuid, lease_expiration FROM {}.\"{}\" WHERE root_key = ? AND k = ?",
+                KEYSPACE, namespace
+            ))
+            .await?;
+
         Ok(Self {
             session,
             namespace,
@@ -206,6 +243,9 @@ impl ScyllaDbClient {
             find_key_values_by_prefix_bounded,
             multi_key_values: papaya::HashMap::new(),
             multi_keys: papaya::HashMap::new(),
+            lease_obtain_lwt,
+            lease_delete_lwt,
+            lease_read_lease_info,
         })
     }
 
@@ -710,6 +750,129 @@ impl DirectWritableKeyValueStore for ScyllaDbStoreInternal {
         let _guard = self.acquire().await;
         store.write_batch_internal(&self.root_key, batch).await
     }
+
+    async fn obtain_lease(
+        &self,
+        key: Vec<u8>,
+        uuid: u64,
+        ttl: std::time::Duration,
+    ) -> Result<Result<(), LeaseConflict>, ScyllaDbStoreInternalError> {
+        ScyllaDbClient::check_key_size(&key)?;
+
+        // Calculate expiration timestamp
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let expiration = now + ttl.as_secs();
+
+        let store = self.store.deref();
+
+        // Convert u64 to i64 for varint compatibility
+        let uuid_i64 = uuid as i64;
+        let expiration_i64 = expiration as i64;
+
+        // Use single atomic LWT that handles insert and update cases
+        // The condition checks:
+        // - lease_uuid = NULL (row doesn't exist)
+        // - lease_uuid = ? (same owner renewing)
+        // - lease_expiration < ? (lease has expired)
+        let values = (
+            uuid_i64,
+            expiration_i64,
+            self.root_key.to_vec(),
+            key.clone(),
+            uuid_i64,
+            now as i64,
+        );
+
+        let (result, _) = store
+            .session
+            .execute_single_page(
+                &store.lease_obtain_lwt,
+                &values,
+                scylla::response::PagingState::start(),
+            )
+            .await?;
+
+        // Check if the LWT was applied
+        let rows = result.into_rows_result()?;
+        let mut rows = rows.rows::<(bool,)>()?;
+
+        if let Some(row) = rows.next() {
+            let (applied,) = row?;
+            if applied {
+                // Successfully obtained/renewed lease
+                return Ok(Ok(()));
+            }
+        }
+
+        // LWT failed - a different non-expired lease exists
+        // Read the UUID and expiration for error reporting
+        let (read_result, _) = store
+            .session
+            .execute_single_page(
+                &store.lease_read_lease_info,
+                &(self.root_key.to_vec(), key),
+                scylla::response::PagingState::start(),
+            )
+            .await?;
+
+        let read_rows = read_result.into_rows_result()?;
+        let mut read_rows = read_rows.rows::<(i64, i64)>()?;
+
+        let (existing_uuid, expiration) = if let Some(row) = read_rows.next() {
+            let (uuid, exp) = row?;
+            (uuid as u64, exp as u64)
+        } else {
+            (0, 0)
+        };
+
+        Ok(Err(LeaseConflict {
+            uuid: existing_uuid,
+            timestamp: expiration,
+        }))
+    }
+
+    async fn discard_lease(
+        &self,
+        key: Vec<u8>,
+        uuid: u64,
+    ) -> Result<(), ScyllaDbStoreInternalError> {
+        ScyllaDbClient::check_key_size(&key)?;
+
+        let store = self.store.deref();
+
+        // Convert u64 to i64 for varint compatibility
+        let uuid_i64 = uuid as i64;
+
+        // Use lightweight transaction: DELETE IF lease_uuid = ?
+        let values = (self.root_key.to_vec(), key.clone(), uuid_i64);
+
+        let (result, _) = store
+            .session
+            .execute_single_page(
+                &store.lease_delete_lwt,
+                &values,
+                scylla::response::PagingState::start(),
+            )
+            .await?;
+
+        // Check if the LWT was applied
+        let rows = result.into_rows_result()?;
+        let mut rows = rows.rows::<(bool,)>()?;
+
+        if let Some(row) = rows.next() {
+            let (applied,) = row?;
+            if !applied {
+                // Delete failed - UUID doesn't match or row doesn't exist
+                tracing::warn!("Failed to discard lease");
+                return Ok(());
+            }
+        }
+
+        Ok(())
+    }
 }
 
 // ScyllaDB requires that the keys are non-empty.
@@ -918,6 +1081,8 @@ impl KeyValueDatabase for ScyllaDbDatabaseInternal {
                     root_key blob, \
                     k blob, \
                     v blob, \
+                    lease_uuid varint, \
+                    lease_expiration bigint, \
                     PRIMARY KEY (root_key, k) \
                 ) \
                 WITH compaction = {{ \


### PR DESCRIPTION
## Motivation

Prevent DB corruption

## Proposal

* Add a lease management API to DirectWritableKeyValueStore
* Use it in journaling.rs

TODO:
* tests
* add journaling to the storage-service?
* deduplicate code
* make the TTL configurable
* in scylladb we could also use `USING TTL`

## Test Plan

CI + TBD

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.
