### PR TITLE
[testnet] Fix docker-compose build. (#5200)

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -53,7 +53,7 @@ jobs:
         # run: echo 1048576 > /proc/sys/fs/aio-max-nr
       - name: Build client binary
         run: |
-          cargo install --path linera-service --bin linera --bin linera-server --debug
+          cargo install --path linera-service --bin linera --bin linera-server --debug --locked
       # TODO(#2709): Remove this step once this workflow runs in a custom runner
       - name: Patch Docker compose file to run ScyllaDB in developer mode
         run: |

--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 async-graphql = {{ version = "=7.0.17", default-features = false }}
+async-graphql-value = {{ version = "=7.0.17" }}
 {linera_sdk_dep}
 futures = {{ version = "0.3 "}}
 serde = {{ version = "1.0", features = ["derive"] }}


### PR DESCRIPTION
Backport of #5200.

## Motivation

`cargo install --path linera-service --bin linera --debug` [fails](https://github.com/linera-io/linera-protocol/actions/runs/20711224126/job/59451976233): It uses `async-graphql-value-7.1.0`, which requires a newer Rust version.

Also `test_project_new` fails, for the same reason.

## Proposal

Use `--locked` in the docker compose build, pin async-graphql-value to version 7.0.17.

## Test Plan

I tried it locally. After this PR, I'd expect the `compose` check to pass again in CI.

## Release Plan

- These changes should be released in a new SDK.

## Links

- PR to main: #5200
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)