### PR TITLE
Cap log level to debug on web

### DIFF
--- a/web/@linera/client/Cargo.toml
+++ b/web/@linera/client/Cargo.toml
@@ -23,7 +23,7 @@ serde.workspace = true
 serde-wasm-bindgen.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
-tracing.workspace = true
+tracing = { workspace = true, features = ["release_max_level_debug"] }
 tracing-web.workspace = true
 tsify.workspace = true
 wasm-bindgen.workspace = true


### PR DESCRIPTION
## Motivation

We are seeing `TRACE` level logs in the web console. They are very spammy and are potentially slowing down the app.

## Proposal

Cap the level to `DEBUG` for Linera web client.

## Test Plan

Manual.

## Release Plan

- These changes should
    - be released in a new SDK,

## Links

https://github.com/linera-io/linera-protocol/issues/5175

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
