### PR TITLE
Move `previous_…_blocks` into the execution state.

### DIFF
--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -177,8 +177,6 @@ async fn get_chain(node: &str, chain_id: ChainId) -> Result<Box<Chain>> {
         chain_id,
         inboxes_input: None,
         outboxes_input: None,
-        previous_message_blocks_input: None,
-        previous_event_blocks_input: None,
     };
     let chain = request::<gql_service::Chain, _>(&client, node, variables)
         .await?

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -125,8 +125,6 @@ query Chain(
   $chainId: ChainId!,
   $inboxesInput: MapInput_ChainId_37f83aa9,
   $outboxesInput: MapInput_ChainId_37f83aa9,
-  $previousMessageBlocksInput: MapInput_ChainId_37f83aa9,
-  $previousEventBlocksInput: MapInput_StreamIdInput_b7c3909d,
 ) {
   chain(chainId: $chainId) {
     chainId
@@ -273,26 +271,6 @@ query Chain(
       }
     }
     outboxCounters
-    previousMessageBlocks {
-      keys
-      entries(input: $previousMessageBlocksInput) {
-        key
-        value
-      }
-    }
-    previousEventBlocks {
-      keys {
-        applicationId
-        streamName
-      }
-      entries(input: $previousEventBlocksInput) {
-        key {
-          applicationId
-          streamName
-        }
-        value
-      }
-    }
   }
 }
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -401,14 +401,6 @@ type ChainStateExtendedView {
 	"""
 	removedUnskippableBundles: SetView_BundleInInbox_092a4377!
 	"""
-	The heights of previous blocks that sent messages to the same recipients.
-	"""
-	previousMessageBlocks: MapView_ChainId_BlockHeight_f2e56e12!
-	"""
-	The heights of previous blocks that published events to the same streams.
-	"""
-	previousEventBlocks: MapView_StreamId_BlockHeight_e6657ad9!
-	"""
 	Mailboxes used to send messages, indexed by their target.
 	"""
 	outboxes: ReentrantCollectionView_ChainId_OutboxStateView_06c2376d!
@@ -597,14 +589,6 @@ type Entry_BlockHeight_CryptoHash_74e16b71 {
 """
 A GraphQL-visible map item, complete with key.
 """
-type Entry_ChainId_BlockHeight_2fe78645 {
-	key: ChainId!
-	value: BlockHeight
-}
-
-"""
-A GraphQL-visible map item, complete with key.
-"""
 type Entry_ChainId_InboxStateView_a9e4d828 {
 	key: ChainId!
 	value: InboxStateView!
@@ -616,14 +600,6 @@ A GraphQL-visible map item, complete with key.
 type Entry_ChainId_OutboxStateView_855dcf53 {
 	key: ChainId!
 	value: OutboxStateView!
-}
-
-"""
-A GraphQL-visible map item, complete with key.
-"""
-type Entry_StreamId_BlockHeight_50cd702e {
-	key: StreamId!
-	value: BlockHeight
 }
 
 """
@@ -813,20 +789,6 @@ type MapView_BlockHeight_CryptoHash_1bae6d76 {
 	count: Int!
 	entry(key: BlockHeight!): Entry_BlockHeight_CryptoHash_74e16b71!
 	entries(input: MapInput_BlockHeight_e824a938): [Entry_BlockHeight_CryptoHash_74e16b71!]!
-}
-
-type MapView_ChainId_BlockHeight_f2e56e12 {
-	keys(count: Int): [ChainId!]!
-	count: Int!
-	entry(key: ChainId!): Entry_ChainId_BlockHeight_2fe78645!
-	entries(input: MapInput_ChainId_37f83aa9): [Entry_ChainId_BlockHeight_2fe78645!]!
-}
-
-type MapView_StreamId_BlockHeight_e6657ad9 {
-	keys(count: Int): [StreamId!]!
-	count: Int!
-	entry(key: StreamIdInput!): Entry_StreamId_BlockHeight_50cd702e!
-	entries(input: MapInput_StreamIdInput_b7c3909d): [Entry_StreamId_BlockHeight_50cd702e!]!
 }
 
 type MapView_StreamId_Int_3d7f5335 {


### PR DESCRIPTION
## Motivation

`previous_message_blocks` and `previous_event_blocks` are really part of the execution state conceptually: they get updated only when blocks are executed. Specifically for implementing checkpointing it's inconvenient if the are outside of it, in the chain state view.

## Proposal

Move the fields into the execution state view.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #5068.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
