### PR TITLE
[testnet] Collect pending messages after acquiring client lock. (#5091)

### DIFF
--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -454,7 +454,6 @@ where
     // the next round to succeed.
     builder.set_fault_type([0, 1, 2, 3], FaultType::Honest);
     client.synchronize_from_validators().await.unwrap();
-    client.process_inbox().await.unwrap();
     assert_eq!(
         client.local_balance().await.unwrap(),
         Amount::from_tokens(2)


### PR DESCRIPTION
Backport of #5091.

## Motivation

We currently collect the pending messages before acquiring the client lock. That can lead to race conditions where two futures do that at the same time, the first one commits a block with the messages, and then the other one tries to add another block with the same messages, resulting in a "messages out of order" error.

## Proposal

Acquire the lock first.

A side effect of this is that `process_inbox` will try to finalize the pending block even if there are no pending messages. That made one test fail, but the call in that test was not needed anyway.

## Test Plan

CI

## Release Plan

- These changes should be released in a new SDK.

## Links

- PR to main: #5091
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
