### PR TITLE
Implement asynchronous iterators for reading data in the storage.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6267,6 +6267,7 @@ name = "linera-storage"
 version = "0.16.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bcs",
  "cfg-if",
@@ -6313,6 +6314,7 @@ version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-lock",
+ "async-stream",
  "bcs",
  "cfg_aliases",
  "clap",
@@ -6381,6 +6383,7 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "async-lock",
+ "async-stream",
  "aws-config",
  "aws-sdk-dynamodb",
  "aws-smithy-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ async-graphql-axum = "=7.0.17"
 async-graphql-derive = "=7.0.17"
 async-graphql-value = { version = "=7.0.17", features = ["raw_value"] }
 async-lock = "3.3.0"
+async-stream = "0.3"
 async-trait = "0.1.77"
 async-tungstenite = { version = "0.22", features = ["tokio-runtime"] }
 aws-smithy-types = "1.3.1"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4052,6 +4052,7 @@ dependencies = [
 name = "linera-storage"
 version = "0.16.0"
 dependencies = [
+ "async-stream",
  "async-trait",
  "bcs",
  "cfg-if",
@@ -4075,6 +4076,7 @@ version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-lock",
+ "async-stream",
  "bcs",
  "cfg_aliases",
  "clap",
@@ -4121,6 +4123,7 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "async-lock",
+ "async-stream",
  "bcs",
  "cfg_aliases",
  "convert_case",

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -394,17 +394,28 @@ where
 
         let (missing_indices, missing_blob_ids) = missing_indices_blob_ids(&maybe_blobs);
         if !missing_indices.is_empty() {
-            let all_entries_pending_blobs = self
+            let mut remaining = missing_indices
+                .into_iter()
+                .zip(missing_blob_ids)
+                .collect::<Vec<_>>();
+            let mut iter = self
                 .chain
                 .pending_proposed_blobs
-                .try_load_all_entries()
+                .try_load_all_entries_iter()
                 .await?;
-            for (index, blob_id) in missing_indices.into_iter().zip(missing_blob_ids) {
-                for (_, pending_blobs) in &all_entries_pending_blobs {
-                    if let Some(blob) = pending_blobs.get(&blob_id).await? {
-                        maybe_blobs[index].1 = Some(blob);
-                        break;
+            while let Some((_, pending_blobs)) = iter.next().await? {
+                let mut i = 0;
+                while i < remaining.len() {
+                    let (index, blob_id) = &remaining[i];
+                    if let Some(blob) = pending_blobs.get(blob_id).await? {
+                        maybe_blobs[*index].1 = Some(blob);
+                        remaining.swap_remove(i);
+                    } else {
+                        i += 1;
                     }
+                }
+                if remaining.is_empty() {
+                    break;
                 }
             }
         }

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -3179,45 +3179,46 @@ impl<Env: Environment> ChainClient<Env> {
             .map(BlockHeight)
             .collect();
 
-        let certificates = self
-            .client
-            .storage_client()
-            .read_certificates_by_heights(self.chain_id, &heights)
-            .await?
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
+        Box::pin(async {
+            let mut cert_stream = self
+                .client
+                .storage_client()
+                .read_certificates_by_heights_iter(self.chain_id, heights);
 
-        for certificate in certificates {
-            match remote_node
-                .handle_confirmed_certificate(
-                    certificate.clone(),
-                    CrossChainMessageDelivery::NonBlocking,
-                )
-                .await
-            {
-                Ok(_) => (),
-                Err(NodeError::BlobsNotFound(missing_blob_ids)) => {
-                    // Upload the missing blobs we have and retry.
-                    let missing_blobs: Vec<_> = self
-                        .client
-                        .storage_client()
-                        .read_blobs(&missing_blob_ids)
-                        .await?
-                        .into_iter()
-                        .flatten()
-                        .collect();
-                    remote_node.upload_blobs(missing_blobs).await?;
-                    remote_node
-                        .handle_confirmed_certificate(
-                            certificate,
-                            CrossChainMessageDelivery::NonBlocking,
-                        )
-                        .await?;
+            while let Some(result) = cert_stream.next().await {
+                let certificate = result?;
+                match remote_node
+                    .handle_confirmed_certificate(
+                        certificate.clone(),
+                        CrossChainMessageDelivery::NonBlocking,
+                    )
+                    .await
+                {
+                    Ok(_) => (),
+                    Err(NodeError::BlobsNotFound(missing_blob_ids)) => {
+                        // Upload the missing blobs we have and retry.
+                        let missing_blobs: Vec<_> = self
+                            .client
+                            .storage_client()
+                            .read_blobs(&missing_blob_ids)
+                            .await?
+                            .into_iter()
+                            .flatten()
+                            .collect();
+                        remote_node.upload_blobs(missing_blobs).await?;
+                        remote_node
+                            .handle_confirmed_certificate(
+                                certificate,
+                                CrossChainMessageDelivery::NonBlocking,
+                            )
+                            .await?;
+                    }
+                    Err(err) => return Err(err.into()),
                 }
-                Err(err) => return Err(err.into()),
             }
-        }
+            Ok::<_, Error>(())
+        })
+        .await?;
 
         Ok(())
     }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -40,7 +40,7 @@ use linera_chain::{
     ChainError,
 };
 use linera_execution::{committee::Committee, ExecutionError};
-use linera_storage::{Clock as _, Storage as _};
+use linera_storage::{Clock as _, ResultReadCertificates, Storage as _};
 use rand::seq::SliceRandom;
 use received_log::ReceivedLogs;
 use serde::{Deserialize, Serialize};
@@ -559,24 +559,21 @@ impl<Env: Environment> Client<Env> {
             .local_node
             .get_preprocessed_block_hashes(chain_id, next_height, end)
             .await?;
-        last_info = Box::pin(async {
-            let certificates = self.storage_client().read_certificates(&hashes).await?;
-            let mut info = last_info;
-            // Missing certificates are skipped; they will be downloaded from the remote node below.
-            for certificate in certificates.into_iter().flatten() {
-                if let Some(until) = until_block_time {
-                    if certificate.value().block().header.timestamp >= until {
-                        break;
-                    }
-                }
-                info = self
-                    .handle_certificate(Arc::unwrap_or_clone(certificate))
-                    .await?
-                    .info;
+        let certificates = self.storage_client().read_certificates(&hashes).await?;
+        let certificates = match ResultReadCertificates::new(certificates, hashes) {
+            ResultReadCertificates::Certificates(certificates) => certificates,
+            ResultReadCertificates::InvalidHashes(hashes) => {
+                return Err(chain_client::Error::ReadCertificatesError(hashes))
             }
-            Ok::<_, chain_client::Error>(info)
-        })
-        .await?;
+        };
+        for certificate in certificates {
+            if let Some(until) = until_block_time {
+                if certificate.value().block().header.timestamp >= until {
+                    break;
+                }
+            }
+            last_info = self.handle_certificate(certificate).await?.info;
+        }
         Ok(last_info)
     }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -40,7 +40,7 @@ use linera_chain::{
     ChainError,
 };
 use linera_execution::{committee::Committee, ExecutionError};
-use linera_storage::{Clock as _, ResultReadCertificates, Storage as _};
+use linera_storage::{Clock as _, Storage as _};
 use rand::seq::SliceRandom;
 use received_log::ReceivedLogs;
 use serde::{Deserialize, Serialize};
@@ -365,10 +365,6 @@ impl<Env: Environment> Client<Env> {
         self.environment.network()
     }
 
-    pub(crate) fn options(&self) -> &chain_client::Options {
-        &self.options
-    }
-
     /// Handles any pending local cross-chain requests, notifying subscribers.
     pub async fn retry_pending_cross_chain_requests(
         &self,
@@ -563,21 +559,24 @@ impl<Env: Environment> Client<Env> {
             .local_node
             .get_preprocessed_block_hashes(chain_id, next_height, end)
             .await?;
-        let certificates = self.storage_client().read_certificates(&hashes).await?;
-        let certificates = match ResultReadCertificates::new(certificates, hashes) {
-            ResultReadCertificates::Certificates(certificates) => certificates,
-            ResultReadCertificates::InvalidHashes(hashes) => {
-                return Err(chain_client::Error::ReadCertificatesError(hashes))
-            }
-        };
-        for certificate in certificates {
-            if let Some(until) = until_block_time {
-                if certificate.value().block().header.timestamp >= until {
-                    break;
+        last_info = Box::pin(async {
+            let certificates = self.storage_client().read_certificates(&hashes).await?;
+            let mut info = last_info;
+            // Missing certificates are skipped; they will be downloaded from the remote node below.
+            for certificate in certificates.into_iter().flatten() {
+                if let Some(until) = until_block_time {
+                    if certificate.value().block().header.timestamp >= until {
+                        break;
+                    }
                 }
+                info = self
+                    .handle_certificate(Arc::unwrap_or_clone(certificate))
+                    .await?
+                    .info;
             }
-            last_info = self.handle_certificate(certificate).await?.info;
-        }
+            Ok::<_, chain_client::Error>(info)
+        })
+        .await?;
         Ok(last_info)
     }
 

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -770,17 +770,17 @@ where
             return Ok(info);
         }
 
-        let batch_size = self.client.options().certificate_upload_batch_size as usize;
-        for chunk in heights.chunks(batch_size) {
-            let certificates = self
-                .read_certificates_for_heights(chain_id, chunk.to_vec())
-                .await?;
-
-            for certificate in certificates {
-                self.send_confirmed_certificate(&certificate, delivery)
+        // Send any additional missing certificates in order
+        Box::pin(async {
+            let storage = self.client.local_node.storage_client();
+            let mut stream = storage.read_certificates_by_heights_iter(chain_id, heights);
+            while let Some(certificate) = stream.next().await {
+                self.send_confirmed_certificate(&certificate?, delivery)
                     .await?;
             }
-        }
+            Ok::<_, chain_client::Error>(())
+        })
+        .await?;
 
         Ok(info)
     }
@@ -947,28 +947,18 @@ where
             .into_iter()
             .map(|(chain_id, heights)| {
                 let mut updater = self.clone();
-                async move {
-                    // Get all block hashes for this chain at the specified heights in one call
-                    let heights_vec: Vec<_> = heights.into_iter().collect();
-                    let certificates = updater
-                        .client
-                        .local_node
-                        .storage_client()
-                        .read_certificates_by_heights(chain_id, &heights_vec)
-                        .await?
-                        .into_iter()
-                        .flatten()
-                        .collect::<Vec<_>>();
-
-                    // Send each certificate
-                    for certificate in certificates {
+                Box::pin(async move {
+                    let heights_vec = heights.into_iter().collect::<Vec<_>>();
+                    let storage = updater.client.local_node.storage_client();
+                    let mut stream =
+                        storage.read_certificates_by_heights_iter(chain_id, heights_vec);
+                    while let Some(certificate) = stream.next().await {
                         updater
-                            .send_confirmed_certificate(&certificate, delivery)
+                            .send_confirmed_certificate(&certificate?, delivery)
                             .await?;
                     }
-
                     Ok::<_, chain_client::Error>(())
-                }
+                })
             })
             .collect::<FuturesUnordered<_>>()
             .try_collect::<Vec<_>>()

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -778,11 +778,9 @@ where
                 self.send_confirmed_certificate(&certificate?, delivery)
                     .await?;
             }
-            Ok::<_, chain_client::Error>(())
+            Ok::<_, chain_client::Error>(info)
         })
-        .await?;
-
-        Ok(info)
+        .await
     }
 
     /// Reads certificates for the given heights from storage.

--- a/linera-sdk/tests/fixtures/Cargo.lock
+++ b/linera-sdk/tests/fixtures/Cargo.lock
@@ -2427,6 +2427,7 @@ dependencies = [
 name = "linera-storage"
 version = "0.16.0"
 dependencies = [
+ "async-stream",
  "async-trait",
  "bcs",
  "cfg-if",
@@ -2450,6 +2451,7 @@ version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-lock",
+ "async-stream",
  "bcs",
  "cfg_aliases",
  "clap",
@@ -2496,6 +2498,7 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "async-lock",
+ "async-stream",
  "bcs",
  "cfg_aliases",
  "convert_case",

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -27,6 +27,7 @@ path = "src/server.rs"
 [dependencies]
 anyhow.workspace = true
 async-lock.workspace = true
+async-stream.workspace = true
 bcs.workspace = true
 clap.workspace = true
 futures.workspace = true

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -19,7 +19,9 @@ use linera_views::store::TestKeyValueDatabase;
 use linera_views::{
     batch::{Batch, WriteOperation},
     lru_caching::LruCachingDatabase,
-    store::{KeyValueDatabase, ReadableKeyValueStore, WithError, WritableKeyValueStore},
+    store::{
+        KeyValueDatabase, ReadValueStream, ReadableKeyValueStore, WithError, WritableKeyValueStore,
+    },
 };
 use serde::de::DeserializeOwned;
 use tonic::transport::{Channel, Endpoint};
@@ -44,6 +46,9 @@ use crate::{
 
 // The maximum key size is set to 1M rather arbitrarily.
 const MAX_KEY_SIZE: usize = 1000000;
+
+// The batch size in `read_multi_values_bytes_iter`.
+const BATCH_SIZE: usize = 50;
 
 // The shared store client.
 // * Interior mutability is required for the client because
@@ -206,6 +211,19 @@ impl ReadableKeyValueStore for StorageServiceStoreInternal {
         } else {
             self.read_entries(message_index, num_chunks).await
         }
+    }
+
+    fn read_multi_values_bytes_iter(&self, keys: Vec<Vec<u8>>) -> ReadValueStream<'_, Self::Error> {
+        let store = self.clone();
+
+        Box::pin(async_stream::try_stream! {
+            for chunk in keys.chunks(BATCH_SIZE) {
+                let values = store.read_multi_values_bytes(chunk).await?;
+                for value in values {
+                    yield value;
+                }
+            }
+        })
     }
 
     async fn find_keys_by_prefix(

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -37,6 +37,7 @@ web = [
 ]
 
 [dependencies]
+async-stream.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
 cfg-if.workspace = true

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use futures::stream::StreamExt;
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
@@ -43,7 +44,7 @@ use {
     std::cmp::Reverse,
 };
 
-use crate::{ChainRuntimeContext, Clock, Storage};
+use crate::{ChainRuntimeContext, Clock, Storage, StorageStream};
 
 #[cfg(with_metrics)]
 pub mod metrics {
@@ -1275,6 +1276,58 @@ where
                 Some(raw) => self.deserialize_and_cache_certificate(&raw.0, &raw.1),
             })
             .collect()
+    }
+
+    fn read_certificate_hashes_by_heights_iter(
+        &self,
+        chain_id: ChainId,
+        heights: Vec<BlockHeight>,
+    ) -> StorageStream<'_, Result<Option<CryptoHash>, ViewError>> {
+        Box::pin(async_stream::try_stream! {
+            let index_root_key = RootKey::BlockByHeight(chain_id).bytes();
+            let store = self.database.open_shared(&index_root_key)?;
+            let height_keys: Vec<Vec<u8>> = heights.iter().map(|h| to_height_key(*h)).collect();
+            let mut stream = store.read_multi_values_bytes_iter(height_keys);
+            while let Some(result) = stream.next().await {
+                let opt = result?;
+                let hash = opt
+                    .map(|bytes| bcs::from_bytes::<CryptoHash>(&bytes))
+                    .transpose()?;
+                yield hash;
+            }
+        })
+    }
+
+    fn read_certificates_by_heights_iter(
+        &self,
+        chain_id: ChainId,
+        heights: Vec<BlockHeight>,
+    ) -> StorageStream<'_, Result<Arc<ConfirmedBlockCertificate>, ViewError>> {
+        Box::pin(async_stream::try_stream! {
+            let mut hash_stream = self.read_certificate_hashes_by_heights_iter(chain_id, heights);
+            let block_keys = get_block_keys();
+            while let Some(result) = hash_stream.next().await {
+                let Some(hash) = result? else {
+                    continue;
+                };
+                let root_key = RootKey::BlockHash(hash).bytes();
+                let store = self.database.open_shared(&root_key)?;
+                let values = store.read_multi_values_bytes(&block_keys).await?;
+                match (values[0].as_ref(), values[1].as_ref()) {
+                    (Some(lite_cert_bytes), Some(confirmed_block_bytes)) => {
+                        if let Some(arc) = self
+                            .deserialize_and_cache_certificate(lite_cert_bytes, confirmed_block_bytes)?
+                        {
+                            yield arc;
+                        }
+                    }
+                    _ => {
+                        // Height mapped to a hash but the certificate is missing.
+                        // Skip, consistent with the flatten() in the non-streaming version.
+                    }
+                }
+            }
+        })
     }
 
     #[instrument(skip_all, fields(event_id = ?event_id))]

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -5,9 +5,10 @@
 
 mod db_storage;
 
-use std::sync::Arc;
+use std::{pin::Pin, sync::Arc};
 
 use async_trait::async_trait;
+use futures::stream::Stream;
 use itertools::Itertools;
 use linera_base::{
     crypto::CryptoHash,
@@ -47,6 +48,14 @@ pub use crate::db_storage::{TestClock, DEFAULT_STORAGE_CACHE_CONFIG};
 
 /// The default namespace to be used when none is specified
 pub const DEFAULT_NAMESPACE: &str = "default";
+
+/// A boxed stream that is `Send` on native and not on web.
+#[cfg(not(web))]
+pub type StorageStream<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + 'a>>;
+
+/// A boxed stream that is `Send` on native and not on web.
+#[cfg(web)]
+pub type StorageStream<'a, T> = Pin<Box<dyn Stream<Item = T> + 'a>>;
 
 /// Communicate with a persistent storage using the "views" abstraction.
 #[cfg_attr(not(web), async_trait)]
@@ -221,6 +230,22 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         &self,
         event_ids: &[EventId],
     ) -> Result<Vec<Option<BlockHeight>>, ViewError>;
+
+    /// Returns a stream of certificate hashes for the requested chain and heights.
+    /// Yields `Ok(Option<CryptoHash>)` for each height.
+    fn read_certificate_hashes_by_heights_iter(
+        &self,
+        chain_id: ChainId,
+        heights: Vec<BlockHeight>,
+    ) -> StorageStream<'_, Result<Option<CryptoHash>, ViewError>>;
+
+    /// Returns a stream of certificates for the requested chain and heights,
+    /// skipping heights with no certificate.
+    fn read_certificates_by_heights_iter(
+        &self,
+        chain_id: ChainId,
+        heights: Vec<BlockHeight>,
+    ) -> StorageStream<'_, Result<Arc<ConfirmedBlockCertificate>, ViewError>>;
 
     /// Reads the event with the given ID.
     async fn read_event(&self, id: EventId) -> Result<Option<Arc<Vec<u8>>>, ViewError>;

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -36,6 +36,7 @@ allocative.workspace = true
 anyhow.workspace = true
 async-graphql.workspace = true
 async-lock.workspace = true
+async-stream.workspace = true
 aws-config = { workspace = true, optional = true }
 aws-sdk-dynamodb = { workspace = true, optional = true }
 aws-smithy-types = { workspace = true, optional = true }

--- a/linera-views/src/backends/dual.rs
+++ b/linera-views/src/backends/dual.rs
@@ -3,6 +3,7 @@
 
 //! Implements [`crate::store::KeyValueStore`] by combining two existing stores.
 
+use futures::stream::StreamExt;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -11,7 +12,7 @@ use crate::store::TestKeyValueDatabase;
 use crate::{
     batch::Batch,
     store::{
-        KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore, WithError,
+        KeyValueDatabase, KeyValueStoreError, ReadValueStream, ReadableKeyValueStore, WithError,
         WritableKeyValueStore,
     },
 };
@@ -159,6 +160,25 @@ where
                 .map_err(DualStoreError::Second)?,
         };
         Ok(result)
+    }
+
+    fn read_multi_values_bytes_iter(&self, keys: Vec<Vec<u8>>) -> ReadValueStream<'_, Self::Error> {
+        Box::pin(async_stream::try_stream! {
+            match self {
+                Self::First(store) => {
+                    let mut stream = store.read_multi_values_bytes_iter(keys);
+                    while let Some(result) = stream.next().await {
+                        yield result.map_err(DualStoreError::First)?;
+                    }
+                }
+                Self::Second(store) => {
+                    let mut stream = store.read_multi_values_bytes_iter(keys);
+                    while let Some(result) = stream.next().await {
+                        yield result.map_err(DualStoreError::Second)?;
+                    }
+                }
+            }
+        })
     }
 
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -47,8 +47,8 @@ use crate::{
     journaling::JournalingKeyValueDatabase,
     lru_caching::{LruCachingConfig, LruCachingDatabase},
     store::{
-        DirectWritableKeyValueStore, KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore,
-        WithError,
+        DirectWritableKeyValueStore, KeyValueDatabase, KeyValueStoreError, ReadValueStream,
+        ReadableKeyValueStore, WithError,
     },
     value_splitting::{ValueSplittingDatabase, ValueSplittingError},
 };
@@ -811,6 +811,7 @@ impl WithError for DynamoDbStoreInternal {
     type Error = DynamoDbStoreInternalError;
 }
 
+/// Iterator for reading multiple values from DynamoDB.
 impl ReadableKeyValueStore for DynamoDbStoreInternal {
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
 
@@ -871,6 +872,25 @@ impl ReadableKeyValueStore for DynamoDbStoreInternal {
             .into_iter()
             .collect::<Result<_, _>>()?;
         Ok(results.into_iter().flatten().collect())
+    }
+
+    fn read_multi_values_bytes_iter(&self, keys: Vec<Vec<u8>>) -> ReadValueStream<'_, Self::Error> {
+        // Split keys into batches
+        let chunks = keys
+            .chunks(MAX_BATCH_GET_ITEM_SIZE)
+            .map(|chunk| chunk.to_vec())
+            .collect::<Vec<_>>();
+        let store = self.clone();
+
+        Box::pin(async_stream::try_stream! {
+            for chunk in chunks {
+                let values = store.read_batch_values_bytes(&chunk).await?;
+
+                for value in values {
+                    yield value;
+                }
+            }
+        })
     }
 
     async fn find_keys_by_prefix(

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -811,7 +811,6 @@ impl WithError for DynamoDbStoreInternal {
     type Error = DynamoDbStoreInternalError;
 }
 
-/// Iterator for reading multiple values from DynamoDB.
 impl ReadableKeyValueStore for DynamoDbStoreInternal {
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
 

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -105,6 +105,7 @@ impl WithError for IndexedDbDatabase {
     type Error = IndexedDbStoreError;
 }
 
+/// Iterator for reading multiple values from IndexedDbStore.
 impl ReadableKeyValueStore for IndexedDbStore {
     const MAX_KEY_SIZE: usize = usize::MAX;
 

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -105,7 +105,6 @@ impl WithError for IndexedDbDatabase {
     type Error = IndexedDbStoreError;
 }
 
-/// Iterator for reading multiple values from IndexedDbStore.
 impl ReadableKeyValueStore for IndexedDbStore {
     const MAX_KEY_SIZE: usize = usize::MAX;
 

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -19,6 +19,7 @@
 //! time the data in a block are written, the journal header is updated in the same
 //! transaction to mark the block as processed.
 
+use futures::stream::StreamExt;
 use serde::{Deserialize, Serialize};
 use static_assertions as sa;
 use thiserror::Error;
@@ -26,8 +27,8 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, BatchValueWriter, DeletePrefixExpander, SimplifiedBatch},
     store::{
-        DirectKeyValueStore, KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore,
-        WithError, WritableKeyValueStore,
+        DirectKeyValueStore, KeyValueDatabase, KeyValueStoreError, ReadValueStream,
+        ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
     views::MIN_VIEW_TAG,
 };
@@ -190,6 +191,14 @@ where
         keys: &[Vec<u8>],
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
         Ok(self.store.read_multi_values_bytes(keys).await?)
+    }
+
+    fn read_multi_values_bytes_iter(&self, keys: Vec<Vec<u8>>) -> ReadValueStream<'_, Self::Error> {
+        Box::pin(
+            self.store
+                .read_multi_values_bytes_iter(keys)
+                .map(|r| Ok(r?)),
+        )
     }
 
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -328,15 +328,16 @@ where
                             value
                         } else {
                             // The key has been evicted. Should be rare.
+                            #[cfg(with_metrics)]
+                            metrics::READ_VALUE_CACHE_MISS_COUNT.with_label_values(&[]).inc();
                             self.store.read_value_bytes(key).await?
                         }
                     } else {
+                        #[cfg(with_metrics)]
+                        metrics::READ_VALUE_CACHE_MISS_COUNT.with_label_values(&[]).inc();
                         uncached_stream.next().await
                             .expect("read_multi_values_bytes_iter stream ended before yielding all values")?
                     };
-
-                    #[cfg(with_metrics)]
-                    metrics::READ_VALUE_CACHE_MISS_COUNT.with_label_values(&[]).inc();
 
                     {
                         let mut cache = cache.lock().unwrap();

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -5,6 +5,7 @@
 
 use std::sync::{Arc, Mutex};
 
+use futures::stream::StreamExt;
 use serde::{Deserialize, Serialize};
 
 #[cfg(with_testing)]
@@ -14,7 +15,9 @@ use crate::store::TestKeyValueDatabase;
 use crate::{
     batch::{Batch, WriteOperation},
     lru_prefix_cache::{LruPrefixCache, StorageCacheConfig},
-    store::{KeyValueDatabase, ReadableKeyValueStore, WithError, WritableKeyValueStore},
+    store::{
+        KeyValueDatabase, ReadValueStream, ReadableKeyValueStore, WithError, WritableKeyValueStore,
+    },
 };
 
 #[cfg(with_metrics)]
@@ -291,6 +294,64 @@ where
             }
         }
         Ok(result)
