### PR TITLE
Thread latest certficiate for chain updates (#4963)

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -539,7 +539,16 @@ impl<C: ClientContext + 'static> ChainListener<C> {
     async fn update_validators(&self, notification: &Notification) -> Result<(), Error> {
         let chain_id = notification.chain_id;
         let listening_client = self.listening.get(&chain_id).expect("missing client");
-        if let Err(error) = listening_client.client.update_validators(None).await {
+        let latest_block = if let Reason::NewBlock { hash, .. } = &notification.reason {
+            listening_client.client.read_certificate(*hash).await.ok()
+        } else {
+            None
+        };
+        if let Err(error) = listening_client
+            .client
+            .update_validators(None, latest_block)
+            .await
+        {
             warn!(
                 "Failed to update validators about the local chain after \
                  receiving {notification:?} with error: {error:?}"

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -724,6 +724,7 @@ impl<Env: Environment> Client<Env> {
         chain_id: ChainId,
         height: BlockHeight,
         delivery: CrossChainMessageDelivery,
+        latest_certificate: Option<GenericCertificate<ConfirmedBlock>>,
     ) -> Result<(), chain_client::Error> {
         let nodes = self.make_nodes(committee)?;
         communicate_with_quorum(
@@ -736,9 +737,10 @@ impl<Env: Environment> Client<Env> {
                     client: self.clone(),
                     admin_id: self.admin_id,
                 };
+                let certificate = latest_certificate.clone();
                 Box::pin(async move {
                     updater
-                        .send_chain_information(chain_id, height, delivery)
+                        .send_chain_information(chain_id, height, delivery, certificate)
                         .await
                 })
             },

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1097,7 +1097,7 @@ where
         Some(cert2)
     );
     client1
-        .communicate_chain_updates(&builder.initial_committee)
+        .communicate_chain_updates(&builder.initial_committee, None)
         .await
         .unwrap();
     // Client2 does not know about the money yet.
@@ -2978,7 +2978,7 @@ where
 
     // Update the validators on the chain.
     // If it works, it means the validator has been correctly updated.
-    client2.update_validators(None).await.unwrap();
+    client2.update_validators(None, None).await.unwrap();
 
     client2
         .transfer(


### PR DESCRIPTION
## Motivation

When debugging Faucet performance we noticed that
`communicate_with_quorum` takes significantly longer when sending chain updates (compared to submitting block proposals and validated certificates). Comparing the work being done between the calls, `send_chain_information` additionally has to load the latest hash from the `local_node.chain_state_view` (which is two async calls) and then read a certificate for it from the storage (another async call).

## Proposal

Thread through the latest certificate if it's known and don't read it from the storage in `send_chain_information`.

## Test Plan

Tests are updated.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
