### PR TITLE
Fix central monitoring traces forwarding with fan-out architecture

### DIFF
--- a/kubernetes/linera-validator/values-local.yaml.gotmpl
+++ b/kubernetes/linera-validator/values-local.yaml.gotmpl
@@ -4,7 +4,19 @@
 lineraImage: {{ env "LINERA_HELMFILE_LINERA_IMAGE" | default "linera:latest" }}
 lineraImagePullPolicy: Never
 logLevel: "debug"
-otlpExporterEndpoint: {{ env "LINERA_HELMFILE_SET_OTLP_EXPORTER_ENDPOINT" | default "" }}
+# OTLP Exporter Endpoint configuration:
+# - If observability-alloy is enabled with traces, route through Alloy for fan-out to both local and central
+# - Otherwise, use the direct endpoint (local Tempo or empty to disable)
+{{- $observabilityAlloyEnabled := eq (env "LINERA_HELMFILE_SET_ENABLE_OBSERVABILITY_ALLOY" | default "false") "true" }}
+{{- $tempoEnabled := eq (env "LINERA_HELMFILE_SET_TEMPO_ENABLED" | default "false") "true" }}
+{{- $explicitEndpoint := env "LINERA_HELMFILE_SET_OTLP_EXPORTER_ENDPOINT" }}
+{{- if and $observabilityAlloyEnabled $tempoEnabled }}
+# Observability-alloy is enabled with traces - route through Alloy for dual forwarding (local + central)
+otlpExporterEndpoint: {{ $explicitEndpoint | default "http://observability-alloy.monitoring.svc.cluster.local:4317" }}
+{{- else }}
+# Direct endpoint (local Tempo or disabled)
+otlpExporterEndpoint: {{ $explicitEndpoint | default "" }}
+{{- end }}
 proxyPort: 19100
 metricsPort: 21100
 numShards: {{ env "LINERA_HELMFILE_SET_NUM_SHARDS" | default 10 }}

--- a/kubernetes/linera-validator/values-observability-alloy.yaml.gotmpl
+++ b/kubernetes/linera-validator/values-observability-alloy.yaml.gotmpl
@@ -5,6 +5,16 @@
 alloy:
   controller:
     type: daemonset
+  # Expose OTLP receiver ports for traces ingestion
+  extraPorts:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
   configMap:
     create: true
     content: |-
@@ -202,6 +212,8 @@ alloy:
 
       {{- if eq (env "LINERA_HELMFILE_SET_TEMPO_ENABLED" | default "false") "true" }}
       // ==================== Tempo Traces Collection ====================
+      // Receives traces via OTLP and forwards to BOTH local Tempo (preserves local monitoring)
+      // AND central Tempo (external monitoring stack)
 
       // OTLP receiver for traces
       otelcol.receiver.otlp "default" {
@@ -214,11 +226,27 @@ alloy:
         }
 
         output {
-          traces  = [otelcol.exporter.otlphttp.central.input]
+          // Fan-out to both local and central Tempo
+          traces = [
+            otelcol.exporter.otlp.local_tempo.input,
+            otelcol.exporter.otlphttp.central.input,
+          ]
         }
       }
 
-      // Export traces to external Tempo
+      // Export traces to LOCAL Tempo (preserves existing local monitoring)
+      // Uses gRPC OTLP to local Tempo in tempo namespace
+      otelcol.exporter.otlp "local_tempo" {
+        client {
+          endpoint = "tempo.tempo.svc.cluster.local:4317"
+
+          tls {
+            insecure = true
+          }
+        }
+      }
+
+      // Export traces to external/central Tempo
       otelcol.exporter.otlphttp "central" {
         client {
           endpoint = env("TEMPO_OTLP_URL")
@@ -230,7 +258,7 @@ alloy:
         }
       }
 
-      // Basic auth for OTLP
+      // Basic auth for central OTLP
       otelcol.auth.basic "credentials" {
         username = env("TEMPO_OTLP_USER")
         password = env("TEMPO_OTLP_PASS")


### PR DESCRIPTION
## Summary
- Fix trace forwarding to central monitoring by exposing OTLP receiver ports (4317/4318) on the observability-alloy Service
- Implement fan-out architecture: Alloy now forwards traces to BOTH local Tempo (preserving existing monitoring) AND central Tempo
- Make OTLP endpoint conditional in values-local.yaml.gotmpl - automatically routes through Alloy when observability-alloy is enabled with traces

## Problem
Central monitoring was not receiving traces from validators. Investigation revealed:
1. The observability-alloy Service only exposed port 12345 (http-metrics), missing the OTLP receiver ports 4317/4318
2. Linera apps (shards/proxy) were sending traces directly to local Tempo, bypassing Alloy entirely

## Solution
1. Added `extraPorts` to expose OTLP receiver ports 4317 (gRPC) and 4318 (HTTP) on the Alloy Service
2. Modified Alloy trace config to fan-out to both:
   - Local Tempo: `tempo.tempo.svc.cluster.local:4317` (preserves existing local monitoring)
   - Central Tempo: via OTLP HTTP with basic auth
3. Made `otlpExporterEndpoint` conditional - when observability-alloy AND tempo are enabled, automatically route through Alloy for dual forwarding

## Test plan
- [ ] Verify Alloy Service now exposes ports 4317 and 4318
- [ ] Verify traces still appear in local Tempo/Grafana
- [ ] Verify traces now appear in central Grafana Cloud
- [ ] Confirm no impact to existing local monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)