### PR TITLE
Fix docker compose validator

### DIFF
--- a/docker/alloy-config.river
+++ b/docker/alloy-config.river
@@ -19,17 +19,36 @@ prometheus.scrape "proxy_metrics" {
   scrape_timeout  = "10s"
 }
 
-// Scrape metrics from shard services (all 4 replicas)
+// Scrape metrics from all shard services
 prometheus.scrape "shard_metrics" {
   targets = [
     {
-      __address__ = "shard:21100",
+      __address__ = "docker-shard-1:21100",
       job         = "linera-shard",
+      shard       = "0",
+      instance    = env("HOSTNAME"),
+    },
+    {
+      __address__ = "docker-shard-2:21100",
+      job         = "linera-shard",
+      shard       = "1",
+      instance    = env("HOSTNAME"),
+    },
+    {
+      __address__ = "docker-shard-3:21100",
+      job         = "linera-shard",
+      shard       = "2",
+      instance    = env("HOSTNAME"),
+    },
+    {
+      __address__ = "docker-shard-4:21100",
+      job         = "linera-shard",
+      shard       = "3",
       instance    = env("HOSTNAME"),
     },
   ]
 
-  // Conditionally forward to OTLP converter if Prometheus export is enabled
+  // Conditional forwarding - only export if PROMETHEUS_ENABLED is set to "true"
   forward_to = env("PROMETHEUS_ENABLED") == "true" ? [otelcol.receiver.prometheus.default.receiver] : []
 
   scrape_interval = "15s"

--- a/docker/docker-compose.alloy.yml
+++ b/docker/docker-compose.alloy.yml
@@ -52,4 +52,7 @@ services:
       com.centurylinklabs.watchtower.enable: "true"
     depends_on:
       - proxy
-      - shard
+      - shard-0
+      - shard-1
+      - shard-2
+      - shard-3

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,7 +65,7 @@ services:
     labels:
       com.centurylinklabs.watchtower.enable: "true"
     healthcheck:
-      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/localhost/19100' || exit 1"]
+      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/localhost/21100' || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -76,10 +76,12 @@ services:
       scylla:
         condition: service_healthy
 
-  shard:
+  # Each shard must run with a unique --shard number matching the server.json configuration.
+  # Docker Compose replicas don't support per-replica arguments, so we define separate services.
+  shard-0:
     image: "${LINERA_IMAGE:-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest}"
-    deploy:
-      replicas: 4
+    container_name: docker-shard-1
+    hostname: docker-shard-1
     command:
       - ./linera-server
       - run
@@ -89,6 +91,75 @@ services:
       - /config/server.json
       - --shard
       - "0"
+      - --storage-replication-factor
+      - "1"
+    volumes:
+      - .:/config
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
+    depends_on:
+      shard-init:
+        condition: service_completed_successfully
+
+  shard-1:
+    image: "${LINERA_IMAGE:-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest}"
+    container_name: docker-shard-2
+    hostname: docker-shard-2
+    command:
+      - ./linera-server
+      - run
+      - --storage
+      - scylladb:tcp:scylla:9042
+      - --server
+      - /config/server.json
+      - --shard
+      - "1"
+      - --storage-replication-factor
+      - "1"
+    volumes:
+      - .:/config
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
+    depends_on:
+      shard-init:
+        condition: service_completed_successfully
+
+  shard-2:
+    image: "${LINERA_IMAGE:-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest}"
+    container_name: docker-shard-3
+    hostname: docker-shard-3
+    command:
+      - ./linera-server
+      - run
+      - --storage
+      - scylladb:tcp:scylla:9042
+      - --server
+      - /config/server.json
+      - --shard
+      - "2"
+      - --storage-replication-factor
+      - "1"
+    volumes:
+      - .:/config
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
+    depends_on:
+      shard-init:
+        condition: service_completed_successfully
+
+  shard-3:
+    image: "${LINERA_IMAGE:-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest}"
+    container_name: docker-shard-4
+    hostname: docker-shard-4
+    command:
+      - ./linera-server
+      - run
+      - --storage
+      - scylladb:tcp:scylla:9042
+      - --server
+      - /config/server.json
+      - --shard
+      - "3"
       - --storage-replication-factor
       - "1"
     volumes:

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -2,6 +2,14 @@ global:
   scrape_interval: 15s
 
 scrape_configs:
-  - job_name: 'metrics-server'
+  - job_name: 'proxy'
     static_configs:
-      - targets: ['proxy:21100', 'shard:21100']
+      - targets: ['proxy:21100']
+
+  - job_name: 'shards'
+    static_configs:
+      - targets:
+        - 'docker-shard-1:21100'
+        - 'docker-shard-2:21100'
+        - 'docker-shard-3:21100'
+        - 'docker-shard-4:21100'


### PR DESCRIPTION
## Motivation

The Docker Compose validator setup has a bug: all 4 shard containers run with --shard 0 instead of each having a unique shard number (0, 1, 2, 3). This causes inter-shard communication to fail because all shards are configured identically rather than as distinct shards of the validator.

Additionally, the proxy health check was checking port 19100, which is an internal port. Checking on port 21100 instead, which is for metrics.

## Proposal

1. Fix shard configuration: Replace the single shard service using replicas: 4 with 4 separate services (shard-0, shard-1, shard-2, shard-3), each with the correct --shard argument. Docker Compose's replicas feature doesn't support per-replica command arguments, so separate service definitions are required.
2. Fix proxy health check: Change the health check port from 19100 to 21100 (the metrics port that the proxy actually listens on).
3. Update alloy override: Update docker-compose.alloy.yml dependencies to reference the new shard service names.

## Test Plan

- Deployed the fix to the OVH docker compose validator (ovh-or1-compose-validator-01)
- Verified all 4 shards start with correct shard numbers (0, 1, 2, 3)
- Verified inter-shard connectivity works
- Verified proxy health check passes

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.