+    }
+
+    fn read_multi_values_bytes_iter(&self, keys: Vec<Vec<u8>>) -> ReadValueStream<'_, Self::Error> {
+        Box::pin(async_stream::try_stream! {
+            if let Some(cache) = &self.cache {
+                let mut is_cached = Vec::new();
+                let mut uncached_keys = Vec::new();
+
+                {
+                    let cache = cache.lock().unwrap();
+                    for key in &keys {
+                        if cache.test_key_presence(key) {
+                            is_cached.push(true);
+                        } else {
+                            is_cached.push(false);
+                            uncached_keys.push(key.clone());
+                        }
+                    }
+                }
+
+                let mut uncached_stream = self.store.read_multi_values_bytes_iter(uncached_keys);
+
+                for (i, key) in keys.iter().enumerate() {
+                    let value = if is_cached[i] {
+                        let cached_value = {
+                            let mut cache = cache.lock().unwrap();
+                            cache.query_read_value(key)
+                        };
+                        if let Some(value) = cached_value {
+                            #[cfg(with_metrics)]
+                            metrics::READ_VALUE_CACHE_HIT_COUNT.with_label_values(&[]).inc();
+                            value
+                        } else {
+                            // The key has been evicted. Should be rare.
+                            self.store.read_value_bytes(key).await?
+                        }
+                    } else {
+                        uncached_stream.next().await
+                            .expect("read_multi_values_bytes_iter stream ended before yielding all values")?
+                    };
+
+                    #[cfg(with_metrics)]
+                    metrics::READ_VALUE_CACHE_MISS_COUNT.with_label_values(&[]).inc();
+
+                    {
+                        let mut cache = cache.lock().unwrap();
+                        cache.insert_read_value(key, &value);
+                    }
+
+                    yield value;
+                }
+            } else {
+                let mut stream = self.store.read_multi_values_bytes_iter(keys);
+                while let Some(item) = stream.next().await {
+                    yield item?;
+                }
+            }
+        })
     }
 
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -126,6 +126,7 @@ impl WithError for MemoryStore {
     type Error = MemoryStoreError;
 }
 
