### PR TITLE
support listening to chains without services

### DIFF
--- a/examples/controller/src/state.rs
+++ b/examples/controller/src/state.rs
@@ -34,4 +34,6 @@ pub struct ControllerState {
     /// backup).
     // NOTE: Currently, services should run on a single worker at a time.
     pub services: MapView<ManagedServiceId, HashSet<ChainId>>,
+    /// All the chains currently being followed and by which workers.
+    pub chains: MapView<ChainId, HashSet<ChainId>>,
 }

--- a/linera-sdk/src/abis/controller.rs
+++ b/linera-sdk/src/abis/controller.rs
@@ -68,6 +68,17 @@ pub enum ControllerCommand {
     UpdateAllServices {
         services: Vec<(ManagedServiceId, Vec<ChainId>)>,
     },
+    /// Update the state of a particular chain to be listened to on the specific workers.
+    UpdateChain {
+        chain_id: ChainId,
+        workers: Vec<ChainId>,
+    },
+    /// Remove a chain from the map entirely.
+    RemoveChain { chain_id: ChainId },
+    /// Set the states of all chains at once, possibly removing some of them.
+    UpdateAllChains {
+        chains: Vec<(ChainId, Vec<ChainId>)>,
+    },
 }
 
 scalar!(ControllerCommand);


### PR DESCRIPTION
## Motivation

Workers should be able to listen to chains that don't have a "service" application.

## Proposal

Finish the support for local_chains that was overlooked in previous PRs.

## Test Plan

CI

## Release Plan

These changes should be backported to the latest `testnet` branch, then be released in a new SDK,
