### PR TITLE
Remove `follow-only` flag.

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -108,6 +108,7 @@ pub trait ClientContext {
                 .await
                 .map_err(error::Inner::wallet)?
                 .unwrap_or_default();
+            let follow_only = chain.is_follow_only();
             Ok(self.client().create_chain_client(
                 chain_id,
                 chain.block_hash,
@@ -115,7 +116,7 @@ pub trait ClientContext {
                 chain.pending_proposal,
                 chain.owner,
                 self.timing_sender(),
-                chain.follow_only,
+                follow_only,
             ))
         }
     }
@@ -261,7 +262,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
                 .into_iter()
                 .map(|result| {
                     let (chain_id, chain) = result?;
-                    let mode = if chain.follow_only {
+                    let mode = if chain.is_follow_only() {
                         ListeningMode::FollowChain
                     } else {
                         ListeningMode::FullChain

--- a/linera-client/src/error.rs
+++ b/linera-client/src/error.rs
@@ -68,8 +68,6 @@ pub(crate) enum Inner {
         chain_id: ChainId,
         error: Box<NodeError>,
     },
-    #[error("Chain {0} not found in wallet")]
-    UnknownChainId(ChainId),
 }
 
 impl Inner {

--- a/linera-core/src/environment/wallet/mod.rs
+++ b/linera-core/src/environment/wallet/mod.rs
@@ -23,11 +23,6 @@ pub struct Chain {
     pub timestamp: Timestamp,
     pub pending_proposal: Option<PendingProposal>,
     pub epoch: Option<Epoch>,
-    /// If true, we only follow this chain's blocks without downloading sender chain blocks
-    /// or participating in consensus rounds. Use this for chains we're interested in observing
-    /// but don't intend to propose blocks for.
-    #[serde(default)]
-    pub follow_only: bool,
 }
 
 impl From<&ChainInfo> for Chain {
@@ -39,7 +34,6 @@ impl From<&ChainInfo> for Chain {
             timestamp: info.timestamp,
             pending_proposal: None,
             epoch: Some(info.epoch),
-            follow_only: false,
         }
     }
 }
@@ -72,8 +66,15 @@ impl Chain {
             next_block_height: BlockHeight::ZERO,
             pending_proposal: None,
             epoch: Some(current_epoch),
-            follow_only: false,
         }
+    }
+
+    /// Returns `true` if we only follow this chain's blocks without participating in consensus.
+    ///
+    /// A chain is follow-only if there is no key pair configured for it, i.e., if `owner` is
+    /// `None`.
+    pub fn is_follow_only(&self) -> bool {
+        self.owner.is_none()
     }
 }
 

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -470,7 +470,7 @@ impl Runnable for Job {
                 let follow_only = context
                     .wallet()
                     .get(chain_id)
-                    .is_some_and(|chain| chain.follow_only);
+                    .is_some_and(|chain| chain.is_follow_only());
                 if follow_only {
                     anyhow::bail!(
                         "Cannot process inbox for follow-only chain {chain_id}. \
@@ -1637,7 +1637,8 @@ impl Runnable for Job {
                     chain_client.fetch_chain_info().await?;
                 }
                 context.update_wallet_from_client(&chain_client).await?;
-                context.set_follow_only(chain_id, true).await?;
+                // Update the in-memory state to follow-only mode.
+                context.client.set_chain_follow_only(chain_id, true);
                 info!(
                     "Chain followed and added in {} ms",
                     start_time.elapsed().as_millis()

--- a/linera-service/src/wallet.rs
+++ b/linera-service/src/wallet.rs
@@ -60,7 +60,7 @@ impl ChainDetails {
         if self.is_admin {
             tags.push("ADMIN");
         }
-        if self.user_chain.follow_only {
+        if self.user_chain.is_follow_only() {
             tags.push("FOLLOW-ONLY");
         }
         if !tags.is_empty() {
@@ -290,13 +290,9 @@ impl Wallet {
     }
 
     pub fn forget_keys(&self, chain_id: ChainId) -> anyhow::Result<AccountOwner> {
-        self.mutate(chain_id, |chain| {
-            // Without keys we can no longer propose blocks, so switch to follow-only mode.
-            chain.follow_only = true;
-            chain.owner.take()
-        })
-        .ok_or(anyhow::anyhow!("nonexistent chain `{chain_id}`"))??
-        .ok_or(anyhow::anyhow!("keypair not found for chain `{chain_id}`"))
+        self.mutate(chain_id, |chain| chain.owner.take())
+            .ok_or(anyhow::anyhow!("nonexistent chain `{chain_id}`"))??
+            .ok_or(anyhow::anyhow!("keypair not found for chain `{chain_id}`"))
     }
 
     pub fn forget_chain(&self, chain_id: ChainId) -> anyhow::Result<wallet::Chain> {


### PR DESCRIPTION
## Motivation

This flag is set explicitly in the wallet, but we want a chain to be "in follow-only mode" if and only if we don't have an owner key pair assigned to it.

## Proposal

Remove the flag.

## Test Plan

Tests were updated.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
