### PR TITLE
Do not reset epoch and timestamp for existing chains.

### DIFF
--- a/linera-core/src/environment/wallet/memory.rs
+++ b/linera-core/src/environment/wallet/memory.rs
@@ -107,4 +107,12 @@ impl Wallet for Memory {
     fn items(&self) -> impl Stream<Item = Result<(ChainId, Chain), Self::Error>> {
         futures::stream::iter(self.items()).map(Ok)
     }
+
+    async fn modify(
+        &self,
+        id: ChainId,
+        f: impl FnMut(&mut Chain) + Send,
+    ) -> Result<Option<()>, Self::Error> {
+        Ok(self.mutate(id, f))
+    }
 }

--- a/linera-service/src/wallet.rs
+++ b/linera-service/src/wallet.rs
@@ -129,6 +129,14 @@ impl linera_core::Wallet for Wallet {
         self.save()?;
         Ok(chain)
     }
+
+    async fn modify(
+        &self,
+        id: ChainId,
+        f: impl FnMut(&mut wallet::Chain) + Send,
+    ) -> Result<Option<()>, Self::Error> {
+        self.mutate(id, f).transpose()
+    }
 }
 
 impl Extend<(ChainId, wallet::Chain)> for Wallet {


### PR DESCRIPTION
## Motivation

`assign_new_chain_to_key` overwrites timestamp and epoch for existing entries.

## Proposal

Only set them for _new_ entries, like we do on main.

## Test Plan

(Trivial change; code matches main branch now.)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #5247.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
