### PR TITLE
Measure operation/message execution latency in microseconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ linera-web/**/*-lock.json
 .claude
 CLAUDE.md
 .serena
+docs/

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -100,6 +100,14 @@ pub fn linear_bucket_interval(start_value: f64, width: f64, end_value: f64) -> O
     Some(buckets)
 }
 
+/// The unit of measurement for latency metrics.
+enum MeasurementUnit {
+    /// Measure latency in milliseconds.
+    Milliseconds,
+    /// Measure latency in microseconds.
+    Microseconds,
+}
+
 /// A guard for an active latency measurement.
 ///
 /// Finishes the measurement when dropped, and then updates the `Metric`.
@@ -109,6 +117,7 @@ where
 {
     start: Instant,
     metric: Option<&'metric Metric>,
+    unit: MeasurementUnit,
 }
 
 impl<Metric> ActiveMeasurementGuard<'_, Metric>
@@ -116,17 +125,23 @@ where
     Metric: MeasureLatency,
 {
     /// Finishes the measurement, updates the `Metric` and returns the measured latency in
-    /// milliseconds.
+    /// the unit specified when the measurement was started.
     pub fn finish(mut self) -> f64 {
         self.finish_by_ref()
     }
 
     /// Finishes the measurement without taking ownership of this [`ActiveMeasurementGuard`],
-    /// updates the `Metric` and returns the measured latency in milliseconds.
+    /// updates the `Metric` and returns the measured latency in the unit specified when
+    /// the measurement was started.
     fn finish_by_ref(&mut self) -> f64 {
         match self.metric.take() {
             Some(metric) => {
-                let latency = self.start.elapsed().as_secs_f64() * 1000.0;
+                let latency = match self.unit {
+                    MeasurementUnit::Milliseconds => self.start.elapsed().as_secs_f64() * 1000.0,
+                    MeasurementUnit::Microseconds => {
+                        self.start.elapsed().as_secs_f64() * 1_000_000.0
+                    }
+                };
                 metric.finish_measurement(latency);
                 latency
             }
@@ -150,9 +165,13 @@ where
 
 /// An extension trait for metrics that can be used to measure latencies.
 pub trait MeasureLatency: Sized {
-    /// Starts measuring the latency, finishing when the returned
+    /// Starts measuring the latency in milliseconds, finishing when the returned
     /// [`ActiveMeasurementGuard`] is dropped.
     fn measure_latency(&self) -> ActiveMeasurementGuard<'_, Self>;
+
+    /// Starts measuring the latency in microseconds, finishing when the returned
+    /// [`ActiveMeasurementGuard`] is dropped.
+    fn measure_latency_us(&self) -> ActiveMeasurementGuard<'_, Self>;
 
     /// Updates the metric with measured latency in `milliseconds`.
     fn finish_measurement(&self, milliseconds: f64);
@@ -163,6 +182,15 @@ impl MeasureLatency for HistogramVec {
         ActiveMeasurementGuard {
             start: Instant::now(),
             metric: Some(self),
+            unit: MeasurementUnit::Milliseconds,
+        }
+    }
+
+    fn measure_latency_us(&self) -> ActiveMeasurementGuard<'_, Self> {
+        ActiveMeasurementGuard {
+            start: Instant::now(),
+            metric: Some(self),
+            unit: MeasurementUnit::Microseconds,
         }
     }
 
@@ -176,6 +204,15 @@ impl MeasureLatency for Histogram {
         ActiveMeasurementGuard {
             start: Instant::now(),
             metric: Some(self),
+            unit: MeasurementUnit::Milliseconds,
+        }
+    }
+
+    fn measure_latency_us(&self) -> ActiveMeasurementGuard<'_, Self> {
+        ActiveMeasurementGuard {
+            start: Instant::now(),
+            metric: Some(self),
+            unit: MeasurementUnit::Microseconds,
         }
     }
 

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -141,7 +141,7 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                     .track_block_size_of(&operation)
                     .with_execution_context(chain_execution_context)?;
                 #[cfg(with_metrics)]
-                let _operation_latency = metrics::OPERATION_EXECUTION_LATENCY.measure_latency();
+                let _operation_latency = metrics::OPERATION_EXECUTION_LATENCY.measure_latency_us();
                 let context = OperationContext {
                     chain_id: self.chain_id,
                     height: self.block_height,
@@ -196,7 +196,7 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         C::Extra: ExecutionRuntimeContext,
     {
         #[cfg(with_metrics)]
-        let _message_latency = metrics::MESSAGE_EXECUTION_LATENCY.measure_latency();
+        let _message_latency = metrics::MESSAGE_EXECUTION_LATENCY.measure_latency_us();
         let context = MessageContext {
             chain_id: self.chain_id,
             origin: incoming_bundle.origin,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -76,7 +76,7 @@ pub(crate) mod metrics {
             "block_execution_latency",
             "Block execution latency",
             &[],
-            exponential_bucket_latencies(1000.0),
+            exponential_bucket_interval(50.0_f64, 10_000_000.0),
         )
     });
 
@@ -86,7 +86,7 @@ pub(crate) mod metrics {
             "message_execution_latency",
             "Message execution latency",
             &[],
-            exponential_bucket_latencies(50.0),
+            exponential_bucket_interval(0.1_f64, 50_000.0),
         )
     });
 
@@ -95,7 +95,7 @@ pub(crate) mod metrics {
             "operation_execution_latency",
             "Operation execution latency",
             &[],
-            exponential_bucket_latencies(50.0),
+            exponential_bucket_interval(0.1_f64, 50_000.0),
         )
     });
 
@@ -781,7 +781,7 @@ where
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
     ) -> Result<BlockExecutionOutcome, ChainError> {
         #[cfg(with_metrics)]
-        let _execution_latency = metrics::BLOCK_EXECUTION_LATENCY.measure_latency();
+        let _execution_latency = metrics::BLOCK_EXECUTION_LATENCY.measure_latency_us();
         chain.system.timestamp.set(block.timestamp);
 
         let policy = chain


### PR DESCRIPTION
## Motivation

Our latency for operation/message execution is actually in the microseconds in the benchmarks. So it makes sense to actually track this in microseconds instead, to avoid dealing with super small numbers

## Proposal

Added support for measuring latency in different units, and started measuring operation/message execution in microseconds.

## Test Plan

Deployed a network with this, saw the updated metric

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
