### PR TITLE
`linera-execution`: preload required applications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11466,9 +11466,9 @@ dependencies = [
 
 [[package]]
 name = "web-thread"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245e52bf989a62768130a869d12298265bdf7593de7d137dfdf65088122ac4a1"
+checksum = "060cfc12637ebaf48b344331cea64fe6d13fed9a1381fb6cce10c3c7495778b4"
 dependencies = [
  "futures",
  "pin-project-lite",

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -258,13 +258,18 @@ where
         let mut txn_tracker = TransactionTracker::default().with_blobs(created_blobs);
         let mut resource_controller = ResourceController::default();
         let mut actor = ExecutionStateActor::new(self, &mut txn_tracker, &mut resource_controller);
-        let (code, description) = actor.load_service(application_id).await?;
+
+        let (codes, descriptions) = actor.service_and_dependencies(application_id).await?;
 
         let thread = web_thread::Thread::new();
-        let service_runtime_task = thread.run_send(code, move |code| async move {
+        let service_runtime_task = thread.run_send(codes, move |codes| async move {
             let mut runtime =
                 ServiceSyncRuntime::new_with_deadline(execution_state_sender, context, deadline);
-            runtime.preload_service(application_id, code, description)?;
+
+            for (code, description) in codes.into_iter().zip(descriptions) {
+                runtime.preload_service(ApplicationId::from(&description), code, description)?;
+            }
+
             runtime.run_query(application_id, query)
         });
 

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -755,6 +755,54 @@ where
             .await
     }
 
+    // TODO(#5034): unify with `contract_and_dependencies`
+    pub(crate) async fn service_and_dependencies(
+        &mut self,
+        application: ApplicationId,
+    ) -> Result<(Vec<UserServiceCode>, Vec<ApplicationDescription>), ExecutionError> {
+        // cyclic futures are illegal so we need to either box the frames or keep our own
+        // stack
+        let mut stack = vec![application];
+        let mut codes = vec![];
+        let mut descriptions = vec![];
+
+        while let Some(id) = stack.pop() {
+            let (code, description) = self.load_service(id).await?;
+            stack.extend(description.required_application_ids.iter().rev().copied());
+            codes.push(code);
+            descriptions.push(description);
+        }
+
+        codes.reverse();
+        descriptions.reverse();
+
+        Ok((codes, descriptions))
+    }
+
+    // TODO(#5034): unify with `service_and_dependencies`
+    async fn contract_and_dependencies(
+        &mut self,
+        application: ApplicationId,
+    ) -> Result<(Vec<UserContractCode>, Vec<ApplicationDescription>), ExecutionError> {
+        // cyclic futures are illegal so we need to either box the frames or keep our own
+        // stack
+        let mut stack = vec![application];
+        let mut codes = vec![];
+        let mut descriptions = vec![];
+
+        while let Some(id) = stack.pop() {
+            let (code, description) = self.load_contract(id).await?;
+            stack.extend(description.required_application_ids.iter().rev().copied());
+            codes.push(code);
+            descriptions.push(description);
+        }
+
+        codes.reverse();
+        descriptions.reverse();
+
+        Ok((codes, descriptions))
+    }
+
     async fn run_user_action_with_runtime(
         &mut self,
         application_id: ApplicationId,
@@ -777,10 +825,11 @@ where
         let (execution_state_sender, mut execution_state_receiver) =
             futures::channel::mpsc::unbounded();
 
-        let (code, description) = self.load_contract(application_id).await?;
+        let (codes, descriptions): (Vec<_>, Vec<_>) =
+            self.contract_and_dependencies(application_id).await?;
 
         let thread = web_thread::Thread::new();
-        let contract_runtime_task = thread.run_send(code, move |code| async move {
+        let contract_runtime_task = thread.run_send(codes, move |codes| async move {
             let runtime = ContractSyncRuntime::new(
                 execution_state_sender,
                 chain_id,
@@ -788,7 +837,11 @@ where
                 controller,
                 &action,
             );
-            runtime.preload_contract(application_id, code, description)?;
+
+            for (code, description) in codes.into_iter().zip(descriptions) {
+                runtime.preload_contract(ApplicationId::from(&description), code, description)?;
+            }
+
             runtime.run_action(application_id, chain_id, action)
         });
 


### PR DESCRIPTION
## Motivation

It turns out that we never preloaded the required applications for an application and relied on dynamic application loading to load the dependencies just-in-time.  Unfortunately, dynamic application loading doesn't work on the Web, which means we can't currently make cross-application calls there even in the static case where the dependencies are known ahead of time.

## Proposal

Recursively load the tree of application dependencies before executing the application call, both in service and contract.

## Test Plan

It would be nice to have a test for this, but I've postponed it as https://github.com/linera-io/linera-protocol/issues/5035.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,

(Hopefully, the execution with preloading is equivalent to the execution with dynamic loading.)

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
