### PR TITLE
Several dashboard changes

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera/execution.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/execution.json
@@ -15,22 +15,36 @@
       }
     ]
   },
+  "description": "Execution metrics for Linera validators including block execution latency, operation processing, message handling, and WebAssembly performance statistics.",
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 2,
+  "graphTooltip": 1,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 0
       },
-      "id": 11,
+      "id": 1,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Latencies",
       "type": "row"
     },
@@ -39,6 +53,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Time taken to execute a block, including all operations and state transitions",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -82,15 +97,58 @@
               {
                 "color": "green",
                 "value": null
-              },
+              }
+            ]
+          },
+          "unit": "µs"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
               {
-                "color": "red",
-                "value": 80
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
-        },
-        "overrides": []
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -101,15 +159,17 @@
       "id": 2,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -119,21 +179,36 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "disableTextWrap": false,
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(rate(linera_block_execution_latency_bucket[1m])) by (le))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_block_execution_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
           "range": true,
-          "refId": "A",
-          "useBackend": false
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_block_execution_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_block_execution_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Block Execution Latency p99 ms (1m)",
+      "title": "Block Execution Latency",
       "type": "timeseries"
     },
     {
@@ -141,6 +216,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Time taken to execute a single operation within a block",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -184,15 +260,58 @@
               {
                 "color": "green",
                 "value": null
-              },
+              }
+            ]
+          },
+          "unit": "µs"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
               {
-                "color": "red",
-                "value": 80
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
-        },
-        "overrides": []
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -200,18 +319,183 @@
         "x": 12,
         "y": 1
       },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_operation_execution_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_operation_execution_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_operation_execution_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Operation Execution Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Time taken to execute a cross-chain message",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "µs"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
       "id": 4,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -222,114 +506,35 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_block_execution_latency_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_message_execution_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
           "range": true,
           "refId": "A"
-        }
-      ],
-      "title": "Block Execution Latency p50 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 9
-      },
-      "id": 21,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "disableTextWrap": false,
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(rate(linera_operation_execution_latency_bucket[1m])) by (le))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_message_execution_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
           "range": true,
-          "refId": "A",
-          "useBackend": false
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_message_execution_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Operation Execution Latency p99 ms (1m)",
+      "title": "Message Execution Latency",
       "type": "timeseries"
     },
     {
@@ -337,6 +542,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Time taken to decompress WebAssembly bytecode before execution",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -380,15 +586,58 @@
               {
                 "color": "green",
                 "value": null
-              },
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
               {
-                "color": "red",
-                "value": 80
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
-        },
-        "overrides": []
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -396,18 +645,20 @@
         "x": 12,
         "y": 9
       },
-      "id": 22,
+      "id": 5,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -417,20 +668,36 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "disableTextWrap": false,
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.50, sum(rate(linera_operation_execution_latency_bucket[1m])) by (le))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_bytecode_decompression_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
           "range": true,
-          "refId": "A",
-          "useBackend": false
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_bytecode_decompression_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_bytecode_decompression_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Operation Execution Latency p50 ms (1m)",
+      "title": "Bytecode Decompression Latency",
       "type": "timeseries"
     },
     {
@@ -438,6 +705,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Time taken to compute cryptographic hash of chain state",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -481,15 +749,58 @@
               {
                 "color": "green",
                 "value": null
-              },
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
               {
-                "color": "red",
-                "value": 80
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
-        },
-        "overrides": []
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -497,18 +808,20 @@
         "x": 0,
         "y": 17
       },
-      "id": 23,
+      "id": 6,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -518,20 +831,36 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "disableTextWrap": false,
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(rate(linera_message_execution_latency_bucket[1m])) by (le))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_state_hash_computation_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
           "range": true,
-          "refId": "A",
-          "useBackend": false
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_state_hash_computation_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_state_hash_computation_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Message Execution Latency p99 ms (1m)",
+      "title": "State Hash Computation Latency",
       "type": "timeseries"
     },
     {
@@ -539,6 +868,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Time messages spend waiting in the cross-chain message queue",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -582,15 +912,58 @@
               {
                 "color": "green",
                 "value": null
-              },
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
               {
-                "color": "red",
-                "value": 80
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
-        },
-        "overrides": []
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -598,18 +971,20 @@
         "x": 12,
         "y": 17
       },
-      "id": 24,
+      "id": 7,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -619,20 +994,36 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "disableTextWrap": false,
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.50, sum(rate(linera_message_execution_latency_bucket[1m])) by (le))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_cross_chain_queue_wait_time_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
           "range": true,
-          "refId": "A",
-          "useBackend": false
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_cross_chain_queue_wait_time_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_cross_chain_queue_wait_time_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Message Execution Latency p50 ms (1m)",
+      "title": "Cross Chain Queue Wait Time",
       "type": "timeseries"
     },
     {
@@ -640,6 +1031,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Time requests spend waiting in the chain worker processing queue",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -683,15 +1075,58 @@
               {
                 "color": "green",
                 "value": null
-              },
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
               {
-                "color": "red",
-                "value": 80
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
-        },
-        "overrides": []
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -699,18 +1134,20 @@
         "x": 0,
         "y": 25
       },
-      "id": 18,
+      "id": 8,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -721,13 +1158,35 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(linera_bytecode_decompression_latency_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_chain_worker_request_queue_wait_time_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_chain_worker_request_queue_wait_time_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_chain_worker_request_queue_wait_time_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Bytecode decompression latency p99 (1m)",
+      "title": "Chain Worker Request Queue Wait Time",
       "type": "timeseries"
     },
     {
@@ -735,6 +1194,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Time taken to create and process network initialization actions",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -778,15 +1238,58 @@
               {
                 "color": "green",
                 "value": null
-              },
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
               {
-                "color": "red",
-                "value": 80
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
-        },
-        "overrides": []
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -794,18 +1297,20 @@
         "x": 12,
         "y": 25
       },
-      "id": 20,
+      "id": 9,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -816,13 +1321,35 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_bytecode_decompression_latency_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_create_network_actions_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_create_network_actions_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_create_network_actions_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Bytecode decompression latency p50 (1m)",
+      "title": "Create Network Actions Latency",
       "type": "timeseries"
     },
     {
@@ -830,6 +1357,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Ratio of cache hits to total cache accesses for value cache",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -879,7 +1407,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "percentunit"
         },
         "overrides": []
       },
@@ -888,209 +1417,6 @@
         "w": 12,
         "x": 0,
         "y": 33
-      },
-      "id": 34,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(linera_state_hash_computation_latency_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "State hash computation latency p99 (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 33
-      },
-      "id": 35,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_state_hash_computation_latency_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "State hash computation latency p50 (1m)",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 41
-      },
-      "id": 12,
-      "panels": [],
-      "title": "Rates",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 42
       },
       "id": 56,
       "options": {
@@ -1101,47 +1427,59 @@
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
-            "type": "loki",
-            "uid": "P8E80F9AEF21F6940"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_open_chain_count[1m])) by (pod)",
-          "legendFormat": "__auto",
-          "queryType": "range",
+          "expr": "sum by (validator) (rate(linera_value_cache_hit{validator=~\"$validator\"}[1m]))\n/\n(\n  sum by (validator) (rate(linera_value_cache_hit{validator=~\"$validator\"}[1m]))\n+ (\n    sum by (validator) (rate(linera_value_cache_miss{validator=~\"$validator\"}[1m]))\n    or on (validator) vector(0)\n  )\n)",
+          "instant": false,
+          "legendFormat": "{{validator}} - Cache Hit Ratio",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "P8E80F9AEF21F6940"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(linera_open_chain_count[1m]))",
-          "hide": false,
-          "legendFormat": "Total",
-          "queryType": "range",
-          "range": true,
-          "refId": "B"
         }
       ],
-      "title": "Chains opened per second (averaged for the past minute)",
+      "title": "Value Cache Hit Ratio",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 10,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Rates",
+      "type": "row"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Rate at which new chains are being opened in the network",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1185,13 +1523,113 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
-          }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_open_chain_count{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_open_chain_count{validator=~\"$validator\"}[1m]))",
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Chains Opened per Second (1m avg)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate at which blocks are being added to chains",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -1201,7 +1639,7 @@
         "x": 12,
         "y": 42
       },
-      "id": 57,
+      "id": 12,
       "options": {
         "legend": {
           "calcs": [],
@@ -1210,124 +1648,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "sum(rate(linera_num_blocks[1m])) by (pod)",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "sum(rate(linera_num_blocks[1m]))",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "legendFormat": "Total",
-          "range": true,
-          "refId": "B",
-          "useBackend": false
-        }
-      ],
-      "title": "Blocks added to chains per second (averaged for the past minute)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 50
-      },
-      "id": 7,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -1338,8 +1660,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_num_blocks_executed[1m])) by (pod)",
-          "legendFormat": "__auto",
+          "expr": "sum(rate(linera_num_blocks{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         },
@@ -1349,14 +1671,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_num_blocks_executed[1m]))",
-          "hide": false,
+          "expr": "sum(rate(linera_num_blocks{validator=~\"$validator\"}[1m]))",
           "legendFormat": "Total",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Blocks executed per second (averaged for the past minute)",
+      "title": "Blocks Added to Chains per Second (1m avg)",
       "type": "timeseries"
     },
     {
@@ -1364,6 +1685,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Rate at which blocks are being executed by validators",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1407,13 +1729,113 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
-          }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 50
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_num_blocks_executed{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_num_blocks_executed{validator=~\"$validator\"}[1m]))",
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Blocks Executed per Second (1m avg)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of transaction processing across the network",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -1422,6 +1844,521 @@
         "w": 12,
         "x": 12,
         "y": 50
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_transaction_count{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_transaction_count{validator=~\"$validator\"}[1m]))",
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Transactions per Second (1m avg)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of individual operations being executed",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 58
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_operation_count{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_operation_count{validator=~\"$validator\"}[1m]))",
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Operations per Second (1m avg)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of incoming message bundles from other chains",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 58
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_incoming_bundle_count{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_incoming_bundle_count{validator=~\"$validator\"}[1m]))",
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Incoming Bundles per Second (1m avg)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of incoming messages from other chains",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 66
+      },
+      "id": 50,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_incoming_message_count{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_incoming_message_count{validator=~\"$validator\"}[1m]))",
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Incoming Messages per Second (1m avg)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate at which the cross-chain message channel reaches capacity",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 66
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_cross_chain_message_channel_full{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_cross_chain_message_channel_full{validator=~\"$validator\"}[1m]))",
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Cross Chain Message Channel Full per Second (1m avg)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate at which the cross-chain message channel reaches capacity",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 66
       },
       "id": 59,
       "options": {
@@ -1432,9 +2369,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -1445,8 +2381,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_transaction_count[1m])) by (pod)",
-          "legendFormat": "__auto",
+          "expr": "sum(rate(linera_notifications_skipped_receiver_lag{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         },
@@ -1456,14 +2392,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_transaction_count[1m]))",
-          "hide": false,
+          "expr": "sum(rate(linera_notifications_skipped_receiver_lag{validator=~\"$validator\"}[1m]))",
           "legendFormat": "Total",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Transactions per second (averaged for the past minute)",
+      "title": "Notifications Skipped - Receiver lag, per Second (1m avg)",
       "type": "timeseries"
     },
     {
@@ -1471,6 +2406,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Rate at which the cross-chain message channel reaches capacity",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1514,13 +2450,10 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
-          }
+          },
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -1528,7 +2461,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 58
+        "y": 74
       },
       "id": 60,
       "options": {
@@ -1539,9 +2472,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -1552,8 +2484,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_operation_count[1m])) by (pod)",
-          "legendFormat": "__auto",
+          "expr": "sum(rate(linera_notifications_dropped_no_receiver{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         },
@@ -1563,14 +2495,1283 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_operation_count[1m]))",
-          "hide": false,
+          "expr": "sum(rate(linera_notifications_dropped_no_receiver{validator=~\"$validator\"}[1m]))",
           "legendFormat": "Total",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Operations per second (averaged for the past minute)",
+      "title": "Notifications dropped - No receiver, per Second (1m avg)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate at which each validator is signing certificates",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 74
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_certificates_signed_count{validator=~\"$validator\"}[1m])) by (validator)",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_certificates_signed_count{validator=~\"$validator\"}[1m]))",
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Certificates Signed per Second per Validator (1m avg)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 82
+      },
+      "id": 21,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Other",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of inbox queues maintained by each chain",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 83
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_num_inboxes_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_num_inboxes_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_num_inboxes_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Number of Inboxes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of outbox queues maintained by each chain",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 83
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_num_outboxes_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_num_outboxes_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_num_outboxes_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Number of Outboxes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of messages pending in chain inbox queues",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 91
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_inbox_size_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_inbox_size_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_inbox_size_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Inbox Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of messages pending in chain outbox queues",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 91
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_outbox_size_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_outbox_size_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_outbox_size_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Outbox Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of message bundles removed during processing",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 99
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_removed_bundles_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_removed_bundles_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_removed_bundles_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Removed Bundles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of consensus rounds in block proposal phase",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 99
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_num_rounds_in_block_proposal_bucket{validator=~\"$validator\"}[1m])) by (le, round_type))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_num_rounds_in_block_proposal_bucket{validator=~\"$validator\"}[1m])) by (le, round_type))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_num_rounds_in_block_proposal_bucket{validator=~\"$validator\"}[1m])) by (le, round_type))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Rounds in Block Proposal",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of consensus rounds required to create a certificate",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 107
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_num_rounds_in_certificate_bucket{validator=~\"$validator\"}[1m])) by (le, certificate_value, round_type))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_num_rounds_in_certificate_bucket{validator=~\"$validator\"}[1m])) by (le, certificate_value, round_type))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_num_rounds_in_certificate_bucket{validator=~\"$validator\"}[1m])) by (le, certificate_value, round_type))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Rounds in Certificate",
       "type": "timeseries"
     },
     {
@@ -1635,114 +3836,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 58
-      },
-      "id": 61,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(linera_incoming_bundle_count[1m])) by (pod)",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(linera_incoming_bundle_count[1m]))",
-          "hide": false,
-          "legendFormat": "Total",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Incoming bundles per second (averaged for the past minute)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 66
+        "y": 107
       },
       "id": 55,
       "options": {
@@ -1767,7 +3861,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(linera_cross_chain_message_tasks) by (pod)",
+          "expr": "sum(linera_cross_chain_message_tasks{validator=~\"$validator\"}) by (pod)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
@@ -1782,7 +3876,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(linera_cross_chain_message_tasks)",
+          "expr": "sum(linera_cross_chain_message_tasks{validator=~\"$validator\"})",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1800,6 +3894,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Total number of certificates signed by each validator",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1843,1021 +3938,10 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 66
-      },
-      "id": 62,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "rate(linera_notification_channel_full[1m])",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Notification channel full per second (averaged for the past minute)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 74
-      },
-      "id": 9,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(linera_certificates_signed[1m])) by (validator_name)",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Certificates signed per second per validator (averaged for the past minute)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 74
-      },
-      "id": 54,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(linera_cross_chain_message_channel_full[1m])",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Cross chain message channel full per second (averaged for the past minute)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "percent"
-        },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "Cache hit pct %"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 82
-      },
-      "id": 14,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "((\n  sum(rate(linera_value_cache_hit[1m])) by (key_type, value_type) or vector(0)\n)\n/\n(\n  sum(rate(linera_value_cache_hit[1m])) by (key_type, value_type) or vector(0)\n  +\n  sum(rate(linera_value_cache_miss[1m])) by (key_type, value_type) or vector(0)\n)) * 100",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Value cache hit ratio",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 90
-      },
-      "id": 13,
-      "panels": [],
-      "title": "Other",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 91
-      },
-      "id": 40,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(rate(linera_num_rounds_in_certificate_bucket[1m])) by (le, certificate_value, round_type))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "{{certificate_value}} - {{round_type}}",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Rounds in certificate p99 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 91
-      },
-      "id": 41,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_num_rounds_in_certificate_bucket[1m])) by (le, certificate_value, round_type))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Rounds in certificate p50 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 99
-      },
-      "id": 44,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(rate(linera_num_inboxes_bucket[1m])) by (le))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Number of inboxes p99 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 99
-      },
-      "id": 45,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_num_inboxes_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Number of inboxes p50 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 107
-      },
-      "id": 46,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(rate(linera_num_outboxes_bucket[1m])) by (le))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Number of outboxes p99 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 107
-      },
-      "id": 47,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_num_outboxes_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Number of outboxes p50 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
+          "unit": "short"
         },
         "overrides": []
       },
@@ -2866,1645 +3950,6 @@
         "w": 12,
         "x": 0,
         "y": 115
