### PR TITLE
Fix missing committee blob handling. (#4978)

### DIFF
--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -263,7 +263,7 @@ where
         let mut sent_admin_chain = false;
         let mut sent_blobs = false;
         loop {
-            result = match result {
+            match result {
                 Err(NodeError::EventsNotFound(event_ids))
                     if !sent_admin_chain
                         && certificate.inner().chain_id() != self.admin_id
@@ -275,9 +275,6 @@ where
                     // The validator doesn't have the committee that signed the certificate.
                     self.update_admin_chain().await?;
                     sent_admin_chain = true;
-                    self.remote_node
-                        .handle_confirmed_certificate(certificate.clone(), delivery)
-                        .await
                 }
                 Err(NodeError::BlobsNotFound(blob_ids)) if !sent_blobs => {
                     // The validator is missing the blobs required by the certificate.
@@ -292,12 +289,13 @@ where
                     let blobs = maybe_blobs.ok_or(NodeError::BlobsNotFound(blob_ids))?;
                     self.remote_node.node.upload_blobs(blobs).await?;
                     sent_blobs = true;
-                    self.remote_node
-                        .handle_confirmed_certificate(certificate.clone(), delivery)
-                        .await
                 }
                 result => return Ok(result?),
-            };
+            }
+            result = self
+                .remote_node
+                .handle_confirmed_certificate(certificate.clone(), delivery)
+                .await;
         }
     }
 
@@ -312,7 +310,7 @@ where
             .await;
 
         let chain_id = certificate.inner().chain_id();
-        Ok(match &result {
+        match &result {
             Err(original_err @ NodeError::BlobsNotFound(blob_ids)) => {
                 self.remote_node
                     .check_blobs_not_found(&certificate, blob_ids)?;
@@ -325,9 +323,6 @@ where
                     .await?
                     .ok_or_else(|| original_err.clone())?;
                 self.remote_node.send_pending_blobs(chain_id, blobs).await?;
-                self.remote_node
-                    .handle_validated_certificate(certificate)
-                    .await
             }
             Err(error) => {
                 self.sync_if_needed(
@@ -337,12 +332,13 @@ where
                     error,
                 )
                 .await?;
-                self.remote_node
-                    .handle_validated_certificate(certificate)
-                    .await
             }
-            _ => result,
-        }?)
+            _ => return Ok(result?),
+        }
+        Ok(self
+            .remote_node
+            .handle_validated_certificate(certificate)
+            .await?)
     }
 
     /// Requests a vote for a timeout certificate for the given round from the remote node.
