### PR TITLE
Log method name on more metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5766,6 +5766,7 @@ dependencies = [
  "clap",
  "ed25519-dalek",
  "futures",
+ "http 1.3.1",
  "insta",
  "linera-base",
  "linera-chain",

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -56,6 +56,7 @@ cfg-if.workspace = true
 clap.workspace = true
 ed25519-dalek.workspace = true
 futures.workspace = true
+http.workspace = true
 linera-base.workspace = true
 linera-chain.workspace = true
 linera-core.workspace = true


### PR DESCRIPTION
## Motivation

We don't have the `method_name` label for all the proxy/server level metrics, and we should.

## Proposal

Add `method_name` label

## Test Plan

Will deploy a small network and make sure this works as expected.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.