-      },
-      "id": 48,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(rate(linera_inbox_size_bucket[1m])) by (le))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Inbox size p99 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 115
-      },
-      "id": 49,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_inbox_size_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Inbox size p50 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 123
-      },
-      "id": 52,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(rate(linera_outbox_size_bucket[1m])) by (le))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Outbox size p99 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 123
-      },
-      "id": 53,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_outbox_size_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Outbox size p50 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 131
-      },
-      "id": 50,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(rate(linera_removed_bundles_bucket[1m])) by (le))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Removed bundles p99 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 131
-      },
-      "id": 51,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_removed_bundles_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Removed bundles p50 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 139
-      },
-      "id": 42,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(rate(linera_num_rounds_in_block_proposal_bucket[1m])) by (le, round_type))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Rounds in block proposal p99 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 139
-      },
-      "id": 43,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_num_rounds_in_block_proposal_bucket[1m])) by (le, round_type))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Rounds in block proposal p50 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 147
-      },
-      "id": 10,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "Value"
-          }
-        ]
-      },
-      "pluginVersion": "10.1.1",
-      "targets": [
-        {
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(linera_certificates_signed) by (validator_name)",
-          "format": "table",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Certificates signed per validator",
-      "type": "table"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 155
-      },
-      "id": 25,
-      "panels": [],
-      "title": "Wasm",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 156
-      },
-      "id": 36,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(rate(linera_wasm_contract_instantiation_latency_bucket[1m])) by (le))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Wasm Contract Instantiation Latency p99 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 156
-      },
-      "id": 37,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.50, sum(rate(linera_wasm_contract_instantiation_latency_bucket[1m])) by (le))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Wasm Contract Instantiation Latency p50 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 164
-      },
-      "id": 38,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(rate(linera_wasm_service_instantiation_latency_bucket[1m])) by (le))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Wasm Service Instantiation Latency p99 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 164
-      },
-      "id": 39,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.50, sum(rate(linera_wasm_service_instantiation_latency_bucket[1m])) by (le))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "{{pod}} - {{le}}",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Wasm Service Instantiation Latency p50 ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 172
-      },
-      "id": 26,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(linera_wasm_fuel_used_per_block_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Wasm fuel used per block p99 (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 172
-      },
-      "id": 27,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_wasm_fuel_used_per_block_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Wasm fuel used per block p50 (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 180
-      },
-      "id": 28,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(linera_wasm_num_reads_per_block_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Wasm num reads per block p99 (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 180
-      },
-      "id": 29,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_wasm_num_reads_per_block_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Wasm num reads per block p50 (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 188
       },
       "id": 30,
       "options": {
@@ -4515,9 +3960,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -4528,114 +3972,47 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(linera_wasm_bytes_read_per_block_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
+          "expr": "linera_certificates_signed_count{validator=~\"$validator\"}",
+          "legendFormat": "{{validator}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Wasm bytes read per block p99 (1m)",
+      "title": "Certificates Signed per Validator",
       "type": "timeseries"
     },
     {
+      "collapsed": false,
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 188
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 123
       },
       "id": 31,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
+      "panels": [],
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_wasm_bytes_read_per_block_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
-          "range": true,
           "refId": "A"
         }
       ],
-      "title": "Wasm bytes read per block p50 (1m)",
-      "type": "timeseries"
+      "title": "Wasm",
+      "type": "row"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Time taken to instantiate a WebAssembly contract module",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4677,35 +4054,81 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
-              },
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
               {
-                "color": "red",
-                "value": 80
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
-        },
-        "overrides": []
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 196
+        "y": 124
       },
       "id": 32,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -4716,13 +4139,35 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(linera_wasm_bytes_written_per_block_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_wasm_contract_instantiation_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_wasm_contract_instantiation_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_wasm_contract_instantiation_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Wasm bytes written per block p99 (1m)",
+      "title": "Wasm Contract Instantiation Latency",
       "type": "timeseries"
     },
     {
@@ -4730,6 +4175,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Time taken to instantiate a WebAssembly service module",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4771,35 +4217,81 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
-              },
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
               {
-                "color": "red",
-                "value": 80
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
-        },
-        "overrides": []
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 196
+        "y": 124
       },
       "id": 33,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -4810,13 +4302,687 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_wasm_bytes_written_per_block_bucket[1m])) by (le))",
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_wasm_service_instantiation_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_wasm_service_instantiation_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_wasm_service_instantiation_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Wasm bytes written per block p50 (1m)",
+      "title": "Wasm Service Instantiation Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Amount of WebAssembly execution fuel consumed per block",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 132
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_wasm_fuel_used_per_block_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_wasm_fuel_used_per_block_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_wasm_fuel_used_per_block_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Wasm Fuel Used per Block",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of storage read operations during WebAssembly execution per block",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 132
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_wasm_num_reads_per_block_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_wasm_num_reads_per_block_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_wasm_num_reads_per_block_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Wasm Num Reads per Block",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Total bytes read from storage during WebAssembly execution per block",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 140
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_wasm_bytes_read_per_block_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_wasm_bytes_read_per_block_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_wasm_bytes_read_per_block_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Wasm Bytes Read per Block",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Total bytes written to storage during WebAssembly execution per block",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 140
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_wasm_bytes_written_per_block_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_wasm_bytes_written_per_block_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_wasm_bytes_written_per_block_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Wasm Bytes Written per Block",
       "type": "timeseries"
     },
     {
@@ -4873,8 +5039,7 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "ms"
+          }
         },
         "overrides": []
       },
@@ -4882,7 +5047,122 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 196
+        "y": 148
+      },
+      "id": 61,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum(linera_chain_worker_actors_active{validator=~\"$validator\"}) by (pod)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum(linera_chain_worker_actors_active{validator=~\"$validator\"})",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Chain Worker Actors Active",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 148
       },
       "id": 62,
       "options": {
@@ -4906,17 +5186,33 @@
             "uid": "prometheus"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_cross_chain_queue_wait_time_bucket[1m])))",
+          "editorMode": "code",
+          "expr": "sum(linera_chain_worker_states_loaded{validator=~\"$validator\"}) by (pod)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum(linera_chain_worker_states_loaded{validator=~\"$validator\"})",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
         }
       ],
-      "title": "Cross chain queue wait time p99 (1m)",
+      "title": "Chain Worker States Loaded",
       "type": "timeseries"
     },
     {
@@ -4973,16 +5269,15 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "ms"
+          }
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 196
+        "x": 0,
+        "y": 156
       },
       "id": 63,
       "options": {
@@ -5006,300 +5301,15 @@
             "uid": "prometheus"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "histogram_quantile(0.5, sum by(le) (rate(linera_cross_chain_queue_wait_time_bucket[1m])))",
+          "editorMode": "code",
+          "expr": "sum(linera_chain_worker_endpoints_cached{validator=~\"$validator\"}) by (pod)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",
           "useBackend": false
-        }
-      ],
-      "title": "Cross chain queue wait time p50 (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ms"
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 204
-      },
-      "id": 64,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_chain_worker_request_queue_wait_time_bucket[1m])))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Chain worker request queue wait time p99 (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 204
-      },
-      "id": 65,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "histogram_quantile(0.5, sum by(le) (rate(linera_chain_worker_request_queue_wait_time_bucket[1m])))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Chain worker request queue wait time p50 (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 212
-      },
-      "id": 66,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
@@ -5307,134 +5317,67 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_create_network_actions_latency_bucket[1m])))",
+          "expr": "sum(linera_chain_worker_endpoints_cached{validator=~\"$validator\"})",
           "fullMetaSearch": false,
+          "hide": false,
           "includeNullMetadata": true,
-          "legendFormat": "__auto",
+          "legendFormat": "Total",
           "range": true,
-          "refId": "A",
+          "refId": "B",
           "useBackend": false
         }
       ],
-      "title": "Create network actions latency p99 (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 212
-      },
-      "id": 67,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_create_network_actions_latency_bucket[1m])))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Create network actions latency p50 (1m)",
+      "title": "Chain Worker Endpoints Cached",
       "type": "timeseries"
     }
   ],
   "refresh": "5s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "linera"
+  ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allFormat": "glob",
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(linera_block_execution_latency_bucket, validator)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Validator",
+        "multi": false,
+        "name": "validator",
+        "options": [],
+        "query": {
+          "query": "label_values(linera_block_execution_latency_bucket, validator)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
   },
   "time": {
     "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "browser",
+  "timezone": "",
   "title": "Execution",
   "uid": "aeeg4vnzeku80d",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }

--- a/kubernetes/linera-validator/grafana-dashboards/linera/general.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/general.json
@@ -15,9 +15,10 @@
       }
     ]
   },
+  "description": "Comprehensive monitoring dashboard for Linera validator infrastructure including proxy metrics, server performance, and cluster resource utilization",
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 2,
+  "graphTooltip": 1,
   "links": [],
   "liveNow": true,
   "panels": [
@@ -39,6 +40,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Rate of incoming requests to the proxy layer, aggregated per pod",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -89,7 +91,7 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -109,8 +111,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -121,7 +123,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_proxy_request_count[1m])) by (pod)",
+          "expr": "sum(rate(linera_proxy_request_count{validator=~\"$validator\"}[1m])) by (pod)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -135,6 +137,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Percentage of failed proxy requests over 1 minute intervals",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -205,8 +208,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -219,7 +222,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(\n    (\n        rate(linera_proxy_request_error[1m])\n    ) / (\n        (\n            (\n                rate(linera_proxy_request_success[1m])\n            ) + (\n                rate(linera_proxy_request_error[1m])\n            )\n        )\n    )\n) * 100",
+          "expr": "(\n    (\n        rate(linera_proxy_request_error{validator=~\"$validator\"}[1m])\n    ) / (\n        (\n            (\n                rate(linera_proxy_request_success{validator=~\"$validator\"}[1m])\n            ) + (\n                rate(linera_proxy_request_error{validator=~\"$validator\"}[1m])\n            )\n        )\n    )\n) * 100",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -238,6 +241,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Request latency percentiles for the proxy layer over 1 minute intervals",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -290,7 +294,53 @@
           },
           "unit": "ms"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -307,9 +357,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -321,212 +370,42 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_proxy_request_latency_bucket[1m])))",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_proxy_request_latency_bucket{validator=~\"$validator\"}[1m])))",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "p99",
           "range": true,
           "refId": "A",
           "useBackend": false
-        }
-      ],
-      "title": "Proxy p99 latency ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ms"
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 9
-      },
-      "id": 19,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(rate(linera_proxy_request_latency_bucket[1m])) by (le))",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_proxy_request_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "p90",
           "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Proxy p90 latency ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ms"
+          "refId": "B"
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 17
-      },
-      "id": 20,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_proxy_request_latency_bucket[1m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_proxy_request_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "p50",
           "range": true,
-          "refId": "A"
+          "refId": "C"
         }
       ],
-      "title": "Proxy p50 latency ms (1m)",
+      "title": "Proxy Latency (ms)",
       "type": "timeseries"
     },
     {
@@ -535,7 +414,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 17
       },
       "id": 15,
       "panels": [],
@@ -547,6 +426,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Rate of incoming requests to the validator server, aggregated per pod",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -596,7 +476,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -604,7 +485,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 18
       },
       "id": 22,
       "options": {
@@ -616,8 +497,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -628,7 +509,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_server_request_count[1m])) by (pod)",
+          "expr": "sum(rate(linera_server_request_count{validator=~\"$validator\"}[1m])) by (pod)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -639,7 +520,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_server_request_count[1m]))",
+          "expr": "sum(rate(linera_server_request_count{validator=~\"$validator\"}[1m]))",
           "hide": false,
           "legendFormat": "Total",
           "range": true,
@@ -654,6 +535,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Percentage of failed server requests over 1 minute intervals",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -712,7 +594,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 26
+        "y": 18
       },
       "id": 12,
       "options": {
@@ -724,8 +606,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -737,7 +619,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "(\n    (\n        sum(rate(linera_server_request_error[1m])) by (method_name, pod)\n    ) / (\n        (\n            (\n                sum(rate(linera_server_request_success[1m])) by (method_name, pod)\n            ) + (\n                sum(rate(linera_server_request_error[1m])) by (method_name, pod)\n            )\n        )\n    )\n) * 100",
+          "expr": "(\n    (\n        sum(rate(linera_server_request_error{validator=~\"$validator\"}[1m])) by (method_name, pod)\n    ) / (\n        (\n            (\n                sum(rate(linera_server_request_success{validator=~\"$validator\"}[1m])) by (method_name, pod)\n            ) + (\n                sum(rate(linera_server_request_error{validator=~\"$validator\"}[1m])) by (method_name, pod)\n            )\n        )\n    )\n) * 100",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -755,6 +637,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Request latency percentiles for the server over 1 minute intervals",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -796,7 +679,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -806,13 +690,59 @@
           },
           "unit": "ms"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 34
+        "y": 26
       },
       "id": 13,
       "options": {
@@ -823,9 +753,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -837,209 +766,41 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(linera_server_request_latency_bucket[1m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_server_request_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "p99",
           "range": true,
           "refId": "A",
           "useBackend": false
-        }
-      ],
-      "title": "Server p99 latency ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ms"
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 34
-      },
-      "id": 16,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(rate(linera_server_request_latency_bucket[1m])) by (le))",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_server_request_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "p90",
           "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Server p90 latency ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ms"
+          "refId": "B"
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 42
-      },
-      "id": 17,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_server_request_latency_bucket[1m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_server_request_latency_bucket{validator=~\"$validator\"}[1m])) by (le))",
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "p50",
           "range": true,
-          "refId": "A"
+          "refId": "C"
         }
       ],
-      "title": "Server p50 latency ms (1m)",
+      "title": "Server Latency (ms)",
       "type": "timeseries"
     },
     {
@@ -1047,6 +808,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Request latency percentiles broken down by request type over 1 minute intervals",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1088,7 +850,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1098,13 +861,59 @@
           },
           "unit": "ms"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 26
       },
       "id": 23,
       "options": {
@@ -1115,9 +924,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -1129,99 +937,15 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(linera_server_request_latency_per_request_type_bucket[1m])) by (le, method_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_server_request_latency_per_request_type_bucket{validator=~\"$validator\"}[1m])) by (le, method_name))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{method_name}} - p99",
           "range": true,
           "refId": "A",
           "useBackend": false
-        }
-      ],
-      "title": "Server p99 latency per request type ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ms"
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 50
-      },
-      "id": 24,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
@@ -1229,99 +953,15 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(rate(linera_server_request_latency_per_request_type_bucket[1m])) by (le, method_name))",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_server_request_latency_per_request_type_bucket{validator=~\"$validator\"}[1m])) by (le, method_name))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{method_name}} - p90",
           "range": true,
-          "refId": "A",
+          "refId": "B",
           "useBackend": false
-        }
-      ],
-      "title": "Server p90 latency per request type ms (1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ms"
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 50
-      },
-      "id": 25,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
@@ -1329,17 +969,17 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(linera_server_request_latency_per_request_type_bucket[1m])) by (le, method_name))",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_server_request_latency_per_request_type_bucket{validator=~\"$validator\"}[1m])) by (le, method_name))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{method_name}} - p50",
           "range": true,
-          "refId": "A",
+          "refId": "C",
           "useBackend": false
         }
       ],
-      "title": "Server p50 latency per request type ms (1m)",
+      "title": "Server Latency by Request Type (ms)",
       "type": "timeseries"
     },
     {
@@ -1348,7 +988,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 34
       },
       "id": 8,
       "panels": [],
