### PR TITLE
Remove remaining `let _x`; clarify `CONTRIBUTING.md`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Contributions should generally follow the [Rust API guidelines](https://rust-lan
 * Re-exports (`pub use foo = bar::foo`) should be limited to definitions that would be private otherwise.
 
 * Avoid `let _ = ...` to discard values, because it can hide important information like
-  unawaited futures or unhandled errors.
+  unawaited futures or unhandled errors. `let _x =` should only be used for RAII guards.
 
 
 ## Formatting and linting

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -41,7 +41,7 @@ impl Contract for CrowdFundingContract {
 
     async fn instantiate(&mut self, argument: InstantiationArgument) {
         // Validate that the application parameters were configured correctly.
-        let _parameters = self.runtime.application_parameters();
+        self.runtime.application_parameters();
 
         self.state.instantiation_argument.set(Some(argument));
 

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -42,7 +42,7 @@ impl Contract for FungibleTokenContract {
 
     async fn instantiate(&mut self, state: Self::InstantiationArgument) {
         // Validate that the application parameters were configured correctly.
-        let _parameters = self.runtime.application_parameters();
+        self.runtime.application_parameters();
 
         let mut total_supply = Amount::ZERO;
         for value in state.accounts.values() {

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -58,8 +58,7 @@ impl chain_listener::ClientContext for ClientContext {
         epoch: Epoch,
     ) -> Result<(), Error> {
         // Ignore if chain already exists in wallet; test mock doesn't care.
-        let _insert_result = self
-            .wallet()
+        self.wallet()
             .try_insert(chain_id, wallet::Chain::new(owner, epoch, timestamp));
         Ok(())
     }


### PR DESCRIPTION
## Motivation

In #5261, some `let _ =` were removed, but some were unnecessarily replaced by `let _x =`.

## Proposal

Remove them, and clarify that `let _x =` should only be used for RAII guards.

## Test Plan

No change in logic.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- This was already applied to the backport #5272 of #5261.

## Links

- Follow-up to #5261. Port of one commit of #5272.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
