### PR TITLE
Increase machine size for test-crates-and-docrs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -57,8 +57,8 @@ jobs:
         force_orphan: true
 
   test-crates-and-docrs:
-    runs-on: ubuntu-latest-4-cores
-    timeout-minutes: 90
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation

We're lacking disk space

## Proposal

Move to a bigger machine, which has more disk space. Reduce timeout, as the bigger machine should run the test faster.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
