### PR TITLE
Fix monitoring stack

### DIFF
--- a/kubernetes/linera-validator/helmfile.yaml
+++ b/kubernetes/linera-validator/helmfile.yaml
@@ -182,5 +182,6 @@ releases:
     namespace: tempo
     chart: grafana/tempo
     timeout: 900
+    installed: {{ env "LINERA_HELMFILE_SET_TEMPO_ENABLED" | default "false" }}
     values:
       - {{ env "LINERA_HELMFILE_VALUES_LINERA_CORE" | default "values-local.yaml.gotmpl" }}

--- a/kubernetes/linera-validator/values-local.yaml.gotmpl
+++ b/kubernetes/linera-validator/values-local.yaml.gotmpl
@@ -59,6 +59,7 @@ alloy:
 
 # Loki
 loki-stack:
+  enabled: true
   loki:
     enabled: true
     isDefault: false
@@ -76,6 +77,7 @@ loki-stack:
 
 # Prometheus/Grafana
 kube-prometheus-stack:
+  enabled: true
   grafana:
     sidecar:
       dashboards:


### PR DESCRIPTION
## Motivation

We need to make sure the monitoring stack is explicitly enabled, and that tempo only gets installed when enabled

## Proposal

Do the proposed fixes

## Test Plan

Deploying a network with this, saw that the monitoring stack is there as expected (it wasn't before).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