+/// Iterator for reading multiple values from MemoryStore.
 impl ReadableKeyValueStore for MemoryStore {
     const MAX_KEY_SIZE: usize = usize::MAX;
 

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -126,7 +126,6 @@ impl WithError for MemoryStore {
     type Error = MemoryStoreError;
 }
 
-/// Iterator for reading multiple values from MemoryStore.
 impl ReadableKeyValueStore for MemoryStore {
     const MAX_KEY_SIZE: usize = usize::MAX;
 

--- a/linera-views/src/backends/metering.rs
+++ b/linera-views/src/backends/metering.rs
@@ -19,7 +19,9 @@ use prometheus::{exponential_buckets, HistogramVec, IntCounterVec};
 use crate::store::TestKeyValueDatabase;
 use crate::{
     batch::Batch,
-    store::{KeyValueDatabase, ReadableKeyValueStore, WithError, WritableKeyValueStore},
+    store::{
+        KeyValueDatabase, ReadValueStream, ReadableKeyValueStore, WithError, WritableKeyValueStore,
+    },
 };
 
 #[derive(Clone)]
@@ -414,6 +416,21 @@ where
             .with_label_values(&[])
             .observe(key_sizes as f64);
         self.store.read_multi_values_bytes(keys).await
+    }
+
+    fn read_multi_values_bytes_iter(&self, keys: Vec<Vec<u8>>) -> ReadValueStream<'_, Self::Error> {
+        // Record metrics for the iterator creation
+        self.counter
+            .read_multi_values_num_entries
+            .with_label_values(&[])
+            .observe(keys.len() as f64);
+        let key_sizes = keys.iter().map(|k| k.len()).sum::<usize>();
+        self.counter
+            .read_multi_values_key_sizes
+            .with_label_values(&[])
+            .observe(key_sizes as f64);
+
+        self.store.read_multi_values_bytes_iter(keys)
     }
 
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {

--- a/linera-views/src/backends/metering.rs
+++ b/linera-views/src/backends/metering.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use convert_case::{Case, Casing};
+use futures::stream::StreamExt;
 use linera_base::prometheus_util::{
     exponential_bucket_latencies, register_histogram_vec, register_int_counter_vec,
     MeasureLatency as _,
@@ -419,7 +420,6 @@ where
     }
 
     fn read_multi_values_bytes_iter(&self, keys: Vec<Vec<u8>>) -> ReadValueStream<'_, Self::Error> {
-        // Record metrics for the iterator creation
         self.counter
             .read_multi_values_num_entries
             .with_label_values(&[])
@@ -430,7 +430,15 @@ where
             .with_label_values(&[])
             .observe(key_sizes as f64);
 
-        self.store.read_multi_values_bytes_iter(keys)
+        // Latency is measured from the first poll until the stream is exhausted or
+        // dropped. The guard lives in the async block, which is entered on first poll.
+        Box::pin(async_stream::try_stream! {
+            let _latency = self.counter.read_multi_values_bytes_latency.measure_latency();
+            let mut stream = self.store.read_multi_values_bytes_iter(keys);
+            while let Some(item) = stream.next().await {
+                yield item?;
+            }
+        })
     }
 
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -29,7 +29,7 @@ use crate::{
     common::get_upper_bound_option,
     lru_caching::{LruCachingConfig, LruCachingDatabase},
     store::{
-        KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore, WithError,
+        KeyValueDatabase, KeyValueStoreError, ReadValueStream, ReadableKeyValueStore, WithError,
         WritableKeyValueStore,
     },
     value_splitting::{ValueSplittingDatabase, ValueSplittingError},
@@ -66,6 +66,9 @@ fn get_available_cpus() -> i32 {
 }
 
 const HYPER_CLOCK_CACHE_BLOCK_SIZE: usize = 8 * 1024; // 8 KiB
+
+// The size of batches in the `read_multi_values_bytes_iter`.
+const BATCH_SIZE: usize = 50;
 
 /// The RocksDB client that we use.
 type DB = rocksdb::DBWithThreadMode<rocksdb::MultiThreaded>;
@@ -510,6 +513,36 @@ impl ReadableKeyValueStore for RocksDbStoreInternal {
                 keys.to_vec(),
             )
             .await
+    }
+
+    fn read_multi_values_bytes_iter(&self, keys: Vec<Vec<u8>>) -> ReadValueStream<'_, Self::Error> {
+        let executor = self.executor.clone();
+        let spawn_mode = self.spawn_mode;
+
+        Box::pin(async_stream::try_stream! {
+            let mut current_position = 0;
+            while current_position < keys.len() {
+                // Calculate the end position for this batch
+                let end_position = std::cmp::min(current_position + BATCH_SIZE, keys.len());
+
+                // Extract the next batch of keys
+                let chunk = keys[current_position..end_position].to_vec();
+                current_position = end_position;
+
+                // Load the batch
+                let executor = executor.clone();
+                let values = spawn_mode
+                    .spawn(
+                        move |x| executor.read_multi_values_bytes_internal(x),
+                        chunk,
+                    )
+                    .await?;
+
+                for value in values {
+                    yield value;
+                }
+            }
+        })
     }
 
     async fn find_keys_by_prefix(

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -47,8 +47,8 @@ use crate::{
     journaling::{JournalingError, JournalingKeyValueDatabase},
     lru_caching::{LruCachingConfig, LruCachingDatabase},
     store::{
-        DirectWritableKeyValueStore, KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore,
-        WithError,
+        DirectWritableKeyValueStore, KeyValueDatabase, KeyValueStoreError, ReadValueStream,
+        ReadableKeyValueStore, WithError,
     },
     value_splitting::{ValueSplittingDatabase, ValueSplittingError},
 };
@@ -656,6 +656,29 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
             .into_iter()
             .collect::<Result<_, _>>()?;
         Ok(results.into_iter().flatten().collect())
+    }
+
+    fn read_multi_values_bytes_iter(&self, keys: Vec<Vec<u8>>) -> ReadValueStream<'_, Self::Error> {
+        let chunks = keys
+            .chunks(MAX_MULTI_KEYS)
+            .map(|chunk| chunk.to_vec())
+            .collect::<Vec<_>>();
+        let store = self.clone();
+
+        Box::pin(async_stream::try_stream! {
+            for chunk in chunks {
+                let values = {
+                    let store_ref = store.store.deref();
+                    let root_key = store.root_key.clone();
+                    let _guard = store.acquire().await;
+                    Box::pin(store_ref.read_multi_values_internal(&root_key, chunk)).await?
+                };
+
+                for value in values {
+                    yield value;
+                }
+            }
+        })
     }
 
     async fn find_keys_by_prefix(

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -3,13 +3,14 @@
 
 //! Adds support for large values to a given store by splitting them between several keys.
 
+use futures::stream::StreamExt;
 use linera_base::ensure;
 use thiserror::Error;
 
 use crate::{
     batch::{Batch, WriteOperation},
     store::{
-        KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore, WithError,
+        KeyValueDatabase, KeyValueStoreError, ReadValueStream, ReadableKeyValueStore, WithError,
         WritableKeyValueStore,
     },
 };
@@ -204,6 +205,70 @@ where
             }
         }
         Ok(big_values)
