### PR TITLE
Check block cache on create_cross_chain_requests

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -538,26 +538,50 @@ where
             })?;
             hashes.push(hash);
         }
-        let certificates = self.storage.read_certificates(hashes.clone()).await?;
-        let certificates = match ResultReadCertificates::new(certificates, hashes) {
-            ResultReadCertificates::Certificates(certificates) => certificates,
-            ResultReadCertificates::InvalidHashes(hashes) => {
-                return Err(WorkerError::ReadCertificatesError(hashes))
+
+        let mut uncached_hashes = Vec::new();
+        let mut height_to_blocks: HashMap<BlockHeight, Hashed<Block>> = HashMap::new();
+
+        for hash in hashes {
+            if let Some(hashed_block) = self.block_values.get(&hash) {
+                height_to_blocks.insert(hashed_block.inner().header.height, hashed_block);
+            } else {
+                uncached_hashes.push(hash);
             }
-        };
-        let height_to_certificates = heights
-            .into_iter()
-            .zip(certificates)
-            .collect::<HashMap<_, _>>();
-        // For each medium, select the relevant messages.
+        }
+
+        if !uncached_hashes.is_empty() {
+            let certificates = self
+                .storage
+                .read_certificates(uncached_hashes.clone())
+                .await?;
+            let certificates = match ResultReadCertificates::new(certificates, uncached_hashes) {
+                ResultReadCertificates::Certificates(certificates) => certificates,
+                ResultReadCertificates::InvalidHashes(hashes) => {
+                    return Err(WorkerError::ReadCertificatesError(hashes))
+                }
+            };
+
+            for cert in certificates {
+                let hashed_block = cert.into_value().into_inner();
+                let height = hashed_block.inner().header.height;
+                self.block_values.insert(Cow::Owned(hashed_block.clone()));
+                height_to_blocks.insert(height, hashed_block);
+            }
+        }
+
         let mut cross_chain_requests = Vec::new();
         for (recipient, heights) in heights_by_recipient {
             let mut bundles = Vec::new();
             for height in heights {
-                let cert = height_to_certificates
+                let hashed_block = height_to_blocks
                     .get(&height)
-                    .ok_or_else(|| ChainError::InternalError("missing certificates".to_string()))?;
-                bundles.extend(cert.message_bundles_for(recipient));
+                    .ok_or_else(|| ChainError::InternalError("missing block".to_string()))?;
+                bundles.extend(
+                    hashed_block
+                        .inner()
+                        .message_bundles_for(recipient, hashed_block.hash()),
+                );
             }
             let request = CrossChainRequest::UpdateRecipient {
                 sender: self.chain.chain_id(),


### PR DESCRIPTION
## Motivation

Under high load, create_network_actions was observed taking ~70% of CPU time. Profiling showed the bottleneck was in the call chain:

`create_network_actions`​ -> `create_cross_chain_requests`​ -> `read_certificates`​ -> `deserialize_certificate`​

Certificate deserialization alone was consuming ~60% of CPU. Since these are certificates for blocks on the current chain, many of them should already be available in the block_values cache.

## Proposal

- Check the `block_values`​ cache before reading from storage in `create_cross_chain_requests`​
- Only fetch certificates from storage for blocks not found in the cache
- Insert fetched blocks into the cache so subsequent lookups can benefit
- Work directly with `Hashed<Block>`​ instead of certificates, since only the block data is needed for constructing message bundles

This avoids repeated deserialization of certificates that are already cached.

## Test Plan

- CI passes
- Deployed to a test network and verified the optimization reduces CPU usage during sustained load

## Release Plan

- Nothing to do / These changes follow the usual release cycle.