### PR TITLE
Reduce sizes of large futures.

### DIFF
--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -72,7 +72,9 @@ pub struct Committee {
     /// less than `validity_threshold` are faulty.
     validity_threshold: u64,
     /// The policy agreed on for this epoch.
-    policy: ResourceControlPolicy,
+    // Boxed to reduce the size of `Committee` from 464 to ~56 bytes, which significantly
+    // reduces async future sizes throughout the codebase.
+    policy: Box<ResourceControlPolicy>,
 }
 
 impl Serialize for Committee {
@@ -167,7 +169,7 @@ impl<'a> From<&'a Committee> for CommitteeFull<'a> {
             total_votes: *total_votes,
             quorum_threshold: *quorum_threshold,
             validity_threshold: *validity_threshold,
-            policy: Cow::Borrowed(policy),
+            policy: Cow::Borrowed(policy.as_ref()),
         }
     }
 }
@@ -190,7 +192,7 @@ impl<'a> From<&'a Committee> for CommitteeMinimal<'a> {
         } = committee;
         CommitteeMinimal {
             validators: Cow::Borrowed(validators),
-            policy: Cow::Borrowed(policy),
+            policy: Cow::Borrowed(policy.as_ref()),
         }
     }
 }
@@ -233,7 +235,7 @@ impl Committee {
             total_votes,
             quorum_threshold,
             validity_threshold,
-            policy,
+            policy: Box::new(policy),
         }
     }
 


### PR DESCRIPTION
## Motivation

We are always close to the configured futures size limit of 7000 bytes, and halving the Tokio thread stack size makes the client prone to stack overflows.

## Proposal

I had Claude analyze the sizes of futures, and `Box` some large ones, as well as the resource control policy. The latter reduces the stack size of committees. Claude's explanation:

```
  Summary of Changes

  1. Boxing ResourceControlPolicy in Committee (linera-execution/src/committee.rs)

  Changed the policy field from inline to boxed:
  // Before: 464 bytes
  policy: ResourceControlPolicy,

  // After: 56 bytes (88% reduction)
  policy: Box<ResourceControlPolicy>,

  This cascades to reduce the size of all futures that hold Committee instances.

  2. Added Box::pin at Strategic Locations (linera-core/src/client/chain_client/mod.rs)

  Added Box::pin to break up large nested futures:

  | Line      | Function                              | Call Boxed                                             |
  |-----------|---------------------------------------|--------------------------------------------------------|
  | 724, 731  | update_validators                     | communicate_chain_updates                              |
  | 1606      | transfer_to_account                   | transfer                                               |
  | 1618      | burn                                  | transfer                                               |
  | 1765-1769 | process_pending_block_without_prepare | submit_block_proposal (fast round)                     |
  | 1772-1777 | process_pending_block_without_prepare | submit_block_proposal + finalize_block (regular round) |
  | 1781      | process_pending_block_without_prepare | update_validators                                      |
  | 1832-1834 | finalize_locking_block                | finalize_block + update_validators                     |
  | 2028      | open_chain                            | execute_block                                          |
  | 2148      | create_application                    | create_application_untyped                             |

  Results

  Before changes:
  - Largest future: 6544 bytes
  - Multiple futures between 5000-6500 bytes
  - 11+ futures above 4000 bytes in core crates

  After changes:
  - Largest future in production code: under 4000 bytes
  - Only 2 futures above 4000 bytes (both in test utilities: DbStorage::new_for_testing)
  - All production futures well under the 7000-byte threshold
  - Committee type reduced from 464 to 56 bytes (88% reduction)

  Why This Works

  1. Boxing ResourceControlPolicy: This single change removes 408 bytes from every Committee instance. Since Committee is held across await points in many async functions, this significantly reduces future sizes throughout the codebase.
  2. Strategic Box::pin: When you Box::pin a future, the inner future is allocated on the heap instead of being embedded inline in the outer future's state machine. This breaks the chain of nested futures that accumulate size.
```

## Test Plan

CI

## Release Plan

- These changes could be backported to `testnet_conway`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
