### PR TITLE
Improve the native fungible token ABI

### DIFF
--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -5,7 +5,7 @@
 
 use linera_sdk::{
     abis::fungible::{
-        FungibleResponse, InitialState, NativeFungibleOperation, NativeFungibleTokenAbi, Parameters,
+        FungibleOperation, FungibleResponse, FungibleTokenAbi, InitialState, Parameters,
     },
     linera_base_types::{Account, AccountOwner, ChainId, WithContractAbi},
     Contract, ContractRuntime,
@@ -19,7 +19,7 @@ pub struct NativeFungibleTokenContract {
 linera_sdk::contract!(NativeFungibleTokenContract);
 
 impl WithContractAbi for NativeFungibleTokenContract {
-    type Abi = NativeFungibleTokenAbi;
+    type Abi = FungibleTokenAbi;
 }
 
 impl Contract for NativeFungibleTokenContract {
@@ -49,16 +49,20 @@ impl Contract for NativeFungibleTokenContract {
 
     async fn execute_operation(&mut self, operation: Self::Operation) -> Self::Response {
         match operation {
-            NativeFungibleOperation::Balance { owner } => {
+            FungibleOperation::Balance { owner } => {
                 let balance = self.runtime.owner_balance(owner);
                 FungibleResponse::Balance(balance)
             }
 
-            NativeFungibleOperation::TickerSymbol => {
+            FungibleOperation::TickerSymbol => {
                 FungibleResponse::TickerSymbol(String::from(TICKER_SYMBOL))
             }
 
-            NativeFungibleOperation::Transfer {
+            FungibleOperation::Approve { .. } => {
+                panic!("Approve operation is not supported by native fungible token")
+            }
+
+            FungibleOperation::Transfer {
                 owner,
                 amount,
                 target_account,
@@ -76,7 +80,11 @@ impl Contract for NativeFungibleTokenContract {
                 FungibleResponse::Ok
             }
 
-            NativeFungibleOperation::Claim {
+            FungibleOperation::TransferFrom { .. } => {
+                panic!("TransferFrom operation is not supported by native fungible token")
+            }
+
+            FungibleOperation::Claim {
                 source_account,
                 amount,
                 target_account,

--- a/examples/native-fungible/src/service.rs
+++ b/examples/native-fungible/src/service.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
 use fungible::Parameters;
 use linera_sdk::{
-    abis::fungible::{NativeFungibleOperation, NativeFungibleTokenAbi},
+    abis::fungible::{FungibleOperation, FungibleTokenAbi},
     graphql::GraphQLMutationRoot as _,
     linera_base_types::{AccountOwner, WithServiceAbi},
     Service, ServiceRuntime,
@@ -23,7 +23,7 @@ pub struct NativeFungibleTokenService {
 linera_sdk::service!(NativeFungibleTokenService);
 
 impl WithServiceAbi for NativeFungibleTokenService {
-    type Abi = NativeFungibleTokenAbi;
+    type Abi = FungibleTokenAbi;
 }
 
 impl Service for NativeFungibleTokenService {
@@ -38,7 +38,7 @@ impl Service for NativeFungibleTokenService {
     async fn handle_query(&self, request: Request) -> Response {
         let schema = Schema::build(
             self.clone(),
-            NativeFungibleOperation::mutation_root(self.runtime.clone()),
+            FungibleOperation::mutation_root(self.runtime.clone()),
             EmptySubscription,
         )
         .finish();

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use fungible::{self, NativeFungibleTokenAbi};
+use fungible::{self, FungibleTokenAbi};
 use linera_sdk::{
     linera_base_types::{Account, AccountOwner, Amount, CryptoHash},
     test::{ActiveChain, TestValidator},
@@ -21,7 +21,7 @@ async fn chain_balance_transfers() {
     };
     let initial_state = fungible::InitialStateBuilder::default().build();
     let (validator, _application_id, recipient_chain) = TestValidator::with_current_application::<
-        NativeFungibleTokenAbi,
+        FungibleTokenAbi,
         _,
         _,
     >(parameters, initial_state)
@@ -58,7 +58,7 @@ async fn transfer_to_owner() {
     };
     let initial_state = fungible::InitialStateBuilder::default().build();
     let (validator, _application_id, recipient_chain) = TestValidator::with_current_application::<
-        NativeFungibleTokenAbi,
+        FungibleTokenAbi,
         _,
         _,
     >(parameters, initial_state)
@@ -92,7 +92,7 @@ async fn transfer_to_multiple_owners() {
     };
     let initial_state = fungible::InitialStateBuilder::default().build();
     let (validator, _application_id, recipient_chain) = TestValidator::with_current_application::<
-        NativeFungibleTokenAbi,
+        FungibleTokenAbi,
         _,
         _,
     >(parameters, initial_state)
@@ -140,7 +140,7 @@ async fn emptied_account_disappears_from_queries() {
     };
     let initial_state = fungible::InitialStateBuilder::default().build();
     let (validator, _application_id, recipient_chain) = TestValidator::with_current_application::<
-        NativeFungibleTokenAbi,
+        FungibleTokenAbi,
         _,
         _,
     >(parameters, initial_state)

--- a/linera-sdk/src/abis/fungible.rs
+++ b/linera-sdk/src/abis/fungible.rs
@@ -16,51 +16,6 @@ use serde::{Deserialize, Serialize};
 
 /// An operation
 #[derive(Debug, Deserialize, Serialize, GraphQLMutationRootInCrate)]
-pub enum NativeFungibleOperation {
-    /// Requests an account balance.
-    Balance {
-        /// Owner to query the balance for
-        owner: AccountOwner,
-    },
-    /// Requests this fungible token's ticker symbol.
-    TickerSymbol,
-    /// Transfers tokens from a (locally owned) account to a (possibly remote) account.
-    Transfer {
-        /// Owner to transfer from
-        owner: AccountOwner,
-        /// Amount to be transferred
-        amount: Amount,
-        /// Target account to transfer the amount to
-        target_account: Account,
-    },
-    /// Same as `Transfer` but the source account may be remote. Depending on its
-    /// configuration, the target chain may take time or refuse to process
-    /// the message.
-    Claim {
-        /// Source account to claim amount from
-        source_account: Account,
-        /// Amount to be claimed
-        amount: Amount,
-        /// Target account to claim the amount into
-        target_account: Account,
-    },
-}
-
-/// An ABI for applications that implement a fungible token.
-pub struct NativeFungibleTokenAbi;
-
-impl ContractAbi for NativeFungibleTokenAbi {
-    type Operation = NativeFungibleOperation;
-    type Response = FungibleResponse;
-}
-
-impl ServiceAbi for NativeFungibleTokenAbi {
-    type Query = Request;
-    type QueryResponse = Response;
-}
-
-/// An operation
-#[derive(Debug, Deserialize, Serialize, GraphQLMutationRootInCrate)]
 pub enum FungibleOperation {
     /// Requests an account balance.
     Balance {

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -30,7 +30,7 @@ use linera_base::{
 };
 use linera_core::worker::{Notification, Reason};
 use linera_sdk::{
-    abis::fungible::NativeFungibleTokenAbi,
+    abis::fungible::FungibleTokenAbi,
     linera_base_types::{AccountSecretKey, BlobContent, BlockHeight, DataBlobHash},
 };
 #[cfg(any(
@@ -77,7 +77,7 @@ fn get_account_owner(client: &ClientWrapper) -> AccountOwner {
     client.get_owner().unwrap()
 }
 
-struct NativeFungibleApp(ApplicationWrapper<NativeFungibleTokenAbi>);
+struct NativeFungibleApp(ApplicationWrapper<FungibleTokenAbi>);
 
 impl NativeFungibleApp {
     async fn get_amount(&self, account_owner: &AccountOwner) -> Amount {
@@ -2137,12 +2137,12 @@ async fn publish_and_create_native_fungible(
     params: &fungible::Parameters,
     state: &fungible::InitialState,
     chain_id: Option<ChainId>,
-) -> Result<ApplicationId<NativeFungibleTokenAbi>> {
+) -> Result<ApplicationId<FungibleTokenAbi>> {
     let (contract, service) = client.build_example(name).await?;
-    use fungible::{FungibleTokenAbi, InitialState, Parameters};
+    use fungible::{InitialState, Parameters};
     if name == "native-fungible" {
         client
-            .publish_and_create::<NativeFungibleTokenAbi, Parameters, InitialState>(
+            .publish_and_create::<FungibleTokenAbi, Parameters, InitialState>(
                 contract,
                 service,
                 VmRuntime::Wasm,


### PR DESCRIPTION
## Motivation

A step towards making the native fungible token usable in CLOB etc.

## Proposal

* Remove NativeFungibleTokenAbi and use FungibleTokenAbi instead
* Accept that some allowance operations are not available (yet).

This PR does NOT address #4416, though.

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK