### PR TITLE
Background sync of received certificates fix

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -275,7 +275,10 @@ impl<C: ClientContext + 'static> ChainListener<C> {
         if enable_background_sync {
             let context = Arc::clone(&self.context);
             let cancellation_token = self.cancellation_token.clone();
-            for chain_id in chain_ids.keys() {
+            for (chain_id, mode) in chain_ids.iter() {
+                if mode != &ListeningMode::FullChain {
+                    continue;
+                }
                 let context = Arc::clone(&context);
                 let cancellation_token = cancellation_token.clone();
                 let chain_id = *chain_id;


### PR DESCRIPTION
## Motivation

We are synchronising sender chains that we shouldn't be b/c they're sending messages to a chain we follow in `FollowOnly` mode.

## Proposal

Filter out chains which we don't follow in `FullChain` mode.

## Test Plan

manual.

## Release Plan

- These changes should be
    - be released in a new SDK,
    - backported to `main`

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
