### PR TITLE
`web`: minor documentation tweaks

### DIFF
--- a/web/@linera/client/README.md
+++ b/web/@linera/client/README.md
@@ -13,11 +13,6 @@ policies, including in-memory keys and signing using an existing MetaMask wallet
 
 <!-- cargo-rdme end -->
 
-## Building
-
-Make sure your `cargo` invokes a nightly `rustc`. Then, you can build
-the package with `pnpm build` and publish it with `pnpm publish`.
-
 ## Contributing
 
 See the [CONTRIBUTING](../../../CONTRIBUTING.md) file for how to help out.

--- a/web/README.md
+++ b/web/README.md
@@ -4,3 +4,8 @@ This directory contains bindings and utilities for using Linera from
 the Web platform.
 
 They are published on npm under the `@linera` namespace.
+
+## Building
+
+Make sure your `cargo` invokes a nightly `rustc`. Then, you can build
+and publish the workspace with `pnpm publish -r`.


### PR DESCRIPTION
## Motivation

We should build the workspace together.

## Proposal

Move the build documentation to the `web` root, and add the `-r` flag to build the whole workspace.

## Test Plan

Documentation only.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
