### PR TITLE
Backport: Merge tracked chains with listening mode map. (#5232)

### DIFF
--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -11,7 +11,7 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_core::{
-    client::{ChainClient, ChainClientOptions, Client},
+    client::{ChainClient, ChainClientOptions, Client, ListeningMode},
     environment,
     test_utils::{MemoryStorageBuilder, StorageBuilder as _, TestBuilder},
     wallet,
@@ -112,7 +112,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
             },
             admin_id,
             false,
-            [chain_id0],
+            [(chain_id0, ListeningMode::FullChain)],
             format!("Client node for {:.8}", chain_id0),
             Duration::from_secs(30),
             Duration::from_secs(1),
@@ -220,7 +220,10 @@ async fn test_chain_listener_follow_only() -> anyhow::Result<()> {
             },
             admin_id,
             false,
-            [chain_a_id, chain_b_id],
+            [
+                (chain_a_id, ListeningMode::FollowChain),
+                (chain_b_id, ListeningMode::FullChain),
+            ],
             "Client node with follow-only and owned chains".to_string(),
             Duration::from_secs(30),
             Duration::from_secs(1),
@@ -367,7 +370,7 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
             },
             admin_id,
             false,
-            [],
+            std::iter::empty::<(ChainId, ListeningMode)>(),
             "Client node with no chains".to_string(),
             Duration::from_secs(30),
             Duration::from_secs(1),

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -5,7 +5,7 @@
 
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     iter,
     sync::{self, Arc},
 };
@@ -43,6 +43,7 @@ use tracing::{debug, instrument, trace, warn};
 
 use super::{ChainWorkerConfig, ChainWorkerRequest, DeliveryNotifier, EventSubscriptionsResult};
 use crate::{
+    client::ListeningMode,
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     value_cache::ValueCache,
     worker::{NetworkActions, Notification, Reason, WorkerError},
@@ -60,7 +61,7 @@ where
     service_runtime_endpoint: Option<ServiceRuntimeEndpoint>,
     block_values: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
     execution_state_cache: Arc<ValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>,
-    tracked_chains: Option<Arc<sync::RwLock<HashSet<ChainId>>>>,
+    chain_modes: Option<Arc<sync::RwLock<BTreeMap<ChainId, ListeningMode>>>>,
     delivery_notifier: DeliveryNotifier,
     knows_chain_is_active: bool,
 }
@@ -86,7 +87,7 @@ where
         storage: StorageClient,
         block_values: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
         execution_state_cache: Arc<ValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>,
-        tracked_chains: Option<Arc<sync::RwLock<HashSet<ChainId>>>>,
+        chain_modes: Option<Arc<sync::RwLock<BTreeMap<ChainId, ListeningMode>>>>,
         delivery_notifier: DeliveryNotifier,
         chain_id: ChainId,
         service_runtime_endpoint: Option<ServiceRuntimeEndpoint>,
@@ -101,7 +102,7 @@ where
             service_runtime_endpoint,
             block_values,
             execution_state_cache,
-            tracked_chains,
+            chain_modes,
             delivery_notifier,
             knows_chain_is_active: false,
         })
@@ -400,23 +401,27 @@ where
         Ok(maybe_blobs)
     }
 
-    /// Adds any newly created chains to the set of `tracked_chains`, if the parent chain is
-    /// also tracked.
+    /// Adds any newly created chains to the set of tracked chains, if the parent chain is
+    /// a full chain (i.e., we synchronize its sender chains and update its inbox).
     ///