@@ -1360,6 +1000,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Total transmitted network bytes per validator pod",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1401,7 +1042,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1417,7 +1059,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 59
+        "y": 35
       },
       "id": 9,
       "options": {
@@ -1429,8 +1071,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -1441,7 +1083,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"(proxy|shards)-.*\"}[60s])) by (pod)",
+          "expr": "sum(rate(container_network_transmit_bytes_total{validator=~\"$validator\",pod=~\"(proxy|shards)-.*\"}[60s])) by (pod)",
           "hide": false,
           "instant": false,
           "legendFormat": "tx - {{pod}}",
@@ -1454,7 +1096,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"shards-.*\"}[60s]))",
+          "expr": "sum(rate(container_network_transmit_bytes_total{validator=~\"$validator\",pod=~\"shards-.*\"}[60s]))",
           "hide": false,
           "instant": false,
           "legendFormat": "tx - Total shards",
@@ -1470,6 +1112,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Total received network bytes per validator pod",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1511,7 +1154,659 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 47,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_network_receive_bytes_total{validator=~\"$validator\",pod=~\"(proxy|shards)-.*\"}[60s])) by (pod)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "tx - {{pod}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_network_receive_bytes_total{validator=~\"$validator\",pod=~\"shards-.*\"}[60s]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "tx - Total shards",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Network bytes RX total per pod",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Termination events per validator container",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(kube_pod_container_status_last_terminated_reason{validator=~\"$validator\"}[1m])) by (pod, reason)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pod}} - {{reason}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Container termination",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Exit codes from terminated validator containers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "kube_pod_container_status_last_terminated_exitcode{validator=~\"$validator\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Container termination exit code",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "CPU utilization per validator container",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 51
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{validator=~\"$validator\",pod=~\"(proxy|shards)-.*\"}[60s])) by (pod)",
+          "instant": false,
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{validator=~\"$validator\",container=~\"linera-.*\"}[60s])) by (container)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{container}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{validator=~\"$validator\"}[60s]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Container CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Memory allocation failures per validator container",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 51
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(pod, failure_type) (rate(container_memory_failures_total{validator=~\"$validator\",pod=~\"(proxy|shards)-.*\", failure_type!=\"pgfault\"}[60s]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{pod}} - {{failure_type}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Container Memory Failures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Filesystem read operations per second for validator shards",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "iops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 59
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_fs_reads_total{validator=~\"$validator\",container=\"linera-server\"}[60s])) by (pod)",
+          "instant": false,
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_fs_reads_total{validator=~\"$validator\",container=\"linera-server\"}[60s]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Shards FS reads per second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Memory usage in bytes per validator container",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1529,237 +1824,6 @@
         "x": 12,
         "y": 59
       },
-      "id": 47,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"(proxy|shards)-.*\"}[60s])) by (pod)",
-          "instant": false,
-          "legendFormat": "rx - {{pod}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"shards-.*\"}[60s]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "rx - Total shards",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Network bytes RX total per pod",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 67
-      },
-      "id": 36,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"(proxy|shards)-.*\"}[60s])) by (pod)",
-          "instant": false,
-          "legendFormat": "{{pod}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(container_cpu_usage_seconds_total{container=~\"linera-.*\"}[60s])) by (container)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{container}}",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(container_cpu_usage_seconds_total[60s]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Total",
-          "range": true,
-          "refId": "C"
-        }
-      ],
-      "title": "Container CPU Usage",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 67
-      },
       "id": 5,
       "options": {
         "legend": {
@@ -1772,8 +1836,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "none",
-          "sort": "asc"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -1785,7 +1849,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(container_memory_usage_bytes{container=~\"linera.*\"}) by (container)",
+          "expr": "sum(container_memory_usage_bytes{validator=~\"$validator\",container=~\"linera.*\"}) by (container)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1800,7 +1864,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(container_memory_usage_bytes{pod=~\"(proxy|shards).*\"}) by (pod)",
+          "expr": "sum(container_memory_usage_bytes{validator=~\"$validator\",pod=~\"(proxy|shards).*\"}) by (pod)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pod}}",
@@ -1814,7 +1878,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(container_memory_usage_bytes{container=~\"linera.*\"})",
+          "expr": "sum(container_memory_usage_bytes{validator=~\"$validator\",container=~\"linera.*\"})",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1833,6 +1897,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Filesystem read throughput in bytes per second for validator shards",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1874,207 +1939,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 75
-      },
-      "id": 29,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "none",
-          "sort": "asc"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "sum by(pod, failure_type) (rate(container_memory_failures_total{pod=~\"(proxy|shards)-.*\", failure_type!=\"pgfault\"}[60s]))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "{{pod}} - {{failure_type}}",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Container Memory Failures",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 75
-      },
-      "id": 39,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "10.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(kube_pod_container_status_last_terminated_reason[1m])) by (pod, reason)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{pod}} - {{reason}}",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Container termination",
-      "transformations": [],
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2090,7 +1956,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 83
+        "y": 67
       },
       "id": 32,
       "options": {
@@ -2102,8 +1968,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -2114,7 +1980,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_fs_reads_bytes_total{container=\"linera-server\"}[60s])) by (pod)",
+          "expr": "sum(rate(container_fs_reads_bytes_total{validator=~\"$validator\",container=\"linera-server\"}[60s])) by (pod)",
           "instant": false,
           "legendFormat": "{{pod}}",
           "range": true,
@@ -2126,7 +1992,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_fs_reads_bytes_total{container=\"linera-server\"}[60s]))",
+          "expr": "sum(rate(container_fs_reads_bytes_total{validator=~\"$validator\",container=\"linera-server\"}[60s]))",
           "hide": false,
           "instant": false,
           "legendFormat": "Total",
@@ -2142,7 +2008,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Some useful codes to remember:\n137 - SIGKILL - can happen on OOMs\n143 - SIGTERM",
+      "description": "Filesystem write operations per second for validator shards",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2184,14 +2050,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "iops"
         },
         "overrides": []
       },
@@ -2199,9 +2067,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 83
+        "y": 67
       },
-      "id": 46,
+      "id": 31,
       "options": {
         "legend": {
           "calcs": [],
@@ -2211,30 +2079,39 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "10.1.1",
+      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "kube_pod_container_status_last_terminated_exitcode",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
+          "editorMode": "code",
+          "expr": "sum(rate(container_fs_writes_total{validator=~\"$validator\",container=\"linera-server\"}[60s])) by (pod)",
           "instant": false,
           "legendFormat": "{{pod}}",
           "range": true,
-          "refId": "A",
-          "useBackend": false
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_fs_writes_total{validator=~\"$validator\",container=\"linera-server\"}[60s]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
-      "title": "Container termination exit code",
+      "title": "Shards FS writes per second",
       "type": "timeseries"
     },
     {
@@ -2242,6 +2119,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Filesystem write throughput in bytes per second for validator shards",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2283,7 +2161,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2299,7 +2178,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 91
+        "y": 75
       },
       "id": 44,
       "options": {
@@ -2311,8 +2190,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -2323,7 +2202,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_fs_writes_bytes_total{container=\"linera-server\"}[60s])) by (pod)",
+          "expr": "sum(rate(container_fs_writes_bytes_total{validator=~\"$validator\",container=\"linera-server\"}[60s])) by (pod)",
           "instant": false,
           "legendFormat": "{{pod}}",
           "range": true,
@@ -2335,7 +2214,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_fs_writes_bytes_total{container=\"linera-server\"}[60s]))",
+          "expr": "sum(rate(container_fs_writes_bytes_total{validator=~\"$validator\",container=\"linera-server\"}[60s]))",
           "hide": false,
           "instant": false,
           "legendFormat": "Total",
@@ -2347,230 +2226,12 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 91
-      },
-      "id": 41,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(container_fs_reads_total{container=\"linera-server\"}[60s])) by (pod)",
-          "instant": false,
-          "legendFormat": "{{pod}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(container_fs_reads_total{container=\"linera-server\"}[60s]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Total",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Shards FS reads per second",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 99
-      },
-      "id": 31,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(container_fs_writes_total{container=\"linera-server\"}[60s])) by (pod)",
-          "instant": false,
-          "legendFormat": "{{pod}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(container_fs_writes_total{container=\"linera-server\"}[60s]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Total",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Shards FS writes per second",
-      "type": "timeseries"
-    },
-    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 107
+        "y": 83
       },
       "id": 34,
       "panels": [],
@@ -2582,6 +2243,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Total transmitted network bytes for ScyllaDB pods",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2623,7 +2285,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2639,7 +2302,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 108
+        "y": 84
       },
       "id": 30,
       "options": {
@@ -2651,8 +2314,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -2663,7 +2326,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"scylla-validator.*\"}[60s])) by (pod)",
+          "expr": "sum(rate(container_network_transmit_bytes_total{validator=~\"$validator\",pod=~\"scylla-validator.*\"}[60s])) by (pod)",
           "instant": false,
           "legendFormat": "{{container}}",
           "range": true,
@@ -2678,6 +2341,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Total received network bytes for ScyllaDB pods",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2719,7 +2383,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2735,7 +2400,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 108
+        "y": 84
       },
       "id": 48,
       "options": {
@@ -2747,8 +2412,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -2759,7 +2424,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"scylla-validator.*\"}[60s])) by (pod)",
+          "expr": "sum(rate(container_network_receive_bytes_total{validator=~\"$validator\",pod=~\"scylla-validator.*\"}[60s])) by (pod)",
           "instant": false,
           "legendFormat": "{{container}}",
           "range": true,
@@ -2774,6 +2439,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Termination events for ScyllaDB containers",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2815,206 +2481,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 116
-      },
-      "id": 26,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"scylla-validator-.*\"}[60s])) by (pod)",
-          "instant": false,
-          "legendFormat": "{{container}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "ScyllaDB Total CPU Usage",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 116
-      },
-      "id": 10,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "none",
-          "sort": "asc"
-        }
-      },
-      "pluginVersion": "10.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "sum(container_memory_usage_bytes{pod=~\"scylla-validator.*\"}) by (pod)",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Scylla Memory Usage Bytes",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3030,7 +2498,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 124
+        "y": 92
       },
       "id": 45,
       "options": {
@@ -3042,8 +2510,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -3055,7 +2523,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(rate(kube_pod_container_status_last_terminated_reason{pod=~\"(scylla)-.*\"}[1m])) by (pod, reason)",
+          "expr": "sum(rate(kube_pod_container_status_last_terminated_reason{validator=~\"$validator\",validator=~\"$validator\",pod=~\"(scylla)-.*\"}[1m])) by (pod, reason)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -3073,6 +2541,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Memory allocation failures for ScyllaDB containers",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3114,7 +2583,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3130,7 +2600,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 124
+        "y": 92
       },
       "id": 27,
       "options": {
@@ -3144,8 +2614,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "none",
-          "sort": "asc"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -3157,7 +2627,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(failure_type) (rate(container_memory_failures_total{container=\"scylla\", failure_type!=\"pgfault\"}[60s]))",
+          "expr": "sum by(failure_type) (rate(container_memory_failures_total{validator=~\"$validator\",container=\"scylla\", failure_type!=\"pgfault\"}[60s]))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -3175,6 +2645,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "CPU utilization for ScyllaDB containers",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3216,7 +2687,106 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 100
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{validator=~\"$validator\",pod=~\"scylla-validator-.*\"}[60s])) by (pod)",
+          "instant": false,
+          "legendFormat": "{{container}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "ScyllaDB Total CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Out-of-memory events per second for ScyllaDB containers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3231,8 +2801,110 @@
       "gridPos": {
         "h": 8,
         "w": 12,
+        "x": 12,
+        "y": 100
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum(rate(container_oom_events_total{validator=~\"$validator\",pod=~\"scylla-validator-.*\"}[1m])) by (pod)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "ScyllaDB OOM events per second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Filesystem read operations per second for ScyllaDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "iops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
         "x": 0,
-        "y": 132
+        "y": 108
       },
       "id": 28,
       "options": {
@@ -3244,8 +2916,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -3256,7 +2928,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_fs_reads_total{container=\"scylla\"}[60s])) by (container)",
+          "expr": "sum(rate(container_fs_reads_total{validator=~\"$validator\",container=\"scylla\"}[60s])) by (container)",
           "instant": false,
           "legendFormat": "{{container}}",
           "range": true,
@@ -3271,6 +2943,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Memory usage in bytes for ScyllaDB containers",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3312,7 +2985,112 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 108
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum(container_memory_usage_bytes{validator=~\"$validator\",pod=~\"scylla-validator.*\"}) by (pod)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Scylla Memory Usage Bytes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Filesystem read throughput in bytes per second for ScyllaDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3327,8 +3105,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 132
+        "x": 0,
+        "y": 116
       },
       "id": 42,
       "options": {
@@ -3340,8 +3118,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -3352,7 +3130,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_fs_reads_bytes_total{container=\"scylla\"}[60s])) by (container)",
+          "expr": "sum(rate(container_fs_reads_bytes_total{validator=~\"$validator\",container=\"scylla\"}[60s])) by (container)",
           "instant": false,
           "legendFormat": "{{container}}",
           "range": true,
@@ -3367,6 +3145,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Filesystem write operations per second for ScyllaDB",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3408,7 +3187,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3416,15 +3196,15 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "iops"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 140
+        "x": 12,
+        "y": 116
       },
       "id": 43,
       "options": {
@@ -3436,8 +3216,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -3448,7 +3228,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_fs_writes_total{container=\"scylla\"}[60s])) by (container)",
+          "expr": "sum(rate(container_fs_writes_total{validator=~\"$validator\",container=\"scylla\"}[60s])) by (container)",
           "instant": false,
           "legendFormat": "{{container}}",
           "range": true,
@@ -3463,6 +3243,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Filesystem write throughput in bytes per second for ScyllaDB",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3504,7 +3285,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3519,8 +3301,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 140
+        "x": 0,
+        "y": 124
       },
       "id": 33,
       "options": {
@@ -3532,8 +3314,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.6.0-83314",
@@ -3544,7 +3326,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_fs_writes_bytes_total{container=\"scylla\"}[60s])) by (container)",
+          "expr": "sum(rate(container_fs_writes_bytes_total{validator=~\"$validator\",container=\"scylla\"}[60s])) by (container)",
           "instant": false,
           "legendFormat": "{{container}}",
           "range": true,
@@ -3552,106 +3334,6 @@
         }
       ],
       "title": "ScyllaDB FS written bytes per second",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 148
-      },
-      "id": 38,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "sum(rate(container_oom_events_total{pod=~\"scylla-validator-.*\"}[1m])) by (pod)",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "ScyllaDB OOM events per second",
       "type": "timeseries"
     }
   ],
@@ -3662,7 +3344,33 @@
     "linera"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Validator",
+        "multi": true,
+        "name": "validator",
+        "options": [],
+        "query": "label_values(linera_proxy_request_count, validator)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
   },
   "time": {
     "from": "now-1h",

--- a/kubernetes/linera-validator/grafana-dashboards/linera/storage/rocksdb.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/storage/rocksdb.json
@@ -1,0 +1,2352 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "RocksDB Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Internal RocksDB write batch latency",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_rocksdb_internal_write_batch_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_rocksdb_internal_write_batch_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_rocksdb_internal_write_batch_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RocksDB Write Batch Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Internal RocksDB read value latency",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_rocksdb_internal_read_value_bytes_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_rocksdb_internal_read_value_bytes_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_rocksdb_internal_read_value_bytes_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RocksDB Read Value Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Internal RocksDB contains key latency",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_rocksdb_internal_contains_key_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_rocksdb_internal_contains_key_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_rocksdb_internal_contains_key_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RocksDB Contains Key Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Internal RocksDB prefix scan latency",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_rocksdb_internal_find_keys_by_prefix_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_rocksdb_internal_find_keys_by_prefix_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_rocksdb_internal_find_keys_by_prefix_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RocksDB Find Keys By Prefix Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Size of write batches to RocksDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_rocksdb_internal_write_batch_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_rocksdb_internal_write_batch_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_rocksdb_internal_write_batch_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RocksDB Write Batch Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Size of keys read from RocksDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_rocksdb_internal_read_value_key_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_rocksdb_internal_read_value_key_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_rocksdb_internal_read_value_key_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RocksDB Read Value Key Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Size of values read from RocksDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_rocksdb_internal_read_value_value_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_rocksdb_internal_read_value_value_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_rocksdb_internal_read_value_value_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RocksDB Read Value Value Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Internal RocksDB batch contains check latency",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_rocksdb_internal_contains_keys_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_rocksdb_internal_contains_keys_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_rocksdb_internal_contains_keys_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RocksDB Batch Contains Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Internal RocksDB batch read latency",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_rocksdb_internal_read_multi_value_bytes_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_rocksdb_internal_read_multi_value_bytes_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_rocksdb_internal_read_multi_value_bytes_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RocksDB Batch Read Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of keys per batch read",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_rocksdb_internal_read_multi_values_num_entries_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_rocksdb_internal_read_multi_values_num_entries_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_rocksdb_internal_read_multi_values_num_entries_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RocksDB Batch Read Entries",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Internal RocksDB prefix scan with values latency",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_rocksdb_internal_find_key_values_by_prefix_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_rocksdb_internal_find_key_values_by_prefix_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_rocksdb_internal_find_key_values_by_prefix_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RocksDB Find Key Values By Prefix Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Total size of keys per prefix scan",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_rocksdb_internal_find_keys_by_prefix_keys_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_rocksdb_internal_find_keys_by_prefix_keys_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_rocksdb_internal_find_keys_by_prefix_keys_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RocksDB Prefix Scan Keys Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of keys found per prefix scan",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_rocksdb_internal_find_keys_by_prefix_num_keys_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_rocksdb_internal_find_keys_by_prefix_num_keys_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_rocksdb_internal_find_keys_by_prefix_num_keys_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RocksDB Prefix Scan Keys Found",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of read operations where the key did not exist in the database",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_rocksdb_internal_read_value_none_cases{validator=~\"$validator\"}[1m]))",
+          "legendFormat": "rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RocksDB Read Key Not Found Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "linera",
+    "storage",
+    "rocksdb"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(linera_load_view_latency_bucket, validator)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Validator",
+        "multi": false,
+        "name": "validator",
+        "options": [],
+        "query": {
+          "query": "label_values(linera_load_view_latency_bucket, validator)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "RocksDB",
+  "uid": "linera-rocksdb",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kubernetes/linera-validator/grafana-dashboards/linera/storage/scylladb.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/storage/scylladb.json
@@ -1,0 +1,2352 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "ScyllaDB Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Internal ScyllaDB write batch latency",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_scylladb_internal_write_batch_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_scylladb_internal_write_batch_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_scylladb_internal_write_batch_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "ScyllaDB Write Batch Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Internal ScyllaDB read value latency",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_scylladb_internal_read_value_bytes_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_scylladb_internal_read_value_bytes_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_scylladb_internal_read_value_bytes_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "ScyllaDB Read Value Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Internal ScyllaDB contains key latency",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_scylladb_internal_contains_key_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_scylladb_internal_contains_key_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_scylladb_internal_contains_key_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "ScyllaDB Contains Key Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Internal ScyllaDB prefix scan latency",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_scylladb_internal_find_keys_by_prefix_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_scylladb_internal_find_keys_by_prefix_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_scylladb_internal_find_keys_by_prefix_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "ScyllaDB Find Keys By Prefix Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Size of write batches to ScyllaDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_scylladb_internal_write_batch_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_scylladb_internal_write_batch_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_scylladb_internal_write_batch_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "ScyllaDB Write Batch Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Size of keys read from ScyllaDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_scylladb_internal_read_value_key_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_scylladb_internal_read_value_key_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_scylladb_internal_read_value_key_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "ScyllaDB Read Value Key Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Size of values read from ScyllaDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_scylladb_internal_read_value_value_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_scylladb_internal_read_value_value_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_scylladb_internal_read_value_value_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "ScyllaDB Read Value Value Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Internal ScyllaDB batch contains check latency",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_scylladb_internal_contains_keys_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_scylladb_internal_contains_keys_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_scylladb_internal_contains_keys_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "ScyllaDB Batch Contains Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Internal ScyllaDB batch read latency",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_scylladb_internal_read_multi_value_bytes_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_scylladb_internal_read_multi_value_bytes_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_scylladb_internal_read_multi_value_bytes_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "ScyllaDB Batch Read Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of keys per batch read",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_scylladb_internal_read_multi_values_num_entries_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_scylladb_internal_read_multi_values_num_entries_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_scylladb_internal_read_multi_values_num_entries_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "ScyllaDB Batch Read Entries",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Internal ScyllaDB prefix scan with values latency",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_scylladb_internal_find_key_values_by_prefix_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_scylladb_internal_find_key_values_by_prefix_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_scylladb_internal_find_key_values_by_prefix_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "ScyllaDB Find Key Values By Prefix Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Total size of keys per prefix scan",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_scylladb_internal_find_keys_by_prefix_keys_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_scylladb_internal_find_keys_by_prefix_keys_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_scylladb_internal_find_keys_by_prefix_keys_size_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "ScyllaDB Prefix Scan Keys Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of keys found per prefix scan",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_scylladb_internal_find_keys_by_prefix_num_keys_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_scylladb_internal_find_keys_by_prefix_num_keys_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_scylladb_internal_find_keys_by_prefix_num_keys_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "ScyllaDB Prefix Scan Keys Found",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of read operations where the key did not exist in the database",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_scylladb_internal_read_value_none_cases{validator=~\"$validator\"}[1m]))",
+          "legendFormat": "rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "ScyllaDB Read Key Not Found Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "linera",
+    "storage",
+    "scylladb"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(linera_load_view_latency_bucket, validator)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Validator",
+        "multi": false,
+        "name": "validator",
+        "options": [],
+        "query": {
+          "query": "label_values(linera_load_view_latency_bucket, validator)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "ScyllaDB",
+  "uid": "linera-scylladb",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kubernetes/linera-validator/grafana-dashboards/linera/storage/storage.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/storage/storage.json
@@ -15,9 +15,10 @@
       }
     ]
   },
+  "description": "Storage layer metrics including latencies for loading views, chains, contracts, and services, plus I/O operation rates",
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 2,
+  "graphTooltip": 1,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -29,7 +30,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 20,
+      "id": 1,
       "panels": [],
       "title": "Latencies",
       "type": "row"
@@ -39,6 +40,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Time to load chain state from storage. p50 is median, p90 is most users' experience, p99 captures tail latency.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -88,9 +90,56 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "ms"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -98,21 +147,23 @@
         "x": 0,
         "y": 1
       },
-      "id": 16,
+      "id": 2,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
@@ -120,13 +171,35 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_load_view_latency_bucket[1m])))",
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_load_chain_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_load_chain_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_load_chain_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Load view latency p99 (1m)",
+      "title": "Load Chain Latency",
       "type": "timeseries"
     },
     {
@@ -134,6 +207,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Time to load a contract from storage. p50 is median, p90 is most users' experience, p99 captures tail latency.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -183,9 +257,56 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "ms"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -193,21 +314,23 @@
         "x": 12,
         "y": 1
       },
-      "id": 17,
+      "id": 3,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
@@ -215,13 +338,35 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_load_view_latency_bucket[1m])))",
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_load_contract_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_load_contract_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_load_contract_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Load view latency p50 (1m)",
+      "title": "Load Contract Latency",
       "type": "timeseries"
     },
     {
@@ -229,6 +374,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Time to load a service from storage. p50 is median, p90 is most users' experience, p99 captures tail latency.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -278,7 +424,1691 @@
                 "value": 80
               }
             ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_load_service_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_load_service_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_load_service_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Load Service Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Time to read a certificate from storage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_read_certificate_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_read_certificate_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_read_certificate_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Read Certificate Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Time to read a blob from storage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_read_blob_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_read_blob_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_read_blob_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Read Blob Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Time to write a blob to storage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_write_blob_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_write_blob_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_write_blob_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Write Blob Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Time to read an event from storage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_read_event_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_read_event_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_read_event_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Read Event Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Time to write events to storage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_write_event_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_write_event_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_write_event_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Write Event Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Time to write a batch to storage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_write_batch_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_write_batch_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_write_batch_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Write Batch Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Time to check if a certificate exists in storage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_contains_certificate_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_contains_certificate_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_contains_certificate_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Contains Certificate Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Time to check if a blob exists in storage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_contains_blob_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_contains_blob_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_contains_blob_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Contains Blob Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Time to check if an event exists in storage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_contains_event_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_contains_event_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_contains_event_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Contains Event Latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 106
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Rates",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of contains_blobs operations per second by pod.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -286,7 +2116,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 9
+        "y": 107
       },
       "id": 15,
       "options": {
@@ -298,11 +2128,10 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
@@ -310,13 +2139,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_load_chain_latency_bucket[1m])))",
-          "legendFormat": "__auto",
+          "expr": "sum(rate(linera_contains_blobs{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Load chain latency p99 (1m)",
+      "title": "Contains Blobs Rate",
       "type": "timeseries"
     },
     {
@@ -324,6 +2153,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Rate of contains_blob_state operations per second by pod.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -373,7 +2203,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -381,7 +2212,295 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 9
+        "y": 107
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_contains_blob_state{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Contains Blob State Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of event write operations per second by pod.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 115
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_write_event{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Write Event Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of event read operations per second by pod.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 115
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_read_event{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Read Event Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of certificate read operations (batch) per second by pod.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 123
       },
       "id": 19,
       "options": {
@@ -393,11 +2512,10 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
@@ -405,13 +2523,25 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_load_chain_latency_bucket[1m])))",
-          "legendFormat": "__auto",
+          "expr": "sum(rate(linera_read_certificates{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_read_certificates{validator=~\"$validator\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
-      "title": "Load chain latency p50 (1m)",
+      "title": "Read Certificates Rate (batch)",
       "type": "timeseries"
     },
     {
@@ -419,6 +2549,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Rate of single certificate read operations per second by pod.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -468,7 +2599,104 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 123
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_read_certificate{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Read Certificate Rate (single)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of blob state read operations (batch) per second by pod.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -476,7 +2704,103 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 17
+        "y": 131
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_read_blob_states{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Read Blob States Rate (batch)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of single blob state read operations per second by pod.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 131
       },
       "id": 22,
       "options": {
@@ -488,11 +2812,10 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
@@ -500,13 +2823,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_load_contract_latency_bucket[1m])))",
-          "legendFormat": "__auto",
+          "expr": "sum(rate(linera_read_blob_state{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Load contract latency p99 (1m)",
+      "title": "Read Blob State Rate (single)",
       "type": "timeseries"
     },
     {
@@ -514,6 +2837,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Rate of blob write operations per second by pod.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -563,15 +2887,16 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "ops"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 17
+        "x": 0,
+        "y": 139
       },
       "id": 23,
       "options": {
@@ -583,11 +2908,10 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
@@ -595,13 +2919,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_load_contract_latency_bucket[1m])))",
-          "legendFormat": "__auto",
+          "expr": "sum(rate(linera_write_blob{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Load contract latency p50 (1m)",
+      "title": "Write Blob Rate",
       "type": "timeseries"
     },
     {
@@ -609,6 +2933,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Rate of blob read operations per second by pod.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -658,15 +2983,16 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "ops"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 25
+        "x": 12,
+        "y": 139
       },
       "id": 24,
       "options": {
@@ -678,11 +3004,10 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
@@ -690,13 +3015,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_load_service_latency_bucket[1m])))",
-          "legendFormat": "__auto",
+          "expr": "sum(rate(linera_read_blob{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Load service latency p99 (1m)",
+      "title": "Read Blob Rate",
       "type": "timeseries"
     },
     {
@@ -704,6 +3029,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Rate of certificate write operations per second by pod.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -753,15 +3079,16 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "ops"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 25
+        "x": 0,
+        "y": 147
       },
       "id": 25,
       "options": {
@@ -773,11 +3100,10 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
@@ -785,498 +3111,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_load_service_latency_bucket[1m])))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Load service latency p50 (1m)",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 33
-      },
-      "id": 21,
-      "panels": [],
-      "title": "Rates",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 34
-      },
-      "id": 2,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(linera_contains_blobs[1m])) by (pod)",
+          "expr": "sum(rate(linera_write_certificate{validator=~\"$validator\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
-        }
-      ],
-      "title": "Contains blobs per second (averaged for the past minute)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 34
-      },
-      "id": 3,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(linera_contains_blob_state[1m])) by (pod)",
-          "legendFormat": "{{pod}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Contains blob state per second (averaged for the past minute)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 42
-      },
-      "id": 14,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(linera_write_event[1m])",
-          "legendFormat": "{{pod}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Write event per second (averaged for the past minute)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 42
-      },
-      "id": 13,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(linera_read_event[1m])) by (pod)",
-          "legendFormat": "{{pod}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Read event per second (averaged for the past minute)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 50
-      },
-      "id": 11,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(linera_read_certificates[1m])) by (pod)",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
         },
         {
           "datasource": {
@@ -1284,14 +3122,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_read_certificates[1m]))",
+          "expr": "sum(rate(linera_write_certificate{validator=~\"$validator\"}[1m]))",
           "hide": false,
           "legendFormat": "Total",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Read certificates per second (averaged for the past minute)",
