### PR TITLE
Make notification and cross chain queue sizes grow with network size

### DIFF
--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -133,7 +133,13 @@ spec:
                 --storage {{ .Values.storage | quote }} \
                 --server /config/server.json \
                 --shard $ORDINAL \
-                --storage-replication-factor {{ .Values.storageReplicationFactor | quote }}
+                --storage-replication-factor {{ .Values.storageReplicationFactor | quote }} \
+                {{- if .Values.crossChainQueueSize }}
+                --cross-chain-queue-size {{ .Values.crossChainQueueSize }}
+                {{- end }}
+                {{- if .Values.notificationQueueSize }}
+                --notification-queue-size {{ .Values.notificationQueueSize }}
+                {{- end }}
           env:
             - name: RUST_LOG
               value: {{ .Values.logLevel }}

--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -54,6 +54,14 @@ proxyResources: {}
 # Set to empty string to use default Tokio thread count
 serverTokioThreads: ""
 
+# Cross-chain message queue size (default in binary is 1000)
+# Set to empty string to use default
+crossChainQueueSize: ""
+
+# Notification queue size for proxy notifications (default in binary is 1000)
+# Set to empty string to use default
+notificationQueueSize: ""
+
 # ============================================================================
 # Storage Configuration
 # ============================================================================


### PR DESCRIPTION
## Motivation

Queue sizes need to scale with network size to avoid backpressure in larger deployments.

## Proposal

Add Helm values for scalable queue sizes:

- `crossChainQueueSize`
- `notificationQueueSize`

## Test Plan

- Deploy with different network sizes
- Verify queue sizes are set correctly
- Monitor for queue-related issues

## Release Plan

- Nothing to do / These changes follow the usual release cycle.