### PR TITLE
Add `midpoint` to wrapped integers.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -439,6 +439,11 @@ macro_rules! impl_wrapped_number {
                 Self(self.0.abs_diff(other.0))
             }
 
+            /// Returns the midpoint of `self` and `other`, rounded down.
+            pub const fn midpoint(self, other: Self) -> Self {
+                Self(self.0.midpoint(other.0))
+            }
+
             /// Checked in-place addition.
             pub fn try_add_assign(&mut self, other: Self) -> Result<(), ArithmeticError> {
                 self.0 = self


### PR DESCRIPTION
## Motivation

`midpoint` was added to the Rust standard library to avoid pitfalls with `(a + b) / 2` overflows.

## Proposal

Add it to the wrapped integer types, too, in particular to `Amount`, which is exposed through the SDK. This is useful e.g. for binary searches.

## Test Plan

(No new logic, just delegation.)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
