### PR TITLE
Reorder operations in `write_batch`.

### DIFF
--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -356,11 +356,8 @@ where
     const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), Self::Error> {
-        let Some(cache) = &self.cache else {
-            return self.store.write_batch(batch).await;
-        };
-
-        {
+        self.store.write_batch(batch.clone()).await?;
+        if let Some(cache) = &self.cache {
             let mut cache = cache.lock().unwrap();
             for operation in &batch.operations {
                 match operation {
@@ -376,7 +373,7 @@ where
                 }
             }
         }
-        self.store.write_batch(batch).await
+        Ok(())
     }
 
     async fn clear_journal(&self) -> Result<(), Self::Error> {


### PR DESCRIPTION
## Motivation

The LRU caching was updating the cache before the batch was written. This means the cache could be invalid if write failed.

## Proposal

Change the order of the operations.

## Test Plan

CI.

## Release Plan

Could be of course backported.

## Links

None.