### PR TITLE
Set RUST_LOG=linera=info for remote compatibility and rust tests

### DIFF
--- a/.github/workflows/remote_compatibility.yml
+++ b/.github/workflows/remote_compatibility.yml
@@ -33,7 +33,7 @@ env:
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
-  RUST_LOG: linera=debug
+  RUST_LOG: linera=info
   RUST_LOG_FORMAT: plain
   # The remote faucet for this branch
   LINERA_FAUCET_URL: https://faucet.testnet-conway.linera.net

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ env:
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
-  RUST_LOG: linera=debug
+  RUST_LOG: linera=info
   RUST_LOG_FORMAT: plain
   LINERA_STORAGE_SERVICE: 127.0.0.1:1235
   LINERA_WALLET: /tmp/local-linera-net/wallet_0.json


### PR DESCRIPTION
## Motivation

Our tests' logging is very noisy.

## Proposal

Set `linera=info` for remote compatibility tests and `rust.yml`.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
