### PR TITLE
Enable memory profiling with a flag

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -257,6 +257,7 @@ Client implementation and command-line tool for the Linera blockchain
 * `--execution-state-cache-size <EXECUTION_STATE_CACHE_SIZE>` — Size of the execution state cache (default: 10000)
 
   Default value: `10000`
+* `--enable-memory-profiling` — Enable memory profiling (requires jemalloc feature and metrics). Exposes /debug/pprof and /debug/flamegraph endpoints on the metrics server
 
 
 

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -929,7 +929,11 @@ where
         let index_handler = axum::routing::get(graphiql).post(Self::index_handler);
 
         #[cfg(feature = "metrics")]
-        monitoring_server::start_metrics(self.metrics_address(), cancellation_token.clone());
+        monitoring_server::start_metrics(
+            self.metrics_address(),
+            cancellation_token.clone(),
+            monitoring_server::MemoryProfiling::Disabled,
+        );
 
         let app = Router::new()
             .route("/", index_handler)

--- a/linera-metrics/Cargo.toml
+++ b/linera-metrics/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 workspace = true
 
 [features]
-memory-profiling = ["jemalloc_pprof"]
+jemalloc = ["jemalloc_pprof"]
 
 [dependencies]
 anyhow.workspace = true

--- a/linera-metrics/src/lib.rs
+++ b/linera-metrics/src/lib.rs
@@ -5,5 +5,5 @@
 
 pub mod monitoring_server;
 
-#[cfg(feature = "memory-profiling")]
+#[cfg(feature = "jemalloc")]
 pub mod memory_profiler;

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -52,12 +52,10 @@ metrics = [
     "linera-faucet-server/metrics",
     "linera-metrics",
 ]
-jemalloc = ["tikv-jemallocator"]
-memory-profiling = [
-    "metrics",
-    "jemalloc",
+jemalloc = [
+    "tikv-jemallocator",
     "tikv-jemallocator/profiling",
-    "linera-metrics/memory-profiling",
+    "linera-metrics/jemalloc",
 ]
 storage-service = ["linera-storage-service"]
 

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -9,20 +9,21 @@
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 // jemalloc configuration for memory profiling with jemalloc_pprof
-// prof:true,prof_active:true - Enable profiling from start
+// prof:true - Enable profiling infrastructure
+// prof_active:false - Sampling disabled by default, enabled via --enable-memory-profiling
 // lg_prof_sample:19 - Sample every 512KB for good detail/overhead balance
 
 // Linux/other platforms: use unprefixed malloc (with unprefixed_malloc_on_supported_platforms)
-#[cfg(all(feature = "memory-profiling", not(target_os = "macos")))]
+#[cfg(all(feature = "jemalloc", not(target_os = "macos")))]
 #[allow(non_upper_case_globals)]
 #[export_name = "malloc_conf"]
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+pub static malloc_conf: &[u8] = b"prof:true,prof_active:false,lg_prof_sample:19\0";
 
 // macOS: use prefixed malloc (without unprefixed_malloc_on_supported_platforms)
-#[cfg(all(feature = "memory-profiling", target_os = "macos"))]
+#[cfg(all(feature = "jemalloc", target_os = "macos"))]
 #[allow(non_upper_case_globals)]
 #[export_name = "_rjem_malloc_conf"]
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+pub static malloc_conf: &[u8] = b"prof:true,prof_active:false,lg_prof_sample:19\0";
 
 mod options;
 use std::{
@@ -800,6 +801,7 @@ impl Runnable for Job {
                         monitoring_server::start_metrics(
                             metrics_address,
                             shutdown_notifier.clone(),
+                            options.enable_memory_profiling.into(),
                         );
                     }
 
@@ -1071,6 +1073,7 @@ impl Runnable for Job {
                         monitoring_server::start_metrics(
                             metrics_address,
                             shutdown_notifier.clone(),
+                            options.enable_memory_profiling.into(),
                         );
                     }
 
@@ -1904,6 +1907,21 @@ fn main() -> anyhow::Result<process::ExitCode> {
 
 async fn run(options: &Options) -> Result<i32, Error> {
     let _guard = init_tracing(options)?;
+
+    // Activate memory profiling if requested
+    if options.enable_memory_profiling {
+        #[cfg(feature = "jemalloc")]
+        {
+            linera_metrics::memory_profiler::MemoryProfiler::activate()
+                .await
+                .expect("Failed to activate memory profiling");
+        }
+        #[cfg(not(feature = "jemalloc"))]
+        {
+            bail!("--enable-memory-profiling requires the binary to be compiled with the 'jemalloc' feature");
+        }
+    }
+
     match &options.command {
         ClientCommand::HelpMarkdown => {
             clap_markdown::print_help_markdown::<Options>();

--- a/linera-service/src/cli/options.rs
+++ b/linera-service/src/cli/options.rs
@@ -90,6 +90,11 @@ pub struct Options {
     )]
     pub execution_state_cache_size: usize,
 
+    /// Enable memory profiling (requires jemalloc feature and metrics).
+    /// Exposes /debug/pprof and /debug/flamegraph endpoints on the metrics server.
+    #[arg(long, env = "LINERA_ENABLE_MEMORY_PROFILING")]
+    pub enable_memory_profiling: bool,
+
     /// Subcommand.
     #[command(subcommand)]
     pub command: ClientCommand,

--- a/linera-service/src/exporter/main.rs
+++ b/linera-service/src/exporter/main.rs
@@ -104,7 +104,11 @@ impl Runnable for ExporterContext {
         tokio::spawn(listen_for_shutdown_signals(shutdown_notifier.clone()));
 
         #[cfg(with_metrics)]
-        monitoring_server::start_metrics(self.config.metrics_address(), shutdown_notifier.clone());
+        monitoring_server::start_metrics(
+            self.config.metrics_address(),
+            shutdown_notifier.clone(),
+            monitoring_server::MemoryProfiling::Disabled,
+        );
 
         let (sender, handle) = start_block_processor_task(
             storage,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -959,7 +959,11 @@ where
             axum::routing::get(util::graphiql).post(Self::application_handler);
 
         #[cfg(with_metrics)]
-        monitoring_server::start_metrics(self.metrics_address(), cancellation_token.clone());
+        monitoring_server::start_metrics(
+            self.metrics_address(),
+            cancellation_token.clone(),
+            monitoring_server::MemoryProfiling::Disabled,
+        );
 
         let app = Router::new()
             .route("/", index_handler)

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -244,12 +244,20 @@ where
         ),
         err,
     )]
-    pub async fn run(self, shutdown_signal: CancellationToken) -> Result<()> {
+    pub async fn run(
+        self,
+        shutdown_signal: CancellationToken,
+        _enable_memory_profiling: bool,
+    ) -> Result<()> {
         info!("Starting proxy");
         let mut join_set = JoinSet::new();
 
         #[cfg(with_metrics)]
-        monitoring_server::start_metrics(self.metrics_address(), shutdown_signal.clone());
+        monitoring_server::start_metrics(
+            self.metrics_address(),
+            shutdown_signal.clone(),
+            _enable_memory_profiling.into(),
+        );
 
         let (health_reporter, health_service) = tonic_health::server::health_reporter();
         health_reporter


### PR DESCRIPTION
## Motivation

Right now memory profiling is always enabled if the code is compiled with the `memory-profiling` feature.
That is not good and was an oversight in the initial implementation of this.

## Proposal

Actual memory profiling should be enabled by a CLI flag. So let's do that.

## Test Plan

Will deploy a small network with this and make sure that it works

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
