### PR TITLE
Remove the need for listening to event publishers in FullChain mode

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -340,8 +340,8 @@ impl<C: ClientContext + 'static> ChainListener<C> {
                         self.listen_recursively(publishers).await?;
                         self.maybe_process_inbox(notification.chain_id).await?;
                     }
-                    self.process_new_events(notification.chain_id).await?;
                 }
+                self.process_new_events(notification.chain_id).await?;
             }
             Reason::BlockExecuted { .. } => {}
         }
@@ -557,7 +557,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
             .event_stream_publishers()
             .await?
             .into_iter()
-            .map(|chain_id| (chain_id, (ListeningMode::FullChain, None)))
+            .map(|chain_id| (chain_id, (ListeningMode::FollowChain, None)))
             .collect();
         for publisher_id in publishing_chains.keys() {
             self.event_subscribers


### PR DESCRIPTION
## Motivation

Currently, when we start listening to a chain because we subscribe to this chain's events, we do it in the `FullChain` mode. We should be able to use the `FollowChain` mode for that.

## Proposal

Fix an issue that broke listening to events in `FollowChain` mode, and switch to that mode when starting to listen to subscribed chains.

## Test Plan

CI will catch regressions.

## Release Plan

- These changes should be released in a new SDK,

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
