### PR TITLE
Add `--allow-fast-blocks` option.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -146,6 +146,7 @@ Client implementation and command-line tool for the Linera blockchain
 
   Default value: `10`
 * `--wait-for-outgoing-messages` — Whether to wait until a quorum of validators has confirmed that all sent cross-chain messages have been delivered
+* `--allow-fast-blocks` — Whether to allow creating blocks in the fast round. Fast blocks have lower latency but must be used carefully so that there are never any conflicting fast block proposals
 * `--long-lived-services` — (EXPERIMENTAL) Whether application services can persist in some cases between queries
 * `--blanket-message-policy <BLANKET_MESSAGE_POLICY>` — The policy for handling incoming messages
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -88,6 +88,11 @@ pub struct Options {
     #[arg(long)]
     pub wait_for_outgoing_messages: bool,
 
+    /// Whether to allow creating blocks in the fast round. Fast blocks have lower latency but
+    /// must be used carefully so that there are never any conflicting fast block proposals.
+    #[arg(long)]
+    pub allow_fast_blocks: bool,
+
     /// (EXPERIMENTAL) Whether application services can persist in some cases between queries.
     #[arg(long)]
     pub long_lived_services: bool,
@@ -260,6 +265,7 @@ impl Options {
             certificate_download_batch_size: self.certificate_download_batch_size,
             sender_certificate_download_batch_size: self.sender_certificate_download_batch_size,
             max_joined_tasks: self.max_joined_tasks,
+            allow_fast_blocks: self.allow_fast_blocks,
         }
     }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -517,7 +517,7 @@ where
     let mut signer = InMemorySigner::new(None);
     let regular_owner = signer.generate_new().into();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
-    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let mut sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let super_owner = sender.identity().await?;
 
     // Configure chain with one super owner and one regular owner, no multi-leader rounds.
@@ -530,6 +530,9 @@ where
         timeout_config: TimeoutConfig::default(),
     });
     sender.execute_operation(owner_change_op).await.unwrap();
+
+    // Enable fast blocks so the super owner can propose in the Fast round.
+    sender.options_mut().allow_fast_blocks = true;
 
     // The super owner can still burn tokens since that doesn't use the validation round oracle.
     sender
@@ -2614,7 +2617,9 @@ where
     let signer = InMemorySigner::new(None);
     let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
-    let client0 = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
+    let mut client0 = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
+    // Enable fast blocks for this test that specifically tests fast block behavior.
+    client0.options_mut().allow_fast_blocks = true;
     let chain_id = client0.chain_id();
     let owner0 = client0.identity().await.unwrap();
     let owner1 = builder.signer.generate_new().into();
@@ -2639,6 +2644,7 @@ where
             BlockHeight::from(1),
         )
         .await?;
+    client1.options_mut().allow_fast_blocks = true;
     client1.set_preferred_owner(owner1);
 
     // Client 0 transfers 5 tokens from the chain account to themselves.
@@ -2829,13 +2835,14 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer)
         .await?
         .with_policy(policy.clone());
-    let client1 = builder.add_root_chain(1, Amount::ONE).await?;
-    let client2 = builder.add_root_chain(2, Amount::ONE).await?;
-    let client3 = builder.add_root_chain(3, Amount::ONE).await?;
+    let mut client1 = builder.add_root_chain(1, Amount::ONE).await?;
+    let mut client2 = builder.add_root_chain(2, Amount::ONE).await?;
+    let mut client3 = builder.add_root_chain(3, Amount::ONE).await?;
     let chain_id3 = client3.chain_id();
 
-    // Configure the clients as super owners, so they make fast blocks by default.
-    for client in [&client1, &client2, &client3] {
+    // Configure the clients as super owners with fast blocks enabled.
+    for client in [&mut client1, &mut client2, &mut client3] {
+        client.options_mut().allow_fast_blocks = true;
         let owner = client.identity().await?;
         let ownership = ChainOwnership::single_super(owner);
         client.change_ownership(ownership).await.unwrap();
@@ -3392,6 +3399,63 @@ where
     assert!(
         balance >= Amount::from_tokens(3),
         "New chain should have received the transferred funds, got {balance}"
+    );
+
+    Ok(())
+}
+
+/// Tests the `allow_fast_blocks` option: when enabled, a super owner produces `Fast` blocks;
+/// when disabled, they produce `MultiLeader(0)` blocks instead.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_disallow_fast_blocks<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+
+    // Create a chain and get its owner.
+    let mut client = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let super_owner = client.identity().await?;
+
+    // Change ownership to make the owner a super owner.
+    let owner_change_op = Operation::system(SystemOperation::ChangeOwnership {
+        super_owners: vec![super_owner],
+        owners: vec![],
+        first_leader: None,
+        multi_leader_rounds: 10,
+        open_multi_leader_rounds: false,
+        timeout_config: TimeoutConfig::default(),
+    });
+    client.execute_operation(owner_change_op).await.unwrap();
+
+    // With fast blocks enabled, the super owner creates a block in the Fast round.
+    client.options_mut().allow_fast_blocks = true;
+    let certificate = client
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(1))
+        .await
+        .unwrap_ok_committed();
+    assert_eq!(
+        certificate.round,
+        Round::Fast,
+        "Block should be in Fast round when fast blocks are enabled"
+    );
+
+    // With fast blocks disabled, the super owner creates a block in MultiLeader(0) instead.
+    client.options_mut().allow_fast_blocks = false;
+    let certificate = client
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(1))
+        .await
+        .unwrap_ok_committed();
+    assert_eq!(
+        certificate.round,
+        Round::MultiLeader(0),
+        "Block should be in MultiLeader(0) when fast blocks are disabled"
     );
 
     Ok(())


### PR DESCRIPTION
## Motivation

Fast blocks should only be used if great care is taken to make sure there are no conflicting proposals.

## Proposal

Make it the default to never use them. Only with the new `--allow-fast-blocks` option will the client now create fast blocks.

## Test Plan

A test was added.

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a new SDK.

## Links

- Closes #5268.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
