### PR TITLE
Restructure the `MultiPartitionBatch` and the keys.

### DIFF
--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -1127,7 +1127,7 @@ mod tests {
         },
     };
 
-    use crate::db_storage::{to_event_key, RootKey, BLOB_ID_TAG, CHAIN_ID_TAG};
+    use crate::db_storage::{to_event_key, RootKey, BLOB_ID_TAG, CHAIN_ID_TAG, EVENT_ID_TAG};
 
     // Several functionalities of the storage rely on the way that the serialization
     // is done. Thus we need to check that the serialization works in the way that
@@ -1181,6 +1181,8 @@ mod tests {
             stream_id,
             index,
         };
+        let root_key = RootKey::Event(chain_id).bytes();
+        assert_eq!(root_key[0], EVENT_ID_TAG);
         let key = to_event_key(&event_id);
         assert!(key.starts_with(&prefix));
     }


### PR DESCRIPTION
## Motivation

Due to the effort to make the database migration as good as possible, the database schema of `testnet_conway` ends up being better than the one of `main`.

## Proposal

Backport the changes from the `testnet_conway` to `main` (reverse of the usual way).
This covers two changes:
* The `MultiPartitionBatch` can support several `key/values` on the sme `root_key`.
* The keys are now no longer `[0]` and `[1]` which is a little better.

## Test Plan

The CI.

## Release Plan

Unify the `testnet_conway` and `main` is the end result of the PR.

## Links

None.