### PR TITLE
Port the `ListeningMode` enum to the testnet branch

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -14,7 +14,7 @@ use linera_base::{
 };
 use linera_chain::{manager::LockingBlock, types::ConfirmedBlockCertificate};
 use linera_core::{
-    client::{ChainClient, Client},
+    client::{ChainClient, Client, ListeningMode},
     data_types::{ChainInfo, ChainInfoQuery, ClientOutcome},
     join_set_ext::JoinSet,
     node::ValidatorNode,
@@ -450,7 +450,8 @@ impl<Env: Environment> ClientContext<Env> {
         }
 
         // Start listening for notifications, so we learn about new rounds and blocks.
-        let (listener, _listen_handle, mut notification_stream) = chain_client.listen().await?;
+        let (listener, _listen_handle, mut notification_stream) =
+            chain_client.listen(ListeningMode::FullChain).await?;
         self.chain_listeners.spawn_task(listener);
 
         loop {
@@ -525,7 +526,8 @@ impl<Env: Environment> ClientContext<Env> {
         }
 
         // Start listening for notifications, so we learn about new rounds and blocks.
-        let (listener, _listen_handle, mut notification_stream) = client.listen().await?;
+        let (listener, _listen_handle, mut notification_stream) =
+            client.listen(ListeningMode::FullChain).await?;
         self.chain_listeners.spawn_task(listener);
 
         loop {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -46,7 +46,7 @@ use crate::test_utils::ServiceStorageBuilder;
 use crate::{
     client::{
         BlanketMessagePolicy, ChainClient, ChainClientError, ChainClientOptions, ClientOutcome,
-        MessageAction, MessagePolicy,
+        ListeningMode, MessageAction, MessagePolicy,
     },
     local_node::LocalNodeError,
     node::{
@@ -74,7 +74,8 @@ fn test_listener_is_send() {
     async fn check_listener(
         chain_client: ChainClient<impl Environment>,
     ) -> Result<(), ChainClientError> {
-        let (listener, _abort_notifications, _notifications) = chain_client.listen().await?;
+        let (listener, _abort_notifications, _notifications) =
+            chain_client.listen(ListeningMode::FullChain).await?;
         ensure_send(&listener);
         Ok(())
     }
@@ -102,7 +103,7 @@ where
     let chain_2 = builder.add_root_chain(2, Amount::ZERO).await?;
     // Listen to the notifications on the sender chain.
     let mut notifications = sender.subscribe()?;
-    let (listener, _listen_handle, _) = sender.listen().await?;
+    let (listener, _listen_handle, _) = sender.listen(ListeningMode::FullChain).await?;
     tokio::spawn(listener);
     {
         let certificate = sender

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -48,8 +48,11 @@ use linera_client::{
     config::{CommitteeConfig, GenesisConfig},
 };
 use linera_core::{
-    client::ChainClientError, data_types::ClientOutcome, wallet, worker::Reason, JoinSetExt as _,
-    LocalNodeError,
+    client::{ChainClientError, ListeningMode},
+    data_types::ClientOutcome,
+    wallet,
+    worker::Reason,
+    JoinSetExt as _, LocalNodeError,
 };
 use linera_execution::{committee::Committee, WasmRuntime, WithWasmDefault as _};
 use linera_faucet_server::{FaucetConfig, FaucetService};
@@ -1032,7 +1035,8 @@ impl Runnable for Job {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
                 let chain_client = context.make_chain_client(chain_id).await?;
                 info!("Watching for notifications for chain {:?}", chain_id);
-                let (listener, _listen_handle, mut notifications) = chain_client.listen().await?;
+                let (listener, _listen_handle, mut notifications) =
+                    chain_client.listen(ListeningMode::FullChain).await?;
                 join_set.spawn_task(listener);
                 while let Some(notification) = notifications.next().await {
                     if let Reason::NewBlock { .. } = notification.reason {


### PR DESCRIPTION
## Motivation

As a part of the sparse event chains PR (#4466), an enum controlling how the listener listens to chains was introduced. This mechanism will now be useful for some features being ported to the testnet branch.

## Proposal

Port the enum and its usage to the testnet branch. Omit the `EventsOnly` variant for now. This makes the changes in this PR kind of pointless by themselves, but they will make it easier to introduce further changes in the future.

## Test Plan

CI

## Release Plan

- These changes should be released in a new SDK

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
