### PR TITLE
Limit max pending message bundles in benchmarks

### DIFF
--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -865,6 +865,7 @@ impl Runnable for Job {
                                 None,
                                 n,
                                 on_drop,
+                                benchmark_options.transactions_per_block,
                                 vec![
                                     "--storage-max-stream-queries".to_string(),
                                     "50".to_string(),

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -109,6 +109,7 @@ impl ClientWrapper {
             testing_prng_seed,
             id,
             on_drop,
+            10_000,
             vec!["--wait-for-outgoing-messages".to_string()],
         )
     }
@@ -119,6 +120,7 @@ impl ClientWrapper {
         testing_prng_seed: Option<u64>,
         id: usize,
         on_drop: OnClientDrop,
+        max_pending_message_bundles: usize,
         extra_args: Vec<String>,
     ) -> Self {
         let storage = format!(
@@ -134,7 +136,7 @@ impl ClientWrapper {
             storage,
             wallet,
             keystore,
-            max_pending_message_bundles: 10_000,
+            max_pending_message_bundles,
             network,
             path_provider,
             on_drop,


### PR DESCRIPTION
## Motivation

Benchmarks were hardcoding 10k pending message bundles, which is a bit arbitrary.

## Proposal

Make `max_pending_message_bundles` be limited by the number of transactions per block, since currently each transaction will create at most one message.

## Test Plan

- Run benchmarks with the new limit
- Check benchmark results are still valid

## Release Plan

- Nothing to do / These changes follow the usual release cycle.