+    }
+
+    fn read_multi_values_bytes_iter(&self, keys: Vec<Vec<u8>>) -> ReadValueStream<'_, Self::Error> {
+        // Create big_keys (keys with [0,0,0,0] suffix) for the first segments
+        let big_keys = keys
+            .iter()
+            .map(|key| {
+                let mut big_key = key.clone();
+                big_key.extend(&[0, 0, 0, 0]);
+                big_key
+            })
+            .collect::<Vec<_>>();
+
+        let mut first_segments_stream = self.store.read_multi_values_bytes_iter(big_keys);
+
+        Box::pin(async_stream::stream! {
+            for key in keys {
+                // Get the next value from the first segments stream
+                let value = match first_segments_stream.next().await {
+                    Some(result) => result.map_err(ValueSplittingError::InnerStoreError)?,
+                    None => {
+                        yield Err(ValueSplittingError::MissingSegment);
+                        return;
+                    }
+                };
+
+                let Some(value) = value else {
+                    yield Ok(None);
+                    continue;
+                };
+
+                // Read the count from the first segment
+                let count = ValueSplittingStore::<S>::read_count_from_value(&value)?;
+
+                let mut big_value = value[4..].to_vec();
+
+                if count == 1 {
+                    yield Ok(Some(big_value));
+                    continue;
+                }
+
+                // Need to fetch additional segments
+                let segment_keys = (1..count)
+                    .map(|i| ValueSplittingStore::<S>::get_segment_key(&key, i))
+                    .collect::<Result<Vec<_>,_>>()?;
+
+                let segments = self.store.read_multi_values_bytes(&segment_keys).await
+                    .map_err(ValueSplittingError::InnerStoreError)?;
+
+                for segment in segments {
+                    match segment {
+                        None => {
+                            yield Err(ValueSplittingError::MissingSegment);
+                            return;
+                        }
+                        Some(segment) => {
+                            big_value.extend(segment);
+                        }
+                    }
+                }
+
+                yield Ok(Some(big_value));
+            }
+        })
     }
 
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {
@@ -457,6 +522,10 @@ impl ReadableKeyValueStore for LimitedTestMemoryStore {
         keys: &[Vec<u8>],
     ) -> Result<Vec<Option<Vec<u8>>>, MemoryStoreError> {
         self.inner.read_multi_values_bytes(keys).await
+    }
+
+    fn read_multi_values_bytes_iter(&self, keys: Vec<Vec<u8>>) -> ReadValueStream<'_, Self::Error> {
+        self.inner.read_multi_values_bytes_iter(keys)
     }
 
     async fn find_keys_by_prefix(

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -220,6 +220,9 @@ where
 
         let mut first_segments_stream = self.store.read_multi_values_bytes_iter(big_keys);
 
+        // We use `stream!` rather than `try_stream!` because `MissingSegment` is yielded as an
+        // explicit `Err` item (without an inner cause to propagate via `?`), and `try_stream!`
+        // wraps bare yields in `Ok`, which would turn a `yield Err(...)` into `Ok(Err(...))`.
         Box::pin(async_stream::stream! {
             for key in keys {
                 // Get the next value from the first segments stream

--- a/linera-views/src/lru_prefix_cache.rs
+++ b/linera-views/src/lru_prefix_cache.rs
@@ -820,6 +820,20 @@ impl LruPrefixCache {
         }
     }
 
+    /// Returns whether the cache can decide if a key is present or not.
+    pub(crate) fn test_key_presence(&self, key: &[u8]) -> bool {
+        // First, query the value map
+        if matches!(self.value_map.get(key), Some(ValueEntry::Value(_))) {
+            return true;
+        }
+        if self.has_exclusive_access {
+            // Now trying the FindKeyValues map.
+            self.get_existing_find_key_values_entry(key).is_some()
+        } else {
+            false
+        }
+    }
+
     /// Returns the cached value, or `Some(None)` if the entry does not exist in the
     /// database. If `None` is returned, the entry might exist in the database but is
     /// not in the cache.

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -3,8 +3,9 @@
 
 //! This provides the trait definitions for the stores.
 
-use std::{fmt::Debug, future::Future};
+use std::{fmt::Debug, future::Future, pin::Pin};
 
+use futures::stream::Stream;
 use serde::{de::DeserializeOwned, Serialize};
 
 #[cfg(with_testing)]
@@ -14,6 +15,15 @@ use crate::{
     common::from_bytes_option,
     ViewError,
 };
+
+/// A boxed stream for reading multiple values from a key-value store.
+#[cfg(not(web))]
+pub type ReadValueStream<'a, E> =
+    Pin<Box<dyn Stream<Item = Result<Option<Vec<u8>>, E>> + Send + 'a>>;
+
+/// A boxed stream for reading multiple values from a key-value store.
+#[cfg(web)]
+pub type ReadValueStream<'a, E> = Pin<Box<dyn Stream<Item = Result<Option<Vec<u8>>, E>> + 'a>>;
 
 /// The error type for the key-value stores.
 pub trait KeyValueStoreError:
@@ -72,6 +82,24 @@ pub trait ReadableKeyValueStore: WithError {
         &self,
         keys: &[Vec<u8>],
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error>;
+
+    /// Returns a boxed stream for reading multiple values using the provided `keys`.
+    /// The stream yields `Result<Option<Vec<u8>>, Self::Error>` where:
+    /// - `Ok(None)` when a key doesn't exist
+    /// - `Ok(Some(value))` when a key exists with a value
+    /// - `Err(e)` on error
+    ///
+    /// The default implementation fetches all values at once and yields them one by one.
+    /// Returns a boxed stream to avoid deeply nested monomorphized types that cause
+    /// stack overflows when multiple store wrapper layers are composed.
+    fn read_multi_values_bytes_iter(&self, keys: Vec<Vec<u8>>) -> ReadValueStream<'_, Self::Error> {
+        Box::pin(async_stream::try_stream! {
+            let values = self.read_multi_values_bytes(&keys).await?;
+            for value in values {
+                yield value;
+            }
+        })
+    }
 
     /// Finds the `key` matching the prefix. The prefix is not included in the returned keys.
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error>;

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -9,6 +9,7 @@ pub mod performance;
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
+use futures::TryStreamExt;
 use rand::{seq::SliceRandom, Rng};
 
 use crate::{
@@ -235,6 +236,13 @@ pub async fn run_reads<S: KeyValueStore>(store: S, key_values: Vec<(Vec<u8>, Vec
         }
         let test_exists_direct = store.contains_keys(&keys).await.unwrap();
         let values_read = store.read_multi_values_bytes(&keys).await.unwrap();
+        // Test read_multi_values_bytes_iter
+        let values_from_iter = store
+            .read_multi_values_bytes_iter(keys)
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("Error reading from iterator");
+        assert_eq!(values_read, values_from_iter);
         assert_eq!(values, values_read);
         assert_eq!(values, values_single_read);
         let values_read_stat = values_read.iter().map(|x| x.is_some()).collect::<Vec<_>>();
@@ -452,7 +460,9 @@ where
 {
     let mut rng = make_deterministic_rng();
     let namespace = generate_test_namespace();
-    let store = D::connect(&config, &namespace).await.unwrap();
+    let store = D::maybe_create_and_connect(&config, &namespace)
+        .await
+        .unwrap();
     let store = store.open_exclusive(&[]).unwrap();
     let key_prefix = vec![42, 54];
     let mut batch = Batch::new();
@@ -471,6 +481,13 @@ where
     let store = D::connect(&config, &namespace).await.unwrap();
     let store = store.open_exclusive(&[]).unwrap();
     let values_read = store.read_multi_values_bytes(&keys).await.unwrap();
+    // Test read_multi_values_bytes_iter
+    let values_from_iter = store
+        .read_multi_values_bytes_iter(keys)
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("Error reading from iterator");
+    assert_eq!(values_read, values_from_iter);
     assert_eq!(values, values_read);
 }
 

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -44,6 +44,7 @@ use std::{
 };
 
 use allocative::Allocative;
+use futures::stream::StreamExt;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
@@ -55,7 +56,7 @@ use crate::{
     context::{BaseKey, Context},
     hashable_wrapper::WrappedHashableContainerView,
     historical_hash_wrapper::HistoricallyHashableView,
-    store::ReadableKeyValueStore as _,
+    store::{KeyValueStoreError, ReadableKeyValueStore},
     views::{ClonableView, HashableView, Hasher, ReplaceContext, View, ViewError},
 };
 
@@ -70,6 +71,47 @@ pub struct ByteMapView<C, V> {
     deletion_set: DeletionSet,
     /// Pending changes not yet persisted to storage.
     updates: BTreeMap<Vec<u8>, Update<V>>,
+}
+
+/// State of a value slot in the multi-get iterator.
+enum SlotState<V> {
+    /// Value is already known (from updates or deletions).
+    Cached(Option<V>),
+    /// Value needs to be fetched from store.
+    NeedsFetch,
+}
+
+/// Type alias for the stream used in multi-get operations.
+type MultiGetStream<'a, C> =
+    crate::store::ReadValueStream<'a, <<C as Context>::Store as crate::store::WithError>::Error>;
+
+/// Iterator for multi-get operations on map views.
+pub struct MapViewMultiGet<V, I> {
+    cached_iter: std::vec::IntoIter<SlotState<V>>,
+    store_iter: I,
+}
+
+impl<V, I> MapViewMultiGet<V, I> {
+    /// Returns the next value, or None if iteration is complete.
+    pub async fn next<E>(&mut self) -> Result<Option<Option<V>>, ViewError>
+    where
+        V: DeserializeOwned,
+        I: futures::stream::Stream<Item = Result<Option<Vec<u8>>, E>> + Unpin,
+        E: KeyValueStoreError,
+    {
+        match self.cached_iter.next() {
+            None => Ok(None),
+            Some(SlotState::Cached(value)) => Ok(Some(value)),
+            Some(SlotState::NeedsFetch) => {
+                let value_bytes = self.store_iter.next().await.transpose()?;
+                let value = match value_bytes {
+                    Some(bytes) => from_bytes_option(&bytes)?,
+                    None => None,
+                };
+                Ok(Some(value))
+            }
+        }
+    }
 }
 
 impl<C: Context, C2: Context, V> ReplaceContext<C2> for ByteMapView<C, V>
@@ -382,6 +424,57 @@ where
             results[i] = from_bytes_option(&value)?;
         }
         Ok(results)
+    }
+
+    /// Returns an iterator over the key-value pairs at the given positions.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::map_view::ByteMapView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut map = ByteMapView::load(context).await.unwrap();
+    /// map.insert(vec![0, 1], String::from("Hello"));
+    /// let mut iter = map.multi_get_iter(&[vec![0, 1], vec![0, 2]]);
+    /// let value1 = iter.next().await.unwrap().unwrap();
+    /// assert_eq!(value1, Some(String::from("Hello")));
+    /// assert!(iter.next().await.unwrap().unwrap().is_none());
+    /// assert!(iter.next().await.unwrap().is_none());
+    /// # })
+    /// ```
+    pub fn multi_get_iter(
+        &self,
+        short_keys: &[Vec<u8>],
+    ) -> MapViewMultiGet<V, MultiGetStream<'_, C>> {
+        let size = short_keys.len();
+        let mut vector_query = Vec::new();
+        let mut cached = Vec::with_capacity(size);
+
+        for short_key in short_keys.iter() {
+            if let Some(update) = self.updates.get(short_key) {
+                let value = match update {
+                    Update::Removed => None,
+                    Update::Set(value) => Some(value.clone()),
+                };
+                cached.push(SlotState::Cached(value));
+            } else if self.deletion_set.contains_prefix_of(short_key) {
+                cached.push(SlotState::Cached(None));
+            } else {
+                cached.push(SlotState::NeedsFetch);
+                let key = self.context.base_key().base_index(short_key);
+                vector_query.push(key);
+            }
+        }
+
+        let store_iter = self
+            .context
+            .store()
+            .read_multi_values_bytes_iter(vector_query);
+
+        MapViewMultiGet {
+            cached_iter: cached.into_iter(),
+            store_iter,
+        }
     }
 
     /// Reads the key-value pairs at the given positions, if any.
@@ -1234,6 +1327,22 @@ where
         self.map.multi_get(short_keys).await
     }
 
+    /// Returns an iterator for reading multiple values at the given indices.
+    pub fn multi_get_iter<'a, Q>(
+        &self,
+        indices: impl IntoIterator<Item = &'a Q>,
+    ) -> Result<MapViewMultiGet<V, MultiGetStream<'_, C>>, ViewError>
+    where
+        I: Borrow<Q>,
+        Q: Serialize + 'a,
+    {
+        let short_keys = indices
+            .into_iter()
+            .map(|index| BaseKey::derive_short_key(index))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(self.map.multi_get_iter(&short_keys))
+    }
+
     /// Reads the index-value pairs at the given positions, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
