### PR TITLE
chore: bump checkout to v6

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 40
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Clear up some space
       run: |


### PR DESCRIPTION
Updated actions/checkout from v4 to v6 in ci.yml workflow 
