### PR TITLE
[testnet] Add the corrections for the autocompletion.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -71,6 +71,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera storage list-namespaces`↴](#linera-storage-list-namespaces)
 * [`linera storage list-blob-ids`↴](#linera-storage-list-blob-ids)
 * [`linera storage list-chain-ids`↴](#linera-storage-list-chain-ids)
+* [`linera completion`↴](#linera-completion)
 
 ## `linera`
 
@@ -116,6 +117,7 @@ Client implementation and command-line tool for the Linera blockchain
 * `net` — Manage a local Linera Network
 * `validator` — Manage validators in the committee
 * `storage` — Operation on the storage
+* `completion` — Generate shell completion scripts
 
 ###### **Options:**
 
@@ -1426,6 +1428,21 @@ List the blob IDs in the database
 List the chain IDs in the database
 
 **Usage:** `linera storage list-chain-ids`
+
+
+
+## `linera completion`
+
+Generate shell completion scripts
+
+**Usage:** `linera completion <SHELL>`
+
+###### **Arguments:**
+
+* `<SHELL>` — The shell to generate completions for
+
+  Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
+
 
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2337,6 +2337,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39615915e2ece2550c0149addac32fb5bd312c657f43845bb9088cb9c8a7c992"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5882,6 +5891,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap-markdown",
+ "clap_complete",
  "clio",
  "colored",
  "convert_case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ cfg_aliases = "0.2.1"
 chrono = { version = "0.4.35", default-features = false }
 clap = { version = "4", features = ["cargo", "derive", "env"] }
 clap-markdown = "0.1.3"
+clap_complete = "4"
 clio = "0.3.5"
 colored = "2.1.0"
 console_error_panic_hook = "0.1.7"

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -79,6 +79,7 @@ cfg-if.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 clap.workspace = true
 clap-markdown.workspace = true
+clap_complete.workspace = true
 clio.workspace = true
 colored.workspace = true
 convert_case.workspace = true

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -934,6 +934,13 @@ pub enum ClientCommand {
         #[arg(long, default_value = DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS, value_parser = util::parse_secs)]
         pause_after_gql_mutations: Duration,
     },
+
+    /// Generate shell completion scripts
+    Completion {
+        /// The shell to generate completions for
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
+    },
 }
 
 impl ClientCommand {
@@ -977,9 +984,9 @@ impl ClientCommand {
             ClientCommand::Storage { .. } => "storage".into(),
             ClientCommand::Service { port, .. } => format!("service-{port}").into(),
             ClientCommand::Faucet { .. } => "faucet".into(),
-            ClientCommand::HelpMarkdown | ClientCommand::ExtractScriptFromMarkdown { .. } => {
-                "tool".into()
-            }
+            ClientCommand::HelpMarkdown
+            | ClientCommand::ExtractScriptFromMarkdown { .. }
+            | ClientCommand::Completion { .. } => "tool".into(),
         }
     }
 }

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -29,6 +29,7 @@ use std::{collections::BTreeSet, env, path::PathBuf, process, sync::Arc};
 use anyhow::{anyhow, bail, ensure, Context, Error};
 use async_trait::async_trait;
 use chrono::Utc;
+use clap_complete::generate;
 use colored::Colorize;
 use futures::{lock::Mutex, FutureExt as _, StreamExt};
 use linera_base::{
@@ -1615,7 +1616,8 @@ impl Runnable for Job {
             | Storage { .. }
             | Wallet(_)
             | ExtractScriptFromMarkdown { .. }
-            | HelpMarkdown => {
+            | HelpMarkdown
+            | Completion { .. } => {
                 unreachable!()
             }
         }
@@ -2028,6 +2030,17 @@ async fn run(options: &ClientOptions) -> Result<i32, Error> {
                 pause_after_linera_service,
                 pause_after_gql_mutations,
             )?;
+            Ok(0)
+        }
+
+        ClientCommand::Completion { shell } => {
+            let mut cmd = <ClientOptions as clap::CommandFactory>::command();
+            generate(
+                *shell,
+                &mut cmd,
+                env!("CARGO_BIN_NAME"),
+                &mut std::io::stdout(),
+            );
             Ok(0)
         }
 


### PR DESCRIPTION
## Motivation

Add the autocompletion as in the main.

## Proposal

The autocompletion is available via
```bash
linera completion bash > .linera.bash
source .linera.bash
```

Similar command for rsh, fish, elcis, and powershell.

## Test Plan

The CI.

## Release Plan

The CI.

## Links

None.