### PR TITLE
Add functionality to the QueueView / SetView.

### DIFF
--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -276,6 +276,27 @@ where
         }
     }
 
+    /// Pops the front value, if any.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::queue_view::QueueView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut queue = QueueView::load(context).await.unwrap();
+    /// queue.push_back(42);
+    /// queue.push_back(34);
+    /// assert_eq!(queue.pop().await.unwrap(), Some(42));
+    /// assert_eq!(queue.pop().await.unwrap(), Some(34));
+    /// assert_eq!(queue.pop().await.unwrap(), None);
+    /// # })
+    /// ```
+    pub async fn pop(&mut self) -> Result<Option<T>, ViewError> {
+        let value = self.front().await?;
+        self.delete_front();
+        Ok(value)
+    }
+
     /// Pushes a value to the end of the queue.
     /// ```rust
     /// # tokio_test::block_on(async {


### PR DESCRIPTION
## Motivation

The `QueueView` has `front` / `delete_front` while we may want to have a `pop`.
The `SetView` also has the `contains` / `remove`, and we may want to do both at once.

## Proposal

Implement a `.pop()` for `QueueView`. Implement a `remove_if_present` for `SetView`.

Unfortunately, the `front` is not systematically followed by a `delete_front`. So, we cannot use it in the code.
For the `SetView` change, another PR indicates a different direction: Altogether removal of the unskippable entries.

## Test Plan

CI. Unit tests have been added.

## Release Plan

Not that important. Could be 

## Links

None.