@@ -1785,6 +1894,22 @@ where
             .map(|index| index.to_custom_bytes())
             .collect::<Result<_, _>>()?;
         self.map.multi_get(short_keys).await
+    }
+
+    /// Returns an iterator for reading multiple values at the given indices.
+    pub fn multi_get_iter<'a, Q>(
+        &self,
+        indices: impl IntoIterator<Item = &'a Q>,
+    ) -> Result<MapViewMultiGet<V, MultiGetStream<'_, C>>, ViewError>
+    where
+        I: Borrow<Q>,
+        Q: CustomSerialize + 'a,
+    {
+        let short_keys = indices
+            .into_iter()
+            .map(|index| index.to_custom_bytes())
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(self.map.multi_get_iter(&short_keys))
     }
 
     /// Read index-value pairs at several positions, if any.

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -103,12 +103,12 @@ impl<V, I> MapViewMultiGet<V, I> {
             None => Ok(None),
             Some(SlotState::Cached(value)) => Ok(Some(value)),
             Some(SlotState::NeedsFetch) => {
-                let value_bytes = self.store_iter.next().await.transpose()?;
-                let value = match value_bytes {
-                    Some(bytes) => from_bytes_option(&bytes)?,
-                    None => None,
-                };
-                Ok(Some(value))
+                let value_bytes = self.store_iter.next().await.transpose()?.ok_or_else(|| {
+                    ViewError::MissingEntries(
+                        "store stream ended before all values were read".to_string(),
+                    )
+                })?;
+                Ok(Some(from_bytes_option(&value_bytes)?))
             }
         }
     }

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -13,6 +13,7 @@ use std::{
 
 use allocative::{Allocative, Key, Visitor};
 use async_lock::{RwLock, RwLockReadGuardArc, RwLockWriteGuardArc};
+use futures::stream::StreamExt;
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
 use serde::{de::DeserializeOwned, Serialize};
@@ -71,6 +72,131 @@ impl<T> std::ops::Deref for WriteGuardedView<T> {
 impl<T> std::ops::DerefMut for WriteGuardedView<T> {
     fn deref_mut(&mut self) -> &mut T {
         self.0.deref_mut()
+    }
+}
+
+enum LoadInfo<W> {
+    Loaded {
+        short_key: Vec<u8>,
+        view: Arc<RwLock<W>>,
+    },
+    NotLoaded {
+        short_key: Vec<u8>,
+    },
+}
+
+/// Iterator for try_load_all_entries on ReentrantByteCollectionView.
+pub struct ByteReentrantCollectionViewTryLoadAllEntries<C, W, S>
+where
+    C: Context,
+{
+    context: C,
+    load_infos: std::vec::IntoIter<LoadInfo<W>>,
+    store_iter: S,
+    current_loaded_values: Vec<Option<Vec<u8>>>,
+}
+
+impl<C, W, S> ByteReentrantCollectionViewTryLoadAllEntries<C, W, S>
+where
+    C: Context,
+    W: View<Context = C>,
+    S: futures::stream::Stream<
+            Item = Result<Option<Vec<u8>>, <C::Store as crate::store::WithError>::Error>,
+        > + Unpin,
+{
+    /// Returns the next entry, or None if iteration is complete.
+    pub async fn next(&mut self) -> Result<Option<(Vec<u8>, ReadGuardedView<W>)>, ViewError> {
+        let Some(load_info) = self.load_infos.next() else {
+            return Ok(None);
+        };
+
+        let (short_key, view) = match load_info {
+            LoadInfo::Loaded { short_key, view } => (short_key, view),
+            LoadInfo::NotLoaded { short_key } => {
+                self.current_loaded_values.clear();
+                for _ in 0..W::NUM_INIT_KEYS {
+                    let value = self.store_iter.next().await.transpose()?.ok_or_else(|| {
+                        ViewError::MissingEntries(
+                            "store stream ended before all values were read".to_string(),
+                        )
+                    })?;
+                    self.current_loaded_values.push(value);
+                }
+                let key = self
+                    .context
+                    .base_key()
+                    .base_tag_index(KeyTag::Subview as u8, &short_key);
+                let context = self.context.clone_with_base_key(key);
+                let view = W::post_load(context, &self.current_loaded_values)?;
+                let wrapped_view = Arc::new(RwLock::new(view));
+                (short_key, wrapped_view)
+            }
+        };
+        let guard = ReadGuardedView(
+            view.try_read_arc()
+                .ok_or_else(|| ViewError::TryLockError(short_key.clone()))?,
+        );
+        Ok(Some((short_key, guard)))
+    }
+}
+
+/// Iterator for try_load_all_entries on ReentrantCollectionView.
+pub struct ReentrantCollectionViewTryLoadAllEntries<C, I, W, S>
+where
+    C: Context,
+{
+    inner: ByteReentrantCollectionViewTryLoadAllEntries<C, W, S>,
+    _phantom: PhantomData<I>,
+}
+
+impl<C, I, W, S> ReentrantCollectionViewTryLoadAllEntries<C, I, W, S>
+where
+    C: Context,
+    W: View<Context = C>,
+    I: Serialize + DeserializeOwned,
+    S: futures::stream::Stream<
+            Item = Result<Option<Vec<u8>>, <C::Store as crate::store::WithError>::Error>,
+        > + Unpin,
+{
+    /// Returns the next entry, or None if iteration is complete.
+    pub async fn next(&mut self) -> Result<Option<(I, ReadGuardedView<W>)>, ViewError> {
+        match self.inner.next().await? {
+            None => Ok(None),
+            Some((short_key, view)) => {
+                let index = BaseKey::deserialize_value(&short_key)?;
+                Ok(Some((index, view)))
+            }
+        }
+    }
+}
+
+/// Iterator for try_load_all_entries on ReentrantCustomCollectionView.
+pub struct ReentrantCustomCollectionViewTryLoadAllEntries<C, I, W, S>
+where
+    C: Context,
+{
+    inner: ByteReentrantCollectionViewTryLoadAllEntries<C, W, S>,
+    _phantom: PhantomData<I>,
+}
+
+impl<C, I, W, S> ReentrantCustomCollectionViewTryLoadAllEntries<C, I, W, S>
+where
+    C: Context,
+    W: View<Context = C>,
+    I: CustomSerialize,
+    S: futures::stream::Stream<
+            Item = Result<Option<Vec<u8>>, <C::Store as crate::store::WithError>::Error>,
+        > + Unpin,
+{
+    /// Returns the next entry, or None if iteration is complete.
+    pub async fn next(&mut self) -> Result<Option<(I, ReadGuardedView<W>)>, ViewError> {
+        match self.inner.next().await? {
+            None => Ok(None),
+            Some((short_key, view)) => {
+                let index = I::from_custom_bytes(&short_key)?;
+                Ok(Some((index, view)))
+            }
+        }
     }
 }
 
@@ -829,6 +955,72 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
             .collect()
     }
 
+    /// Returns an iterator for loading all entries.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
+    /// # use linera_views::register_view::RegisterView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut view: ReentrantByteCollectionView<_, RegisterView<_, String>> =
+    ///     ReentrantByteCollectionView::load(context).await.unwrap();
+    /// {
+    ///     let _subview = view.try_load_entry_mut(&[0, 1]).await.unwrap();
+    /// }
+    /// let mut iter = view.try_load_all_entries_iter().await.unwrap();
+    /// assert!(iter.next().await.unwrap().is_some());
+    /// assert!(iter.next().await.unwrap().is_none());
+    /// # })
+    /// ```
+    pub async fn try_load_all_entries_iter(
+        &self,
+    ) -> Result<
+        ByteReentrantCollectionViewTryLoadAllEntries<
+            W::Context,
+            W,
+            impl futures::stream::Stream<
+                    Item = Result<Option<Vec<u8>>, <W::Context as Context>::Error>,
+                > + Unpin
+                + '_,
+        >,
+        ViewError,
+    > {
+        // First determine the short_keys
+        let short_keys = self.keys().await?;
+
+        // Extract updates (only Set variants) into a map
+        let mut load_infos = Vec::new();
+        let mut keys = Vec::new();
+        for short_key in short_keys {
+            if let Some(Update::Set(view)) = self.updates.get(&short_key) {
+                load_infos.push(LoadInfo::Loaded {
+                    short_key,
+                    view: view.clone(),
+                });
+            } else if !self.delete_storage_first {
+                let key = self
+                    .context
+                    .base_key()
+                    .base_tag_index(KeyTag::Subview as u8, &short_key);
+                let context = self.context.clone_with_base_key(key);
+                keys.extend(W::pre_load(&context)?);
+                load_infos.push(LoadInfo::NotLoaded { short_key });
+            }
+        }
+
+        // Third, create the iter from the "keys"
+        let store_iter = self.context.store().read_multi_values_bytes_iter(keys);
+
+        // Create the iterator struct with context
+        Ok(ByteReentrantCollectionViewTryLoadAllEntries {
+            context: self.context.clone(),
+            load_infos: load_infos.into_iter(),
+            store_iter,
+            current_loaded_values: Vec::with_capacity(W::NUM_INIT_KEYS),
+        })
+    }
+
     /// Loads all the entries for writing at once.
     /// ```rust
     /// # tokio_test::block_on(async {
@@ -1560,6 +1752,45 @@ where
             })
             .collect()
     }