+      "title": "Write Certificate Rate",
       "type": "timeseries"
     },
     {
@@ -1299,6 +3137,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Rate of confirmed block read operations per second by pod.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1348,7 +3187,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -1356,9 +3196,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 50
+        "y": 147
       },
-      "id": 10,
+      "id": 26,
       "options": {
         "legend": {
           "calcs": [],
@@ -1368,11 +3208,10 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
@@ -1380,13 +3219,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_read_certificate[1m])) by (pod)",
+          "expr": "sum(rate(linera_read_confirmed_block{validator=~\"$validator\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Read certificate per second (averaged for the past minute)",
+      "title": "Read Confirmed Block Rate",
       "type": "timeseries"
     },
     {
@@ -1394,6 +3233,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Rate of contains_blob operations per second by pod.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1443,7 +3283,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -1451,9 +3292,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 58
+        "y": 155
       },
-      "id": 8,
+      "id": 27,
       "options": {
         "legend": {
           "calcs": [],
@@ -1463,11 +3304,10 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
@@ -1475,13 +3315,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_read_blob_states[1m])) by (pod)",
+          "expr": "sum(rate(linera_contains_blob{validator=~\"$validator\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Read blob states per second (averaged for the past minute)",
+      "title": "Contains Blob Rate",
       "type": "timeseries"
     },
     {
@@ -1489,6 +3329,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Rate of contains_certificate operations per second by pod.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1538,7 +3379,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -1546,9 +3388,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 58
+        "y": 155
       },
-      "id": 7,
+      "id": 28,
       "options": {
         "legend": {
           "calcs": [],
@@ -1558,11 +3400,10 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
@@ -1570,604 +3411,53 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_read_blob_state[1m])) by (pod)",
+          "expr": "sum(rate(linera_contains_certificate{validator=~\"$validator\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Read blob state per second (averaged for the past minute)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 66
-      },
-      "id": 9,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(linera_write_blob[1m])) by (pod)",
-          "legendFormat": "{{pod}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Write blob per second (averaged for the last minute)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 66
-      },
-      "id": 6,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(linera_read_blob[1m])) by (pod)",
-          "legendFormat": "{{pod}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Read blob per second (averaged for the past minute)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 74
-      },
-      "id": 12,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(linera_write_certificate[1m])) by (pod)",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(linera_write_certificate[1m]))",
-          "hide": false,
-          "legendFormat": "Total",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Write certificate per second (averaged for the past minute)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 74
-      },
-      "id": 5,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(linera_read_confirmed_block[1m])) by (pod)",
-          "legendFormat": "{{pod}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Read hashed confirmed block per second (averaged for the past minute)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 82
-      },
-      "id": 1,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(linera_contains_blob[1m])) by (pod)",
-          "legendFormat": "{{[pod}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Contains Blob per second (averaged for the past minute)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 82
-      },
-      "id": 4,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0-83314",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(linera_contains_certificate[1m])) by (pod)",
-          "legendFormat": "{{pod}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Contains certificate per second (averaged for the past minute)",
+      "title": "Contains Certificate Rate",
       "type": "timeseries"
     }
   ],
   "refresh": "5s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "linera"
+  ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(linera_load_view_latency_bucket, validator)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Validator",
+        "multi": false,
+        "name": "validator",
+        "options": [],
+        "query": {
+          "query": "label_values(linera_load_view_latency_bucket, validator)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
   },
   "time": {
     "from": "now-1h",

--- a/kubernetes/linera-validator/grafana-dashboards/linera/views.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/views.json
@@ -15,17 +15,32 @@
       }
     ]
   },
+  "description": "Metrics related to view loading, saving, and caching operations",
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 2,
+  "graphTooltip": 1,
   "links": [],
   "liveNow": false,
   "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Latencies",
+      "type": "row"
+    },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Time to load a view from storage. p50 is median, p90 is most users' experience, p99 captures tail latency.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -63,19 +78,322 @@
             }
           },
           "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
               {
-                "color": "green",
-                "value": null
-              },
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
               {
-                "color": "red",
-                "value": 80
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(linera_load_view_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(linera_load_view_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(linera_load_view_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Load View Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Time to save a view to storage. p50 is median, p90 is most users' experience, p99 captures tail latency. Broken down by view type.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*p50.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*p90.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*p99.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(le, type) (rate(linera_save_view_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "{{type}} p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le, type) (rate(linera_save_view_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "{{type}} p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le, type) (rate(linera_save_view_latency_bucket{validator=~\"$validator\"}[1m])))",
+          "legendFormat": "{{type}} p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Save View Latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Rates",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of view save operations per second, broken down by pod. Higher values indicate more state changes being persisted.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -83,7 +401,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 10
       },
       "id": 3,
       "options": {
@@ -95,11 +413,10 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
@@ -107,8 +424,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_save_view[1m])) by (pod)",
-          "legendFormat": "__auto",
+          "expr": "sum(rate(linera_save_view{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         },
@@ -118,14 +435,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_save_view[1m]))",
+          "expr": "sum(rate(linera_save_view{validator=~\"$validator\"}[1m]))",
           "hide": false,
           "legendFormat": "Total",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Save view per second (averaged for the past minute)",
+      "title": "Save View Rate",
       "type": "timeseries"
     },
     {
@@ -133,6 +450,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Rate of view load operations per second, broken down by pod. Higher values indicate more state being read from storage.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -170,19 +488,7 @@
             }
           },
           "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -190,7 +496,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 10
       },
       "id": 2,
       "options": {
@@ -202,11 +508,10 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
@@ -214,8 +519,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_load_view[1m])) by (pod)",
-          "legendFormat": "__auto",
+          "expr": "sum(rate(linera_load_view{validator=~\"$validator\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         },
@@ -225,14 +530,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_load_view[1m])) ",
+          "expr": "sum(rate(linera_load_view{validator=~\"$validator\"}[1m]))",
           "hide": false,
           "legendFormat": "Total",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Load view per second (averaged for the past minute)",
+      "title": "Load View Rate",
       "type": "timeseries"
     },
     {
@@ -240,6 +545,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Percentage of cache hits vs total cache accesses. Higher values indicate better cache efficiency and less storage I/O.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -277,19 +583,6 @@
             }
           },
           "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "percent"
         },
         "overrides": []
@@ -298,7 +591,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 18
       },
       "id": 1,
       "options": {
@@ -310,11 +603,10 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
@@ -322,22 +614,51 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n    sum(rate(linera_num_cache_success[1m])) by (pod)\n    /\n    (\n        sum(rate(linera_num_cache_success[1m])) by (pod)\n        + sum(rate(linera_num_cache_fault[1m])) by (pod)\n    )\n) * 100",
-          "legendFormat": "__auto",
+          "expr": "(\n    sum(rate(linera_num_cache_success{validator=~\"$validator\"}[1m])) by (pod)\n    /\n    (\n        sum(rate(linera_num_cache_success{validator=~\"$validator\"}[1m])) by (pod)\n        + sum(rate(linera_num_cache_fault{validator=~\"$validator\"}[1m])) by (pod)\n    )\n) * 100",
+          "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Cache hit ratio (1m)",
+      "title": "Cache Hit Ratio",
       "type": "timeseries"
     }
   ],
   "refresh": "5s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": [],
