### PR TITLE
Improve exporter logging.

### DIFF
--- a/linera-service/src/exporter/runloops/task_manager.rs
+++ b/linera-service/src/exporter/runloops/task_manager.rs
@@ -79,10 +79,10 @@ where
             {
                 self.current_committee_destinations
                     .insert(destination.clone());
-                tracing::trace!(id=?destination, "starting committee exporter");
+                tracing::info!(id=?destination, "starting committee exporter");
                 self.spawn(destination);
             } else {
-                tracing::trace!(id=?destination, "skipping already running committee exporter");
+                tracing::info!(id=?destination, "skipping already running committee exporter");
             }
         }
     }
@@ -94,7 +94,7 @@ where
             .current_committee_destinations
             .difference(&new_committee.iter().cloned().collect())
         {
-            tracing::trace!(id=?id, "shutting down old committee member");
+            tracing::info!(id=?id, "shutting down old committee member");
             if let Some(abort_handle) = self.join_handles.remove(id) {
                 abort_handle.abort();
             }

--- a/linera-service/src/exporter/storage.rs
+++ b/linera-service/src/exporter/storage.rs
@@ -333,7 +333,7 @@ where
         committee_destinations.into_iter().for_each(|id| {
             let state = match self.shared_storage.destination_states.get(&id) {
                 None => {
-                    tracing::trace!(id=?id, "adding new committee member");
+                    tracing::info!(id=?id, "adding new committee member");
                     #[cfg(with_metrics)]
                     {
                         metrics::DESTINATION_STATE_COUNTER


### PR DESCRIPTION
Backport of #4996 

## Motivation

Some logs were missing from the output that are useful for debugging.

## Proposal

Turns out it's easier in our infra to re-deploy a new binary than change the logging level: so change TRACE to INFO.

## Test Plan

Manual.

## Release Plan

- Nothing to do
- 
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