@@ -658,22 +654,15 @@ where
                     .ok_or_else(|| ChainClientError::MissingConfirmedBlock(hash))?
             };
             let info = match self.send_confirmed_certificate(certificate, delivery).await {
-                Err(ChainClientError::RemoteNodeError(NodeError::EventsNotFound(event_ids)))
-                    if event_ids.iter().all(|event_id| {
-                        event_id.stream_id == StreamId::system(EPOCH_STREAM_NAME)
-                            && event_id.chain_id == self.admin_id
-                    }) =>
-                {
-                    if chain_id != self.admin_id {
-                        tracing::error!(
-                            "Missing epochs were not handled by send_confirmed_certificate."
-                        );
-                    }
+                Ok(info) => info,
+                Err(error) => {
+                    tracing::debug!(
+                        address = self.remote_node.address(), %error,
+                        "validator failed to handle confirmed certificate; sending whole chain",
+                    );
                     let query = ChainInfoQuery::new(chain_id);
                     self.remote_node.handle_chain_info_query(query).await?
                 }
-                Err(err) => return Err(err),
-                Ok(info) => info,
             };
             // Obtain the missing blocks and the manager state from the local node.
             let heights = (info.next_block_height.0..target_block_height.0).map(BlockHeight);

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -171,6 +171,9 @@ pub enum WorkerError {
     #[error(transparent)]
     ChainError(#[from] Box<ChainError>),
 
+    #[error(transparent)]
+    BcsError(#[from] bcs::Error),
+
     // Chain access control
     #[error("Block was not signed by an authorized owner")]
     InvalidOwner,
@@ -278,7 +281,8 @@ impl WorkerError {
             | WorkerError::UnexpectedBlob
             | WorkerError::TooManyPublishedBlobs(_)
             | WorkerError::ViewError(ViewError::NotFound(_)) => false,
-            WorkerError::InvalidCrossChainRequest
+            WorkerError::BcsError(_)
+            | WorkerError::InvalidCrossChainRequest
             | WorkerError::ViewError(_)
             | WorkerError::ConfirmedLogEntryNotFound { .. }
             | WorkerError::PreprocessedBlocksEntryNotFound { .. }
@@ -296,16 +300,14 @@ impl From<ChainError> for WorkerError {
     #[instrument(level = "trace", skip(chain_error))]
     fn from(chain_error: ChainError) -> Self {
         match chain_error {
-            ChainError::ExecutionError(execution_error, context) => {
-                if let ExecutionError::BlobsNotFound(blob_ids) = *execution_error {
-                    Self::BlobsNotFound(blob_ids)
-                } else {
-                    Self::ChainError(Box::new(ChainError::ExecutionError(
-                        execution_error,
-                        context,
-                    )))
-                }
-            }
+            ChainError::ExecutionError(execution_error, context) => match *execution_error {
+                ExecutionError::BlobsNotFound(blob_ids) => Self::BlobsNotFound(blob_ids),
+                ExecutionError::EventsNotFound(event_ids) => Self::EventsNotFound(event_ids),
+                _ => Self::ChainError(Box::new(ChainError::ExecutionError(
+                    execution_error,
+                    context,
+                ))),
+            },
             error => Self::ChainError(Box::new(error)),
         }
     }

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -68,7 +68,8 @@ pub struct Committee {
     total_votes: u64,
     /// The threshold to form a quorum.
     quorum_threshold: u64,
-    /// The threshold to prove the validity of a statement.
+    /// The threshold to prove the validity of a statement. I.e. the assumption is that strictly
+    /// less than `validity_threshold` are faulty.
     validity_threshold: u64,
     /// The policy agreed on for this epoch.
     policy: ResourceControlPolicy,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -37,10 +37,10 @@ use linera_base::{
         Bytecode, DecompressionError, Epoch, NetworkDescription, SendMessageRequest, StreamUpdate,
         Timestamp,
     },
-    doc_scalar, hex_debug, http,
+    doc_scalar, ensure, hex_debug, http,
     identifiers::{
         Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, DataBlobHash, EventId,
-        GenericApplicationId, ModuleId, StreamName,
+        GenericApplicationId, ModuleId, StreamId, StreamName,
     },
     ownership::ChainOwnership,
     vm::VmRuntime,
@@ -52,6 +52,7 @@ use thiserror::Error;
 
 #[cfg(with_revm)]
 use crate::evm::EvmExecutionError;
+use crate::system::EPOCH_STREAM_NAME;
 #[cfg(with_testing)]
 use crate::test_utils::dummy_chain_description;
 #[cfg(all(with_testing, with_wasm_runtime))]
@@ -462,10 +463,81 @@ pub trait ExecutionRuntimeContext {
 
     async fn get_network_description(&self) -> Result<Option<NetworkDescription>, ViewError>;
 
-    async fn committees_for(
+    /// Returns the committees for the epochs in the given range.
+    async fn get_committees(
         &self,
         epoch_range: RangeInclusive<Epoch>,
-    ) -> Result<BTreeMap<Epoch, Committee>, ViewError>;
+    ) -> Result<BTreeMap<Epoch, Committee>, ExecutionError> {
+        let net_description = self
+            .get_network_description()
+            .await?
+            .ok_or(ExecutionError::NoNetworkDescriptionFound)?;
+        let committee_hashes = futures::future::join_all(
+            (epoch_range.start().0..=epoch_range.end().0).map(|epoch| async move {
+                if epoch == 0 {
+                    // Genesis epoch is stored in NetworkDescription.
+                    Ok((epoch, net_description.genesis_committee_blob_hash))
+                } else {
+                    let event_id = EventId {
+                        chain_id: net_description.admin_chain_id,
+                        stream_id: StreamId::system(EPOCH_STREAM_NAME),
+                        index: epoch,
+                    };
+                    let event = self
+                        .get_event(event_id.clone())
+                        .await?
+                        .ok_or_else(|| ExecutionError::EventsNotFound(vec![event_id]))?;
+                    Ok((epoch, bcs::from_bytes(&event)?))
+                }
+            }),
+        )
+        .await;
+        let missing_events = committee_hashes
+            .iter()
+            .filter_map(|result| {
+                if let Err(ExecutionError::EventsNotFound(event_ids)) = result {
+                    return Some(event_ids);
+                }
+                None
+            })
+            .flatten()
+            .cloned()
+            .collect::<Vec<_>>();
+        ensure!(
+            missing_events.is_empty(),
+            ExecutionError::EventsNotFound(missing_events)
+        );
+        let committee_hashes = committee_hashes
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+        let committees = futures::future::join_all(committee_hashes.into_iter().map(
+            |(epoch, committee_hash)| async move {
+                let blob_id = BlobId::new(committee_hash, BlobType::Committee);
+                let committee_blob = self
+                    .get_blob(blob_id)
+                    .await?
+                    .ok_or_else(|| ExecutionError::BlobsNotFound(vec![blob_id]))?;
+                Ok((Epoch(epoch), bcs::from_bytes(committee_blob.bytes())?))
+            },
+        ))
+        .await;
+        let missing_blobs = committees
+            .iter()
+            .filter_map(|result| {
+                if let Err(ExecutionError::BlobsNotFound(blob_ids)) = result {
+                    return Some(blob_ids);
+                }
+                None
+            })
+            .flatten()
+            .cloned()
+            .collect::<Vec<_>>();
+        ensure!(
+            missing_blobs.is_empty(),
+            ExecutionError::BlobsNotFound(missing_blobs)
+        );
+        committees.into_iter().collect()
+    }
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError>;
 
@@ -1157,33 +1229,21 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
     }
 
     async fn get_network_description(&self) -> Result<Option<NetworkDescription>, ViewError> {
+        let pinned = self.blobs.pin();
+        let genesis_committee_blob_hash = pinned
+            .iter()
+            .find(|(_, blob)| blob.content().blob_type() == BlobType::Committee)
+            .map_or_else(
+                || CryptoHash::test_hash("genesis committee"),
+                |(_, blob)| blob.id().hash,
+            );
         Ok(Some(NetworkDescription {
             admin_chain_id: dummy_chain_description(0).id(),
             genesis_config_hash: CryptoHash::test_hash("genesis config"),
             genesis_timestamp: Timestamp::from(0),
-            genesis_committee_blob_hash: CryptoHash::test_hash("genesis committee"),
+            genesis_committee_blob_hash,
             name: "dummy network description".to_string(),
         }))
-    }
-
-    async fn committees_for(
-        &self,
-        epoch_range: RangeInclusive<Epoch>,
-    ) -> Result<BTreeMap<Epoch, Committee>, ViewError> {
-        let pinned = self.blobs.pin();
-        let committee_blob_bytes = pinned
-            .values()
-            .find(|blob| blob.content().blob_type() == BlobType::Committee)
-            .ok_or_else(|| ViewError::NotFound("committee not found".to_owned()))?
-            .bytes()
-            .to_vec();
-        let committee: Committee = bcs::from_bytes(&committee_blob_bytes)?;
-        // TODO(#4146): this currently assigns the first found committee to all epochs,
-        // which should be fine for the tests we have at the moment, but might not be in
-        // the future.
-        Ok((epoch_range.start().0..=epoch_range.end().0)
-            .map(|epoch| (Epoch::from(epoch), committee.clone()))
-            .collect())
     }
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -781,17 +781,18 @@ where
         let committees = self
             .context()
             .extra()
-            .committees_for(min_active_epoch..=max_active_epoch)
+            .get_committees(min_active_epoch..=max_active_epoch)
             .await?;
-        self.committees.set(committees);
-        let admin_id = self
+        let admin_chain_id = self
             .context()
             .extra()
             .get_network_description()
             .await?
             .ok_or(ExecutionError::NoNetworkDescriptionFound)?
             .admin_chain_id;
-        self.admin_id.set(Some(admin_id));
+
+        self.committees.set(committees);
+        self.admin_id.set(Some(admin_chain_id));
         self.ownership.set(ownership);
         self.balance.set(balance);
         self.application_permissions.set(application_permissions);

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -480,7 +480,8 @@ input Committee {
 	"""
 	quorumThreshold: Int!
 	"""
-	The threshold to prove the validity of a statement.
+	The threshold to prove the validity of a statement. I.e. the assumption is that strictly
+	less than `validity_threshold` are faulty.
 	"""
 	validityThreshold: Int!
 	"""

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -2234,6 +2234,8 @@ fn main() -> anyhow::Result<process::ExitCode> {
         builder
     };
 
+    // The default stack size 2 MiB causes some stack overflows in ValidatorUpdater methods.
+    runtime.thread_stack_size(4 << 20);
     if let Some(blocking_threads) = options.tokio_blocking_threads {
         runtime.max_blocking_threads(blocking_threads);
     }


### PR DESCRIPTION
Partial backport of #4978.

## Motivation

The current `Committee` implementation is a bit complicated, and sometimes sets the quorum threshold higher than necessary.

## Proposal

#4978 revealed an issue with the certificate handling logic in the worker: `committees_for` returns `ViewErrors` instead of `BlobsNotFound`/`EventsNotFound`, so the client fails to send the validators the admin chain if needed.

This was fixed; I also kept minor cleanups I made while debugging this. I got a few stack overflows, so I doubled the client's Tokio thread stack size.

## Test Plan

CI

## Release Plan

- The fixes (but maybe not the quorum change) should be
    - released in a new SDK and
    - released in a validator hotfix.

## Links

- PR to main: #4978
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
