### PR TITLE
Use prebuilt `jemalloc-sys`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -21,6 +21,7 @@
     git
     wasm-bindgen-cli
     pnpm
+    rust-jemalloc-sys
   ];
   checkInputs = with pkgs; [
     jq


### PR DESCRIPTION
## Motivation

jemalloc's feature detection is broken under Nix
(https://github.com/NixOS/nixpkgs/issues/370494).

Thankfully nixpkgs provides a patched version, which also saves us building it from source.

## Proposal

Add the prebuilt `rust-jemalloc-sys` to `buildInputs`.

## Test Plan

Built locally.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
