### PR TITLE
[testnet] Don't automatically make every child chain a full chain. (#5238)

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -18,7 +18,7 @@ use linera_base::{
     },
     ensure,
     hashed::Hashed,
-    identifiers::{AccountOwner, ApplicationId, BlobId, BlobType, ChainId, StreamId},
+    identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, StreamId},
 };
 use linera_chain::{
     data_types::{
@@ -399,43 +399,6 @@ where
             maybe_blobs.insert(blob_id, maybe_blob);
         }
         Ok(maybe_blobs)
-    }
-
-    /// Adds any newly created chains to the set of tracked chains, if the parent chain is
-    /// a full chain (i.e., we synchronize its sender chains and update its inbox).
-    ///
-    /// Chains that are not full are usually processed only because they sent some message
-    /// to one of our full chains. In most use cases, their children won't be of interest.
-    fn track_newly_created_chains(
-        &self,
-        proposed_block: &ProposedBlock,
-        outcome: &BlockExecutionOutcome,
-    ) {
-        if let Some(chain_modes) = self.chain_modes.as_ref() {
-            {
-                let modes = chain_modes
-                    .read()
-                    .expect("Panics should not happen while holding a lock to `chain_modes`");
-                let is_full = modes
-                    .get(&proposed_block.chain_id)
-                    .is_some_and(ListeningMode::is_full);
-                if !is_full {
-                    return; // The parent chain is not a full chain; don't track the child.
-                }
-            }
-            let new_chain_ids = outcome
-                .created_blobs_ids()
-                .into_iter()
-                .filter(|blob_id| blob_id.blob_type == BlobType::ChainDescription)
-                .map(|blob_id| ChainId(blob_id.hash));
-
-            let mut modes = chain_modes
-                .write()
-                .expect("Panics should not happen while holding a lock to `chain_modes`");
-            for chain_id in new_chain_ids {
-                modes.insert(chain_id, ListeningMode::FullChain);
-            }
-        }
     }
 
     /// Loads pending cross-chain requests, and adds `NewRound` notifications where appropriate.
@@ -956,7 +919,6 @@ where
         chain
             .apply_confirmed_block(certificate.value(), local_time)
             .await?;
-        self.track_newly_created_chains(&proposed_block, &outcome);
         let mut actions = self.create_network_actions(None).await?;
         trace!("Processed confirmed block {height} on chain {chain_id:.8}");
         let hash = certificate.hash();

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -46,7 +46,7 @@ use crate::test_utils::ServiceStorageBuilder;
 use crate::{
     client::{
         BlanketMessagePolicy, ChainClient, ChainClientError, ChainClientOptions, ClientOutcome,
-        MessageAction, MessagePolicy,
+        ListeningMode, MessageAction, MessagePolicy,
     },
     environment::wallet::Chain,
     local_node::LocalNodeError,
@@ -3222,6 +3222,78 @@ where
     assert!(
         clock.current_time() >= future_time,
         "Clock should have advanced to at least the block timestamp"
+    );
+
+    Ok(())
+}
+
+/// Tests that when a chain is opened for a key we own, the new chain is automatically
+/// tracked as a full chain and its inbox is updated when messages are sent to it.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_open_chain_for_owned_key_is_fully_tracked<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, signer)
+        .await?
+        .with_policy(ResourceControlPolicy::only_fuel());
+
+    // New chains use the admin chain to verify their creation certificate.
+    let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
+    let parent = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
+    let sender = builder.add_root_chain(2, Amount::from_tokens(10)).await?;
+
+    // Generate a new key in the same signer that the parent uses.
+    let new_public_key = builder.signer.generate_new();
+
+    // Open a new chain for the key we own.
+    let (new_description, _certificate) = Box::pin(parent.open_chain(
+        ChainOwnership::single(new_public_key.into()),
+        ApplicationPermissions::default(),
+        Amount::from_tokens(1),
+    ))
+    .await
+    .unwrap_ok_committed();
+    let new_chain_id = new_description.id();
+
+    // Verify the new chain is tracked as FullChain.
+    assert_eq!(
+        parent.client.chain_mode(new_chain_id),
+        Some(ListeningMode::FullChain),
+        "New chain should be tracked as FullChain since we own the key"
+    );
+
+    // Create a client for the new chain.
+    let mut new_chain_client = builder
+        .make_client(new_chain_id, None, BlockHeight::ZERO)
+        .await?;
+    new_chain_client.set_preferred_owner(new_public_key.into());
+
+    // Send a transfer from `sender` to the new chain.
+    sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(3),
+            Account::chain(new_chain_id),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    // Synchronize the new chain and process its inbox.
+    new_chain_client.synchronize_from_validators().await?;
+    new_chain_client.process_inbox().await?;
+
+    // Verify the new chain received the funds (initial 1 token + 3 transferred).
+    let balance = new_chain_client.local_balance().await?;
+    assert!(
+        balance >= Amount::from_tokens(3),
+        "New chain should have received the transferred funds, got {balance}"
     );
 
     Ok(())


### PR DESCRIPTION
Backport of #5238.

## Motivation

The chain worker used to add every chain that was opened as a child of a tracked chain to the tracked chains, too. That was so that _if_ the current user owned the child chain, and the chain listener added it, it would be able to receive messages.

But now tracked chains have been merged with the listening modes (https://github.com/linera-io/linera-protocol/pull/5232), so it suffices to add these in the chain listener.

## Proposal

Move that functionality from the chain worker to the client/listener.

## Test Plan

CI

## Release Plan

- These changes should be released in a new SDK.

## Links

- PR to main: #5238
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)