### PR TITLE
First request should be subject to a delayed alternative.

### DIFF
--- a/linera-core/src/client/requests_scheduler/in_flight_tracker.rs
+++ b/linera-core/src/client/requests_scheduler/in_flight_tracker.rs
@@ -192,7 +192,7 @@ impl<N: Clone> InFlightTracker<N> {
     /// Pops and returns the newest alternative peer from the list.
     ///
     /// Removes and returns the last peer from the alternative peers list (LIFO - newest first).
-    /// Returns None if the entry doesn't exist or the list is empty.
+    /// Returns `None` if the entry doesn't exist or the list is empty.
     ///
     /// # Arguments
     /// - `key`: The request key to look up

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -1314,7 +1314,7 @@ mod tests {
         // Give time for alternative peers to register
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        // With the new implementation, alternatives are being popped as staggered parallel runs.
+        // Alternatives are being popped as staggered parallel runs.
         // The first request is blocked waiting for the signal, so staggered parallel has started
         // and may have already popped one or both alternatives. We just verify that at least
         // one alternative was registered (before being popped).
@@ -1457,7 +1457,7 @@ mod tests {
         );
 
         // Second call should start immediately after first fails (aggressive retry)
-        // With new implementation, when node 0 fails immediately, we immediately start node 1
+        // When node 0 fails immediately, we immediately start node 1
         if times.len() > 1 {
             let delay = times[1].1.as_millis();
             assert!(


### PR DESCRIPTION
## Motivation

`RequestsScheduler` sends a request to a first peer and, if it fails or time out, enter `try_staggerred_parallel` function which will try new requests after ever-increasing delay (but before the requests time out or fail). This is inconsistent and vulnerable when first request is sent to a slow/unavailable/malicious peer.

## Proposal

Make the logic consistent: first request is subject to the same retry-after-delay logic as the rest. If delay fires first, a new request (to an alternative peer) is started and delay updated. If any request fails w/ an error – a new request is started.

## Test Plan

A unit test already exists for this.

## Release Plan

- These changes should be deployed to testnet and then backported to `main`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
