### PR TITLE
[matching engine] Track pending orders on user chains

### DIFF
--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -11,7 +11,7 @@ use linera_sdk::{
     Contract, ContractRuntime,
 };
 use matching_engine::{
-    MatchingEngineAbi, Message, Operation, Order, OrderNature, Parameters, Price,
+    MatchingEngineAbi, Message, Operation, Order, OrderNature, Parameters, PendingOrderInfo, Price,
 };
 use state::{MatchingEngineState, ModifyQuantity, Transfer};
 
@@ -89,15 +89,16 @@ impl Contract for MatchingEngineContract {
         }
     }
 
-    /// Execution of the order on the creation chain
+    /// Execution of messages
     async fn execute_message(&mut self, message: Message) {
-        assert_eq!(
-            self.runtime.chain_id(),
-            self.runtime.application_creator_chain_id(),
-            "Action can only be executed on the chain that created the matching engine"
-        );
         match message {
             Message::ExecuteOrder { order } => {
+                // This message can only be executed on the matching engine chain
+                assert_eq!(
+                    self.runtime.chain_id(),
+                    self.runtime.application_creator_chain_id(),
+                    "ExecuteOrder can only be executed on the chain that created the matching engine"
+                );
                 let owner = order.owner();
                 let origin_chain_id = self.runtime.message_origin_chain_id().expect(
                     "Incoming message origin chain ID has to be available when executing a message",
@@ -106,6 +107,53 @@ impl Contract for MatchingEngineContract {
                     .check_account_permission(owner)
                     .expect("Permission for ExecuteOrder message");
                 self.execute_order_local(order, origin_chain_id).await;
+            }
+            Message::OrderPending {
+                owner,
+                order_id,
+                order_info,
+            } => {
+                // This message is received on the sender chain from the matching engine
+                // Order was inserted and is pending
+                let pending_orders = self
+                    .state
+                    .pending_orders
+                    .get_mut_or_default(&owner)
+                    .await
+                    .expect("Failed to load pending orders");
+                pending_orders.insert(order_id, order_info);
+            }
+            Message::OrderUpdated {
+                owner,
+                order_id,
+                new_quantity,
+            } => {
+                // This message is received on the sender chain from the matching engine
+                let pending_orders = self
+                    .state
+                    .pending_orders
+                    .get_mut(&owner)
+                    .await
+                    .expect("Failed to load pending orders")
+                    .expect("Account should have pending orders");
+
+                // Update the pending order
+                if let Some(order) = pending_orders.get_mut(&order_id) {
+                    order.quantity = new_quantity;
+                }
+            }
+            Message::OrderRemoved { owner, order_id } => {
+                // This message is received on the sender chain from the matching engine
+                let pending_orders = self
+                    .state
+                    .pending_orders
+                    .get_mut(&owner)
+                    .await
+                    .expect("Failed to load pending orders")
+                    .expect("Account should have pending orders");
+
+                // Remove the pending order
+                pending_orders.remove(&order_id);
             }
         }
     }
@@ -178,22 +226,93 @@ impl MatchingEngineContract {
             } => {
                 self.receive_from_account(&owner, &quantity, &nature, &price);
                 let account = Account { chain_id, owner };
-                let transfers = self
+                let (transfers, order_id, remaining_quantity, filled_orders) = self
                     .state
                     .insert_and_uncross_market(&account, quantity, nature, &price)
                     .await;
                 for transfer in transfers {
                     self.send_to(transfer);
                 }
+
+                // Send removal notifications for filled orders
+                let matching_engine_chain = self.runtime.chain_id();
+                for (filled_chain_id, filled_owner, filled_order_id) in filled_orders {
+                    if filled_chain_id != matching_engine_chain {
+                        let removal_message = Message::OrderRemoved {
+                            owner: filled_owner,
+                            order_id: filled_order_id,
+                        };
+                        self.runtime
+                            .prepare_message(removal_message)
+                            .with_authentication()
+                            .send_to(filled_chain_id);
+                    }
+                }
+
+                // Send acknowledgment to the sender chain (if different from matching engine chain)
+                if remaining_quantity > Amount::ZERO {
+                    let order_info = PendingOrderInfo {
+                        nature,
+                        price,
+                        quantity: remaining_quantity,
+                    };
+                    if chain_id != self.runtime.chain_id() {
+                        let pending_message = Message::OrderPending {
+                            owner,
+                            order_id,
+                            order_info,
+                        };
+                        self.runtime
+                            .prepare_message(pending_message)
+                            .with_authentication()
+                            .send_to(chain_id);
+                    } else {
+                        let pending_orders = self
+                            .state
+                            .pending_orders
+                            .get_mut_or_default(&owner)
+                            .await
+                            .expect("Failed to load pending orders");
+                        pending_orders.insert(order_id, order_info);
+                    }
+                }
             }
             Order::Cancel { owner, order_id } => {
                 self.state.check_order_id(&order_id, &owner).await;
+                let key_book = self
+                    .state
+                    .orders
+                    .get(&order_id)
+                    .await
+                    .expect("Failed to load order")
+                    .expect("Order should exist");
+                let sender_chain_id = key_book.account.chain_id;
+
                 let transfer = self
                     .state
                     .modify_order(order_id, ModifyQuantity::All)
                     .await
                     .expect("Order is not present therefore cannot be cancelled");
                 self.send_to(transfer);
+
+                // Send removal notification to the sender chain (if different from matching engine chain)
+                if sender_chain_id != self.runtime.chain_id() {
+                    let removal_message = Message::OrderRemoved { owner, order_id };
+                    self.runtime
+                        .prepare_message(removal_message)
+                        .with_authentication()
+                        .send_to(sender_chain_id);
+                } else {
+                    let pending_orders = self
+                        .state
+                        .pending_orders
+                        .get_mut(&owner)
+                        .await
+                        .expect("Failed to load pending orders")
+                        .expect("Account should have pending orders");
+                    // Remove the pending order
+                    pending_orders.remove(&order_id);
+                }
             }
             Order::Modify {
                 owner,
@@ -201,12 +320,69 @@ impl MatchingEngineContract {
                 reduce_quantity,
             } => {
                 self.state.check_order_id(&order_id, &owner).await;
+                let key_book = self
+                    .state
+                    .orders
+                    .get(&order_id)
+                    .await
+                    .expect("Failed to load order")
+                    .expect("Order should exist");
+                let sender_chain_id = key_book.account.chain_id;
+
                 let transfer = self
                     .state
                     .modify_order(order_id, ModifyQuantity::Partial(reduce_quantity))
                     .await
                     .expect("Order is not present therefore cannot be cancelled");
                 self.send_to(transfer);
+
+                // Get the remaining quantity after modification
+                if let Some(new_quantity) = self.state.get_order_quantity(&order_id).await {
+                    // Order still exists with reduced amount
+                    if sender_chain_id != self.runtime.chain_id() {
+                        // Send update notification to the sender chain (if different from matching engine chain)
+                        let update_message = Message::OrderUpdated {
+                            owner,
+                            order_id,
+                            new_quantity,
+                        };
+                        self.runtime
+                            .prepare_message(update_message)
+                            .with_authentication()
+                            .send_to(sender_chain_id);
+                    } else {
+                        let pending_orders = self
+                            .state
+                            .pending_orders
+                            .get_mut(&owner)
+                            .await
+                            .expect("Failed to load pending orders")
+                            .expect("Account should have pending orders");
+                        // Update the pending order
+                        if let Some(order) = pending_orders.get_mut(&order_id) {
+                            order.quantity = new_quantity;
+                        }
+                    }
+                } else {
+                    // Order was fully cancelled
+                    if sender_chain_id != self.runtime.chain_id() {
+                        let removal_message = Message::OrderRemoved { owner, order_id };
+                        self.runtime
+                            .prepare_message(removal_message)
+                            .with_authentication()
+                            .send_to(sender_chain_id);
+                    } else {
+                        let pending_orders = self
+                            .state
+                            .pending_orders
+                            .get_mut(&owner)
+                            .await
+                            .expect("Failed to load pending orders")
+                            .expect("Account should have pending orders");
+                        // Remove the pending order
+                        pending_orders.remove(&order_id);
+                    }
+                }
             }
         }
     }

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -13,7 +13,7 @@ use linera_sdk::{
 use matching_engine::{
     MatchingEngineAbi, Message, Operation, Order, OrderNature, Parameters, PendingOrderInfo, Price,
 };
-use state::{MatchingEngineState, ModifyQuantity, Transfer};
+use state::{MatchingEngineState, Transfer};
 
 pub struct MatchingEngineContract {
     state: MatchingEngineState,
@@ -76,7 +76,7 @@ impl Contract for MatchingEngineContract {
                     .await
                     .expect("Failed to read existing order IDs");
                 for order_id in order_ids {
-                    match self.state.modify_order(order_id, ModifyQuantity::All).await {
+                    match self.state.modify_order(order_id, Amount::ZERO).await {
                         Some(transfer) => self.send_to(transfer),
                         // Orders with amount zero may have been cleared in an earlier iteration.
                         None => continue,
@@ -137,23 +137,15 @@ impl Contract for MatchingEngineContract {
                     .expect("Failed to load pending orders")
                     .expect("Account should have pending orders");
 
-                // Update the pending order
-                if let Some(order) = pending_orders.get_mut(&order_id) {
-                    order.quantity = new_quantity;
+                if new_quantity == Amount::ZERO {
+                    // Remove the pending order
+                    pending_orders.remove(&order_id);
+                } else {
+                    // Update the pending order
+                    if let Some(order) = pending_orders.get_mut(&order_id) {
+                        order.quantity = new_quantity;
+                    }
                 }
-            }
-            Message::OrderRemoved { owner, order_id } => {
-                // This message is received on the sender chain from the matching engine
-                let pending_orders = self
-                    .state
-                    .pending_orders
-                    .get_mut(&owner)
-                    .await
-                    .expect("Failed to load pending orders")
-                    .expect("Account should have pending orders");
-
-                // Remove the pending order
-                pending_orders.remove(&order_id);
             }
         }
     }
@@ -238,9 +230,10 @@ impl MatchingEngineContract {
                 let matching_engine_chain = self.runtime.chain_id();
                 for (filled_chain_id, filled_owner, filled_order_id) in filled_orders {
                     if filled_chain_id != matching_engine_chain {
-                        let removal_message = Message::OrderRemoved {
+                        let removal_message = Message::OrderUpdated {
                             owner: filled_owner,
                             order_id: filled_order_id,
+                            new_quantity: Amount::ZERO,
                         };
                         self.runtime
                             .prepare_message(removal_message)
@@ -277,47 +270,10 @@ impl MatchingEngineContract {
                     }
                 }
             }
-            Order::Cancel { owner, order_id } => {
-                self.state.check_order_id(&order_id, &owner).await;
-                let key_book = self
-                    .state
-                    .orders
-                    .get(&order_id)
-                    .await
-                    .expect("Failed to load order")
-                    .expect("Order should exist");
-                let sender_chain_id = key_book.account.chain_id;
-
-                let transfer = self
-                    .state
-                    .modify_order(order_id, ModifyQuantity::All)
-                    .await
-                    .expect("Order is not present therefore cannot be cancelled");
-                self.send_to(transfer);
-
-                // Send removal notification to the sender chain (if different from matching engine chain)
-                if sender_chain_id != self.runtime.chain_id() {
-                    let removal_message = Message::OrderRemoved { owner, order_id };
-                    self.runtime
-                        .prepare_message(removal_message)
-                        .with_authentication()
-                        .send_to(sender_chain_id);
-                } else {
-                    let pending_orders = self
-                        .state
-                        .pending_orders
-                        .get_mut(&owner)
-                        .await
-                        .expect("Failed to load pending orders")
-                        .expect("Account should have pending orders");
-                    // Remove the pending order
-                    pending_orders.remove(&order_id);
-                }
-            }
             Order::Modify {
                 owner,
                 order_id,
-                reduce_quantity,
+                new_quantity,
             } => {
                 self.state.check_order_id(&order_id, &owner).await;
                 let key_book = self
@@ -331,56 +287,34 @@ impl MatchingEngineContract {
 
                 let transfer = self
                     .state
-                    .modify_order(order_id, ModifyQuantity::Partial(reduce_quantity))
+                    .modify_order(order_id, new_quantity)
                     .await
-                    .expect("Order is not present therefore cannot be cancelled");
+                    .expect("Failed to modify order");
                 self.send_to(transfer);
 
-                // Get the remaining quantity after modification
-                if let Some(new_quantity) = self.state.get_order_quantity(&order_id).await {
-                    // Order still exists with reduced amount
-                    if sender_chain_id != self.runtime.chain_id() {
-                        // Send update notification to the sender chain (if different from matching engine chain)
-                        let update_message = Message::OrderUpdated {
-                            owner,
-                            order_id,
-                            new_quantity,
-                        };
-                        self.runtime
-                            .prepare_message(update_message)
-                            .with_authentication()
-                            .send_to(sender_chain_id);
-                    } else {
-                        let pending_orders = self
-                            .state
-                            .pending_orders
-                            .get_mut(&owner)
-                            .await
-                            .expect("Failed to load pending orders")
-                            .expect("Account should have pending orders");
-                        // Update the pending order
-                        if let Some(order) = pending_orders.get_mut(&order_id) {
-                            order.quantity = new_quantity;
-                        }
-                    }
+                // Order still exists with reduced amount
+                if sender_chain_id != self.runtime.chain_id() {
+                    // Send update notification to the sender chain (if different from matching engine chain)
+                    let update_message = Message::OrderUpdated {
+                        owner,
+                        order_id,
+                        new_quantity,
+                    };
+                    self.runtime
+                        .prepare_message(update_message)
+                        .with_authentication()
+                        .send_to(sender_chain_id);
                 } else {
-                    // Order was fully cancelled
-                    if sender_chain_id != self.runtime.chain_id() {
-                        let removal_message = Message::OrderRemoved { owner, order_id };
-                        self.runtime
-                            .prepare_message(removal_message)
-                            .with_authentication()
-                            .send_to(sender_chain_id);
-                    } else {
-                        let pending_orders = self
-                            .state
-                            .pending_orders
-                            .get_mut(&owner)
-                            .await
-                            .expect("Failed to load pending orders")
-                            .expect("Account should have pending orders");
-                        // Remove the pending order
-                        pending_orders.remove(&order_id);
+                    let pending_orders = self
+                        .state
+                        .pending_orders
+                        .get_mut(&owner)
+                        .await
+                        .expect("Failed to load pending orders")
+                        .expect("Account should have pending orders");
+                    // Update the pending order
+                    if let Some(order) = pending_orders.get_mut(&order_id) {
+                        order.quantity = new_quantity;
                     }
                 }
             }

--- a/examples/matching-engine/src/lib.rs
+++ b/examples/matching-engine/src/lib.rs
@@ -124,7 +124,7 @@ impl CustomSerialize for PriceBid {
 /// An identifier for a buy or sell order
 pub type OrderId = u64;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum OrderNature {
     /// A bid for buying token 1 and paying in token 0
     Bid,
@@ -264,11 +264,37 @@ pub enum Operation {
     CloseChain,
 }
 
+/// Information about a pending order. The order ID is stored separately.
+#[derive(Clone, Debug, Serialize, Deserialize, SimpleObject)]
+pub struct PendingOrderInfo {
+    pub nature: OrderNature,
+    pub price: Price,
+    pub quantity: Amount,
+}
+
 /// Messages that can be processed by the application.
 #[derive(Debug, Deserialize, Serialize)]
 pub enum Message {
     /// The order being transmitted from the chain and received by the chain of the order book.
     ExecuteOrder { order: Order },
+    /// Acknowledgment sent from the matching engine to the order sender when an order is
+    /// inserted and at least partially pending.
+    OrderPending {
+        owner: AccountOwner,
+        order_id: OrderId,
+        order_info: PendingOrderInfo,
+    },
+    /// Notification sent from the matching engine when an order is modified or cancelled.
+    OrderUpdated {
+        owner: AccountOwner,
+        order_id: OrderId,
+        new_quantity: Amount,
+    },
+    /// Notification sent from the matching engine when an order is fully cancelled or filled.
+    OrderRemoved {
+        owner: AccountOwner,
+        order_id: OrderId,
+    },
 }
 
 #[cfg(test)]

--- a/examples/matching-engine/src/lib.rs
+++ b/examples/matching-engine/src/lib.rs
@@ -143,7 +143,7 @@ pub enum Order {
         nature: OrderNature,
         price: Price,
     },
-    /// Modify an order. The quantity can only be decreased. If nul, the order is
+    /// Modify an order. The quantity can only be decreased. If zero, the order is
     /// canceled.
     Modify {
         owner: AccountOwner,

--- a/examples/matching-engine/src/state.rs
+++ b/examples/matching-engine/src/state.rs
@@ -251,8 +251,8 @@ impl MatchingEngineState {
     /// * If after the level clearing the order is completely filled then it is not
     ///   inserted. Otherwise, it became a liquidity order in the matching engine
     ///
-    /// Returns: (transfers, order_id, remaining_amount, filled_orders)
-    /// where filled_orders contains (chain_id, owner, order_id) for each filled order
+    /// Returns: `(transfers, order_id, remaining_amount, filled_orders)`
+    /// where `filled_orders` contains `(chain_id, owner, order_id)` for each filled order
     pub async fn insert_and_uncross_market(
         &mut self,
         account: &Account,

--- a/examples/matching-engine/src/state.rs
+++ b/examples/matching-engine/src/state.rs
@@ -360,7 +360,7 @@ impl MatchingEngineState {
                             .remove_entry(&price_bid)
                             .expect("Failed to remove bid level");
                     }
-                    // Collect filled orders with chain_id information
+                    // Collect filled orders with chain ID information
                     for (owner, order_id) in &remove_entry {
                         if let Some(key_book) = self
                             .orders

--- a/examples/matching-engine/src/state.rs
+++ b/examples/matching-engine/src/state.rs
@@ -78,7 +78,7 @@ pub struct LevelView {
 #[view(context = Context)]
 pub struct MatchingEngineState {
     /// Pending orders tracked on user chains (not used on matching engine chain).
-    /// Maps owner to a map of order_id to pending order details.
+    /// Maps owner to a map of order ID to pending order details.
     pub pending_orders: MapView<AccountOwner, BTreeMap<OrderId, PendingOrderInfo>>,
 
     // -- Matching engine chain only --

--- a/examples/matching-engine/src/state.rs
+++ b/examples/matching-engine/src/state.rs
@@ -3,16 +3,21 @@
 
 #![allow(dead_code)]
 
-use std::{cmp::min, collections::BTreeSet};
+use std::{
+    cmp::min,
+    collections::{BTreeMap, BTreeSet},
+};
 
 use async_graphql::SimpleObject;
 use linera_sdk::{
-    linera_base_types::{Account, AccountOwner, Amount},
+    linera_base_types::{Account, AccountOwner, Amount, ChainId},
     views::{linera_views, linera_views::context::Context as _},
     KeyValueStore,
 };
 use linera_views::views::{RootView, View};
-use matching_engine::{OrderId, OrderNature, Parameters, Price, PriceAsk, PriceBid};
+use matching_engine::{
+    OrderId, OrderNature, Parameters, PendingOrderInfo, Price, PriceAsk, PriceBid,
+};
 use serde::{Deserialize, Serialize};
 
 pub type Context = linera_views::context::ViewContext<Parameters, KeyValueStore>;
@@ -50,7 +55,7 @@ pub struct KeyBook {
 }
 
 /// The AccountInfo used for storing which order_id are owned by
-/// each owner.
+/// each owner on the matching engine chain.
 #[derive(Default, Clone, Debug, Serialize, Deserialize, SimpleObject)]
 pub struct AccountInfo {
     /// The list of orders
@@ -72,6 +77,11 @@ pub struct LevelView {
 #[derive(RootView, SimpleObject)]
 #[view(context = Context)]
 pub struct MatchingEngineState {
+    /// Pending orders tracked on user chains (not used on matching engine chain).
+    /// Maps owner to a map of order_id to pending order details.
+    pub pending_orders: MapView<AccountOwner, BTreeMap<OrderId, PendingOrderInfo>>,
+
+    // -- Matching engine chain only --
     /// The next order_id to be used.
     pub next_order_id: RegisterView<OrderId>,
     /// The map of the outstanding bids, by the bitwise complement of
@@ -86,7 +96,7 @@ pub struct MatchingEngineState {
     /// fundamental information on the order (price, nature, account)
     pub orders: MapView<OrderId, KeyBook>,
     /// The map giving for each account owner the set of order_id
-    /// owned by that owner.
+    /// owned by that owner (used on the matching engine chain).
     pub account_info: MapView<AccountOwner, AccountInfo>,
 }
 
@@ -125,6 +135,28 @@ impl MatchingEngineState {
                     &value.account.owner, owner,
                     "The owner of the order is not matching with the owner put"
                 );
+            }
+        }
+    }
+
+    /// Gets the current amount of an order from the order book.
+    /// Returns None if the order doesn't exist or has been fully filled/cancelled.
+    pub async fn get_order_quantity(&mut self, order_id: &OrderId) -> Option<Amount> {
+        let key_book = self.orders.get(order_id).await.ok()??;
+
+        // Find the order in the appropriate price level
+        match key_book.nature {
+            OrderNature::Bid => {
+                let view = self.bid_level(&key_book.price.to_bid()).await;
+                let mut iter = view.queue.iter_mut().await.expect("Failed to iterate");
+                iter.find(|order| order.order_id == *order_id)
+                    .map(|order| order.quantity)
+            }
+            OrderNature::Ask => {
+                let view = self.ask_level(&key_book.price.to_ask()).await;
+                let mut iter = view.queue.iter_mut().await.expect("Failed to iterate");
+                iter.find(|order| order.order_id == *order_id)
+                    .map(|order| order.quantity)
             }
         }
     }
@@ -240,13 +272,21 @@ impl MatchingEngineState {
     /// * That clearing creates a number of transfer orders.
     /// * If after the level clearing the order is completely filled then it is not
     ///   inserted. Otherwise, it became a liquidity order in the matching engine
+    ///
+    /// Returns: (transfers, order_id, remaining_amount, filled_orders)
+    /// where filled_orders contains (chain_id, owner, order_id) for each filled order
     pub async fn insert_and_uncross_market(
         &mut self,
         account: &Account,
         quantity: Amount,
         nature: OrderNature,
         price: &Price,
-    ) -> Vec<Transfer> {
+    ) -> (
+        Vec<Transfer>,
+        OrderId,
+        Amount,
+        Vec<(ChainId, AccountOwner, OrderId)>,
+    ) {
         // Bids are ordered from the highest bid (most preferable) to the smallest bid.
         // Asks are ordered from the smallest (most preferable) to the highest.
         // The prices have custom serialization so that they are in increasing order.
@@ -254,6 +294,7 @@ impl MatchingEngineState {
         let order_id = self.get_new_order_id();
         let mut final_quantity = quantity;
         let mut transfers = Vec::new();
+        let mut filled_orders = Vec::new();
         match nature {
             OrderNature::Bid => {
                 let mut matching_price_asks = Vec::new();
@@ -283,6 +324,17 @@ impl MatchingEngineState {
                         self.asks
                             .remove_entry(&price_ask)
                             .expect("Failed to remove ask level");
+                    }
+                    // Collect filled orders with chain_id information
+                    for (owner, order_id) in &remove_entry {
+                        if let Some(key_book) = self
+                            .orders
+                            .get(order_id)
+                            .await
+                            .expect("Failed to load order")
+                        {
+                            filled_orders.push((key_book.account.chain_id, *owner, *order_id));
+                        }
                     }
                     self.remove_order_ids(remove_entry).await;
                     if final_quantity == Amount::ZERO {
@@ -330,6 +382,17 @@ impl MatchingEngineState {
                             .remove_entry(&price_bid)
                             .expect("Failed to remove bid level");
                     }
+                    // Collect filled orders with chain_id information
+                    for (owner, order_id) in &remove_entry {
+                        if let Some(key_book) = self
+                            .orders
+                            .get(order_id)
+                            .await
+                            .expect("Failed to load order")
+                        {
+                            filled_orders.push((key_book.account.chain_id, *owner, *order_id));
+                        }
+                    }
                     self.remove_order_ids(remove_entry).await;
                     if final_quantity == Amount::ZERO {
                         break;
@@ -348,7 +411,7 @@ impl MatchingEngineState {
                 }
             }
         }
-        transfers
+        (transfers, order_id, final_quantity, filled_orders)
     }
 }
 

--- a/examples/matching-engine/src/state.rs
+++ b/examples/matching-engine/src/state.rs
@@ -139,35 +139,13 @@ impl MatchingEngineState {
         }
     }
 
-    /// Gets the current amount of an order from the order book.
-    /// Returns None if the order doesn't exist or has been fully filled/cancelled.
-    pub async fn get_order_quantity(&mut self, order_id: &OrderId) -> Option<Amount> {
-        let key_book = self.orders.get(order_id).await.ok()??;
-
-        // Find the order in the appropriate price level
-        match key_book.nature {
-            OrderNature::Bid => {
-                let view = self.bid_level(&key_book.price.to_bid()).await;
-                let mut iter = view.queue.iter_mut().await.expect("Failed to iterate");
-                iter.find(|order| order.order_id == *order_id)
-                    .map(|order| order.quantity)
-            }
-            OrderNature::Ask => {
-                let view = self.ask_level(&key_book.price.to_ask()).await;
-                let mut iter = view.queue.iter_mut().await.expect("Failed to iterate");
-                iter.find(|order| order.order_id == *order_id)
-                    .map(|order| order.quantity)
-            }
-        }
-    }
-
     /// Modifies the order from the order_id.
     /// This means that some transfers have to be done and the size depends
     /// whether ask or bid.
     pub async fn modify_order(
         &mut self,
         order_id: OrderId,
-        cancel_quantity: ModifyQuantity,
+        new_quantity: Amount,
     ) -> Option<Transfer> {
         let key_book = self
             .orders
@@ -178,7 +156,7 @@ impl MatchingEngineState {
             OrderNature::Bid => {
                 let view = self.bid_level(&key_book.price.to_bid()).await;
                 let (cancel_quantity, remove_order_id) =
-                    view.modify_order_level(order_id, cancel_quantity).await?;
+                    view.modify_order_level(order_id, new_quantity).await?;
                 if remove_order_id {
                     self.remove_order_id((key_book.account.owner, order_id))
                         .await;
@@ -195,7 +173,7 @@ impl MatchingEngineState {
             OrderNature::Ask => {
                 let view = self.ask_level(&key_book.price.to_ask()).await;
                 let (cancel_quantity, remove_order_id) =
-                    view.modify_order_level(order_id, cancel_quantity).await?;
+                    view.modify_order_level(order_id, new_quantity).await?;
                 if remove_order_id {
                     self.remove_order_id((key_book.account.owner, order_id))
                         .await;
@@ -426,15 +404,6 @@ pub struct Transfer {
     pub token_idx: u32,
 }
 
-/// An order can be cancelled which removes it totally or
-/// modified which is a partial cancellation. The size of the
-/// order can never increase.
-#[derive(Clone, Debug)]
-pub enum ModifyQuantity {
-    All,
-    Partial(Amount),
-}
-
 impl LevelView {
     fn parameters(&self) -> Parameters {
         *self.context().extra()
@@ -609,7 +578,7 @@ impl LevelView {
     pub async fn modify_order_level(
         &mut self,
         order_id: OrderId,
-        reduce_quantity: ModifyQuantity,
+        new_quantity: Amount,
     ) -> Option<(Amount, bool)> {
         let mut iter = self
             .queue
@@ -617,16 +586,12 @@ impl LevelView {
             .await
             .expect("Failed to load iterator over level queue");
         let state_order = iter.find(|order| order.order_id == order_id)?;
-        let new_quantity = match reduce_quantity {
-            ModifyQuantity::All => Amount::ZERO,
-            ModifyQuantity::Partial(reduce_quantity) => state_order
-                .quantity
-                .try_sub(reduce_quantity)
-                .expect("Attempt to cancel a larger quantity than available"),
-        };
-        let corr_reduce_quantity = state_order.quantity.try_sub(new_quantity).unwrap();
+        let cancel_quantity = state_order
+            .quantity
+            .try_sub(new_quantity)
+            .expect("Attempt to increase quantity");
         state_order.quantity = new_quantity;
         self.remove_zero_orders_from_level().await;
-        Some((corr_reduce_quantity, new_quantity == Amount::ZERO))
+        Some((cancel_quantity, new_quantity == Amount::ZERO))
     }
 }

--- a/examples/matching-engine/src/state.rs
+++ b/examples/matching-engine/src/state.rs
@@ -303,7 +303,7 @@ impl MatchingEngineState {
                             .remove_entry(&price_ask)
                             .expect("Failed to remove ask level");
                     }
-                    // Collect filled orders with chain_id information
+                    // Collect filled orders with chain ID information
                     for (owner, order_id) in &remove_entry {
                         if let Some(key_book) = self
                             .orders

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -246,9 +246,10 @@ async fn single_transaction() {
     }
 
     // Cancel A's order.
-    let order = Order::Cancel {
+    let order = Order::Modify {
         owner: owner_a,
         order_id: order_ids_a[0],
+        new_quantity: Amount::ZERO,
     };
     let operation = Operation::ExecuteOrder { order };
     let order_certificate = user_chain_a

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -3262,17 +3262,19 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     // Now cancelling all the orders
     for order_id in order_ids_a {
         app_matching_a
-            .order(matching_engine::Order::Cancel {
+            .order(matching_engine::Order::Modify {
                 owner: owner_a,
                 order_id,
+                new_quantity: Amount::ZERO,
             })
             .await;
     }
     for order_id in order_ids_b {
         app_matching_b
-            .order(matching_engine::Order::Cancel {
+            .order(matching_engine::Order::Modify {
                 owner: owner_b,
                 order_id,
+                new_quantity: Amount::ZERO,
             })
             .await;
     }


### PR DESCRIPTION
## Motivation

Allow users to display their pending orders without following the entire CLOB appchain

## Proposal

* Add a new type of message and a field of user chains
* Replace `Cancel` orders by `Modify` with new quantity equal to `0`
* Simplify `ModifyQuantity` to avoid code duplication

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch