### PR TITLE
[testnet] Allow filtering incoming messages by application. (#4989)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -164,6 +164,8 @@ Client implementation and command-line tool for the Linera blockchain
     Don't include any messages in blocks, and don't make any decision whether to accept or reject
 
 * `--restrict-chain-ids-to <RESTRICT_CHAIN_IDS_TO>` — A set of chains to restrict incoming messages from. By default, messages from all chains are accepted. To reject messages from all chains, specify an empty string
+* `--reject-message-bundles-without-application-ids <REJECT_MESSAGE_BUNDLES_WITHOUT_APPLICATION_IDS>` — A set of application IDs. If specified, only bundles with at least one message from one of these applications will be accepted
+* `--reject-message-bundles-with-other-application-ids <REJECT_MESSAGE_BUNDLES_WITH_OTHER_APPLICATION_IDS>` — A set of application IDs. If specified, only bundles where all messages are from one of these applications will be accepted
 * `--timings` — Enable timing reports during operations
 * `--timing-interval <TIMING_INTERVAL>` — Interval in seconds between timing reports (defaults to 5)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5317,6 +5317,7 @@ dependencies = [
  "clap",
  "counter",
  "criterion",
+ "crowd-funding",
  "custom_debug_derive",
  "fungible",
  "futures",

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -5,7 +5,7 @@ use std::{collections::HashSet, fmt, iter, path::PathBuf};
 
 use linera_base::{
     data_types::{ApplicationPermissions, TimeDelta},
-    identifiers::{AccountOwner, ApplicationId, ChainId},
+    identifiers::{AccountOwner, ApplicationId, ChainId, GenericApplicationId},
     ownership::{ChainOwnership, TimeoutConfig},
     time::Duration,
 };
@@ -135,6 +135,16 @@ pub struct ClientContextOptions {
     #[arg(long, value_parser = util::parse_chain_set)]
     pub restrict_chain_ids_to: Option<HashSet<ChainId>>,
 
+    /// A set of application IDs. If specified, only bundles with at least one message from one of
+    /// these applications will be accepted.
+    #[arg(long, value_parser = util::parse_app_set)]
+    pub reject_message_bundles_without_application_ids: Option<HashSet<GenericApplicationId>>,
+
+    /// A set of application IDs. If specified, only bundles where all messages are from one of
+    /// these applications will be accepted.
+    #[arg(long, value_parser = util::parse_app_set)]
+    pub reject_message_bundles_with_other_application_ids: Option<HashSet<GenericApplicationId>>,
+
     /// Enable timing reports during operations
     #[cfg(not(web))]
     #[arg(long)]
@@ -247,6 +257,9 @@ impl ClientContextOptions {
         let message_policy = MessagePolicy::new(
             self.blanket_message_policy,
             self.restrict_chain_ids_to.clone(),
+            self.reject_message_bundles_without_application_ids.clone(),
+            self.reject_message_bundles_with_other_application_ids
+                .clone(),
         );
         let cross_chain_message_delivery =
             CrossChainMessageDelivery::new(self.wait_for_outgoing_messages);

--- a/linera-client/src/util.rs
+++ b/linera-client/src/util.rs
@@ -7,7 +7,7 @@ use futures::future;
 use linera_base::{
     crypto::CryptoError,
     data_types::{TimeDelta, Timestamp},
-    identifiers::ChainId,
+    identifiers::{ApplicationId, ChainId, GenericApplicationId},
     time::Duration,
 };
 use linera_core::{data_types::RoundTimeout, node::NotificationStream, worker::Reason};
@@ -30,6 +30,16 @@ pub fn parse_chain_set(s: &str) -> Result<HashSet<ChainId>, CryptoError> {
         "" => Ok(HashSet::new()),
         s => s.split(",").map(ChainId::from_str).collect(),
     }
+}
+
+pub fn parse_app_set(s: &str) -> anyhow::Result<HashSet<GenericApplicationId>> {
+    s.trim()
+        .split(",")
+        .map(|app_str| {
+            GenericApplicationId::from_str(app_str)
+                .or_else(|_| Ok(ApplicationId::from_str(app_str)?.into()))
+        })
+        .collect()
 }
 
 pub fn parse_ascii_alphanumeric_string(s: &str) -> Result<String, &'static str> {

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -98,6 +98,7 @@ alloy-primitives.workspace = true
 assert_matches.workspace = true
 counter.workspace = true
 criterion.workspace = true
+crowd-funding.workspace = true
 fungible.workspace = true
 hex-game.workspace = true
 linera-core = { path = ".", default-features = false, features = ["test"] }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -27,8 +27,8 @@ use linera_base::{
     },
     ensure,
     identifiers::{
-        Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, EventId, IndexAndEvent,
-        ModuleId, StreamId,
+        Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, EventId,
+        GenericApplicationId, IndexAndEvent, ModuleId, StreamId,
     },
     ownership::{ChainOwnership, TimeoutConfig},
     time::{Duration, Instant},
@@ -1392,6 +1392,12 @@ pub struct MessagePolicy {
     /// accepted. `Option::None` means that messages from all chains are accepted. An empty
     /// `HashSet` denotes that messages from no chains are accepted.
     restrict_chain_ids_to: Option<HashSet<ChainId>>,
+    /// A collection of applications: If `Some`, only bundles with at least one message by any
+    /// of these applications will be accepted.
+    reject_message_bundles_without_application_ids: Option<HashSet<GenericApplicationId>>,
+    /// A collection of applications: If `Some`, only bundles all of whose messages are by these
+    /// applications will be accepted.
+    reject_message_bundles_with_other_application_ids: Option<HashSet<GenericApplicationId>>,
 }
 
 #[derive(Copy, Clone, Debug, clap::ValueEnum)]
@@ -1410,10 +1416,14 @@ impl MessagePolicy {
     pub fn new(
         blanket: BlanketMessagePolicy,
         restrict_chain_ids_to: Option<HashSet<ChainId>>,
+        reject_message_bundles_without_application_ids: Option<HashSet<GenericApplicationId>>,
+        reject_message_bundles_with_other_application_ids: Option<HashSet<GenericApplicationId>>,
     ) -> Self {
         Self {
             blanket,
             restrict_chain_ids_to,
+            reject_message_bundles_without_application_ids,
+            reject_message_bundles_with_other_application_ids,
         }
     }
 
@@ -1422,22 +1432,42 @@ impl MessagePolicy {
         Self {
             blanket: BlanketMessagePolicy::Accept,
             restrict_chain_ids_to: None,
+            reject_message_bundles_without_application_ids: None,
+            reject_message_bundles_with_other_application_ids: None,
         }
     }
 
     #[instrument(level = "trace", skip(self))]
-    fn must_handle(&self, bundle: &mut IncomingBundle) -> bool {
+    fn apply(&self, mut bundle: IncomingBundle) -> Option<IncomingBundle> {
+        if let Some(chain_ids) = &self.restrict_chain_ids_to {
+            if !chain_ids.contains(&bundle.origin) {
+                return None;
+            }
+        }
+        if let Some(app_ids) = &self.reject_message_bundles_without_application_ids {
+            if !bundle
+                .messages()
+                .any(|posted_msg| app_ids.contains(&posted_msg.message.application_id()))
+            {
+                return None;
+            }
+        }
+        if let Some(app_ids) = &self.reject_message_bundles_with_other_application_ids {
+            if !bundle
+                .messages()
+                .all(|posted_msg| app_ids.contains(&posted_msg.message.application_id()))
+            {
+                return None;
+            }
+        }
         if self.is_reject() {
             if bundle.bundle.is_skippable() {
-                return false;
+                return None;
             } else if !bundle.bundle.is_protected() {
                 bundle.action = MessageAction::Reject;
             }
         }
-        match &self.restrict_chain_ids_to {
-            None => true,
-            Some(chains) => chains.contains(&bundle.origin),
-        }
+        Some(bundle)
     }
 
     #[instrument(level = "trace", skip(self))]
@@ -1865,12 +1895,7 @@ impl<Env: Environment> ChainClient<Env> {
         Ok(info
             .requested_pending_message_bundles
             .into_iter()
-            .filter_map(|mut bundle| {
-                self.options
-                    .message_policy
-                    .must_handle(&mut bundle)
-                    .then_some(bundle)
-            })
+            .filter_map(|bundle| self.options.message_policy.apply(bundle))
             .take(self.options.max_pending_message_bundles)
             .collect())
     }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2600,7 +2600,8 @@ where
         Amount::from_tokens(3)
     );
 
-    receiver.options_mut().message_policy = MessagePolicy::new(BlanketMessagePolicy::Ignore, None);
+    receiver.options_mut().message_policy =
+        MessagePolicy::new(BlanketMessagePolicy::Ignore, None, None, None);
     receiver.synchronize_from_validators().await?;
     assert!(receiver.process_inbox().await?.0.is_empty());
     // The message was ignored.
@@ -2611,7 +2612,8 @@ where
         Amount::from_tokens(3)
     );
 
-    receiver.options_mut().message_policy = MessagePolicy::new(BlanketMessagePolicy::Reject, None);
+    receiver.options_mut().message_policy =
+        MessagePolicy::new(BlanketMessagePolicy::Reject, None, None, None);
     let certs = receiver.process_inbox().await?.0;
     assert_eq!(certs.len(), 1);
     sender.synchronize_from_validators().await?;
@@ -2645,6 +2647,8 @@ where
     receiver.options_mut().message_policy = MessagePolicy::new(
         BlanketMessagePolicy::Accept,
         Some([sender.chain_id()].into_iter().collect()),
+        None,
+        None,
     );
     receiver.synchronize_from_validators().await?;
     let certs = receiver.process_inbox().await?.0;
@@ -2653,7 +2657,8 @@ where
     assert_eq!(receiver.local_balance().await.unwrap(), Amount::ONE);
 
     // Let's accept the other one, too.
-    receiver.options_mut().message_policy = MessagePolicy::new(BlanketMessagePolicy::Accept, None);
+    receiver.options_mut().message_policy =
+        MessagePolicy::new(BlanketMessagePolicy::Accept, None, None, None);
     let certs = receiver.process_inbox().await?.0;
     assert_eq!(certs.len(), 1);
     assert_eq!(
@@ -3027,7 +3032,7 @@ where
             None,
             BlockHeight::ZERO,
             ChainClientOptions {
-                message_policy: MessagePolicy::new(BlanketMessagePolicy::Reject, None),
+                message_policy: MessagePolicy::new(BlanketMessagePolicy::Reject, None, None, None),
                 ..ChainClientOptions::test_default()
             },
         )

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -18,6 +18,7 @@ use std::collections::BTreeMap;
 use assert_matches::assert_matches;
 use async_graphql::Request;
 use counter::CounterAbi;
+use crowd_funding::{CrowdFundingAbi, InstantiationArgument, Operation as CrowdFundingOperation};
 use fungible::{FungibleOperation, InitialState, Parameters};
 use hex_game::{HexAbi, Operation as HexOperation, Timeouts};
 use linera_base::{
@@ -796,6 +797,8 @@ where
     receiver.options_mut().message_policy = MessagePolicy::new(
         BlanketMessagePolicy::Accept,
         Some([sender.chain_id()].into_iter().collect()),
+        None,
+        None,
     );
 
     // Receiver should only process the event from sender now.
@@ -817,7 +820,8 @@ where
     );
 
     // Let's receive from everyone again.
-    receiver.options_mut().message_policy = MessagePolicy::new(BlanketMessagePolicy::Accept, None);
+    receiver.options_mut().message_policy =
+        MessagePolicy::new(BlanketMessagePolicy::Accept, None, None, None);
 
     // Receiver should now process the event from sender2 as well.
     let certs = receiver.process_inbox().await.unwrap().0;
@@ -885,6 +889,227 @@ where
         operations: vec![],
     };
     assert_eq!(outcome, expected);
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
+#[test_log::test(tokio::test)]
+async fn test_memory_message_policy_accept_apps(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
+    run_test_message_policy_accept_apps(MemoryStorageBuilder::with_wasm_runtime(wasm_runtime)).await
+}
+
+#[ignore]
+#[cfg(feature = "storage-service")]
+#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
+#[test_log::test(tokio::test)]
+async fn test_service_message_policy_accept_apps(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
+    run_test_message_policy_accept_apps(ServiceStorageBuilder::with_wasm_runtime(wasm_runtime))
+        .await
+}
+
+#[ignore]
+#[cfg(feature = "rocksdb")]
+#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
+#[test_log::test(tokio::test)]
+async fn test_rocks_db_message_policy_accept_apps(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
+    run_test_message_policy_accept_apps(
+        RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime).await,
+    )
+    .await
+}
+
+#[ignore]
+#[cfg(feature = "dynamodb")]
+#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
+#[test_log::test(tokio::test)]
+async fn test_dynamo_db_message_policy_accept_apps(
+    wasm_runtime: WasmRuntime,
+) -> anyhow::Result<()> {
+    run_test_message_policy_accept_apps(DynamoDbStorageBuilder::with_wasm_runtime(wasm_runtime))
+        .await
+}
+
+#[ignore]
+#[cfg(feature = "scylladb")]
+#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
+#[test_log::test(tokio::test)]
+async fn test_scylla_db_message_policy_accept_apps(
+    wasm_runtime: WasmRuntime,
+) -> anyhow::Result<()> {
+    run_test_message_policy_accept_apps(ScyllaDbStorageBuilder::with_wasm_runtime(wasm_runtime))
+        .await
+}
+
+async fn run_test_message_policy_accept_apps<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let keys = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, keys)
+        .await?
+        .with_policy(ResourceControlPolicy::all_categories());
+    let pledger_chain = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
+    let mut campaign_chain = builder.add_root_chain(2, Amount::from_tokens(10)).await?;
+
+    let pledger_owner = pledger_chain.preferred_owner().unwrap();
+    let campaign_owner = campaign_chain.preferred_owner().unwrap();
+
+    // Create a fungible token application.
+    let fungible_module = pledger_chain.publish_wasm_example("fungible").await?;
+    let fungible_module =
+        fungible_module.with_abi::<fungible::FungibleTokenAbi, Parameters, InitialState>();
+    let accounts = BTreeMap::from_iter([(pledger_owner, Amount::from_tokens(1_000))]);
+    let state = InitialState { accounts };
+    let params = Parameters::new("FUN");
+    let (fungible_id, _cert) = pledger_chain
+        .create_application(fungible_module, &params, &state, vec![])
+        .await
+        .unwrap_ok_committed();
+
+    // Create a crowd-funding application that uses the fungible token.
+    let crowd_funding_module = pledger_chain.publish_wasm_example("crowd-funding").await?;
+    let crowd_funding_module =
+        crowd_funding_module.with_abi::<CrowdFundingAbi, ApplicationId, InstantiationArgument>();
+    let deadline = Timestamp::from(u64::MAX);
+    let target = Amount::from_tokens(10);
+    let instantiation_arg = InstantiationArgument {
+        owner: campaign_owner,
+        deadline,
+        target,
+    };
+    let (crowd_funding_id, _cert) = campaign_chain
+        .create_application(
+            crowd_funding_module,
+            &fungible_id.forget_abi(),
+            &instantiation_arg,
+            vec![],
+        )
+        .await
+        .unwrap_ok_committed();
+
+    // Make a pledge from pledger_chain to campaign_chain.
+    // This creates a cross-chain bundle with messages from both fungible and crowd-funding apps.
+    let pledge_amount = Amount::from_tokens(5);
+    pledger_chain
+        .execute_operation(Operation::user(
+            crowd_funding_id,
+            &CrowdFundingOperation::Pledge {
+                owner: pledger_owner,
+                amount: pledge_amount,
+            },
+        )?)
+        .await
+        .unwrap_ok_committed();
+
+    campaign_chain.synchronize_from_validators().await?;
+
+    // Test 1: Accept bundles with at least one message from fungible app.
+    campaign_chain.options_mut().message_policy = MessagePolicy::new(
+        BlanketMessagePolicy::Accept,
+        None,
+        Some([fungible_id.forget_abi().into()].into_iter().collect()),
+        None,
+    );
+    let certs = campaign_chain.process_inbox().await?.0;
+    assert_eq!(certs.len(), 1, "Should accept bundle with fungible message");
+
+    // Reset for next test by making another pledge.
+    pledger_chain
+        .execute_operation(Operation::user(
+            crowd_funding_id,
+            &CrowdFundingOperation::Pledge {
+                owner: pledger_owner,
+                amount: pledge_amount,
+            },
+        )?)
+        .await
+        .unwrap_ok_committed();
+    campaign_chain.synchronize_from_validators().await?;
+
+    // Test 2: Accept bundles with at least one message from crowd-funding app.
+    campaign_chain.options_mut().message_policy = MessagePolicy::new(
+        BlanketMessagePolicy::Accept,
+        None,
+        Some([crowd_funding_id.forget_abi().into()].into_iter().collect()),
+        None,
+    );
+    let certs = campaign_chain.process_inbox().await?.0;
+    assert_eq!(
+        certs.len(),
+        1,
+        "Should accept bundle with crowd-funding message"
+    );
+
+    // Reset for next test.
+    pledger_chain
+        .execute_operation(Operation::user(
+            crowd_funding_id,
+            &CrowdFundingOperation::Pledge {
+                owner: pledger_owner,
+                amount: pledge_amount,
+            },
+        )?)
+        .await
+        .unwrap_ok_committed();
+    campaign_chain.synchronize_from_validators().await?;
+
+    // Test 3: Reject bundles without any message from a non-existent app.
+    // Use a different application description hash to create a fake app ID.
+    let fake_app_id = ApplicationId::new(CryptoHash::test_hash("fake app"));
+    campaign_chain.options_mut().message_policy = MessagePolicy::new(
+        BlanketMessagePolicy::Accept,
+        None,
+        Some([fake_app_id.into()].into_iter().collect()),
+        None,
+    );
+    let certs = campaign_chain.process_inbox().await?.0;
+    assert_eq!(
+        certs.len(),
+        0,
+        "Should reject bundle without message from fake app"
+    );
+
+    // Test 4: Reject bundles that contain messages from apps not in the allowlist.
+    // The bundle has messages from both fungible and crowd-funding, but we only allow fungible.
+    campaign_chain.options_mut().message_policy = MessagePolicy::new(
+        BlanketMessagePolicy::Accept,
+        None,
+        None,
+        Some([fungible_id.forget_abi().into()].into_iter().collect()),
+    );
+    let certs = campaign_chain.process_inbox().await?.0;
+    assert_eq!(
+        certs.len(),
+        0,
+        "Should reject bundle with message from non-allowed crowd-funding app"
+    );
+
+    // Test 5: Accept bundles when all app messages are in the allowlist.
+    campaign_chain.options_mut().message_policy = MessagePolicy::new(
+        BlanketMessagePolicy::Accept,
+        None,
+        None,
+        Some(
+            [
+                fungible_id.forget_abi().into(),
+                crowd_funding_id.forget_abi().into(),
+            ]
+            .into_iter()
+            .collect(),
+        ),
+    );
+    let certs = campaign_chain.process_inbox().await?.0;
+    assert_eq!(
+        certs.len(),
+        1,
+        "Should accept bundle when all app messages are allowed"
+    );
 
     Ok(())
 }

--- a/web/@linera/client/src/lib.rs
+++ b/web/@linera/client/src/lib.rs
@@ -82,6 +82,8 @@ pub const OPTIONS: ClientContextOptions = ClientContextOptions {
     wait_for_outgoing_messages: false,
     blanket_message_policy: linera_core::client::BlanketMessagePolicy::Accept,
     restrict_chain_ids_to: None,
+    reject_message_bundles_without_application_ids: None,
+    reject_message_bundles_with_other_application_ids: None,
     long_lived_services: false,
     blob_download_timeout: linera_base::time::Duration::from_millis(1000),
     certificate_batch_download_timeout: linera_base::time::Duration::from_millis(1000),


### PR DESCRIPTION
Backport of #4989.

## Motivation

It's useful to filter out spam messages on a node service that e.g. is running a chain specifically for one application.

## Proposal

Allow filtering in two ways:
* All bundles that contain _at least one_ message for a whitelisted app.
* All bundles that contain _only_ messages for whitelisted apps.

The latter is stricter, but the former can be useful e.g. for apps that create other apps and then call them.

## Test Plan

A test for the new filtering options was added. (Claude)

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a new SDK.

## Links

- PR to main: #4989.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)