### PR TITLE
Support opt-in enabling of application logging. (#5099)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -238,6 +238,7 @@ Client implementation and command-line tool for the Linera blockchain
 
   Default value: `1`
 * `--wasm-runtime <WASM_RUNTIME>` — The WebAssembly runtime to use
+* `--with_application_logs` — Output log messages from contract execution
 * `--tokio-threads <TOKIO_THREADS>` — The number of Tokio worker threads to use
 * `--tokio-blocking-threads <TOKIO_BLOCKING_THREADS>` — The number of Tokio blocking threads to use
 

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -34,9 +34,9 @@ use super::{execution_state_actor::ExecutionRequest, runtime::ServiceRuntimeRequ
 use crate::{
     execution_state_actor::ExecutionStateActor, resources::ResourceController,
     system::SystemExecutionStateView, ApplicationDescription, ApplicationId, BcsHashable,
-    Deserialize, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, JsVec,
-    MessageContext, OperationContext, ProcessStreamsContext, Query, QueryContext, QueryOutcome,
-    Serialize, ServiceSyncRuntime, Timestamp, TransactionTracker, FLAG_ZERO_HASH,
+    Deserialize, ExecutionError, ExecutionRuntimeContext, JsVec, MessageContext, OperationContext,
+    ProcessStreamsContext, Query, QueryContext, QueryOutcome, Serialize, ServiceSyncRuntime,
+    Timestamp, TransactionTracker, FLAG_ZERO_HASH,
 };
 
 /// A view accessing the execution state of a chain.
@@ -241,7 +241,6 @@ where
                 application_id,
                 bytes,
             } => {
-                let ExecutionRuntimeConfig {} = self.context().extra().execution_runtime_config();
                 let outcome = match endpoint {
                     Some(endpoint) => {
                         self.query_user_application_with_long_lived_service(

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -28,11 +28,10 @@ use crate::{
     runtime::ContractSyncRuntime,
     system::{CreateApplicationResult, OpenChainConfig},
     util::{OracleResponseExt as _, RespondExt as _},
-    ApplicationDescription, ApplicationId, ExecutionError, ExecutionRuntimeConfig,
-    ExecutionRuntimeContext, ExecutionStateView, JsVec, Message, MessageContext, MessageKind,
-    ModuleId, Operation, OperationContext, OutgoingMessage, ProcessStreamsContext, QueryContext,
-    QueryOutcome, ResourceController, SystemMessage, TransactionTracker, UserContractCode,
-    UserServiceCode,
+    ApplicationDescription, ApplicationId, ExecutionError, ExecutionRuntimeContext,
+    ExecutionStateView, JsVec, Message, MessageContext, MessageKind, ModuleId, Operation,
+    OperationContext, OutgoingMessage, ProcessStreamsContext, QueryContext, QueryOutcome,
+    ResourceController, SystemMessage, TransactionTracker, UserContractCode, UserServiceCode,
 };
 
 /// Actor for handling requests to the execution state.
@@ -660,6 +659,16 @@ where
                     .to_round()?;
                 callback.respond(validation_round);
             }
+
+            AllowApplicationLogs { callback } => {
+                let allow = self
+                    .state
+                    .context()
+                    .extra()
+                    .execution_runtime_config()
+                    .allow_application_logs;
+                callback.respond(allow);
+            }
         }
 
         Ok(())
@@ -721,7 +730,6 @@ where
         refund_grant_to: Option<Account>,
         grant: Option<&mut Amount>,
     ) -> Result<(), ExecutionError> {
-        let ExecutionRuntimeConfig {} = self.state.context().extra().execution_runtime_config();
         self.run_user_action_with_runtime(application_id, action, refund_grant_to, grant)
             .await
     }
@@ -799,6 +807,13 @@ where
         let (codes, descriptions): (Vec<_>, Vec<_>) =
             self.contract_and_dependencies(application_id).await?;
 
+        let allow_application_logs = self
+            .state
+            .context()
+            .extra()
+            .execution_runtime_config()
+            .allow_application_logs;
+
         let contract_runtime_task = self
             .state
             .context()
@@ -811,6 +826,7 @@ where
                     refund_grant_to,
                     controller,
                     &action,
+                    allow_application_logs,
                 );
 
                 for (code, description) in codes.0.into_iter().zip(descriptions) {
@@ -1262,5 +1278,10 @@ pub enum ExecutionRequest {
         round: Option<u32>,
         #[debug(skip)]
         callback: Sender<Option<u32>>,
+    },
+
+    AllowApplicationLogs {
+        #[debug(skip)]
+        callback: Sender<bool>,
     },
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -464,7 +464,11 @@ pub trait UserService {
 
 /// Configuration options for the execution runtime available to applications.
 #[derive(Clone, Copy, Default)]
-pub struct ExecutionRuntimeConfig {}
+pub struct ExecutionRuntimeConfig {
+    /// Whether contract log messages should be output.
+    /// This is typically enabled for clients but disabled for validators.
+    pub allow_application_logs: bool,
+}
 
 /// Requirements for the `extra` field in our state views (and notably the
 /// [`ExecutionStateView`]).
@@ -855,6 +859,10 @@ pub trait BaseRuntime {
 
     /// Asserts the existence of a data blob with the given hash.
     fn assert_data_blob_exists(&mut self, hash: DataBlobHash) -> Result<(), ExecutionError>;
+
+    /// Returns whether contract log messages should be output.
+    /// This is typically enabled for clients but disabled for validators.
+    fn allow_application_logs(&mut self) -> Result<bool, ExecutionError>;
 }
 
 pub trait ServiceRuntime: BaseRuntime {

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -130,6 +130,8 @@ pub struct SyncRuntimeInternal<UserInstance: WithContext> {
     resource_controller: ResourceController,
     /// Additional context for the runtime.
     user_context: UserInstance::UserContext,
+    /// Whether contract log messages should be output.
+    allow_application_logs: bool,
 }
 
 /// The runtime status of an application.
@@ -317,6 +319,7 @@ impl<UserInstance: WithContext> SyncRuntimeInternal<UserInstance> {
         refund_grant_to: Option<Account>,
         resource_controller: ResourceController,
         user_context: UserInstance::UserContext,
+        allow_application_logs: bool,
     ) -> Self {
         Self {
             chain_id,
@@ -336,6 +339,7 @@ impl<UserInstance: WithContext> SyncRuntimeInternal<UserInstance> {
             resource_controller,
             scheduled_operations: Vec::new(),
             user_context,
+            allow_application_logs,
         }
     }
 
@@ -932,6 +936,10 @@ where
             .recv_response()?;
         Ok(())
     }
+
+    fn allow_application_logs(&mut self) -> Result<bool, ExecutionError> {
+        Ok(self.inner().allow_application_logs)
+    }
 }
 
 /// An extension trait to determine in compile time the different behaviors between contract and
@@ -966,6 +974,7 @@ impl ContractSyncRuntime {
         refund_grant_to: Option<Account>,
         resource_controller: ResourceController,
         action: &UserAction,
+        allow_application_logs: bool,
     ) -> Self {
         SyncRuntime(Some(ContractSyncRuntimeHandle::from(
             SyncRuntimeInternal::new(
@@ -982,6 +991,7 @@ impl ContractSyncRuntime {
                 refund_grant_to,
                 resource_controller,
                 action.timestamp(),
+                allow_application_logs,
             ),
         )))
     }
@@ -1580,6 +1590,13 @@ impl ServiceSyncRuntime {
         context: QueryContext,
         deadline: Option<Instant>,
     ) -> Self {
+        // Query the allow_application_logs setting from the execution state.
+        let allow_application_logs = execution_state_sender
+            .send_request(|callback| ExecutionRequest::AllowApplicationLogs { callback })
+            .ok()
+            .and_then(|receiver| receiver.recv_response().ok())
+            .unwrap_or(false);
+
         let runtime = SyncRuntime(Some(
             SyncRuntimeInternal::new(
                 context.chain_id,
@@ -1591,6 +1608,7 @@ impl ServiceSyncRuntime {
                 None,
                 ResourceController::default(),
                 (),
+                allow_application_logs,
             )
             .into(),
         ));

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -185,6 +185,7 @@ where
         None,
         resource_controller,
         Default::default(),
+        true,
     );
 
     (runtime, execution_state_receiver)

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -232,14 +232,23 @@ where
     }
 
     /// Logs a `message` with the provided information `level`.
-    fn log(_caller: &mut Caller, message: String, level: log::Level) {
-        match level {
-            log::Level::Trace => tracing::trace!("{message}"),
-            log::Level::Debug => tracing::debug!("{message}"),
-            log::Level::Info => tracing::info!("{message}"),
-            log::Level::Warn => tracing::warn!("{message}"),
-            log::Level::Error => tracing::error!("{message}"),
+    fn log(caller: &mut Caller, message: String, level: log::Level) -> Result<(), RuntimeError> {
+        let allowed = caller
+            .user_data_mut()
+            .runtime
+            .allow_application_logs()
+            .map_err(|error| RuntimeError::Custom(error.into()))?;
+
+        if allowed {
+            match level {
+                log::Level::Trace => tracing::trace!("{message}"),
+                log::Level::Debug => tracing::debug!("{message}"),
+                log::Level::Info => tracing::info!("{message}"),
+                log::Level::Warn => tracing::warn!("{message}"),
+                log::Level::Error => tracing::error!("{message}"),
+            }
         }
+        Ok(())
     }
 
     /// Creates a new promise to check if the `key` is in storage.

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1636,6 +1636,10 @@ struct ClientOptions {
     #[arg(long)]
     wasm_runtime: Option<WasmRuntime>,
 
+    /// Output log messages from contract execution.
+    #[arg(long = "with_application_logs")]
+    application_logs: bool,
+
     /// The number of Tokio worker threads to use.
     #[arg(long, env = "LINERA_CLIENT_TOKIO_THREADS")]
     tokio_threads: Option<usize>,
@@ -1689,9 +1693,12 @@ impl ClientOptions {
             .clone()
             .run_with_store(StorageMigration)
             .await?;
-        let output =
-            Box::pin(store_config.run_with_storage(self.wasm_runtime.with_wasm_default(), job))
-                .await?;
+        let output = Box::pin(store_config.run_with_storage(
+            self.wasm_runtime.with_wasm_default(),
+            self.application_logs,
+            job,
+        ))
+        .await?;
         Ok(output)
     }
 

--- a/linera-service/src/exporter/main.rs
+++ b/linera-service/src/exporter/main.rs
@@ -187,7 +187,12 @@ impl ExporterOptions {
                 .clone()
                 .run_with_store(StorageMigration)
                 .await?;
-            store_config.run_with_storage(None, context).boxed().await
+            // Exporters are part of validator infrastructure and should not output contract logs.
+            let allow_application_logs = false;
+            store_config
+                .run_with_storage(None, allow_application_logs, context)
+                .boxed()
+                .await
         };
 
         runtime.block_on(future)?.map_err(|e| e.into())

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -497,8 +497,14 @@ impl ProxyOptions {
             .storage_config
             .add_common_storage_options(&self.common_storage_options)?;
         store_config.clone().run_with_store(AssertStorageV1).await?;
+        // Proxies are part of validator infrastructure and should not output contract logs.
+        let allow_application_logs = false;
         store_config
-            .run_with_storage(None, ProxyContext::from_options(self)?)
+            .run_with_storage(
+                None,
+                allow_application_logs,
+                ProxyContext::from_options(self)?,
+            )
             .boxed()
             .await?
     }

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -543,13 +543,15 @@ async fn run(options: ServerOptions) {
             let store_config = storage_config
                 .add_common_storage_options(&common_storage_options)
                 .unwrap();
+            // Validators should not output contract logs.
+            let allow_application_logs = false;
             store_config
                 .clone()
                 .run_with_store(AssertStorageV1)
                 .await
                 .unwrap();
             store_config
-                .run_with_storage(wasm_runtime, job)
+                .run_with_storage(wasm_runtime, allow_application_logs, job)
                 .boxed()
                 .await
                 .unwrap()

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -629,6 +629,7 @@ impl StoreConfig {
     pub async fn run_with_storage<Job>(
         self,
         wasm_runtime: Option<WasmRuntime>,
+        allow_application_logs: bool,
         job: Job,
     ) -> Result<Job::Output, anyhow::Error>
     where
@@ -645,7 +646,8 @@ impl StoreConfig {
                     &namespace,
                     wasm_runtime,
                 )
-                .await?;
+                .await?
+                .with_allow_application_logs(allow_application_logs);
                 let genesis_config = crate::util::read_json::<GenesisConfig>(genesis_path)?;
                 // Memory storage must be initialized every time.
                 genesis_config.initialize_storage(&mut storage).await?;
@@ -658,28 +660,32 @@ impl StoreConfig {
                     &namespace,
                     wasm_runtime,
                 )
-                .await?;
+                .await?
+                .with_allow_application_logs(allow_application_logs);
                 Ok(job.run(storage).await)
             }
             #[cfg(feature = "rocksdb")]
             StoreConfig::RocksDb { config, namespace } => {
                 let storage =
                     DbStorage::<RocksDbDatabase, _>::connect(&config, &namespace, wasm_runtime)
-                        .await?;
+                        .await?
+                        .with_allow_application_logs(allow_application_logs);
                 Ok(job.run(storage).await)
             }
             #[cfg(feature = "dynamodb")]
             StoreConfig::DynamoDb { config, namespace } => {
                 let storage =
                     DbStorage::<DynamoDbDatabase, _>::connect(&config, &namespace, wasm_runtime)
-                        .await?;
+                        .await?
+                        .with_allow_application_logs(allow_application_logs);
                 Ok(job.run(storage).await)
             }
             #[cfg(feature = "scylladb")]
             StoreConfig::ScyllaDb { config, namespace } => {
                 let storage =
                     DbStorage::<ScyllaDbDatabase, _>::connect(&config, &namespace, wasm_runtime)
-                        .await?;
+                        .await?
+                        .with_allow_application_logs(allow_application_logs);
                 Ok(job.run(storage).await)
             }
             #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
@@ -688,7 +694,8 @@ impl StoreConfig {
                     DualDatabase<RocksDbDatabase, ScyllaDbDatabase, ChainStatesFirstAssignment>,
                     _,
                 >::connect(&config, &namespace, wasm_runtime)
-                .await?;
+                .await?
+                .with_allow_application_logs(allow_application_logs);
                 Ok(job.run(storage).await)
             }
         }

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -1125,6 +1125,12 @@ where
             execution_runtime_config: ExecutionRuntimeConfig::default(),
         }
     }
+
+    /// Sets whether contract log messages should be output.
+    pub fn with_allow_application_logs(mut self, allow: bool) -> Self {
+        self.execution_runtime_config.allow_application_logs = allow;
+        self
+    }
 }
 
 impl<Database> DbStorage<Database, WallClock>

--- a/web/@linera/client/src/lib.rs
+++ b/web/@linera/client/src/lib.rs
@@ -145,8 +145,11 @@ impl Client {
         wallet: &Wallet,
         signer: Signer,
         skip_process_inbox: bool,
+        allow_application_logs: bool,
     ) -> Result<Client, JsError> {
-        let mut storage = get_storage().await?;
+        let mut storage = get_storage()
+            .await?
+            .with_allow_application_logs(allow_application_logs);
         wallet
             .genesis_config
             .initialize_storage(&mut storage)


### PR DESCRIPTION
Backport of #5099 

## Motivation

We have a `BaseRuntimeApi::log` endpoint that, when called from contracts and services, will log to the stdout. This leads to massive amounts of logs on validators.

## Proposal

Support opt-in enabling of the feature.

This is achieved by adding a boolean, config flag to `ExecutionRuntimeConfig` which is then accessed from within the `BaseRuntimeApi`.

## Test Plan

Manual

```
➜  linera-protocol git:(testnet_conway) ✗ ./target/debug/linera --contract-logs wallet follow-chain 6dbf54bd5dfb29560c7911f3e6763bb8c792da46f604f3d2b6b52a91521a9edf --sync
2025-12-09T11:55:17.268236Z  WARN handle_chain_info_query{address="https://linera-testnet.runtime-client-rpc.com:443"}: grpc_client: error=Blobs not found: [BlobId { blob_type: ChainDescription, hash: 6dbf54bd5dfb29560c7911f3e6763bb8c792da46f604f3d2b6b52a91521a9edf }]
2025-12-09T11:55:17.311762Z  WARN handle_chain_info_query{address="https://linera.everstake.one:443"}: grpc_client: error=Blobs not found: [BlobId { blob_type: ChainDescription, hash: 6dbf54bd5dfb29560c7911f3e6763bb8c792da46f604f3d2b6b52a91521a9edf }]
2025-12-09T11:55:18.480625Z  INFO linera_execution::wasm::runtime_api: Fund success transfer_id 1985 fund type Swap on chain 6dbf54bd5dfb29560c7911f3e6763bb8c792da46f604f3d2b6b52a91521a9edf
^C
➜  linera-protocol git:(testnet_conway) ✗ ./target/debug/linera  wallet follow-chain 6dbf54bd5dfb29560c7911f3e6763bb8c792da46f604f3d2b6b52a91521a9edf --sync
2025-12-09T11:55:34.824419Z  WARN handle_chain_info_query{address="https://linera-testnet.runtime-client-rpc.com:443"}: grpc_client: error=Blobs not found: [BlobId { blob_type: ChainDescription, hash: 6dbf54bd5dfb29560c7911f3e6763bb8c792da46f604f3d2b6b52a91521a9edf }]
2025-12-09T11:55:34.862661Z  WARN handle_chain_info_query{address="https://linera.everstake.one:443"}: grpc_client: error=Blobs not found: [BlobId { blob_type: ChainDescription, hash: 6dbf54bd5dfb29560c7911f3e6763bb8c792da46f604f3d2b6b52a91521a9edf }]
2025-12-09T11:55:41.903767Z  WARN handle_chain_info_query{address="https://linera-testnet-validator.contributiondao.com:443"}: grpc_client: error=Blobs not found: [BlobId { blob_type: ChainDescription, hash: 6dbf54bd5dfb29560c7911f3e6763bb8c792da46f604f3d2b6b52a91521a9edf }]
```

## Release Plan

- These changes should be
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
