### PR TITLE
Don't compare block time if we can't vote on the proposal anyway.

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1580,15 +1580,17 @@ where
             outcome,
         } = content;
 
-        if block.timestamp.duration_since(local_time) > self.config.block_time_grace_period {
-            return Err(WorkerError::InvalidTimestamp {
-                local_time,
-                block_timestamp: block.timestamp,
-                block_time_grace_period: self.config.block_time_grace_period,
-            });
-        }
+        if self.config.key_pair().is_some() {
+            if block.timestamp.duration_since(local_time) > self.config.block_time_grace_period {
+                return Err(WorkerError::InvalidTimestamp {
+                    local_time,
+                    block_timestamp: block.timestamp,
+                    block_time_grace_period: self.config.block_time_grace_period,
+                });
+            }
 
-        self.storage.clock().sleep_until(block.timestamp).await;
+            self.storage.clock().sleep_until(block.timestamp).await;
+        }
         let local_time = self.storage.clock().current_time();
 
         self.chain


### PR DESCRIPTION
## Motivation

The block time grace period makes sure validators don't vote on proposals with a timestamp in the future but don't reject them if it's close (they `sleep` instead).

On the client, the grace period is 0 by default and not configurable, because it used to not matter for clients. However, if a client gets a proposal from a validator (so that they know in which round to propose), they sometimes print an error. This is confusing and not useful.

## Proposal

Only do the timestamp check for proposals if we have a key pair and can vote on it (i.e. we are a validator).

## Test Plan

CI (trivial change)

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a new SDK.

## Links

- Possibly related to https://github.com/linera-io/linera-protocol/issues/5023.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