+
+    /// Returns an iterator over all the entries in the collection.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
+    /// # use linera_views::register_view::RegisterView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut view: ReentrantCollectionView<_, u64, RegisterView<_, String>> =
+    ///     ReentrantCollectionView::load(context).await.unwrap();
+    /// {
+    ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
+    /// }
+    /// let mut iter = view.try_load_all_entries_iter().await.unwrap();
+    /// assert!(iter.next().await.unwrap().is_some());
+    /// assert!(iter.next().await.unwrap().is_none());
+    /// # })
+    /// ```
+    pub async fn try_load_all_entries_iter(
+        &self,
+    ) -> Result<
+        ReentrantCollectionViewTryLoadAllEntries<
+            W::Context,
+            I,
+            W,
+            impl futures::stream::Stream<
+                    Item = Result<Option<Vec<u8>>, <W::Context as Context>::Error>,
+                > + Unpin
+                + '_,
+        >,
+        ViewError,
+    > {
+        let inner = self.collection.try_load_all_entries_iter().await?;
+        Ok(ReentrantCollectionViewTryLoadAllEntries {
+            inner,
+            _phantom: PhantomData,
+        })
+    }
 }
 
 impl<I, W> ReentrantCollectionView<W::Context, I, W>
@@ -2122,6 +2353,45 @@ where
                 Ok((index, view))
             })
             .collect()
