### PR TITLE
Decrease certificate and block proposal stack size.

### DIFF
--- a/linera-chain/src/certificate/generic.rs
+++ b/linera-chain/src/certificate/generic.rs
@@ -16,7 +16,7 @@ use crate::{data_types::LiteValue, ChainError};
 /// Generic type representing a certificate for `value` of type `T`.
 #[derive(Debug)]
 pub struct GenericCertificate<T: CertificateValue> {
-    value: T,
+    value: Box<T>,
     pub round: Round,
     signatures: Vec<(ValidatorPublicKey, ValidatorSignature)>,
 }
@@ -41,7 +41,7 @@ impl<T: CertificateValue> GenericCertificate<T> {
         signatures.sort_by_key(|&(validator_name, _)| validator_name);
 
         Self {
-            value,
+            value: Box::new(value),
             round,
             signatures,
         }
@@ -54,7 +54,7 @@ impl<T: CertificateValue> GenericCertificate<T> {
 
     /// Consumes this certificate, returning the value it contains.
     pub fn into_value(self) -> T {
-        self.value
+        *self.value
     }
 
     /// Returns reference to the value contained in this certificate.
@@ -64,7 +64,7 @@ impl<T: CertificateValue> GenericCertificate<T> {
 
     /// Consumes this certificate, returning the value it contains.
     pub fn into_inner(self) -> T {
-        self.value
+        *self.value
     }
 
     /// Returns the certified value's hash.
@@ -73,7 +73,7 @@ impl<T: CertificateValue> GenericCertificate<T> {
     }
 
     pub fn destructure(self) -> (T, Round, Vec<(ValidatorPublicKey, ValidatorSignature)>) {
-        (self.value, self.round, self.signatures)
+        (*self.value, self.round, self.signatures)
     }
 
     pub fn signatures(&self) -> &Vec<(ValidatorPublicKey, ValidatorSignature)> {
@@ -126,7 +126,7 @@ impl<T: CertificateValue> GenericCertificate<T> {
         T: CertificateValue,
     {
         crate::certificate::LiteCertificate {
-            value: LiteValue::new(&self.value),
+            value: LiteValue::new(self.value.as_ref()),
             round: self.round,
             signatures: std::borrow::Cow::Borrowed(&self.signatures),
         }
@@ -136,7 +136,7 @@ impl<T: CertificateValue> GenericCertificate<T> {
 impl<T: CertificateValue> Clone for GenericCertificate<T> {
     fn clone(&self) -> Self {
         Self {
-            value: self.value.clone(),
+            value: Box::new((*self.value).clone()),
             round: self.round,
             signatures: self.signatures.clone(),
         }

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -345,7 +345,7 @@ where
         // if there is a validated block certificate from a later round.
         if let Some(vote) = self.confirmed_vote() {
             ensure!(
-                match proposal.original_proposal.as_ref() {
+                match proposal.original_proposal.as_deref() {
                     None => false,
                     Some(OriginalProposal::Regular { certificate }) =>
                         vote.round <= certificate.round,
@@ -457,7 +457,7 @@ where
     ) -> Result<Option<ValidatedOrConfirmedVote>, ChainError> {
         let round = proposal.content.round;
 
-        match &proposal.original_proposal {
+        match proposal.original_proposal.as_deref() {
             // If the validated block certificate is more recent, update our locking block.
             Some(OriginalProposal::Regular { certificate }) => {
                 if self
@@ -477,7 +477,7 @@ where
             Some(OriginalProposal::Fast(signature)) => {
                 if self.locking_block.get().is_none() {
                     let original_proposal = BlockProposal {
-                        signature: *signature,
+                        signature: Box::new(*signature),
                         ..proposal.clone()
                     };
                     self.update_locking(LockingBlock::Fast(original_proposal), blobs.clone())?;

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -569,7 +569,7 @@ where
         .await
         .unwrap();
     let unknown_key_pair = AccountSecretKey::generate();
-    let original_public_key = match block_proposal.signature {
+    let original_public_key = match *block_proposal.signature {
         AccountSignature::Ed25519 { public_key, .. } => public_key,
         _ => {
             panic!(
@@ -579,14 +579,14 @@ where
         }
     };
     let mut bad_signature_block_proposal = block_proposal.clone();
-    let bad_signature = match unknown_key_pair.sign(&block_proposal.content) {
+    let bad_signature = match unknown_key_pair.sign(block_proposal.content.as_ref()) {
         AccountSignature::Ed25519 { signature, .. } => AccountSignature::Ed25519 {
             public_key: original_public_key,
             signature,
         },
         _ => panic!("Expected an Ed25519 signature"),
     };
-    bad_signature_block_proposal.signature = bad_signature;
+    bad_signature_block_proposal.signature = Box::new(bad_signature);
     assert_matches!(
         env.worker()
             .handle_block_proposal(bad_signature_block_proposal)


### PR DESCRIPTION
## Motivation

We have seen stack overflows before that we fixed by `Box`ing some large futures: https://github.com/linera-io/linera-protocol/pull/4882

The root cause for some of these is that we often put large types like certificates and block proposals on the stack.

## Proposal

Box the `value` in certificates: this usually contains a whole block.

Box the `BlockProposal` fields.

Both mostly done by Claude. Its summary:

  - `GenericCertificate<ConfirmedBlock>`: 664 bytes → 40 bytes (94% reduction)
  - `GenericCertificate<ValidatedBlock>`: 664 bytes → 40 bytes (94% reduction)
  - `GenericCertificate<Timeout>`: 112 bytes → 40 bytes (64% reduction)
  - `BlockProposal`: 688 bytes → 24 bytes (96.5% reduction)
  - `LockingBlock` enum: 688 bytes → 40 bytes (94% reduction)

A possible alternative: Accept that some types are very large; avoid passing them by value and holding them on the stack across an `await` point. (I.e. in practice keep them in a `Box` most of the time.)

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- These changes _could_ be backported to `testnet_conway`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
