### PR TITLE
Remove `let _ =`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,9 @@ Contributions should generally follow the [Rust API guidelines](https://rust-lan
 
 * Re-exports (`pub use foo = bar::foo`) should be limited to definitions that would be private otherwise.
 
+* Avoid `let _ = ...` to discard values, because it can hide important information like
+  unawaited futures or unhandled errors.
+
 
 ## Formatting and linting
 

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -41,7 +41,7 @@ impl Contract for CrowdFundingContract {
 
     async fn instantiate(&mut self, argument: InstantiationArgument) {
         // Validate that the application parameters were configured correctly.
-        let _ = self.runtime.application_parameters();
+        let _parameters = self.runtime.application_parameters();
 
         self.state.instantiation_argument.set(Some(argument));
 

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -42,7 +42,7 @@ impl Contract for FungibleTokenContract {
 
     async fn instantiate(&mut self, state: Self::InstantiationArgument) {
         // Validate that the application parameters were configured correctly.
-        let _ = self.runtime.application_parameters();
+        let _parameters = self.runtime.application_parameters();
 
         let mut total_supply = Amount::ZERO;
         for value in state.accounts.values() {

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -434,8 +434,7 @@ impl<Env: Environment> ClientContext<Env> {
         timestamp: Timestamp,
         epoch: Epoch,
     ) -> Result<(), Error> {
-        let _ = self
-            .wallet()
+        self.wallet()
             .try_insert(
                 chain_id,
                 linera_core::wallet::Chain::new(owner, epoch, timestamp),

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -57,7 +57,8 @@ impl chain_listener::ClientContext for ClientContext {
         timestamp: Timestamp,
         epoch: Epoch,
     ) -> Result<(), Error> {
-        let _ = self
+        // Ignore if chain already exists in wallet; test mock doesn't care.
+        let _insert_result = self
             .wallet()
             .try_insert(chain_id, wallet::Chain::new(owner, epoch, timestamp));
         Ok(())

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -400,7 +400,7 @@ where
                     clock.sleep_until(delay_until).await;
                     // Re-insert the request into the queue. If the channel is closed,
                     // the actor is shutting down, so we can ignore the error.
-                    let _ = sender.send((request, span, queued_at));
+                    sender.send((request, span, queued_at)).ok();
                 })
                 .forget();
                 return None;

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -1326,7 +1326,7 @@ mod tests {
         // Wait for all requests to complete
         let _result1 = first_request.await.unwrap();
         for handle in handles {
-            let _ = handle.await.unwrap();
+            handle.await.unwrap().ok();
         }
 
         // After completion, the in-flight entry should be removed

--- a/linera-core/src/environment/wallet/memory.rs
+++ b/linera-core/src/environment/wallet/memory.rs
@@ -80,7 +80,7 @@ impl Extend<(ChainId, Chain)> for Memory {
     fn extend<It: IntoIterator<Item = (ChainId, Chain)>>(&mut self, chains: It) {
         let map = self.0.pin();
         for (id, chain) in chains {
-            let _ = map.insert(id, chain);
+            map.insert(id, chain);
         }
     }
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -216,7 +216,7 @@ where
         index: u32,
     ) -> Result<(ApplicationId, MockApplication), anyhow::Error> {
         let mut chain = self.worker.storage.load_chain(chain_id).await?;
-        let _ = chain
+        chain
             .execution_state
             .register_mock_application(index)
             .await?;
@@ -4253,8 +4253,7 @@ where
         .into_first_proposal(owner, &signer)
         .await
         .unwrap();
-    let _ = env
-        .executing_worker()
+    env.executing_worker()
         .handle_block_proposal(block_proposal)
         .await?;
 
@@ -4279,7 +4278,7 @@ where
     }
     .into_view()
     .await;
-    let _ = state.register_mock_application(0).await?;
+    state.register_mock_application(0).await?;
 
     let certificate = env.execute_proposal(block.clone(), vec![]).await?;
 

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -596,7 +596,10 @@ where
                         "validator's clock is behind; waiting and retrying",
                     );
                     // Report the clock skew before sleeping so the caller can aggregate.
-                    let _ = clock_skew_sender.send((self.remote_node.public_key, clock_skew));
+                    // Receiver may have been dropped if the caller is no longer interested.
+                    clock_skew_sender
+                        .send((self.remote_node.public_key, clock_skew))
+                        .ok();
                     storage
                         .clock()
                         .sleep_until(block_timestamp.saturating_add(clock_skew))

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -965,10 +965,10 @@ where
     #[cfg(web)]
     fn send_log(&mut self, message: String, level: tracing::log::Level) {
         let this = self.inner();
-        // Fire-and-forget: ignore errors since logging shouldn't affect execution
-        let _ = this
-            .execution_state_sender
-            .unbounded_send(ExecutionRequest::Log { message, level });
+        // Fire-and-forget: ignore errors since logging shouldn't affect execution.
+        this.execution_state_sender
+            .unbounded_send(ExecutionRequest::Log { message, level })
+            .ok();
     }
 }
 

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -653,7 +653,8 @@ async fn route_aux(
             let page_result = page(page_name, &node, &indexer, chain_id, &args).await;
             if chain_changed {
                 if let Some(ws) = WEBSOCKET.get() {
-                    let _ = ws.close().await;
+                    // Ignore close errors; we're switching to a new connection anyway.
+                    ws.close().await.ok();
                 }
                 let address = url(&data.config, Protocol::Websocket, AddressKind::Node);
                 subscribe_chain(app, &address, chain_id).await;
@@ -758,7 +759,8 @@ async fn subscribe_chain(app: &JsValue, address: &str, chain: ChainId) {
             }
         }
     });
-    let _ = WEBSOCKET.set(ws);
+    // Ignore if already set; this can happen during re-subscription.
+    WEBSOCKET.set(ws).ok();
 }
 
 /// Initializes pages and subscribes to notifications.
@@ -782,7 +784,7 @@ pub async fn start(app: JsValue) {
         }
         Ok(default_chain) => {
             let indexer = url(&data.config, Protocol::Http, AddressKind::Indexer);
-            let _ = plugins(&app, &indexer).await;
+            plugins(&app, &indexer).await;
             let uri = web_sys::window()
                 .expect("window object not found")
                 .location()

--- a/linera-faucet/server/src/tests.rs
+++ b/linera-faucet/server/src/tests.rs
@@ -183,7 +183,7 @@ async fn test_faucet_rate_limiting() {
 
     // Clean up
     cancellation_token.cancel();
-    let _ = processor_task.await;
+    processor_task.await.unwrap();
 }
 
 #[test]
@@ -393,7 +393,7 @@ async fn test_faucet_persistence() {
 
     // Stop the batch processor
     cancellation_token.cancel();
-    let _ = processor_task.await;
+    processor_task.await.unwrap();
 
     // Drop the first faucet instance to simulate shutdown
     drop(root);
@@ -513,7 +513,7 @@ async fn test_faucet_persistence() {
 
     // Clean up
     cancellation_token_2.cancel();
-    let _ = processor_task_2.await;
+    processor_task_2.await.unwrap();
 }
 
 #[test_log::test(tokio::test)]
@@ -614,7 +614,7 @@ async fn test_blockchain_sync_after_database_deletion() {
 
     // Stop the batch processor and clean up first instance
     cancellation_token.cancel();
-    let _ = processor_task.await;
+    processor_task.await.unwrap();
     drop(root);
     drop(faucet_storage);
 
@@ -724,5 +724,5 @@ async fn test_blockchain_sync_after_database_deletion() {
 
     // Clean up
     cancellation_token_2.cancel();
-    let _ = processor_task_2.await;
+    processor_task_2.await.unwrap();
 }

--- a/linera-rpc/tests/transport.rs
+++ b/linera-rpc/tests/transport.rs
@@ -24,7 +24,7 @@ async fn client() {
         timeout: Some(Duration::from_millis(100)),
     };
     let channel = create_channel(address.clone(), &options).unwrap();
-    let _ = GrpcClient::new(address, channel, retry_delay, max_retries)
+    GrpcClient::new(address, channel, retry_delay, max_retries)
         .get_version_info()
         .await
         .unwrap();

--- a/linera-sdk/tests/fixtures/meta-counter/src/contract.rs
+++ b/linera-sdk/tests/fixtures/meta-counter/src/contract.rs
@@ -72,8 +72,7 @@ impl Contract for MetaCounterContract {
         if query_service {
             // Make a service query: The result will be logged in the block.
             let counter_id = self.counter_id();
-            let _ = self
-                .runtime
+            self.runtime
                 .query_service(counter_id, &"query { value }".into());
         }
         message.send_to(recipient_id);

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1712,11 +1712,13 @@ impl Runnable for Job {
 async fn kill_all_processes(pids: &[u32]) {
     for &pid in pids {
         info!("Killing benchmark process (pid {})", pid);
-        let _ = Command::new("kill")
+        // Ignore kill errors; the process may have already exited.
+        Command::new("kill")
             .arg("-9")
             .arg(pid.to_string())
             .status()
-            .await;
+            .await
+            .ok();
     }
 }
 

--- a/linera-service/src/exporter/runloops/block_processor/mod.rs
+++ b/linera-service/src/exporter/runloops/block_processor/mod.rs
@@ -248,7 +248,7 @@ mod test {
         );
         let (block_ids, state) = make_state(&storage).await;
         for id in block_ids {
-            let _ = tx.send(id);
+            tx.send(id).ok();
         }
 
         tokio::select! {
@@ -383,7 +383,7 @@ mod test {
             false,
         );
         let (block_id, state) = make_state_2(&storage).await;
-        let _ = tx.send(block_id);
+        tx.send(block_id).ok();
 
         tokio::select! {
             _ = tokio::time::sleep(Duration::from_secs(10)) => {},
@@ -499,7 +499,7 @@ mod test {
             false,
         );
         let (block_id, state) = make_state_3(&storage).await;
-        let _ = tx.send(block_id);
+        tx.send(block_id).ok();
 
         tokio::select! {
             _ = tokio::time::sleep(Duration::from_secs(10)) => {},
@@ -586,7 +586,7 @@ mod test {
             false,
         );
         let (block_id, state) = make_state_4(&storage).await;
-        let _ = tx.send(block_id);
+        tx.send(block_id).ok();
 
         tokio::select! {
             _ = tokio::time::sleep(Duration::from_secs(10)) => {},
@@ -695,7 +695,7 @@ mod test {
             false,
         );
         let (block_id, expected_state) = make_simple_state_with_blobs(&storage).await;
-        let _ = tx.send(block_id);
+        tx.send(block_id).ok();
 
         tokio::select! {
             _ = tokio::time::sleep(Duration::from_secs(10)) => {},

--- a/linera-service/src/exporter/runloops/block_processor/walker.rs
+++ b/linera-service/src/exporter/runloops/block_processor/walker.rs
@@ -80,7 +80,7 @@ where
                 let block_to_push = CanonicalBlock::new(block_id.hash, &blobs_to_send);
                 self.storage.push_block(block_to_push);
                 for blob in blobs_to_index_block_with {
-                    let _ = self.storage.index_blob(blob);
+                    self.storage.index_blob(blob).ok();
                 }
             }
 

--- a/linera-service/src/exporter/runloops/indexer/indexer_exporter.rs
+++ b/linera-service/src/exporter/runloops/indexer/indexer_exporter.rs
@@ -130,7 +130,7 @@ impl AcknowledgementTask {
     }
 
     fn increment_destination_state(&self) {
-        let _ = self.destination_state.fetch_add(1, Ordering::Release);
+        self.destination_state.fetch_add(1, Ordering::Release);
     }
 }
 

--- a/linera-service/src/exporter/runloops/validator_exporter.rs
+++ b/linera-service/src/exporter/runloops/validator_exporter.rs
@@ -139,7 +139,7 @@ where
     }
 
     fn increment_destination_state(&self) {
-        let _ = self.destination_state.fetch_add(1, Ordering::Release);
+        self.destination_state.fetch_add(1, Ordering::Release);
         #[cfg(with_metrics)]
         crate::metrics::DESTINATION_STATE_COUNTER
             .with_label_values(&[self.node.address()])
@@ -172,7 +172,7 @@ where
             }
         });
 
-        let _ = try_join_all(tasks).await?;
+        try_join_all(tasks).await?;
 
         Ok(())
     }
@@ -256,7 +256,8 @@ where
         }
 
         while let Some(certificate) = futures.next().await.transpose()? {
-            let _ = self.buffer.send(certificate).await;
+            // Ignore send errors; the receiver may have been dropped during shutdown.
+            self.buffer.send(certificate).await.ok();
             futures.push_back(self.get_block_task(index));
             index += 1;
         }

--- a/linera-service/src/exporter/storage.rs
+++ b/linera-service/src/exporter/storage.rs
@@ -112,7 +112,7 @@ where
                 let block = self.storage.read_certificate(hash).await?;
                 let block = block.ok_or_else(|| ExporterError::ReadCertificateError(hash))?;
                 let heaped_block = Arc::new(block);
-                let _ = guard.insert(heaped_block.clone());
+                guard.insert(heaped_block.clone()).ok();
                 Ok(heaped_block)
             }
         }
@@ -126,7 +126,7 @@ where
                 metrics::GET_BLOB_HISTOGRAM.measure_latency();
                 let blob = self.storage.read_blob(blob_id).await?.unwrap();
                 let heaped_blob = Arc::new(blob);
-                let _ = guard.insert(heaped_blob.clone());
+                guard.insert(heaped_blob.clone()).ok();
                 Ok(heaped_blob)
             }
         }
@@ -454,7 +454,7 @@ where
                         .ok_or(ExporterError::UnprocessedBlock)?
                 };
 
-                let _ = guard.insert(block.clone());
+                guard.insert(block.clone()).ok();
                 Ok(block)
             }
         }

--- a/linera-service/src/tracing/chrome.rs
+++ b/linera-service/src/tracing/chrome.rs
@@ -47,6 +47,7 @@ pub fn build(
 /// In that case, tracing may not work as expected.
 pub fn init(log_name: &str, writer: impl std::io::Write + Send + 'static) -> ChromeTraceGuard {
     let (subscriber, guard) = build(log_name, writer);
-    let _ = subscriber.try_init();
+    // May fail if a global subscriber is already set.
+    subscriber.try_init().ok();
     guard
 }


### PR DESCRIPTION
## Motivation

`let _ =` can hide unawaited futures and discarded errors.

## Proposal

Add to `CONTRIBUTING.md` that we want to avoid this.

Fix the occurrences. Some were unnecessary in the first place; some were missing `unwrap` or `?`s in tests.

In some cases I added `.ok()`, replacing the `Result` with an `Option`. This is slightly better because I believe the compiler would still complain if it e.g. were a _nested_ result.

## Test Plan

CI

## Release Plan

- These changes could be backported to `testnet_conway`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