+  "tags": ["linera"],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(linera_load_view, validator)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Validator",
+        "multi": false,
+        "name": "validator",
+        "options": [],
+        "query": {
+          "query": "label_values(linera_load_view, validator)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
   },
   "time": {
     "from": "now-1h",

--- a/kubernetes/linera-validator/grafana-dashboards/linera/vms/ethereum.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/vms/ethereum.json
@@ -17,7 +17,7 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 2,
+  "graphTooltip": 1,
   "links": [],
   "liveNow": false,
   "panels": [

--- a/kubernetes/linera-validator/grafana-dashboards/profiling/cpu.json
+++ b/kubernetes/linera-validator/grafana-dashboards/profiling/cpu.json
@@ -17,7 +17,7 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "links": [],
   "liveNow": false,
   "panels": [

--- a/kubernetes/linera-validator/grafana-dashboards/profiling/jemalloc-memory.json
+++ b/kubernetes/linera-validator/grafana-dashboards/profiling/jemalloc-memory.json
@@ -17,7 +17,7 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "links": [],
   "liveNow": false,
   "panels": [

--- a/kubernetes/linera-validator/templates/grafana-linera-dashboards-config.yaml
+++ b/kubernetes/linera-validator/templates/grafana-linera-dashboards-config.yaml
@@ -9,5 +9,7 @@ metadata:
 data:
   linera_general.json: {{ .Files.Get "grafana-dashboards/linera/general.json" | quote | indent 4 }}
   linera_execution.json: {{ .Files.Get "grafana-dashboards/linera/execution.json" | quote | indent 4 }}
-  linera_storage.json: {{ .Files.Get "grafana-dashboards/linera/storage.json" | quote | indent 4 }}
+  linera_storage.json: {{ .Files.Get "grafana-dashboards/linera/storage/storage.json" | quote | indent 4 }}
+  linera_storage_rocksdb.json: {{ .Files.Get "grafana-dashboards/linera/storage/rocksdb.json" | quote | indent 4 }}
+  linera_storage_scylladb.json: {{ .Files.Get "grafana-dashboards/linera/storage/scylladb.json" | quote | indent 4 }}
   linera_views.json: {{ .Files.Get "grafana-dashboards/linera/views.json" | quote | indent 4 }}

--- a/rustc-ice-2026-01-07T22_25_43-46144.txt
+++ b/rustc-ice-2026-01-07T22_25_43-46144.txt
@@ -1,0 +1,327 @@
+thread 'rustc' panicked at compiler/rustc_trait_selection/src/traits/normalize.rs:69:17:
+Box<dyn Any>
+stack backtrace:
+   0:        0x11364af54 - std::backtrace::Backtrace::create::ha8ad3a274d69bc73
+   1:        0x1118139bc - std[b5799de7b54252e2]::panicking::update_hook::<alloc[aa6ffa18488a0c9c]::boxed::Box<rustc_driver_impl[c369b46601ddfb4f]::install_ice_hook::{closure#1}>>::{closure#0}
+   2:        0x113666344 - std::panicking::rust_panic_with_hook::h99b909b88606ba45
+   3:        0x111892d2c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}
+   4:        0x1118813ec - std[b5799de7b54252e2]::sys::backtrace::__rust_end_short_backtrace::<std[b5799de7b54252e2]::panicking::begin_panic<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}, !>
+   5:        0x11632523c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>
+   6:        0x116325614 - <rustc_errors[cee812b0c52ce615]::diagnostic::BugAbort as rustc_errors[cee812b0c52ce615]::diagnostic::EmissionGuarantee>::emit_producing_guarantee
+   7:        0x11638f294 - <rustc_errors[cee812b0c52ce615]::DiagCtxtHandle>::span_bug::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span, alloc[aa6ffa18488a0c9c]::string::String>
+   8:        0x116397fb8 - rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}
+   9:        0x112459f1c - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt::<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}
+  10:        0x1124599ec - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_context_opt::<rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}, !>
+  11:        0x116397f28 - rustc_middle[59a3c7ee8a751ae9]::util::bug::span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>
+  12:        0x11341e5ec - <rustc_trait_selection[5441f2d24210d1ab]::traits::engine::ObligationCtxt>::deeply_normalize::<rustc_middle[59a3c7ee8a751ae9]::ty::Ty>
+  13:        0x11342ade8 - rustc_trait_selection[5441f2d24210d1ab]::traits::query::dropck_outlives::compute_dropck_outlives_inner
+  14:        0x1135209f4 - rustc_traits[8fea4450c6aad02a]::dropck_outlives::dropck_outlives
+  15:        0x112dba41c - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  16:        0x112d5b954 - <rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2} as core[77a302ba8aa64981]::ops::function::FnOnce<(rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>)>>::call_once
+  17:        0x112bbec2c - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::DefaultCache<rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  18:        0x112e33bd8 - rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::get_query_incr::__rust_end_short_backtrace
+  19:        0x11342f544 - <rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::QueryTypeOp>::perform_query
+  20:        0x111241058 - <rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives> as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::TypeOp>::fully_perform
+  21:        0x111336408 - <rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::LivenessContext>::compute_drop_data
+  22:        0x111335298 - rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::trace
+  23:        0x11133e310 - rustc_borrowck[1ede31b1eb994a06]::type_check::type_check
+  24:        0x11130f784 - rustc_borrowck[1ede31b1eb994a06]::nll::compute_regions
+  25:        0x111382600 - rustc_borrowck[1ede31b1eb994a06]::do_mir_borrowck
+  26:        0x111348374 - rustc_borrowck[1ede31b1eb994a06]::mir_borrowck
+  27:        0x112db96a0 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  28:        0x112c12344 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_data_structures[acd479fe9d24c68]::vec_cache::VecCache<rustc_span[2f93acfc3e5da0ca]::def_id::LocalDefId, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>, rustc_query_system[b220bb2763f61922]::dep_graph::graph::DepNodeIndex>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  29:        0x112dec5b0 - rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
+  30:        0x11204abb0 - <rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt>::par_hir_body_owners::<rustc_interface[a600a78ab89f7261]::passes::run_required_analyses::{closure#2}::{closure#0}>::{closure#0}
+  31:        0x1120d2c00 - rustc_interface[a600a78ab89f7261]::passes::run_required_analyses
+  32:        0x1120d4ff4 - rustc_interface[a600a78ab89f7261]::passes::analysis
+  33:        0x112dbee40 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>
+  34:        0x112ba7dc8 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::SingleCache<rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  35:        0x112dc9440 - rustc_query_impl[1048ca99148785d2]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
+  36:        0x111801910 - rustc_interface[a600a78ab89f7261]::passes::create_and_enter_global_ctxt::<core[77a302ba8aa64981]::option::Option<rustc_interface[a600a78ab89f7261]::queries::Linker>, rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}::{closure#2}>
+  37:        0x111810588 - rustc_interface[a600a78ab89f7261]::interface::run_compiler::<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}
+  38:        0x1118031b4 - std[b5799de7b54252e2]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
+  39:        0x111817370 - <<std[b5799de7b54252e2]::thread::Builder>::spawn_unchecked_<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[77a302ba8aa64981]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  40:        0x11366c8bc - std::sys::pal::unix::thread::Thread::new::thread_start::h44f82d9477b86743
+  41:        0x19d6b42e4 - __pthread_deallocate
+
+
+rustc version: 1.87.0-nightly (78948ac25 2025-03-20)
+platform: aarch64-apple-darwin
+
+query stack during panic:
+#0 [dropck_outlives] computing dropck types for `Client`
+#1 [mir_borrowck] borrow-checking `<impl at web/@linera/client/src/lib.rs:50:1: 50:16>::into_abi`
+#2 [analysis] running analysis passes on this crate
+end of query stack
+thread 'rustc' panicked at compiler/rustc_trait_selection/src/traits/normalize.rs:69:17:
+Box<dyn Any>
+stack backtrace:
+   0:        0x11364af54 - std::backtrace::Backtrace::create::ha8ad3a274d69bc73
+   1:        0x1118139bc - std[b5799de7b54252e2]::panicking::update_hook::<alloc[aa6ffa18488a0c9c]::boxed::Box<rustc_driver_impl[c369b46601ddfb4f]::install_ice_hook::{closure#1}>>::{closure#0}
+   2:        0x113666344 - std::panicking::rust_panic_with_hook::h99b909b88606ba45
+   3:        0x111892d2c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}
+   4:        0x1118813ec - std[b5799de7b54252e2]::sys::backtrace::__rust_end_short_backtrace::<std[b5799de7b54252e2]::panicking::begin_panic<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}, !>
+   5:        0x11632523c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>
+   6:        0x116325614 - <rustc_errors[cee812b0c52ce615]::diagnostic::BugAbort as rustc_errors[cee812b0c52ce615]::diagnostic::EmissionGuarantee>::emit_producing_guarantee
+   7:        0x11638f294 - <rustc_errors[cee812b0c52ce615]::DiagCtxtHandle>::span_bug::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span, alloc[aa6ffa18488a0c9c]::string::String>
+   8:        0x116397fb8 - rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}
+   9:        0x112459f1c - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt::<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}
+  10:        0x1124599ec - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_context_opt::<rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}, !>
+  11:        0x116397f28 - rustc_middle[59a3c7ee8a751ae9]::util::bug::span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>
+  12:        0x11341e5ec - <rustc_trait_selection[5441f2d24210d1ab]::traits::engine::ObligationCtxt>::deeply_normalize::<rustc_middle[59a3c7ee8a751ae9]::ty::Ty>
+  13:        0x11342ade8 - rustc_trait_selection[5441f2d24210d1ab]::traits::query::dropck_outlives::compute_dropck_outlives_inner
+  14:        0x1135209f4 - rustc_traits[8fea4450c6aad02a]::dropck_outlives::dropck_outlives
+  15:        0x112dba41c - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  16:        0x112d5b954 - <rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2} as core[77a302ba8aa64981]::ops::function::FnOnce<(rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>)>>::call_once
+  17:        0x112bbec2c - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::DefaultCache<rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  18:        0x112e33bd8 - rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::get_query_incr::__rust_end_short_backtrace
+  19:        0x11342f544 - <rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::QueryTypeOp>::perform_query
+  20:        0x111241058 - <rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives> as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::TypeOp>::fully_perform
+  21:        0x111336408 - <rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::LivenessContext>::compute_drop_data
+  22:        0x111335298 - rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::trace
+  23:        0x11133e310 - rustc_borrowck[1ede31b1eb994a06]::type_check::type_check
+  24:        0x11130f784 - rustc_borrowck[1ede31b1eb994a06]::nll::compute_regions
+  25:        0x111382600 - rustc_borrowck[1ede31b1eb994a06]::do_mir_borrowck
+  26:        0x111348374 - rustc_borrowck[1ede31b1eb994a06]::mir_borrowck
+  27:        0x112db96a0 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  28:        0x112c12344 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_data_structures[acd479fe9d24c68]::vec_cache::VecCache<rustc_span[2f93acfc3e5da0ca]::def_id::LocalDefId, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>, rustc_query_system[b220bb2763f61922]::dep_graph::graph::DepNodeIndex>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  29:        0x112dec5b0 - rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
+  30:        0x11204abb0 - <rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt>::par_hir_body_owners::<rustc_interface[a600a78ab89f7261]::passes::run_required_analyses::{closure#2}::{closure#0}>::{closure#0}
+  31:        0x1120d2c00 - rustc_interface[a600a78ab89f7261]::passes::run_required_analyses
+  32:        0x1120d4ff4 - rustc_interface[a600a78ab89f7261]::passes::analysis
+  33:        0x112dbee40 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>
+  34:        0x112ba7dc8 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::SingleCache<rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  35:        0x112dc9440 - rustc_query_impl[1048ca99148785d2]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
+  36:        0x111801910 - rustc_interface[a600a78ab89f7261]::passes::create_and_enter_global_ctxt::<core[77a302ba8aa64981]::option::Option<rustc_interface[a600a78ab89f7261]::queries::Linker>, rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}::{closure#2}>
+  37:        0x111810588 - rustc_interface[a600a78ab89f7261]::interface::run_compiler::<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}
+  38:        0x1118031b4 - std[b5799de7b54252e2]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
+  39:        0x111817370 - <<std[b5799de7b54252e2]::thread::Builder>::spawn_unchecked_<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[77a302ba8aa64981]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  40:        0x11366c8bc - std::sys::pal::unix::thread::Thread::new::thread_start::h44f82d9477b86743
+  41:        0x19d6b42e4 - __pthread_deallocate
+
+
+query stack during panic:
+#0 [dropck_outlives] computing dropck types for `wasm_bindgen::__rt::RcRef<Client>`
+#1 [mir_borrowck] borrow-checking `<impl at web/@linera/client/src/lib.rs:50:1: 50:16>::ref_from_abi`
+#2 [analysis] running analysis passes on this crate
+end of query stack
+thread 'rustc' panicked at compiler/rustc_trait_selection/src/traits/normalize.rs:69:17:
+Box<dyn Any>
+stack backtrace:
+   0:        0x11364af54 - std::backtrace::Backtrace::create::ha8ad3a274d69bc73
+   1:        0x1118139bc - std[b5799de7b54252e2]::panicking::update_hook::<alloc[aa6ffa18488a0c9c]::boxed::Box<rustc_driver_impl[c369b46601ddfb4f]::install_ice_hook::{closure#1}>>::{closure#0}
+   2:        0x113666344 - std::panicking::rust_panic_with_hook::h99b909b88606ba45
+   3:        0x111892d2c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}
+   4:        0x1118813ec - std[b5799de7b54252e2]::sys::backtrace::__rust_end_short_backtrace::<std[b5799de7b54252e2]::panicking::begin_panic<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}, !>
+   5:        0x11632523c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>
+   6:        0x116325614 - <rustc_errors[cee812b0c52ce615]::diagnostic::BugAbort as rustc_errors[cee812b0c52ce615]::diagnostic::EmissionGuarantee>::emit_producing_guarantee
+   7:        0x11638f294 - <rustc_errors[cee812b0c52ce615]::DiagCtxtHandle>::span_bug::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span, alloc[aa6ffa18488a0c9c]::string::String>
+   8:        0x116397fb8 - rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}
+   9:        0x112459f1c - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt::<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}
+  10:        0x1124599ec - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_context_opt::<rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}, !>
+  11:        0x116397f28 - rustc_middle[59a3c7ee8a751ae9]::util::bug::span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>
+  12:        0x11341e5ec - <rustc_trait_selection[5441f2d24210d1ab]::traits::engine::ObligationCtxt>::deeply_normalize::<rustc_middle[59a3c7ee8a751ae9]::ty::Ty>
+  13:        0x11342ade8 - rustc_trait_selection[5441f2d24210d1ab]::traits::query::dropck_outlives::compute_dropck_outlives_inner
+  14:        0x1135209f4 - rustc_traits[8fea4450c6aad02a]::dropck_outlives::dropck_outlives
+  15:        0x112dba41c - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  16:        0x112d5b954 - <rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2} as core[77a302ba8aa64981]::ops::function::FnOnce<(rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>)>>::call_once
+  17:        0x112bbec2c - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::DefaultCache<rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  18:        0x112e33bd8 - rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::get_query_incr::__rust_end_short_backtrace
+  19:        0x11342f544 - <rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::QueryTypeOp>::perform_query
+  20:        0x111241058 - <rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives> as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::TypeOp>::fully_perform
+  21:        0x111336408 - <rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::LivenessContext>::compute_drop_data
+  22:        0x111335298 - rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::trace
+  23:        0x11133e310 - rustc_borrowck[1ede31b1eb994a06]::type_check::type_check
+  24:        0x11130f784 - rustc_borrowck[1ede31b1eb994a06]::nll::compute_regions
+  25:        0x111382600 - rustc_borrowck[1ede31b1eb994a06]::do_mir_borrowck
+  26:        0x111348374 - rustc_borrowck[1ede31b1eb994a06]::mir_borrowck
+  27:        0x112db96a0 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  28:        0x112c12344 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_data_structures[acd479fe9d24c68]::vec_cache::VecCache<rustc_span[2f93acfc3e5da0ca]::def_id::LocalDefId, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>, rustc_query_system[b220bb2763f61922]::dep_graph::graph::DepNodeIndex>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  29:        0x112dec5b0 - rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
+  30:        0x11204abb0 - <rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt>::par_hir_body_owners::<rustc_interface[a600a78ab89f7261]::passes::run_required_analyses::{closure#2}::{closure#0}>::{closure#0}
+  31:        0x1120d2c00 - rustc_interface[a600a78ab89f7261]::passes::run_required_analyses
+  32:        0x1120d4ff4 - rustc_interface[a600a78ab89f7261]::passes::analysis
+  33:        0x112dbee40 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>
+  34:        0x112ba7dc8 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::SingleCache<rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  35:        0x112dc9440 - rustc_query_impl[1048ca99148785d2]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
+  36:        0x111801910 - rustc_interface[a600a78ab89f7261]::passes::create_and_enter_global_ctxt::<core[77a302ba8aa64981]::option::Option<rustc_interface[a600a78ab89f7261]::queries::Linker>, rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}::{closure#2}>
+  37:        0x111810588 - rustc_interface[a600a78ab89f7261]::interface::run_compiler::<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}
+  38:        0x1118031b4 - std[b5799de7b54252e2]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
+  39:        0x111817370 - <<std[b5799de7b54252e2]::thread::Builder>::spawn_unchecked_<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[77a302ba8aa64981]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  40:        0x11366c8bc - std::sys::pal::unix::thread::Thread::new::thread_start::h44f82d9477b86743
+  41:        0x19d6b42e4 - __pthread_deallocate
+
+
+query stack during panic:
+#0 [dropck_outlives] computing dropck types for `wasm_bindgen::__rt::RcRefMut<Client>`
+#1 [mir_borrowck] borrow-checking `<impl at web/@linera/client/src/lib.rs:50:1: 50:16>::ref_mut_from_abi`
+#2 [analysis] running analysis passes on this crate
+end of query stack
+thread 'rustc' panicked at compiler/rustc_trait_selection/src/traits/normalize.rs:69:17:
+Box<dyn Any>
+stack backtrace:
+   0:        0x11364af54 - std::backtrace::Backtrace::create::ha8ad3a274d69bc73
+   1:        0x1118139bc - std[b5799de7b54252e2]::panicking::update_hook::<alloc[aa6ffa18488a0c9c]::boxed::Box<rustc_driver_impl[c369b46601ddfb4f]::install_ice_hook::{closure#1}>>::{closure#0}
+   2:        0x113666344 - std::panicking::rust_panic_with_hook::h99b909b88606ba45
+   3:        0x111892d2c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}
+   4:        0x1118813ec - std[b5799de7b54252e2]::sys::backtrace::__rust_end_short_backtrace::<std[b5799de7b54252e2]::panicking::begin_panic<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}, !>
+   5:        0x11632523c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>
+   6:        0x116325614 - <rustc_errors[cee812b0c52ce615]::diagnostic::BugAbort as rustc_errors[cee812b0c52ce615]::diagnostic::EmissionGuarantee>::emit_producing_guarantee
+   7:        0x11638f294 - <rustc_errors[cee812b0c52ce615]::DiagCtxtHandle>::span_bug::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span, alloc[aa6ffa18488a0c9c]::string::String>
+   8:        0x116397fb8 - rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}
+   9:        0x112459f1c - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt::<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}
+  10:        0x1124599ec - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_context_opt::<rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}, !>
+  11:        0x116397f28 - rustc_middle[59a3c7ee8a751ae9]::util::bug::span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>
+  12:        0x11341e5ec - <rustc_trait_selection[5441f2d24210d1ab]::traits::engine::ObligationCtxt>::deeply_normalize::<rustc_middle[59a3c7ee8a751ae9]::ty::Ty>
+  13:        0x11342ade8 - rustc_trait_selection[5441f2d24210d1ab]::traits::query::dropck_outlives::compute_dropck_outlives_inner
+  14:        0x1135209f4 - rustc_traits[8fea4450c6aad02a]::dropck_outlives::dropck_outlives
+  15:        0x112dba41c - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  16:        0x112d5b954 - <rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2} as core[77a302ba8aa64981]::ops::function::FnOnce<(rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>)>>::call_once
+  17:        0x112bbec2c - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::DefaultCache<rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  18:        0x112e33bd8 - rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::get_query_incr::__rust_end_short_backtrace
+  19:        0x11342f544 - <rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::QueryTypeOp>::perform_query
+  20:        0x111241058 - <rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives> as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::TypeOp>::fully_perform
+  21:        0x111336408 - <rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::LivenessContext>::compute_drop_data
+  22:        0x111335298 - rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::trace
+  23:        0x11133e310 - rustc_borrowck[1ede31b1eb994a06]::type_check::type_check
+  24:        0x11130f784 - rustc_borrowck[1ede31b1eb994a06]::nll::compute_regions
+  25:        0x111382600 - rustc_borrowck[1ede31b1eb994a06]::do_mir_borrowck
+  26:        0x111348374 - rustc_borrowck[1ede31b1eb994a06]::mir_borrowck
+  27:        0x112db96a0 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  28:        0x112c12344 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_data_structures[acd479fe9d24c68]::vec_cache::VecCache<rustc_span[2f93acfc3e5da0ca]::def_id::LocalDefId, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>, rustc_query_system[b220bb2763f61922]::dep_graph::graph::DepNodeIndex>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  29:        0x112dec5b0 - rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
+  30:        0x11204abb0 - <rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt>::par_hir_body_owners::<rustc_interface[a600a78ab89f7261]::passes::run_required_analyses::{closure#2}::{closure#0}>::{closure#0}
+  31:        0x1120d2c00 - rustc_interface[a600a78ab89f7261]::passes::run_required_analyses
+  32:        0x1120d4ff4 - rustc_interface[a600a78ab89f7261]::passes::analysis
+  33:        0x112dbee40 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>
+  34:        0x112ba7dc8 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::SingleCache<rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  35:        0x112dc9440 - rustc_query_impl[1048ca99148785d2]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
+  36:        0x111801910 - rustc_interface[a600a78ab89f7261]::passes::create_and_enter_global_ctxt::<core[77a302ba8aa64981]::option::Option<rustc_interface[a600a78ab89f7261]::queries::Linker>, rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}::{closure#2}>
+  37:        0x111810588 - rustc_interface[a600a78ab89f7261]::interface::run_compiler::<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}
+  38:        0x1118031b4 - std[b5799de7b54252e2]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
+  39:        0x111817370 - <<std[b5799de7b54252e2]::thread::Builder>::spawn_unchecked_<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[77a302ba8aa64981]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  40:        0x11366c8bc - std::sys::pal::unix::thread::Thread::new::thread_start::h44f82d9477b86743
+  41:        0x19d6b42e4 - __pthread_deallocate
+
+
+query stack during panic:
+#0 [dropck_outlives] computing dropck types for `core::result::Result<Client, wasm_bindgen::JsValue>`
+#1 [mir_borrowck] borrow-checking `<impl at web/@linera/client/src/lib.rs:50:1: 50:16>::try_from_js_value`
+#2 [analysis] running analysis passes on this crate
+end of query stack
+thread 'rustc' panicked at compiler/rustc_trait_selection/src/traits/normalize.rs:69:17:
+Box<dyn Any>
+stack backtrace:
+   0:        0x11364af54 - std::backtrace::Backtrace::create::ha8ad3a274d69bc73
+   1:        0x1118139bc - std[b5799de7b54252e2]::panicking::update_hook::<alloc[aa6ffa18488a0c9c]::boxed::Box<rustc_driver_impl[c369b46601ddfb4f]::install_ice_hook::{closure#1}>>::{closure#0}
+   2:        0x113666344 - std::panicking::rust_panic_with_hook::h99b909b88606ba45
+   3:        0x111892d2c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}
+   4:        0x1118813ec - std[b5799de7b54252e2]::sys::backtrace::__rust_end_short_backtrace::<std[b5799de7b54252e2]::panicking::begin_panic<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}, !>
+   5:        0x11632523c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>
+   6:        0x116325614 - <rustc_errors[cee812b0c52ce615]::diagnostic::BugAbort as rustc_errors[cee812b0c52ce615]::diagnostic::EmissionGuarantee>::emit_producing_guarantee
+   7:        0x11638f294 - <rustc_errors[cee812b0c52ce615]::DiagCtxtHandle>::span_bug::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span, alloc[aa6ffa18488a0c9c]::string::String>
+   8:        0x116397fb8 - rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}
+   9:        0x112459f1c - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt::<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}
+  10:        0x1124599ec - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_context_opt::<rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}, !>
+  11:        0x116397f28 - rustc_middle[59a3c7ee8a751ae9]::util::bug::span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>
+  12:        0x11341e5ec - <rustc_trait_selection[5441f2d24210d1ab]::traits::engine::ObligationCtxt>::deeply_normalize::<rustc_middle[59a3c7ee8a751ae9]::ty::Ty>
+  13:        0x11342ade8 - rustc_trait_selection[5441f2d24210d1ab]::traits::query::dropck_outlives::compute_dropck_outlives_inner
+  14:        0x1135209f4 - rustc_traits[8fea4450c6aad02a]::dropck_outlives::dropck_outlives
+  15:        0x112dba41c - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  16:        0x112d5b954 - <rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2} as core[77a302ba8aa64981]::ops::function::FnOnce<(rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>)>>::call_once
+  17:        0x112bbec2c - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::DefaultCache<rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  18:        0x112e33bd8 - rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::get_query_incr::__rust_end_short_backtrace
+  19:        0x11342f544 - <rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::QueryTypeOp>::perform_query
+  20:        0x111241058 - <rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives> as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::TypeOp>::fully_perform
+  21:        0x111336408 - <rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::LivenessContext>::compute_drop_data
+  22:        0x111335298 - rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::trace
+  23:        0x11133e310 - rustc_borrowck[1ede31b1eb994a06]::type_check::type_check
+  24:        0x11130f784 - rustc_borrowck[1ede31b1eb994a06]::nll::compute_regions
+  25:        0x111382600 - rustc_borrowck[1ede31b1eb994a06]::do_mir_borrowck
+  26:        0x111348374 - rustc_borrowck[1ede31b1eb994a06]::mir_borrowck
+  27:        0x112db96a0 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  28:        0x112c12344 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_data_structures[acd479fe9d24c68]::vec_cache::VecCache<rustc_span[2f93acfc3e5da0ca]::def_id::LocalDefId, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>, rustc_query_system[b220bb2763f61922]::dep_graph::graph::DepNodeIndex>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  29:        0x112dec5b0 - rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
+  30:        0x11204abb0 - <rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt>::par_hir_body_owners::<rustc_interface[a600a78ab89f7261]::passes::run_required_analyses::{closure#2}::{closure#0}>::{closure#0}
+  31:        0x1120d2c00 - rustc_interface[a600a78ab89f7261]::passes::run_required_analyses
+  32:        0x1120d4ff4 - rustc_interface[a600a78ab89f7261]::passes::analysis
+  33:        0x112dbee40 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>
+  34:        0x112ba7dc8 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::SingleCache<rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  35:        0x112dc9440 - rustc_query_impl[1048ca99148785d2]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
+  36:        0x111801910 - rustc_interface[a600a78ab89f7261]::passes::create_and_enter_global_ctxt::<core[77a302ba8aa64981]::option::Option<rustc_interface[a600a78ab89f7261]::queries::Linker>, rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}::{closure#2}>
+  37:        0x111810588 - rustc_interface[a600a78ab89f7261]::interface::run_compiler::<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}
+  38:        0x1118031b4 - std[b5799de7b54252e2]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
+  39:        0x111817370 - <<std[b5799de7b54252e2]::thread::Builder>::spawn_unchecked_<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[77a302ba8aa64981]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  40:        0x11366c8bc - std::sys::pal::unix::thread::Thread::new::thread_start::h44f82d9477b86743
+  41:        0x19d6b42e4 - __pthread_deallocate
+
+
+query stack during panic:
+#0 [dropck_outlives] computing dropck types for `alloc::boxed::Box<[Client]>`
+#1 [mir_borrowck] borrow-checking `<impl at web/@linera/client/src/lib.rs:50:1: 50:16>::vector_into_abi`
+#2 [analysis] running analysis passes on this crate
+end of query stack
+thread 'rustc' panicked at compiler/rustc_trait_selection/src/traits/normalize.rs:69:17:
+Box<dyn Any>
+stack backtrace:
+   0:        0x11364af54 - std::backtrace::Backtrace::create::ha8ad3a274d69bc73
+   1:        0x1118139bc - std[b5799de7b54252e2]::panicking::update_hook::<alloc[aa6ffa18488a0c9c]::boxed::Box<rustc_driver_impl[c369b46601ddfb4f]::install_ice_hook::{closure#1}>>::{closure#0}
+   2:        0x113666344 - std::panicking::rust_panic_with_hook::h99b909b88606ba45
+   3:        0x111892d2c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}
+   4:        0x1118813ec - std[b5799de7b54252e2]::sys::backtrace::__rust_end_short_backtrace::<std[b5799de7b54252e2]::panicking::begin_panic<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}, !>
+   5:        0x11632523c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>
+   6:        0x116325614 - <rustc_errors[cee812b0c52ce615]::diagnostic::BugAbort as rustc_errors[cee812b0c52ce615]::diagnostic::EmissionGuarantee>::emit_producing_guarantee
+   7:        0x11638f294 - <rustc_errors[cee812b0c52ce615]::DiagCtxtHandle>::span_bug::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span, alloc[aa6ffa18488a0c9c]::string::String>
+   8:        0x116397fb8 - rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}
+   9:        0x112459f1c - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt::<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}
+  10:        0x1124599ec - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_context_opt::<rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}, !>
+  11:        0x116397f28 - rustc_middle[59a3c7ee8a751ae9]::util::bug::span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>
+  12:        0x11341e5ec - <rustc_trait_selection[5441f2d24210d1ab]::traits::engine::ObligationCtxt>::deeply_normalize::<rustc_middle[59a3c7ee8a751ae9]::ty::Ty>
+  13:        0x11342ade8 - rustc_trait_selection[5441f2d24210d1ab]::traits::query::dropck_outlives::compute_dropck_outlives_inner
+  14:        0x1135209f4 - rustc_traits[8fea4450c6aad02a]::dropck_outlives::dropck_outlives
+  15:        0x112dba41c - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  16:        0x112d5b954 - <rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2} as core[77a302ba8aa64981]::ops::function::FnOnce<(rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>)>>::call_once
+  17:        0x112bbec2c - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::DefaultCache<rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  18:        0x112e33bd8 - rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::get_query_incr::__rust_end_short_backtrace
+  19:        0x11342f544 - <rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::QueryTypeOp>::perform_query
+  20:        0x111241058 - <rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives> as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::TypeOp>::fully_perform
+  21:        0x111336408 - <rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::LivenessContext>::compute_drop_data
+  22:        0x111335298 - rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::trace
+  23:        0x11133e310 - rustc_borrowck[1ede31b1eb994a06]::type_check::type_check
+  24:        0x11130f784 - rustc_borrowck[1ede31b1eb994a06]::nll::compute_regions
+  25:        0x111382600 - rustc_borrowck[1ede31b1eb994a06]::do_mir_borrowck
+  26:        0x111348374 - rustc_borrowck[1ede31b1eb994a06]::mir_borrowck
+  27:        0x112db96a0 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  28:        0x112c12344 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_data_structures[acd479fe9d24c68]::vec_cache::VecCache<rustc_span[2f93acfc3e5da0ca]::def_id::LocalDefId, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>, rustc_query_system[b220bb2763f61922]::dep_graph::graph::DepNodeIndex>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  29:        0x112dec5b0 - rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
+  30:        0x11134417c - <rustc_borrowck[1ede31b1eb994a06]::type_check::TypeChecker>::prove_closure_bounds
+  31:        0x11137cc38 - <rustc_borrowck[1ede31b1eb994a06]::type_check::TypeChecker as rustc_middle[59a3c7ee8a751ae9]::mir::visit::Visitor>::visit_rvalue
+  32:        0x111377b98 - <rustc_borrowck[1ede31b1eb994a06]::type_check::TypeChecker as rustc_middle[59a3c7ee8a751ae9]::mir::visit::Visitor>::visit_statement
+  33:        0x111377210 - <rustc_borrowck[1ede31b1eb994a06]::type_check::TypeChecker as rustc_middle[59a3c7ee8a751ae9]::mir::visit::Visitor>::visit_body
+  34:        0x11133cc48 - rustc_borrowck[1ede31b1eb994a06]::type_check::type_check
+  35:        0x11130f784 - rustc_borrowck[1ede31b1eb994a06]::nll::compute_regions
+  36:        0x111382600 - rustc_borrowck[1ede31b1eb994a06]::do_mir_borrowck
+  37:        0x111348374 - rustc_borrowck[1ede31b1eb994a06]::mir_borrowck
+  38:        0x112db96a0 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  39:        0x112c12344 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_data_structures[acd479fe9d24c68]::vec_cache::VecCache<rustc_span[2f93acfc3e5da0ca]::def_id::LocalDefId, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>, rustc_query_system[b220bb2763f61922]::dep_graph::graph::DepNodeIndex>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  40:        0x112dec5b0 - rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
+  41:        0x11204abb0 - <rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt>::par_hir_body_owners::<rustc_interface[a600a78ab89f7261]::passes::run_required_analyses::{closure#2}::{closure#0}>::{closure#0}
+  42:        0x1120d2c00 - rustc_interface[a600a78ab89f7261]::passes::run_required_analyses
+  43:        0x1120d4ff4 - rustc_interface[a600a78ab89f7261]::passes::analysis
+  44:        0x112dbee40 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>
+  45:        0x112ba7dc8 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::SingleCache<rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  46:        0x112dc9440 - rustc_query_impl[1048ca99148785d2]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
+  47:        0x111801910 - rustc_interface[a600a78ab89f7261]::passes::create_and_enter_global_ctxt::<core[77a302ba8aa64981]::option::Option<rustc_interface[a600a78ab89f7261]::queries::Linker>, rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}::{closure#2}>
+  48:        0x111810588 - rustc_interface[a600a78ab89f7261]::interface::run_compiler::<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}
+  49:        0x1118031b4 - std[b5799de7b54252e2]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
+  50:        0x111817370 - <<std[b5799de7b54252e2]::thread::Builder>::spawn_unchecked_<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[77a302ba8aa64981]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  51:        0x11366c8bc - std::sys::pal::unix::thread::Thread::new::thread_start::h44f82d9477b86743
+  52:        0x19d6b42e4 - __pthread_deallocate
+
+
+query stack during panic:
+#0 [dropck_outlives] computing dropck types for `core::result::Result<Client, wasm_bindgen::JsError>`
+#1 [mir_borrowck] borrow-checking `<impl at web/@linera/client/src/lib.rs:62:1: 62:12>::new::{closure#0}::_::__wasm_bindgen_generated_Client_new::{closure#0}`
+#2 [mir_borrowck] borrow-checking `<impl at web/@linera/client/src/lib.rs:62:1: 62:12>::new::{closure#0}::_::__wasm_bindgen_generated_Client_new`
+#3 [analysis] running analysis passes on this crate
+end of query stack

