### PR TITLE
Avoid using the shared chain state view. (#5063)

### DIFF
--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -12,7 +12,7 @@ pub(super) use self::delivery_notifier::DeliveryNotifier;
 #[cfg(test)]
 pub(crate) use self::state::CrossChainUpdateHelper;
 pub(crate) use self::{
-    actor::{ChainWorkerActor, ChainWorkerRequest},
+    actor::{ChainWorkerActor, ChainWorkerRequest, EventSubscriptionsResult},
     config::ChainWorkerConfig,
     state::BlockOutcome,
 };

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1794,16 +1794,14 @@ impl<Env: Environment> ChainClient<Env> {
     /// Returns chain IDs that this chain subscribes to.
     #[instrument(level = "trace", skip(self))]
     pub async fn event_stream_publishers(&self) -> Result<BTreeSet<ChainId>, LocalNodeError> {
-        let mut publishers = self
-            .chain_state_view()
-            .await?
-            .execution_state
-            .system
-            .event_subscriptions
-            .indices()
-            .await?
+        let subscriptions = self
+            .client
+            .local_node
+            .get_event_subscriptions(self.chain_id)
+            .await?;
+        let mut publishers = subscriptions
             .into_iter()
-            .map(|(chain_id, _)| chain_id)
+            .map(|((chain_id, _), _)| chain_id)
             .collect::<BTreeSet<_>>();
         if self.chain_id != self.client.admin_id {
             publishers.insert(self.client.admin_id);
@@ -1907,12 +1905,9 @@ impl<Env: Environment> ChainClient<Env> {
     async fn collect_stream_updates(&self) -> Result<Option<Operation>, ChainClientError> {
         // Load all our subscriptions.
         let subscription_map = self
-            .chain_state_view()
-            .await?
-            .execution_state
-            .system
-            .event_subscriptions
-            .index_values()
+            .client
+            .local_node
+            .get_event_subscriptions(self.chain_id)
             .await?;
         // Collect the indices of all new events.
         let futures = subscription_map
@@ -1927,13 +1922,12 @@ impl<Env: Environment> ChainClient<Env> {
             .map(|((chain_id, stream_id), subscriptions)| {
                 let client = self.client.clone();
                 async move {
-                    let chain = client.local_node.chain_state_view(chain_id).await?;
-                    if let Some(next_index) = chain
-                        .execution_state
-                        .stream_event_counts
-                        .get(&stream_id)
-                        .await?
-                        .filter(|next_index| *next_index > subscriptions.next_index)
+                    let next_index = client
+                        .local_node
+                        .get_stream_event_count(chain_id, stream_id.clone())
+                        .await?;
+                    if let Some(next_index) =
+                        next_index.filter(|next_index| *next_index > subscriptions.next_index)
                     {
                         Ok(Some((chain_id, stream_id, next_index)))
                     } else {
@@ -2146,16 +2140,14 @@ impl<Env: Environment> ChainClient<Env> {
     /// Synchronizes all chains that any application on this chain subscribes to.
     /// We always consider the admin chain a relevant publishing chain, for new epochs.
     async fn synchronize_publisher_chains(&self) -> Result<(), ChainClientError> {
-        let chain_ids = self
-            .chain_state_view()
-            .await?
-            .execution_state
-            .system
-            .event_subscriptions
-            .indices()
-            .await?
+        let subscriptions = self
+            .client
+            .local_node
+            .get_event_subscriptions(self.chain_id)
+            .await?;
+        let chain_ids = subscriptions
             .iter()
-            .map(|(chain_id, _)| *chain_id)
+            .map(|((chain_id, _), _)| *chain_id)
             .chain(iter::once(self.client.admin_id))
             .filter(|chain_id| *chain_id != self.chain_id)
             .collect::<BTreeSet<_>>();
@@ -2196,11 +2188,8 @@ impl<Env: Environment> ChainClient<Env> {
         let trackers = self
             .client
             .local_node
-            .chain_state_view(chain_id)
-            .await?
-            .received_certificate_trackers
-            .get()
-            .clone();
+            .get_received_certificate_trackers(chain_id)
+            .await?;
 
         trace!("find_received_certificates: read trackers");
 
@@ -3293,8 +3282,12 @@ impl<Env: Environment> ChainClient<Env> {
         identity: &AccountOwner,
         has_oracle_responses: bool,
     ) -> Result<Either<Round, RoundTimeout>, ChainClientError> {
-        let seed = *self.chain_state_view().await?.manager.seed.get();
         let manager = &info.manager;
+        let seed = self
+            .client
+            .local_node
+            .get_manager_seed(self.chain_id)
+            .await?;
         // If there is a conflicting proposal in the current round, we can only propose if the
         // next round can be started without a timeout, i.e. if we are in a multi-leader round.
         // Similarly, we cannot propose a block that uses oracles in the fast round.
@@ -4168,32 +4161,25 @@ impl<Env: Environment> ChainClient<Env> {
             .handle_chain_info_query(ChainInfoQuery::new(self.chain_id))
             .await
         {
-            Ok(info) => info.info.next_block_height.0,
-            Err(NodeError::BlobsNotFound(_)) => 0,
+            Ok(info) => info.info.next_block_height,
+            Err(NodeError::BlobsNotFound(_)) => BlockHeight::ZERO,
             Err(err) => return Err(err.into()),
         };
-        let local_chain_state = self.chain_info().await?;
+        let local_next_block_height = self.chain_info().await?.next_block_height;
 
-        let Some(missing_certificate_count) = local_chain_state
-            .next_block_height
-            .0
-            .checked_sub(validator_next_block_height)
-            .filter(|count| *count > 0)
-        else {
+        if validator_next_block_height >= local_next_block_height {
             debug!("Validator is up-to-date with local state");
             return Ok(());
-        };
+        }
 
-        let missing_certificates_end = usize::try_from(local_chain_state.next_block_height.0)
-            .expect("`usize` should be at least `u64`");
-        let missing_certificates_start = missing_certificates_end
-            - usize::try_from(missing_certificate_count).expect("`usize` should be at least `u64`");
+        let heights: Vec<_> = (validator_next_block_height.0..local_next_block_height.0)
+            .map(BlockHeight)
+            .collect();
 
         let missing_certificate_hashes = self
-            .chain_state_view()
-            .await?
-            .confirmed_log
-            .read(missing_certificates_start..missing_certificates_end)
+            .client
+            .local_node
+            .get_block_hashes(self.chain_id, heights)
             .await?;
 
         let certificates = self

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -502,14 +502,13 @@ where
     let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     // Open the new chain.
-    let (new_description, _certificate) = sender
-        .open_chain(
-            ChainOwnership::single(new_public_key.into()),
-            ApplicationPermissions::default(),
-            Amount::ZERO,
-        )
-        .await
-        .unwrap_ok_committed();
+    let (new_description, _certificate) = Box::pin(sender.open_chain(
+        ChainOwnership::single(new_public_key.into()),
+        ApplicationPermissions::default(),
+        Amount::ZERO,
+    ))
+    .await
+    .unwrap_ok_committed();
     let new_id = new_description.id();
 
     assert_eq!(
@@ -613,14 +612,13 @@ where
         .await
         .unwrap();
     // Open the new chain.
-    let (new_description2, certificate) = parent
-        .open_chain(
-            ChainOwnership::single(new_public_key.into()),
-            ApplicationPermissions::default(),
-            Amount::ZERO,
-        )
-        .await
-        .unwrap_ok_committed();
+    let (new_description2, certificate) = Box::pin(parent.open_chain(
+        ChainOwnership::single(new_public_key.into()),
+        ApplicationPermissions::default(),
+        Amount::ZERO,
+    ))
+    .await
+    .unwrap_ok_committed();
     let new_id2 = new_description2.id();
     assert_eq!(new_id, new_id2);
     assert_eq!(
@@ -690,10 +688,10 @@ where
     // Open the new chain. We are both regular and super owner.
     let ownership = ChainOwnership::single(new_public_key.into())
         .with_regular_owner(new_public_key.into(), 100);
-    let (new_description, _creation_certificate) = sender
-        .open_chain(ownership, ApplicationPermissions::default(), Amount::ZERO)
-        .await
-        .unwrap_ok_committed();
+    let (new_description, _creation_certificate) =
+        Box::pin(sender.open_chain(ownership, ApplicationPermissions::default(), Amount::ZERO))
+            .await
+            .unwrap_ok_committed();
     let new_id = new_description.id();
     // Transfer after creating the chain.
     sender
@@ -2889,14 +2887,13 @@ where
     client1.process_inbox().await.unwrap();
 
     // Open a chain
-    let (new_chain_desc, certificate1) = client1
-        .open_chain(
-            ChainOwnership::single(new_public_key.into()),
-            ApplicationPermissions::default(),
-            Amount::from_tokens(10),
-        )
-        .await
-        .unwrap_ok_committed();
+    let (new_chain_desc, certificate1) = Box::pin(client1.open_chain(
+        ChainOwnership::single(new_public_key.into()),
+        ApplicationPermissions::default(),
+        Amount::from_tokens(10),
+    ))
+    .await
+    .unwrap_ok_committed();
 
     // Check that the epoch has been migrated.
     assert_eq!(certificate1.block().header.epoch, Epoch::from(1));

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -36,6 +36,8 @@ use thiserror::Error;
 use tokio::sync::{mpsc, oneshot, OwnedRwLockReadGuard};
 use tracing::{error, instrument, trace, warn};
 
+/// Re-export of [`EventSubscriptionsResult`] for use by other crate modules.
+pub(crate) use crate::chain_worker::EventSubscriptionsResult;
 use crate::{
     chain_worker::{
         BlockOutcome, ChainWorkerActor, ChainWorkerConfig, ChainWorkerRequest, DeliveryNotifier,
@@ -1269,25 +1271,97 @@ where
         .await
     }
 
-    /// Reads a range from the confirmed log.
-    #[instrument(skip_all, fields(
-        nickname = %self.nickname,
-        chain_id = %chain_id,
-        start = %start,
-        end = %end
-    ))]
-    pub async fn read_confirmed_log(
+    /// Gets block hashes for the given heights.
+    pub async fn get_block_hashes(
         &self,
         chain_id: ChainId,
-        start: BlockHeight,
-        end: BlockHeight,
+        heights: Vec<BlockHeight>,
     ) -> Result<Vec<CryptoHash>, WorkerError> {
         self.query_chain_worker(chain_id, move |callback| {
-            ChainWorkerRequest::ReadConfirmedLog {
-                start,
-                end,
+            ChainWorkerRequest::GetBlockHashes { heights, callback }
+        })
+        .await
+    }
+
+    /// Gets proposed blobs from the manager for specified blob IDs.
+    pub async fn get_proposed_blobs(
+        &self,
+        chain_id: ChainId,
+        blob_ids: Vec<BlobId>,
+    ) -> Result<Vec<Blob>, WorkerError> {
+        self.query_chain_worker(chain_id, move |callback| {
+            ChainWorkerRequest::GetProposedBlobs { blob_ids, callback }
+        })
+        .await
+    }
+
+    /// Gets event subscriptions from the chain.
+    pub async fn get_event_subscriptions(
+        &self,
+        chain_id: ChainId,
+    ) -> Result<EventSubscriptionsResult, WorkerError> {
+        self.query_chain_worker(chain_id, |callback| {
+            ChainWorkerRequest::GetEventSubscriptions { callback }
+        })
+        .await
+    }
+
+    /// Gets the stream event count for a stream.
+    pub async fn get_stream_event_count(
+        &self,
+        chain_id: ChainId,
+        stream_id: StreamId,
+    ) -> Result<Option<u32>, WorkerError> {
+        self.query_chain_worker(chain_id, move |callback| {
+            ChainWorkerRequest::GetStreamEventCount {
+                stream_id,
                 callback,
             }
+        })
+        .await
+    }
+
+    /// Gets received certificate trackers.
+    pub async fn get_received_certificate_trackers(
+        &self,
+        chain_id: ChainId,
+    ) -> Result<HashMap<ValidatorPublicKey, u64>, WorkerError> {
+        self.query_chain_worker(chain_id, |callback| {
+            ChainWorkerRequest::GetReceivedCertificateTrackers { callback }
+        })
+        .await
+    }
+
+    /// Gets tip state and outbox info for next_outbox_heights calculation.
+    pub async fn get_tip_state_and_outbox_info(
+        &self,
+        chain_id: ChainId,
+        receiver_id: ChainId,
+    ) -> Result<(BlockHeight, Option<BlockHeight>), WorkerError> {
+        self.query_chain_worker(chain_id, move |callback| {
+            ChainWorkerRequest::GetTipStateAndOutboxInfo {
+                receiver_id,
+                callback,
+            }
+        })
+        .await
+    }
+
+    /// Gets the next height to preprocess.
+    pub async fn get_next_height_to_preprocess(
+        &self,
+        chain_id: ChainId,
+    ) -> Result<BlockHeight, WorkerError> {
+        self.query_chain_worker(chain_id, |callback| {
+            ChainWorkerRequest::GetNextHeightToPreprocess { callback }
+        })
+        .await
+    }
+
+    /// Gets the chain manager's seed for leader election.
+    pub async fn get_manager_seed(&self, chain_id: ChainId) -> Result<u64, WorkerError> {
+        self.query_chain_worker(chain_id, |callback| ChainWorkerRequest::GetManagerSeed {
+            callback,
         })
         .await
     }

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -179,9 +179,12 @@ impl Runnable for Job {
 
                         let chain_client = chain_client.clone();
                         async move {
-                            chain_client
-                                .open_chain(ownership, ApplicationPermissions::default(), balance)
-                                .await
+                            Box::pin(chain_client.open_chain(
+                                ownership,
+                                ApplicationPermissions::default(),
+                                balance,
+                            ))
+                            .await
                         }
                     })
                     .await
@@ -230,9 +233,12 @@ impl Runnable for Job {
                         let application_permissions = application_permissions.clone();
                         let chain_client = chain_client.clone();
                         async move {
-                            chain_client
-                                .open_chain(ownership, application_permissions, balance)
-                                .await
+                            Box::pin(chain_client.open_chain(
+                                ownership,
+                                application_permissions,
+                                balance,
+                            ))
+                            .await
                         }
                     })
                     .await

--- a/linera-service/src/cli/validator.rs
+++ b/linera-service/src/cli/validator.rs
@@ -326,7 +326,7 @@ where
             let context =
                 ClientContext::new(storage.clone(), context_options.clone(), wallet, signer);
             let context = Arc::new(Mutex::new(context));
-            handle_sync(context, address, chains, check_online).await
+            Box::pin(handle_sync(context, address, chains, check_online)).await
         }
     }
 }
@@ -916,7 +916,7 @@ where
         info!("Syncing chain {} to {}", chain_id, address);
         let chain = context.make_chain_client(chain_id);
 
-        chain.sync_validator(validator.clone()).await?;
+        Box::pin(chain.sync_validator(validator.clone())).await?;
         info!("Chain {} synced successfully", chain_id);
     }
 


### PR DESCRIPTION
Backport of #5063.

## Motivation

This is only meant for GraphQL (and maybe tests), but we use it a lot in the chain client implementation. The shared chain state view is protected by a lock and blocks the ongoing request in the chain actor: it can only save once all locks are released.

I started fixing this in
https://github.com/linera-io/linera-protocol/pull/4797 but didn't address all occurrences.

## Proposal

Add new chain actor requests instead.
(With Claude)

(On `testnet_conway` this required even more `Box::pin` additions than on `main` to fix the "large futures" lints.)

## Test Plan

CI

## Release Plan

- These changes should be released in a new SDK.

## Links

- PR to main: #5063 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
