### PR TITLE
Backport: Move `TaskProcessor`-related types to `linera_base`

### DIFF
--- a/examples/task-processor/src/service.rs
+++ b/examples/task-processor/src/service.rs
@@ -7,9 +7,10 @@ mod state;
 
 use std::sync::Arc;
 
-use async_graphql::{EmptySubscription, InputObject, Object, Request, Response, Schema};
+use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
 use linera_sdk::{
     linera_base_types::{Timestamp, WithServiceAbi},
+    task_processor::{ProcessorActions, Task, TaskOutcome},
     views::View,
     Service, ServiceRuntime,
 };
@@ -60,35 +61,6 @@ impl Service for TaskProcessorService {
 struct QueryRoot {
     state: Arc<TaskProcessorState>,
     runtime: Arc<ServiceRuntime<TaskProcessorService>>,
-}
-
-/// The actions requested by this application for off-chain processing.
-#[derive(Default, Debug, serde::Serialize, serde::Deserialize)]
-struct ProcessorActions {
-    /// Request a callback at the given timestamp.
-    request_callback: Option<Timestamp>,
-    /// Tasks to execute off-chain.
-    execute_tasks: Vec<Task>,
-}
-
-async_graphql::scalar!(ProcessorActions);
-
-/// A task to be executed by an off-chain operator.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-struct Task {
-    /// The name of the operator to execute.
-    operator: String,
-    /// The input to pass to the operator (JSON string).
-    input: String,
-}
-
-/// The outcome of executing an off-chain task.
-#[derive(Debug, InputObject, serde::Serialize, serde::Deserialize)]
-struct TaskOutcome {
-    /// The name of the operator that executed the task.
-    operator: String,
-    /// The output from the operator (JSON string).
-    output: String,
 }
 
 #[Object]

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -34,6 +34,7 @@ pub mod port;
 pub mod prometheus_util;
 #[cfg(not(chain))]
 pub mod task;
+pub mod task_processor;
 pub mod time;
 #[cfg_attr(web, path = "tracing_web.rs")]
 pub mod tracing;

--- a/linera-base/src/task_processor.rs
+++ b/linera-base/src/task_processor.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types related to the task processor features in the node service.
+
+use async_graphql::scalar;
+use serde::{Deserialize, Serialize};
+
+use crate::data_types::Timestamp;
+
+/// The off-chain actions requested by the service of an on-chain application.
+///
+/// On-chain applications should be ready to respond to GraphQL queries of the form:
+/// ```ignore
+/// query {
+///   nextActions(lastRequestedCallback: Timestamp, now: Timestamp!): ProcessorActions!
+/// }
+///
+/// query {
+///   processTaskOutcome(outcome: TaskOutcome!)
+/// }
+/// ```
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct ProcessorActions {
+    /// The application is requesting to be called back no later than the given timestamp.
+    pub request_callback: Option<Timestamp>,
+    /// The application is requesting the execution of the given tasks.
+    pub execute_tasks: Vec<Task>,
+}
+
+scalar!(ProcessorActions);
+
+/// An off-chain task requested by an on-chain application.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Task {
+    /// The operator handling the task.
+    pub operator: String,
+    /// The input argument in JSON.
+    pub input: String,
+}
+
+/// The result of executing an off-chain operator.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TaskOutcome {
+    /// The operator handling the task.
+    pub operator: String,
+    /// The JSON output.
+    pub output: String,
+}
+
+scalar!(TaskOutcome);

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -47,7 +47,7 @@ pub use bcs;
 pub use linera_base::{
     abi,
     data_types::{Resources, SendMessageRequest},
-    ensure, http,
+    ensure, http, task_processor,
 };
 use linera_base::{
     abi::{ContractAbi, ServiceAbi, WithContractAbi, WithServiceAbi},


### PR DESCRIPTION
## Motivation

Some types are now duplicated between `linera_service` and the `task_processor` in `examples`.

## Proposal

Move the duplicated types to `linera_base`, re-export them from `linera_sdk`.

## Test Plan

CI

## Release Plan

- These changes should be released in a new SDK,

## Links

- Backport of #5179 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
