### PR TITLE
Correction to the remote EVM contract call.

### DIFF
--- a/linera-service/tests/fixtures/evm_child_subcontract.sol
+++ b/linera-service/tests/fixtures/evm_child_subcontract.sol
@@ -1,6 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
+pragma solidity ^0.8.0;
 
 // Simple subcontract
 contract Counter {
@@ -44,5 +44,15 @@ contract CounterFactory {
     function get_balance(address account) external returns (uint256) {
         uint256 balance = account.balance;
         return balance;
+    }
+
+    function remote_increment(uint256 index) external {
+        Counter counter = counters[index];
+        counter.increment();
+    }
+
+    function remote_value(uint256 index) external returns (uint256) {
+        Counter counter = counters[index];
+        return counter.get_value();
     }
 }


### PR DESCRIPTION
## Motivation

In previous work, the ability to create an EVM contract was introduced.
We already had the functionality of calling an EVM contract from another EVM contract.
So, it was reasonable to think that the created contract B from contract A could be called from contract A. That is not so. The contract had to be registered.

## Proposal

Add the registration of the created contract to the journal (this was found by extensive
interaction with Claude).

## Test Plan

Add the calls of contract B from contract A. This has been combined with calls directly to contract B.
Then the values are checked by service queries.

## Release Plan

I would support enabling EVM in TestNet Conway.

## Links

None.