+    }
+
+    /// Returns an iterator over all the entries in the collection.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
+    /// # use linera_views::register_view::RegisterView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut view: ReentrantCustomCollectionView<_, u128, RegisterView<_, String>> =
+    ///     ReentrantCustomCollectionView::load(context).await.unwrap();
+    /// {
+    ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
+    /// }
+    /// let mut iter = view.try_load_all_entries_iter().await.unwrap();
+    /// assert!(iter.next().await.unwrap().is_some());
+    /// assert!(iter.next().await.unwrap().is_none());
+    /// # })
+    /// ```
+    pub async fn try_load_all_entries_iter(
+        &self,
+    ) -> Result<
+        ReentrantCustomCollectionViewTryLoadAllEntries<
+            W::Context,
+            I,
+            W,
+            impl futures::stream::Stream<
+                    Item = Result<Option<Vec<u8>>, <W::Context as Context>::Error>,
+                > + Unpin
+                + '_,
+        >,
+        ViewError,
+    > {
+        let inner = self.collection.try_load_all_entries_iter().await?;
+        Ok(ReentrantCustomCollectionViewTryLoadAllEntries {
+            inner,
+            _phantom: PhantomData,
+        })
     }
 }
 

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -36,7 +36,7 @@ async fn test_read_multi_values_memory() {
 async fn test_read_multi_values_dynamo_db() {
     use linera_views::dynamo_db::DynamoDbDatabase;
     let config = DynamoDbDatabase::new_test_config().await.unwrap();
-    big_read_multi_values::<DynamoDbDatabase>(config, 22000000, 1000).await;
+    big_read_multi_values::<DynamoDbDatabase>(config, 22000000, 200).await;
 }
 
 #[ignore]


### PR DESCRIPTION
## Motivation

Accessing data at once can be suboptimal when reading data.
The solution to that is to implement asynchronous iterators.

Fixes https://github.com/linera-io/linera-protocol/issues/4831
Fixes https://github.com/linera-io/linera-protocol/issues/2742

## Proposal

The implementation takes the keys by value (that is `Vec<Vec<u8>>`).
We cannot use references because when we create specific keys in
lru-caching and value-splitting, we would need to have a self-reference
which is not allowed.

The implementation by container is then as follows:
* For DynamoDB and ScyllaDB, the downloading of data is done by block of 99 or 40 keys. So, the implementation of the iterator is straightforward to do.
* For RocksDB / LineraStorageService, we download by blocks of 50 keys.This is somewhat artificial. But better than downloading all the data.
* For lru-caching, value-splitting, we predetermine the needed keys. But when needed, sometimes we need to access keys (keys that were removed from the cache or additional segments) and so we access to the storage.

The implementation in the views is done for two cases where we have a use case in the code (the two issues in question):
* Access to multiple keys in `MapView`.
* Access to multiple views in `try_load_all_entries`.

For those two use cases, the loop can end prematurely, justifying the use of iterators.
It is unsure whether we can really reduce memory usage 

## Test Plan

The CI.

## Release Plan

Those changes could be backported to TestNet Conway.

## Links

None.