### PR TITLE
Autosigning improvements (#5126)

### DIFF
--- a/examples/counter/index.html
+++ b/examples/counter/index.html
@@ -82,19 +82,19 @@
               logs.insertBefore(entry, logs.firstChild);
           }
 
-          async function updateCount(block_hash) {
-              const response = await counter.query('{ "query": "query { value }" }', block_hash);
+          async function updateCount(blockHash) {
+              const response = await counter.query('{ "query": "query { value }" }', { blockHash });
               document.getElementById('count').innerText
                   = JSON.parse(response).data.value;
           }
 
-          updateCount(null);
+          updateCount();
           client.onNotification(notification => {
               let newBlock = notification.reason.NewBlock;
               if (notification.reason.BlockExecuted) {
                 let hash = notification.reason.BlockExecuted.hash;
                 updateCount(hash);
-              } else if(newBlock) {
+              } else if (newBlock) {
                 addLogEntry(newBlock);
                 updateCount(null);
               }

--- a/examples/counter/metamask/index.html
+++ b/examples/counter/metamask/index.html
@@ -52,61 +52,64 @@
     </div>
 
     <script type="module">
-      import * as linera from '@linera/client';
-      import * as linera_metamask from '@linera/metamask';
+     import * as linera from '@linera/client';
+     import * as linera_metamask from '@linera/metamask';
 
-      async function run() {
-          await linera.initialize();
-          const faucet = await new linera.Faucet(import.meta.env.LINERA_FAUCET_URL);
-          const signer = await new linera_metamask.Signer();
-          const wallet = await faucet.createWallet();
-          const owner = await signer.address();
-          const chain = await faucet.claimChain(wallet, owner);
-          document.getElementById('owner').innerText = owner;
-          document.getElementById('chain-id').innerText = chain;
+     const logs = document.getElementById('logs');
+     const incrementButton = document.getElementById('increment-btn');
+     const blockTemplate = document.getElementById('block-template');
 
-          // add a new local wallet to the chain that can autosign blocks
-          // without prompting every time
-          const autosigner = linera.signer.PrivateKey.createRandom();
-          const client = await new linera.Client(wallet, new linera.signer.Composite(autosigner, signer));
-          await client.addOwner(autosigner.address());
-          wallet.setOwner(chain, autosigner.address());
+     // Initialize the Linera client and set up the MetaMask signer.
+     await linera.initialize();
+     const faucet = await new linera.Faucet(import.meta.env.LINERA_FAUCET_URL);
+     const signer = await new linera_metamask.Signer();
+     const wallet = await faucet.createWallet();
+     const owner = await signer.address();
+     const chain = await faucet.claimChain(wallet, owner);
+     document.getElementById('owner').innerText = owner;
+     document.getElementById('chain-id').innerText = chain;
 
-          const counter = await client.application(import.meta.env.LINERA_APPLICATION_ID);
-          const logs = document.getElementById('logs');
-          const incrementButton = document.getElementById('increment-btn');
-          const blockTemplate = document.getElementById('block-template');
+     // For autosigning: first we set up a local (in-memory) signer, and provide it to the
+     // client along with the MetaMask signer
+     const autosigner = linera.signer.PrivateKey.createRandom();
+     const client = await new linera.Client(wallet, new linera.signer.Composite(autosigner, signer));
 
-          function addLogEntry(block) {
-              const entry = logs.getElementsByTagName('template')[0].content.cloneNode(true);
-              entry.querySelector('.height').textContent = block.height;
-              entry.querySelector('.hash').textContent = block.hash;
-              logs.insertBefore(entry, logs.firstChild);
-          }
+     // Connect to the counter application.
+     const counter = await client.application(import.meta.env.LINERA_APPLICATION_ID);
 
-          async function updateCount() {
-              const response = await counter.query('{ "query": "query { value }" }');
-              document.getElementById('count').innerText
-                  = JSON.parse(response).data.value;
-          }
+     // When we get a new block, show it in the UI and update the counter from the chain state.
+     client.onNotification(notification => {
+         let newBlock = notification.reason.NewBlock;
+         if (!newBlock) return;
+         addLogEntry(newBlock);
+         updateCount(newBlock.hash);
+     });
 
-          updateCount();
-          client.onNotification(notification => {
-              let newBlock = notification.reason.NewBlock;
-              if (!newBlock) return;
-              addLogEntry(newBlock);
-              updateCount();
-          });
+     // For autosigning: we then add the in-memory signer as an owner of the chain in the
+     // wallet, and set it as the default owner (so it will be used to process messages and
+     // events).
+     await client.addOwner(autosigner.address());
+     wallet.setOwner(chain, autosigner.address());
 
-          incrementButton.addEventListener('click', () => {
-              counter.query('{ "query": "mutation { increment(value: 1) }" }');
-          });
-      }
+     function addLogEntry(block) {
+         const entry = logs.getElementsByTagName('template')[0].content.cloneNode(true);
+         entry.querySelector('.height').textContent = block.height;
+         entry.querySelector('.hash').textContent = block.hash;
+         logs.insertBefore(entry, logs.firstChild);
+     }
 
-      if (document.readyState === 'loading')
-          document.addEventListener('DOMContentLoaded', run);
-      else
-          run();
+     async function updateCount(blockHash) {
+         const response = await counter.query('{ "query": "query { value }" }', { blockHash });
+         document.getElementById('count').innerText = JSON.parse(response).data.value;
+     }
+
+     updateCount();
+
+     incrementButton.addEventListener('click', () => {
+         // For autosigning: when we make user-initiated mutations, we explicitly make them with
+         // the original (MetaMask) owner by providing the `owner` option to the `query` call.
+         counter.query('{ "query": "mutation { increment(value: 1) }" }', { owner });
+     });
     </script>
   </body>
 </html>

--- a/examples/native-fungible/index.html
+++ b/examples/native-fungible/index.html
@@ -164,7 +164,10 @@
       }
 
       async function updateBalance(application, owner, blockHash) {
-          const response = JSON.parse(await application.query(gql(`query { tickerSymbol, accounts { entry(key: "${owner}") { value } } }`), blockHash));
+          const response = JSON.parse(await application.query(
+              gql(`query { tickerSymbol, accounts { entry(key: "${owner}") { value } } }`),
+              { blockHash },
+          ));
           console.debug('application response:', response);
           document.querySelector('#ticker-symbol').textContent = response.data.tickerSymbol;
           document.querySelector('#balance').textContent = (+(response?.data?.accounts?.entry.value || 0)).toFixed(2);

--- a/web/@linera/client/src/lib.rs
+++ b/web/@linera/client/src/lib.rs
@@ -133,6 +133,13 @@ struct TransferParams {
     recipient: linera_base::identifiers::Account,
 }
 
+#[derive(Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct QueryOptions {
+    block_hash: Option<String>,
+    owner: Option<AccountOwner>,
+}
+
 #[wasm_bindgen]
 impl Client {
     /// Creates a new client and connects to the network.
@@ -310,11 +317,21 @@ impl Client {
     ///
     /// If the owner is in the wrong format, or the chain client can't be instantiated.
     #[wasm_bindgen(js_name = addOwner)]
-    pub async fn add_owner(&self, owner: JsValue) -> JsResult<()> {
+    pub async fn add_owner(&self, owner: JsValue, options: JsValue) -> JsResult<()> {
+        #[derive(Default, serde::Deserialize)]
+        struct Options {
+            #[serde(default)]
+            weight: u64,
+        }
+
         let owner = serde_wasm_bindgen::from_value(owner)?;
+        let Options { weight } =
+            serde_wasm_bindgen::from_value::<Option<_>>(options)?.unwrap_or_default();
         let chain_client = self.default_chain_client().await?;
-        self.apply_client_command(&chain_client, || chain_client.share_ownership(owner, 100))
-            .await??;
+        self.apply_client_command(&chain_client, || {
+            chain_client.share_ownership(owner, weight)
+        })
+        .await??;
         Ok(())
     }
 
@@ -404,9 +421,14 @@ impl Application {
     #[wasm_bindgen]
     // TODO(#14) allow passing bytes here rather than just strings
     // TODO(#15) a lot of this logic is shared with `linera_service::node_service`
-    pub async fn query(&self, query: &str, block_hash: Option<String>) -> JsResult<String> {
+    pub async fn query(&self, query: &str, options: JsValue) -> JsResult<String> {
         tracing::debug!("querying application: {query}");
-        let chain_client = self.client.default_chain_client().await?;
+        let QueryOptions { block_hash, owner } =
+            serde_wasm_bindgen::from_value::<Option<_>>(options)?.unwrap_or_default();
+        let mut chain_client = self.client.default_chain_client().await?;
+        if let Some(owner) = owner {
+            chain_client.set_preferred_owner(owner);
+        }
         let block_hash = if let Some(hash) = block_hash {
             Some(hash.as_str().parse()?)
         } else {


### PR DESCRIPTION
## Motivation

@afck pointed out that having a lot of owners with non-zero weights would slow the chain down in single-leader rounds.

@ma2bd pointed out that we need to make mutations using the original owner.

## Proposal

Add a `weight` option to `addOwner` in an options object, and default it to zero.

Add an optional `owner` option to `query` in an options object, and use it to sign mutations. Also, document the above inline.

## Test Plan

Tested locally. Also, CI should test some of the API (but sadly not yet as much as we'd like it to).

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)