### PR TITLE
fix(explorer): use relative API URL by default in Dockerfile

### DIFF
--- a/docker/Dockerfile.explorer
+++ b/docker/Dockerfile.explorer
@@ -3,7 +3,9 @@
 FROM node:18-alpine AS frontend-builder
 
 # Build argument for API base URL (injected at build time)
-ARG VITE_API_BASE_URL=http://localhost:3002/api
+# Default to relative URL for production deployments (proxied via ingress)
+# For local dev, override with: --build-arg VITE_API_BASE_URL=http://localhost:3002/api
+ARG VITE_API_BASE_URL=/api
 
 RUN apk add --no-cache python3 make g++
 


### PR DESCRIPTION
## Summary

Forward port of #5275 (testnet_conway) to main.

- Change `VITE_API_BASE_URL` default from `http://localhost:3002/api` to `/api`
- Fixes CORS errors in production deployments where frontend and backend are served from the same domain via ingress

## Problem

The explorer frontend was trying to fetch from `http://localhost:3002/api` in production, causing CORS errors:
```
Access to fetch at 'http://localhost:3002/api/blocks?limit=50&offset=0' from origin 'https://explorer.testnet-conway.linera.net' has been blocked by CORS policy
```

This happened because the `localhost` URL was baked into the frontend bundle at Docker build time.

## Why runtime ENV doesn't work

Vite bakes `VITE_*` env vars into the JS bundle at **build time**. By runtime, the value is already hardcoded in the JavaScript. Setting container env vars via `docker run -e` has no effect because the browser can't access container environment variables.

## Solution

Default to relative URL `/api` which nginx/ingress proxies correctly to the backend. For local development, the original URL can still be passed via:
```
--build-arg VITE_API_BASE_URL=http://localhost:3002/api
```

## Test plan

- [ ] Rebuild explorer image without passing `VITE_API_BASE_URL` build arg
- [ ] Deploy explorer
- [ ] Verify explorer loads blocks without CORS errors