### PR TITLE
Improve block timestamp errors.

### DIFF
--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -23,7 +23,7 @@ pub struct ChainWorkerConfig {
     pub long_lived_services: bool,
     /// Blocks with a timestamp this far in the future will still be accepted, but the validator
     /// will wait until that timestamp before voting.
-    pub grace_period: Duration,
+    pub block_time_grace_period: Duration,
     /// Idle chain workers free their memory after that duration without requests.
     pub ttl: Duration,
     /// TTL for sender chains.
@@ -60,7 +60,7 @@ impl Default for ChainWorkerConfig {
             allow_inactive_chains: false,
             allow_messages_from_deprecated_epochs: false,
             long_lived_services: false,
-            grace_period: Default::default(),
+            block_time_grace_period: Default::default(),
             ttl: Default::default(),
             sender_chain_ttl: Duration::from_secs(1),
             chain_info_max_received_log_entries: CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1486,7 +1486,7 @@ where
         } = content;
 
         ensure!(
-            block.timestamp.duration_since(local_time) <= self.config.grace_period,
+            block.timestamp.duration_since(local_time) <= self.config.block_time_grace_period,
             WorkerError::InvalidTimestamp {
                 local_time,
                 block_timestamp: block.timestamp,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -156,7 +156,7 @@ where
         .with_allow_inactive_chains(is_client)
         .with_allow_messages_from_deprecated_epochs(is_client)
         .with_long_lived_services(has_long_lived_services)
-        .with_grace_period(Duration::from_micros(TEST_GRACE_PERIOD_MICROS));
+        .with_block_time_grace_period(Duration::from_micros(TEST_GRACE_PERIOD_MICROS));
         Self {
             committee,
             worker,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -470,8 +470,8 @@ where
     /// Blocks with a timestamp this far in the future will still be accepted, but the validator
     /// will wait until that timestamp before voting.
     #[instrument(level = "trace", skip(self))]
-    pub fn with_grace_period(mut self, grace_period: Duration) -> Self {
-        self.chain_worker_config.grace_period = grace_period;
+    pub fn with_block_time_grace_period(mut self, grace_period: Duration) -> Self {
+        self.chain_worker_config.block_time_grace_period = grace_period;
         self
     }
 

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -68,7 +68,7 @@ struct ServerContext {
     cross_chain_config: CrossChainConfig,
     notification_config: NotificationConfig,
     shard: Option<usize>,
-    grace_period: Duration,
+    block_time_grace_period: Duration,
     chain_worker_ttl: Duration,
     block_cache_size: usize,
     execution_state_cache_size: usize,
@@ -100,7 +100,7 @@ impl ServerContext {
         )
         .with_allow_inactive_chains(false)
         .with_allow_messages_from_deprecated_epochs(false)
-        .with_grace_period(self.grace_period)
+        .with_block_time_grace_period(self.block_time_grace_period)
         .with_chain_worker_ttl(self.chain_worker_ttl)
         .with_chain_info_max_received_log_entries(self.chain_info_max_received_log_entries);
         (state, shard_id, shard.clone())
@@ -387,7 +387,7 @@ enum ServerCommand {
         /// Blocks with a timestamp this far in the future will still be accepted, but the validator
         /// will wait until that timestamp before voting.
         #[arg(long = "grace-period-ms", default_value = "500", value_parser = util::parse_millis)]
-        grace_period: Duration,
+        block_time_grace_period: Duration,
 
         /// The WebAssembly runtime to use.
         #[arg(long)]
@@ -535,7 +535,7 @@ async fn run(options: ServerOptions) {
             cross_chain_config,
             notification_config,
             shard,
-            grace_period,
+            block_time_grace_period,
             wasm_runtime,
             chain_worker_ttl,
             chain_info_max_received_log_entries,
@@ -551,7 +551,7 @@ async fn run(options: ServerOptions) {
                 cross_chain_config,
                 notification_config,
                 shard,
-                grace_period,
+                block_time_grace_period,
                 chain_worker_ttl,
                 block_cache_size: options.block_cache_size,
                 execution_state_cache_size: options.execution_state_cache_size,


### PR DESCRIPTION
## Motivation

Some users are seeing "timestamp in the future" errors. (See also https://github.com/linera-io/linera-protocol/issues/5023.)

## Proposal

Print the actual timestamps (local and block) in the error message.

Rename `grace_period` to `block_time_grace_period` to distinguish it from the quorum grace period.

## Test Plan

CI

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a validator hotfix.

## Links

- Should help with https://github.com/linera-io/linera-protocol/issues/5023.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
