### PR TITLE
Combine building binaries into 1 cargo build command

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,9 +74,11 @@ COPY rust-toolchain* Cargo.* ./
 ENV GIT_COMMIT=${git_commit}
 ENV RUSTFLAGS=${rustflags}
 
-RUN cargo build ${build_flag:+"$build_flag"} --target "$target" --bin linera-proxy --features $build_features
-RUN cargo build ${build_flag:+"$build_flag"} --target "$target" --bin linera-server --features $build_features
-RUN cargo build ${build_flag:+"$build_flag"} --target "$target" --bin linera --features $build_features
+RUN cargo build ${build_flag:+"$build_flag"} --target "$target" \
+    --bin linera-proxy \
+    --bin linera-server \
+    --bin linera \
+    --features $build_features
 
 RUN mv \
     target/"$target"/"$build_folder"/linera \


### PR DESCRIPTION
## Motivation

Building binaries with separate `cargo build` commands is slower than building them together, as Cargo can
parallelize compilation better.

## Proposal

Combine multiple `cargo build` commands in Dockerfile into a single command that builds all required binaries at
once.

## Test Plan

- Build Docker image with new Dockerfile
- Verify all binaries are present
- Compare build time to previous approach

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.