### PR TITLE
Add liveness probes to proxy/shards (#5169)

### DIFF
--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -108,6 +108,13 @@ spec:
               value: {{ .Values.logLevel }}
             - name: LINERA_OTLP_EXPORTER_ENDPOINT
               value: {{ .Values.otlpExporterEndpoint }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.proxyPort }}
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
           volumeMounts:
             - name: config
               mountPath: "/config"

--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -6,9 +6,9 @@ metadata:
     app: shards
 spec:
   ports:
-    - port: 19100
+    - port: {{ .Values.shardPort }}
       name: http
-    - port: 21100
+    - port: {{ .Values.metricsPort }}
       name: metrics
   clusterIP: None
   selector:
@@ -82,8 +82,17 @@ spec:
           image: {{ .Values.lineraImage }}
           imagePullPolicy: {{ .Values.lineraImagePullPolicy }}
           ports:
+            - containerPort: {{ .Values.shardPort }}
+              name: grpc
             - containerPort: {{ .Values.metricsPort }}
               name: metrics
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.shardPort }}
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
           command:
             - sh
             - -c

--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -19,6 +19,7 @@ otlpExporterEndpoint: ""
 
 # Network ports
 proxyPort: 19100
+shardPort: 19100
 metricsPort: 21100
 
 # Deployment scaling


### PR DESCRIPTION
## Motivation

This is a backport of #5169.
Shards can occasionally become completely unresponsive due to, for
example, deadlocks or livelocks. When this happens, the pod can stay
"Running" but for example accepts no connections, requiring manual
intervention to detect and restart.

## Proposal

Add TCP liveness probes to proxy and shard pods so Kubernetes
automatically restarts unresponsive pods.

## Test Plan

Deployed a temporary network with these changes to make sure everything seems to work

