### PR TITLE
feat(helm): Use separate image for block-exporter

### DIFF
--- a/kubernetes/linera-validator/templates/block-exporter.yaml
+++ b/kubernetes/linera-validator/templates/block-exporter.yaml
@@ -42,8 +42,8 @@ spec:
     spec:
       initContainers:
         - name: linera-exporter-initializer
-          image: {{ .Values.indexer.image }}
-          imagePullPolicy: {{ .Values.indexer.imagePullPolicy }}
+          image: {{ .Values.lineraImage }}
+          imagePullPolicy: {{ .Values.lineraImagePullPolicy }}
           securityContext:
             runAsNonRoot: true
             runAsUser: 65534
@@ -153,8 +153,8 @@ spec:
               done
       containers:
         - name: linera-block-exporter
-          image: {{ .Values.indexer.image }}
-          imagePullPolicy: {{ .Values.indexer.imagePullPolicy }}
+          image: {{ .Values.blockExporter.image }}
+          imagePullPolicy: {{ .Values.blockExporter.imagePullPolicy }}
           command:
             - "./linera-exporter"
             - "--storage"

--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -78,6 +78,8 @@ validator:
 # Block Exporter - exports blocks for indexing
 blockExporter:
   enabled: false
+  image: "linera-exporter:latest"
+  imagePullPolicy: "IfNotPresent"
   replicas: 1
   port: 8882
   metricsPort: 9091


### PR DESCRIPTION
## Summary
Backport of #5118 to `testnet_conway`

- Add dedicated `image` and `imagePullPolicy` configuration for `blockExporter` in the Helm chart
- Block exporter now uses its own image instead of reusing the indexer image
- Init container uses `lineraImage` for storage check
- This allows independent versioning of the block exporter container

## Changes
- `kubernetes/linera-validator/values.yaml`: Added `blockExporter.image` and `blockExporter.imagePullPolicy`
- `kubernetes/linera-validator/templates/block-exporter.yaml`: Changed from `indexer.image` to `blockExporter.image`

## Related
- Original PR: #5118
- Requires corresponding lineractl changes: linera-io/linera-infra PR (pending)