### PR TITLE
Remove the `InactiveChain` from the code.

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -281,6 +281,14 @@ impl BlobId {
     pub fn new(hash: CryptoHash, blob_type: BlobType) -> Self {
         Self { hash, blob_type }
     }
+
+    /// Creates a new `BlobId` from a `ChainId`.
+    pub fn chain(chain_id: ChainId) -> Self {
+        Self {
+            hash: chain_id.0,
+            blob_type: BlobType::ChainDescription,
+        }
+    }
 }
 
 impl fmt::Display for BlobId {

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -14,7 +14,7 @@ use linera_base::{
         OracleResponse, Timestamp,
     },
     ensure,
-    identifiers::{AccountOwner, ApplicationId, BlobType, ChainId, StreamId},
+    identifiers::{AccountOwner, ApplicationId, BlobId, BlobType, ChainId, StreamId},
     ownership::ChainOwnership,
 };
 use linera_execution::{
@@ -648,7 +648,7 @@ where
         self.execution_state
             .system
             .current_committee()
-            .ok_or_else(|| ChainError::InactiveChain(self.chain_id()))
+            .ok_or_else(|| ChainError::BlobsNotFound(vec![BlobId::chain(self.chain_id())]))
     }
 
     pub fn ownership(&self) -> &ChainOwnership {
@@ -786,7 +786,7 @@ where
         let policy = chain
             .system
             .current_committee()
-            .ok_or_else(|| ChainError::InactiveChain(block.chain_id))?
+            .ok_or_else(|| ChainError::BlobsNotFound(vec![BlobId::chain(block.chain_id)]))?
             .1
             .policy()
             .clone();

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -26,7 +26,7 @@ use linera_base::{
     bcs,
     crypto::CryptoError,
     data_types::{ArithmeticError, BlockHeight, Round, Timestamp},
-    identifiers::{ApplicationId, ChainId},
+    identifiers::{ApplicationId, BlobId, ChainId},
 };
 use linera_execution::ExecutionError;
 use linera_views::ViewError;
@@ -43,8 +43,8 @@ pub enum ChainError {
     #[error("Execution error: {0} during {1:?}")]
     ExecutionError(Box<ExecutionError>, ChainExecutionContext),
 
-    #[error("The chain being queried is not active {0}")]
-    InactiveChain(ChainId),
+    #[error("Blobs not found: {0:?}")]
+    BlobsNotFound(Vec<BlobId>),
     #[error(
         "Cannot vote for block proposal of chain {chain_id} because a message \
          from chain {origin} at height {height} has not been received yet"
@@ -168,7 +168,7 @@ impl ChainError {
             ChainError::CryptoError(_)
             | ChainError::ArithmeticError(_)
             | ChainError::ViewError(ViewError::NotFound(_))
-            | ChainError::InactiveChain(_)
+            | ChainError::BlobsNotFound(_)
             | ChainError::IncorrectMessageOrder { .. }
             | ChainError::CannotRejectMessage { .. }
             | ChainError::CannotSkipMessage { .. }

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -626,7 +626,7 @@ impl<Env: Environment> ChainClient<Env> {
         let manager = self.chain_info().await?.manager;
         ensure!(
             manager.ownership.is_active(),
-            LocalNodeError::InactiveChain(self.chain_id)
+            LocalNodeError::BlobsNotFound(vec![BlobId::chain(self.chain_id)])
         );
 
         let is_owner = manager
@@ -1950,7 +1950,7 @@ impl<Env: Environment> ChainClient<Env> {
             let ownership = self.prepare_chain().await?.manager.ownership;
             ensure!(
                 ownership.is_active(),
-                ChainError::InactiveChain(self.chain_id)
+                ChainError::BlobsNotFound(vec![BlobId::chain(self.chain_id)])
             );
             let mut owners = ownership.owners.into_iter().collect::<Vec<_>>();
             owners.extend(ownership.super_owners.into_iter().zip(iter::repeat(100)));
@@ -2429,7 +2429,7 @@ impl<Env: Environment> ChainClient<Env> {
                 self.client.update_from_info(&info);
                 Ok(Some(info))
             }
-            Err(LocalNodeError::BlobsNotFound(_) | LocalNodeError::InactiveChain(_)) => Ok(None),
+            Err(LocalNodeError::BlobsNotFound(_)) => Ok(None),
             Err(err) => Err(err.into()),
         }
     }

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -231,9 +231,6 @@ pub enum NodeError {
     WorkerError { error: String },
 
     // This error must be normalized during conversions.
-    #[error("The chain {0} is not active in validator")]
-    InactiveChain(ChainId),
-
     #[error("Round number should be {0:?}")]
     WrongRound(Round),
 
@@ -385,7 +382,7 @@ impl From<ChainError> for NodeError {
                 origin,
                 height,
             },
-            ChainError::InactiveChain(chain_id) => Self::InactiveChain(chain_id),
+            ChainError::BlobsNotFound(blob_ids) => Self::BlobsNotFound(blob_ids),
             ChainError::ExecutionError(execution_error, context) => match *execution_error {
                 ExecutionError::BlobsNotFound(blob_ids) => Self::BlobsNotFound(blob_ids),
                 ExecutionError::EventsNotFound(event_ids) => Self::EventsNotFound(event_ids),

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -859,7 +859,7 @@ where
     assert_matches!(
         result,
         Err(chain_client::Error::CommunicationError(
-            CommunicationError::Trusted(NodeError::InactiveChain(_))
+            CommunicationError::Trusted(NodeError::BlobsNotFound(_))
         )),
         "unexpected result"
     );

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -350,7 +350,9 @@ where
             FaultType::Offline | FaultType::OfflineWithInfo => Err(NodeError::ClientIoError {
                 error: "offline".to_string(),
             }),
-            FaultType::NoChains => Err(NodeError::InactiveChain(proposal.content.block.chain_id)),
+            FaultType::NoChains => Err(NodeError::BlobsNotFound(vec![BlobId::chain(
+                proposal.content.block.chain_id,
+            )])),
             FaultType::DontSendValidateVote
             | FaultType::Honest
             | FaultType::DontSendConfirmVote
@@ -410,7 +412,9 @@ where
                     error: "refusing to process validated block".to_string(),
                 })
             }
-            FaultType::NoChains => Err(NodeError::InactiveChain(certificate.value().chain_id())),
+            FaultType::NoChains => Err(NodeError::BlobsNotFound(vec![BlobId::chain(
+                certificate.value().chain_id(),
+            )])),
             FaultType::Honest
             | FaultType::DontSendConfirmVote
             | FaultType::DontProcessValidated
@@ -458,7 +462,9 @@ where
             FaultType::Offline => Err(NodeError::ClientIoError {
                 error: "offline".to_string(),
             }),
-            FaultType::NoChains => Err(NodeError::InactiveChain(query.chain_id)),
+            FaultType::NoChains => Err(NodeError::BlobsNotFound(vec![BlobId::chain(
+                query.chain_id,
+            )])),
             FaultType::Honest
             | FaultType::DontSendConfirmVote
             | FaultType::DontProcessValidated

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -411,20 +411,7 @@ where
                 )
                 .await?;
             }
