### PR TITLE
Make the `--owners` CLI argument to `change-ownership` a map

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -306,15 +306,8 @@ Open (i.e. activate) a new multi-owner chain deriving the UID from an existing o
 
 * `--from <CHAIN_ID>` — Chain ID (must be one of our chains)
 * `--super-owners <SUPER_OWNERS>` — A JSON list of the new super owners. Absence of the argument leaves the current set of super owners unchanged
-* `--owners <OWNERS>` — A JSON list of the new owners. Absence of the argument leaves the current list of owners unchanged
+* `--owners <OWNERS>` — A JSON map of the new owners to their weights. Absence of the argument leaves the current set of owners unchanged
 * `--first-leader <FIRST_LEADER>` — The leader of the first single-leader round. If set to null, this is random like other rounds. Absence of the argument leaves the current setting unchanged
-* `--owner-weights <OWNER_WEIGHTS>` — A JSON list of weights for the new owners.
-
-   If they are specified there must be exactly one weight for each owner.
-
-   Absence of the argument gives each owner a weight of 100 if --owners is specified, or leaves the owners unchanged if it is not specified.
-
-   Note: if --owner is not specified, but this argument is, the weights will be assigned to the existing owners in lexicographical order.
 * `--multi-leader-rounds <MULTI_LEADER_ROUNDS>` — The number of rounds in which every owner can propose blocks, i.e. the first round number in which only a single designated leader is allowed to propose blocks. "null" is equivalent to 2^32 - 1. Absence of the argument leaves the current setting unchanged
 * `--open-multi-leader-rounds` — Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners. This should only be `true` on chains with restrictive application permissions and an application-based mechanism to select block proposers
 * `--fast-round-ms <FAST_ROUND_DURATION>` — The duration of the fast round, in milliseconds. "null" means the fast round will not time out. Absence of the argument leaves the current setting unchanged
@@ -356,15 +349,8 @@ Specify the complete set of new owners, by public key. Existing owners that are 
 
 * `--chain-id <CHAIN_ID>` — The ID of the chain whose owners will be changed
 * `--super-owners <SUPER_OWNERS>` — A JSON list of the new super owners. Absence of the argument leaves the current set of super owners unchanged
-* `--owners <OWNERS>` — A JSON list of the new owners. Absence of the argument leaves the current list of owners unchanged
+* `--owners <OWNERS>` — A JSON map of the new owners to their weights. Absence of the argument leaves the current set of owners unchanged
 * `--first-leader <FIRST_LEADER>` — The leader of the first single-leader round. If set to null, this is random like other rounds. Absence of the argument leaves the current setting unchanged
-* `--owner-weights <OWNER_WEIGHTS>` — A JSON list of weights for the new owners.
-
-   If they are specified there must be exactly one weight for each owner.
-
-   Absence of the argument gives each owner a weight of 100 if --owners is specified, or leaves the owners unchanged if it is not specified.
-
-   Note: if --owner is not specified, but this argument is, the weights will be assigned to the existing owners in lexicographical order.
 * `--multi-leader-rounds <MULTI_LEADER_ROUNDS>` — The number of rounds in which every owner can propose blocks, i.e. the first round number in which only a single designated leader is allowed to propose blocks. "null" is equivalent to 2^32 - 1. Absence of the argument leaves the current setting unchanged
 * `--open-multi-leader-rounds` — Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners. This should only be `true` on chains with restrictive application permissions and an application-based mechanism to select block proposers
 * `--fast-round-ms <FAST_ROUND_DURATION>` — The duration of the fast round, in milliseconds. "null" means the fast round will not time out. Absence of the argument leaves the current setting unchanged

--- a/examples/amm/README.md
+++ b/examples/amm/README.md
@@ -254,7 +254,7 @@ with empty blocks.
 kill %% && sleep 1    # Kill the service so we can use CLI commands for chain 1.
 
 linera --wait-for-outgoing-messages change-ownership \
-    --owners "[\"$OWNER_AMM\",\"$OWNER_2\"]"
+    --owners "{\"$OWNER_AMM\":100,\"$OWNER_2\":100}"
 
 linera --wait-for-outgoing-messages change-application-permissions \
     --execute-operations "[\"$AMM_APPLICATION_ID\"]" \

--- a/examples/matching-engine/README.md
+++ b/examples/matching-engine/README.md
@@ -183,7 +183,7 @@ Engine to close the chain.
 kill %% && sleep 1    # Kill the service so we can use CLI commands for chain 1.
 
 linera --wait-for-outgoing-messages change-ownership \
