### PR TITLE
Don't fail w/ an error on destinations mismatch (#5095)

### DIFF
--- a/linera-service/src/exporter/state.rs
+++ b/linera-service/src/exporter/state.rs
@@ -53,19 +53,21 @@ where
             .await
             .map_err(ExporterError::StateError)?;
 
-        let destinations_len = destinations.len();
+        let stored_destinations = {
+            let pinned = view.destination_states.get().states.pin();
+            pinned.iter().map(|(id, _)| id).cloned().collect::<Vec<_>>()
+        };
+
+        tracing::info!(
+            init_destinations=?destinations,
+            ?stored_destinations,
+            "initialized exporter state with destinations",
+        );
 
         if view.destination_states.get().states.is_empty() {
             let states = DestinationStates::new(destinations);
             view.destination_states.set(states);
         }
-
-        ensure!(
-            view.destination_states.get().states.len() == destinations_len,
-            ExporterError::GenericError(
-                "inconsistent number of destinations in the toml file".into()
-            )
-        );
 
         let states = view.destination_states.get().clone();
         let canonical_state = view.canonical_state.clone_unchecked()?;


### PR DESCRIPTION
Backport of #5095 

## Motivation

We have the case of failing exporters on startup due to the mismatch. Config files didn't change so there might be a problem with the DB state.

## Proposal

Don't crash on destination mismatch.

## Test Plan

Manual.

## Release Plan
 -These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)