### PR TITLE
Add `Amount::to_attos` and `abs_diff`.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -434,6 +434,11 @@ macro_rules! impl_wrapped_number {
                 Self(val)
             }
 
+            /// Returns the absolute difference between `self` and `other`.
+            pub fn abs_diff(self, other: Self) -> Self {
+                Self(self.0.abs_diff(other.0))
+            }
+
             /// Checked in-place addition.
             pub fn try_add_assign(&mut self, other: Self) -> Result<(), ArithmeticError> {
                 self.0 = self
@@ -719,6 +724,11 @@ impl Amount {
     /// Returns an `Amount` corresponding to that many attotokens.
     pub const fn from_attos(attotokens: u128) -> Amount {
         Amount(attotokens)
+    }
+
+    /// Returns the number of attotokens.
+    pub const fn to_attos(self) -> u128 {
+        self.0
     }
 
     /// Helper function to obtain the 64 most significant bits of the balance.


### PR DESCRIPTION
## Motivation

`amount.to_attos()` is clearer than `amount.into::<u128>()`.

`a.abs_diff(b)` makes sense for all wrapped numbers, since they also implement e.g. `saturating_sub`.

## Proposal

Add `Amount::to_attos` and add `abs_diff` to all wrapped numbers.

## Test Plan

(No new logic; only delegates to standard library.)

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a new SDK.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/5028.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
