### PR TITLE
Returns generated block of processed messages in handle_received_messages

### DIFF
--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -295,7 +295,7 @@ impl ActiveChain {
     /// Adds a block to this microchain that receives all queued messages in the microchains
     /// inboxes.
     ///
-    /// Returns the generate block of processed messages.
+    /// Returns the certificate of the latest block added to the chain, if any.
     pub async fn handle_received_messages(&self) -> Option<ConfirmedBlockCertificate> {
         let chain_id = self.id();
         let (information, _) = self


### PR DESCRIPTION
## Motivation

Right now if we create a chain in message which is processed in `handle_received_messages` , we cannot get the `ChainDescription` of the created chain.

## Proposal

Returns the generated block from `handle_received_messages` then unit tests can get `ChainDescription` from the block.

## Test Plan

CI

## Release Plan

These changes follow the usual release cycle