-    --owners "[\"$OWNER_1\",\"$OWNER_2\"]"
+    --owners "{\"$OWNER_1\":100,\"$OWNER_2\":100}"
 
 linera --wait-for-outgoing-messages change-application-permissions \
     --execute-operations "[\"$MATCHING_ENGINE\"]" \

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, fmt, iter};
+use std::{
+    collections::{BTreeMap, HashSet},
+    fmt,
+};
 
 use linera_base::{
     data_types::{ApplicationPermissions, TimeDelta},
@@ -305,27 +308,15 @@ pub struct ChainOwnershipConfig {
     #[arg(long, value_parser = util::parse_json::<Vec<AccountOwner>>)]
     pub super_owners: Option<std::vec::Vec<AccountOwner>>,
 
-    /// A JSON list of the new owners. Absence of the argument leaves the current list of
-    /// owners unchanged.
-    #[arg(long, value_parser = util::parse_json::<Vec<AccountOwner>>)]
-    pub owners: Option<std::vec::Vec<AccountOwner>>,
+    /// A JSON map of the new owners to their weights. Absence of the argument leaves the current
+    /// set of owners unchanged.
+    #[arg(long, value_parser = util::parse_json::<BTreeMap<AccountOwner, u64>>)]
+    pub owners: Option<BTreeMap<AccountOwner, u64>>,
 
     /// The leader of the first single-leader round. If set to null, this is random like other
     /// rounds. Absence of the argument leaves the current setting unchanged.
     #[arg(long, value_parser = util::parse_json::<Option<AccountOwner>>)]
     pub first_leader: Option<std::option::Option<AccountOwner>>,
-
-    /// A JSON list of weights for the new owners.
-    ///
-    /// If they are specified there must be exactly one weight for each owner.
-    ///
-    /// Absence of the argument gives each owner a weight of 100 if --owners is specified,
-    /// or leaves the owners unchanged if it is not specified.
-    ///
-    /// Note: if --owner is not specified, but this argument is, the weights will be
-    /// assigned to the existing owners in lexicographical order.
-    #[arg(long, value_parser = util::parse_json::<Vec<u64>>)]
-    pub owner_weights: Option<std::vec::Vec<u64>>,
 
     /// The number of rounds in which every owner can propose blocks, i.e. the first round
     /// number in which only a single designated leader is allowed to propose blocks. "null" is
@@ -376,7 +367,6 @@ impl ChainOwnershipConfig {
             super_owners,
             owners,
             first_leader,
-            owner_weights,
             multi_leader_rounds,
             fast_round_duration,
             open_multi_leader_rounds,
@@ -385,18 +375,8 @@ impl ChainOwnershipConfig {
             fallback_duration,
         } = self;
 
-        if let Some(owner_weights) = owner_weights {
-            let owners = owners
-                .unwrap_or_else(|| chain_ownership.owners.keys().cloned().collect::<Vec<_>>());
-            if owner_weights.len() != owners.len() {
-                return Err(Error::MisalignedWeights {
-                    public_keys: owners.len(),
-                    weights: owner_weights.len(),
-                });
-            }
-            chain_ownership.owners = owners.into_iter().zip(owner_weights).collect();
-        } else if let Some(owners) = owners {
-            chain_ownership.owners = owners.into_iter().zip(iter::repeat(100)).collect();
+        if let Some(owners) = owners {
+            chain_ownership.owners = owners;
         }
 
         if let Some(super_owners) = super_owners {

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -891,8 +891,7 @@ impl ClientWrapper {
     pub async fn open_multi_owner_chain(
         &self,
         from: ChainId,
-        owners: Vec<AccountOwner>,
-        weights: Vec<u64>,
+        owners: BTreeMap<AccountOwner, u64>,
         multi_leader_rounds: u32,
         balance: Amount,
         base_timeout_ms: u64,
@@ -904,11 +903,6 @@ impl ClientWrapper {
             .arg("--owners")
             .arg(serde_json::to_string(&owners)?)
             .args(["--base-timeout-ms", &base_timeout_ms.to_string()]);
-        if !weights.is_empty() {
-            command
-                .arg("--owner-weights")
-                .arg(serde_json::to_string(&weights)?);
-        };
         command
             .args(["--multi-leader-rounds", &multi_leader_rounds.to_string()])
             .args(["--initial-balance", &balance.to_string()]);
@@ -933,7 +927,12 @@ impl ClientWrapper {
         command
             .arg("--super-owners")
             .arg(serde_json::to_string(&super_owners)?);
-        command.arg("--owners").arg(serde_json::to_string(&owners)?);
+        command.arg("--owners").arg(serde_json::to_string(
+            &owners
+                .into_iter()
+                .zip(std::iter::repeat(100u64))
+                .collect::<BTreeMap<_, _>>(),
+        )?);
         command.spawn_and_wait_for_stdout().await?;
         Ok(())
     }

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2303,8 +2303,9 @@ async fn test_wasm_end_to_end_allowances_fungible(config: impl LineraNetConfig) 
     let chain2 = client1
         .open_multi_owner_chain(
             chain1,
-            vec![owner1, owner2, owner3],
-            vec![100, 100, 100],
+            vec![(owner1, 100), (owner2, 100), (owner3, 100)]
+                .into_iter()
+                .collect(),
             u32::MAX,
             Amount::from_tokens(6),
             10_000,
@@ -4289,8 +4290,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) ->
     let chain2 = client1
         .open_multi_owner_chain(
             chain1,
-            vec![owner1, owner2],
-            vec![100, 100],
+            vec![(owner1, 100), (owner2, 100)].into_iter().collect(),
             u32::MAX,
             Amount::from_tokens(6),
             10_000,
@@ -4805,8 +4805,7 @@ async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> 
     let chain2 = client1
         .open_multi_owner_chain(
             chain1,
-            vec![owner1, owner2],
-            vec![100, 100],            // Both owners have equal weight.
+            vec![(owner1, 100), (owner2, 100)].into_iter().collect(),
             0,                         // No multi-leader rounds.
             Amount::from_millis(8900), // Only 8 transfers can be made.
             u64::MAX,                  // 585 million years


### PR DESCRIPTION
## Motivation

Right now `change-ownership` takes the owners and their weights in separate arguments. Since we're already using JSON for both, we can unify them into a single map argument.

## Proposal

Parse the value passed to `--owners` as a map.

This also affects `open-multi-owner-chain`.

## Test Plan

CI will catch regressions.

Readme tests were run manually to check that the new format is handled correctly.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