--- a/rustc-ice-2026-01-07T22_25_43-46145.txt
+++ b/rustc-ice-2026-01-07T22_25_43-46145.txt
@@ -1,0 +1,327 @@
+thread 'rustc' panicked at compiler/rustc_trait_selection/src/traits/normalize.rs:69:17:
+Box<dyn Any>
+stack backtrace:
+   0:        0x10ec36f54 - std::backtrace::Backtrace::create::ha8ad3a274d69bc73
+   1:        0x10cdff9bc - std[b5799de7b54252e2]::panicking::update_hook::<alloc[aa6ffa18488a0c9c]::boxed::Box<rustc_driver_impl[c369b46601ddfb4f]::install_ice_hook::{closure#1}>>::{closure#0}
+   2:        0x10ec52344 - std::panicking::rust_panic_with_hook::h99b909b88606ba45
+   3:        0x10ce7ed2c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}
+   4:        0x10ce6d3ec - std[b5799de7b54252e2]::sys::backtrace::__rust_end_short_backtrace::<std[b5799de7b54252e2]::panicking::begin_panic<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}, !>
+   5:        0x11191123c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>
+   6:        0x111911614 - <rustc_errors[cee812b0c52ce615]::diagnostic::BugAbort as rustc_errors[cee812b0c52ce615]::diagnostic::EmissionGuarantee>::emit_producing_guarantee
+   7:        0x11197b294 - <rustc_errors[cee812b0c52ce615]::DiagCtxtHandle>::span_bug::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span, alloc[aa6ffa18488a0c9c]::string::String>
+   8:        0x111983fb8 - rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}
+   9:        0x10da45f1c - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt::<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}
+  10:        0x10da459ec - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_context_opt::<rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}, !>
+  11:        0x111983f28 - rustc_middle[59a3c7ee8a751ae9]::util::bug::span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>
+  12:        0x10ea0a5ec - <rustc_trait_selection[5441f2d24210d1ab]::traits::engine::ObligationCtxt>::deeply_normalize::<rustc_middle[59a3c7ee8a751ae9]::ty::Ty>
+  13:        0x10ea16de8 - rustc_trait_selection[5441f2d24210d1ab]::traits::query::dropck_outlives::compute_dropck_outlives_inner
+  14:        0x10eb0c9f4 - rustc_traits[8fea4450c6aad02a]::dropck_outlives::dropck_outlives
+  15:        0x10e3a641c - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  16:        0x10e347954 - <rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2} as core[77a302ba8aa64981]::ops::function::FnOnce<(rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>)>>::call_once
+  17:        0x10e1aac2c - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::DefaultCache<rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  18:        0x10e41fbd8 - rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::get_query_incr::__rust_end_short_backtrace
+  19:        0x10ea1b544 - <rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::QueryTypeOp>::perform_query
+  20:        0x10c82d058 - <rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives> as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::TypeOp>::fully_perform
+  21:        0x10c922408 - <rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::LivenessContext>::compute_drop_data
+  22:        0x10c921298 - rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::trace
+  23:        0x10c92a310 - rustc_borrowck[1ede31b1eb994a06]::type_check::type_check
+  24:        0x10c8fb784 - rustc_borrowck[1ede31b1eb994a06]::nll::compute_regions
+  25:        0x10c96e600 - rustc_borrowck[1ede31b1eb994a06]::do_mir_borrowck
+  26:        0x10c934374 - rustc_borrowck[1ede31b1eb994a06]::mir_borrowck
+  27:        0x10e3a56a0 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  28:        0x10e1fe344 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_data_structures[acd479fe9d24c68]::vec_cache::VecCache<rustc_span[2f93acfc3e5da0ca]::def_id::LocalDefId, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>, rustc_query_system[b220bb2763f61922]::dep_graph::graph::DepNodeIndex>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  29:        0x10e3d85b0 - rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
+  30:        0x10d636bb0 - <rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt>::par_hir_body_owners::<rustc_interface[a600a78ab89f7261]::passes::run_required_analyses::{closure#2}::{closure#0}>::{closure#0}
+  31:        0x10d6bec00 - rustc_interface[a600a78ab89f7261]::passes::run_required_analyses
+  32:        0x10d6c0ff4 - rustc_interface[a600a78ab89f7261]::passes::analysis
+  33:        0x10e3aae40 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>
+  34:        0x10e193dc8 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::SingleCache<rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  35:        0x10e3b5440 - rustc_query_impl[1048ca99148785d2]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
+  36:        0x10cded910 - rustc_interface[a600a78ab89f7261]::passes::create_and_enter_global_ctxt::<core[77a302ba8aa64981]::option::Option<rustc_interface[a600a78ab89f7261]::queries::Linker>, rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}::{closure#2}>
+  37:        0x10cdfc588 - rustc_interface[a600a78ab89f7261]::interface::run_compiler::<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}
+  38:        0x10cdef1b4 - std[b5799de7b54252e2]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
+  39:        0x10ce03370 - <<std[b5799de7b54252e2]::thread::Builder>::spawn_unchecked_<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[77a302ba8aa64981]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  40:        0x10ec588bc - std::sys::pal::unix::thread::Thread::new::thread_start::h44f82d9477b86743
+  41:        0x19d6b42e4 - __pthread_deallocate
+
+
+rustc version: 1.87.0-nightly (78948ac25 2025-03-20)
+platform: aarch64-apple-darwin
+
+query stack during panic:
+#0 [dropck_outlives] computing dropck types for `Client`
+#1 [mir_borrowck] borrow-checking `<impl at web/@linera/client/src/lib.rs:50:1: 50:16>::into_abi`
+#2 [analysis] running analysis passes on this crate
+end of query stack
+thread 'rustc' panicked at compiler/rustc_trait_selection/src/traits/normalize.rs:69:17:
+Box<dyn Any>
+stack backtrace:
+   0:        0x10ec36f54 - std::backtrace::Backtrace::create::ha8ad3a274d69bc73
+   1:        0x10cdff9bc - std[b5799de7b54252e2]::panicking::update_hook::<alloc[aa6ffa18488a0c9c]::boxed::Box<rustc_driver_impl[c369b46601ddfb4f]::install_ice_hook::{closure#1}>>::{closure#0}
+   2:        0x10ec52344 - std::panicking::rust_panic_with_hook::h99b909b88606ba45
+   3:        0x10ce7ed2c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}
+   4:        0x10ce6d3ec - std[b5799de7b54252e2]::sys::backtrace::__rust_end_short_backtrace::<std[b5799de7b54252e2]::panicking::begin_panic<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}, !>
+   5:        0x11191123c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>
+   6:        0x111911614 - <rustc_errors[cee812b0c52ce615]::diagnostic::BugAbort as rustc_errors[cee812b0c52ce615]::diagnostic::EmissionGuarantee>::emit_producing_guarantee
+   7:        0x11197b294 - <rustc_errors[cee812b0c52ce615]::DiagCtxtHandle>::span_bug::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span, alloc[aa6ffa18488a0c9c]::string::String>
+   8:        0x111983fb8 - rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}
+   9:        0x10da45f1c - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt::<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}
+  10:        0x10da459ec - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_context_opt::<rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}, !>
+  11:        0x111983f28 - rustc_middle[59a3c7ee8a751ae9]::util::bug::span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>
+  12:        0x10ea0a5ec - <rustc_trait_selection[5441f2d24210d1ab]::traits::engine::ObligationCtxt>::deeply_normalize::<rustc_middle[59a3c7ee8a751ae9]::ty::Ty>
+  13:        0x10ea16de8 - rustc_trait_selection[5441f2d24210d1ab]::traits::query::dropck_outlives::compute_dropck_outlives_inner
+  14:        0x10eb0c9f4 - rustc_traits[8fea4450c6aad02a]::dropck_outlives::dropck_outlives
+  15:        0x10e3a641c - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  16:        0x10e347954 - <rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2} as core[77a302ba8aa64981]::ops::function::FnOnce<(rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>)>>::call_once
+  17:        0x10e1aac2c - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::DefaultCache<rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  18:        0x10e41fbd8 - rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::get_query_incr::__rust_end_short_backtrace
+  19:        0x10ea1b544 - <rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::QueryTypeOp>::perform_query
+  20:        0x10c82d058 - <rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives> as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::TypeOp>::fully_perform
+  21:        0x10c922408 - <rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::LivenessContext>::compute_drop_data
+  22:        0x10c921298 - rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::trace
+  23:        0x10c92a310 - rustc_borrowck[1ede31b1eb994a06]::type_check::type_check
+  24:        0x10c8fb784 - rustc_borrowck[1ede31b1eb994a06]::nll::compute_regions
+  25:        0x10c96e600 - rustc_borrowck[1ede31b1eb994a06]::do_mir_borrowck
+  26:        0x10c934374 - rustc_borrowck[1ede31b1eb994a06]::mir_borrowck
+  27:        0x10e3a56a0 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  28:        0x10e1fe344 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_data_structures[acd479fe9d24c68]::vec_cache::VecCache<rustc_span[2f93acfc3e5da0ca]::def_id::LocalDefId, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>, rustc_query_system[b220bb2763f61922]::dep_graph::graph::DepNodeIndex>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  29:        0x10e3d85b0 - rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
+  30:        0x10d636bb0 - <rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt>::par_hir_body_owners::<rustc_interface[a600a78ab89f7261]::passes::run_required_analyses::{closure#2}::{closure#0}>::{closure#0}
+  31:        0x10d6bec00 - rustc_interface[a600a78ab89f7261]::passes::run_required_analyses
+  32:        0x10d6c0ff4 - rustc_interface[a600a78ab89f7261]::passes::analysis
+  33:        0x10e3aae40 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>
+  34:        0x10e193dc8 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::SingleCache<rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  35:        0x10e3b5440 - rustc_query_impl[1048ca99148785d2]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
+  36:        0x10cded910 - rustc_interface[a600a78ab89f7261]::passes::create_and_enter_global_ctxt::<core[77a302ba8aa64981]::option::Option<rustc_interface[a600a78ab89f7261]::queries::Linker>, rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}::{closure#2}>
+  37:        0x10cdfc588 - rustc_interface[a600a78ab89f7261]::interface::run_compiler::<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}
+  38:        0x10cdef1b4 - std[b5799de7b54252e2]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
+  39:        0x10ce03370 - <<std[b5799de7b54252e2]::thread::Builder>::spawn_unchecked_<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[77a302ba8aa64981]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  40:        0x10ec588bc - std::sys::pal::unix::thread::Thread::new::thread_start::h44f82d9477b86743
+  41:        0x19d6b42e4 - __pthread_deallocate
+
+
+query stack during panic:
+#0 [dropck_outlives] computing dropck types for `wasm_bindgen::__rt::RcRef<Client>`
+#1 [mir_borrowck] borrow-checking `<impl at web/@linera/client/src/lib.rs:50:1: 50:16>::ref_from_abi`
+#2 [analysis] running analysis passes on this crate
+end of query stack
+thread 'rustc' panicked at compiler/rustc_trait_selection/src/traits/normalize.rs:69:17:
+Box<dyn Any>
+stack backtrace:
+   0:        0x10ec36f54 - std::backtrace::Backtrace::create::ha8ad3a274d69bc73
+   1:        0x10cdff9bc - std[b5799de7b54252e2]::panicking::update_hook::<alloc[aa6ffa18488a0c9c]::boxed::Box<rustc_driver_impl[c369b46601ddfb4f]::install_ice_hook::{closure#1}>>::{closure#0}
+   2:        0x10ec52344 - std::panicking::rust_panic_with_hook::h99b909b88606ba45
+   3:        0x10ce7ed2c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}
+   4:        0x10ce6d3ec - std[b5799de7b54252e2]::sys::backtrace::__rust_end_short_backtrace::<std[b5799de7b54252e2]::panicking::begin_panic<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}, !>
+   5:        0x11191123c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>
+   6:        0x111911614 - <rustc_errors[cee812b0c52ce615]::diagnostic::BugAbort as rustc_errors[cee812b0c52ce615]::diagnostic::EmissionGuarantee>::emit_producing_guarantee
+   7:        0x11197b294 - <rustc_errors[cee812b0c52ce615]::DiagCtxtHandle>::span_bug::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span, alloc[aa6ffa18488a0c9c]::string::String>
+   8:        0x111983fb8 - rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}
+   9:        0x10da45f1c - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt::<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}
+  10:        0x10da459ec - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_context_opt::<rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}, !>
+  11:        0x111983f28 - rustc_middle[59a3c7ee8a751ae9]::util::bug::span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>
+  12:        0x10ea0a5ec - <rustc_trait_selection[5441f2d24210d1ab]::traits::engine::ObligationCtxt>::deeply_normalize::<rustc_middle[59a3c7ee8a751ae9]::ty::Ty>
+  13:        0x10ea16de8 - rustc_trait_selection[5441f2d24210d1ab]::traits::query::dropck_outlives::compute_dropck_outlives_inner
+  14:        0x10eb0c9f4 - rustc_traits[8fea4450c6aad02a]::dropck_outlives::dropck_outlives
+  15:        0x10e3a641c - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  16:        0x10e347954 - <rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2} as core[77a302ba8aa64981]::ops::function::FnOnce<(rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>)>>::call_once
+  17:        0x10e1aac2c - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::DefaultCache<rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  18:        0x10e41fbd8 - rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::get_query_incr::__rust_end_short_backtrace
+  19:        0x10ea1b544 - <rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::QueryTypeOp>::perform_query
+  20:        0x10c82d058 - <rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives> as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::TypeOp>::fully_perform
+  21:        0x10c922408 - <rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::LivenessContext>::compute_drop_data
+  22:        0x10c921298 - rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::trace
+  23:        0x10c92a310 - rustc_borrowck[1ede31b1eb994a06]::type_check::type_check
+  24:        0x10c8fb784 - rustc_borrowck[1ede31b1eb994a06]::nll::compute_regions
+  25:        0x10c96e600 - rustc_borrowck[1ede31b1eb994a06]::do_mir_borrowck
+  26:        0x10c934374 - rustc_borrowck[1ede31b1eb994a06]::mir_borrowck
+  27:        0x10e3a56a0 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  28:        0x10e1fe344 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_data_structures[acd479fe9d24c68]::vec_cache::VecCache<rustc_span[2f93acfc3e5da0ca]::def_id::LocalDefId, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>, rustc_query_system[b220bb2763f61922]::dep_graph::graph::DepNodeIndex>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  29:        0x10e3d85b0 - rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
+  30:        0x10d636bb0 - <rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt>::par_hir_body_owners::<rustc_interface[a600a78ab89f7261]::passes::run_required_analyses::{closure#2}::{closure#0}>::{closure#0}
+  31:        0x10d6bec00 - rustc_interface[a600a78ab89f7261]::passes::run_required_analyses
+  32:        0x10d6c0ff4 - rustc_interface[a600a78ab89f7261]::passes::analysis
+  33:        0x10e3aae40 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>
+  34:        0x10e193dc8 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::SingleCache<rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  35:        0x10e3b5440 - rustc_query_impl[1048ca99148785d2]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
+  36:        0x10cded910 - rustc_interface[a600a78ab89f7261]::passes::create_and_enter_global_ctxt::<core[77a302ba8aa64981]::option::Option<rustc_interface[a600a78ab89f7261]::queries::Linker>, rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}::{closure#2}>
+  37:        0x10cdfc588 - rustc_interface[a600a78ab89f7261]::interface::run_compiler::<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}
+  38:        0x10cdef1b4 - std[b5799de7b54252e2]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
+  39:        0x10ce03370 - <<std[b5799de7b54252e2]::thread::Builder>::spawn_unchecked_<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[77a302ba8aa64981]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  40:        0x10ec588bc - std::sys::pal::unix::thread::Thread::new::thread_start::h44f82d9477b86743
+  41:        0x19d6b42e4 - __pthread_deallocate
+
+
+query stack during panic:
+#0 [dropck_outlives] computing dropck types for `wasm_bindgen::__rt::RcRefMut<Client>`
+#1 [mir_borrowck] borrow-checking `<impl at web/@linera/client/src/lib.rs:50:1: 50:16>::ref_mut_from_abi`
+#2 [analysis] running analysis passes on this crate
+end of query stack
+thread 'rustc' panicked at compiler/rustc_trait_selection/src/traits/normalize.rs:69:17:
+Box<dyn Any>
+stack backtrace:
+   0:        0x10ec36f54 - std::backtrace::Backtrace::create::ha8ad3a274d69bc73
+   1:        0x10cdff9bc - std[b5799de7b54252e2]::panicking::update_hook::<alloc[aa6ffa18488a0c9c]::boxed::Box<rustc_driver_impl[c369b46601ddfb4f]::install_ice_hook::{closure#1}>>::{closure#0}
+   2:        0x10ec52344 - std::panicking::rust_panic_with_hook::h99b909b88606ba45
+   3:        0x10ce7ed2c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}
+   4:        0x10ce6d3ec - std[b5799de7b54252e2]::sys::backtrace::__rust_end_short_backtrace::<std[b5799de7b54252e2]::panicking::begin_panic<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}, !>
+   5:        0x11191123c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>
+   6:        0x111911614 - <rustc_errors[cee812b0c52ce615]::diagnostic::BugAbort as rustc_errors[cee812b0c52ce615]::diagnostic::EmissionGuarantee>::emit_producing_guarantee
+   7:        0x11197b294 - <rustc_errors[cee812b0c52ce615]::DiagCtxtHandle>::span_bug::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span, alloc[aa6ffa18488a0c9c]::string::String>
+   8:        0x111983fb8 - rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}
+   9:        0x10da45f1c - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt::<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}
+  10:        0x10da459ec - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_context_opt::<rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}, !>
+  11:        0x111983f28 - rustc_middle[59a3c7ee8a751ae9]::util::bug::span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>
+  12:        0x10ea0a5ec - <rustc_trait_selection[5441f2d24210d1ab]::traits::engine::ObligationCtxt>::deeply_normalize::<rustc_middle[59a3c7ee8a751ae9]::ty::Ty>
+  13:        0x10ea16de8 - rustc_trait_selection[5441f2d24210d1ab]::traits::query::dropck_outlives::compute_dropck_outlives_inner
+  14:        0x10eb0c9f4 - rustc_traits[8fea4450c6aad02a]::dropck_outlives::dropck_outlives
+  15:        0x10e3a641c - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  16:        0x10e347954 - <rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2} as core[77a302ba8aa64981]::ops::function::FnOnce<(rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>)>>::call_once
+  17:        0x10e1aac2c - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::DefaultCache<rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  18:        0x10e41fbd8 - rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::get_query_incr::__rust_end_short_backtrace
+  19:        0x10ea1b544 - <rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::QueryTypeOp>::perform_query
+  20:        0x10c82d058 - <rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives> as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::TypeOp>::fully_perform
+  21:        0x10c922408 - <rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::LivenessContext>::compute_drop_data
+  22:        0x10c921298 - rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::trace
+  23:        0x10c92a310 - rustc_borrowck[1ede31b1eb994a06]::type_check::type_check
+  24:        0x10c8fb784 - rustc_borrowck[1ede31b1eb994a06]::nll::compute_regions
+  25:        0x10c96e600 - rustc_borrowck[1ede31b1eb994a06]::do_mir_borrowck
+  26:        0x10c934374 - rustc_borrowck[1ede31b1eb994a06]::mir_borrowck
+  27:        0x10e3a56a0 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  28:        0x10e1fe344 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_data_structures[acd479fe9d24c68]::vec_cache::VecCache<rustc_span[2f93acfc3e5da0ca]::def_id::LocalDefId, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>, rustc_query_system[b220bb2763f61922]::dep_graph::graph::DepNodeIndex>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  29:        0x10e3d85b0 - rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
+  30:        0x10d636bb0 - <rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt>::par_hir_body_owners::<rustc_interface[a600a78ab89f7261]::passes::run_required_analyses::{closure#2}::{closure#0}>::{closure#0}
+  31:        0x10d6bec00 - rustc_interface[a600a78ab89f7261]::passes::run_required_analyses
+  32:        0x10d6c0ff4 - rustc_interface[a600a78ab89f7261]::passes::analysis
+  33:        0x10e3aae40 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>
+  34:        0x10e193dc8 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::SingleCache<rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  35:        0x10e3b5440 - rustc_query_impl[1048ca99148785d2]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
+  36:        0x10cded910 - rustc_interface[a600a78ab89f7261]::passes::create_and_enter_global_ctxt::<core[77a302ba8aa64981]::option::Option<rustc_interface[a600a78ab89f7261]::queries::Linker>, rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}::{closure#2}>
+  37:        0x10cdfc588 - rustc_interface[a600a78ab89f7261]::interface::run_compiler::<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}
+  38:        0x10cdef1b4 - std[b5799de7b54252e2]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
+  39:        0x10ce03370 - <<std[b5799de7b54252e2]::thread::Builder>::spawn_unchecked_<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[77a302ba8aa64981]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  40:        0x10ec588bc - std::sys::pal::unix::thread::Thread::new::thread_start::h44f82d9477b86743
+  41:        0x19d6b42e4 - __pthread_deallocate
+
+
+query stack during panic:
+#0 [dropck_outlives] computing dropck types for `core::result::Result<Client, wasm_bindgen::JsValue>`
+#1 [mir_borrowck] borrow-checking `<impl at web/@linera/client/src/lib.rs:50:1: 50:16>::try_from_js_value`
+#2 [analysis] running analysis passes on this crate
+end of query stack
+thread 'rustc' panicked at compiler/rustc_trait_selection/src/traits/normalize.rs:69:17:
+Box<dyn Any>
+stack backtrace:
+   0:        0x10ec36f54 - std::backtrace::Backtrace::create::ha8ad3a274d69bc73
+   1:        0x10cdff9bc - std[b5799de7b54252e2]::panicking::update_hook::<alloc[aa6ffa18488a0c9c]::boxed::Box<rustc_driver_impl[c369b46601ddfb4f]::install_ice_hook::{closure#1}>>::{closure#0}
+   2:        0x10ec52344 - std::panicking::rust_panic_with_hook::h99b909b88606ba45
+   3:        0x10ce7ed2c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}
+   4:        0x10ce6d3ec - std[b5799de7b54252e2]::sys::backtrace::__rust_end_short_backtrace::<std[b5799de7b54252e2]::panicking::begin_panic<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}, !>
+   5:        0x11191123c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>
+   6:        0x111911614 - <rustc_errors[cee812b0c52ce615]::diagnostic::BugAbort as rustc_errors[cee812b0c52ce615]::diagnostic::EmissionGuarantee>::emit_producing_guarantee
+   7:        0x11197b294 - <rustc_errors[cee812b0c52ce615]::DiagCtxtHandle>::span_bug::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span, alloc[aa6ffa18488a0c9c]::string::String>
+   8:        0x111983fb8 - rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}
+   9:        0x10da45f1c - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt::<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}
+  10:        0x10da459ec - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_context_opt::<rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}, !>
+  11:        0x111983f28 - rustc_middle[59a3c7ee8a751ae9]::util::bug::span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>
+  12:        0x10ea0a5ec - <rustc_trait_selection[5441f2d24210d1ab]::traits::engine::ObligationCtxt>::deeply_normalize::<rustc_middle[59a3c7ee8a751ae9]::ty::Ty>
+  13:        0x10ea16de8 - rustc_trait_selection[5441f2d24210d1ab]::traits::query::dropck_outlives::compute_dropck_outlives_inner
+  14:        0x10eb0c9f4 - rustc_traits[8fea4450c6aad02a]::dropck_outlives::dropck_outlives
+  15:        0x10e3a641c - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  16:        0x10e347954 - <rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2} as core[77a302ba8aa64981]::ops::function::FnOnce<(rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>)>>::call_once
+  17:        0x10e1aac2c - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::DefaultCache<rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  18:        0x10e41fbd8 - rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::get_query_incr::__rust_end_short_backtrace
+  19:        0x10ea1b544 - <rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::QueryTypeOp>::perform_query
+  20:        0x10c82d058 - <rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives> as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::TypeOp>::fully_perform
+  21:        0x10c922408 - <rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::LivenessContext>::compute_drop_data
+  22:        0x10c921298 - rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::trace
+  23:        0x10c92a310 - rustc_borrowck[1ede31b1eb994a06]::type_check::type_check
+  24:        0x10c8fb784 - rustc_borrowck[1ede31b1eb994a06]::nll::compute_regions
+  25:        0x10c96e600 - rustc_borrowck[1ede31b1eb994a06]::do_mir_borrowck
+  26:        0x10c934374 - rustc_borrowck[1ede31b1eb994a06]::mir_borrowck
+  27:        0x10e3a56a0 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  28:        0x10e1fe344 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_data_structures[acd479fe9d24c68]::vec_cache::VecCache<rustc_span[2f93acfc3e5da0ca]::def_id::LocalDefId, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>, rustc_query_system[b220bb2763f61922]::dep_graph::graph::DepNodeIndex>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  29:        0x10e3d85b0 - rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
+  30:        0x10d636bb0 - <rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt>::par_hir_body_owners::<rustc_interface[a600a78ab89f7261]::passes::run_required_analyses::{closure#2}::{closure#0}>::{closure#0}
+  31:        0x10d6bec00 - rustc_interface[a600a78ab89f7261]::passes::run_required_analyses
+  32:        0x10d6c0ff4 - rustc_interface[a600a78ab89f7261]::passes::analysis
+  33:        0x10e3aae40 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>
+  34:        0x10e193dc8 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::SingleCache<rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  35:        0x10e3b5440 - rustc_query_impl[1048ca99148785d2]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
+  36:        0x10cded910 - rustc_interface[a600a78ab89f7261]::passes::create_and_enter_global_ctxt::<core[77a302ba8aa64981]::option::Option<rustc_interface[a600a78ab89f7261]::queries::Linker>, rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}::{closure#2}>
+  37:        0x10cdfc588 - rustc_interface[a600a78ab89f7261]::interface::run_compiler::<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}
+  38:        0x10cdef1b4 - std[b5799de7b54252e2]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
+  39:        0x10ce03370 - <<std[b5799de7b54252e2]::thread::Builder>::spawn_unchecked_<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[77a302ba8aa64981]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  40:        0x10ec588bc - std::sys::pal::unix::thread::Thread::new::thread_start::h44f82d9477b86743
+  41:        0x19d6b42e4 - __pthread_deallocate
+
+
+query stack during panic:
+#0 [dropck_outlives] computing dropck types for `alloc::boxed::Box<[Client]>`
+#1 [mir_borrowck] borrow-checking `<impl at web/@linera/client/src/lib.rs:50:1: 50:16>::vector_into_abi`
+#2 [analysis] running analysis passes on this crate
+end of query stack
+thread 'rustc' panicked at compiler/rustc_trait_selection/src/traits/normalize.rs:69:17:
+Box<dyn Any>
+stack backtrace:
+   0:        0x10ec36f54 - std::backtrace::Backtrace::create::ha8ad3a274d69bc73
+   1:        0x10cdff9bc - std[b5799de7b54252e2]::panicking::update_hook::<alloc[aa6ffa18488a0c9c]::boxed::Box<rustc_driver_impl[c369b46601ddfb4f]::install_ice_hook::{closure#1}>>::{closure#0}
+   2:        0x10ec52344 - std::panicking::rust_panic_with_hook::h99b909b88606ba45
+   3:        0x10ce7ed2c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}
+   4:        0x10ce6d3ec - std[b5799de7b54252e2]::sys::backtrace::__rust_end_short_backtrace::<std[b5799de7b54252e2]::panicking::begin_panic<rustc_errors[cee812b0c52ce615]::ExplicitBug>::{closure#0}, !>
+   5:        0x11191123c - std[b5799de7b54252e2]::panicking::begin_panic::<rustc_errors[cee812b0c52ce615]::ExplicitBug>
+   6:        0x111911614 - <rustc_errors[cee812b0c52ce615]::diagnostic::BugAbort as rustc_errors[cee812b0c52ce615]::diagnostic::EmissionGuarantee>::emit_producing_guarantee
+   7:        0x11197b294 - <rustc_errors[cee812b0c52ce615]::DiagCtxtHandle>::span_bug::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span, alloc[aa6ffa18488a0c9c]::string::String>
+   8:        0x111983fb8 - rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}
+   9:        0x10da45f1c - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt::<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}
+  10:        0x10da459ec - rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_context_opt::<rustc_middle[59a3c7ee8a751ae9]::ty::context::tls::with_opt<rustc_middle[59a3c7ee8a751ae9]::util::bug::opt_span_bug_fmt<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>::{closure#0}, !>::{closure#0}, !>
+  11:        0x111983f28 - rustc_middle[59a3c7ee8a751ae9]::util::bug::span_bug_fmt::<rustc_span[2f93acfc3e5da0ca]::span_encoding::Span>
+  12:        0x10ea0a5ec - <rustc_trait_selection[5441f2d24210d1ab]::traits::engine::ObligationCtxt>::deeply_normalize::<rustc_middle[59a3c7ee8a751ae9]::ty::Ty>
+  13:        0x10ea16de8 - rustc_trait_selection[5441f2d24210d1ab]::traits::query::dropck_outlives::compute_dropck_outlives_inner
+  14:        0x10eb0c9f4 - rustc_traits[8fea4450c6aad02a]::dropck_outlives::dropck_outlives
+  15:        0x10e3a641c - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  16:        0x10e347954 - <rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::dynamic_query::{closure#2} as core[77a302ba8aa64981]::ops::function::FnOnce<(rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>)>>::call_once
+  17:        0x10e1aac2c - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::DefaultCache<rustc_type_ir[4ea652f9c23551af]::canonical::CanonicalQueryInput<rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt, rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives>>, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  18:        0x10e41fbd8 - rustc_query_impl[1048ca99148785d2]::query_impl::dropck_outlives::get_query_incr::__rust_end_short_backtrace
+  19:        0x10ea1b544 - <rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::QueryTypeOp>::perform_query
+  20:        0x10c82d058 - <rustc_middle[59a3c7ee8a751ae9]::ty::ParamEnvAnd<rustc_middle[59a3c7ee8a751ae9]::traits::query::type_op::DropckOutlives> as rustc_trait_selection[5441f2d24210d1ab]::traits::query::type_op::TypeOp>::fully_perform
+  21:        0x10c922408 - <rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::LivenessContext>::compute_drop_data
+  22:        0x10c921298 - rustc_borrowck[1ede31b1eb994a06]::type_check::liveness::trace::trace
+  23:        0x10c92a310 - rustc_borrowck[1ede31b1eb994a06]::type_check::type_check
+  24:        0x10c8fb784 - rustc_borrowck[1ede31b1eb994a06]::nll::compute_regions
+  25:        0x10c96e600 - rustc_borrowck[1ede31b1eb994a06]::do_mir_borrowck
+  26:        0x10c934374 - rustc_borrowck[1ede31b1eb994a06]::mir_borrowck
+  27:        0x10e3a56a0 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  28:        0x10e1fe344 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_data_structures[acd479fe9d24c68]::vec_cache::VecCache<rustc_span[2f93acfc3e5da0ca]::def_id::LocalDefId, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>, rustc_query_system[b220bb2763f61922]::dep_graph::graph::DepNodeIndex>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  29:        0x10e3d85b0 - rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
+  30:        0x10c93017c - <rustc_borrowck[1ede31b1eb994a06]::type_check::TypeChecker>::prove_closure_bounds
+  31:        0x10c968c38 - <rustc_borrowck[1ede31b1eb994a06]::type_check::TypeChecker as rustc_middle[59a3c7ee8a751ae9]::mir::visit::Visitor>::visit_rvalue
+  32:        0x10c963b98 - <rustc_borrowck[1ede31b1eb994a06]::type_check::TypeChecker as rustc_middle[59a3c7ee8a751ae9]::mir::visit::Visitor>::visit_statement
+  33:        0x10c963210 - <rustc_borrowck[1ede31b1eb994a06]::type_check::TypeChecker as rustc_middle[59a3c7ee8a751ae9]::mir::visit::Visitor>::visit_body
+  34:        0x10c928c48 - rustc_borrowck[1ede31b1eb994a06]::type_check::type_check
+  35:        0x10c8fb784 - rustc_borrowck[1ede31b1eb994a06]::nll::compute_regions
+  36:        0x10c96e600 - rustc_borrowck[1ede31b1eb994a06]::do_mir_borrowck
+  37:        0x10c934374 - rustc_borrowck[1ede31b1eb994a06]::mir_borrowck
+  38:        0x10e3a56a0 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>>
+  39:        0x10e1fe344 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_data_structures[acd479fe9d24c68]::vec_cache::VecCache<rustc_span[2f93acfc3e5da0ca]::def_id::LocalDefId, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 8usize]>, rustc_query_system[b220bb2763f61922]::dep_graph::graph::DepNodeIndex>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  40:        0x10e3d85b0 - rustc_query_impl[1048ca99148785d2]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
+  41:        0x10d636bb0 - <rustc_middle[59a3c7ee8a751ae9]::ty::context::TyCtxt>::par_hir_body_owners::<rustc_interface[a600a78ab89f7261]::passes::run_required_analyses::{closure#2}::{closure#0}>::{closure#0}
+  42:        0x10d6bec00 - rustc_interface[a600a78ab89f7261]::passes::run_required_analyses
+  43:        0x10d6c0ff4 - rustc_interface[a600a78ab89f7261]::passes::analysis
+  44:        0x10e3aae40 - rustc_query_impl[1048ca99148785d2]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[1048ca99148785d2]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>
+  45:        0x10e193dc8 - rustc_query_system[b220bb2763f61922]::query::plumbing::try_execute_query::<rustc_query_impl[1048ca99148785d2]::DynamicConfig<rustc_query_system[b220bb2763f61922]::query::caches::SingleCache<rustc_middle[59a3c7ee8a751ae9]::query::erase::Erased<[u8; 0usize]>>, false, false, false>, rustc_query_impl[1048ca99148785d2]::plumbing::QueryCtxt, true>
+  46:        0x10e3b5440 - rustc_query_impl[1048ca99148785d2]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
+  47:        0x10cded910 - rustc_interface[a600a78ab89f7261]::passes::create_and_enter_global_ctxt::<core[77a302ba8aa64981]::option::Option<rustc_interface[a600a78ab89f7261]::queries::Linker>, rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}::{closure#2}>
+  48:        0x10cdfc588 - rustc_interface[a600a78ab89f7261]::interface::run_compiler::<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}
+  49:        0x10cdef1b4 - std[b5799de7b54252e2]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
+  50:        0x10ce03370 - <<std[b5799de7b54252e2]::thread::Builder>::spawn_unchecked_<rustc_interface[a600a78ab89f7261]::util::run_in_thread_with_globals<rustc_interface[a600a78ab89f7261]::util::run_in_thread_pool_with_globals<rustc_interface[a600a78ab89f7261]::interface::run_compiler<(), rustc_driver_impl[c369b46601ddfb4f]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[77a302ba8aa64981]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  51:        0x10ec588bc - std::sys::pal::unix::thread::Thread::new::thread_start::h44f82d9477b86743
+  52:        0x19d6b42e4 - __pthread_deallocate
+
+
+query stack during panic:
+#0 [dropck_outlives] computing dropck types for `core::result::Result<Client, wasm_bindgen::JsError>`
+#1 [mir_borrowck] borrow-checking `<impl at web/@linera/client/src/lib.rs:62:1: 62:12>::new::{closure#0}::_::__wasm_bindgen_generated_Client_new::{closure#0}`
+#2 [mir_borrowck] borrow-checking `<impl at web/@linera/client/src/lib.rs:62:1: 62:12>::new::{closure#0}::_::__wasm_bindgen_generated_Client_new`
+#3 [analysis] running analysis passes on this crate
+end of query stack


### PR DESCRIPTION
## Motivation

Grafana dashboards needed reorganization for better usability, especially separating storage metrics by backend type.

## Proposal

- Split storage dashboard into rocksdb and scylladb sections
- Reorganize panels for better logical grouping
- Update panel queries for new metric names

## Test Plan

- Import updated dashboards to Grafana
- Verify all panels render correctly
- Check data is displayed accurately

## Release Plan

- Nothing to do / These changes follow the usual release cycle.