-    /// Chains that are not tracked are usually processed only because they sent some message
-    /// to one of the tracked chains. In most use cases, their children won't be of interest.
+    /// Chains that are not full are usually processed only because they sent some message
+    /// to one of our full chains. In most use cases, their children won't be of interest.
     fn track_newly_created_chains(
         &self,
         proposed_block: &ProposedBlock,
         outcome: &BlockExecutionOutcome,
     ) {
-        if let Some(tracked_chains) = self.tracked_chains.as_ref() {
-            if !tracked_chains
-                .read()
-                .expect("Panics should not happen while holding a lock to `tracked_chains`")
-                .contains(&proposed_block.chain_id)
+        if let Some(chain_modes) = self.chain_modes.as_ref() {
             {
-                return; // The parent chain is not tracked; don't track the child.
+                let modes = chain_modes
+                    .read()
+                    .expect("Panics should not happen while holding a lock to `chain_modes`");
+                let is_full = modes
+                    .get(&proposed_block.chain_id)
+                    .is_some_and(ListeningMode::is_full);
+                if !is_full {
+                    return; // The parent chain is not a full chain; don't track the child.
+                }
             }
             let new_chain_ids = outcome
                 .created_blobs_ids()
@@ -424,10 +429,12 @@ where
                 .filter(|blob_id| blob_id.blob_type == BlobType::ChainDescription)
                 .map(|blob_id| ChainId(blob_id.hash));
 
-            tracked_chains
+            let mut modes = chain_modes
                 .write()
-                .expect("Panics should not happen while holding a lock to `tracked_chains`")
-                .extend(new_chain_ids);
+                .expect("Panics should not happen while holding a lock to `chain_modes`");
+            for chain_id in new_chain_ids {
+                modes.insert(chain_id, ListeningMode::FullChain);
+            }
         }
     }
 
@@ -441,11 +448,12 @@ where
     ) -> Result<NetworkActions, WorkerError> {
         let mut heights_by_recipient = BTreeMap::<_, Vec<_>>::new();
         let mut targets = self.chain.nonempty_outbox_chain_ids();
-        if let Some(tracked_chains) = self.tracked_chains.as_ref() {
-            let tracked_chains = tracked_chains
+        if let Some(chain_modes) = self.chain_modes.as_ref() {
+            let chain_modes = chain_modes
                 .read()
-                .expect("Panics should not happen while holding a lock to `tracked_chains`");
-            targets.retain(|target| tracked_chains.contains(target));
+                .expect("Panics should not happen while holding a lock to `chain_modes`");
+            // Only process outboxes for full chains (those whose inboxes we update).
+            targets.retain(|target| chain_modes.get(target).is_some_and(ListeningMode::is_full));
         }
         let outboxes = self.chain.load_outboxes(&targets).await?;
         for (target, outbox) in targets.into_iter().zip(outboxes) {
@@ -570,7 +578,7 @@ where
     }
 
     /// Returns true if there are no more outgoing messages in flight up to the given
-    /// block height.
+    /// block height for all tracked chains (those whose inboxes we update).
     #[instrument(skip_all, fields(
         chain_id = %self.chain_id(),
         height = %height
@@ -582,13 +590,14 @@ where
         if self.chain.all_messages_delivered_up_to(height) {
             return Ok(true);
         }
-        let Some(tracked_chains) = self.tracked_chains.as_ref() else {
+        let Some(chain_modes) = self.chain_modes.as_ref() else {
             return Ok(false);
         };
         let mut targets = self.chain.nonempty_outbox_chain_ids();
         {
-            let tracked_chains = tracked_chains.read().unwrap();
-            targets.retain(|target| tracked_chains.contains(target));
+            let chain_modes = chain_modes.read().unwrap();
+            // Only consider full chains (those whose inboxes we update).
+            targets.retain(|target| chain_modes.get(target).is_some_and(ListeningMode::is_full));
         }
         let outboxes = self.chain.load_outboxes(&targets).await?;
         for outbox in outboxes {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -46,7 +46,7 @@ use crate::test_utils::ServiceStorageBuilder;
 use crate::{
     client::{
         BlanketMessagePolicy, ChainClient, ChainClientError, ChainClientOptions, ClientOutcome,
-        ListeningMode, MessageAction, MessagePolicy,
+        MessageAction, MessagePolicy,
     },
     environment::wallet::Chain,
     local_node::LocalNodeError,
@@ -75,8 +75,7 @@ fn test_listener_is_send() {
     async fn check_listener(
         chain_client: ChainClient<impl Environment>,
     ) -> Result<(), ChainClientError> {
-        let (listener, _abort_notifications, _notifications) =
-            chain_client.listen(ListeningMode::FullChain).await?;
+        let (listener, _abort_notifications, _notifications) = chain_client.listen().await?;
         ensure_send(&listener);
         Ok(())
     }
@@ -104,7 +103,7 @@ where
     let chain_2 = builder.add_root_chain(2, Amount::ZERO).await?;
     // Listen to the notifications on the sender chain.
     let mut notifications = sender.subscribe()?;
-    let (listener, _listen_handle, _) = sender.listen(ListeningMode::FullChain).await?;
+    let (listener, _listen_handle, _) = sender.listen().await?;
     tokio::spawn(listener);
     {
         let certificate = sender

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -48,7 +48,7 @@ use {
 };
 
 use crate::{
-    client::{ChainClientOptions, Client},
+    client::{ChainClientOptions, Client, ListeningMode},
     data_types::*,
     environment::{wallet::Chain, TestSigner, TestWallet},
     node::{
@@ -1060,7 +1060,7 @@ where
             },
             self.admin_id(),
             false,
-            [chain_id],
+            [(chain_id, ListeningMode::FullChain)],
             format!("Client node for {:.8}", chain_id),
             Duration::from_secs(30),
             Duration::from_secs(1),

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
     sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
@@ -44,6 +44,7 @@ use crate::{
     chain_worker::{
         BlockOutcome, ChainWorkerActor, ChainWorkerConfig, ChainWorkerRequest, DeliveryNotifier,
     },
+    client::ListeningMode,
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     join_set_ext::{JoinSet, JoinSetExt},
     notifier::Notifier,
@@ -368,8 +369,8 @@ where
     chain_worker_config: ChainWorkerConfig,
     block_cache: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
     execution_state_cache: Arc<ValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>,
-    /// Chain IDs that should be tracked by a worker.
-    tracked_chains: Option<Arc<RwLock<HashSet<ChainId>>>>,
+    /// Chains tracked by a worker, along with their listening modes.
+    chain_modes: Option<Arc<RwLock<BTreeMap<ChainId, ListeningMode>>>>,
     /// One-shot channels to notify callers when messages of a particular chain have been
     /// delivered.
     delivery_notifiers: Arc<Mutex<DeliveryNotifiers>>,
@@ -390,7 +391,7 @@ where
             chain_worker_config: self.chain_worker_config.clone(),
             block_cache: self.block_cache.clone(),
             execution_state_cache: self.execution_state_cache.clone(),
-            tracked_chains: self.tracked_chains.clone(),
+            chain_modes: self.chain_modes.clone(),
             delivery_notifiers: self.delivery_notifiers.clone(),
             chain_worker_tasks: self.chain_worker_tasks.clone(),
             chain_workers: self.chain_workers.clone(),
@@ -423,7 +424,7 @@ where
             chain_worker_config: ChainWorkerConfig::default().with_key_pair(key_pair),
             block_cache: Arc::new(ValueCache::new(BLOCK_CACHE_SIZE)),
             execution_state_cache: Arc::new(ValueCache::new(EXECUTION_STATE_CACHE_SIZE)),
-            tracked_chains: None,
+            chain_modes: None,
             delivery_notifiers: Arc::default(),
             chain_worker_tasks: Arc::default(),
             chain_workers: Arc::new(Mutex::new(BTreeMap::new())),
@@ -434,7 +435,7 @@ where
     pub fn new_for_client(
         nickname: String,
         storage: StorageClient,
-        tracked_chains: Arc<RwLock<HashSet<ChainId>>>,
+        chain_modes: Arc<RwLock<BTreeMap<ChainId, ListeningMode>>>,
     ) -> Self {
         WorkerState {
             nickname,
@@ -442,7 +443,7 @@ where
             chain_worker_config: ChainWorkerConfig::default(),
             block_cache: Arc::new(ValueCache::new(BLOCK_CACHE_SIZE)),
             execution_state_cache: Arc::new(ValueCache::new(EXECUTION_STATE_CACHE_SIZE)),
-            tracked_chains: Some(tracked_chains),
+            chain_modes: Some(chain_modes),
             delivery_notifiers: Arc::default(),
             chain_worker_tasks: Arc::default(),
             chain_workers: Arc::new(Mutex::new(BTreeMap::new())),
@@ -848,17 +849,20 @@ where
                 .or_default()
                 .clone();
 
-            let is_tracked = self
-                .tracked_chains
-                .as_ref()
-                .is_some_and(|tracked_chains| tracked_chains.read().unwrap().contains(&chain_id));
+            let is_tracked = self.chain_modes.as_ref().is_some_and(|chain_modes| {
+                chain_modes
+                    .read()
+                    .unwrap()
+                    .get(&chain_id)
+                    .is_some_and(ListeningMode::is_full)
+            });
 
             let actor_task = ChainWorkerActor::run(
                 self.chain_worker_config.clone(),
                 self.storage.clone(),
                 self.block_cache.clone(),
                 self.execution_state_cache.clone(),
-                self.tracked_chains.clone(),
+                self.chain_modes.clone(),
                 delivery_notifier,
                 chain_id,
                 receiver,

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1045,8 +1045,7 @@ impl Runnable for Job {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
                 let chain_client = context.make_chain_client(chain_id).await?;
                 info!("Watching for notifications for chain {:?}", chain_id);
-                let (listener, _listen_handle, mut notifications) =
-                    chain_client.listen(ListeningMode::FullChain).await?;
+                let (listener, _listen_handle, mut notifications) = chain_client.listen().await?;
                 join_set.spawn_task(listener);
                 while let Some(notification) = notifications.next().await {
                     if let Reason::NewBlock { .. } = notification.reason {
@@ -1538,7 +1537,9 @@ impl Runnable for Job {
                     .create_client_context(storage, wallet, signer.into_value())
                     .await?;
                 let start_time = Instant::now();
-                context.client.track_chain(chain_id);
+                context
+                    .client
+                    .extend_chain_mode(chain_id, ListeningMode::FollowChain);
                 let chain_client = context.make_chain_client(chain_id).await?;
                 if sync {
                     chain_client.synchronize_chain_state(chain_id).await?;

--- a/linera-service/tests/wallet.rs
+++ b/linera-service/tests/wallet.rs
@@ -10,7 +10,7 @@ use linera_base::{
 use linera_chain::data_types::ProposedBlock;
 use linera_client::{client_context::ClientContext, config::GenesisConfig};
 use linera_core::{
-    client::{Client, PendingProposal},
+    client::{Client, ListeningMode, PendingProposal},
     join_set_ext::JoinSet,
     test_utils::{MemoryStorageBuilder, StorageBuilder, TestBuilder},
     wallet,
@@ -40,6 +40,7 @@ pub async fn new_test_client_context(
         max_retries,
     };
     let chain_ids: Vec<_> = wallet.chain_ids();
+    let chain_modes = chain_ids.iter().map(|id| (*id, ListeningMode::FullChain));
     let name = match chain_ids.len() {
         0 => "Client node".to_string(),
         1 => format!("Client node for {:.8}", chain_ids[0]),
@@ -58,7 +59,7 @@ pub async fn new_test_client_context(
             },
             genesis_config.admin_id(),
             false,
-            chain_ids,
+            chain_modes,
             name,
             chain_worker_ttl,
             sender_chain_worker_ttl,


### PR DESCRIPTION
## Motivation

`tracked_chains` and `ListeningMode`s both express the client's relation to a chain, and affect how e.g. cross-chain messages to these chains are treated.

## Proposal

Merge them to have a single source of truth.

This is a backport of @afck 's #5232 

## Test Plan

This is mostly a refactoring, so existing tests should suffice.

## Release Plan

- These changes should be released in a new SDK,

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