-            NodeError::InactiveChain(chain_id) => {
-                tracing::debug!(
-                    address,
-                    %chain_id,
-                    "Validator has inactive chain; sending chain info.",
-                );
-                self.send_chain_information(
-                    *chain_id,
-                    height,
-                    CrossChainMessageDelivery::NonBlocking,
-                    None,
-                )
-                .await?;
-            }
+
             _ => {}
         }
         Ok(())
@@ -537,9 +524,7 @@ where
                     )
                     .await?;
                 }
-                Err(NodeError::BlobsNotFound(_) | NodeError::InactiveChain(_))
-                    if !blob_ids.is_empty() =>
-                {
+                Err(NodeError::BlobsNotFound(_)) if !blob_ids.is_empty() => {
                     tracing::debug!("Missing blobs");
                     // For `BlobsNotFound`, we assume that the local node should already be
                     // updated with the needed blobs, so sending the chain information about the

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -280,8 +280,7 @@ pub enum ExecutionError {
     InvalidUrlForHttpRequest(#[from] url::ParseError),
     #[error("Worker thread failure: {0:?}")]
     Thread(#[from] web_thread::Error),
-    #[error("The chain being queried is not active {0}")]
-    InactiveChain(ChainId),
+
     #[error("Blobs not found: {0:?}")]
     BlobsNotFound(Vec<BlobId>),
     #[error("Events not found: {0:?}")]
@@ -360,7 +359,6 @@ impl ExecutionError {
             | ExecutionError::BytecodeTooLarge
             | ExecutionError::UnauthorizedHttpRequest(_)
             | ExecutionError::InvalidUrlForHttpRequest(_)
-            | ExecutionError::InactiveChain(_)
             | ExecutionError::BlobsNotFound(_)
             | ExecutionError::EventsNotFound(_)
             | ExecutionError::InvalidHeaderName(_)

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -488,10 +488,9 @@ where
             }
             ProcessNewEpoch(epoch) => {
                 self.check_next_epoch(epoch)?;
-                let admin_id = self
-                    .admin_id
-                    .get()
-                    .ok_or_else(|| ExecutionError::InactiveChain(context.chain_id))?;
+                let admin_id = self.admin_id.get().ok_or_else(|| {
+                    ExecutionError::BlobsNotFound(vec![BlobId::chain(context.chain_id)])
+                })?;
                 let event_id = EventId {
                     chain_id: admin_id,
                     stream_id: StreamId::system(EPOCH_STREAM_NAME),
@@ -515,10 +514,9 @@ where
                     self.committees.get_mut().remove(&epoch).is_some(),
                     ExecutionError::InvalidCommitteeRemoval
                 );
-                let admin_id = self
-                    .admin_id
-                    .get()
-                    .ok_or_else(|| ExecutionError::InactiveChain(context.chain_id))?;
+                let admin_id = self.admin_id.get().ok_or_else(|| {
+                    ExecutionError::BlobsNotFound(vec![BlobId::chain(context.chain_id)])
+                })?;
                 let event_id = EventId {
                     chain_id: admin_id,
                     stream_id: StreamId::system(REMOVED_EPOCH_STREAM_NAME),

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -699,21 +699,17 @@ NodeError:
         STRUCT:
           - error: STR
     5:
-      InactiveChain:
-        NEWTYPE:
-          TYPENAME: ChainId
-    6:
       WrongRound:
         NEWTYPE:
           TYPENAME: Round
-    7:
+    6:
       UnexpectedBlockHeight:
         STRUCT:
           - expected_block_height:
               TYPENAME: BlockHeight
           - found_block_height:
               TYPENAME: BlockHeight
-    8:
+    7:
       MissingCrossChainUpdate:
         STRUCT:
           - chain_id:
@@ -722,63 +718,63 @@ NodeError:
               TYPENAME: ChainId
           - height:
               TYPENAME: BlockHeight
-    9:
+    8:
       BlobsNotFound:
         NEWTYPE:
           SEQ:
             TYPENAME: BlobId
-    10:
+    9:
       EventsNotFound:
         NEWTYPE:
           SEQ:
             TYPENAME: EventId
-    11:
+    10:
       MissingCertificateValue: UNIT
-    12:
+    11:
       MissingCertificates:
         NEWTYPE:
           SEQ:
             TYPENAME: CryptoHash
-    13:
+    12:
       MissingVoteInValidatorResponse:
         NEWTYPE: STR
-    14:
+    13:
       InvalidChainInfoResponse: UNIT
-    15:
+    14:
       UnexpectedCertificateValue: UNIT
-    16:
+    15:
       InvalidDecoding: UNIT
-    17:
+    16:
       UnexpectedMessage: UNIT
-    18:
+    17:
       GrpcError:
         STRUCT:
           - error: STR
-    19:
+    18:
       ClientIoError:
         STRUCT:
           - error: STR
-    20:
+    19:
       CannotResolveValidatorAddress:
         STRUCT:
           - address: STR
-    21:
+    20:
       SubscriptionError:
         STRUCT:
           - transport: STR
-    22:
+    21:
       SubscriptionFailed:
         STRUCT:
           - status: STR
-    23:
+    22:
       InvalidCertificateForBlob:
         NEWTYPE:
           TYPENAME: BlobId
-    24:
+    23:
       DuplicatesInBlobsNotFound: UNIT
-    25:
+    24:
       UnexpectedEntriesInBlobsNotFound: UNIT
-    26:
+    25:
       UnexpectedCertificates:
         STRUCT:
           - returned:
@@ -787,13 +783,13 @@ NodeError:
           - requested:
               SEQ:
                 TYPENAME: CryptoHash
-    27:
+    26:
       EmptyBlobsNotFound: UNIT
-    28:
+    27:
       ResponseHandlingError:
         STRUCT:
           - error: STR
-    29:
+    28:
       MissingCertificatesByHeights:
         STRUCT:
           - chain_id:
@@ -801,7 +797,7 @@ NodeError:
           - heights:
               SEQ:
                 TYPENAME: BlockHeight
-    30:
+    29:
       TooManyCertificatesReturned:
         STRUCT:
           - chain_id:


### PR DESCRIPTION
## Motivation

The `InactiveChain` and `BlobsNotFound` are used somewhat interchangeably in the code. This has to be addressed.

Fixes #3927 

## Proposal

The `BlobsNotFound` carries an error with it, while `InactiveChain` does not. In truth, it is impossible to determine whether a chain is active or not in the code, since it is unclear whether this is an error or not.

Potentially, we could add processing of the `BlobsNotFound` errors in the `client`.

## Test Plan

The CI.

## Release Plan

The change of errors means that it is difficult to see whether we could backport it to `testnet_conway`.

## Links

None.