### PR TITLE
Don't fail w/ an error on destinations mismatch

### DIFF
--- a/linera-service/src/exporter/state.rs
+++ b/linera-service/src/exporter/state.rs
@@ -53,7 +53,7 @@ where
             .await
             .map_err(ExporterError::StateError)?;
 
-        let stored_destinations: Vec<DestinationId> = {
+        let stored_destinations = {
             let pinned = view.destination_states.get().states.pin();
             pinned.iter().map(|(id, _)| id).cloned().collect::<Vec<_>>()
         };


### PR DESCRIPTION
## Motivation

We have the case of failing exporters on startup due to the mismatch. Config files didn't change so there might be a problem with the DB state.

## Proposal

Don't crash on destination mismatch.

## Test Plan

Manual.

## Release Plan
 -These changes follow the usual release cycle.
- These changes should be backported 

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
