### PR TITLE
Track queue time for cross chain messages

### DIFF
--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -5,8 +5,9 @@
 
 use prometheus::{
     exponential_buckets, histogram_opts, linear_buckets, register_histogram,
-    register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge_vec,
-    Histogram, HistogramVec, IntCounter, IntCounterVec, IntGaugeVec, Opts,
+    register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
+    register_int_gauge_vec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge,
+    IntGaugeVec, Opts,
 };
 
 use crate::time::Instant;
@@ -54,6 +55,12 @@ pub fn register_histogram(name: &str, description: &str, buckets: Option<Vec<f64
     };
 
     register_histogram!(histogram_opts).expect("Histogram can be created")
+}
+
+/// Wrapper around Prometheus `register_int_gauge!` macro which also sets the `linera` namespace
+pub fn register_int_gauge(name: &str, description: &str) -> IntGauge {
+    let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
+    register_int_gauge!(gauge_opts).expect("IntGauge can be created")
 }
 
 /// Wrapper around Prometheus `register_int_gauge_vec!` macro which also sets the `linera` namespace


### PR DESCRIPTION
## Motivation

Sometimes our cross chain message latency can come from actually just waiting in the queue, which could indicate that we're failing to process the load efficiently

## Proposal

Add a metric to track that

## Test Plan

Deployed a network with this metric

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
