### PR TITLE
Introduce read_confirmed_blocks

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -35,7 +35,7 @@ use linera_execution::{
     Committee, ExecutionRuntimeContext as _, ExecutionStateView, Query, QueryContext, QueryOutcome,
     ServiceRuntimeEndpoint,
 };
-use linera_storage::{Clock as _, ResultReadCertificates, Storage};
+use linera_storage::{Clock as _, ResultReadConfirmedBlocks, Storage};
 use linera_views::{
     context::{Context, InactiveContext},
     views::{ClonableView, ReplaceContext as _, RootView as _, View as _},
@@ -575,19 +575,19 @@ where
         }
 
         if !uncached_hashes.is_empty() {
-            let certificates = self
+            let blocks = self
                 .storage
-                .read_certificates(uncached_hashes.clone())
+                .read_confirmed_blocks(uncached_hashes.clone())
                 .await?;
-            let certificates = match ResultReadCertificates::new(certificates, uncached_hashes) {
-                ResultReadCertificates::Certificates(certificates) => certificates,
-                ResultReadCertificates::InvalidHashes(hashes) => {
+            let blocks = match ResultReadConfirmedBlocks::new(blocks, uncached_hashes) {
+                ResultReadConfirmedBlocks::Blocks(blocks) => blocks,
+                ResultReadConfirmedBlocks::InvalidHashes(hashes) => {
                     return Err(WorkerError::ReadCertificatesError(hashes))
                 }
             };
 
-            for cert in certificates {
-                let hashed_block = cert.into_value().into_inner();
+            for block in blocks {
+                let hashed_block = block.into_inner();
                 let height = hashed_block.inner().header.height;
                 self.block_values.insert(Cow::Owned(hashed_block.clone()));
                 height_to_blocks.insert(height, hashed_block);

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -94,6 +94,17 @@ pub mod metrics {
         )
     });
 
+    /// The metric counting how often confirmed blocks are read from storage.
+    #[doc(hidden)]
+    pub(super) static READ_CONFIRMED_BLOCKS_COUNTER: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec(
+                "read_confirmed_blocks",
+                "The metric counting how often confirmed blocks are read from storage",
+                &[],
+            )
+        });
+
     /// The metric counting how often a blob is read from storage.
     #[doc(hidden)]
     pub(super) static READ_BLOB_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -630,6 +641,28 @@ where
             .with_label_values(&[])
             .inc();
         Ok(value)
+    }
+
+    #[instrument(skip_all)]
+    async fn read_confirmed_blocks<I: IntoIterator<Item = CryptoHash> + Send>(
+        &self,
+        hashes: I,
+    ) -> Result<Vec<Option<ConfirmedBlock>>, ViewError> {
+        let hashes = hashes.into_iter().collect::<Vec<_>>();
+        if hashes.is_empty() {
+            return Ok(Vec::new());
+        }
+        let root_keys = Self::get_root_keys_for_certificates(&hashes);
+        let mut blocks = Vec::new();
+        for root_key in root_keys {
+            let store = self.database.open_shared(&root_key)?;
+            blocks.push(store.read_value(BLOCK_KEY).await?);
+        }
+        #[cfg(with_metrics)]
+        metrics::READ_CONFIRMED_BLOCKS_COUNTER
+            .with_label_values(&[])
+            .inc_by(hashes.len() as u64);
+        Ok(blocks)
     }
 
     #[instrument(skip_all, fields(%blob_id))]

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -86,6 +86,12 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         hash: CryptoHash,
     ) -> Result<Option<ConfirmedBlock>, ViewError>;
 
+    /// Reads a number of confirmed blocks by their hashes.
+    async fn read_confirmed_blocks<I: IntoIterator<Item = CryptoHash> + Send>(
+        &self,
+        hashes: I,
+    ) -> Result<Vec<Option<ConfirmedBlock>>, ViewError>;
+
     /// Reads the blob with the given blob ID.
     async fn read_blob(&self, blob_id: BlobId) -> Result<Option<Blob>, ViewError>;
 
@@ -374,6 +380,30 @@ impl ResultReadCertificates {
             });
         if invalid_hashes.is_empty() {
             Self::Certificates(certificates)
+        } else {
+            Self::InvalidHashes(invalid_hashes)
+        }
+    }
+}
+
+/// The result of processing the obtained read confirmed blocks.
+pub enum ResultReadConfirmedBlocks {
+    Blocks(Vec<ConfirmedBlock>),
+    InvalidHashes(Vec<CryptoHash>),
+}
+
+impl ResultReadConfirmedBlocks {
+    /// Creating the processed read confirmed blocks.
+    pub fn new(blocks: Vec<Option<ConfirmedBlock>>, hashes: Vec<CryptoHash>) -> Self {
+        let (blocks, invalid_hashes) = blocks
+            .into_iter()
+            .zip(hashes)
+            .partition_map::<Vec<_>, Vec<_>, _, _, _>(|(block, hash)| match block {
+                Some(block) => itertools::Either::Left(block),
+                None => itertools::Either::Right(hash),
+            });
+        if invalid_hashes.is_empty() {
+            Self::Blocks(blocks)
         } else {
             Self::InvalidHashes(invalid_hashes)
         }


### PR DESCRIPTION
## Motivation

We have this for single blocks, but not for multiple.

## Proposal

Create the multiple blocks version

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.
