### PR TITLE
Ignore missing cert errors if it's expected. Load it from env

### DIFF
--- a/linera-service/src/exporter/runloops/block_processor/mod.rs
+++ b/linera-service/src/exporter/runloops/block_processor/mod.rs
@@ -148,7 +148,11 @@ where
 
                         Err(ExporterError::ReadCertificateError(hash)) => {
                             if self.known_missing_certs.contains(&hash) {
-                                tracing::debug!(?hash, "certificate known to be missing, skipping retry");
+                                tracing::debug!(
+                                    block_id=?next_block_notification,
+                                    missing_cert=?hash,
+                                    "certificate known to be missing, skipping retry of this notification"
+                                );
                                 continue;
                             }
                             match self.retried_certs.remove(&hash) {


### PR DESCRIPTION
## Motivation

We know that on testnet some certs are missing so it doesn't make sense to raise critical errors on them which crash the exporter.

## Proposal

Load, from an env var `LINERA_KNOWN_MISSING_CERTS`, list of hashes that are expected to be missing. If we fail to read a certificate that is on that list, we don't treat it as an error.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->

## Release Plan

- Testnet only.
-
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
