### PR TITLE
nit: rename ViewContext::new_unsafe into new_unchecked

### DIFF
--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -66,7 +66,7 @@ where
 
     /// Returns a storage context suitable for a root view.
     pub fn root_view_storage_context(&self) -> ViewStorageContext {
-        ViewStorageContext::new_unsafe(self.key_value_store(), Vec::new(), ())
+        ViewStorageContext::new_unchecked(self.key_value_store(), Vec::new(), ())
     }
 }
 

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -144,7 +144,7 @@ where
 
     /// Returns a storage context suitable for a root view.
     pub fn root_view_storage_context(&self) -> ViewStorageContext {
-        ViewStorageContext::new_unsafe(self.key_value_store(), Vec::new(), ())
+        ViewStorageContext::new_unchecked(self.key_value_store(), Vec::new(), ())
     }
 
     /// Configures the application parameters to return during the test.

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -58,7 +58,7 @@ where
 
     /// Returns a storage context suitable for a root view.
     pub fn root_view_storage_context(&self) -> ViewStorageContext {
-        ViewStorageContext::new_unsafe(self.key_value_store(), Vec::new(), ())
+        ViewStorageContext::new_unchecked(self.key_value_store(), Vec::new(), ())
     }
 }
 

--- a/linera-sdk/src/service/test_runtime.rs
+++ b/linera-sdk/src/service/test_runtime.rs
@@ -78,7 +78,7 @@ where
 
     /// Returns a storage context suitable for a root view.
     pub fn root_view_storage_context(&self) -> ViewStorageContext {
-        ViewStorageContext::new_unsafe(self.key_value_store(), Vec::new(), ())
+        ViewStorageContext::new_unchecked(self.key_value_store(), Vec::new(), ())
     }
 
     /// Configures the application parameters to return during the test.

--- a/linera-views/src/context.rs
+++ b/linera-views/src/context.rs
@@ -161,7 +161,7 @@ where
     /// returned.
     pub async fn create_root_context(store: S, extra: E) -> Result<Self, S::Error> {
         store.clear_journal().await?;
-        Ok(Self::new_unsafe(store, Vec::new(), extra))
+        Ok(Self::new_unchecked(store, Vec::new(), extra))
     }
 }
 
@@ -169,7 +169,7 @@ impl<E, S> ViewContext<E, S> {
     /// Creates a context for the given base key, store, and an extra argument. NOTE: this
     /// constructor doesn't check the journal of the store. In doubt, use
     /// [`ViewContext::create_root_context`] instead.
-    pub fn new_unsafe(store: S, base_key: Vec<u8>, extra: E) -> Self {
+    pub fn new_unchecked(store: S, base_key: Vec<u8>, extra: E) -> Self {
         Self {
             store,
             base_key: BaseKey { bytes: base_key },

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -111,7 +111,7 @@ impl StateStorage for KeyValueStoreTestStorage {
         self.accessed_chains.insert(id);
         let base_key = bcs::to_bytes(&id)?;
         let store = self.store.clone();
-        let context = Self::Context::new_unsafe(store, base_key, id);
+        let context = Self::Context::new_unchecked(store, base_key, id);
         StateView::load(context).await
     }
 }


### PR DESCRIPTION
## Motivation

We use "unchecked" in other places to mean the DB can be corrupted.
"unsafe" usually means memory corruption

## Proposal

rename ViewContext::new_unsafe into new_unchecked

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
